### PR TITLE
完善 SmartTurn 日语停顿确认与实机证据

### DIFF
--- a/docs/design/smart-turn-v3-human-electron-validation.md
+++ b/docs/design/smart-turn-v3-human-electron-validation.md
@@ -256,15 +256,22 @@ uv run python scripts/evaluate_smart_turn_v3.py `
 $LASTEXITCODE
 ```
 
+When `--criteria` is present, the evaluator rejects any `--asset-dir` whose
+SmartTurn model digest differs from the production asset manifest before the
+runtime is loaded or inference begins. Exploratory runs without criteria may
+still select another self-consistent asset directory, but they cannot produce a
+registered acceptance result.
+
 The evaluator writes requested JSON/Markdown reports before returning. When a
 criteria file is supplied, both `blocked` and `fail` return exit code `2`; only
 `pass` returns `0`. Exploratory runs without criteria return `0` but are not an
 acceptance signal.
 
-The gate first requires the loaded manifest SHA-256 to match the digest frozen
-inside the criteria. The report also binds the evidence to the manifest and
-criteria SHA-256 values, the
-pinned model version/SHA, and the evaluator script SHA-256. Provenance also
+The gate first requires the loaded evidence manifest SHA-256 to match the digest
+frozen inside the criteria, while the CLI separately requires the selected
+model SHA-256 to match the production asset manifest. The report also binds the
+evidence to the manifest and criteria SHA-256 values, the pinned model
+version/SHA, and the evaluator script SHA-256. Provenance also
 contains Git revision (suffixed `-dirty` when tracked or untracked changes are
 present), platform, Python, NumPy, and ONNX Runtime versions. Latency is split
 between calibration and holdout and separates the cold first inference from

--- a/docs/design/smart-turn-v3-human-electron-validation.md
+++ b/docs/design/smart-turn-v3-human-electron-validation.md
@@ -187,7 +187,10 @@ matrix-compliant speaker, one or more false-complete decisions across that
 speaker's incomplete cases count as one speaker with a premature split. One or
 more false-incomplete decisions across the speaker's complete cases count as
 one speaker with a missed endpoint. Wilson intervals are calculated over those
-speaker-level any-error counts.
+speaker-level any-error counts. They are two-sided at `confidence_level`, using
+`NormalDist().inv_cdf(0.5 + confidence_level / 2.0)`; the reported upper bound
+therefore uses the `(1 + confidence_level) / 2` quantile (0.975 when
+`confidence_level` is 0.95).
 
 Raw case confusion cells, complete recall, continuation specificity,
 premature-split rate, missed-endpoint rate, and balanced accuracy remain useful

--- a/docs/design/smart-turn-v3-human-electron-validation.md
+++ b/docs/design/smart-turn-v3-human-electron-validation.md
@@ -1,0 +1,404 @@
+# SmartTurn v3 human-voice and Electron validation
+
+## Status and evidence boundary
+
+SmartTurn v3 is not yet approved as product-quality endpointing for Chinese,
+English, or Japanese. Validation deliberately produces two different evidence
+layers:
+
+1. **Model checkpoint replay** feeds authorized, labelled 16 kHz mono PCM16 WAV
+   tails directly to the pinned SmartTurn ONNX model.
+2. **Live Electron route acceptance** exercises the real Electron microphone,
+   AudioWorklet, WebSocket, VAD, coordinator, SmartTurn, turn seal, and ASR
+   route.
+
+A checkpoint pass says only that the pinned model classified the registered
+tails within the pre-registered bounds. It does not exercise Electron capture,
+Silero candidate timing, coordinator retries, provider commit, or ASR/network
+behavior. Consequently, `product_quality_approval.status` remains `blocked`
+even when `gate.outcome` is `pass`; the registered live Electron matrix is
+separate, required evidence.
+
+## Privacy and local storage
+
+Human recordings, manifests, criteria drafts, authorization records, run
+sheets, reports, and diagnostic traces belong under
+`data/smart_turn_v3_human/`. The repository ignores `/data/`, so raw voice and
+its local metadata are not committed by the workflow.
+
+- Obtain the speaker's authorization before recording or replaying their voice.
+- Use independent, opaque 128-bit identifiers in the form
+  `<type>-<32 lowercase hexadecimal characters>`, for example
+  `speaker-0123456789abcdef0123456789abcdef`. The evaluator enforces this for
+  dataset, case, source-group, speaker, session, device, and criteria IDs.
+- Never encode a name, email, prompt, language, scenario, date, device serial,
+  or filename in an ID. Keep the authorization-to-speaker mapping outside the
+  manifest and report.
+- Do not store transcripts, API keys, OS device labels, or absolute paths in
+  the manifest or runtime trace.
+- The evaluator's public case results retain only opaque case IDs and approved
+  evaluation fields. WAV paths/basenames, speaker IDs, session IDs, device IDs,
+  source-group IDs, and individual audio hashes are not emitted.
+- Runtime diagnostics are disabled by default and accept no PCM or transcript
+  payload.
+
+## Versioned checkpoint manifest
+
+The manifest is a JSON object with `schema_version: 1`, an opaque `dataset_id`,
+and a non-empty `cases` array. Each case has exactly these fields:
+
+```json
+{
+  "id": "case-0123456789abcdef0123456789abcdef",
+  "path": "recordings/turn-0001.wav",
+  "audio_sha256": "<64 lowercase hexadecimal characters>",
+  "expected": "incomplete",
+  "language": "zh-CN",
+  "scenario": "sentence_internal_pause",
+  "source_group": "source-0123456789abcdef0123456789abcdef",
+  "speaker_id": "speaker-0123456789abcdef0123456789abcdef",
+  "session_id": "session-0123456789abcdef0123456789abcdef",
+  "device_id": "device-0123456789abcdef0123456789abcdef",
+  "capture_surface": "electron",
+  "capture_route_context": "dummy",
+  "split": "holdout",
+  "pause_ms": 650
+}
+```
+
+The loader enforces these evidence contracts:
+
+- `language` is `zh-CN`, `en-US`, or `ja-JP`; `expected` is `complete` or
+  `incomplete`.
+- `scenario` is `terminal_end`, `sentence_internal_pause`,
+  `hesitation_continue`, `long_pause_continue`, `keyboard_noise`, or
+  `barge_in`.
+- `capture_route_context` is `dummy`, `glm`, or `gemini`. It is provenance in
+  checkpoint replay, not a distinct model path: all three use the same pinned
+  model and production decision threshold. Do not duplicate audio across route
+  labels.
+- WAV input is non-empty, at most eight seconds, mono, 16 kHz, and signed
+  PCM16. Paths are relative to the manifest and cannot escape through `..`, an
+  absolute path, or a symlink.
+- `audio_sha256` must match the exact WAV file bytes. The loader also hashes the
+  decoded PCM and rejects duplicate audio even if it was repackaged into a
+  byte-different WAV. The report exposes one `dataset.audio_corpus_sha256`
+  derived from the sorted PCM digests, rather than exposing per-file hashes.
+- Case IDs and paths are unique. A speaker or source group cannot cross the
+  calibration/holdout boundary. Tails cut from one continuous recording must
+  share one `source_group`.
+- The collector and human label review must confirm that `pause_ms` is an
+  actual silent or speech-inactive interval in the WAV. The loader cannot
+  prove that acoustic fact; it enforces arithmetic feasibility only:
+  `pause_ms` must be at least the deployed `candidate_silence_ms` (currently
+  300 ms), and WAV duration must be at least
+  `pause_ms + minimum_speech_ms` (currently another 200 ms). It also rejects a
+  WAV whose decoded PCM is shorter than the frame count claimed by its header.
+
+Generate `audio_sha256` locally from the final WAV bytes after capture and any
+authorized trimming. Changing the audio afterward intentionally invalidates the
+manifest.
+
+## Collection matrix
+
+A complete label means the speaker intended the turn to end at the labelled
+pause. An incomplete label means they intended to continue after that pause.
+Record intent before inference; do not infer it from punctuation or the model's
+answer.
+
+| Scenario | Required label shape | Human action |
+| --- | --- | --- |
+| `terminal_end` | complete only | Finish a natural sentence and remain silent. |
+| `sentence_internal_pause` | incomplete only | Pause naturally between clauses, then continue. |
+| `hesitation_continue` | incomplete only | Use a filled hesitation, pause, then continue. |
+| `long_pause_continue` | incomplete only | Deliberately pause longer than an ordinary clause pause, then continue. |
+| `keyboard_noise` | both labels | Repeat complete and continuation cases while typing nearby. |
+| `barge_in` | both labels | Begin while N.E.K.O audio is ending, then finish or continue as labelled. |
+
+Use semantically equivalent natural prompts in each language, with varied
+speaking rate, pitch, accent, and hesitation. The product owner must
+pre-register the exact speaker count, a SHA-256 digest of the sorted opaque
+speaker roster, device minimum, exact per-speaker scenario-by-label matrix,
+confidence level, and error bounds before collecting the holdout. Freeze and
+archive the manifest and criteria before running inference. Every holdout
+speaker in a language must match both the frozen roster and that matrix
+exactly; replacing, adding, or removing a speaker or tail makes the evidence
+`blocked` rather than silently changing the stopping rule or reweighting a
+speaker.
+
+Generate the frozen evidence digests with the supported evaluator mode; do not
+write a one-off manifest scanner:
+
+```powershell
+uv run python scripts/evaluate_smart_turn_v3.py `
+  --manifest data/smart_turn_v3_human/pilot/manifest.json `
+  --evidence-digest-output `
+    data/smart_turn_v3_human/pilot/evidence-digests.json
+```
+
+This mode validates the complete manifest and every WAV, writes the exact
+`manifest_sha256`, and writes `speaker_count` plus
+`speaker_roster_sha256` for each language's holdout. It returns before loading
+the ONNX model, so generating registration material cannot expose model
+results. Copy these values into the criteria file, then archive both inputs.
+
+For independent verification, the roster digest is defined over the unique
+holdout `speaker_id` values for one language. Sort the opaque IDs in ascending
+ASCII order, serialize the array as UTF-8/ASCII JSON with no whitespace and no
+trailing newline, and SHA-256 those exact bytes. In Python notation, the
+canonical bytes are:
+
+```python
+json.dumps(sorted(unique_speaker_ids), separators=(",", ":")).encode("ascii")
+```
+
+For two IDs, the hashed bytes therefore look exactly like
+`["speaker-0123...","speaker-abcd..."]`. The supported command above is the
+source of truth and avoids differences caused by newlines, locale sorting, or
+pretty-printed JSON.
+
+## Pre-registered checkpoint gate
+
+The criteria file is separate from the manifest so observed probabilities
+cannot move the goalposts. Its `schema_version: 1` payload contains an opaque
+`criteria_id`, `manifest_sha256` for the complete frozen manifest,
+`confidence_method: "wilson"`, a confidence level, and one language entry for
+each of `zh-CN`, `en-US`, and `ja-JP`. Freeze the manifest and fill this digest
+before any model inference. A later change to a case ID, audio hash, speaker
+assignment, scenario, label, split, or other manifest evidence blocks the
+gate, even if speaker counts and the roster itself still match.
+
+`decision_threshold` must equal the deployed
+`SmartTurnConfig().evaluation_threshold`, currently `0.5`. A different value
+is rejected; the evaluator cannot be used to claim acceptance at a friendlier
+non-production threshold. Each language entry pre-registers:
+
+- exact `speaker_count`, `speaker_roster_sha256` derived from the sorted opaque
+  speaker IDs, and `min_devices`;
+- the exact `speaker_scenario_matrix`, including complete and incomplete counts
+  for all six scenarios;
+- `max_speakers_with_any_premature_split` and
+  `max_speakers_with_any_missed_endpoint`;
+- maximum Wilson upper bounds for the speaker premature-split and
+  missed-endpoint rates.
+
+The statistical unit is a speaker, not a correlated audio tail. For every
+matrix-compliant speaker, one or more false-complete decisions across that
+speaker's incomplete cases count as one speaker with a premature split. One or
+more false-incomplete decisions across the speaker's complete cases count as
+one speaker with a missed endpoint. Wilson intervals are calculated over those
+speaker-level any-error counts.
+
+Raw case confusion cells, complete recall, continuation specificity,
+premature-split rate, missed-endpoint rate, and balanced accuracy remain useful
+descriptive diagnostics. They are named `descriptive_case_*` in the report and
+are not gate confidence intervals because repeated tails from one speaker are
+correlated.
+
+No product-owner values for speaker count or allowable error have been
+committed here. Without a criteria file the result is `exploratory`. Missing or
+matrix-noncompliant evidence is `blocked`; adequate evidence outside an error
+bound is `fail`; only a complete holdout within every bound is `pass`.
+Calibration is reported separately and never participates in the gate.
+
+The criteria shape below is intentionally a non-runnable template: replace
+every angle-bracket placeholder with a JSON number or digest chosen/frozen by
+the product owner. Do not derive an allowable error after seeing predictions.
+Repeat the complete language object for `en-US` and `ja-JP` using their own
+generated roster values.
+
+```jsonc
+{
+  "schema_version": 1,
+  "criteria_id": "criteria-<32 lowercase hexadecimal characters>",
+  "manifest_sha256": "<copy from evidence-digests.json>",
+  "decision_threshold": 0.5,
+  "confidence_level": <product-owner value between 0.5 and 1.0>,
+  "confidence_method": "wilson",
+  "holdout": {
+    "languages": {
+      "zh-CN": {
+        "speaker_count": <copy generated integer>,
+        "speaker_roster_sha256": "<copy generated digest>",
+        "min_devices": <pre-registered integer>,
+        "speaker_scenario_matrix": {
+          "terminal_end": {"complete": <count>, "incomplete": 0},
+          "sentence_internal_pause": {"complete": 0, "incomplete": <count>},
+          "hesitation_continue": {"complete": 0, "incomplete": <count>},
+          "long_pause_continue": {"complete": 0, "incomplete": <count>},
+          "keyboard_noise": {"complete": <count>, "incomplete": <count>},
+          "barge_in": {"complete": <count>, "incomplete": <count>}
+        },
+        "max_speakers_with_any_premature_split": <pre-registered integer>,
+        "max_speakers_with_any_missed_endpoint": <pre-registered integer>,
+        "max_speaker_premature_split_rate_upper_bound": <rate from 0 to 1>,
+        "max_speaker_missed_endpoint_rate_upper_bound": <rate from 0 to 1>
+      },
+      "en-US": {"<same required fields>": "<language-specific values>"},
+      "ja-JP": {"<same required fields>": "<language-specific values>"}
+    }
+  }
+}
+```
+
+Run checkpoint replay with the pinned model:
+
+```powershell
+uv run python scripts/prepare_voice_turn_assets.py
+uv run python scripts/evaluate_smart_turn_v3.py `
+  --manifest data/smart_turn_v3_human/pilot/manifest.json `
+  --criteria data/smart_turn_v3_human/pilot/criteria.json `
+  --output data/smart_turn_v3_human/pilot/report.json `
+  --markdown-output data/smart_turn_v3_human/pilot/report.md
+$LASTEXITCODE
+```
+
+The evaluator writes requested JSON/Markdown reports before returning. When a
+criteria file is supplied, both `blocked` and `fail` return exit code `2`; only
+`pass` returns `0`. Exploratory runs without criteria return `0` but are not an
+acceptance signal.
+
+The gate first requires the loaded manifest SHA-256 to match the digest frozen
+inside the criteria. The report also binds the evidence to the manifest and
+criteria SHA-256 values, the
+pinned model version/SHA, and the evaluator script SHA-256. Provenance also
+contains Git revision (suffixed `-dirty` when tracked or untracked changes are
+present), platform, Python, NumPy, and ONNX Runtime versions. Latency is split
+between calibration and holdout and separates the cold first inference from
+warm measurements. These bindings make a run auditable; they do not remove the
+need to archive the ignored local inputs securely.
+
+## Legacy JSONL compatibility
+
+`--fixture-dir` plus `--labels` remains available only to replay old unversioned
+fixtures. Legacy cases have unknown speaker, session, device, and source-group
+provenance, cannot use a criteria file, and always remain exploratory. For
+compatibility, an old WAV longer than eight seconds is accepted and the model's
+existing trailing-window behavior is preserved. This mode redacts filenames
+from results but cannot satisfy the versioned evidence, deduplication, matrix,
+or speaker-level gate requirements; do not use it for product-quality claims.
+
+## Opt-in runtime diagnostics
+
+Enable the privacy-minimized runtime trace before starting the backend. The
+path must resolve under this repository's ignored `data/` directory and end in
+`.jsonl`; otherwise diagnostics safely remain disabled.
+
+```powershell
+# N.E.K.O backend terminal, set before launcher.py
+$env:NEKO_SMART_TURN_DIAGNOSTICS = '1'
+$env:NEKO_SMART_TURN_DIAGNOSTICS_PATH = `
+  'data/smart_turn_v3_human/pilot/runtime-diagnostics.jsonl'
+```
+
+Accepted opt-in values are `1`, `true`, `yes`, and `on`. If no path is set,
+the default is `data/smart_turn/runtime-diagnostics.jsonl`.
+
+Each diagnostics sink/session receives a fresh random 128-bit `run_id`. JSONL
+events contain only the schema, sequence number, monotonic elapsed
+milliseconds, event type, and an event-specific allowlist:
+
+- `session_start` and `session_end`;
+- `candidate` with a bounded reason;
+- `evaluation` with reason, outcome, evaluation duration, a valid bounded
+  probability when available, and the coordinator's actual threshold;
+- `complete` with reason; and
+- `failure` with bounded kind and stage.
+
+There is no wall-clock timestamp, PCM, transcript, prompt, case/speaker/device
+identifier, path, provider credential, or API key. Invalid probabilities are
+omitted. Writing occurs on a daemon worker; flush/close acknowledgement is
+bounded to 50 ms, and trace I/O failure does not block the voice runtime. Treat
+the trace as operational sequence evidence, not proof of the user's labelled
+intent; correlate it with a separate local, opaque run sheet.
+
+## Opt-in local audio evidence
+
+Raw SmartTurn audio evidence is a separate opt-in from the privacy-minimized
+JSONL trace. Use it only after the speaker has authorized local retention of
+their voice. The recorder stores completed SmartTurn turn windows as 16 kHz
+mono PCM16 WAV files plus a JSONL index under the ignored `data/` tree; it
+does not store transcripts, prompts, API keys, microphone names, or absolute
+paths.
+
+```powershell
+# N.E.K.O backend terminal, set before launcher.py
+$env:NEKO_SMART_TURN_AUDIO_EVIDENCE = '1'
+$env:NEKO_SMART_TURN_AUDIO_EVIDENCE_DIR = `
+  'data/smart_turn_v3_human/pilot/audio-evidence'
+```
+
+Accepted opt-in values are `1`, `true`, `yes`, and `on`. If no directory is
+set, the default is `data/smart_turn/audio-evidence`. A configured directory
+outside repository `data/` disables capture. Each runtime session writes to a
+fresh random run directory containing `turn-0001.wav`, `turn-0002.wav`, and an
+`index.jsonl` with duration, SHA-256, decision reason, probability, threshold,
+and truncation metadata.
+
+For Japanese continuation reproduction, use this sentence first. Read through
+the comma with a natural 0.5-0.8 second pause, then continue without pressing
+stop:
+
+```text
+今日は駅で友達と待ち合わせをして、そのあと新しい喫茶店に行きます。
+```
+
+The 2026-08-04 live Japanese pilot showed three premature completions from a
+single read of this sentence. All completions were direct `candidate_pause`
+decisions with high SmartTurn probabilities, so protecting only the
+`strict_retry` path is insufficient. Product runtime now treats a SmartTurn
+`candidate_pause` COMPLETE as provisional for
+`SmartTurnConfig.candidate_complete_confirmation_seconds` (default 1.0 s).
+If Silero reports resumed speech inside that window, the provisional completion
+is cancelled and audio stays in the same logical turn; otherwise the completion
+is published after the short confirmation delay.
+
+## Live Electron acceptance
+
+Start with the `dummy` ASR override. It retains the real Electron microphone,
+48 kHz AudioWorklet capture, PCM conversion, WebSocket, VAD, SmartTurn, and turn
+seal path while removing cloud credentials, provider/network latency, and
+transcription variability from the endpointing result:
+
+```powershell
+# N.E.K.O backend terminal
+uv run python scripts/prepare_voice_turn_assets.py
+$env:NEKO_SMART_TURN_DIAGNOSTICS = '1'
+$env:NEKO_SMART_TURN_DIAGNOSTICS_PATH = `
+  'data/smart_turn_v3_human/pilot/runtime-diagnostics.jsonl'
+$env:NEKO_SMART_TURN_AUDIO_EVIDENCE = '1'
+$env:NEKO_SMART_TURN_AUDIO_EVIDENCE_DIR = `
+  'data/smart_turn_v3_human/pilot/audio-evidence'
+$env:ASR_PROVIDER = 'dummy'
+uv run python launcher.py
+```
+
+```powershell
+# N.E.K.O.-PC terminal
+$env:NEKO_USER_DATA_DIR = '<an isolated local directory>'
+npm ci
+npm start
+```
+
+Use F2 or the microphone button to start and stop an actual voice session. Run
+the complete pre-registered scenario/label matrix in all three languages. In a
+local opaque run sheet, record the intended label and trace run, then verify:
+
+- candidate, evaluation, completion, and final ordering with relative timing;
+- premature split, missed endpoint, duplicate final, and recovery behavior;
+- microphone permission denial/regrant, mute, stop/restart, device switch, and
+  hot-plug behavior; and
+- clean teardown with no late seal or final from the old session.
+
+A dummy pass validates endpointing-path integration, not GLM or Gemini service
+acceptance. After isolation, remove `ASR_PROVIDER` and repeat the fully
+registered matrix on each supported segmented provider route separately. Never
+merge routes or use a partial rerun to clear a failed or missing stratum.
+
+## Required interpretation
+
+Checkpoint replay answers, “How did the pinned model classify these authorized
+tails?” Live Electron acceptance answers, “Did the shipped interaction path
+seal the intended turn at the right time and recover correctly?” Provider-route
+acceptance additionally answers whether the real service commits and returns
+correctly. No one layer can substitute for the others.

--- a/docs/design/smart-turn-v3-provider-neutral.md
+++ b/docs/design/smart-turn-v3-provider-neutral.md
@@ -177,12 +177,30 @@ Before treating the integrated routes as product-quality, maintainers must run
 `scripts/evaluate_smart_turn_v3.py` on an authorized labelled set that
 includes sentence-internal pauses, hesitation followed by continuation,
 complete turns, keyboard noise, and barge-in. The report always includes all
-four confusion-matrix cells and per-sample probabilities.
+four confusion-matrix cells and per-case probabilities, but those case rates
+are descriptive only. The registered gate uses each speaker's any-error result
+over a fixed scenario-by-label matrix and speaker-level Wilson intervals. The
+versioned, privacy-minimizing manifest, pre-registered checkpoint gate,
+multilingual collection matrix, opt-in runtime diagnostics, and separate
+Electron live-route procedure are specified in
+[`smart-turn-v3-human-electron-validation.md`](smart-turn-v3-human-electron-validation.md).
 
-No numeric product-quality threshold has been approved yet. Before any future
-approval run, the product owner must pre-register, for every language and
-route, the minimum labelled sample count, metric thresholds, maximum permitted
-premature-split count, and confidence method. Missing pre-registered criteria
-or failure of any criterion blocks product-quality approval. Remediation must
-tune the detector or route without weakening fail-closed behavior, then rerun
-the complete registered matrix; a partial rerun cannot clear the gate.
+The direct evaluator is checkpoint replay only. It does not exercise Electron,
+Silero candidate timing, coordinator retries, provider commit, or ASR network
+behavior. Even a passing checkpoint gate therefore leaves product-quality
+approval blocked until the registered live Electron route matrix passes.
+
+The deployed model decision threshold is fixed at `0.5`, and the evaluator
+rejects criteria that substitute another threshold. No numeric
+product-quality bounds have been approved yet. Before any future approval run,
+the product owner must freeze the complete manifest digest and pre-register,
+for every language, the exact speaker count and opaque-roster digest, minimum
+devices, the exact per-speaker
+scenario-by-label matrix, permitted
+speaker-level any-premature-split and any-missed-endpoint counts, Wilson upper
+bounds, and confidence level. Missing or matrix-noncompliant evidence blocks
+the checkpoint gate; a registered miss fails it. Either result produces a
+nonzero evaluator exit when criteria were supplied, and even a checkpoint pass
+leaves product approval blocked until the complete live Electron route matrix
+passes. Remediation must preserve fail-closed behavior and rerun the complete
+registered matrix; a partial rerun cannot clear the gate.

--- a/main_logic/asr_client/endpointing/config.py
+++ b/main_logic/asr_client/endpointing/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 
@@ -32,7 +33,10 @@ class SmartTurnConfig:
             raise ValueError("max_audio_seconds must be positive")
         if self.inference_error_limit <= 0:
             raise ValueError("inference_error_limit must be positive")
-        if self.candidate_complete_confirmation_seconds < 0:
+        if (
+            not math.isfinite(self.candidate_complete_confirmation_seconds)
+            or self.candidate_complete_confirmation_seconds < 0
+        ):
             raise ValueError(
-                "candidate_complete_confirmation_seconds must be non-negative"
+                "candidate_complete_confirmation_seconds must be finite and non-negative"
             )

--- a/main_logic/asr_client/endpointing/config.py
+++ b/main_logic/asr_client/endpointing/config.py
@@ -17,6 +17,7 @@ class SmartTurnConfig:
     minimum_speech_ms: int = 200
     max_audio_seconds: int = 8
     inference_error_limit: int = 3
+    candidate_complete_confirmation_seconds: float = 1.0
 
     def __post_init__(self) -> None:
         for name in ("evaluation_threshold", "onset_probability", "offset_probability"):
@@ -31,3 +32,7 @@ class SmartTurnConfig:
             raise ValueError("max_audio_seconds must be positive")
         if self.inference_error_limit <= 0:
             raise ValueError("inference_error_limit must be positive")
+        if self.candidate_complete_confirmation_seconds < 0:
+            raise ValueError(
+                "candidate_complete_confirmation_seconds must be non-negative"
+            )

--- a/main_logic/asr_client/endpointing/coordinator.py
+++ b/main_logic/asr_client/endpointing/coordinator.py
@@ -42,7 +42,9 @@ class CoordinatorState(Enum):
 class TurnCoordinator:
     """Own model evaluation state, but never commit a provider buffer."""
 
-    def __init__(self, predictor: ProbabilityPredictor, config: SmartTurnConfig) -> None:
+    def __init__(
+        self, predictor: ProbabilityPredictor, config: SmartTurnConfig
+    ) -> None:
         self._predictor = predictor
         self._config = config
         self._buffer = Pcm16RingBuffer(config.max_audio_seconds)
@@ -64,6 +66,10 @@ class TurnCoordinator:
         return self._activity_seq
 
     @property
+    def evaluation_threshold(self) -> float:
+        return self._config.evaluation_threshold
+
+    @property
     def state(self) -> CoordinatorState:
         return self._state
 
@@ -78,7 +84,10 @@ class TurnCoordinator:
         async with self._state_lock:
             if self._closed:
                 return
-            if event in (SpeechActivityEvent.SPEECH_STARTED, SpeechActivityEvent.SPEECH_RESUMED):
+            if event in (
+                SpeechActivityEvent.SPEECH_STARTED,
+                SpeechActivityEvent.SPEECH_RESUMED,
+            ):
                 self._activity_seq += 1
                 self._state = CoordinatorState.SPEECH_ACTIVE
             elif event is SpeechActivityEvent.CANDIDATE_PAUSE:
@@ -114,24 +123,36 @@ class TurnCoordinator:
             activity_seq = self._activity_seq
             if self._closed:
                 return self._non_ok(
-                    EvaluationStatus.STALE, generation, activity_seq, "coordinator_closed"
+                    EvaluationStatus.STALE,
+                    generation,
+                    activity_seq,
+                    "coordinator_closed",
                 )
 
         async with self._evaluation_lock:
             async with self._state_lock:
                 if request != self._latest_request:
                     return self._non_ok(
-                        EvaluationStatus.STALE, generation, activity_seq, "candidate_superseded"
+                        EvaluationStatus.STALE,
+                        generation,
+                        activity_seq,
+                        "candidate_superseded",
                     )
                 if generation != self._generation or activity_seq != self._activity_seq:
                     return self._non_ok(
-                        EvaluationStatus.STALE, generation, activity_seq, "activity_changed"
+                        EvaluationStatus.STALE,
+                        generation,
+                        activity_seq,
+                        "activity_changed",
                     )
                 self._state = CoordinatorState.EVALUATING
 
             if not audio_tail:
                 result = self._non_ok(
-                    EvaluationStatus.UNAVAILABLE, generation, activity_seq, "empty_audio"
+                    EvaluationStatus.UNAVAILABLE,
+                    generation,
+                    activity_seq,
+                    "empty_audio",
                 )
             else:
                 try:
@@ -144,7 +165,10 @@ class TurnCoordinator:
                             "model_unavailable",
                         )
                     else:
-                        audio = np.frombuffer(audio_tail, dtype="<i2").astype(np.float32) / 32768.0
+                        audio = (
+                            np.frombuffer(audio_tail, dtype="<i2").astype(np.float32)
+                            / 32768.0
+                        )
                         probability = await self._run_predictor_call(
                             self._predictor.predict_probability, audio
                         )
@@ -191,7 +215,10 @@ class TurnCoordinator:
                     or activity_seq != self._activity_seq
                 ):
                     return self._non_ok(
-                        EvaluationStatus.STALE, generation, activity_seq, "result_became_stale"
+                        EvaluationStatus.STALE,
+                        generation,
+                        activity_seq,
+                        "result_became_stale",
                     )
                 self._state = (
                     CoordinatorState.WAIT_CONTINUATION

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -758,8 +758,7 @@ class _VoiceTurnAdapter:
                 elif item.reason == "strict_retry":
                     confirmation_seconds = self._strict_complete_confirmation_seconds
             if confirmation_seconds > 0:
-                for tail_item in evaluation_tail:
-                    await self._process_audio(tail_item)
+                self._observe_evaluation_tail(evaluation_tail)
                 if (
                     self._closed
                     or self._failed

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -165,12 +166,20 @@ class _VoiceTurnAdapter:
             raise ValueError(
                 "max_endpoint_wait_seconds must not be shorter than continuation timeout"
             )
-        if candidate_complete_confirmation_seconds < 0:
+        if (
+            not math.isfinite(candidate_complete_confirmation_seconds)
+            or candidate_complete_confirmation_seconds < 0
+        ):
             raise ValueError(
-                "candidate complete confirmation delay must be non-negative"
+                "candidate complete confirmation delay must be finite and non-negative"
             )
-        if strict_complete_confirmation_seconds < 0:
-            raise ValueError("strict complete confirmation delay must be non-negative")
+        if (
+            not math.isfinite(strict_complete_confirmation_seconds)
+            or strict_complete_confirmation_seconds < 0
+        ):
+            raise ValueError(
+                "strict complete confirmation delay must be finite and non-negative"
+            )
         if smart_turn_warm_seconds <= 0:
             raise ValueError("smart_turn_warm_seconds must be positive")
         if fallback_evaluation_interval_ms <= 0:
@@ -530,16 +539,13 @@ class _VoiceTurnAdapter:
                 duration_us=item.duration_us,
                 detector_identity=item.detector_identity,
             )
-        if self._evaluation_task is not None:
+        defers_for_evaluation = self._evaluation_task is not None
+        if defers_for_evaluation:
             self._evaluation_tail.append(item)
             self._evaluation_tail_duration_us += item.duration_us
-        else:
-            self._observe_accepted_audio(item)
-        self._retain_confirmation_audio(item)
-        self._smart_turn_audio_evidence.accepted_audio(
-            identity=item.identity,
-            pcm16=item.pcm16,
-        )
+        retained_for_confirmation = self._retain_confirmation_audio(item)
+        if not defers_for_evaluation and not retained_for_confirmation:
+            self._attribute_accepted_audio(item)
         self._latest_detector_identity = item.detector_identity
         self._coordinator.push_audio(item.pcm16)
         if self._vad_degraded:
@@ -784,7 +790,6 @@ class _VoiceTurnAdapter:
                 elif item.reason == "strict_retry":
                     confirmation_seconds = self._strict_complete_confirmation_seconds
             if confirmation_seconds > 0:
-                self._observe_evaluation_tail(evaluation_tail)
                 if (
                     self._closed
                     or self._failed
@@ -847,11 +852,18 @@ class _VoiceTurnAdapter:
         except Exception:
             return
 
+    def _attribute_accepted_audio(self, item: _AudioItem) -> None:
+        self._observe_accepted_audio(item)
+        self._smart_turn_audio_evidence.accepted_audio(
+            identity=item.identity,
+            pcm16=item.pcm16,
+        )
+
     def _observe_evaluation_tail(self, items: tuple[_AudioItem, ...]) -> None:
         for item in items:
-            self._observe_accepted_audio(item)
+            self._attribute_accepted_audio(item)
 
-    def _retain_confirmation_audio(self, item: _AudioItem) -> None:
+    def _retain_confirmation_audio(self, item: _AudioItem) -> bool:
         pending = self._pending_complete_confirmation
         candidate = pending.detector_identity if pending is not None else None
         incoming = item.detector_identity
@@ -863,9 +875,10 @@ class _VoiceTurnAdapter:
             or incoming.detector_epoch != candidate.detector_epoch
             or incoming.sequence_no <= candidate.sequence_no
         ):
-            return
+            return False
         self._confirmation_tail.append(item)
         self._confirmation_tail_duration_us += item.duration_us
+        return True
 
     def _clear_confirmation_audio(self) -> tuple[_AudioItem, ...]:
         items = tuple(self._confirmation_tail)
@@ -896,7 +909,7 @@ class _VoiceTurnAdapter:
             # current turn; a stale one must not roll the identity back or
             # cancel the newer turn's work.
             return
-        self._cancel_fallback()
+        self._cancel_fallback(attribute_confirmation_tail=False)
         self._cancel_smart_turn_unload()
         # Invalidate callbacks before awaiting their cancellation. A callback
         # may suppress CancelledError, but it must still observe the new turn.
@@ -1050,6 +1063,13 @@ class _VoiceTurnAdapter:
                 and self._coordinator.state is not CoordinatorState.PAUSE_CANDIDATE
             )
         ):
+            if (
+                not self._closed
+                and not self._failed
+                and pending.identity == self._identity
+                and self._evaluation_task is None
+            ):
+                self._observe_evaluation_tail(confirmation_tail)
             return False
         await self._publish_complete_result(
             pending.identity,
@@ -1057,7 +1077,6 @@ class _VoiceTurnAdapter:
             pending.reason,
             probability=pending.probability,
             evaluation_tail=confirmation_tail,
-            tail_already_observed=True,
             wait_for_commit=wait_for_commit,
         )
         return True
@@ -1091,17 +1110,10 @@ class _VoiceTurnAdapter:
         *,
         probability: float | None,
         evaluation_tail: tuple[_AudioItem, ...],
-        tail_already_observed: bool = False,
         wait_for_commit: bool = False,
     ) -> None:
         self._strict_endpoint_deadline = None
         self._smart_turn_diagnostics.complete(reason=reason)
-        self._smart_turn_audio_evidence.complete(
-            identity=identity,
-            reason=reason,
-            probability=probability,
-            threshold=getattr(self._coordinator, "evaluation_threshold", None),
-        )
         self._complete_observed_candidate(detector_identity)
         active_identity = identity
         if self._on_completion_fence is not None and detector_identity is not None:
@@ -1109,16 +1121,24 @@ class _VoiceTurnAdapter:
                 *identity,
                 detector_identity,
             )
-            if active_identity != identity:
-                await self._process_reset(
-                    active_identity,
-                    requester=asyncio.current_task(),
-                )
-                self._successor_audio_fence = (
-                    identity,
-                    detector_identity.sequence_no,
-                    active_identity,
-                )
+        if active_identity == identity:
+            self._observe_evaluation_tail(evaluation_tail)
+        self._smart_turn_audio_evidence.complete(
+            identity=identity,
+            reason=reason,
+            probability=probability,
+            threshold=getattr(self._coordinator, "evaluation_threshold", None),
+        )
+        if active_identity != identity:
+            await self._process_reset(
+                active_identity,
+                requester=asyncio.current_task(),
+            )
+            self._successor_audio_fence = (
+                identity,
+                detector_identity.sequence_no,
+                active_identity,
+            )
         callback_tasks_before = tuple(self._callback_tasks)
         completion_published = self._dispatch_commit(
             identity,
@@ -1139,8 +1159,6 @@ class _VoiceTurnAdapter:
         elif completion_published is not None:
             _ = await completion_published
         if active_identity == identity:
-            if not tail_already_observed:
-                self._observe_evaluation_tail(evaluation_tail)
             return
         for tail_item in evaluation_tail:
             await self._process_audio(
@@ -1152,9 +1170,11 @@ class _VoiceTurnAdapter:
                 )
             )
 
-    def _cancel_fallback(self) -> None:
+    def _cancel_fallback(self, *, attribute_confirmation_tail: bool = True) -> None:
         self._pending_complete_confirmation = None
-        self._clear_confirmation_audio()
+        confirmation_tail = self._clear_confirmation_audio()
+        if attribute_confirmation_tail:
+            self._observe_evaluation_tail(confirmation_tail)
         task = self._fallback_task
         self._fallback_task = None
         if task is not None:
@@ -1206,7 +1226,7 @@ class _VoiceTurnAdapter:
         self._failed = True
         self._failure = _VoiceTurnFailure(kind, stage)
         self._smart_turn_diagnostics.failure(kind=kind, stage=stage)
-        self._cancel_fallback()
+        self._cancel_fallback(attribute_confirmation_tail=False)
         self._cancel_smart_turn_unload()
         current_task = asyncio.current_task()
         for task in tuple(self._callback_tasks):

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -453,7 +453,10 @@ class _VoiceTurnAdapter:
             await self._close_resources()
             return
         completed = asyncio.get_running_loop().create_future()
-        self._queue.put_control_nowait(_CloseItem(completed), priority=True)
+        # Preserve FIFO for PCM that push_audio() already admitted. In
+        # particular, continuation audio must be allowed to cancel a pending
+        # provisional COMPLETE before shutdown resolves it.
+        self._queue.put_control_nowait(_CloseItem(completed))
         await completed
         await task
 

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -196,6 +196,8 @@ class _VoiceTurnAdapter:
         self._evaluation_tail_capacity_us = queue_capacity_ms * 1_000
         self._evaluation_tail: list[_AudioItem] = []
         self._evaluation_tail_duration_us = 0
+        self._confirmation_tail: list[_AudioItem] = []
+        self._confirmation_tail_duration_us = 0
         self._continuation_timeout_seconds = continuation_timeout_seconds
         self._max_endpoint_wait_seconds = max_endpoint_wait_seconds
         self._candidate_complete_confirmation_seconds = (
@@ -330,9 +332,20 @@ class _VoiceTurnAdapter:
         self._ensure_running()
         samples = len(pcm16) // 2
         duration_us = (samples * 1_000_000 + sample_rate_hz - 1) // sample_rate_hz
+        pending = self._pending_complete_confirmation
+        retains_for_confirmation = (
+            pending is not None
+            and pending.identity == (generation, buffer_epoch, utterance_id)
+            and pending.detector_identity is not None
+            and detector_identity is not None
+            and detector_identity.detector_epoch
+            == pending.detector_identity.detector_epoch
+            and detector_identity.sequence_no > pending.detector_identity.sequence_no
+        )
         if (
-            self._evaluation_task is not None
+            (self._evaluation_task is not None or retains_for_confirmation)
             and self._evaluation_tail_duration_us
+            + self._confirmation_tail_duration_us
             + self._queue.audio_duration_us
             + duration_us
             > self._evaluation_tail_capacity_us
@@ -522,6 +535,7 @@ class _VoiceTurnAdapter:
             self._evaluation_tail_duration_us += item.duration_us
         else:
             self._observe_accepted_audio(item)
+        self._retain_confirmation_audio(item)
         self._smart_turn_audio_evidence.accepted_audio(
             identity=item.identity,
             pcm16=item.pcm16,
@@ -785,6 +799,7 @@ class _VoiceTurnAdapter:
                     item.reason,
                     probability=probability,
                     delay_seconds=confirmation_seconds,
+                    evaluation_tail=evaluation_tail,
                 )
                 return
             await self._publish_complete_result(
@@ -836,6 +851,28 @@ class _VoiceTurnAdapter:
         for item in items:
             self._observe_accepted_audio(item)
 
+    def _retain_confirmation_audio(self, item: _AudioItem) -> None:
+        pending = self._pending_complete_confirmation
+        candidate = pending.detector_identity if pending is not None else None
+        incoming = item.detector_identity
+        if (
+            pending is None
+            or candidate is None
+            or incoming is None
+            or item.identity != pending.identity
+            or incoming.detector_epoch != candidate.detector_epoch
+            or incoming.sequence_no <= candidate.sequence_no
+        ):
+            return
+        self._confirmation_tail.append(item)
+        self._confirmation_tail_duration_us += item.duration_us
+
+    def _clear_confirmation_audio(self) -> tuple[_AudioItem, ...]:
+        items = tuple(self._confirmation_tail)
+        self._confirmation_tail.clear()
+        self._confirmation_tail_duration_us = 0
+        return items
+
     def _complete_observed_candidate(
         self,
         detector_identity: DetectorIngressIdentity | None,
@@ -880,6 +917,7 @@ class _VoiceTurnAdapter:
         self._latest_detector_identity = None
         self._evaluation_tail.clear()
         self._evaluation_tail_duration_us = 0
+        self._clear_confirmation_audio()
         self._successor_audio_fence = None
         self._smart_turn_audio_evidence.discard()
         await self._coordinator.reset()
@@ -953,6 +991,7 @@ class _VoiceTurnAdapter:
         *,
         probability: float | None,
         delay_seconds: float,
+        evaluation_tail: tuple[_AudioItem, ...] = (),
     ) -> None:
         self._cancel_fallback()
         pending = _PendingCompleteConfirmation(
@@ -962,6 +1001,8 @@ class _VoiceTurnAdapter:
             probability=probability,
         )
         self._pending_complete_confirmation = pending
+        for item in evaluation_tail:
+            self._retain_confirmation_audio(item)
 
         async def confirm_complete() -> None:
             await asyncio.sleep(delay_seconds)
@@ -998,6 +1039,7 @@ class _VoiceTurnAdapter:
         if current_task is self._fallback_task:
             self._fallback_task = None
         self._pending_complete_confirmation = None
+        confirmation_tail = self._clear_confirmation_audio()
         if (
             self._closed
             or self._failed
@@ -1014,7 +1056,8 @@ class _VoiceTurnAdapter:
             pending.detector_identity,
             pending.reason,
             probability=pending.probability,
-            evaluation_tail=(),
+            evaluation_tail=confirmation_tail,
+            tail_already_observed=True,
             wait_for_commit=wait_for_commit,
         )
         return True
@@ -1048,6 +1091,7 @@ class _VoiceTurnAdapter:
         *,
         probability: float | None,
         evaluation_tail: tuple[_AudioItem, ...],
+        tail_already_observed: bool = False,
         wait_for_commit: bool = False,
     ) -> None:
         self._strict_endpoint_deadline = None
@@ -1081,8 +1125,6 @@ class _VoiceTurnAdapter:
             detector_identity,
             active_identity=active_identity,
         )
-        if completion_published is not None:
-            await completion_published
         if wait_for_commit and completion_published is not None:
             commit_tasks = tuple(
                 task
@@ -1094,6 +1136,12 @@ class _VoiceTurnAdapter:
                     commit_tasks,
                     timeout=_COMMIT_DRAIN_ON_CLOSE_SECONDS,
                 )
+        elif completion_published is not None:
+            await completion_published
+        if active_identity == identity:
+            if not tail_already_observed:
+                self._observe_evaluation_tail(evaluation_tail)
+            return
         for tail_item in evaluation_tail:
             await self._process_audio(
                 _AudioItem(
@@ -1106,6 +1154,7 @@ class _VoiceTurnAdapter:
 
     def _cancel_fallback(self) -> None:
         self._pending_complete_confirmation = None
+        self._clear_confirmation_audio()
         task = self._fallback_task
         self._fallback_task = None
         if task is not None:

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -202,7 +202,25 @@ class _VoiceTurnAdapter:
                 max_frames=queue_maxsize,
             )
         )
-        self._evaluation_tail_capacity_us = queue_capacity_ms * 1_000
+        queue_capacity_us = queue_capacity_ms * 1_000
+        confirmation_capacity_us = 0
+        if smart_turn_required:
+            confirmation_capacity_us = math.ceil(
+                max(
+                    candidate_complete_confirmation_seconds,
+                    strict_complete_confirmation_seconds,
+                )
+                * 1_000_000
+            )
+        # Retained audio can already occupy one queue-capacity window while an
+        # evaluation is in flight. A configured confirmation then needs its own
+        # full window plus one bounded queue window for frame granularity and
+        # event-loop scheduling before the confirmation control item is handled.
+        self._evaluation_tail_capacity_us = (
+            queue_capacity_us
+            + confirmation_capacity_us
+            + (queue_capacity_us if confirmation_capacity_us else 0)
+        )
         self._evaluation_tail: list[_AudioItem] = []
         self._evaluation_tail_duration_us = 0
         self._confirmation_tail: list[_AudioItem] = []
@@ -1015,7 +1033,13 @@ class _VoiceTurnAdapter:
         )
         self._pending_complete_confirmation = pending
         for item in evaluation_tail:
-            self._retain_confirmation_audio(item)
+            if pending.detector_identity is None and item.detector_identity is None:
+                # The internal ASR path has no completion fence that can move
+                # these samples to a successor identity. Attribute them now so
+                # the deferred evaluation interval cannot leave an evidence gap.
+                self._attribute_accepted_audio(item)
+            else:
+                self._retain_confirmation_audio(item)
 
         async def confirm_complete() -> None:
             await asyncio.sleep(delay_seconds)

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -35,6 +35,8 @@ from .detector import (
     SmartTurnCompletionFence,
 )
 from .silero_vad import SileroActivityGate, SileroVad
+from .smart_turn_audio_evidence import create_smart_turn_audio_evidence_recorder
+from .smart_turn_diagnostics import create_smart_turn_runtime_diagnostics
 from .smart_turn_v3 import SmartTurnV3
 from .throttle_policy import (
     ThrottleAction,
@@ -54,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 _Identity: TypeAlias = tuple[int, int, int]
 _FallbackReason: TypeAlias = Literal["semantic_incomplete", "semantic_degraded"]
+_COMMIT_DRAIN_ON_CLOSE_SECONDS = 0.5
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,6 +97,14 @@ class _EvaluationResultItem:
     error: BaseException | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _PendingCompleteConfirmation:
+    identity: _Identity
+    detector_identity: DetectorIngressIdentity | None
+    reason: Literal["candidate_pause", "periodic_no_vad", "strict_retry"]
+    probability: float | None
+
+
 _ControlItem: TypeAlias = _ResetItem | _CloseItem | _EvaluationResultItem
 _QueueItem: TypeAlias = _AudioItem | _ControlItem
 
@@ -121,9 +132,7 @@ class _VoiceTurnAdapter:
             [SpeechActivityEvent, DetectorIngressIdentity], Awaitable[None]
         ]
         | None = None,
-        on_accepted_audio: Callable[
-            [bytes, int, DetectorIngressIdentity | None], None
-        ]
+        on_accepted_audio: Callable[[bytes, int, DetectorIngressIdentity | None], None]
         | None = None,
         on_candidate_complete: Callable[[DetectorIngressIdentity | None], None]
         | None = None,
@@ -131,6 +140,8 @@ class _VoiceTurnAdapter:
         queue_capacity_ms: int = 1_000,
         continuation_timeout_seconds: float = 2.0,
         max_endpoint_wait_seconds: float = 15.0,
+        candidate_complete_confirmation_seconds: float = 0.0,
+        strict_complete_confirmation_seconds: float = 0.6,
         smart_turn_required: bool = False,
         smart_turn_warm_seconds: float = 60.0,
         fallback_evaluation_interval_ms: int = 500,
@@ -147,6 +158,12 @@ class _VoiceTurnAdapter:
             raise ValueError(
                 "max_endpoint_wait_seconds must not be shorter than continuation timeout"
             )
+        if candidate_complete_confirmation_seconds < 0:
+            raise ValueError(
+                "candidate complete confirmation delay must be non-negative"
+            )
+        if strict_complete_confirmation_seconds < 0:
+            raise ValueError("strict complete confirmation delay must be non-negative")
         if smart_turn_warm_seconds <= 0:
             raise ValueError("smart_turn_warm_seconds must be positive")
         if fallback_evaluation_interval_ms <= 0:
@@ -154,6 +171,8 @@ class _VoiceTurnAdapter:
         self._vad = vad
         self._gate = gate
         self._coordinator = coordinator
+        self._smart_turn_diagnostics = create_smart_turn_runtime_diagnostics()
+        self._smart_turn_audio_evidence = create_smart_turn_audio_evidence_recorder()
         self._on_commit = on_commit
         self._on_completion_fence = on_completion_fence
         self._on_activity = on_activity
@@ -172,6 +191,12 @@ class _VoiceTurnAdapter:
         self._evaluation_tail_duration_us = 0
         self._continuation_timeout_seconds = continuation_timeout_seconds
         self._max_endpoint_wait_seconds = max_endpoint_wait_seconds
+        self._candidate_complete_confirmation_seconds = (
+            candidate_complete_confirmation_seconds
+        )
+        self._strict_complete_confirmation_seconds = (
+            strict_complete_confirmation_seconds
+        )
         self._smart_turn_required = smart_turn_required
         self._smart_turn_warm_seconds = smart_turn_warm_seconds
         self._fallback_evaluation_interval_ms = fallback_evaluation_interval_ms
@@ -181,9 +206,10 @@ class _VoiceTurnAdapter:
         self._smart_turn_unload_task: asyncio.Task[None] | None = None
         self._evaluation_task: asyncio.Task[None] | None = None
         self._reevaluation_requested = False
-        self._reevaluation_reason: Literal[
-            "candidate_pause", "periodic_no_vad", "strict_retry"
-        ] | None = None
+        self._reevaluation_reason: (
+            Literal["candidate_pause", "periodic_no_vad", "strict_retry"] | None
+        ) = None
+        self._pending_complete_confirmation: _PendingCompleteConfirmation | None = None
         self._strict_endpoint_deadline: float | None = None
         self._latest_detector_identity: DetectorIngressIdentity | None = None
         self._smart_turn_evaluation_ms = 0
@@ -293,14 +319,10 @@ class _VoiceTurnAdapter:
         if not pcm16:
             return
         if sample_rate_hz != 16_000:
-            raise ValueError(
-                "ASR_INVALID_SAMPLE_RATE: Voice Turn requires 16 kHz"
-            )
+            raise ValueError("ASR_INVALID_SAMPLE_RATE: Voice Turn requires 16 kHz")
         self._ensure_running()
         samples = len(pcm16) // 2
-        duration_us = (
-            samples * 1_000_000 + sample_rate_hz - 1
-        ) // sample_rate_hz
+        duration_us = (samples * 1_000_000 + sample_rate_hz - 1) // sample_rate_hz
         if (
             self._evaluation_task is not None
             and self._evaluation_tail_duration_us
@@ -488,6 +510,10 @@ class _VoiceTurnAdapter:
             self._evaluation_tail_duration_us += item.duration_us
         else:
             self._observe_accepted_audio(item)
+        self._smart_turn_audio_evidence.accepted_audio(
+            identity=item.identity,
+            pcm16=item.pcm16,
+        )
         self._latest_detector_identity = item.detector_identity
         self._coordinator.push_audio(item.pcm16)
         if self._vad_degraded:
@@ -524,7 +550,10 @@ class _VoiceTurnAdapter:
         for event in events:
             if self._on_activity is not None:
                 await self._on_activity(event)
-            if self._on_scoped_activity is not None and item.detector_identity is not None:
+            if (
+                self._on_scoped_activity is not None
+                and item.detector_identity is not None
+            ):
                 await self._on_scoped_activity(event, item.detector_identity)
             await self._coordinator.on_activity_event(event)
 
@@ -566,7 +595,10 @@ class _VoiceTurnAdapter:
             event = SpeechActivityEvent.SPEECH_STARTED
             if self._on_activity is not None:
                 await self._on_activity(event)
-            if self._on_scoped_activity is not None and item.detector_identity is not None:
+            if (
+                self._on_scoped_activity is not None
+                and item.detector_identity is not None
+            ):
                 await self._on_scoped_activity(event, item.detector_identity)
             await self._coordinator.on_activity_event(event)
         self._fallback_audio_bytes += len(item.pcm16)
@@ -598,6 +630,7 @@ class _VoiceTurnAdapter:
             return
         coordinator_generation = int(getattr(self._coordinator, "generation", 0))
         activity_seq = int(getattr(self._coordinator, "activity_seq", 0))
+        self._smart_turn_diagnostics.candidate(reason=reason)
 
         async def evaluate() -> None:
             started_at = time.perf_counter()
@@ -643,13 +676,52 @@ class _VoiceTurnAdapter:
         activity_matches = item.activity_seq == int(
             getattr(self._coordinator, "activity_seq", item.activity_seq)
         )
+        result = item.result
+        status = getattr(result, "status", None)
+        decision = getattr(result, "decision", None)
+        probability = getattr(result, "probability", None)
         if (
             self._closed
             or self._failed
             or not identity_matches
             or not generation_matches
         ):
-            if reevaluate and identity_matches and not self._closed and not self._failed:
+            diagnostic_outcome = "discarded"
+        elif not activity_matches:
+            diagnostic_outcome = "superseded"
+        elif item.error is not None:
+            diagnostic_outcome = "error"
+        elif status is EvaluationStatus.OK and decision is TurnDecision.COMPLETE:
+            diagnostic_outcome = "complete"
+        elif status is EvaluationStatus.OK and decision is TurnDecision.INCOMPLETE:
+            diagnostic_outcome = "incomplete"
+        elif status is EvaluationStatus.STALE:
+            diagnostic_outcome = "stale"
+        elif status is EvaluationStatus.UNAVAILABLE:
+            diagnostic_outcome = "unavailable"
+        elif status is EvaluationStatus.ERROR:
+            diagnostic_outcome = "error"
+        else:
+            diagnostic_outcome = "unknown"
+        self._smart_turn_diagnostics.evaluation(
+            reason=item.reason,
+            outcome=diagnostic_outcome,
+            evaluation_ms=item.evaluation_ms,
+            probability=probability,
+            threshold=getattr(self._coordinator, "evaluation_threshold", None),
+        )
+        if (
+            self._closed
+            or self._failed
+            or not identity_matches
+            or not generation_matches
+        ):
+            if (
+                reevaluate
+                and identity_matches
+                and not self._closed
+                and not self._failed
+            ):
                 self._request_evaluation(
                     item.identity,
                     reevaluation_reason,
@@ -668,9 +740,6 @@ class _VoiceTurnAdapter:
         if item.error is not None:
             self._report_failure("runtime_error", "smart_turn")
             return
-        result = item.result
-        status = getattr(result, "status", None)
-        decision = getattr(result, "decision", None)
         if status is EvaluationStatus.STALE:
             self._observe_evaluation_tail(evaluation_tail)
             self._smart_turn_stale_result_count += 1
@@ -682,43 +751,38 @@ class _VoiceTurnAdapter:
                 )
             return
         if status is EvaluationStatus.OK and decision is TurnDecision.COMPLETE:
-            self._strict_endpoint_deadline = None
-            self._complete_observed_candidate(item.detector_identity)
-            active_identity = item.identity
-            if (
-                self._on_completion_fence is not None
-                and item.detector_identity is not None
-            ):
-                active_identity = self._on_completion_fence(
-                    *item.identity,
+            confirmation_seconds = 0.0
+            if self._smart_turn_required:
+                if item.reason == "candidate_pause":
+                    confirmation_seconds = self._candidate_complete_confirmation_seconds
+                elif item.reason == "strict_retry":
+                    confirmation_seconds = self._strict_complete_confirmation_seconds
+            if confirmation_seconds > 0:
+                for tail_item in evaluation_tail:
+                    await self._process_audio(tail_item)
+                if (
+                    self._closed
+                    or self._failed
+                    or item.identity != self._identity
+                    or self._evaluation_task is not None
+                    or self._coordinator.state is not CoordinatorState.PAUSE_CANDIDATE
+                ):
+                    return
+                self._schedule_complete_confirmation(
+                    item.identity,
                     item.detector_identity,
+                    item.reason,
+                    probability=probability,
+                    delay_seconds=confirmation_seconds,
                 )
-                if active_identity != item.identity:
-                    await self._process_reset(
-                        active_identity,
-                        requester=asyncio.current_task(),
-                    )
-                    self._successor_audio_fence = (
-                        item.identity,
-                        item.detector_identity.sequence_no,
-                        active_identity,
-                    )
-            completion_published = self._dispatch_commit(
+                return
+            await self._publish_complete_result(
                 item.identity,
                 item.detector_identity,
-                active_identity=active_identity,
+                item.reason,
+                probability=probability,
+                evaluation_tail=evaluation_tail,
             )
-            if completion_published is not None:
-                await completion_published
-            for tail_item in evaluation_tail:
-                await self._process_audio(
-                    _AudioItem(
-                        identity=active_identity,
-                        pcm16=tail_item.pcm16,
-                        duration_us=tail_item.duration_us,
-                        detector_identity=tail_item.detector_identity,
-                    )
-                )
             return
         if status is EvaluationStatus.OK and decision is TurnDecision.INCOMPLETE:
             self._observe_evaluation_tail(evaluation_tail)
@@ -806,6 +870,7 @@ class _VoiceTurnAdapter:
         self._evaluation_tail.clear()
         self._evaluation_tail_duration_us = 0
         self._successor_audio_fence = None
+        self._smart_turn_audio_evidence.discard()
         await self._coordinator.reset()
         await asyncio.to_thread(self._gate.reset)
         self._commit_dispatched.clear()
@@ -815,6 +880,7 @@ class _VoiceTurnAdapter:
             self._schedule_smart_turn_unload(identity)
 
     async def _process_close(self) -> None:
+        await self._publish_pending_complete_before_close()
         self._closed = True
         self._cancel_fallback()
         await self._close_resources()
@@ -835,6 +901,8 @@ class _VoiceTurnAdapter:
             await asyncio.gather(*self._callback_tasks, return_exceptions=True)
         if evaluation_task is not None:
             await asyncio.gather(evaluation_task, return_exceptions=True)
+        await self._smart_turn_diagnostics.close()
+        await self._smart_turn_audio_evidence.close()
 
     def _schedule_fallback(
         self,
@@ -866,6 +934,80 @@ class _VoiceTurnAdapter:
             fallback(), name="asr-voice-turn-fallback"
         )
 
+    def _schedule_complete_confirmation(
+        self,
+        identity: _Identity,
+        detector_identity: DetectorIngressIdentity | None,
+        reason: Literal["candidate_pause", "periodic_no_vad", "strict_retry"],
+        *,
+        probability: float | None,
+        delay_seconds: float,
+    ) -> None:
+        self._cancel_fallback()
+        pending = _PendingCompleteConfirmation(
+            identity=identity,
+            detector_identity=detector_identity,
+            reason=reason,
+            probability=probability,
+        )
+        self._pending_complete_confirmation = pending
+
+        async def confirm_complete() -> None:
+            await asyncio.sleep(delay_seconds)
+            await self._publish_pending_complete_confirmation(pending)
+
+        self._fallback_task = asyncio.create_task(
+            confirm_complete(), name=f"asr-voice-turn-{reason}-complete-confirm"
+        )
+
+    async def _publish_pending_complete_before_close(self) -> None:
+        pending = self._pending_complete_confirmation
+        if pending is None:
+            return
+        task = self._fallback_task
+        self._fallback_task = None
+        if task is not None:
+            task.cancel()
+        await self._publish_pending_complete_confirmation(
+            pending,
+            require_pause_candidate=False,
+            wait_for_commit=True,
+        )
+
+    async def _publish_pending_complete_confirmation(
+        self,
+        pending: _PendingCompleteConfirmation,
+        *,
+        require_pause_candidate: bool = True,
+        wait_for_commit: bool = False,
+    ) -> bool:
+        if self._pending_complete_confirmation is not pending:
+            return False
+        current_task = asyncio.current_task()
+        if current_task is self._fallback_task:
+            self._fallback_task = None
+        self._pending_complete_confirmation = None
+        if (
+            self._closed
+            or self._failed
+            or pending.identity != self._identity
+            or self._evaluation_task is not None
+            or (
+                require_pause_candidate
+                and self._coordinator.state is not CoordinatorState.PAUSE_CANDIDATE
+            )
+        ):
+            return False
+        await self._publish_complete_result(
+            pending.identity,
+            pending.detector_identity,
+            pending.reason,
+            probability=pending.probability,
+            evaluation_tail=(),
+            wait_for_commit=wait_for_commit,
+        )
+        return True
+
     async def _strict_incomplete_wait(self, identity: _Identity) -> None:
         """Schedule one strict retry through the single SmartTurn lane."""
 
@@ -887,7 +1029,72 @@ class _VoiceTurnAdapter:
             self._latest_detector_identity,
         )
 
+    async def _publish_complete_result(
+        self,
+        identity: _Identity,
+        detector_identity: DetectorIngressIdentity | None,
+        reason: Literal["candidate_pause", "periodic_no_vad", "strict_retry"],
+        *,
+        probability: float | None,
+        evaluation_tail: tuple[_AudioItem, ...],
+        wait_for_commit: bool = False,
+    ) -> None:
+        self._strict_endpoint_deadline = None
+        self._smart_turn_diagnostics.complete(reason=reason)
+        self._smart_turn_audio_evidence.complete(
+            identity=identity,
+            reason=reason,
+            probability=probability,
+            threshold=getattr(self._coordinator, "evaluation_threshold", None),
+        )
+        self._complete_observed_candidate(detector_identity)
+        active_identity = identity
+        if self._on_completion_fence is not None and detector_identity is not None:
+            active_identity = self._on_completion_fence(
+                *identity,
+                detector_identity,
+            )
+            if active_identity != identity:
+                await self._process_reset(
+                    active_identity,
+                    requester=asyncio.current_task(),
+                )
+                self._successor_audio_fence = (
+                    identity,
+                    detector_identity.sequence_no,
+                    active_identity,
+                )
+        callback_tasks_before = tuple(self._callback_tasks)
+        completion_published = self._dispatch_commit(
+            identity,
+            detector_identity,
+            active_identity=active_identity,
+        )
+        if completion_published is not None:
+            await completion_published
+        if wait_for_commit and completion_published is not None:
+            commit_tasks = tuple(
+                task
+                for task in self._callback_tasks
+                if task not in callback_tasks_before
+            )
+            if commit_tasks:
+                await asyncio.wait(
+                    commit_tasks,
+                    timeout=_COMMIT_DRAIN_ON_CLOSE_SECONDS,
+                )
+        for tail_item in evaluation_tail:
+            await self._process_audio(
+                _AudioItem(
+                    identity=active_identity,
+                    pcm16=tail_item.pcm16,
+                    duration_us=tail_item.duration_us,
+                    detector_identity=tail_item.detector_identity,
+                )
+            )
+
     def _cancel_fallback(self) -> None:
+        self._pending_complete_confirmation = None
         task = self._fallback_task
         self._fallback_task = None
         if task is not None:
@@ -938,6 +1145,7 @@ class _VoiceTurnAdapter:
             return
         self._failed = True
         self._failure = _VoiceTurnFailure(kind, stage)
+        self._smart_turn_diagnostics.failure(kind=kind, stage=stage)
         self._cancel_fallback()
         self._cancel_smart_turn_unload()
         current_task = asyncio.current_task()
@@ -968,11 +1176,7 @@ class _VoiceTurnAdapter:
 
         async def commit() -> None:
             try:
-                if (
-                    self._closed
-                    or self._failed
-                    or expected_identity != self._identity
-                ):
+                if self._closed or self._failed or expected_identity != self._identity:
                     return
                 if self._on_scoped_commit is not None and detector_identity is not None:
                     await self._on_scoped_commit(*identity, detector_identity)
@@ -984,11 +1188,7 @@ class _VoiceTurnAdapter:
                         return
                 if not completion_published.done():
                     completion_published.set_result(None)
-                if (
-                    self._closed
-                    or self._failed
-                    or expected_identity != self._identity
-                ):
+                if self._closed or self._failed or expected_identity != self._identity:
                     return
                 await self._on_commit(*identity)
             except asyncio.CancelledError:
@@ -999,9 +1199,7 @@ class _VoiceTurnAdapter:
                 if not completion_published.done():
                     completion_published.set_result(None)
 
-        task = asyncio.create_task(
-            commit(), name="asr-voice-turn-commit"
-        )
+        task = asyncio.create_task(commit(), name="asr-voice-turn-commit")
         self._callback_tasks.add(task)
         task.add_done_callback(self._callback_tasks.discard)
         return completion_published
@@ -1030,6 +1228,9 @@ def _create_voice_turn_adapter(
         coordinator=coordinator,
         on_commit=on_commit,
         on_activity=on_activity,
+        candidate_complete_confirmation_seconds=(
+            config.candidate_complete_confirmation_seconds
+        ),
         smart_turn_required=smart_turn_required,
     )
 
@@ -1158,6 +1359,11 @@ class DetectorRuntime:
                 ),
                 config,
             )
+            candidate_complete_confirmation_seconds = (
+                config.candidate_complete_confirmation_seconds
+                if isinstance(semantic_coordinator, TurnCoordinator)
+                else 0.0
+            )
             self._semantic_coordinator = semantic_coordinator
 
             def completion_fence(
@@ -1228,7 +1434,10 @@ class DetectorRuntime:
                 event: SpeechActivityEvent,
                 identity: DetectorIngressIdentity,
             ) -> None:
-                if self._on_event is None or identity.detector_epoch != self._detector_epoch:
+                if (
+                    self._on_event is None
+                    or identity.detector_epoch != self._detector_epoch
+                ):
                     return
                 await self._on_event(
                     DetectorActivityEvent(
@@ -1247,11 +1456,12 @@ class DetectorRuntime:
                 turn_id: int,
                 identity: DetectorIngressIdentity,
             ) -> None:
-                if self._on_event is None or identity.detector_epoch != self._detector_epoch:
+                if (
+                    self._on_event is None
+                    or identity.detector_epoch != self._detector_epoch
+                ):
                     return
-                fence = self._completion_fences.get(
-                    (generation, buffer_epoch, turn_id)
-                )
+                fence = self._completion_fences.get((generation, buffer_epoch, turn_id))
                 candidate = (
                     fence.candidate
                     if fence is not None
@@ -1281,6 +1491,9 @@ class DetectorRuntime:
                     self._finish_smart_turn_speaker_shadow
                     if self._speaker_shadow is not None
                     else None
+                ),
+                candidate_complete_confirmation_seconds=(
+                    candidate_complete_confirmation_seconds
                 ),
                 smart_turn_required=True,
             )
@@ -1320,9 +1533,7 @@ class DetectorRuntime:
     def smart_turn_coalesced_evaluation_count(self) -> int:
         adapter = self._semantic_adapter
         return (
-            adapter.smart_turn_coalesced_evaluation_count
-            if adapter is not None
-            else 0
+            adapter.smart_turn_coalesced_evaluation_count if adapter is not None else 0
         )
 
     async def bind_candidate(
@@ -1591,12 +1802,16 @@ class DetectorRuntime:
         adapter = self._semantic_adapter
         if adapter is not None:
             self._events.clear()
-            effective_ingress = ingress_token or self._ingress_token or VoiceIngressToken(
-                session_epoch=0,
-                connection_id="detector-feed-compat",
-                lease_generation=0,
-                route_generation=0,
-                audio_generation=0,
+            effective_ingress = (
+                ingress_token
+                or self._ingress_token
+                or VoiceIngressToken(
+                    session_epoch=0,
+                    connection_id="detector-feed-compat",
+                    lease_generation=0,
+                    route_generation=0,
+                    audio_generation=0,
+                )
             )
             submitted = await self.submit_audio(
                 pcm16,
@@ -1987,8 +2202,7 @@ class DetectorRuntime:
         if (
             self._on_event is not None
             and self._policy_event_candidate != candidate
-            and throttle.action
-            in {ThrottleAction.PREWARM, ThrottleAction.PROCESS_PCM}
+            and throttle.action in {ThrottleAction.PREWARM, ThrottleAction.PROCESS_PCM}
         ):
             self._policy_event_candidate = candidate
             await self._on_event(
@@ -2012,6 +2226,7 @@ class DetectorRuntime:
             candidate,
             control_event_emitted,
         )
+
     async def _reset_after_overflow(
         self,
         adapter: _VoiceTurnAdapter,

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -1137,7 +1137,7 @@ class _VoiceTurnAdapter:
                     timeout=_COMMIT_DRAIN_ON_CLOSE_SECONDS,
                 )
         elif completion_published is not None:
-            await completion_published
+            _ = await completion_published
         if active_identity == identity:
             if not tail_already_observed:
                 self._observe_evaluation_tail(evaluation_tail)

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -105,7 +105,14 @@ class _PendingCompleteConfirmation:
     probability: float | None
 
 
-_ControlItem: TypeAlias = _ResetItem | _CloseItem | _EvaluationResultItem
+@dataclass(frozen=True, slots=True)
+class _CompleteConfirmationItem:
+    pending: _PendingCompleteConfirmation
+
+
+_ControlItem: TypeAlias = (
+    _ResetItem | _CloseItem | _EvaluationResultItem | _CompleteConfirmationItem
+)
 _QueueItem: TypeAlias = _AudioItem | _ControlItem
 
 
@@ -437,6 +444,11 @@ class _VoiceTurnAdapter:
                     if self._failed:
                         await self._drain_queue_on_failure_exit()
                         return
+                    continue
+                if isinstance(item, _CompleteConfirmationItem):
+                    if self._fallback_task is not None and self._fallback_task.done():
+                        self._fallback_task = None
+                    await self._publish_pending_complete_confirmation(item.pending)
                     continue
                 await self._process_close()
                 if not item.completed.done():
@@ -953,7 +965,7 @@ class _VoiceTurnAdapter:
 
         async def confirm_complete() -> None:
             await asyncio.sleep(delay_seconds)
-            await self._publish_pending_complete_confirmation(pending)
+            self._queue.put_control_nowait(_CompleteConfirmationItem(pending))
 
         self._fallback_task = asyncio.create_task(
             confirm_complete(), name=f"asr-voice-turn-{reason}-complete-confirm"

--- a/main_logic/asr_client/endpointing/smart_turn_audio_evidence.py
+++ b/main_logic/asr_client/endpointing/smart_turn_audio_evidence.py
@@ -1,0 +1,331 @@
+"""Explicitly opted-in SmartTurn audio evidence capture."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import os
+import queue
+import secrets
+import threading
+import time
+import wave
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, TypeAlias
+
+
+SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV = "NEKO_SMART_TURN_AUDIO_EVIDENCE"
+SMART_TURN_AUDIO_EVIDENCE_DIR_ENV = "NEKO_SMART_TURN_AUDIO_EVIDENCE_DIR"
+
+_DEFAULT_RELATIVE_DIR = Path("data/smart_turn/audio-evidence")
+_SCHEMA = "neko.smart_turn.audio_evidence.v1"
+_ENABLED_VALUES = frozenset({"1", "true", "yes", "on"})
+_SAMPLE_RATE_HZ = 16_000
+_SAMPLE_WIDTH_BYTES = 2
+_MAX_CAPTURE_SECONDS = 30
+_MAX_CAPTURE_BYTES = _SAMPLE_RATE_HZ * _SAMPLE_WIDTH_BYTES * _MAX_CAPTURE_SECONDS
+_ACK_TIMEOUT_SECONDS = 0.05
+_COMPLETE_REASONS = frozenset({"candidate_pause", "periodic_no_vad", "strict_retry"})
+
+_Identity: TypeAlias = tuple[int, int, int]
+
+
+class SmartTurnAudioEvidenceRecorder(Protocol):
+    """Narrow contract for opt-in local audio capture."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    def accepted_audio(self, *, identity: _Identity, pcm16: bytes) -> None: ...
+
+    def complete(
+        self,
+        *,
+        identity: _Identity,
+        reason: str,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None: ...
+
+    def discard(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _WriteTurnCommand:
+    wav_path: Path
+    index_line: str
+    pcm16: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _CloseCommand:
+    completed: threading.Event
+
+
+_WriterCommand: TypeAlias = _WriteTurnCommand | _CloseCommand
+
+
+class _DisabledSmartTurnAudioEvidenceRecorder:
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    def accepted_audio(self, *, identity: _Identity, pcm16: bytes) -> None:
+        del identity, pcm16
+
+    def complete(
+        self,
+        *,
+        identity: _Identity,
+        reason: str,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None:
+        del identity, reason, probability, threshold
+
+    def discard(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+_DISABLED_RECORDER = _DisabledSmartTurnAudioEvidenceRecorder()
+
+
+class _WavSmartTurnAudioEvidenceRecorder:
+    def __init__(self, target_root: Path) -> None:
+        self._run_id = secrets.token_hex(16)
+        self._run_dir = target_root / self._run_id
+        self._started_ns = time.monotonic_ns()
+        self._sequence = 0
+        self._state_lock = threading.Lock()
+        self._closed = False
+        self._current_identity: _Identity | None = None
+        self._current_pcm = bytearray()
+        self._current_truncated_prefix = False
+        self._commands: queue.SimpleQueue[_WriterCommand] = queue.SimpleQueue()
+        self._writer = threading.Thread(
+            target=self._writer_loop,
+            name="smart-turn-audio-evidence",
+            daemon=True,
+        )
+        self._writer.start()
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def accepted_audio(self, *, identity: _Identity, pcm16: bytes) -> None:
+        try:
+            if not pcm16 or len(pcm16) % _SAMPLE_WIDTH_BYTES:
+                return
+            with self._state_lock:
+                if self._closed:
+                    return
+                if self._current_identity != identity:
+                    self._current_identity = identity
+                    self._current_pcm = bytearray()
+                    self._current_truncated_prefix = False
+                self._current_pcm.extend(pcm16)
+                overflow = len(self._current_pcm) - _MAX_CAPTURE_BYTES
+                if overflow > 0:
+                    trim = overflow + (overflow % _SAMPLE_WIDTH_BYTES)
+                    del self._current_pcm[:trim]
+                    self._current_truncated_prefix = True
+        except Exception:
+            return
+
+    def complete(
+        self,
+        *,
+        identity: _Identity,
+        reason: str,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None:
+        try:
+            with self._state_lock:
+                if (
+                    self._closed
+                    or self._current_identity != identity
+                    or not self._current_pcm
+                ):
+                    return
+                self._sequence += 1
+                sequence = self._sequence
+                pcm16 = bytes(self._current_pcm)
+                truncated_prefix = self._current_truncated_prefix
+                self._current_identity = None
+                self._current_pcm = bytearray()
+                self._current_truncated_prefix = False
+
+            filename = f"turn-{sequence:04d}.wav"
+            wav_path = self._run_dir / filename
+            record = {
+                "schema": _SCHEMA,
+                "run_id": self._run_id,
+                "sequence": sequence,
+                "elapsed_ms": max(
+                    0,
+                    (time.monotonic_ns() - self._started_ns) // 1_000_000,
+                ),
+                "event": "turn_audio",
+                "file": filename,
+                "sample_rate_hz": _SAMPLE_RATE_HZ,
+                "channels": 1,
+                "sample_width_bytes": _SAMPLE_WIDTH_BYTES,
+                "duration_ms": len(pcm16)
+                // (_SAMPLE_RATE_HZ * _SAMPLE_WIDTH_BYTES // 1_000),
+                "pcm_sha256": hashlib.sha256(pcm16).hexdigest(),
+                "reason": _allowed_value(reason, _COMPLETE_REASONS),
+                "truncated_prefix": truncated_prefix,
+            }
+            bounded_probability = _bounded_probability(probability)
+            bounded_threshold = _bounded_probability(threshold)
+            if bounded_probability is not None:
+                record["probability"] = bounded_probability
+            if bounded_threshold is not None:
+                record["threshold"] = bounded_threshold
+            index_line = json.dumps(
+                record,
+                ensure_ascii=True,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            self._commands.put(_WriteTurnCommand(wav_path, index_line, pcm16))
+        except Exception:
+            return
+
+    def discard(self) -> None:
+        try:
+            with self._state_lock:
+                self._current_identity = None
+                self._current_pcm = bytearray()
+                self._current_truncated_prefix = False
+        except Exception:
+            return
+
+    async def close(self) -> None:
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+            completed = threading.Event()
+            try:
+                self._commands.put(_CloseCommand(completed))
+            except Exception:
+                return
+        try:
+            await asyncio.to_thread(completed.wait, _ACK_TIMEOUT_SECONDS)
+        except Exception:
+            return
+
+    def _writer_loop(self) -> None:
+        index_stream = None
+        broken = False
+        while True:
+            command = self._commands.get()
+            if isinstance(command, _WriteTurnCommand):
+                if broken:
+                    continue
+                try:
+                    self._run_dir.mkdir(parents=True, exist_ok=True)
+                    _write_pcm16_wav(command.wav_path, command.pcm16)
+                    if index_stream is None:
+                        index_stream = (self._run_dir / "index.jsonl").open(
+                            "a",
+                            encoding="utf-8",
+                            newline="\n",
+                        )
+                    index_stream.write(command.index_line)
+                    index_stream.write("\n")
+                    index_stream.flush()
+                except Exception:
+                    broken = True
+                    _close_stream(index_stream)
+                    index_stream = None
+                continue
+            _close_stream(index_stream)
+            command.completed.set()
+            return
+
+
+def create_smart_turn_audio_evidence_recorder(
+    *,
+    environ: Mapping[str, str] | None = None,
+    repo_root: Path | None = None,
+) -> SmartTurnAudioEvidenceRecorder:
+    """Create a local WAV recorder only after explicit opt-in."""
+
+    try:
+        environment = os.environ if environ is None else environ
+        enabled = environment.get(SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV, "")
+        if enabled.strip().casefold() not in _ENABLED_VALUES:
+            return _DISABLED_RECORDER
+
+        root = (
+            Path(__file__).resolve().parents[3]
+            if repo_root is None
+            else repo_root.resolve()
+        )
+        data_root = (root / "data").resolve()
+        configured_dir = environment.get(
+            SMART_TURN_AUDIO_EVIDENCE_DIR_ENV,
+            str(_DEFAULT_RELATIVE_DIR),
+        ).strip()
+        if not configured_dir:
+            configured_dir = str(_DEFAULT_RELATIVE_DIR)
+        target_root = Path(configured_dir)
+        if not target_root.is_absolute():
+            target_root = root / target_root
+        target_root = target_root.resolve()
+        if target_root == data_root:
+            return _DISABLED_RECORDER
+        try:
+            target_root.relative_to(data_root)
+        except ValueError:
+            return _DISABLED_RECORDER
+        return _WavSmartTurnAudioEvidenceRecorder(target_root)
+    except Exception:
+        return _DISABLED_RECORDER
+
+
+def _write_pcm16_wav(path: Path, pcm16: bytes) -> None:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(_SAMPLE_WIDTH_BYTES)
+        wav_file.setframerate(_SAMPLE_RATE_HZ)
+        wav_file.writeframes(pcm16)
+
+
+def _allowed_value(value: str, allowed: frozenset[str]) -> str:
+    return value if value in allowed else "unknown"
+
+
+def _bounded_probability(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(numeric) or not 0.0 <= numeric <= 1.0:
+        return None
+    return numeric
+
+
+def _close_stream(stream) -> None:
+    if stream is None:
+        return
+    try:
+        stream.close()
+    except Exception:
+        return

--- a/main_logic/asr_client/endpointing/smart_turn_audio_evidence.py
+++ b/main_logic/asr_client/endpointing/smart_turn_audio_evidence.py
@@ -15,7 +15,7 @@ import wave
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol, TypeAlias
+from typing import Protocol, TypeAlias
 
 
 SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV = "NEKO_SMART_TURN_AUDIO_EVIDENCE"

--- a/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
+++ b/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
@@ -69,9 +69,11 @@ class SmartTurnRuntimeDiagnostics(Protocol):
     """Narrow event contract that cannot accept audio or transcript payloads."""
 
     @property
-    def enabled(self) -> bool: ...
+    def enabled(self) -> bool:
+        raise NotImplementedError
 
-    def candidate(self, *, reason: str) -> None: ...
+    def candidate(self, *, reason: str) -> None:
+        raise NotImplementedError
 
     def evaluation(
         self,
@@ -81,15 +83,20 @@ class SmartTurnRuntimeDiagnostics(Protocol):
         evaluation_ms: int,
         probability: float | None,
         threshold: float | None,
-    ) -> None: ...
+    ) -> None:
+        raise NotImplementedError
 
-    def complete(self, *, reason: str) -> None: ...
+    def complete(self, *, reason: str) -> None:
+        raise NotImplementedError
 
-    def failure(self, *, kind: str, stage: str) -> None: ...
+    def failure(self, *, kind: str, stage: str) -> None:
+        raise NotImplementedError
 
-    async def flush(self) -> None: ...
+    async def flush(self) -> None:
+        raise NotImplementedError
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True, slots=True)

--- a/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
+++ b/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
@@ -1,0 +1,386 @@
+"""Explicitly opted-in, privacy-safe SmartTurn runtime diagnostics."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+import queue
+import secrets
+import threading
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, TextIO, TypeAlias
+
+
+SMART_TURN_DIAGNOSTICS_ENABLED_ENV = "NEKO_SMART_TURN_DIAGNOSTICS"
+SMART_TURN_DIAGNOSTICS_PATH_ENV = "NEKO_SMART_TURN_DIAGNOSTICS_PATH"
+
+_DEFAULT_RELATIVE_PATH = Path("data/smart_turn/runtime-diagnostics.jsonl")
+_SCHEMA = "neko.smart_turn.runtime_diagnostics.v1"
+_ACK_TIMEOUT_SECONDS = 0.05
+_ENABLED_VALUES = frozenset({"1", "true", "yes", "on"})
+
+EvaluationReason: TypeAlias = Literal[
+    "candidate_pause",
+    "periodic_no_vad",
+    "strict_retry",
+    "unknown",
+]
+EvaluationOutcome: TypeAlias = Literal[
+    "complete",
+    "incomplete",
+    "stale",
+    "unavailable",
+    "error",
+    "discarded",
+    "superseded",
+    "unknown",
+]
+FailureKind: TypeAlias = Literal["unavailable", "runtime_error", "unknown"]
+FailureStage: TypeAlias = Literal[
+    "vad_load",
+    "vad_feed",
+    "smart_turn",
+    "consumer",
+    "unknown",
+]
+
+_EVALUATION_REASONS = frozenset({"candidate_pause", "periodic_no_vad", "strict_retry"})
+_EVALUATION_OUTCOMES = frozenset(
+    {
+        "complete",
+        "incomplete",
+        "stale",
+        "unavailable",
+        "error",
+        "discarded",
+        "superseded",
+    }
+)
+_FAILURE_KINDS = frozenset({"unavailable", "runtime_error"})
+_FAILURE_STAGES = frozenset({"vad_load", "vad_feed", "smart_turn", "consumer"})
+
+
+class SmartTurnRuntimeDiagnostics(Protocol):
+    """Narrow event contract that cannot accept audio or transcript payloads."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    def candidate(self, *, reason: str) -> None: ...
+
+    def evaluation(
+        self,
+        *,
+        reason: str,
+        outcome: str,
+        evaluation_ms: int,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None: ...
+
+    def complete(self, *, reason: str) -> None: ...
+
+    def failure(self, *, kind: str, stage: str) -> None: ...
+
+    async def flush(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _WriteCommand:
+    line: str
+
+
+@dataclass(frozen=True, slots=True)
+class _FlushCommand:
+    completed: threading.Event
+
+
+@dataclass(frozen=True, slots=True)
+class _CloseCommand:
+    completed: threading.Event
+
+
+_WriterCommand: TypeAlias = _WriteCommand | _FlushCommand | _CloseCommand
+
+
+class _DisabledSmartTurnRuntimeDiagnostics:
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    def candidate(self, *, reason: str) -> None:
+        del reason
+
+    def evaluation(
+        self,
+        *,
+        reason: str,
+        outcome: str,
+        evaluation_ms: int,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None:
+        del reason, outcome, evaluation_ms, probability, threshold
+
+    def complete(self, *, reason: str) -> None:
+        del reason
+
+    def failure(self, *, kind: str, stage: str) -> None:
+        del kind, stage
+
+    async def flush(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+_DISABLED_DIAGNOSTICS = _DisabledSmartTurnRuntimeDiagnostics()
+
+
+class _JsonlSmartTurnRuntimeDiagnostics:
+    def __init__(self, target: Path) -> None:
+        self._target = target
+        self._run_id = secrets.token_hex(16)
+        self._started_ns = time.monotonic_ns()
+        self._sequence = 0
+        self._state_lock = threading.Lock()
+        self._closed = False
+        self._commands: queue.SimpleQueue[_WriterCommand] = queue.SimpleQueue()
+        self._writer = threading.Thread(
+            target=self._writer_loop,
+            name="smart-turn-diagnostics",
+            daemon=True,
+        )
+        self._writer.start()
+        self._emit("session_start")
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def candidate(self, *, reason: str) -> None:
+        self._emit(
+            "candidate",
+            reason=_allowed_value(reason, _EVALUATION_REASONS),
+        )
+
+    def evaluation(
+        self,
+        *,
+        reason: str,
+        outcome: str,
+        evaluation_ms: int,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None:
+        try:
+            fields: dict[str, str | int | float] = {
+                "reason": _allowed_value(reason, _EVALUATION_REASONS),
+                "outcome": _allowed_value(outcome, _EVALUATION_OUTCOMES),
+                "evaluation_ms": max(0, int(evaluation_ms)),
+            }
+            bounded_probability = _bounded_probability(probability)
+            bounded_threshold = _bounded_probability(threshold)
+            if bounded_probability is not None:
+                fields["probability"] = bounded_probability
+            if bounded_threshold is not None:
+                fields["threshold"] = bounded_threshold
+            self._emit("evaluation", **fields)
+        except Exception:
+            return
+
+    def complete(self, *, reason: str) -> None:
+        self._emit(
+            "complete",
+            reason=_allowed_value(reason, _EVALUATION_REASONS),
+        )
+
+    def failure(self, *, kind: str, stage: str) -> None:
+        self._emit(
+            "failure",
+            kind=_allowed_value(kind, _FAILURE_KINDS),
+            stage=_allowed_value(stage, _FAILURE_STAGES),
+        )
+
+    async def flush(self) -> None:
+        with self._state_lock:
+            if self._closed:
+                return
+            completed = threading.Event()
+            try:
+                self._commands.put(_FlushCommand(completed))
+            except Exception:
+                return
+        try:
+            await asyncio.to_thread(completed.wait, _ACK_TIMEOUT_SECONDS)
+        except Exception:
+            return
+
+    async def close(self) -> None:
+        with self._state_lock:
+            if self._closed:
+                return
+            try:
+                self._queue_event_locked("session_end", {})
+            except Exception:
+                pass
+            self._closed = True
+            completed = threading.Event()
+            try:
+                self._commands.put(_CloseCommand(completed))
+            except Exception:
+                return
+        try:
+            await asyncio.to_thread(completed.wait, _ACK_TIMEOUT_SECONDS)
+        except Exception:
+            return
+
+    def _emit(self, event: str, **fields: str | int | float) -> None:
+        try:
+            with self._state_lock:
+                if self._closed:
+                    return
+                self._queue_event_locked(event, fields)
+        except Exception:
+            return
+
+    def _queue_event_locked(
+        self,
+        event: str,
+        fields: Mapping[str, str | int | float],
+    ) -> None:
+        self._sequence += 1
+        record: dict[str, str | int | float] = {
+            "schema": _SCHEMA,
+            "run_id": self._run_id,
+            "sequence": self._sequence,
+            "elapsed_ms": max(
+                0,
+                (time.monotonic_ns() - self._started_ns) // 1_000_000,
+            ),
+            "event": event,
+            **fields,
+        }
+        line = json.dumps(
+            record,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        self._commands.put(_WriteCommand(line))
+
+    def _writer_loop(self) -> None:
+        stream: TextIO | None = None
+        broken = False
+        while True:
+            command = self._commands.get()
+            if isinstance(command, _WriteCommand):
+                if broken:
+                    continue
+                try:
+                    if stream is None:
+                        self._target.parent.mkdir(parents=True, exist_ok=True)
+                        stream = self._target.open(
+                            "a",
+                            encoding="utf-8",
+                            newline="\n",
+                        )
+                    stream.write(command.line)
+                    stream.write("\n")
+                except Exception:
+                    broken = True
+                    _close_stream(stream)
+                    stream = None
+                continue
+            if isinstance(command, _FlushCommand):
+                if not broken and stream is not None:
+                    try:
+                        stream.flush()
+                    except Exception:
+                        broken = True
+                        _close_stream(stream)
+                        stream = None
+                command.completed.set()
+                continue
+            if stream is not None:
+                try:
+                    stream.flush()
+                except Exception:
+                    pass
+                _close_stream(stream)
+            command.completed.set()
+            return
+
+
+def create_smart_turn_runtime_diagnostics(
+    *,
+    environ: Mapping[str, str] | None = None,
+    repo_root: Path | None = None,
+) -> SmartTurnRuntimeDiagnostics:
+    """Create a sink only after explicit opt-in and a confined path check."""
+
+    try:
+        environment = os.environ if environ is None else environ
+        enabled = environment.get(SMART_TURN_DIAGNOSTICS_ENABLED_ENV, "")
+        if enabled.strip().casefold() not in _ENABLED_VALUES:
+            return _DISABLED_DIAGNOSTICS
+
+        root = (
+            Path(__file__).resolve().parents[3]
+            if repo_root is None
+            else repo_root.resolve()
+        )
+        data_root = (root / "data").resolve()
+        configured_path = environment.get(
+            SMART_TURN_DIAGNOSTICS_PATH_ENV,
+            str(_DEFAULT_RELATIVE_PATH),
+        ).strip()
+        if not configured_path:
+            configured_path = str(_DEFAULT_RELATIVE_PATH)
+        target = Path(configured_path)
+        if not target.is_absolute():
+            target = root / target
+        target = target.resolve()
+        if target == data_root or target.suffix.casefold() != ".jsonl":
+            return _DISABLED_DIAGNOSTICS
+        try:
+            target.relative_to(data_root)
+        except ValueError:
+            return _DISABLED_DIAGNOSTICS
+        return _JsonlSmartTurnRuntimeDiagnostics(target)
+    except Exception:
+        return _DISABLED_DIAGNOSTICS
+
+
+def _allowed_value(value: str, allowed: frozenset[str]) -> str:
+    return value if value in allowed else "unknown"
+
+
+def _bounded_probability(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(numeric) or not 0.0 <= numeric <= 1.0:
+        return None
+    return numeric
+
+
+def _close_stream(stream: TextIO | None) -> None:
+    if stream is None:
+        return
+    try:
+        stream.close()
+    except Exception:
+        return

--- a/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
+++ b/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
@@ -238,6 +238,7 @@ class _JsonlSmartTurnRuntimeDiagnostics:
             try:
                 self._queue_event_locked("session_end", {})
             except Exception:
+                # Diagnostics are best-effort and must never block session teardown.
                 pass
             self._closed = True
             completed = threading.Event()

--- a/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
+++ b/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
@@ -296,6 +296,7 @@ class _JsonlSmartTurnRuntimeDiagnostics:
                         )
                     stream.write(command.line)
                     stream.write("\n")
+                    stream.flush()
                 except Exception:
                     broken = True
                     _close_stream(stream)

--- a/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
+++ b/main_logic/asr_client/endpointing/smart_turn_diagnostics.py
@@ -324,6 +324,7 @@ class _JsonlSmartTurnRuntimeDiagnostics:
                 try:
                     stream.flush()
                 except Exception:
+                    # Close acknowledgement must survive a best-effort final flush.
                     pass
                 _close_stream(stream)
             command.completed.set()

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -186,13 +186,24 @@ def _reject_json_constant(value: str) -> None:
     raise ValueError(f"non-standard JSON constant is not allowed: {value}")
 
 
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key is not allowed: {key}")
+        value[key] = item
+    return value
+
+
 def _load_json_object_snapshot(
     path: Path, *, description: str
 ) -> tuple[dict[str, Any], str]:
     try:
         encoded = path.read_bytes()
         value = json.loads(
-            encoded.decode("utf-8"), parse_constant=_reject_json_constant
+            encoded.decode("utf-8"),
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_reject_duplicate_json_keys,
         )
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"unable to read {description}: {exc}") from exc

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -1,16 +1,30 @@
-"""Evaluate Smart Turn v3 on an authorized JSONL-labelled WAV fixture set."""
+"""Audit Smart Turn v3 against authorized, local human-voice WAV evidence.
+
+The evaluator is intentionally scoped to direct model-checkpoint replay.  It
+does not exercise Electron capture, VAD candidate timing, coordinator retries,
+provider commits, or ASR network behavior, so it can never grant product-level
+quality approval by itself.
+"""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+import importlib.metadata
+import io
 import json
+import math
+import platform
+import re
 import statistics
+import subprocess
 import sys
 import time
 import wave
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Protocol
+from statistics import NormalDist
+from typing import Any, Mapping, Protocol, Sequence
 
 import numpy as np
 
@@ -20,14 +34,118 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from main_logic.asr_client.endpointing.smart_turn_v3 import SmartTurnV3  # noqa: E402
+from main_logic.asr_client.endpointing.config import SmartTurnConfig  # noqa: E402
+
+
+SUPPORTED_LANGUAGES = frozenset({"zh-CN", "en-US", "ja-JP"})
+SUPPORTED_SCENARIOS = frozenset(
+    {
+        "terminal_end",
+        "sentence_internal_pause",
+        "hesitation_continue",
+        "long_pause_continue",
+        "keyboard_noise",
+        "barge_in",
+    }
+)
+SUPPORTED_SPLITS = frozenset({"calibration", "holdout"})
+SUPPORTED_CAPTURE_ROUTES = frozenset({"dummy", "glm", "gemini"})
+MAX_AUDIO_FRAMES = SmartTurnConfig().max_audio_seconds * 16_000
+MANIFEST_KEYS = frozenset({"schema_version", "dataset_id", "cases"})
+CASE_KEYS = frozenset(
+    {
+        "id",
+        "path",
+        "audio_sha256",
+        "expected",
+        "language",
+        "scenario",
+        "source_group",
+        "speaker_id",
+        "session_id",
+        "device_id",
+        "capture_surface",
+        "capture_route_context",
+        "split",
+        "pause_ms",
+    }
+)
+CRITERIA_KEYS = frozenset(
+    {
+        "schema_version",
+        "criteria_id",
+        "manifest_sha256",
+        "decision_threshold",
+        "confidence_level",
+        "confidence_method",
+        "holdout",
+    }
+)
+LANGUAGE_CRITERIA_KEYS = frozenset(
+    {
+        "speaker_count",
+        "speaker_roster_sha256",
+        "min_devices",
+        "speaker_scenario_matrix",
+        "max_speakers_with_any_premature_split",
+        "max_speakers_with_any_missed_endpoint",
+        "max_speaker_premature_split_rate_upper_bound",
+        "max_speaker_missed_endpoint_rate_upper_bound",
+    }
+)
+SCENARIO_LABEL_KEYS = frozenset({"complete", "incomplete"})
 
 
 @dataclass(frozen=True, slots=True)
 class EvaluationCase:
     path: Path
     expected_complete: bool
-    language: str | None = None
-    category: str | None = None
+    id: str
+    language: str
+    scenario: str
+    source_group: str | None
+    speaker_id: str | None
+    session_id: str | None
+    device_id: str | None
+    capture_surface: str
+    capture_route_context: str
+    split: str
+    pause_ms: int
+    audio_sha256: str | None
+    pcm_sha256: str | None
+    duration_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationManifest:
+    path: Path | None
+    dataset_id: str
+    cases: tuple[EvaluationCase, ...]
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageAcceptanceCriteria:
+    speaker_count: int
+    speaker_roster_sha256: str
+    min_devices: int
+    speaker_scenario_matrix: Mapping[str, Mapping[str, int]]
+    max_speakers_with_any_premature_split: int
+    max_speakers_with_any_missed_endpoint: int
+    max_speaker_premature_split_rate_upper_bound: float
+    max_speaker_missed_endpoint_rate_upper_bound: float
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptanceCriteria:
+    path: Path
+    criteria_id: str
+    manifest_sha256: str
+    decision_threshold: float
+    confidence_level: float
+    confidence_method: str
+    languages: Mapping[str, LanguageAcceptanceCriteria]
+    sha256: str
 
 
 @dataclass(slots=True)
@@ -52,26 +170,497 @@ class Predictor(Protocol):
     def predict_probability(self, audio: np.ndarray) -> float: ...
 
 
-def load_cases(fixture_dir: Path, labels_path: Path) -> list[EvaluationCase]:
-    root = fixture_dir.resolve()
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant is not allowed: {value}")
+
+
+def _load_json_object_snapshot(
+    path: Path, *, description: str
+) -> tuple[dict[str, Any], str]:
+    try:
+        encoded = path.read_bytes()
+        value = json.loads(
+            encoded.decode("utf-8"), parse_constant=_reject_json_constant
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unable to read {description}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{description} must be a JSON object")
+    return value, hashlib.sha256(encoded).hexdigest()
+
+
+def _load_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    value, _sha256_digest = _load_json_object_snapshot(path, description=description)
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any], expected: frozenset[str], *, context: str
+) -> None:
+    keys = set(value)
+    missing = sorted(expected - keys)
+    unknown = sorted(keys - expected)
+    if missing:
+        raise ValueError(f"{context}: missing required fields: {', '.join(missing)}")
+    if unknown:
+        raise ValueError(
+            f"{context}: unknown fields are not allowed: {', '.join(unknown)}"
+        )
+
+
+def _anonymous_id(value: Any, *, prefix: str, context: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(
+        rf"{re.escape(prefix)}-[0-9a-f]{{32}}", value
+    ):
+        raise ValueError(
+            f"{context} must be an opaque {prefix}-prefixed 128-bit hex identifier"
+        )
+    return value
+
+
+def _declared_sha256(value: Any, *, context: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise ValueError(f"{context} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _finite_rate(value: Any, *, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{context} must be a finite number within [0, 1]")
+    rendered = float(value)
+    if not math.isfinite(rendered) or not 0.0 <= rendered <= 1.0:
+        raise ValueError(f"{context} must be a finite number within [0, 1]")
+    return rendered
+
+
+def _non_negative_int(value: Any, *, context: str, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{context} must be an integer >= {minimum}")
+    return value
+
+
+def _read_wav_contract(
+    path: Path, *, enforce_max_duration: bool = True
+) -> tuple[np.ndarray, int, str, str]:
+    try:
+        encoded = path.read_bytes()
+        with wave.open(io.BytesIO(encoded), "rb") as wav_file:
+            if wav_file.getnchannels() != 1:
+                raise ValueError(f"{path}: expected mono WAV")
+            if wav_file.getframerate() != 16_000:
+                raise ValueError(f"{path}: expected 16000 Hz WAV")
+            if wav_file.getsampwidth() != 2:
+                raise ValueError(f"{path}: expected signed PCM16 WAV")
+            frames = wav_file.getnframes()
+            pcm = wav_file.readframes(frames)
+    except (OSError, wave.Error, EOFError) as exc:
+        raise ValueError(f"{path}: unreadable WAV") from exc
+    if frames <= 0:
+        raise ValueError(f"{path}: WAV must contain audio")
+    if enforce_max_duration and frames > MAX_AUDIO_FRAMES:
+        raise ValueError(f"{path}: WAV exceeds the SmartTurn 8 second input window")
+    if len(pcm) != frames * 2:
+        raise ValueError(f"{path}: truncated PCM frames")
+    duration_ms = frames * 1_000 // 16_000
+    audio = np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32768.0
+    return (
+        audio,
+        duration_ms,
+        hashlib.sha256(encoded).hexdigest(),
+        hashlib.sha256(pcm).hexdigest(),
+    )
+
+
+def _inspect_wav_contract(
+    path: Path, *, enforce_max_duration: bool = True
+) -> tuple[int, str]:
+    _audio, duration_ms, _audio_sha256, pcm_sha256 = _read_wav_contract(
+        path, enforce_max_duration=enforce_max_duration
+    )
+    return duration_ms, pcm_sha256
+
+
+def _resolve_audio_path(root: Path, value: Any, *, context: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context}: path must be a non-empty relative string")
+    relative = Path(value)
+    if relative.is_absolute():
+        raise ValueError(f"{context}: path must be relative to the manifest")
+    try:
+        resolved = (root / relative).resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f"{context}: audio path does not exist") from exc
+    if root != resolved and root not in resolved.parents:
+        raise ValueError(f"{context}: audio path escapes the manifest directory")
+    if not resolved.is_file():
+        raise ValueError(f"{context}: audio path must identify a file")
+    if resolved.suffix.lower() != ".wav":
+        raise ValueError(f"{context}: audio path must use the .wav extension")
+    return resolved
+
+
+def load_manifest(manifest_path: Path) -> EvaluationManifest:
+    """Load and validate a privacy-minimizing SmartTurn human-data manifest."""
+
+    manifest_path = manifest_path.resolve()
+    value, manifest_sha256 = _load_json_object_snapshot(
+        manifest_path, description="manifest"
+    )
+    _require_exact_keys(value, MANIFEST_KEYS, context="manifest")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise ValueError("manifest schema_version must be 1")
+    dataset_id = _anonymous_id(
+        value["dataset_id"], prefix="dataset", context="manifest dataset_id"
+    )
+    raw_cases = value["cases"]
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValueError("manifest cases must be a non-empty list")
+
+    root = manifest_path.parent.resolve()
     cases: list[EvaluationCase] = []
-    for line_number, line in enumerate(labels_path.read_text(encoding="utf-8").splitlines(), 1):
-        if not line.strip():
-            continue
-        value = json.loads(line)
-        relative = Path(value["path"])
-        path = (root / relative).resolve()
-        if root not in path.parents:
-            raise ValueError(f"line {line_number}: fixture path escapes fixture directory")
-        expected = value.get("expected")
-        if expected not in ("complete", "incomplete"):
-            raise ValueError(f"line {line_number}: expected must be complete or incomplete")
+    ids: set[str] = set()
+    paths: set[Path] = set()
+    pcm_digests: set[str] = set()
+    for index, raw_case in enumerate(raw_cases, 1):
+        context = f"manifest case {index}"
+        if not isinstance(raw_case, dict):
+            raise ValueError(f"{context} must be a JSON object")
+        _require_exact_keys(raw_case, CASE_KEYS, context=context)
+        case_id = _anonymous_id(raw_case["id"], prefix="case", context=f"{context} id")
+        if case_id in ids:
+            raise ValueError(f"{context}: case ids must be unique")
+        ids.add(case_id)
+        path = _resolve_audio_path(root, raw_case["path"], context=context)
+        if path in paths:
+            raise ValueError(f"{context}: audio paths must be unique")
+        paths.add(path)
+        declared_audio_sha256 = _declared_sha256(
+            raw_case["audio_sha256"], context=f"{context} audio_sha256"
+        )
+        _audio, duration_ms, actual_audio_sha256, pcm_sha256 = _read_wav_contract(path)
+        if declared_audio_sha256 != actual_audio_sha256:
+            raise ValueError(f"{context}: audio_sha256 does not match the WAV file")
+        if pcm_sha256 in pcm_digests:
+            raise ValueError(f"{context}: duplicate PCM content is not allowed")
+        pcm_digests.add(pcm_sha256)
+
+        expected = raw_case["expected"]
+        if not isinstance(expected, str) or expected not in {"complete", "incomplete"}:
+            raise ValueError(f"{context}: expected must be complete or incomplete")
+        language = raw_case["language"]
+        if not isinstance(language, str) or language not in SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"{context}: language must be one of {', '.join(sorted(SUPPORTED_LANGUAGES))}"
+            )
+        scenario = raw_case["scenario"]
+        if not isinstance(scenario, str) or scenario not in SUPPORTED_SCENARIOS:
+            raise ValueError(f"{context}: scenario is unsupported")
+        if scenario == "terminal_end" and expected != "complete":
+            raise ValueError(f"{context}: terminal_end must be labelled complete")
+        if (
+            scenario
+            in {
+                "sentence_internal_pause",
+                "hesitation_continue",
+                "long_pause_continue",
+            }
+            and expected != "incomplete"
+        ):
+            raise ValueError(
+                f"{context}: continuation scenario must be labelled incomplete"
+            )
+        if raw_case["capture_surface"] != "electron":
+            raise ValueError(f"{context}: capture_surface must be electron")
+        capture_route_context = raw_case["capture_route_context"]
+        if (
+            not isinstance(capture_route_context, str)
+            or capture_route_context not in SUPPORTED_CAPTURE_ROUTES
+        ):
+            raise ValueError(f"{context}: capture_route_context is unsupported")
+        split = raw_case["split"]
+        if not isinstance(split, str) or split not in SUPPORTED_SPLITS:
+            raise ValueError(f"{context}: split must be calibration or holdout")
+        pause_ms = _non_negative_int(
+            raw_case["pause_ms"], context=f"{context} pause_ms"
+        )
+        runtime_defaults = SmartTurnConfig()
+        if pause_ms < runtime_defaults.candidate_silence_ms:
+            raise ValueError(
+                f"{context}: pause_ms must reach the production candidate silence"
+            )
+        if duration_ms < pause_ms + runtime_defaults.minimum_speech_ms:
+            raise ValueError(
+                f"{context}: WAV duration must cover pause_ms plus minimum speech"
+            )
+
         cases.append(
             EvaluationCase(
+                id=case_id,
                 path=path,
                 expected_complete=expected == "complete",
-                language=value.get("language"),
-                category=value.get("category"),
+                language=language,
+                scenario=scenario,
+                source_group=_anonymous_id(
+                    raw_case["source_group"],
+                    prefix="source",
+                    context=f"{context} source_group",
+                ),
+                speaker_id=_anonymous_id(
+                    raw_case["speaker_id"],
+                    prefix="speaker",
+                    context=f"{context} speaker_id",
+                ),
+                session_id=_anonymous_id(
+                    raw_case["session_id"],
+                    prefix="session",
+                    context=f"{context} session_id",
+                ),
+                device_id=_anonymous_id(
+                    raw_case["device_id"],
+                    prefix="device",
+                    context=f"{context} device_id",
+                ),
+                capture_surface="electron",
+                capture_route_context=capture_route_context,
+                split=split,
+                pause_ms=pause_ms,
+                audio_sha256=declared_audio_sha256,
+                pcm_sha256=pcm_sha256,
+                duration_ms=duration_ms,
+            )
+        )
+
+    for field in ("speaker_id", "source_group"):
+        splits_by_identity: dict[str, set[str]] = {}
+        for case in cases:
+            splits_by_identity.setdefault(getattr(case, field), set()).add(case.split)
+        if any(len(splits) > 1 for splits in splits_by_identity.values()):
+            raise ValueError(
+                f"manifest {field} values must not cross calibration/holdout split boundaries"
+            )
+
+    source_metadata: dict[str, tuple[str, str, str, str, str]] = {}
+    for case in cases:
+        metadata = (
+            case.speaker_id,
+            case.session_id,
+            case.device_id,
+            case.language,
+            case.capture_route_context,
+        )
+        prior = source_metadata.setdefault(case.source_group, metadata)
+        if prior != metadata:
+            raise ValueError("manifest source_group metadata must remain consistent")
+
+    return EvaluationManifest(
+        path=manifest_path,
+        dataset_id=dataset_id,
+        cases=tuple(cases),
+        sha256=manifest_sha256,
+    )
+
+
+def load_acceptance_criteria(criteria_path: Path) -> AcceptanceCriteria:
+    """Load pre-registered checkpoint criteria without inventing thresholds."""
+
+    criteria_path = criteria_path.resolve()
+    value, criteria_sha256 = _load_json_object_snapshot(
+        criteria_path, description="acceptance criteria"
+    )
+    _require_exact_keys(value, CRITERIA_KEYS, context="acceptance criteria")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise ValueError("acceptance criteria schema_version must be 1")
+    criteria_id = _anonymous_id(
+        value["criteria_id"], prefix="criteria", context="criteria_id"
+    )
+    manifest_sha256 = _declared_sha256(
+        value["manifest_sha256"], context="criteria manifest_sha256"
+    )
+    threshold = _finite_rate(value["decision_threshold"], context="decision_threshold")
+    production_threshold = SmartTurnConfig().evaluation_threshold
+    if not math.isclose(threshold, production_threshold, rel_tol=0.0, abs_tol=1e-12):
+        raise ValueError(
+            "acceptance criteria decision_threshold must match the deployed production threshold"
+        )
+    confidence_level = _finite_rate(
+        value["confidence_level"], context="confidence_level"
+    )
+    if not 0.5 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be greater than 0.5 and less than 1")
+    if value["confidence_method"] != "wilson":
+        raise ValueError("confidence_method must be wilson")
+    holdout = value["holdout"]
+    if not isinstance(holdout, dict):
+        raise ValueError("criteria holdout must be a JSON object")
+    _require_exact_keys(holdout, frozenset({"languages"}), context="criteria holdout")
+    languages = holdout["languages"]
+    if not isinstance(languages, dict) or set(languages) != SUPPORTED_LANGUAGES:
+        raise ValueError("criteria must pre-register zh-CN, en-US, and ja-JP")
+
+    parsed_languages: dict[str, LanguageAcceptanceCriteria] = {}
+    for language in sorted(SUPPORTED_LANGUAGES):
+        raw = languages[language]
+        if not isinstance(raw, dict):
+            raise ValueError(f"criteria {language} must be a JSON object")
+        _require_exact_keys(raw, LANGUAGE_CRITERIA_KEYS, context=f"criteria {language}")
+        raw_matrix = raw["speaker_scenario_matrix"]
+        if not isinstance(raw_matrix, dict) or set(raw_matrix) != SUPPORTED_SCENARIOS:
+            raise ValueError(
+                f"criteria {language} speaker_scenario_matrix must cover every scenario"
+            )
+        scenario_matrix: dict[str, dict[str, int]] = {}
+        for scenario in sorted(SUPPORTED_SCENARIOS):
+            label_counts = raw_matrix[scenario]
+            if not isinstance(label_counts, dict):
+                raise ValueError(
+                    f"criteria {language} {scenario} matrix must be a JSON object"
+                )
+            _require_exact_keys(
+                label_counts,
+                SCENARIO_LABEL_KEYS,
+                context=f"criteria {language} {scenario}",
+            )
+            scenario_matrix[scenario] = {
+                label: _non_negative_int(
+                    label_counts[label],
+                    context=f"criteria {language} {scenario} {label}",
+                )
+                for label in sorted(SCENARIO_LABEL_KEYS)
+            }
+        if (
+            scenario_matrix["terminal_end"]["complete"] < 1
+            or scenario_matrix["terminal_end"]["incomplete"] != 0
+        ):
+            raise ValueError(
+                f"criteria {language} terminal_end needs complete-only evidence"
+            )
+        for scenario in (
+            "sentence_internal_pause",
+            "hesitation_continue",
+            "long_pause_continue",
+        ):
+            if (
+                scenario_matrix[scenario]["complete"] != 0
+                or scenario_matrix[scenario]["incomplete"] < 1
+            ):
+                raise ValueError(
+                    f"criteria {language} {scenario} needs incomplete-only evidence"
+                )
+        for scenario in ("keyboard_noise", "barge_in"):
+            if any(
+                scenario_matrix[scenario][label] < 1 for label in SCENARIO_LABEL_KEYS
+            ):
+                raise ValueError(
+                    f"criteria {language} {scenario} needs complete and incomplete evidence"
+                )
+        parsed_languages[language] = LanguageAcceptanceCriteria(
+            speaker_count=_non_negative_int(
+                raw["speaker_count"],
+                context=f"criteria {language} speaker_count",
+                minimum=1,
+            ),
+            speaker_roster_sha256=_declared_sha256(
+                raw["speaker_roster_sha256"],
+                context=f"criteria {language} speaker_roster_sha256",
+            ),
+            min_devices=_non_negative_int(
+                raw["min_devices"],
+                context=f"criteria {language} min_devices",
+                minimum=1,
+            ),
+            speaker_scenario_matrix=scenario_matrix,
+            max_speakers_with_any_premature_split=_non_negative_int(
+                raw["max_speakers_with_any_premature_split"],
+                context=(f"criteria {language} max_speakers_with_any_premature_split"),
+            ),
+            max_speakers_with_any_missed_endpoint=_non_negative_int(
+                raw["max_speakers_with_any_missed_endpoint"],
+                context=f"criteria {language} max_speakers_with_any_missed_endpoint",
+            ),
+            max_speaker_premature_split_rate_upper_bound=_finite_rate(
+                raw["max_speaker_premature_split_rate_upper_bound"],
+                context=(
+                    f"criteria {language} max_speaker_premature_split_rate_upper_bound"
+                ),
+            ),
+            max_speaker_missed_endpoint_rate_upper_bound=_finite_rate(
+                raw["max_speaker_missed_endpoint_rate_upper_bound"],
+                context=(
+                    f"criteria {language} max_speaker_missed_endpoint_rate_upper_bound"
+                ),
+            ),
+        )
+
+    return AcceptanceCriteria(
+        path=criteria_path,
+        criteria_id=criteria_id,
+        manifest_sha256=manifest_sha256,
+        decision_threshold=threshold,
+        confidence_level=confidence_level,
+        confidence_method="wilson",
+        languages=parsed_languages,
+        sha256=criteria_sha256,
+    )
+
+
+def load_cases(fixture_dir: Path, labels_path: Path) -> list[EvaluationCase]:
+    """Load the legacy JSONL format for compatibility; reports stay exploratory."""
+
+    root = fixture_dir.resolve()
+    cases: list[EvaluationCase] = []
+    for line_number, line in enumerate(
+        labels_path.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        if not line.strip():
+            continue
+        value = json.loads(line, parse_constant=_reject_json_constant)
+        relative = Path(value["path"])
+        if relative.is_absolute():
+            raise ValueError(f"line {line_number}: fixture path must be relative")
+        try:
+            path = (root / relative).resolve(strict=True)
+        except OSError as exc:
+            raise ValueError(
+                f"line {line_number}: fixture path does not exist"
+            ) from exc
+        if root != path and root not in path.parents:
+            raise ValueError(
+                f"line {line_number}: fixture path escapes fixture directory"
+            )
+        expected = value.get("expected")
+        if expected not in ("complete", "incomplete"):
+            raise ValueError(
+                f"line {line_number}: expected must be complete or incomplete"
+            )
+        duration_ms, pcm_sha256 = _inspect_wav_contract(
+            path, enforce_max_duration=False
+        )
+        cases.append(
+            EvaluationCase(
+                id=f"case-legacy-{line_number:04d}",
+                path=path,
+                expected_complete=expected == "complete",
+                language=str(value.get("language") or "legacy-unknown"),
+                scenario=str(value.get("category") or "legacy-unclassified"),
+                source_group=None,
+                speaker_id=None,
+                session_id=None,
+                device_id=None,
+                capture_surface="legacy-unknown",
+                capture_route_context="legacy-unknown",
+                split="holdout",
+                pause_ms=0,
+                audio_sha256=None,
+                pcm_sha256=pcm_sha256,
+                duration_ms=duration_ms,
             )
         )
     if not cases:
@@ -79,90 +668,761 @@ def load_cases(fixture_dir: Path, labels_path: Path) -> list[EvaluationCase]:
     return cases
 
 
-def read_pcm16_wav(path: Path) -> np.ndarray:
-    with wave.open(str(path), "rb") as wav_file:
-        if wav_file.getnchannels() != 1:
-            raise ValueError(f"{path}: expected mono WAV")
-        if wav_file.getframerate() != 16_000:
-            raise ValueError(f"{path}: expected 16000 Hz WAV")
-        if wav_file.getsampwidth() != 2:
-            raise ValueError(f"{path}: expected signed PCM16 WAV")
-        pcm = wav_file.readframes(wav_file.getnframes())
-    return np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32768.0
+def read_pcm16_wav(path: Path, *, enforce_max_duration: bool = True) -> np.ndarray:
+    audio, _duration_ms, _audio_sha256, _pcm_sha256 = _read_wav_contract(
+        path, enforce_max_duration=enforce_max_duration
+    )
+    return audio
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    return numerator / denominator if denominator else None
+
+
+def _wilson_interval(
+    errors: int, total: int, confidence_level: float
+) -> dict[str, float] | None:
+    if total == 0:
+        return None
+    z = NormalDist().inv_cdf(0.5 + confidence_level / 2.0)
+    observed = errors / total
+    denominator = 1.0 + (z * z / total)
+    center = (observed + z * z / (2.0 * total)) / denominator
+    margin = (
+        z
+        * math.sqrt(observed * (1.0 - observed) / total + z * z / (4.0 * total * total))
+        / denominator
+    )
+    return {
+        "confidence_level": confidence_level,
+        "lower": max(0.0, center - margin),
+        "upper": min(1.0, center + margin),
+    }
+
+
+def _summarize_results(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    matrix = ConfusionMatrix()
+    for record in records:
+        matrix.add(
+            expected=record["expected_complete"], predicted=record["predicted_complete"]
+        )
+    cells = asdict(matrix)
+    complete_total = matrix.true_complete + matrix.false_incomplete
+    incomplete_total = matrix.true_incomplete + matrix.false_complete
+    complete_recall = _ratio(matrix.true_complete, complete_total)
+    continuation_specificity = _ratio(matrix.true_incomplete, incomplete_total)
+    premature_split_rate = _ratio(matrix.false_complete, incomplete_total)
+    missed_endpoint_rate = _ratio(matrix.false_incomplete, complete_total)
+    balanced_accuracy = (
+        (complete_recall + continuation_specificity) / 2.0
+        if complete_recall is not None and continuation_specificity is not None
+        else None
+    )
+    return {
+        **cells,
+        "case_count": len(records),
+        "confusion_matrix": cells,
+        "descriptive_case_complete_recall": complete_recall,
+        "descriptive_case_continuation_specificity": continuation_specificity,
+        "descriptive_case_premature_split_rate": premature_split_rate,
+        "descriptive_case_missed_endpoint_rate": missed_endpoint_rate,
+        "descriptive_case_balanced_accuracy": balanced_accuracy,
+    }
+
+
+def _group_metrics(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    def by(field_names: tuple[str, ...]) -> dict[str, Any]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for record in records:
+            key = "|".join(str(record[field]) for field in field_names)
+            grouped.setdefault(key, []).append(record)
+        return {
+            key: _summarize_results(items) for key, items in sorted(grouped.items())
+        }
+
+    return {
+        "overall": _summarize_results(records),
+        "by_language": by(("language",)),
+        "by_scenario": by(("scenario",)),
+        "by_language_scenario": by(("language", "scenario")),
+        # Informational only: the direct GLM/Gemini checkpoint is identical.
+        "by_language_capture_route_context": by(("language", "capture_route_context")),
+    }
+
+
+def _dataset_summary(manifest: EvaluationManifest) -> dict[str, Any]:
+    cases = manifest.cases
+
+    def counts(field: str) -> dict[str, int]:
+        values: dict[str, int] = {}
+        for case in cases:
+            key = str(getattr(case, field))
+            values[key] = values.get(key, 0) + 1
+        return dict(sorted(values.items()))
+
+    def unique_count(selected: Sequence[EvaluationCase], field: str) -> int | None:
+        values = {
+            value for case in selected if (value := getattr(case, field)) is not None
+        }
+        return len(values) if values else None
+
+    by_language: dict[str, dict[str, int | None]] = {}
+    for language in sorted({case.language for case in cases}):
+        selected = [case for case in cases if case.language == language]
+        by_language[language] = {
+            "case_count": len(selected),
+            "complete": sum(case.expected_complete for case in selected),
+            "incomplete": sum(not case.expected_complete for case in selected),
+            "speaker_count": unique_count(selected, "speaker_id"),
+            "session_count": unique_count(selected, "session_id"),
+            "device_count": unique_count(selected, "device_id"),
+            "source_group_count": unique_count(selected, "source_group"),
+        }
+    pcm_digests = sorted(
+        case.pcm_sha256 for case in cases if case.pcm_sha256 is not None
+    )
+    corpus_digest = (
+        hashlib.sha256(
+            json.dumps(pcm_digests, separators=(",", ":")).encode("ascii")
+        ).hexdigest()
+        if pcm_digests
+        else None
+    )
+    return {
+        "dataset_id": manifest.dataset_id,
+        "case_count": len(cases),
+        "audio_corpus_sha256": corpus_digest,
+        "split_counts": counts("split"),
+        "language_counts": counts("language"),
+        "scenario_counts": counts("scenario"),
+        "capture_route_context_counts": counts("capture_route_context"),
+        "speaker_count": unique_count(cases, "speaker_id"),
+        "session_count": unique_count(cases, "session_id"),
+        "device_count": unique_count(cases, "device_id"),
+        "source_group_count": unique_count(cases, "source_group"),
+        "by_language": by_language,
+    }
+
+
+def _gate_check(
+    checks: list[dict[str, Any]],
+    *,
+    language: str,
+    name: str,
+    observed: Any,
+    required: Any,
+    passed: bool,
+    insufficient_evidence: bool = False,
+) -> None:
+    checks.append(
+        {
+            "language": language,
+            "check": name,
+            "observed": observed,
+            "required": required,
+            "status": "pass"
+            if passed
+            else ("blocked" if insufficient_evidence else "fail"),
+        }
+    )
+
+
+def _opaque_roster_sha256(values: Sequence[str]) -> str:
+    encoded = json.dumps(sorted(values), separators=(",", ":")).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _evidence_digest_summary(manifest: EvaluationManifest) -> dict[str, Any]:
+    """Return canonical manifest and holdout-speaker digests for preregistration."""
+
+    languages: dict[str, dict[str, Any]] = {}
+    for language in sorted(SUPPORTED_LANGUAGES):
+        speaker_ids = {
+            case.speaker_id
+            for case in manifest.cases
+            if case.split == "holdout"
+            and case.language == language
+            and case.speaker_id is not None
+        }
+        languages[language] = {
+            "speaker_count": len(speaker_ids),
+            "speaker_roster_sha256": _opaque_roster_sha256(list(speaker_ids)),
+        }
+    return {
+        "schema_version": 1,
+        "manifest_sha256": manifest.sha256,
+        "languages": languages,
+    }
+
+
+def _build_checkpoint_gate(
+    records: Sequence[dict[str, Any]],
+    criteria: AcceptanceCriteria | None,
+    manifest_sha256: str,
+) -> dict[str, Any]:
+    if criteria is None:
+        return {"scope": "model_checkpoint", "outcome": "exploratory", "checks": []}
+
+    checks: list[dict[str, Any]] = []
+    speaker_metrics: dict[str, dict[str, Any]] = {}
+    manifest_matches = manifest_sha256 == criteria.manifest_sha256
+    _gate_check(
+        checks,
+        language="all",
+        name="manifest_binding",
+        observed=manifest_matches,
+        required="match the manifest digest frozen in the acceptance criteria",
+        passed=manifest_matches,
+        insufficient_evidence=True,
+    )
+    holdout = [record for record in records if record["case"].split == "holdout"]
+    for language in sorted(SUPPORTED_LANGUAGES):
+        requirement = criteria.languages[language]
+        selected = [record for record in holdout if record["case"].language == language]
+        records_by_speaker: dict[str, list[dict[str, Any]]] = {}
+        for record in selected:
+            speaker_id = record["case"].speaker_id
+            if speaker_id is not None:
+                records_by_speaker.setdefault(speaker_id, []).append(record)
+
+        compliant_speakers: list[list[dict[str, Any]]] = []
+        for speaker_records in records_by_speaker.values():
+            observed_matrix = {
+                scenario: {"complete": 0, "incomplete": 0}
+                for scenario in SUPPORTED_SCENARIOS
+            }
+            for record in speaker_records:
+                label = "complete" if record["expected_complete"] else "incomplete"
+                observed_matrix[record["scenario"]][label] += 1
+            if observed_matrix == requirement.speaker_scenario_matrix:
+                compliant_speakers.append(speaker_records)
+
+        speaker_count = len(records_by_speaker)
+        compliant_count = len(compliant_speakers)
+        roster_matches = (
+            _opaque_roster_sha256(list(records_by_speaker))
+            == requirement.speaker_roster_sha256
+        )
+        device_count = len(
+            {
+                record["case"].device_id
+                for record in selected
+                if record["case"].device_id is not None
+            }
+        )
+        evidence_checks = (
+            ("speaker_count", speaker_count, requirement.speaker_count),
+            ("min_devices", device_count, requirement.min_devices),
+        )
+        for name, observed, required in evidence_checks:
+            _gate_check(
+                checks,
+                language=language,
+                name=name,
+                observed=observed,
+                required=required,
+                passed=(
+                    observed == required
+                    if name == "speaker_count"
+                    else observed >= required
+                ),
+                insufficient_evidence=True,
+            )
+        _gate_check(
+            checks,
+            language=language,
+            name="speaker_roster_compliance",
+            observed=roster_matches,
+            required="match the pre-registered opaque speaker roster digest",
+            passed=roster_matches,
+            insufficient_evidence=True,
+        )
+        _gate_check(
+            checks,
+            language=language,
+            name="speaker_matrix_compliance",
+            observed={"compliant_speakers": compliant_count, "speakers": speaker_count},
+            required="every speaker exactly matches the pre-registered scenario/label matrix",
+            passed=speaker_count > 0 and compliant_count == speaker_count,
+            insufficient_evidence=True,
+        )
+
+        speakers_with_premature_split = sum(
+            any(
+                not record["expected_complete"] and record["predicted_complete"]
+                for record in speaker_records
+            )
+            for speaker_records in compliant_speakers
+        )
+        speakers_with_missed_endpoint = sum(
+            any(
+                record["expected_complete"] and not record["predicted_complete"]
+                for record in speaker_records
+            )
+            for speaker_records in compliant_speakers
+        )
+        premature_rate = _ratio(speakers_with_premature_split, compliant_count)
+        missed_rate = _ratio(speakers_with_missed_endpoint, compliant_count)
+        premature_interval = _wilson_interval(
+            speakers_with_premature_split, compliant_count, criteria.confidence_level
+        )
+        missed_interval = _wilson_interval(
+            speakers_with_missed_endpoint, compliant_count, criteria.confidence_level
+        )
+        speaker_metrics[language] = {
+            "speaker_count": speaker_count,
+            "matrix_compliant_speaker_count": compliant_count,
+            "matrix_noncompliant_speaker_count": speaker_count - compliant_count,
+            "device_count": device_count,
+            "speaker_roster_compliant": roster_matches,
+            "speakers_with_any_premature_split": speakers_with_premature_split,
+            "speakers_with_any_missed_endpoint": speakers_with_missed_endpoint,
+            "speaker_premature_split_rate": premature_rate,
+            "speaker_premature_split_rate_interval": premature_interval,
+            "speaker_missed_endpoint_rate": missed_rate,
+            "speaker_missed_endpoint_rate_interval": missed_interval,
+        }
+
+        _gate_check(
+            checks,
+            language=language,
+            name="max_speakers_with_any_premature_split",
+            observed=speakers_with_premature_split,
+            required=requirement.max_speakers_with_any_premature_split,
+            passed=(
+                compliant_count > 0
+                and speakers_with_premature_split
+                <= requirement.max_speakers_with_any_premature_split
+            ),
+            insufficient_evidence=compliant_count == 0,
+        )
+        _gate_check(
+            checks,
+            language=language,
+            name="max_speakers_with_any_missed_endpoint",
+            observed=speakers_with_missed_endpoint,
+            required=requirement.max_speakers_with_any_missed_endpoint,
+            passed=(
+                compliant_count > 0
+                and speakers_with_missed_endpoint
+                <= requirement.max_speakers_with_any_missed_endpoint
+            ),
+            insufficient_evidence=compliant_count == 0,
+        )
+        for metric_name, interval, maximum in (
+            (
+                "speaker_premature_split_rate_interval",
+                premature_interval,
+                requirement.max_speaker_premature_split_rate_upper_bound,
+            ),
+            (
+                "speaker_missed_endpoint_rate_interval",
+                missed_interval,
+                requirement.max_speaker_missed_endpoint_rate_upper_bound,
+            ),
+        ):
+            upper = interval["upper"] if interval is not None else None
+            _gate_check(
+                checks,
+                language=language,
+                name=f"max_{metric_name}_upper",
+                observed=upper,
+                required=maximum,
+                passed=upper is not None and upper <= maximum,
+                insufficient_evidence=upper is None,
+            )
+
+    statuses = {check["status"] for check in checks}
+    outcome = (
+        "blocked"
+        if "blocked" in statuses
+        else ("fail" if "fail" in statuses else "pass")
+    )
+    return {
+        "scope": "model_checkpoint",
+        "outcome": outcome,
+        "criteria_id": criteria.criteria_id,
+        "checks": checks,
+        "speaker_metrics": speaker_metrics,
+    }
+
+
+def _runtime_provenance(asset_dir: Path) -> dict[str, Any]:
+    model: dict[str, Any] = {"filename": "smart_turn_v3.onnx"}
+    manifest_path = asset_dir / "manifest.json"
+    if manifest_path.is_file():
+        manifest = _load_json_object(manifest_path, description="asset manifest")
+        for asset in manifest.get("assets", []):
+            if asset.get("filename") == "smart_turn_v3.onnx":
+                model.update(
+                    version=asset.get("version"),
+                    sha256=asset.get("sha256"),
+                )
+                break
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        revision = "unknown"
+    try:
+        dirty = bool(
+            subprocess.run(
+                ["git", "status", "--porcelain", "--untracked-files=normal"],
+                cwd=PROJECT_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout.strip()
+        )
+    except (OSError, subprocess.SubprocessError):
+        dirty = False
+    if dirty and revision != "unknown":
+        revision = f"{revision}-dirty"
+    return {
+        "git_revision": revision,
+        "evaluator_sha256": _sha256(Path(__file__).resolve()),
+        "model": model,
+        "runtime": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "onnxruntime": importlib.metadata.version("onnxruntime"),
+        },
+    }
+
+
+def _latency_summary(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    def distribution(values: Sequence[float]) -> dict[str, Any] | None:
+        if not values:
+            return None
+        ordered = sorted(values)
+
+        def percentile(fraction: float) -> float:
+            index = round((len(ordered) - 1) * fraction)
+            return ordered[index]
+
+        return {
+            "case_count": len(ordered),
+            "median": statistics.median(ordered),
+            "p95": percentile(0.95),
+            "p99": percentile(0.99),
+        }
+
+    all_values = [record["latency_ms"] for record in records]
+    cold_values = [
+        record["latency_ms"] for record in records if record["is_cold_start"]
+    ]
+    warm_values = [
+        record["latency_ms"] for record in records if not record["is_cold_start"]
+    ]
+    overall = distribution(all_values)
+    return {
+        "case_count": len(records),
+        "cold_case_count": len(cold_values),
+        "median": overall["median"] if overall is not None else None,
+        "p95": overall["p95"] if overall is not None else None,
+        "p99": overall["p99"] if overall is not None else None,
+        "cold": distribution(cold_values),
+        "warm": distribution(warm_values),
+    }
+
+
+def evaluate_manifest(
+    manifest: EvaluationManifest,
+    predictor: Predictor,
+    *,
+    threshold: float | None = None,
+    criteria: AcceptanceCriteria | None = None,
+    provenance: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Evaluate a validated manifest and return a privacy-redacted report."""
+
+    selected_threshold = (
+        criteria.decision_threshold
+        if threshold is None and criteria is not None
+        else (
+            SmartTurnConfig().evaluation_threshold if threshold is None else threshold
+        )
+    )
+    selected_threshold = _finite_rate(selected_threshold, context="threshold")
+    if criteria is not None and not math.isclose(
+        selected_threshold, criteria.decision_threshold, rel_tol=0.0, abs_tol=1e-12
+    ):
+        raise ValueError("evaluation threshold must match the pre-registered criteria")
+    records: list[dict[str, Any]] = []
+    public_results: list[dict[str, Any]] = []
+    for inference_index, case in enumerate(manifest.cases):
+        audio, duration_ms, audio_sha256, pcm_sha256 = _read_wav_contract(
+            case.path, enforce_max_duration=manifest.path is not None
+        )
+        if (
+            (case.audio_sha256 is not None and audio_sha256 != case.audio_sha256)
+            or pcm_sha256 != case.pcm_sha256
+            or duration_ms != case.duration_ms
+        ):
+            raise ValueError(
+                f"case {case.id}: WAV changed after manifest or labels validation"
+            )
+        started = time.perf_counter()
+        raw_probability = predictor.predict_probability(audio)
+        latency_ms = (time.perf_counter() - started) * 1000.0
+        try:
+            probability = float(raw_probability)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"case {case.id}: predictor returned an invalid probability"
+            ) from exc
+        if not math.isfinite(probability) or not 0.0 <= probability <= 1.0:
+            raise ValueError(
+                f"case {case.id}: predictor returned an invalid probability"
+            )
+        predicted_complete = probability >= selected_threshold
+        record = {
+            "case": case,
+            "language": case.language,
+            "scenario": case.scenario,
+            "capture_route_context": case.capture_route_context,
+            "expected_complete": case.expected_complete,
+            "predicted_complete": predicted_complete,
+            "latency_ms": latency_ms,
+            "is_cold_start": inference_index == 0,
+        }
+        records.append(record)
+        public_results.append(
+            {
+                "id": case.id,
+                "language": case.language,
+                "scenario": case.scenario,
+                "capture_surface": case.capture_surface,
+                "capture_route_context": case.capture_route_context,
+                "split": case.split,
+                "pause_ms": case.pause_ms,
+                "duration_ms": case.duration_ms,
+                "expected": "complete" if case.expected_complete else "incomplete",
+                "predicted": "complete" if predicted_complete else "incomplete",
+                "probability": probability,
+                "latency_ms": latency_ms,
+                "is_cold_start": inference_index == 0,
+            }
+        )
+
+    metrics = {
+        split: _group_metrics(
+            [record for record in records if record["case"].split == split]
+        )
+        for split in ("calibration", "holdout")
+    }
+    latency = {
+        split: _latency_summary(
+            [record for record in records if record["case"].split == split]
+        )
+        for split in ("calibration", "holdout")
+    }
+
+    report_provenance = dict(provenance or {})
+    report_provenance.setdefault("evaluator_sha256", _sha256(Path(__file__).resolve()))
+    report_provenance["manifest_sha256"] = manifest.sha256
+    report_provenance["criteria_sha256"] = criteria.sha256 if criteria else None
+    gate = _build_checkpoint_gate(records, criteria, manifest.sha256)
+    approval_reasons = ["electron_live_route_evidence_missing"]
+    if gate["outcome"] != "pass":
+        approval_reasons.insert(0, f"model_checkpoint_gate_{gate['outcome']}")
+    holdout_overall = metrics["holdout"]["overall"]
+    return {
+        "schema_version": 1,
+        "scope": "smart_turn_model_checkpoint_replay",
+        "evidence_limitations": [
+            "does_not_exercise_electron_live_capture",
+            "does_not_exercise_vad_candidate_timing_or_coordinator",
+            "does_not_exercise_provider_commit_or_asr_network",
+            "capture_route_context_is_informational_not_an_independent_model_route",
+        ],
+        "threshold": selected_threshold,
+        "dataset": _dataset_summary(manifest),
+        "metrics": metrics,
+        # Compatibility summary: holdout only, never calibration-contaminated.
+        "case_count": holdout_overall["case_count"],
+        "confusion_matrix": holdout_overall["confusion_matrix"],
+        "latency_ms": latency,
+        "gate": gate,
+        "product_quality_approval": {
+            "status": "blocked",
+            "reasons": approval_reasons,
+        },
+        "provenance": report_provenance,
+        "results": public_results,
+    }
 
 
 def evaluate_cases(
     cases: list[EvaluationCase], predictor: Predictor, *, threshold: float = 0.5
-) -> dict[str, object]:
-    if not 0.0 <= threshold <= 1.0:
-        raise ValueError("threshold must be within [0, 1]")
-    matrix = ConfusionMatrix()
-    latencies_ms: list[float] = []
-    results: list[dict[str, object]] = []
-    for case in cases:
-        audio = read_pcm16_wav(case.path)
-        started = time.perf_counter()
-        probability = predictor.predict_probability(audio)
-        latency_ms = (time.perf_counter() - started) * 1000
-        predicted = probability >= threshold
-        matrix.add(expected=case.expected_complete, predicted=predicted)
-        latencies_ms.append(latency_ms)
-        results.append(
-            {
-                "path": case.path.name,
-                "language": case.language,
-                "category": case.category,
-                "expected": "complete" if case.expected_complete else "incomplete",
-                "predicted": "complete" if predicted else "incomplete",
-                "probability": probability,
-                "latency_ms": latency_ms,
-            }
+) -> dict[str, Any]:
+    """Compatibility wrapper for the legacy, unversioned JSONL input."""
+
+    report = evaluate_manifest(
+        EvaluationManifest(
+            path=None,
+            dataset_id="dataset-legacy-unversioned",
+            cases=tuple(cases),
+            sha256="legacy-unversioned",
+        ),
+        predictor,
+        threshold=threshold,
+    )
+    report["scope"] = "smart_turn_legacy_unversioned_checkpoint_replay"
+    return report
+
+
+def render_markdown_report(report: Mapping[str, Any]) -> str:
+    gate = report["gate"]
+    lines = [
+        "# SmartTurn v3 human-voice checkpoint report",
+        "",
+        f"- Checkpoint gate: **{str(gate['outcome']).upper()}**",
+        "- Product quality approval: **BLOCKED** (live Electron route evidence is required)",
+        f"- Decision threshold: `{report['threshold']}`",
+        f"- Holdout cases: `{report['case_count']}`",
+        "",
+        "This report is direct ONNX checkpoint replay. It does not cover live Electron capture, "
+        "VAD/coordinator timing, provider commit, or ASR network behavior.",
+        "",
+        "| Language | Cases | Case premature split | Case missed endpoint | Case balanced accuracy |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    language_metrics = report["metrics"]["holdout"]["by_language"]
+
+    def display(value: Any) -> str:
+        return "n/a" if value is None else f"{value:.3f}"
+
+    for language in sorted(SUPPORTED_LANGUAGES):
+        metrics = language_metrics.get(language, {})
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    language,
+                    str(metrics.get("case_count", 0)),
+                    display(metrics.get("descriptive_case_premature_split_rate")),
+                    display(metrics.get("descriptive_case_missed_endpoint_rate")),
+                    display(metrics.get("descriptive_case_balanced_accuracy")),
+                ]
+            )
+            + " |"
         )
-    ordered = sorted(latencies_ms)
-
-    def percentile(fraction: float) -> float:
-        index = round((len(ordered) - 1) * fraction)
-        return ordered[index]
-
-    return {
-        "threshold": threshold,
-        "case_count": len(cases),
-        "confusion_matrix": asdict(matrix),
-        "latency_ms": {
-            "median": statistics.median(latencies_ms),
-            "p95": percentile(0.95),
-            "p99": percentile(0.99),
-        },
-        "results": results,
-    }
+    lines.append("")
+    return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--fixture-dir", required=True, type=Path)
-    parser.add_argument("--labels", required=True, type=Path)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--criteria", type=Path)
+    parser.add_argument("--fixture-dir", type=Path, help="legacy JSONL mode")
+    parser.add_argument("--labels", type=Path, help="legacy JSONL mode")
     parser.add_argument(
         "--asset-dir",
         type=Path,
         default=PROJECT_ROOT / "main_logic" / "asr_client" / "endpointing" / "models",
     )
-    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--threshold", type=float)
     parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument(
+        "--evidence-digest-output",
+        type=Path,
+        help=(
+            "validate a versioned manifest and write canonical manifest/holdout "
+            "speaker digests without loading the model"
+        ),
+    )
     args = parser.parse_args(argv)
-    runtime = SmartTurnV3(enabled=True, asset_dir=args.asset_dir.resolve())
+
+    if args.evidence_digest_output is not None:
+        if args.manifest is None:
+            parser.error("--evidence-digest-output requires --manifest")
+        if any(
+            value is not None
+            for value in (
+                args.criteria,
+                args.fixture_dir,
+                args.labels,
+                args.threshold,
+                args.output,
+                args.markdown_output,
+            )
+        ):
+            parser.error(
+                "--evidence-digest-output cannot be combined with evaluation or "
+                "legacy input options"
+            )
+        manifest = load_manifest(args.manifest)
+        rendered = json.dumps(
+            _evidence_digest_summary(manifest),
+            ensure_ascii=False,
+            indent=2,
+            allow_nan=False,
+        )
+        args.evidence_digest_output.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence_digest_output.write_text(rendered + "\n", encoding="utf-8")
+        print(rendered)
+        return 0
+
+    if args.manifest is not None:
+        if args.fixture_dir is not None or args.labels is not None:
+            parser.error(
+                "--manifest cannot be combined with legacy --fixture-dir/--labels"
+            )
+        manifest = load_manifest(args.manifest)
+        criteria = load_acceptance_criteria(args.criteria) if args.criteria else None
+    else:
+        if args.fixture_dir is None or args.labels is None:
+            parser.error("provide --manifest or both --fixture-dir and --labels")
+        if args.criteria is not None:
+            parser.error("--criteria requires a versioned --manifest")
+        legacy_cases = load_cases(args.fixture_dir, args.labels)
+        manifest = EvaluationManifest(
+            path=None,
+            dataset_id="dataset-legacy-unversioned",
+            cases=tuple(legacy_cases),
+            sha256="legacy-unversioned",
+        )
+        criteria = None
+
+    asset_dir = args.asset_dir.resolve()
+    runtime = SmartTurnV3(enabled=True, asset_dir=asset_dir)
     if not runtime.load():
         parser.error(f"Smart Turn runtime unavailable: {runtime.unavailable_reason}")
     try:
-        report = evaluate_cases(
-            load_cases(args.fixture_dir, args.labels), runtime, threshold=args.threshold
+        report = evaluate_manifest(
+            manifest,
+            runtime,
+            threshold=args.threshold,
+            criteria=criteria,
+            provenance=_runtime_provenance(asset_dir),
         )
     finally:
         runtime.close()
-    rendered = json.dumps(report, ensure_ascii=False, indent=2)
+    if args.manifest is None:
+        report["scope"] = "smart_turn_legacy_unversioned_checkpoint_replay"
+
+    rendered = json.dumps(report, ensure_ascii=False, indent=2, allow_nan=False)
     if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(rendered + "\n", encoding="utf-8")
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(
+            render_markdown_report(report), encoding="utf-8"
+        )
     print(rendered)
-    return 0
+    return 2 if criteria is not None and report["gate"]["outcome"] != "pass" else 0
 
 
 if __name__ == "__main__":

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -94,6 +94,10 @@ LANGUAGE_CRITERIA_KEYS = frozenset(
     }
 )
 SCENARIO_LABEL_KEYS = frozenset({"complete", "incomplete"})
+SMART_TURN_MODEL_FILENAME = "smart_turn_v3.onnx"
+PRODUCTION_ASSET_DIR = (
+    PROJECT_ROOT / "main_logic" / "asr_client" / "endpointing" / "models"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +234,39 @@ def _declared_sha256(value: Any, *, context: str) -> str:
     if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
         raise ValueError(f"{context} must be a lowercase SHA-256 digest")
     return value
+
+
+def _declared_smart_turn_model_sha256(asset_dir: Path) -> str:
+    manifest = _load_json_object(
+        asset_dir / "manifest.json", description="asset manifest"
+    )
+    assets = manifest.get("assets")
+    if not isinstance(assets, list):
+        raise ValueError("asset manifest assets must be a list")
+    matches = [
+        asset
+        for asset in assets
+        if isinstance(asset, dict)
+        and asset.get("filename") == SMART_TURN_MODEL_FILENAME
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"asset manifest must declare exactly one {SMART_TURN_MODEL_FILENAME}"
+        )
+    return _declared_sha256(
+        matches[0].get("sha256"),
+        context=f"asset manifest {SMART_TURN_MODEL_FILENAME} sha256",
+    )
+
+
+def _require_deployed_model_for_registered_run(asset_dir: Path) -> None:
+    expected = _declared_smart_turn_model_sha256(PRODUCTION_ASSET_DIR)
+    selected = _declared_smart_turn_model_sha256(asset_dir)
+    if selected != expected:
+        raise ValueError(
+            "registered evaluation requires the deployed SmartTurn model SHA-256 "
+            f"{expected}, but --asset-dir declares {selected}"
+        )
 
 
 def _finite_rate(value: Any, *, context: str) -> float:
@@ -1414,6 +1451,11 @@ def main(argv: list[str] | None = None) -> int:
         criteria = None
 
     asset_dir = args.asset_dir.resolve()
+    if criteria is not None:
+        try:
+            _require_deployed_model_for_registered_run(asset_dir)
+        except ValueError as exc:
+            parser.error(str(exc))
     runtime = SmartTurnV3(enabled=True, asset_dir=asset_dir)
     if not runtime.load():
         parser.error(f"Smart Turn runtime unavailable: {runtime.unavailable_reason}")

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -1155,6 +1155,8 @@ def evaluate_manifest(
 ) -> dict[str, Any]:
     """Evaluate a validated manifest and return a privacy-redacted report."""
 
+    if criteria is not None and manifest.sha256 != criteria.manifest_sha256:
+        raise ValueError("manifest SHA-256 does not match the pre-registered criteria")
     selected_threshold = (
         criteria.decision_threshold
         if threshold is None and criteria is not None

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -1217,9 +1217,8 @@ def evaluate_manifest(
         selected_threshold, criteria.decision_threshold, rel_tol=0.0, abs_tol=1e-12
     ):
         raise ValueError("evaluation threshold must match the pre-registered criteria")
-    records: list[dict[str, Any]] = []
-    public_results: list[dict[str, Any]] = []
-    for inference_index, case in enumerate(manifest.cases):
+    validated_audio: list[np.ndarray] = []
+    for case in manifest.cases:
         audio, duration_ms, audio_sha256, pcm_sha256 = _read_wav_contract(
             case.path, enforce_max_duration=manifest.path is not None
         )
@@ -1231,6 +1230,13 @@ def evaluate_manifest(
             raise ValueError(
                 f"case {case.id}: WAV changed after manifest or labels validation"
             )
+        validated_audio.append(audio)
+
+    records: list[dict[str, Any]] = []
+    public_results: list[dict[str, Any]] = []
+    for inference_index, (case, audio) in enumerate(
+        zip(manifest.cases, validated_audio, strict=True)
+    ):
         started = time.perf_counter()
         raw_probability = predictor.predict_probability(audio)
         latency_ms = (time.perf_counter() - started) * 1000.0

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import importlib.metadata
-import io
 import json
 import math
 import platform
@@ -299,8 +298,7 @@ def _read_wav_contract(
     path: Path, *, enforce_max_duration: bool = True
 ) -> tuple[np.ndarray, int, str, str]:
     try:
-        encoded = path.read_bytes()
-        with wave.open(io.BytesIO(encoded), "rb") as wav_file:
+        with path.open("rb") as encoded_file, wave.open(encoded_file, "rb") as wav_file:
             if wav_file.getnchannels() != 1:
                 raise ValueError(f"{path}: expected mono WAV")
             if wav_file.getframerate() != 16_000:
@@ -308,13 +306,19 @@ def _read_wav_contract(
             if wav_file.getsampwidth() != 2:
                 raise ValueError(f"{path}: expected signed PCM16 WAV")
             frames = wav_file.getnframes()
+            if frames <= 0:
+                raise ValueError(f"{path}: WAV must contain audio")
+            if enforce_max_duration and frames > MAX_AUDIO_FRAMES:
+                raise ValueError(
+                    f"{path}: WAV exceeds the SmartTurn 8 second input window"
+                )
             pcm = wav_file.readframes(frames)
+            encoded_file.seek(0)
+            audio_digest = hashlib.sha256()
+            for chunk in iter(lambda: encoded_file.read(1024 * 1024), b""):
+                audio_digest.update(chunk)
     except (OSError, wave.Error, EOFError) as exc:
         raise ValueError(f"{path}: unreadable WAV") from exc
-    if frames <= 0:
-        raise ValueError(f"{path}: WAV must contain audio")
-    if enforce_max_duration and frames > MAX_AUDIO_FRAMES:
-        raise ValueError(f"{path}: WAV exceeds the SmartTurn 8 second input window")
     if len(pcm) != frames * 2:
         raise ValueError(f"{path}: truncated PCM frames")
     duration_ms = frames * 1_000 // 16_000
@@ -322,7 +326,7 @@ def _read_wav_contract(
     return (
         audio,
         duration_ms,
-        hashlib.sha256(encoded).hexdigest(),
+        audio_digest.hexdigest(),
         hashlib.sha256(pcm).hexdigest(),
     )
 
@@ -1140,6 +1144,7 @@ def _runtime_provenance(asset_dir: Path) -> dict[str, Any]:
         )
     except (OSError, subprocess.SubprocessError):
         dirty = False
+        revision = "unknown"
     if dirty and revision != "unknown":
         revision = f"{revision}-dirty"
     return {

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -1047,6 +1047,15 @@ def _build_checkpoint_gate(
     }
 
 
+def _installed_distribution_version(distributions: Sequence[str]) -> str:
+    for distribution in distributions:
+        try:
+            return importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return "unknown"
+
+
 def _runtime_provenance(asset_dir: Path) -> dict[str, Any]:
     model: dict[str, Any] = {"filename": "smart_turn_v3.onnx"}
     manifest_path = asset_dir / "manifest.json"
@@ -1093,7 +1102,9 @@ def _runtime_provenance(asset_dir: Path) -> dict[str, Any]:
             "platform": platform.platform(),
             "python": platform.python_version(),
             "numpy": np.__version__,
-            "onnxruntime": importlib.metadata.version("onnxruntime"),
+            "onnxruntime": _installed_distribution_version(
+                ("onnxruntime", "onnxruntime-gpu", "onnxruntime-directml")
+            ),
         },
     }
 
@@ -1378,6 +1389,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.fixture_dir is not None or args.labels is not None:
             parser.error(
                 "--manifest cannot be combined with legacy --fixture-dir/--labels"
+            )
+        if args.criteria is not None and args.threshold is not None:
+            parser.error(
+                "--threshold cannot be combined with --criteria; the "
+                "pre-registered decision_threshold is authoritative"
             )
         manifest = load_manifest(args.manifest)
         criteria = load_acceptance_criteria(args.criteria) if args.criteria else None

--- a/tests/unit/asr_client/endpointing/test_audio_evidence.py
+++ b/tests/unit/asr_client/endpointing/test_audio_evidence.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import wave
+from pathlib import Path
+
+from main_logic.asr_client.endpointing.smart_turn_audio_evidence import (
+    SMART_TURN_AUDIO_EVIDENCE_DIR_ENV,
+    SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV,
+    create_smart_turn_audio_evidence_recorder,
+)
+
+
+async def test_audio_evidence_is_off_without_explicit_opt_in(tmp_path: Path) -> None:
+    target = tmp_path / "data" / "smart_turn" / "audio-evidence"
+    recorder = create_smart_turn_audio_evidence_recorder(
+        environ={SMART_TURN_AUDIO_EVIDENCE_DIR_ENV: str(target)},
+        repo_root=tmp_path,
+    )
+
+    recorder.accepted_audio(identity=(1, 0, 1), pcm16=b"\x01\x00" * 160)
+    recorder.complete(
+        identity=(1, 0, 1),
+        reason="candidate_pause",
+        probability=0.9,
+        threshold=0.5,
+    )
+    await recorder.close()
+
+    assert recorder.enabled is False
+    assert not target.exists()
+
+
+async def test_audio_evidence_writes_local_wav_and_index_under_data(
+    tmp_path: Path,
+) -> None:
+    pcm16 = b"\x01\x00\x02\x00" * 160
+    target = tmp_path / "data" / "smart_turn" / "audio-evidence"
+    recorder = create_smart_turn_audio_evidence_recorder(
+        environ={
+            SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV: "1",
+            SMART_TURN_AUDIO_EVIDENCE_DIR_ENV: str(target),
+        },
+        repo_root=tmp_path,
+    )
+
+    recorder.accepted_audio(identity=(1, 0, 1), pcm16=pcm16)
+    recorder.complete(
+        identity=(1, 0, 1),
+        reason="strict_retry",
+        probability=0.91,
+        threshold=0.5,
+    )
+    await recorder.close()
+
+    run_dirs = list(target.iterdir())
+    assert recorder.enabled is True
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+    wav_path = run_dir / "turn-0001.wav"
+    index_path = run_dir / "index.jsonl"
+    assert wav_path.exists()
+    assert index_path.exists()
+
+    with wave.open(str(wav_path), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 16_000
+        assert wav_file.readframes(wav_file.getnframes()) == pcm16
+
+    records = [json.loads(line) for line in index_path.read_text("utf-8").splitlines()]
+    assert len(records) == 1
+    record = records[0]
+    assert record["schema"] == "neko.smart_turn.audio_evidence.v1"
+    assert record["event"] == "turn_audio"
+    assert record["file"] == "turn-0001.wav"
+    assert record["reason"] == "strict_retry"
+    assert record["probability"] == 0.91
+    assert record["threshold"] == 0.5
+    assert record["pcm_sha256"] == hashlib.sha256(pcm16).hexdigest()
+    assert record["duration_ms"] == 20
+
+
+async def test_audio_evidence_rejects_paths_outside_repository_data(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    recorder = create_smart_turn_audio_evidence_recorder(
+        environ={
+            SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV: "1",
+            SMART_TURN_AUDIO_EVIDENCE_DIR_ENV: str(outside),
+        },
+        repo_root=tmp_path,
+    )
+
+    recorder.accepted_audio(identity=(1, 0, 1), pcm16=b"\x01\x00" * 160)
+    recorder.complete(
+        identity=(1, 0, 1),
+        reason="candidate_pause",
+        probability=0.9,
+        threshold=0.5,
+    )
+    await recorder.close()
+
+    assert recorder.enabled is False
+    assert not outside.exists()
+
+
+async def test_audio_evidence_discards_uncompleted_audio(tmp_path: Path) -> None:
+    target = tmp_path / "data" / "smart_turn" / "audio-evidence"
+    recorder = create_smart_turn_audio_evidence_recorder(
+        environ={
+            SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV: "1",
+            SMART_TURN_AUDIO_EVIDENCE_DIR_ENV: str(target),
+        },
+        repo_root=tmp_path,
+    )
+
+    recorder.accepted_audio(identity=(1, 0, 1), pcm16=b"\x01\x00" * 160)
+    recorder.discard()
+    recorder.complete(
+        identity=(1, 0, 1),
+        reason="candidate_pause",
+        probability=0.9,
+        threshold=0.5,
+    )
+    await recorder.close()
+
+    assert not target.exists()

--- a/tests/unit/asr_client/endpointing/test_config.py
+++ b/tests/unit/asr_client/endpointing/test_config.py
@@ -15,6 +15,12 @@ def test_config_rejects_negative_candidate_complete_confirmation():
         SmartTurnConfig(candidate_complete_confirmation_seconds=-0.1)
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_config_rejects_non_finite_candidate_complete_confirmation(value: float):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        SmartTurnConfig(candidate_complete_confirmation_seconds=value)
+
+
 def test_config_has_one_endpointing_owned_type_identity():
     assert not hasattr(voice_contracts, "SmartTurnConfig")
     assert detector_runtime.SmartTurnConfig is SmartTurnConfig

--- a/tests/unit/asr_client/endpointing/test_config.py
+++ b/tests/unit/asr_client/endpointing/test_config.py
@@ -10,6 +10,11 @@ def test_config_rejects_missing_vad_hysteresis():
         SmartTurnConfig(onset_probability=0.4, offset_probability=0.4)
 
 
+def test_config_rejects_negative_candidate_complete_confirmation():
+    with pytest.raises(ValueError):
+        SmartTurnConfig(candidate_complete_confirmation_seconds=-0.1)
+
+
 def test_config_has_one_endpointing_owned_type_identity():
     assert not hasattr(voice_contracts, "SmartTurnConfig")
     assert detector_runtime.SmartTurnConfig is SmartTurnConfig

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -502,19 +502,17 @@ def test_gate_binds_the_entire_frozen_manifest_before_inference(tmp_path: Path) 
     payload["cases"][0]["id"] = _token("case", 999)
     manifest_path.write_text(json.dumps(payload), encoding="utf-8")
 
-    report = evaluate_manifest(
-        load_manifest(manifest_path),
-        _Predictor(_passing_probabilities(cases)),
-        criteria=criteria,
-    )
+    class _MustNotPredict:
+        def predict_probability(self, audio: np.ndarray) -> float:
+            del audio
+            raise AssertionError("mismatched frozen evidence must not run inference")
 
-    assert report["gate"]["outcome"] == "blocked"
-    binding_check = next(
-        check
-        for check in report["gate"]["checks"]
-        if check["check"] == "manifest_binding"
-    )
-    assert binding_check["status"] == "blocked"
+    with pytest.raises(ValueError, match="pre-registered criteria"):
+        evaluate_manifest(
+            load_manifest(manifest_path),
+            _MustNotPredict(),
+            criteria=criteria,
+        )
 
 
 def test_criteria_threshold_must_match_the_deployed_smart_turn_config(

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -819,6 +819,58 @@ def test_cli_rejects_threshold_with_registered_criteria(
     assert "--threshold cannot be combined with --criteria" in capsys.readouterr().err
 
 
+def test_cli_rejects_nonproduction_model_before_registered_inference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cases = _multilingual_holdout_cases()
+    manifest_path = _manifest(tmp_path / "evidence", cases)
+    criteria_path = _criteria(manifest_path.parent, manifest_path)
+    asset_dir = tmp_path / "alternate-assets"
+    asset_dir.mkdir()
+    alternate_model = b"self-consistent alternate model"
+    (asset_dir / "smart_turn_v3.onnx").write_bytes(alternate_model)
+    (asset_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "assets": [
+                    {
+                        "filename": "smart_turn_v3.onnx",
+                        "sha256": hashlib.sha256(alternate_model).hexdigest(),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _MustNotLoad:
+        def __init__(self, **kwargs):
+            del kwargs
+            raise AssertionError("registered digest mismatch must fail before load")
+
+    monkeypatch.setattr("scripts.evaluate_smart_turn_v3.SmartTurnV3", _MustNotLoad)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "--manifest",
+                str(manifest_path),
+                "--criteria",
+                str(criteria_path),
+                "--asset-dir",
+                str(asset_dir),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    error = capsys.readouterr().err
+    assert (
+        "registered evaluation requires the deployed SmartTurn model SHA-256" in error
+    )
+    assert hashlib.sha256(alternate_model).hexdigest() in error
+
+
 def test_cli_preserves_report_but_returns_nonzero_when_registered_gate_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -3,13 +3,14 @@ import json
 import math
 import os
 import wave
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 import numpy as np
 import pytest
 
-import scripts.evaluate_smart_turn_v3 as evaluation_tool
 from scripts.evaluate_smart_turn_v3 import (
+    _runtime_provenance,
     evaluate_cases,
     evaluate_manifest,
     load_acceptance_criteria,
@@ -629,8 +630,8 @@ def test_runtime_provenance_marks_dirty_checkout_and_library_versions(
             return _Completed("abc123\n")
         return _Completed(" M scripts/evaluate_smart_turn_v3.py\n")
 
-    monkeypatch.setattr(evaluation_tool.subprocess, "run", fake_run)
-    provenance = evaluation_tool._runtime_provenance(tmp_path)
+    monkeypatch.setattr("scripts.evaluate_smart_turn_v3.subprocess.run", fake_run)
+    provenance = _runtime_provenance(tmp_path)
 
     assert provenance["git_revision"] == "abc123-dirty"
     assert provenance["runtime"]["numpy"] == np.__version__
@@ -662,11 +663,13 @@ def test_runtime_provenance_resolves_onnx_distribution_variants(
     def fake_version(distribution: str) -> str:
         if distribution == available_distribution:
             return versions[distribution]
-        raise evaluation_tool.importlib.metadata.PackageNotFoundError(distribution)
+        raise PackageNotFoundError(distribution)
 
-    monkeypatch.setattr(evaluation_tool.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        "scripts.evaluate_smart_turn_v3.importlib.metadata.version", fake_version
+    )
 
-    provenance = evaluation_tool._runtime_provenance(tmp_path)
+    provenance = _runtime_provenance(tmp_path)
 
     assert provenance["runtime"]["onnxruntime"] == expected_version
 

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -17,6 +17,7 @@ from scripts.evaluate_smart_turn_v3 import (
     load_cases,
     load_manifest,
     main,
+    read_pcm16_wav,
     render_markdown_report,
 )
 
@@ -308,6 +309,24 @@ def test_manifest_rejects_truncated_pcm_that_claims_a_longer_duration(
 
     with pytest.raises(ValueError, match="truncated|PCM|frames"):
         load_manifest(manifest_path)
+
+
+def test_oversized_wav_is_rejected_before_full_file_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audio_path = tmp_path / "oversized.wav"
+    _wav(audio_path, np.zeros(9 * 16_000, dtype="<i2"))
+    real_read_bytes = Path.read_bytes
+
+    def reject_full_read(path: Path) -> bytes:
+        if path == audio_path:
+            raise AssertionError("oversized WAV payload must not be loaded")
+        return real_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", reject_full_read)
+
+    with pytest.raises(ValueError, match="exceeds the SmartTurn 8 second"):
+        read_pcm16_wav(audio_path)
 
 
 @pytest.mark.parametrize("pause_ms", [299, 900])
@@ -671,6 +690,23 @@ def test_runtime_provenance_marks_dirty_checkout_and_library_versions(
     assert provenance["runtime"]["numpy"] == np.__version__
     assert provenance["runtime"]["onnxruntime"]
     assert provenance["evaluator_sha256"]
+
+
+def test_runtime_provenance_does_not_claim_clean_when_git_status_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Completed:
+        stdout = "abc123\n"
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        if command[1] == "rev-parse":
+            return _Completed()
+        raise TimeoutError("git status timed out")
+
+    monkeypatch.setattr("scripts.evaluate_smart_turn_v3.subprocess.run", fake_run)
+
+    assert _runtime_provenance(tmp_path)["git_revision"] == "unknown"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -640,6 +640,39 @@ def test_runtime_provenance_marks_dirty_checkout_and_library_versions(
     assert provenance["evaluator_sha256"]
 
 
+@pytest.mark.parametrize(
+    ("available_distribution", "expected_version"),
+    [
+        ("onnxruntime", "1.20.0"),
+        ("onnxruntime-gpu", "1.20.1"),
+        ("onnxruntime-directml", "1.20.2"),
+        (None, "unknown"),
+    ],
+)
+def test_runtime_provenance_resolves_onnx_distribution_variants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    available_distribution: str | None,
+    expected_version: str,
+) -> None:
+    versions = {
+        "onnxruntime": "1.20.0",
+        "onnxruntime-gpu": "1.20.1",
+        "onnxruntime-directml": "1.20.2",
+    }
+
+    def fake_version(distribution: str) -> str:
+        if distribution == available_distribution:
+            return versions[distribution]
+        raise evaluation_tool.importlib.metadata.PackageNotFoundError(distribution)
+
+    monkeypatch.setattr(evaluation_tool.importlib.metadata, "version", fake_version)
+
+    provenance = evaluation_tool._runtime_provenance(tmp_path)
+
+    assert provenance["runtime"]["onnxruntime"] == expected_version
+
+
 def test_manifest_and_criteria_hash_the_same_bytes_that_were_parsed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -767,6 +800,25 @@ def test_cli_emits_canonical_evidence_digests_without_loading_the_model(
         "speaker_count": 1,
         "speaker_roster_sha256": _roster_sha256(_token("speaker", 1)),
     }
+
+
+def test_cli_rejects_threshold_with_registered_criteria(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "--manifest",
+                "manifest.json",
+                "--criteria",
+                "criteria.json",
+                "--threshold",
+                "0.7",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert "--threshold cannot be combined with --criteria" in capsys.readouterr().err
 
 
 def test_cli_preserves_report_but_returns_nonzero_when_registered_gate_fails(

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -272,6 +272,26 @@ def test_evaluation_rejects_audio_replaced_after_manifest_validation(
         evaluate_manifest(manifest, _Predictor([0.9]))
 
 
+def test_evaluation_preflights_every_wav_before_first_prediction(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(_manifest(tmp_path, [_case(0), _case(1)]))
+    _wav(manifest.cases[1].path, marker=999)
+    prediction_calls = 0
+
+    class _MustNotPredict:
+        def predict_probability(self, audio: np.ndarray) -> float:
+            nonlocal prediction_calls
+            prediction_calls += 1
+            del audio
+            return 0.9
+
+    with pytest.raises(ValueError, match="changed|hash|digest"):
+        evaluate_manifest(manifest, _MustNotPredict())
+
+    assert prediction_calls == 0
+
+
 def test_manifest_rejects_truncated_pcm_that_claims_a_longer_duration(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -32,6 +32,20 @@ SCENARIO_MATRIX = {
 }
 
 
+@pytest.mark.parametrize("loader", [load_manifest, load_acceptance_criteria])
+def test_frozen_json_rejects_duplicate_keys_at_any_depth(
+    tmp_path: Path, loader
+) -> None:
+    snapshot_path = tmp_path / "frozen.json"
+    snapshot_path.write_text(
+        '{"nested":{"expected":"complete","expected":"incomplete"}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate JSON key is not allowed: expected"):
+        loader(snapshot_path)
+
+
 def _token(prefix: str, number: int) -> str:
     return f"{prefix}-{number:032x}"
 

--- a/tests/unit/asr_client/endpointing/test_evaluation_tool.py
+++ b/tests/unit/asr_client/endpointing/test_evaluation_tool.py
@@ -1,13 +1,50 @@
+import hashlib
 import json
+import math
+import os
 import wave
+from pathlib import Path
 
 import numpy as np
 import pytest
 
-from scripts.evaluate_smart_turn_v3 import evaluate_cases, load_cases
+import scripts.evaluate_smart_turn_v3 as evaluation_tool
+from scripts.evaluate_smart_turn_v3 import (
+    evaluate_cases,
+    evaluate_manifest,
+    load_acceptance_criteria,
+    load_cases,
+    load_manifest,
+    main,
+    render_markdown_report,
+)
 
 
-def _wav(path, samples):
+LANGUAGES = ("zh-CN", "en-US", "ja-JP")
+SCENARIO_MATRIX = {
+    "terminal_end": {"complete": 1, "incomplete": 0},
+    "sentence_internal_pause": {"complete": 0, "incomplete": 1},
+    "hesitation_continue": {"complete": 0, "incomplete": 1},
+    "long_pause_continue": {"complete": 0, "incomplete": 1},
+    "keyboard_noise": {"complete": 1, "incomplete": 1},
+    "barge_in": {"complete": 1, "incomplete": 1},
+}
+
+
+def _token(prefix: str, number: int) -> str:
+    return f"{prefix}-{number:032x}"
+
+
+def _roster_sha256(*speaker_ids: str) -> str:
+    encoded = json.dumps(sorted(speaker_ids), separators=(",", ":")).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _wav(path: Path, samples=None, *, marker: int = 1) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if samples is None:
+        samples = np.zeros(16_000, dtype="<i2")
+        samples[0] = marker
     with wave.open(str(path), "wb") as wav_file:
         wav_file.setnchannels(1)
         wav_file.setsampwidth(2)
@@ -15,35 +52,813 @@ def _wav(path, samples):
         wav_file.writeframes(np.asarray(samples, dtype="<i2").tobytes())
 
 
+def _case(
+    index: int,
+    *,
+    language: str = "zh-CN",
+    expected: str = "complete",
+    scenario: str = "terminal_end",
+    split: str = "holdout",
+    speaker: str | None = None,
+    source_group: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": _token("case", index + 1),
+        "path": f"recordings/audio-{index:03d}.wav",
+        "audio_sha256": "0" * 64,
+        "expected": expected,
+        "language": language,
+        "scenario": scenario,
+        "source_group": source_group or _token("source", index + 1),
+        "speaker_id": speaker or _token("speaker", index + 1),
+        "session_id": _token("session", index + 1),
+        "device_id": _token("device", index % 2 + 1),
+        "capture_surface": "electron",
+        "capture_route_context": "dummy",
+        "split": split,
+        "pause_ms": 320,
+    }
+
+
+def _manifest(
+    tmp_path: Path, cases: list[dict[str, object]], *, create_audio: bool = True
+) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    for index, case in enumerate(cases, 1):
+        relative = Path(str(case["path"]))
+        if create_audio and not relative.is_absolute() and ".." not in relative.parts:
+            audio_path = tmp_path / relative
+            _wav(audio_path, marker=index)
+            case["audio_sha256"] = hashlib.sha256(audio_path.read_bytes()).hexdigest()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "dataset_id": _token("dataset", 1),
+                "cases": cases,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _criteria(tmp_path: Path, manifest_path: Path | None = None) -> Path:
+    language_criteria = {
+        language: {
+            "speaker_count": 1,
+            "speaker_roster_sha256": _roster_sha256(_token("speaker", language_index)),
+            "min_devices": 1,
+            "speaker_scenario_matrix": SCENARIO_MATRIX,
+            "max_speakers_with_any_premature_split": 0,
+            "max_speakers_with_any_missed_endpoint": 0,
+            "max_speaker_premature_split_rate_upper_bound": 0.95,
+            "max_speaker_missed_endpoint_rate_upper_bound": 0.95,
+        }
+        for language_index, language in enumerate(LANGUAGES, 1)
+    }
+    path = tmp_path / "criteria.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "criteria_id": _token("criteria", 1),
+                "manifest_sha256": (
+                    hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+                    if manifest_path is not None
+                    else "0" * 64
+                ),
+                "decision_threshold": 0.5,
+                "confidence_level": 0.95,
+                "confidence_method": "wilson",
+                "holdout": {"languages": language_criteria},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 class _Predictor:
-    def __init__(self, probabilities):
+    def __init__(self, probabilities: list[float]):
         self.probabilities = iter(probabilities)
 
-    def predict_probability(self, audio):
+    def predict_probability(self, audio: np.ndarray) -> float:
         return next(self.probabilities)
 
 
-def test_evaluation_reports_all_four_confusion_cells(tmp_path):
-    labels = []
-    for index, expected in enumerate(("complete", "complete", "incomplete", "incomplete")):
-        name = f"case-{index}.wav"
-        _wav(tmp_path / name, [index])
-        labels.append(json.dumps({"path": name, "expected": expected, "language": "zh"}))
-    labels_path = tmp_path / "labels.jsonl"
-    labels_path.write_text("\n".join(labels), encoding="utf-8")
-    report = evaluate_cases(
-        load_cases(tmp_path, labels_path), _Predictor([0.9, 0.1, 0.9, 0.1])
-    )
-    assert report["confusion_matrix"] == {
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda payload: payload.update(schema_version=2), "schema_version"),
+        (lambda payload: payload.update(schema_version=True), "schema_version"),
+        (
+            lambda payload: payload["cases"][1].update(id=_token("case", 1)),
+            "unique",
+        ),
+        (
+            lambda payload: payload["cases"][0].update(
+                speaker_id="speaker-alex-private-recording"
+            ),
+            "opaque",
+        ),
+        (lambda payload: payload["cases"][0].update(language="fr-FR"), "language"),
+        (lambda payload: payload["cases"][0].update(language=["zh-CN"]), "language"),
+        (
+            lambda payload: payload["cases"][0].update(transcript="private words"),
+            "unknown",
+        ),
+    ],
+)
+def test_manifest_requires_versioned_anonymous_multilingual_metadata_and_unique_ids(
+    tmp_path: Path, mutation, message: str
+) -> None:
+    manifest_path = _manifest(tmp_path, [_case(0), _case(1)])
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    mutation(payload)
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_manifest(manifest_path)
+
+
+@pytest.mark.parametrize("bad_path", ["../outside.wav", "missing.wav"])
+def test_manifest_rejects_traversal_and_missing_audio(
+    tmp_path: Path, bad_path: str
+) -> None:
+    case = _case(0)
+    case["path"] = bad_path
+    with pytest.raises(ValueError, match="path|exist"):
+        load_manifest(_manifest(tmp_path, [case], create_audio=False))
+
+
+def test_manifest_rejects_absolute_and_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.wav"
+    _wav(outside)
+    absolute_case = _case(0)
+    absolute_case["path"] = str(outside.resolve())
+    with pytest.raises(ValueError, match="relative"):
+        load_manifest(_manifest(tmp_path, [absolute_case]))
+
+    link = tmp_path / "recordings" / "linked.wav"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.symlink(outside, link)
+    except OSError:
+        pytest.skip("creating a symlink requires Windows Developer Mode or elevation")
+    linked_case = _case(1)
+    linked_case["path"] = "recordings/linked.wav"
+    with pytest.raises(ValueError, match="escapes"):
+        load_manifest(_manifest(tmp_path, [linked_case]))
+
+
+@pytest.mark.parametrize("leaked_field", ["speaker_id", "source_group"])
+def test_manifest_rejects_calibration_holdout_identity_leakage(
+    tmp_path: Path, leaked_field: str
+) -> None:
+    calibration = _case(0, split="calibration")
+    holdout = _case(1, split="holdout")
+    holdout[leaked_field] = calibration[leaked_field]
+    with pytest.raises(ValueError, match="split"):
+        load_manifest(_manifest(tmp_path, [calibration, holdout]))
+
+
+def test_manifest_binds_audio_content_and_rejects_exact_pcm_duplicates(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _manifest(tmp_path, [_case(0), _case(1)])
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["cases"][0]["audio_sha256"] = "f" * 64
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="audio_sha256"):
+        load_manifest(manifest_path)
+
+    manifest_path = _manifest(tmp_path / "duplicate", [_case(2), _case(3)])
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    first = manifest_path.parent / str(payload["cases"][0]["path"])
+    second = manifest_path.parent / str(payload["cases"][1]["path"])
+    second.write_bytes(first.read_bytes())
+    payload["cases"][1]["audio_sha256"] = hashlib.sha256(
+        second.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate PCM"):
+        load_manifest(manifest_path)
+
+
+def test_evaluation_rejects_audio_replaced_after_manifest_validation(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(_manifest(tmp_path, [_case(0)]))
+    _wav(manifest.cases[0].path, marker=999)
+
+    with pytest.raises(ValueError, match="changed|hash|digest"):
+        evaluate_manifest(manifest, _Predictor([0.9]))
+
+
+def test_manifest_rejects_truncated_pcm_that_claims_a_longer_duration(
+    tmp_path: Path,
+) -> None:
+    case = _case(0)
+    case["pause_ms"] = 800
+    manifest_path = _manifest(tmp_path, [case])
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    audio_path = manifest_path.parent / str(payload["cases"][0]["path"])
+    audio_path.write_bytes(audio_path.read_bytes()[:-22_000])
+    payload["cases"][0]["audio_sha256"] = hashlib.sha256(
+        audio_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="truncated|PCM|frames"):
+        load_manifest(manifest_path)
+
+
+@pytest.mark.parametrize("pause_ms", [299, 900])
+def test_manifest_rejects_pause_that_cannot_represent_a_production_candidate(
+    tmp_path: Path, pause_ms: int
+) -> None:
+    case = _case(0)
+    case["pause_ms"] = pause_ms
+    with pytest.raises(ValueError, match="pause_ms|duration"):
+        load_manifest(_manifest(tmp_path, [case]))
+
+
+def test_metrics_are_grouped_and_report_redacts_private_identifiers(
+    tmp_path: Path,
+) -> None:
+    cases = [
+        _case(0, language="zh-CN", expected="complete", scenario="terminal_end"),
+        _case(1, language="zh-CN", expected="complete", scenario="terminal_end"),
+        _case(
+            2,
+            language="en-US",
+            expected="incomplete",
+            scenario="sentence_internal_pause",
+        ),
+        _case(
+            3,
+            language="en-US",
+            expected="incomplete",
+            scenario="sentence_internal_pause",
+        ),
+    ]
+    manifest = load_manifest(_manifest(tmp_path, cases))
+    report = evaluate_manifest(manifest, _Predictor([0.9, 0.1, 0.9, 0.1]))
+
+    overall = report["metrics"]["holdout"]["overall"]
+    assert overall["confusion_matrix"] == {
         "true_complete": 1,
         "false_incomplete": 1,
         "false_complete": 1,
         "true_incomplete": 1,
     }
+    assert overall["descriptive_case_complete_recall"] == 0.5
+    assert overall["descriptive_case_continuation_specificity"] == 0.5
+    assert overall["descriptive_case_premature_split_rate"] == 0.5
+    assert overall["descriptive_case_missed_endpoint_rate"] == 0.5
+    assert "zh-CN|terminal_end" in report["metrics"]["holdout"]["by_language_scenario"]
+    assert (
+        "en-US|sentence_internal_pause"
+        in report["metrics"]["holdout"]["by_language_scenario"]
+    )
+    assert report["latency_ms"]["holdout"]["case_count"] == 4
+    assert report["latency_ms"]["calibration"]["case_count"] == 0
+    assert report["latency_ms"]["holdout"]["cold_case_count"] == 1
+
+    rendered = json.dumps(report, ensure_ascii=False)
+    assert report["dataset"]["audio_corpus_sha256"]
+    for case in cases:
+        assert Path(str(case["path"])).name not in rendered
+        assert str(case["speaker_id"]) not in rendered
+        assert str(case["session_id"]) not in rendered
+        assert str(case["device_id"]) not in rendered
 
 
-def test_labels_cannot_escape_fixture_directory(tmp_path):
+def test_zero_denominator_is_null_and_without_criteria_never_passes(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(_manifest(tmp_path, [_case(0, expected="complete")]))
+    report = evaluate_manifest(manifest, _Predictor([0.9]))
+
+    overall = report["metrics"]["holdout"]["overall"]
+    assert overall["descriptive_case_premature_split_rate"] is None
+    assert "premature_split_rate_interval" not in overall
+    assert report["gate"] == {
+        "scope": "model_checkpoint",
+        "outcome": "exploratory",
+        "checks": [],
+    }
+    assert report["product_quality_approval"]["status"] == "blocked"
+
+
+def _multilingual_holdout_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    index = 0
+    for language_index, language in enumerate(LANGUAGES, 1):
+        speaker = _token("speaker", language_index)
+        for scenario, expected_counts in SCENARIO_MATRIX.items():
+            for expected, count in expected_counts.items():
+                for _ in range(count):
+                    cases.append(
+                        _case(
+                            index,
+                            language=language,
+                            expected=expected,
+                            scenario=scenario,
+                            speaker=speaker,
+                        )
+                    )
+                    index += 1
+    return cases
+
+
+def _passing_probabilities(cases: list[dict[str, object]]) -> list[float]:
+    return [0.9 if case["expected"] == "complete" else 0.1 for case in cases]
+
+
+def test_gate_uses_holdout_and_cannot_grant_product_approval(tmp_path: Path) -> None:
+    holdout_cases = _multilingual_holdout_cases()
+    cases = [
+        _case(
+            90,
+            split="calibration",
+            expected="incomplete",
+            scenario="sentence_internal_pause",
+        ),
+        *holdout_cases,
+    ]
+    manifest_path = _manifest(tmp_path, cases)
+    manifest = load_manifest(manifest_path)
+    criteria = load_acceptance_criteria(_criteria(tmp_path, manifest_path))
+    report = evaluate_manifest(
+        manifest,
+        _Predictor([0.99, *_passing_probabilities(holdout_cases)]),
+        criteria=criteria,
+    )
+
+    assert report["metrics"]["calibration"]["overall"]["false_complete"] == 1
+    assert report["gate"]["outcome"] == "pass"
+    assert report["product_quality_approval"] == {
+        "status": "blocked",
+        "reasons": ["electron_live_route_evidence_missing"],
+    }
+
+
+def test_missing_language_blocks_gate_and_metric_failure_fails_gate(
+    tmp_path: Path,
+) -> None:
+    missing_ja = _multilingual_holdout_cases()[:-2]
+    missing_ja = [case for case in missing_ja if case["language"] != "ja-JP"]
+    blocked_manifest_path = _manifest(tmp_path / "blocked", missing_ja)
+    blocked = evaluate_manifest(
+        load_manifest(blocked_manifest_path),
+        _Predictor(_passing_probabilities(missing_ja)),
+        criteria=load_acceptance_criteria(
+            _criteria(blocked_manifest_path.parent, blocked_manifest_path)
+        ),
+    )
+    assert blocked["gate"]["outcome"] == "blocked"
+
+    all_cases = _multilingual_holdout_cases()
+    probabilities = _passing_probabilities(all_cases)
+    first_incomplete = next(
+        index
+        for index, case in enumerate(all_cases)
+        if case["expected"] == "incomplete"
+    )
+    probabilities[first_incomplete] = 0.9
+    failed_manifest_path = _manifest(tmp_path / "failed", all_cases)
+    failed = evaluate_manifest(
+        load_manifest(failed_manifest_path),
+        _Predictor(probabilities),
+        criteria=load_acceptance_criteria(
+            _criteria(failed_manifest_path.parent, failed_manifest_path)
+        ),
+    )
+    assert failed["gate"]["outcome"] == "fail"
+    zh_metrics = failed["gate"]["speaker_metrics"]["zh-CN"]
+    assert zh_metrics["speakers_with_any_premature_split"] == 1
+    assert zh_metrics["speaker_premature_split_rate"] == 1.0
+
+
+def test_gate_blocks_speaker_without_the_preregistered_fixed_opportunity_matrix(
+    tmp_path: Path,
+) -> None:
+    cases = _multilingual_holdout_cases()
+    extra = _case(
+        100,
+        language="zh-CN",
+        expected="incomplete",
+        scenario="keyboard_noise",
+        speaker=_token("speaker", 1),
+    )
+    cases.append(extra)
+    manifest_path = _manifest(tmp_path, cases)
+    report = evaluate_manifest(
+        load_manifest(manifest_path),
+        _Predictor(_passing_probabilities(cases)),
+        criteria=load_acceptance_criteria(_criteria(tmp_path, manifest_path)),
+    )
+
+    assert report["gate"]["outcome"] == "blocked"
+    matrix_check = next(
+        check
+        for check in report["gate"]["checks"]
+        if check["language"] == "zh-CN"
+        and check["check"] == "speaker_matrix_compliance"
+    )
+    assert matrix_check["status"] == "blocked"
+
+
+def test_gate_blocks_a_post_registered_speaker_roster_swap(tmp_path: Path) -> None:
+    cases = _multilingual_holdout_cases()
+    for case in cases:
+        if case["language"] == "zh-CN":
+            case["speaker_id"] = _token("speaker", 99)
+    manifest_path = _manifest(tmp_path, cases)
+    report = evaluate_manifest(
+        load_manifest(manifest_path),
+        _Predictor(_passing_probabilities(cases)),
+        criteria=load_acceptance_criteria(_criteria(tmp_path, manifest_path)),
+    )
+
+    assert report["gate"]["outcome"] == "blocked"
+    roster_check = next(
+        check
+        for check in report["gate"]["checks"]
+        if check["language"] == "zh-CN"
+        and check["check"] == "speaker_roster_compliance"
+    )
+    assert roster_check["status"] == "blocked"
+
+
+def test_gate_binds_the_entire_frozen_manifest_before_inference(tmp_path: Path) -> None:
+    cases = _multilingual_holdout_cases()
+    manifest_path = _manifest(tmp_path, cases)
+    criteria = load_acceptance_criteria(_criteria(tmp_path, manifest_path))
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["cases"][0]["id"] = _token("case", 999)
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = evaluate_manifest(
+        load_manifest(manifest_path),
+        _Predictor(_passing_probabilities(cases)),
+        criteria=criteria,
+    )
+
+    assert report["gate"]["outcome"] == "blocked"
+    binding_check = next(
+        check
+        for check in report["gate"]["checks"]
+        if check["check"] == "manifest_binding"
+    )
+    assert binding_check["status"] == "blocked"
+
+
+def test_criteria_threshold_must_match_the_deployed_smart_turn_config(
+    tmp_path: Path,
+) -> None:
+    criteria_path = _criteria(tmp_path)
+    payload = json.loads(criteria_path.read_text(encoding="utf-8"))
+    payload["decision_threshold"] = 0.99
+    criteria_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="production|deployed"):
+        load_acceptance_criteria(criteria_path)
+
+
+@pytest.mark.parametrize("probability", [math.nan, math.inf, -0.1, 1.1])
+def test_invalid_probability_cannot_produce_nonstandard_json_or_pass(
+    tmp_path: Path, probability: float
+) -> None:
+    manifest = load_manifest(_manifest(tmp_path, [_case(0)]))
+    with pytest.raises(ValueError, match="probability"):
+        evaluate_manifest(manifest, _Predictor([probability]))
+
+
+def test_report_records_manifest_criteria_model_revision_and_runtime_provenance(
+    tmp_path: Path,
+) -> None:
+    cases = _multilingual_holdout_cases()
+    manifest_path = _manifest(tmp_path, cases)
+    manifest = load_manifest(manifest_path)
+    criteria = load_acceptance_criteria(_criteria(tmp_path, manifest_path))
+    report = evaluate_manifest(
+        manifest,
+        _Predictor(_passing_probabilities(cases)),
+        criteria=criteria,
+        provenance={
+            "git_revision": "abc123",
+            "model": {"version": "v3.2", "sha256": "model-sha"},
+            "runtime": {"platform": "test", "python": "3.11-test"},
+        },
+    )
+
+    assert report["provenance"]["manifest_sha256"] == manifest.sha256
+    assert report["provenance"]["criteria_sha256"] == criteria.sha256
+    assert report["provenance"]["git_revision"] == "abc123"
+    assert report["provenance"]["model"]["sha256"] == "model-sha"
+    assert report["provenance"]["runtime"]["python"] == "3.11-test"
+
+    markdown = render_markdown_report(report)
+    assert "Checkpoint gate: **PASS**" in markdown
+    assert "Product quality approval: **BLOCKED**" in markdown
+    assert "zh-CN" in markdown and "en-US" in markdown and "ja-JP" in markdown
+
+
+def test_legacy_jsonl_remains_exploratory_and_redacts_filenames(tmp_path: Path) -> None:
+    _wav(tmp_path / "private-speaker-name.wav")
     labels = tmp_path / "labels.jsonl"
-    labels.write_text(json.dumps({"path": "../outside.wav", "expected": "complete"}))
+    labels.write_text(
+        json.dumps(
+            {
+                "path": "private-speaker-name.wav",
+                "expected": "complete",
+                "language": "zh",
+                "category": "legacy",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = evaluate_cases(load_cases(tmp_path, labels), _Predictor([0.9]))
+
+    assert report["scope"] == "smart_turn_legacy_unversioned_checkpoint_replay"
+    assert report["gate"]["outcome"] == "exploratory"
+    assert "private-speaker-name.wav" not in json.dumps(report)
+
+
+def test_legacy_jsonl_rejects_path_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.wav"
+    _wav(outside)
+    labels = tmp_path / "labels.jsonl"
+    labels.write_text(
+        json.dumps({"path": f"../{outside.name}", "expected": "complete"}),
+        encoding="utf-8",
+    )
     with pytest.raises(ValueError, match="escapes"):
         load_cases(tmp_path, labels)
+
+
+def test_legacy_jsonl_preserves_trailing_window_compatibility_for_long_wav(
+    tmp_path: Path,
+) -> None:
+    _wav(tmp_path / "long.wav", np.zeros(9 * 16_000, dtype="<i2"))
+    labels = tmp_path / "labels.jsonl"
+    labels.write_text(
+        json.dumps({"path": "long.wav", "expected": "complete"}), encoding="utf-8"
+    )
+
+    report = evaluate_cases(load_cases(tmp_path, labels), _Predictor([0.9]))
+
+    assert report["case_count"] == 1
+    assert report["dataset"]["speaker_count"] is None
+    assert report["dataset"]["device_count"] is None
+
+
+def test_runtime_provenance_marks_dirty_checkout_and_library_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Completed:
+        def __init__(self, stdout: str):
+            self.stdout = stdout
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        if command[1] == "rev-parse":
+            return _Completed("abc123\n")
+        return _Completed(" M scripts/evaluate_smart_turn_v3.py\n")
+
+    monkeypatch.setattr(evaluation_tool.subprocess, "run", fake_run)
+    provenance = evaluation_tool._runtime_provenance(tmp_path)
+
+    assert provenance["git_revision"] == "abc123-dirty"
+    assert provenance["runtime"]["numpy"] == np.__version__
+    assert provenance["runtime"]["onnxruntime"]
+    assert provenance["evaluator_sha256"]
+
+
+def test_manifest_and_criteria_hash_the_same_bytes_that_were_parsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _manifest(tmp_path, [_case(0)])
+    criteria_path = _criteria(tmp_path, manifest_path)
+    originals = {
+        manifest_path.resolve(): manifest_path.read_bytes(),
+        criteria_path.resolve(): criteria_path.read_bytes(),
+    }
+    real_read_bytes = Path.read_bytes
+    replaced: set[Path] = set()
+
+    def read_then_replace(path: Path) -> bytes:
+        encoded = real_read_bytes(path)
+        resolved = path.resolve()
+        if resolved in originals and resolved not in replaced:
+            path.write_bytes(b"{}")
+            replaced.add(resolved)
+        return encoded
+
+    monkeypatch.setattr(Path, "read_bytes", read_then_replace)
+
+    manifest = load_manifest(manifest_path)
+    criteria = load_acceptance_criteria(criteria_path)
+
+    assert manifest_path.read_bytes() == b"{}"
+    assert criteria_path.read_bytes() == b"{}"
+    assert (
+        manifest.sha256
+        == hashlib.sha256(originals[manifest_path.resolve()]).hexdigest()
+    )
+    assert (
+        criteria.sha256
+        == hashlib.sha256(originals[criteria_path.resolve()]).hexdigest()
+    )
+
+
+def test_cli_writes_redacted_json_and_markdown_reports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest_path = _manifest(tmp_path, [_case(0)])
+    json_output = tmp_path / "reports" / "report.json"
+    markdown_output = tmp_path / "reports" / "report.md"
+
+    class _Runtime:
+        def __init__(self, **kwargs):
+            self.unavailable_reason = None
+
+        def load(self) -> bool:
+            return True
+
+        def predict_probability(self, audio: np.ndarray) -> float:
+            return 0.9
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("scripts.evaluate_smart_turn_v3.SmartTurnV3", _Runtime)
+    monkeypatch.setattr(
+        "scripts.evaluate_smart_turn_v3._runtime_provenance",
+        lambda _asset_dir: {
+            "git_revision": "test-revision",
+            "model": {"version": "test", "sha256": "test-sha"},
+            "runtime": {"platform": "test", "python": "3.11"},
+        },
+    )
+
+    assert (
+        main(
+            [
+                "--manifest",
+                str(manifest_path),
+                "--output",
+                str(json_output),
+                "--markdown-output",
+                str(markdown_output),
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(json_output.read_text(encoding="utf-8"))
+    assert report["scope"] == "smart_turn_model_checkpoint_replay"
+    assert report["provenance"]["git_revision"] == "test-revision"
+    assert "private" not in json_output.read_text(encoding="utf-8")
+    assert "Product quality approval: **BLOCKED**" in markdown_output.read_text(
+        encoding="utf-8"
+    )
+    assert json.loads(capsys.readouterr().out)["case_count"] == 1
+
+
+def test_cli_emits_canonical_evidence_digests_without_loading_the_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cases = _multilingual_holdout_cases()
+    manifest_path = _manifest(tmp_path, cases)
+    output = tmp_path / "evidence-digests.json"
+
+    class _MustNotLoad:
+        def __init__(self, **kwargs):
+            del kwargs
+            raise AssertionError("evidence digest mode must not load the model")
+
+    monkeypatch.setattr("scripts.evaluate_smart_turn_v3.SmartTurnV3", _MustNotLoad)
+
+    assert (
+        main(
+            [
+                "--manifest",
+                str(manifest_path),
+                "--evidence-digest-output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(output.read_text(encoding="utf-8"))
+    assert summary == json.loads(capsys.readouterr().out)
+    assert (
+        summary["manifest_sha256"]
+        == hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    )
+    assert summary["languages"]["zh-CN"] == {
+        "speaker_count": 1,
+        "speaker_roster_sha256": _roster_sha256(_token("speaker", 1)),
+    }
+
+
+def test_cli_preserves_report_but_returns_nonzero_when_registered_gate_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cases = _multilingual_holdout_cases()
+    manifest_path = _manifest(tmp_path, cases)
+    criteria_path = _criteria(tmp_path, manifest_path)
+    output = tmp_path / "failed-report.json"
+
+    class _AlwaysCompleteRuntime:
+        unavailable_reason = None
+
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def load(self) -> bool:
+            return True
+
+        def predict_probability(self, audio: np.ndarray) -> float:
+            return 0.9
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "scripts.evaluate_smart_turn_v3.SmartTurnV3", _AlwaysCompleteRuntime
+    )
+    monkeypatch.setattr(
+        "scripts.evaluate_smart_turn_v3._runtime_provenance", lambda _asset_dir: {}
+    )
+
+    exit_code = main(
+        [
+            "--manifest",
+            str(manifest_path),
+            "--criteria",
+            str(criteria_path),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code != 0
+    assert json.loads(output.read_text(encoding="utf-8"))["gate"]["outcome"] == "fail"
+    assert json.loads(capsys.readouterr().out)["gate"]["outcome"] == "fail"
+
+
+def test_cli_preserves_report_but_returns_nonzero_when_evidence_is_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cases = [
+        case for case in _multilingual_holdout_cases() if case["language"] != "ja-JP"
+    ]
+    manifest_path = _manifest(tmp_path, cases)
+    criteria_path = _criteria(tmp_path, manifest_path)
+    output = tmp_path / "blocked-report.json"
+
+    class _Runtime:
+        unavailable_reason = None
+
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def load(self) -> bool:
+            return True
+
+        def predict_probability(self, audio: np.ndarray) -> float:
+            del audio
+            return 0.9
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("scripts.evaluate_smart_turn_v3.SmartTurnV3", _Runtime)
+    monkeypatch.setattr(
+        "scripts.evaluate_smart_turn_v3._runtime_provenance", lambda _asset_dir: {}
+    )
+
+    exit_code = main(
+        [
+            "--manifest",
+            str(manifest_path),
+            "--criteria",
+            str(criteria_path),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 2
+    assert (
+        json.loads(output.read_text(encoding="utf-8"))["gate"]["outcome"] == "blocked"
+    )
+    assert json.loads(capsys.readouterr().out)["gate"]["outcome"] == "blocked"

--- a/tests/unit/asr_client/endpointing/test_runtime_diagnostics.py
+++ b/tests/unit/asr_client/endpointing/test_runtime_diagnostics.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from main_logic.asr_client.endpointing import detector_runtime
+from main_logic.asr_client.endpointing.config import SmartTurnConfig
+from main_logic.asr_client.endpointing.coordinator import TurnCoordinator
+from main_logic.asr_client.endpointing.smart_turn_diagnostics import (
+    SMART_TURN_DIAGNOSTICS_ENABLED_ENV,
+    SMART_TURN_DIAGNOSTICS_PATH_ENV,
+    create_smart_turn_runtime_diagnostics,
+)
+from main_logic.voice_turn.contracts import (
+    EvaluationStatus,
+    TurnDecision,
+    TurnEvaluation,
+)
+
+
+class _RecordingDiagnostics:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+        self.closed = False
+
+    def candidate(self, *, reason: str) -> None:
+        self.events.append(("candidate", {"reason": reason}))
+
+    def evaluation(
+        self,
+        *,
+        reason: str,
+        outcome: str,
+        evaluation_ms: int,
+        probability: float | None,
+        threshold: float | None,
+    ) -> None:
+        self.events.append(
+            (
+                "evaluation",
+                {
+                    "reason": reason,
+                    "outcome": outcome,
+                    "evaluation_ms": evaluation_ms,
+                    "probability": probability,
+                    "threshold": threshold,
+                },
+            )
+        )
+
+    def complete(self, *, reason: str) -> None:
+        self.events.append(("complete", {"reason": reason}))
+
+    def failure(self, *, kind: str, stage: str) -> None:
+        self.events.append(("failure", {"kind": kind, "stage": stage}))
+
+    async def flush(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _BlockingCloseDiagnostics(_RecordingDiagnostics):
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_started = asyncio.Event()
+        self.close_release = asyncio.Event()
+
+    async def close(self) -> None:
+        self.close_started.set()
+        await self.close_release.wait()
+        await super().close()
+
+
+class _FakeVad:
+    def __init__(self, close_log: list[str] | None = None) -> None:
+        self._close_log = close_log
+
+    def close(self) -> None:
+        if self._close_log is not None:
+            self._close_log.append("vad")
+
+
+class _FakeCoordinator:
+    generation = 0
+    activity_seq = 0
+    evaluation_threshold = 0.5
+
+    def __init__(self, close_log: list[str] | None = None) -> None:
+        self._close_log = close_log
+
+    async def evaluate_buffered(self) -> TurnEvaluation:
+        return TurnEvaluation(
+            EvaluationStatus.OK,
+            TurnDecision.COMPLETE,
+            0.9,
+            generation=0,
+            activity_seq=0,
+        )
+
+    async def close(self) -> None:
+        if self._close_log is not None:
+            self._close_log.append("coordinator")
+
+
+async def _noop_commit(
+    generation: int,
+    buffer_epoch: int,
+    utterance_id: int,
+) -> None:
+    del generation, buffer_epoch, utterance_id
+
+
+def test_coordinator_exposes_the_actual_evaluation_threshold() -> None:
+    coordinator = TurnCoordinator(
+        SimpleNamespace(),
+        SmartTurnConfig(evaluation_threshold=0.73),
+    )
+
+    assert coordinator.evaluation_threshold == 0.73
+
+
+async def test_sink_is_off_without_explicit_environment_opt_in(tmp_path: Path) -> None:
+    target = tmp_path / "data" / "smart_turn" / "runtime.jsonl"
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={SMART_TURN_DIAGNOSTICS_PATH_ENV: "data/smart_turn/runtime.jsonl"},
+        repo_root=tmp_path,
+    )
+
+    sink.candidate(reason="candidate_pause")
+    await sink.flush()
+    await sink.close()
+
+    assert sink.enabled is False
+    assert not target.exists()
+
+
+async def test_sink_writes_only_privacy_safe_ordered_jsonl_under_data(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "data" / "smart_turn" / "runtime.jsonl"
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={
+            SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "1",
+            SMART_TURN_DIAGNOSTICS_PATH_ENV: "data/smart_turn/runtime.jsonl",
+        },
+        repo_root=tmp_path,
+    )
+
+    sink.candidate(reason="candidate_pause")
+    sink.evaluation(
+        reason="candidate_pause",
+        outcome="complete",
+        evaluation_ms=23,
+        probability=0.91,
+        threshold=0.5,
+    )
+    sink.complete(reason="candidate_pause")
+    sink.failure(kind="runtime_error", stage="smart_turn")
+    await sink.flush()
+    await sink.close()
+    await sink.close()
+
+    records = [json.loads(line) for line in target.read_text("utf-8").splitlines()]
+    assert sink.enabled is True
+    assert [record["sequence"] for record in records] == [1, 2, 3, 4, 5, 6]
+    assert [record["event"] for record in records] == [
+        "session_start",
+        "candidate",
+        "evaluation",
+        "complete",
+        "failure",
+        "session_end",
+    ]
+    elapsed = [record["elapsed_ms"] for record in records]
+    assert elapsed == sorted(elapsed)
+    assert all(isinstance(value, int) and value >= 0 for value in elapsed)
+    assert records[2]["evaluation_ms"] == 23
+    assert records[2]["probability"] == 0.91
+    assert records[2]["threshold"] == 0.5
+    run_ids = {record["run_id"] for record in records}
+    assert len(run_ids) == 1
+    run_id = run_ids.pop()
+    assert isinstance(run_id, str) and len(run_id) == 32
+    int(run_id, 16)
+
+    allowed_keys = {
+        "schema",
+        "run_id",
+        "sequence",
+        "elapsed_ms",
+        "event",
+        "reason",
+        "outcome",
+        "evaluation_ms",
+        "probability",
+        "threshold",
+        "kind",
+        "stage",
+    }
+    assert all(set(record) <= allowed_keys for record in records)
+    serialized = "\n".join(json.dumps(record) for record in records).lower()
+    assert all(
+        forbidden not in serialized
+        for forbidden in ("pcm", "transcript", "path", "api_key", "device")
+    )
+
+
+async def test_sink_rejects_paths_outside_repository_data(tmp_path: Path) -> None:
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={
+            SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "true",
+            SMART_TURN_DIAGNOSTICS_PATH_ENV: "data/../outside.jsonl",
+        },
+        repo_root=tmp_path,
+    )
+
+    sink.candidate(reason="candidate_pause")
+    await sink.flush()
+    await sink.close()
+
+    assert sink.enabled is False
+    assert not (tmp_path / "outside.jsonl").exists()
+
+
+async def test_appended_runs_have_distinct_anonymous_boundaries(tmp_path: Path) -> None:
+    target = tmp_path / "data" / "smart_turn" / "runtime-diagnostics.jsonl"
+    environment = {SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "1"}
+
+    first = create_smart_turn_runtime_diagnostics(
+        environ=environment,
+        repo_root=tmp_path,
+    )
+    first.candidate(reason="candidate_pause")
+    await first.close()
+    second = create_smart_turn_runtime_diagnostics(
+        environ=environment,
+        repo_root=tmp_path,
+    )
+    second.candidate(reason="strict_retry")
+    await second.close()
+
+    records = [json.loads(line) for line in target.read_text("utf-8").splitlines()]
+    run_ids = [record["run_id"] for record in records]
+    assert len(set(run_ids)) == 2
+    for run_id in set(run_ids):
+        run_records = [record for record in records if record["run_id"] == run_id]
+        assert [record["event"] for record in run_records] == [
+            "session_start",
+            "candidate",
+            "session_end",
+        ]
+        assert [record["sequence"] for record in run_records] == [1, 2, 3]
+
+
+async def test_sink_never_serializes_non_finite_or_out_of_range_scores(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "data" / "smart_turn" / "runtime-diagnostics.jsonl"
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "1"},
+        repo_root=tmp_path,
+    )
+
+    sink.evaluation(
+        reason="candidate_pause",
+        outcome="error",
+        evaluation_ms=2,
+        probability=float("nan"),
+        threshold=0.5,
+    )
+    sink.evaluation(
+        reason="strict_retry",
+        outcome="error",
+        evaluation_ms=3,
+        probability=1.1,
+        threshold=0.5,
+    )
+    sink.evaluation(
+        reason="periodic_no_vad",
+        outcome="error",
+        evaluation_ms=4,
+        probability=0.5,
+        threshold=float("inf"),
+    )
+    await sink.close()
+
+    all_records = [json.loads(line) for line in target.read_text("utf-8").splitlines()]
+    records = [record for record in all_records if record["event"] == "evaluation"]
+    assert all("probability" not in record for record in records[:2])
+    assert records[2]["probability"] == 0.5
+    assert [record["threshold"] for record in records[:2]] == [0.5, 0.5]
+    assert "threshold" not in records[2]
+    assert "nan" not in target.read_text("utf-8").casefold()
+
+
+async def test_sink_write_failure_never_escapes_to_voice_runtime(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    def fail_open(*args, **kwargs):
+        del args, kwargs
+        raise OSError("simulated diagnostics disk failure")
+
+    monkeypatch.setattr(Path, "open", fail_open)
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "1"},
+        repo_root=tmp_path,
+    )
+
+    sink.candidate(reason="candidate_pause")
+    sink.evaluation(
+        reason="candidate_pause",
+        outcome="error",
+        evaluation_ms=1,
+        probability=None,
+        threshold=0.5,
+    )
+    await sink.flush()
+    await sink.close()
+
+
+async def test_stuck_writer_has_bounded_flush_and_close_latency(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    entered_open = threading.Event()
+    release_open = threading.Event()
+    original_open = Path.open
+
+    def blocking_open(path: Path, *args, **kwargs):
+        entered_open.set()
+        assert release_open.wait(timeout=5)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", blocking_open)
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "1"},
+        repo_root=tmp_path,
+    )
+    sink.candidate(reason="candidate_pause")
+    assert await asyncio.to_thread(entered_open.wait, 1)
+
+    started_at = asyncio.get_running_loop().time()
+    await sink.flush()
+    await sink.close()
+    elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert elapsed < 0.25
+    release_open.set()
+    writer = getattr(sink, "_writer")
+    await asyncio.to_thread(writer.join, 1)
+
+
+async def test_voice_turn_adapter_emits_real_lifecycle_keypoints(
+    monkeypatch,
+) -> None:
+    diagnostics = _RecordingDiagnostics()
+    monkeypatch.setattr(
+        detector_runtime,
+        "create_smart_turn_runtime_diagnostics",
+        lambda: diagnostics,
+    )
+    adapter = detector_runtime._VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=SimpleNamespace(),
+        coordinator=_FakeCoordinator(),
+        on_commit=_noop_commit,
+    )
+
+    await adapter.start()
+    adapter._identity = (1, 2, 3)
+    adapter._request_evaluation((1, 2, 3), "candidate_pause")
+    await adapter.wait_idle()
+    adapter._report_failure("runtime_error", "smart_turn")
+    await adapter.close()
+
+    assert [event for event, _fields in diagnostics.events] == [
+        "candidate",
+        "evaluation",
+        "complete",
+        "failure",
+    ]
+    assert diagnostics.events[0][1] == {"reason": "candidate_pause"}
+    evaluation = diagnostics.events[1][1]
+    assert evaluation["reason"] == "candidate_pause"
+    assert evaluation["outcome"] == "complete"
+    assert isinstance(evaluation["evaluation_ms"], int)
+    assert evaluation["evaluation_ms"] >= 0
+    assert evaluation["probability"] == 0.9
+    assert evaluation["threshold"] == 0.5
+    assert diagnostics.events[2][1] == {"reason": "candidate_pause"}
+    assert diagnostics.events[3][1] == {
+        "kind": "runtime_error",
+        "stage": "smart_turn",
+    }
+    assert diagnostics.closed is True
+
+
+async def test_voice_resources_close_before_a_stuck_diagnostics_sink(
+    monkeypatch,
+) -> None:
+    diagnostics = _BlockingCloseDiagnostics()
+    close_log: list[str] = []
+    monkeypatch.setattr(
+        detector_runtime,
+        "create_smart_turn_runtime_diagnostics",
+        lambda: diagnostics,
+    )
+    adapter = detector_runtime._VoiceTurnAdapter(
+        vad=_FakeVad(close_log),
+        gate=SimpleNamespace(),
+        coordinator=_FakeCoordinator(close_log),
+        on_commit=_noop_commit,
+    )
+
+    close_task = asyncio.create_task(adapter.close())
+    await asyncio.wait_for(diagnostics.close_started.wait(), timeout=1)
+
+    assert close_log == ["coordinator", "vad"]
+    assert close_task.done() is False
+    diagnostics.close_release.set()
+    await close_task

--- a/tests/unit/asr_client/endpointing/test_runtime_diagnostics.py
+++ b/tests/unit/asr_client/endpointing/test_runtime_diagnostics.py
@@ -210,6 +210,31 @@ async def test_sink_writes_only_privacy_safe_ordered_jsonl_under_data(
     )
 
 
+async def test_sink_flushes_events_while_session_is_still_active(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "data" / "smart_turn" / "runtime.jsonl"
+    sink = create_smart_turn_runtime_diagnostics(
+        environ={
+            SMART_TURN_DIAGNOSTICS_ENABLED_ENV: "1",
+            SMART_TURN_DIAGNOSTICS_PATH_ENV: "data/smart_turn/runtime.jsonl",
+        },
+        repo_root=tmp_path,
+    )
+
+    def read_if_present() -> str:
+        return target.read_text("utf-8") if target.exists() else ""
+
+    sink.candidate(reason="candidate_pause")
+    async with asyncio.timeout(1):
+        while not (contents := await asyncio.to_thread(read_if_present)):
+            await asyncio.sleep(0.01)
+
+    records = [json.loads(line) for line in contents.splitlines()]
+    assert [record["event"] for record in records] == ["session_start", "candidate"]
+    await sink.close()
+
+
 async def test_sink_rejects_paths_outside_repository_data(tmp_path: Path) -> None:
     sink = create_smart_turn_runtime_diagnostics(
         environ={

--- a/tests/unit/asr_client/endpointing/test_runtime_diagnostics.py
+++ b/tests/unit/asr_client/endpointing/test_runtime_diagnostics.py
@@ -449,4 +449,4 @@ async def test_voice_resources_close_before_a_stuck_diagnostics_sink(
     assert close_log == ["coordinator", "vad"]
     assert close_task.done() is False
     diagnostics.close_release.set()
-    await close_task
+    _ = await close_task

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -718,7 +718,7 @@ async def test_strict_retry_complete_commits_after_confirmation_delay() -> None:
         coordinator=coordinator,
         on_commit=on_commit,
         continuation_timeout_seconds=0.01,
-        strict_complete_confirmation_seconds=0.03,
+        strict_complete_confirmation_seconds=0.2,
         smart_turn_required=True,
     )
 
@@ -832,7 +832,7 @@ async def test_candidate_pause_complete_commits_after_confirmation_delay() -> No
         gate=gate,
         coordinator=coordinator,
         on_commit=on_commit,
-        candidate_complete_confirmation_seconds=0.03,
+        candidate_complete_confirmation_seconds=0.2,
         smart_turn_required=True,
     )
 

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -157,6 +157,42 @@ class _BlockingResultCoordinator(_BlockingSemanticCoordinator):
         return SimpleNamespace(status=self._status, decision=self._decision)
 
 
+class _SequencedSemanticCoordinator(_SemanticCoordinator):
+    def __init__(
+        self,
+        results: list[tuple[TurnDecision, float]],
+    ) -> None:
+        super().__init__()
+        self.results = list(results)
+        self.evaluation_count = 0
+        self.activity_seq = 0
+        self.evaluation_threshold = 0.5
+
+    async def on_activity_event(self, event: SpeechActivityEvent) -> None:
+        if event in (
+            SpeechActivityEvent.SPEECH_STARTED,
+            SpeechActivityEvent.SPEECH_RESUMED,
+        ):
+            self.activity_seq += 1
+            self.state = CoordinatorState.SPEECH_ACTIVE
+        elif event is SpeechActivityEvent.CANDIDATE_PAUSE:
+            self.state = CoordinatorState.PAUSE_CANDIDATE
+
+    async def evaluate_buffered(self):
+        self.evaluation_count += 1
+        decision, probability = self.results.pop(0)
+        self.state = (
+            CoordinatorState.WAIT_CONTINUATION
+            if decision is TurnDecision.INCOMPLETE
+            else CoordinatorState.PAUSE_CANDIDATE
+        )
+        return SimpleNamespace(
+            status=EvaluationStatus.OK,
+            decision=decision,
+            probability=probability,
+        )
+
+
 class _ResetClearsSemanticCoordinator(_SemanticCoordinator):
     def __init__(self) -> None:
         super().__init__()
@@ -657,6 +693,273 @@ async def test_speaker_shadow_keeps_stale_or_incomplete_tail_on_predecessor(
     await detector.close()
 
 
+async def test_strict_retry_complete_commits_after_confirmation_delay() -> None:
+    coordinator = _SequencedSemanticCoordinator(
+        [
+            (TurnDecision.INCOMPLETE, 0.2),
+            (TurnDecision.COMPLETE, 0.8),
+        ]
+    )
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    committed = asyncio.Event()
+    commits: list[tuple[int, int, int]] = []
+
+    async def on_commit(
+        generation: int,
+        buffer_epoch: int,
+        utterance_id: int,
+    ) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+        committed.set()
+
+    adapter = _VoiceTurnAdapter(
+        vad=_Vad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=on_commit,
+        continuation_timeout_seconds=0.01,
+        strict_complete_confirmation_seconds=0.03,
+        smart_turn_required=True,
+    )
+
+    await adapter.start()
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x01\x00" * 160,
+    )
+    await adapter.wait_idle()
+    assert commits == []
+
+    await asyncio.sleep(0.02)
+    await adapter.wait_idle()
+    assert commits == []
+
+    await asyncio.wait_for(committed.wait(), 1)
+    assert commits == [(1, 0, 1)]
+    await adapter.close()
+
+
+async def test_strict_retry_complete_is_cancelled_by_continuation() -> None:
+    coordinator = _SequencedSemanticCoordinator(
+        [
+            (TurnDecision.INCOMPLETE, 0.2),
+            (TurnDecision.COMPLETE, 0.8),
+            (TurnDecision.COMPLETE, 0.9),
+        ]
+    )
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    committed = asyncio.Event()
+    commits: list[tuple[int, int, int]] = []
+
+    async def on_commit(
+        generation: int,
+        buffer_epoch: int,
+        utterance_id: int,
+    ) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+        committed.set()
+
+    adapter = _VoiceTurnAdapter(
+        vad=_Vad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=on_commit,
+        continuation_timeout_seconds=0.01,
+        strict_complete_confirmation_seconds=0.1,
+        smart_turn_required=True,
+    )
+
+    await adapter.start()
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x01\x00" * 160,
+    )
+    await adapter.wait_idle()
+    await asyncio.sleep(0.02)
+    await adapter.wait_idle()
+    assert coordinator.evaluation_count == 2
+    assert commits == []
+
+    gate.events = (SpeechActivityEvent.SPEECH_RESUMED,)
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x02\x00" * 160,
+    )
+    await adapter.wait_idle()
+    await asyncio.sleep(0.12)
+    assert commits == []
+
+    gate.events = (SpeechActivityEvent.CANDIDATE_PAUSE,)
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x03\x00" * 160,
+    )
+    await adapter.wait_idle()
+
+    await asyncio.wait_for(committed.wait(), 1)
+    assert commits == [(1, 0, 1)]
+    await adapter.close()
+
+
+async def test_candidate_pause_complete_commits_after_confirmation_delay() -> None:
+    coordinator = _SequencedSemanticCoordinator(
+        [
+            (TurnDecision.COMPLETE, 0.97),
+        ]
+    )
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    committed = asyncio.Event()
+    commits: list[tuple[int, int, int]] = []
+
+    async def on_commit(
+        generation: int,
+        buffer_epoch: int,
+        utterance_id: int,
+    ) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+        committed.set()
+
+    adapter = _VoiceTurnAdapter(
+        vad=_Vad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=on_commit,
+        candidate_complete_confirmation_seconds=0.03,
+        smart_turn_required=True,
+    )
+
+    await adapter.start()
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x01\x00" * 160,
+    )
+    await adapter.wait_idle()
+    assert commits == []
+
+    await asyncio.sleep(0.02)
+    await adapter.wait_idle()
+    assert commits == []
+
+    await asyncio.wait_for(committed.wait(), 1)
+    assert commits == [(1, 0, 1)]
+    await adapter.close()
+
+
+async def test_candidate_pause_complete_is_cancelled_by_continuation() -> None:
+    coordinator = _SequencedSemanticCoordinator(
+        [
+            (TurnDecision.COMPLETE, 0.97),
+            (TurnDecision.COMPLETE, 0.96),
+        ]
+    )
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    committed = asyncio.Event()
+    commits: list[tuple[int, int, int]] = []
+
+    async def on_commit(
+        generation: int,
+        buffer_epoch: int,
+        utterance_id: int,
+    ) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+        committed.set()
+
+    adapter = _VoiceTurnAdapter(
+        vad=_Vad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=on_commit,
+        candidate_complete_confirmation_seconds=0.1,
+        smart_turn_required=True,
+    )
+
+    await adapter.start()
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x01\x00" * 160,
+    )
+    await adapter.wait_idle()
+    assert coordinator.evaluation_count == 1
+    assert commits == []
+
+    gate.events = (SpeechActivityEvent.SPEECH_RESUMED,)
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x02\x00" * 160,
+    )
+    await adapter.wait_idle()
+    await asyncio.sleep(0.12)
+    assert commits == []
+
+    gate.events = (SpeechActivityEvent.CANDIDATE_PAUSE,)
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x03\x00" * 160,
+    )
+    await adapter.wait_idle()
+
+    await asyncio.wait_for(committed.wait(), 1)
+    assert commits == [(1, 0, 1)]
+    await adapter.close()
+
+
+async def test_candidate_pause_pending_complete_publishes_on_close() -> None:
+    coordinator = _SequencedSemanticCoordinator(
+        [
+            (TurnDecision.COMPLETE, 0.97),
+        ]
+    )
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    commits: list[tuple[int, int, int]] = []
+
+    async def on_commit(
+        generation: int,
+        buffer_epoch: int,
+        utterance_id: int,
+    ) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+
+    adapter = _VoiceTurnAdapter(
+        vad=_Vad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=on_commit,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+
+    await adapter.start()
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=0,
+        utterance_id=1,
+        pcm16=b"\x01\x00" * 160,
+    )
+    await adapter.wait_idle()
+    assert commits == []
+
+    coordinator.state = CoordinatorState.IDLE
+    await adapter.close()
+
+    assert commits == [(1, 0, 1)]
+
+
 async def test_successor_fence_uses_active_identity_for_queued_pause() -> None:
     coordinator = _BlockingSemanticCoordinator()
     detector = DetectorRuntime(
@@ -1046,7 +1349,9 @@ async def test_rnnoise_unavailable_does_not_look_like_zero_probability() -> None
     assert result.events == (SpeechActivityEvent.SPEECH_STARTED,)
 
 
-async def test_active_speech_still_feeds_silero_when_rnnoise_probability_drops() -> None:
+async def test_active_speech_still_feeds_silero_when_rnnoise_probability_drops() -> (
+    None
+):
     gate = _Gate((SpeechActivityEvent.SPEECH_STARTED,))
     detector = DetectorRuntime(vad=_Vad(), gate=gate)
 
@@ -1204,7 +1509,9 @@ async def test_smart_turn_activity_updates_throttle_shadow_metrics() -> None:
     await detector.close()
 
 
-async def test_disabled_resource_optimization_never_skips_quiet_smart_turn_pcm() -> None:
+async def test_disabled_resource_optimization_never_skips_quiet_smart_turn_pcm() -> (
+    None
+):
     detector = DetectorRuntime(
         vad=_Vad(),
         gate=_Gate(),
@@ -1375,8 +1682,7 @@ async def test_deferred_completion_retires_candidate_before_third_turn() -> None
     candidates = []
     detector: DetectorRuntime
     turn_tokens = [
-        VoiceTurnToken(_ingress_token(), turn_id=turn_id)
-        for turn_id in range(1, 4)
+        VoiceTurnToken(_ingress_token(), turn_id=turn_id) for turn_id in range(1, 4)
     ]
 
     async def on_event(event) -> None:
@@ -1478,7 +1784,9 @@ async def test_smart_turn_readiness_is_pinned_to_one_logical_turn() -> None:
     await detector.close()
 
 
-async def test_provider_authority_streaming_never_builds_or_prepares_smart_turn() -> None:
+async def test_provider_authority_streaming_never_builds_or_prepares_smart_turn() -> (
+    None
+):
     coordinator = _SemanticCoordinator()
     detector = DetectorRuntime(
         vad=_Vad(),

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import math
 import threading
 from collections import deque
 from collections.abc import Iterable
@@ -212,8 +213,55 @@ class _FakeCoordinator:
         self.unload_calls += 1
 
 
+class _EvidenceSpy:
+    def __init__(self) -> None:
+        self.accepted: list[bytes] = []
+        self.current: list[bytes] = []
+        self.completed: list[tuple[bytes, ...]] = []
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def accepted_audio(self, *, identity, pcm16: bytes) -> None:
+        del identity
+        self.accepted.append(pcm16)
+        self.current.append(pcm16)
+
+    def complete(self, *, identity, reason, probability, threshold) -> None:
+        del identity, reason, probability, threshold
+        self.completed.append(tuple(self.current))
+        self.current.clear()
+
+    def discard(self) -> None:
+        self.current.clear()
+
+    async def close(self) -> None:
+        return None
+
+
 async def _noop_commit(generation: int, buffer_epoch: int, utterance_id: int) -> None:
     del generation, buffer_epoch, utterance_id
+
+
+@pytest.mark.parametrize(
+    ("argument", "value"),
+    [
+        ("candidate_complete_confirmation_seconds", math.nan),
+        ("candidate_complete_confirmation_seconds", math.inf),
+        ("strict_complete_confirmation_seconds", math.nan),
+        ("strict_complete_confirmation_seconds", math.inf),
+    ],
+)
+def test_confirmation_delays_must_be_finite(argument: str, value: float) -> None:
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        _VoiceTurnAdapter(
+            vad=_FakeVad(),
+            gate=_FakeGate(),
+            coordinator=_FakeCoordinator(),
+            on_commit=_noop_commit,
+            **{argument: value},
+        )
 
 
 async def test_first_audio_lazy_loads_vad_off_loop_once() -> None:
@@ -677,6 +725,10 @@ async def test_confirmation_observes_evaluation_tail_without_refeeding_audio() -
 
 async def test_confirmation_expiry_waits_for_inflight_continuation() -> None:
     commits: list[tuple[int, int, int]] = []
+    first_pcm = b"\x01\x00"
+    continuation_pcm = b"\x02\x00"
+    observed: list[bytes] = []
+    ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
 
     async def commit(generation: int, buffer_epoch: int, utterance_id: int) -> None:
         commits.append((generation, buffer_epoch, utterance_id))
@@ -694,32 +746,43 @@ async def test_confirmation_expiry_waits_for_inflight_continuation() -> None:
         gate=gate,
         coordinator=coordinator,
         on_commit=commit,
+        on_accepted_audio=lambda pcm16, *_args: observed.append(pcm16),
         candidate_complete_confirmation_seconds=0.05,
         smart_turn_required=True,
     )
+    evidence = _EvidenceSpy()
+    adapter._smart_turn_audio_evidence = evidence
     await adapter.start()
     try:
         await adapter.push_audio(
             generation=1,
             buffer_epoch=1,
             utterance_id=1,
-            pcm16=b"\x01\x00",
+            pcm16=first_pcm,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 1),
         )
         await adapter.wait_idle()
         await adapter.push_audio(
             generation=1,
             buffer_epoch=1,
             utterance_id=1,
-            pcm16=b"\x02\x00",
+            pcm16=continuation_pcm,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 2),
         )
         assert await asyncio.to_thread(gate.started[1].wait, 1)
 
         await asyncio.sleep(0.1)
         assert commits == []
+        assert observed == [first_pcm]
+        assert evidence.accepted == [first_pcm]
 
         gate.release[1].set()
         await adapter.wait_idle()
         assert commits == []
+        assert observed == [first_pcm, continuation_pcm]
+        assert evidence.accepted == [first_pcm, continuation_pcm]
+        assert evidence.completed == []
+        assert evidence.current == [first_pcm, continuation_pcm]
     finally:
         gate.release[1].set()
         await adapter.close()
@@ -733,15 +796,27 @@ async def test_confirmation_replays_newer_pcm_once_for_successor() -> None:
     coordinator = _FakeCoordinator([_complete()], block_evaluation=True)
     gate = _FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), (), (), (), ()])
     successor = (2, 1, 2)
+    attribution_log: list[tuple[str, bytes | None]] = []
+
+    def observe_audio(pcm16, _sample_rate_hz, _detector_identity) -> None:
+        attribution_log.append(("audio", pcm16))
+
+    def advance_fence(*_args):
+        attribution_log.append(("fence", None))
+        return successor
+
     adapter = _VoiceTurnAdapter(
         vad=_FakeVad(),
         gate=gate,
         coordinator=coordinator,
         on_commit=_noop_commit,
-        on_completion_fence=lambda *_args: successor,
+        on_accepted_audio=observe_audio,
+        on_completion_fence=advance_fence,
         candidate_complete_confirmation_seconds=10.0,
         smart_turn_required=True,
     )
+    evidence = _EvidenceSpy()
+    adapter._smart_turn_audio_evidence = evidence
     await adapter.start()
     try:
         await adapter.push_audio(
@@ -763,6 +838,8 @@ async def test_confirmation_replays_newer_pcm_once_for_successor() -> None:
         coordinator.evaluate_release.set()
         await adapter.wait_idle()
         assert adapter._pending_complete_confirmation is not None
+        assert attribution_log == [("audio", first_pcm)]
+        assert evidence.accepted == [first_pcm]
 
         await adapter.push_audio(
             generation=1,
@@ -774,10 +851,25 @@ async def test_confirmation_replays_newer_pcm_once_for_successor() -> None:
         await adapter.wait_idle()
         pending = adapter._pending_complete_confirmation
         assert pending is not None
+        assert attribution_log == [("audio", first_pcm)]
+        assert evidence.accepted == [first_pcm]
 
         assert await adapter._publish_pending_complete_confirmation(pending)
 
         assert adapter._identity == successor
+        assert attribution_log == [
+            ("audio", first_pcm),
+            ("fence", None),
+            ("audio", evaluation_tail_pcm),
+            ("audio", confirmation_pcm),
+        ]
+        assert evidence.accepted == [
+            first_pcm,
+            evaluation_tail_pcm,
+            confirmation_pcm,
+        ]
+        assert evidence.completed == [(first_pcm,)]
+        assert evidence.current == [evaluation_tail_pcm, confirmation_pcm]
         assert coordinator.pushed_audio == [
             first_pcm,
             evaluation_tail_pcm,
@@ -797,14 +889,18 @@ async def test_confirmation_does_not_refeed_pcm_without_identity_advance() -> No
     ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
     coordinator = _FakeCoordinator([_complete()])
     gate = _FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), ()])
+    observed: list[bytes] = []
     adapter = _VoiceTurnAdapter(
         vad=_FakeVad(),
         gate=gate,
         coordinator=coordinator,
         on_commit=_noop_commit,
+        on_accepted_audio=lambda pcm16, *_args: observed.append(pcm16),
         candidate_complete_confirmation_seconds=10.0,
         smart_turn_required=True,
     )
+    evidence = _EvidenceSpy()
+    adapter._smart_turn_audio_evidence = evidence
     await adapter.start()
     try:
         for sequence_no, pcm16 in ((1, first_pcm), (2, continuation_pcm)):
@@ -818,9 +914,15 @@ async def test_confirmation_does_not_refeed_pcm_without_identity_advance() -> No
             await adapter.wait_idle()
         pending = adapter._pending_complete_confirmation
         assert pending is not None
+        assert observed == [first_pcm]
+        assert evidence.accepted == [first_pcm]
 
         assert await adapter._publish_pending_complete_confirmation(pending)
 
+        assert observed == [first_pcm, continuation_pcm]
+        assert evidence.accepted == [first_pcm, continuation_pcm]
+        assert evidence.completed == [(first_pcm, continuation_pcm)]
+        assert evidence.current == []
         assert coordinator.pushed_audio == [first_pcm, continuation_pcm]
         assert gate.feed_calls == [first_pcm, continuation_pcm]
     finally:

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -723,6 +723,57 @@ async def test_confirmation_observes_evaluation_tail_without_refeeding_audio() -
         await adapter.close()
 
 
+async def test_confirmation_preserves_unscoped_evaluation_tail_in_evidence() -> None:
+    first_pcm = b"\x01\x00" * 160
+    evaluation_tail_pcm = b"\x02\x00" * 160
+    observed: list[bytes] = []
+    coordinator = _FakeCoordinator([_complete()], block_evaluation=True)
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=_FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), ()]),
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        on_accepted_audio=lambda pcm16, *_args: observed.append(pcm16),
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    evidence = _EvidenceSpy()
+    adapter._smart_turn_audio_evidence = evidence
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=first_pcm,
+        )
+        await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=evaluation_tail_pcm,
+        )
+        await _eventually(lambda: len(coordinator.pushed_audio) == 2)
+
+        coordinator.evaluate_release.set()
+        await adapter.wait_idle()
+        pending = adapter._pending_complete_confirmation
+        assert pending is not None
+        assert observed == [first_pcm, evaluation_tail_pcm]
+        assert evidence.accepted == [first_pcm, evaluation_tail_pcm]
+
+        assert await adapter._publish_pending_complete_confirmation(pending)
+
+        assert observed == [first_pcm, evaluation_tail_pcm]
+        assert evidence.accepted == [first_pcm, evaluation_tail_pcm]
+        assert evidence.completed == [(first_pcm, evaluation_tail_pcm)]
+        assert coordinator.pushed_audio == [first_pcm, evaluation_tail_pcm]
+    finally:
+        coordinator.evaluate_release.set()
+        await adapter.close()
+
+
 async def test_confirmation_expiry_waits_for_inflight_continuation() -> None:
     commits: list[tuple[int, int, int]] = []
     first_pcm = b"\x01\x00"
@@ -958,13 +1009,66 @@ async def test_confirmation_tail_overflow_uses_shared_backpressure_budget() -> N
                 generation=1,
                 buffer_epoch=1,
                 utterance_id=1,
-                pcm16=b"\x04\x00" * 160,
+                pcm16=b"\x04\x00" * (10_030 * 16),
                 detector_identity=DetectorIngressIdentity(ingress, 1, 4),
             )
 
         assert adapter.failed is False
         assert len(coordinator.pushed_audio) == 3
     finally:
+        await adapter.close()
+
+
+async def test_default_confirmation_window_fits_evaluation_and_confirmation_tail() -> (
+    None
+):
+    frame = b"\x01\x00" * 1_600  # 100 ms of 16 kHz mono PCM16.
+    ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
+    coordinator = _FakeCoordinator([_complete()], block_evaluation=True)
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=_FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,)]),
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        candidate_complete_confirmation_seconds=1.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=frame,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 1),
+        )
+        await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=frame,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 2),
+        )
+        await _eventually(lambda: len(coordinator.pushed_audio) == 2)
+        coordinator.evaluate_release.set()
+        await adapter.wait_idle()
+        assert adapter._pending_complete_confirmation is not None
+
+        for sequence_no in range(3, 13):
+            await adapter.push_audio(
+                generation=1,
+                buffer_epoch=1,
+                utterance_id=1,
+                pcm16=frame,
+                detector_identity=DetectorIngressIdentity(ingress, 1, sequence_no),
+            )
+            await adapter.wait_idle()
+
+        assert adapter._pending_complete_confirmation is not None
+        assert len(coordinator.pushed_audio) == 12
+    finally:
+        coordinator.evaluate_release.set()
         await adapter.close()
 
 

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -725,6 +725,184 @@ async def test_confirmation_expiry_waits_for_inflight_continuation() -> None:
         await adapter.close()
 
 
+async def test_confirmation_replays_newer_pcm_once_for_successor() -> None:
+    first_pcm = b"\x01\x00" * 160
+    evaluation_tail_pcm = b"\x02\x00" * 160
+    confirmation_pcm = b"\x03\x00" * 160
+    ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
+    coordinator = _FakeCoordinator([_complete()], block_evaluation=True)
+    gate = _FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), (), (), (), ()])
+    successor = (2, 1, 2)
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        on_completion_fence=lambda *_args: successor,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=first_pcm,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 1),
+        )
+        await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=evaluation_tail_pcm,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 2),
+        )
+        await _eventually(lambda: len(gate.feed_calls) == 2)
+        coordinator.evaluate_release.set()
+        await adapter.wait_idle()
+        assert adapter._pending_complete_confirmation is not None
+
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=confirmation_pcm,
+            detector_identity=DetectorIngressIdentity(ingress, 1, 3),
+        )
+        await adapter.wait_idle()
+        pending = adapter._pending_complete_confirmation
+        assert pending is not None
+
+        assert await adapter._publish_pending_complete_confirmation(pending)
+
+        assert adapter._identity == successor
+        assert coordinator.pushed_audio == [
+            first_pcm,
+            evaluation_tail_pcm,
+            confirmation_pcm,
+            evaluation_tail_pcm,
+            confirmation_pcm,
+        ]
+        assert gate.feed_calls == coordinator.pushed_audio
+    finally:
+        coordinator.evaluate_release.set()
+        await adapter.close()
+
+
+async def test_confirmation_does_not_refeed_pcm_without_identity_advance() -> None:
+    first_pcm = b"\x01\x00" * 160
+    continuation_pcm = b"\x02\x00" * 160
+    ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
+    coordinator = _FakeCoordinator([_complete()])
+    gate = _FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), ()])
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        for sequence_no, pcm16 in ((1, first_pcm), (2, continuation_pcm)):
+            await adapter.push_audio(
+                generation=1,
+                buffer_epoch=1,
+                utterance_id=1,
+                pcm16=pcm16,
+                detector_identity=DetectorIngressIdentity(ingress, 1, sequence_no),
+            )
+            await adapter.wait_idle()
+        pending = adapter._pending_complete_confirmation
+        assert pending is not None
+
+        assert await adapter._publish_pending_complete_confirmation(pending)
+
+        assert coordinator.pushed_audio == [first_pcm, continuation_pcm]
+        assert gate.feed_calls == [first_pcm, continuation_pcm]
+    finally:
+        await adapter.close()
+
+
+async def test_confirmation_tail_overflow_uses_shared_backpressure_budget() -> None:
+    ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
+    coordinator = _FakeCoordinator([_complete()])
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=_FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), (), ()]),
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        queue_capacity_ms=20,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        for sequence_no in (1, 2, 3):
+            await adapter.push_audio(
+                generation=1,
+                buffer_epoch=1,
+                utterance_id=1,
+                pcm16=bytes((sequence_no, 0)) * 160,
+                detector_identity=DetectorIngressIdentity(ingress, 1, sequence_no),
+            )
+            await adapter.wait_idle()
+
+        with pytest.raises(asyncio.QueueFull):
+            await adapter.push_audio(
+                generation=1,
+                buffer_epoch=1,
+                utterance_id=1,
+                pcm16=b"\x04\x00" * 160,
+                detector_identity=DetectorIngressIdentity(ingress, 1, 4),
+            )
+
+        assert adapter.failed is False
+        assert len(coordinator.pushed_audio) == 3
+    finally:
+        await adapter.close()
+
+
+async def test_close_bounds_stalled_pending_completion_callback() -> None:
+    scoped_started = asyncio.Event()
+    never_release = asyncio.Event()
+    ingress = VoiceIngressToken(1, "socket", 1, 1, 1)
+    vad = _FakeVad()
+    coordinator = _FakeCoordinator([_complete()])
+
+    async def stalled_scoped_commit(*_args) -> None:
+        scoped_started.set()
+        await never_release.wait()
+
+    adapter = _VoiceTurnAdapter(
+        vad=vad,
+        gate=_FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,)]),
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        on_scoped_commit=stalled_scoped_commit,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    await adapter.push_audio(
+        generation=1,
+        buffer_epoch=1,
+        utterance_id=1,
+        pcm16=b"\x01\x00" * 160,
+        detector_identity=DetectorIngressIdentity(ingress, 1, 1),
+    )
+    await adapter.wait_idle()
+    assert adapter._pending_complete_confirmation is not None
+
+    await asyncio.wait_for(adapter.close(), 1.5)
+
+    assert scoped_started.is_set()
+    assert (vad.close_calls, coordinator.close_calls) == (1, 1)
+
+
 async def test_multiple_pauses_coalesce_to_one_followup_evaluation() -> None:
     coordinator = _FakeCoordinator(
         [_failed_evaluation(EvaluationStatus.STALE), _complete()],

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -287,7 +287,7 @@ async def test_silent_audio_does_not_extend_smart_turn_warm_ttl() -> None:
     await _eventually(lambda: coordinator.unload_calls == 1, timeout=2.0)
 
     await adapter.reset(generation=1, buffer_epoch=1, utterance_id=3)
-    armed = adapter._smart_turn_unload_task   # reset() 排下的这一轮 TTL 卸载
+    armed = adapter._smart_turn_unload_task  # reset() 排下的这一轮 TTL 卸载
     assert armed is not None
     await adapter.push_audio(
         generation=1,
@@ -548,7 +548,9 @@ async def test_silero_keeps_consuming_while_smart_turn_is_blocked() -> None:
             (SpeechActivityEvent.SPEECH_RESUMED,),
         ]
     )
-    coordinator = _FakeCoordinator([_failed_evaluation(EvaluationStatus.STALE)], block_evaluation=True)
+    coordinator = _FakeCoordinator(
+        [_failed_evaluation(EvaluationStatus.STALE)], block_evaluation=True
+    )
     adapter = _VoiceTurnAdapter(
         vad=_FakeVad(),
         gate=gate,
@@ -626,6 +628,46 @@ async def test_evaluation_tail_overflow_uses_backpressure_without_failure() -> N
         coordinator.evaluate_release.set()
         await adapter.wait_idle()
         assert adapter.failed is False
+    finally:
+        coordinator.evaluate_release.set()
+        await adapter.close()
+
+
+async def test_confirmation_observes_evaluation_tail_without_refeeding_audio() -> None:
+    first_pcm = b"\x01\x00" * 160
+    tail_pcm = b"\x02\x00" * 160
+    coordinator = _FakeCoordinator([_complete()], block_evaluation=True)
+    gate = _FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,), ()])
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=first_pcm,
+        )
+        await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=tail_pcm,
+        )
+        await _eventually(lambda: len(gate.feed_calls) == 2)
+
+        coordinator.evaluate_release.set()
+        await adapter.wait_idle()
+
+        assert coordinator.pushed_audio == [first_pcm, tail_pcm]
+        assert gate.feed_calls == [first_pcm, tail_pcm]
     finally:
         coordinator.evaluate_release.set()
         await adapter.close()
@@ -847,7 +889,9 @@ async def test_required_incomplete_rechecks_and_only_complete_commits() -> None:
     await adapter.close()
 
 
-async def test_required_incomplete_blocks_after_max_endpoint_wait_without_commit() -> None:
+async def test_required_incomplete_blocks_after_max_endpoint_wait_without_commit() -> (
+    None
+):
     commits: list[tuple[int, int, int]] = []
 
     async def commit(generation: int, buffer_epoch: int, utterance_id: int) -> None:
@@ -925,9 +969,7 @@ async def test_semantic_degraded_fallback_is_cancelled_by_speech_resume() -> Non
     async def commit(generation: int, buffer_epoch: int, utterance_id: int) -> None:
         commits.append((generation, buffer_epoch, utterance_id))
 
-    coordinator = _FakeCoordinator(
-        [_failed_evaluation(EvaluationStatus.UNAVAILABLE)]
-    )
+    coordinator = _FakeCoordinator([_failed_evaluation(EvaluationStatus.UNAVAILABLE)])
     adapter = _VoiceTurnAdapter(
         vad=_FakeVad(),
         gate=_FakeGate(

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -1109,6 +1109,69 @@ async def test_close_bounds_stalled_pending_completion_callback() -> None:
     assert (vad.close_calls, coordinator.close_calls) == (1, 1)
 
 
+async def test_close_processes_admitted_continuation_before_pending_complete() -> None:
+    commits: list[tuple[int, int, int]] = []
+    first_pcm = b"\x01\x00" * 160
+    blocker_pcm = b"\x02\x00" * 160
+    continuation_pcm = b"\x03\x00" * 160
+    gate = _BlockingGate(
+        [
+            (SpeechActivityEvent.CANDIDATE_PAUSE,),
+            (),
+            (SpeechActivityEvent.SPEECH_RESUMED,),
+        ],
+        blocked_indices=(1,),
+    )
+    coordinator = _FakeCoordinator([_complete()])
+
+    async def commit(generation: int, buffer_epoch: int, utterance_id: int) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=commit,
+        candidate_complete_confirmation_seconds=10.0,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=first_pcm,
+        )
+        await adapter.wait_idle()
+        assert adapter._pending_complete_confirmation is not None
+
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=blocker_pcm,
+        )
+        await asyncio.to_thread(gate.started[1].wait, 1)
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=continuation_pcm,
+        )
+        close_task = asyncio.create_task(adapter.close())
+        await _eventually(lambda: adapter._queue.qsize() == 2)
+        gate.release[1].set()
+        await asyncio.wait_for(close_task, 1)
+
+        assert gate.feed_calls == [first_pcm, blocker_pcm, continuation_pcm]
+        assert SpeechActivityEvent.SPEECH_RESUMED in coordinator.activity_events
+        assert commits == []
+    finally:
+        gate.release[1].set()
+        await adapter.close()
+
+
 async def test_multiple_pauses_coalesce_to_one_followup_evaluation() -> None:
     coordinator = _FakeCoordinator(
         [_failed_evaluation(EvaluationStatus.STALE), _complete()],

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -666,6 +666,8 @@ async def test_confirmation_observes_evaluation_tail_without_refeeding_audio() -
         coordinator.evaluate_release.set()
         await adapter.wait_idle()
 
+        assert coordinator.evaluate_calls == 1
+        assert adapter.failed is False
         assert coordinator.pushed_audio == [first_pcm, tail_pcm]
         assert gate.feed_calls == [first_pcm, tail_pcm]
     finally:

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -673,6 +673,56 @@ async def test_confirmation_observes_evaluation_tail_without_refeeding_audio() -
         await adapter.close()
 
 
+async def test_confirmation_expiry_waits_for_inflight_continuation() -> None:
+    commits: list[tuple[int, int, int]] = []
+
+    async def commit(generation: int, buffer_epoch: int, utterance_id: int) -> None:
+        commits.append((generation, buffer_epoch, utterance_id))
+
+    gate = _BlockingGate(
+        [
+            (SpeechActivityEvent.CANDIDATE_PAUSE,),
+            (SpeechActivityEvent.SPEECH_RESUMED,),
+        ],
+        blocked_indices=(1,),
+    )
+    coordinator = _FakeCoordinator([_complete()])
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=gate,
+        coordinator=coordinator,
+        on_commit=commit,
+        candidate_complete_confirmation_seconds=0.05,
+        smart_turn_required=True,
+    )
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=b"\x01\x00",
+        )
+        await adapter.wait_idle()
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=b"\x02\x00",
+        )
+        assert await asyncio.to_thread(gate.started[1].wait, 1)
+
+        await asyncio.sleep(0.1)
+        assert commits == []
+
+        gate.release[1].set()
+        await adapter.wait_idle()
+        assert commits == []
+    finally:
+        gate.release[1].set()
+        await adapter.close()
+
+
 async def test_multiple_pauses_coalesce_to_one_followup_evaluation() -> None:
     coordinator = _FakeCoordinator(
         [_failed_evaluation(EvaluationStatus.STALE), _complete()],


### PR DESCRIPTION
## 概述

本 PR 继续完善 SmartTurn v3 的真实可用性，重点处理 Electron 真人语音路线里已经复现的日语自然停顿误截断问题，并补齐后续可复查的实机证据链与注册验证矩阵能力。

当前变更不提交任何本地录音、转写文本、设备名、绝对路径或凭据。真人音频证据仍保存在本地 ignored 的 `data/` 目录，只作为授权调试素材使用。

## 根因与关键决策

这次日语失败不是“日语模型完全不可用”，而是 SmartTurn 对 `candidate_pause` 的高置信 COMPLETE 太快发布。原有保护主要覆盖 strict retry 路径；真实 Electron 采集里，日语长句的句中停顿会让 Silero 先产出 pause candidate，SmartTurn 直接给出高置信 COMPLETE，coordinator 随即提交，导致一句话被切成多段。

因此这版没有降低 SmartTurn 阈值，也没有用语言特化规则硬拦日语，而是在生产 TurnCoordinator 路线增加候选 COMPLETE 确认窗口。SmartTurn 仍然负责判断语义是否完整；确认窗口只给真实语音继续进入同一个 turn 的机会。如果用户继续说话，pending COMPLETE 会被取消；如果没有继续说话，则按原 COMPLETE 结果提交。这样比按语言、句号或固定文本特判更稳。

## 主要改动

- `candidate_pause` 的 COMPLETE 在 SmartTurn-required 产品路线默认等待 1.0 秒确认，期间若有继续语音会取消 pending complete，避免日语长句自然停顿被提前切断。
- strict retry 保留独立确认窗口；测试用 fake coordinator 默认仍不引入候选确认延迟，避免把产品路线行为误扩散到低层单测夹具。
- close 流程会先按 FIFO 处理已经接收的续接 PCM，再 flush 尚未取消的 pending COMPLETE，既避免停止录音时丢尾段，也避免关闭控制项越过续接语音造成提前分段。
- 确认窗口内晚于候选边界的 PCM 使用有界、配置感知的容量预算保留：覆盖评估尾部、完整确认时长及帧/调度余量；completion fence 推进后只向 successor 重放一次，确认取消或身份未推进时不重复喂入。
- close flush 对 completion callback 的等待总计上限为 500 ms；即使 scoped completion consumer 卡住，仍会继续关闭 VAD/coordinator。
- 带预注册 criteria 的 evaluator 在加载模型前要求所选 asset manifest 的 SmartTurn SHA-256 与生产 manifest 一致；自定义 `--asset-dir` 仅允许 exploratory 运行。
- 增加 opt-in SmartTurn runtime diagnostics，记录 session/candidate/evaluation/complete/failure/end 等无隐私事件，便于定位“为什么切/为什么没切”。
- 增加 opt-in audio evidence recorder，只保存完成 turn 的 16 kHz mono PCM16 WAV 与最小化 index，默认关闭，目录受限在 ignored 的 `data/` 下。
- 扩展 SmartTurn v3 evaluator：支持版本化 manifest、固定 0.5 checkpoint 阈值、speaker-level any-error/Wilson gate、语言与场景矩阵校验，并明确 checkpoint replay 不能替代 Electron 实机验收。
- 补充真人多语言与 Electron 实机验收文档，说明当前证据边界、采集口径、诊断/录音开关和后续 product-quality gate。

## 回归报告 / Regression Report

本 PR 修改了 `main_logic/asr_client/endpointing` 下的 Python 运行时逻辑，因此按项目规则给出回归报告。

修改前，Electron 真人日语长句在自然停顿处会被拆成多个短 turn；已经观察到同一句日语被拆成约 0.95 秒、0.92 秒、6.85 秒三段，三段都是 `candidate_pause` 高置信 COMPLETE。中英文样本在同轮人工验证中已通过，问题集中暴露在日语长句停顿形态上。

修改后，同一句日语在 Electron 实机路线通过，最终保存为一个约 9.6 秒的 turn，SmartTurn COMPLETE probability 约 0.985。随后追加的连续日语长句/不同停顿压力样本被保存为 4 个完成 turn，checkpoint replay 结果为 4/4 complete，概率约 0.928、0.959、0.989、0.990。这个结果说明日语不再被当前已复现的句中停顿模式稳定误切；但它仍不是正式 product-quality 批准，因为正式 gate 还需要预注册的多说话人、多设备、多场景 Electron live-route 矩阵。

本轮审查修复后，确认窗口内 partial Silero frame 不再在 predecessor reset 时丢失；关闭流程在 scoped completion consumer 停滞时仍能在有界等待后释放资源；预注册 checkpoint 也不能再用任意自洽模型产生 PASS。最新一轮进一步修正了默认确认窗口与共享预算等长导致的自溢出、冻结 WAV 后置校验可能先泄露前置推理结果、以及无 scoped identity 路径的 evidence gap。failure-mode 覆盖 successor 单次重放、同身份不重复喂入、默认确认预算、超限回压、关闭回调停滞、全量 WAV 预检和无 identity 证据完整性。最新审查又补齐三项边界：close 不再越过已接收续接 PCM；超限 WAV 在读取 payload 前即拒绝且文件摘要改为分块流式计算；git status 失败时 provenance 明确为 unknown，不再误报 clean revision。


## 风险与边界

主要行为风险是 endpoint latency：真实 TurnCoordinator 产品路线在 `candidate_pause` COMPLETE 上默认增加最多 1.0 秒确认等待。这个延迟是有意引入的，用来换取真人长句停顿下更少的 premature split；不影响未启用 SmartTurn-required 的测试夹具路径。

确认尾部与 in-flight evaluation tail 使用配置感知的有界预算：一个评估尾部窗口、配置的最大确认时长和一个队列窗口的帧/调度余量；超出上界仍沿既有 whole-candidate backpressure 路径恢复。注册 gate 只接受生产模型 digest，但不带 criteria 的探索性评测仍保留自定义模型能力。

这版没有声称 SmartTurn 已完成正式验证矩阵，也没有把本地真人音频作为仓库资产提交。PR 的目标是把当前实机发现的问题修到基础可用，并提供后续验收所需的可复查工具与文档边界。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - Smart Turn 支持候选完成确认延迟及状态管理。
  - 新增可选的本地音频证据采集和运行诊断，默认关闭并遵循隐私、路径安全限制。
- **改进**
  - 评估工具支持版本化数据集、音频完整性校验、来源追踪、置信区间及分层验收，并兼容旧格式。
  - 验收失败时提供明确状态及退出结果。
- **文档**
  - 新增中文、英文和日文实时路由、故障恢复及验证准入规范。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->