### PR TITLE
按状态机重划 magic command：/new /clear 摘出自由文本，/stop /approve 收窄，字面命令必须裸斜杠

### DIFF
--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -115,6 +115,15 @@ _APPROVAL_WINDOW_STATUSES = frozenset({"completed"})
 # 批到同一个上游会话里更晚出现的另一个挂起动作上（Codex P1）。
 _APPROVAL_CONSUMED_KEY = "_approval_window_consumed"
 
+# ⚠️ 窗口还要求那条回复**真的问过问题**。原来只判「5 分钟内有任务跑完过」，于是任何一次
+# 成功的任务（哪怕回的是「整理完成，共移动 12 个文件」）都会给随后一句随口的「同意」开闸。
+# 上游那句 reply 就存在 registry 条目的 result 里，拿来判一下几乎不要钱。
+#
+# ⚠️ 判据只认**明确的疑问标记**，不枚举「审批提示长什么样」——后者是开集。代价记在
+# 这里：上游若用不带问号的陈述句征询（英文 "Proceed?" 有问号，但 "Let me know" 没有），
+# 这条会误关窗口，用户得手敲字面命令。方向是 fail-closed。
+_APPROVAL_PROMPT_MARKERS = ("？", "?", "吗", "嗎", "要不要", "是否", "确认", "確認")
+
 
 def _iter_approval_window_tasks(
     *,
@@ -210,6 +219,13 @@ def _iter_approval_window_tasks(
         # ⚠️ 已经兑现过一次推断批准的条目不再算数：一次审批提示只授权一次。
         if info.get(_APPROVAL_CONSUMED_KEY):
             continue
+        # ⚠️ 只有**问过问题**的那条回复才可能是审批提示。作废侧（require_session=False
+        # 那一路）不判这个：宁可多作废，不可漏作废。
+        if require_session:
+            raw = info.get("result")
+            reply = str((raw or {}).get("reply") or "") if isinstance(raw, dict) else ""
+            if not any(marker in reply for marker in _APPROVAL_PROMPT_MARKERS):
+                continue
         if current_session and str(info.get("session_id") or "").strip() != current_session:
             continue
         # ⚠️ 作废时不判龄（age_bounded=False），因为判龄的结果**会随时间翻转**：
@@ -632,6 +648,36 @@ async def dispatch(
                     len(consumed),
                     ", ".join(consumed),
                 )
+            if magic_command == "/stop" and not explicitly_typed:
+                # ⚠️ 「停下来」「别找了」这类祈使句在日常对话里字面完全相同——用户可能是
+                # 对**猫娘本人**说的（角色扮演里尤其常见），不是要掐后台任务。整子句判据
+                # 挡得掉叙述（`雨停下来了` 不命中），挡不掉这一类。
+                # 所以这一档额外要求**确实有在跑的 openclaw 任务**佐证。
+                #
+                # ⚠️ 明确指向 agent 的说法（取消这个任务 / 停止搜索 …）**不受此限**，
+                # 字面命令也不受限。这是有意的：registry 恰恰在最需要 /stop 的时刻说谎
+                # ——请求超时后状态被写成 failed、进程重启后 registry 全空、条目过 TTL
+                # 被删，而这些时刻上游那个活儿可能还在跑。唯一能让上游停手的通道就是
+                # 这次 POST，把它整个门在 registry 上等于把逃生阀焊死。
+                tier = None
+                tier_fn = getattr(_shared.Modules.openclaw, "stop_trigger_tier", None)
+                if callable(tier_fn) and isinstance(result.tool_args, dict):
+                    try:
+                        tier = tier_fn(result.tool_args.get("original_user_text"))
+                    except Exception:
+                        logger.debug("[OpenClaw] stop_trigger_tier failed", exc_info=True)
+                if tier == "ambiguous" and not _collect_active_openclaw_task_ids(
+                    sender_id=nk_sender_id,
+                    lanlan_name=lanlan_name,
+                    exclude_task_id=result.task_id,
+                ):
+                    logger.info(
+                        "[OpenClaw] /stop dropped: ambiguous phrasing with no running "
+                        "task for sender=%s lanlan=%s",
+                        nk_sender_id,
+                        lanlan_name,
+                    )
+                    return
             if magic_command == "/stop":
                 # ⚠️ 作废排在取消 helper **之前**。那个 helper 里有 `await` 和一处没包
                 # try 的 `_task_tracker.record_completed`，一旦抛出就把后面的作废整个

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -231,7 +231,16 @@ def _iter_approval_window_tasks(
             reply = str((raw or {}).get("reply") or "") if isinstance(raw, dict) else ""
             if not any(marker in reply for marker in _APPROVAL_PROMPT_MARKERS):
                 continue
-        if current_session and str(info.get("session_id") or "").strip() != current_session:
+        # ⚠️ `require_session` 关掉的是**整条 session 判据**，不只是「问不出会话时
+        # fail-closed」那一半。写成 `if current_session and ...` 时这个开关名不副实：
+        # 作废侧照样按 session 匹配，于是别的会话里那条窗口谁也作废不掉。虽然轮换后的
+        # 旧 session 再也不会变回当前值（所以那条窗口也开不了闸），但「作废 ⊇ 开闸」
+        # 这条总不变量一旦在某一维上不成立，下一个人就会在这里再踩一次。
+        if (
+            require_session
+            and current_session
+            and str(info.get("session_id") or "").strip() != current_session
+        ):
             continue
         # ⚠️ 作废时不判龄（age_bounded=False），因为判龄的结果**会随时间翻转**：
         #   · 下界：时钟被回拨时 age 为负，条目此刻不算窗口，作废看不见它；等时钟追

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -577,11 +577,14 @@ async def dispatch(
             # exclude_task_id 是防御性的。
             explicitly_typed = False
             if isinstance(result.tool_args, dict):
-                explicitly_typed = (
-                    _shared.Modules.openclaw.normalize_magic_command(
-                        result.tool_args.get("original_user_text")
-                    )
-                    == magic_command
+                # ⚠️ 「用户是不是亲手打的」要用**严格**解析：必须 `/` 开头且整条输入
+                # 就是那个命令。宽松那个会把普通英文词 `stop` / `approve` 当成显式命令，
+                # 于是一句英文闲聊就能拿到「显式豁免」，绕过下面整道审批闸。
+                parse_typed = getattr(
+                    _shared.Modules.openclaw, "parse_typed_magic_command", None
+                )
+                explicitly_typed = callable(parse_typed) and (
+                    parse_typed(result.tool_args.get("original_user_text")) == magic_command
                 )
             # ⚠️ 主动搭话轮**没有用户**。task_executor 在 proactive 轮把意图换成猫娘
             # 自己那句最新台词再喂进分类器，所以她随口一句「没问题」就会被判成批准，

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -679,19 +679,26 @@ async def dispatch(
                 # 相交。只看在跑的任务就会在这里提前 return，于是底下那段作废窗口的代码
                 # 根本不执行：用户那句「停下来」是在**拒绝**刚问出口的提示，结果不但被
                 # 静默丢弃，窗口还留着，随后一句随口的「同意」就能把他刚拒绝的动作批了。
-                # 用和作废同一套放宽过滤（不判龄、不按角色、不要求 session）——这里宁可
-                # 多放行一次 /stop，也不能漏掉一次拒绝。
+                #
+                # ⚠️ 但窗口这一侧要用**窄**判据（`_find_approval_window_task`），不是作废
+                # 用的那套放宽过滤。佐证是**开闸**决策，「开闸窄、作废宽」在这里同样成立：
+                # 终态条目在这条路径上可以无限期留着（清理只在 capabilities 那条路上调），
+                # 用宽过滤的话**一条几小时前的、根本没问过问题的完成记录**就能让之后每一句
+                # 「停下来」都放行——分档守卫等于白加（Codex P2）。窄判据不影响上面那个
+                # 拒绝场景：拒绝提示的当下，窗口本来就是新鲜、同角色、同会话、带问号的。
+                #
+                # ⚠️ 在跑的任务这一侧则**不按角色收窄**：上游会话键只认 sender
+                # （`_build_session_key` 第一行 `del role_name`），所以同一个 sender 在另一个
+                # 角色下跑着的活儿，同样是「停下来」的正当指代对象，而那次 /stop POST 打的
+                # 也正是同一个上游会话。
                 corroborated = _collect_active_openclaw_task_ids(
                     sender_id=nk_sender_id,
-                    lanlan_name=lanlan_name,
+                    lanlan_name=None,
                     exclude_task_id=result.task_id,
-                ) or _iter_approval_window_tasks(
+                ) or _find_approval_window_task(
                     sender_id=nk_sender_id,
                     lanlan_name=lanlan_name,
                     exclude_task_id=result.task_id,
-                    age_bounded=False,
-                    match_lanlan=False,
-                    require_session=False,
                 )
                 if tier == "ambiguous" and not corroborated:
                     logger.info(

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -122,7 +122,12 @@ _APPROVAL_CONSUMED_KEY = "_approval_window_consumed"
 # ⚠️ 判据只认**明确的疑问标记**，不枚举「审批提示长什么样」——后者是开集。代价记在
 # 这里：上游若用不带问号的陈述句征询（英文 "Proceed?" 有问号，但 "Let me know" 没有），
 # 这条会误关窗口，用户得手敲字面命令。方向是 fail-closed。
-_APPROVAL_PROMPT_MARKERS = ("？", "?", "吗", "嗎", "要不要", "是否", "确认", "確認")
+#
+# ⚠️ 曾经还收了 `确认` / `確認` / `是否`，已删——它们在**陈述句**里同样常见，而这里是
+# 子串匹配：`已确认配置无误` / `確認完成` / `已检查是否有重复` 都不是在征询，却会把窗口
+# 顶开，随后一句随口的「同意」就发出去了（Codex P2）。留下的这几个没有这个毛病：`？`
+# `?` 是标点，`吗` `嗎` `要不要` 只出现在真的在问的句子里。
+_APPROVAL_PROMPT_MARKERS = ("？", "?", "吗", "嗎", "要不要")
 
 
 def _iter_approval_window_tasks(
@@ -669,11 +674,26 @@ async def dispatch(
                         tier = tier_fn(result.tool_args.get("original_user_text"))
                     except Exception:
                         logger.debug("[OpenClaw] stop_trigger_tier failed", exc_info=True)
-                if tier == "ambiguous" and not _collect_active_openclaw_task_ids(
+                # ⚠️ 佐证不只是「有任务在跑」，**还站着的审批提示也算**。审批提示出口时
+                # 恰恰没有 queued/running 任务——窗口是 completed 开的，两个状态集合互不
+                # 相交。只看在跑的任务就会在这里提前 return，于是底下那段作废窗口的代码
+                # 根本不执行：用户那句「停下来」是在**拒绝**刚问出口的提示，结果不但被
+                # 静默丢弃，窗口还留着，随后一句随口的「同意」就能把他刚拒绝的动作批了。
+                # 用和作废同一套放宽过滤（不判龄、不按角色、不要求 session）——这里宁可
+                # 多放行一次 /stop，也不能漏掉一次拒绝。
+                corroborated = _collect_active_openclaw_task_ids(
                     sender_id=nk_sender_id,
                     lanlan_name=lanlan_name,
                     exclude_task_id=result.task_id,
-                ):
+                ) or _iter_approval_window_tasks(
+                    sender_id=nk_sender_id,
+                    lanlan_name=lanlan_name,
+                    exclude_task_id=result.task_id,
+                    age_bounded=False,
+                    match_lanlan=False,
+                    require_session=False,
+                )
+                if tier == "ambiguous" and not corroborated:
                     logger.info(
                         "[OpenClaw] /stop dropped: ambiguous phrasing with no running "
                         "task for sender=%s lanlan=%s",

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -696,8 +696,13 @@ async def dispatch(
                     lanlan_name=None,
                     exclude_task_id=result.task_id,
                 ) or _find_approval_window_task(
+                    # ⚠️ 窗口这侧同样**不按角色收窄**——理由和上面那行一样，而且不放宽就
+                    # 内部不一致：作废本来就是角色无关的，在跑任务的佐证上一轮也放宽了，
+                    # 唯独这里还按角色匹配的话，「角色 A 下收到提示 → 切到角色 B 说停下来」
+                    # 会在这里提前 return，作废那段执行不到，A 的窗口留着给下一句「同意」。
+                    # 收窄的那几维（新鲜 / 同会话 / 带疑问标记 / 未兑现）一条没动。
                     sender_id=nk_sender_id,
-                    lanlan_name=lanlan_name,
+                    lanlan_name=None,
                     exclude_task_id=result.task_id,
                 )
                 if tier == "ambiguous" and not corroborated:

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -127,7 +127,7 @@ _APPROVAL_CONSUMED_KEY = "_approval_window_consumed"
 # 子串匹配：`已确认配置无误` / `確認完成` / `已检查是否有重复` 都不是在征询，却会把窗口
 # 顶开，随后一句随口的「同意」就发出去了（Codex P2）。留下的这几个没有这个毛病：`？`
 # `?` 是标点，`吗` `嗎` `要不要` 只出现在真的在问的句子里。
-_APPROVAL_PROMPT_MARKERS = ("？", "?", "吗", "嗎", "要不要")
+_APPROVAL_PROMPT_MARKERS = ("？", "?", "吗", "嗎")
 
 
 def _iter_approval_window_tasks(
@@ -714,7 +714,7 @@ async def dispatch(
                     lanlan_name=None,
                     exclude_task_id=result.task_id,
                 )
-                if tier == "ambiguous" and not corroborated:
+                if tier != "addressed" and not corroborated:
                     logger.info(
                         "[OpenClaw] /stop dropped: ambiguous phrasing with no running "
                         "task for sender=%s lanlan=%s",
@@ -760,9 +760,13 @@ async def dispatch(
                         len(retired),
                         ", ".join(retired),
                     )
+                # ⚠️ 取消也不按角色收窄——否则和上面的佐证自相矛盾：我们**因为**
+                # 另一个角色下有活儿在跑才放行这次 /stop，却不去掐它，UI 和 tracker
+                # 会继续显示用户刚停掉的工作。上游那次 POST 打的是共享会话，本来就把
+                # 它一起停了，本地不跟着写状态就是在说谎。
                 cancelled_task_ids = await _cancel_openclaw_tasks_for_stop(
                     sender_id=nk_sender_id,
-                    lanlan_name=lanlan_name,
+                    lanlan_name=None,
                     exclude_task_id=result.task_id,
                 )
                 if cancelled_task_ids:

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -68,8 +68,10 @@ You are a high-accuracy automation assessment agent, and your task is to determi
 
 # Strategy
 Prefer false negatives over false positives. Only trigger when the user explicitly asks to manipulate system state.
-- Trigger example: "忘了刚才的事吧" -> /clear
-- Misfire trap: "我忘了带伞" / "雨停了" -> do NOT trigger
+Only two commands may be inferred from free text: /stop and /daemon approve.
+- Trigger example: "取消这个任务" -> /stop
+- Trigger example (only right after the backend asked for permission): "同意" -> /daemon approve
+- Misfire trap: "我忘了带伞" / "雨停了" / "换个话题吧" -> do NOT trigger
 
 # Output
 Output strict JSON only:
@@ -425,37 +427,40 @@ _APPROVE_ACTIONS = frozenset({
     "去执行", "去執行", "去执行吧", "去執行吧",
     "没问题去执行", "沒問題去執行",
 })
-_STOP_CLAUSES = frozenset({
-    "别找了", "別找了", "快停下来", "快停下來", "停下来", "停下來",
+# ⚠️ `/stop` 的触发词分**两档**，判据是「这句话在日常对话里会不会有别的意思」。
+#
+# 明确指向「正在干活的 agent」的说法：日常聊天里几乎不会这么讲，单凭词就够。
+_STOP_ADDRESSED = frozenset({
     "取消这个任务", "取消這個任務", "取消这个搜索", "取消這個搜尋",
     "算了别查了", "算了別查了", "停止搜索", "停止搜尋",
 })
-_NEW_CLAUSES = frozenset({
-    "换个话题", "換個話題", "重新开始", "重新開始",
-    "说点别的", "說點別的", "聊点别的", "聊點別的",
-    "重新开个话题", "重新開個話題",
+# 日常对话里同样成立的祈使句：整子句判据已经挡掉了叙述（`雨停下来了` 不命中），但挡不掉
+# 用户对着**猫娘本人**说「停下来」——那句话字面上和对 agent 说的一模一样。
+# 这一档在派单侧**额外要求「确实有在跑的 openclaw 任务」**，见 channels/openclaw.py。
+_STOP_AMBIGUOUS = frozenset({
+    "停下来", "停下來", "快停下来", "快停下來", "别找了", "別找了",
 })
+_STOP_CLAUSES = _STOP_ADDRESSED | _STOP_AMBIGUOUS
 
-# ⚠️ `/clear` 仍走**子串包含**，触发词也仍**刻意保持简体**。
-#
-# 它会不可逆地清掉上游 QwenPaw 的整段会话上下文，而判据是对自由文本做子串包含：
-# 实测 `我想知道如何清除聊天记录`（一句提问）就会返回 /clear。补繁体等于把这个既有
-# 缺陷的暴露面翻倍——`我想知道如何清除聊天記錄` 目前是 None。
-#
-# 上面那套整子句白名单同样适用于它，但 /clear 不在本次拍板的三条里，不擅自扩——
-# 单独评估。繁中用户仍可直接打字面 magic word `/clear`（走 normalize_magic_command，
-# 整句精确匹配）。
-#
-# ⚠️ 别把「LLM 分类器还会兜底」当安全垫——它**不是无条件的**。rule_magic_command 同时
-# 是 task_executor._deterministic_action_signal 的唯一 openclaw 信号，而那个廉价前置闸
-# （task_executor.py 的 `external_intent < AGENT_EXTERNAL_GATE_THRESHOLD and not
-# _deterministic_action_signal(...)` → `return None`）跑在 classify_magic_intent
-# **之前**。规则漏掉 + 小模型把这轮读成闲聊 = 整轮评估直接跳过，LLM 那一路根本到不了。
-# 也就是说规则表收窄的代价在低 external_intent 的短句上是实打实的，不是「多跑一次」。
-_CLEAR_TRIGGERS = (
-    "忘了刚才的事", "忘掉刚才的事", "清除我们的聊天记录",
-    "清除聊天记录", "删掉刚才的记录", "清空聊天记录",
-)
+# ⚠️ 能从**自由文本**推断出来的命令只有这两条。`/new` `/clear` 只认字面命令。
+# 这道过滤挡的是 LLM 那条腿：提示词里写了「只准这两条」，但提示词管不住模型，而这两条
+# 命令的后果都不可逆（覆盖上游会话指针 / 清掉上游上下文），不能只靠模型守规矩。
+_FREE_TEXT_INFERABLE = frozenset({"/stop", "/daemon approve"})
+
+
+def _drop_commands_not_inferable_from_free_text(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Veto an inferred command that free text is not allowed to reach."""
+    if not isinstance(result, dict) or not result.get("is_magic_intent"):
+        return result
+    command = OpenClawAdapter.normalize_magic_command(result.get("command"))
+    if command in _FREE_TEXT_INFERABLE:
+        return result
+    logger.info(
+        "[OpenClaw] magic intent %r dropped: not inferable from free text",
+        result.get("command"),
+    )
+    return {"is_magic_intent": False, "command": None, "source": "free-text-veto"}
+
 
 
 def _approve_clause_kind(clause: str) -> Optional[str]:
@@ -914,9 +919,18 @@ class OpenClawAdapter:
         if any(token in lowered for token in _HIGH_PRECISION_NON_MAGIC):
             return {"is_magic_intent": False, "command": None, "source": "rule"}
 
-        if any(token in text for token in _CLEAR_TRIGGERS):
-            return {"is_magic_intent": True, "command": "/clear", "source": "rule"}
-
+        # ⚠️ `/clear` 与 `/new` **不再从自由文本触发**，只认字面命令
+        # （`normalize_magic_command` 在本函数最开头就拦掉并提前返回）。
+        # 拿掉的理由是实测出来的三条乘在一起：
+        #   · 误触率最高：纯聊天语境的「换话题」说法 6/14 命中，而那 6 条全部指的是
+        #     **聊天话题**，不是 agent 会话；中文语料里 `/new` 触发词出现频率是 `/stop`
+        #     的 4.3 倍（30 次 vs 7 次 / 304 万字）。
+        #   · 零状态可用：这两条命令本地没有任何前置条件可查（不像 `/stop` 有「在跑的
+        #     任务」、approve 有「刚完成的任务」），想拦也无从拦起。
+        #   · 后果不可逆：`/new` 就地覆盖指向上游会话的**唯一**指针，无备份、无写回入口；
+        #     而且之后的 `/stop` 会打到新会话上，旧会话里真正在跑的活儿**停不下来**，
+        #     本地却照样标成 cancelled。
+        # 用户说「换个话题」九成是在说聊天话题，不是要重置 agent 会话。想重置就敲命令。
         clauses = _split_clauses(text)
         if not clauses:
             return {"is_magic_intent": False, "command": None, "source": "rule"}
@@ -968,13 +982,36 @@ class OpenClawAdapter:
             return {"is_magic_intent": True, "command": "/daemon approve", "source": "rule"}
         # ⚠️ 末子句要跳过「只有语气词/装饰」的尾巴，见 _command_clause。
         command_clause = _command_clause(clauses)
-        if _clause_hits(command_clause, _NEW_CLAUSES):
-            return {"is_magic_intent": True, "command": "/new", "source": "rule"}
         # 台湾用「搜尋」不用「搜索」，所以繁体那条不是「搜索」的字形转换。
         if _clause_hits(command_clause, _STOP_CLAUSES):
             return {"is_magic_intent": True, "command": "/stop", "source": "rule"}
 
         return {"is_magic_intent": False, "command": None, "source": "rule"}
+
+    @staticmethod
+    def stop_trigger_tier(user_text: str) -> Optional[str]:
+        """Which `/stop` tier an utterance matched: "addressed", "ambiguous", None.
+
+        Pure function on purpose. The tier decides whether the dispatcher demands
+        corroborating state (an actually running task), and that state lives in
+        agent_server — brain must not reach into it, so brain answers "which kind
+        of phrasing was this" and lets the caller combine it with what it knows.
+
+        A literal magic word returns None: typing the command is unambiguous and
+        must never be gated.
+        """  # noqa: DOCSTRING_CJK
+        text = str(user_text or "").strip()
+        if not text or OpenClawAdapter.normalize_magic_command(text):
+            return None
+        clauses = _split_clauses(text)
+        if not clauses:
+            return None
+        command_clause = _command_clause(clauses)
+        if _clause_hits(command_clause, _STOP_ADDRESSED):
+            return "addressed"
+        if _clause_hits(command_clause, _STOP_AMBIGUOUS):
+            return "ambiguous"
+        return None
 
     @staticmethod
     def rule_magic_command(user_text: str) -> Optional[str]:
@@ -995,7 +1032,7 @@ class OpenClawAdapter:
 
         llm_result = await self._classify_magic_intent_with_llm(text)
         if isinstance(llm_result, dict):
-            return llm_result
+            return _drop_commands_not_inferable_from_free_text(llm_result)
         return self._classify_magic_intent_with_rules(text)
 
     async def stop_running(

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -1034,10 +1034,15 @@ class OpenClawAdapter:
         clauses = _split_clauses(text)
         if not clauses:
             return None
-        command_clause = _command_clause(clauses)
-        if _clause_hits(command_clause, _STOP_ADDRESSED):
+        # ⚠️ 明确档扫**所有**子句，不只是末子句：`取消这个任务，停下来` 里那句无歧义的
+        # 取消在前、模糊的收尾在后，只看末子句会判成 ambiguous，然后在「超时/重启/TTL
+        # 过期」这些没有佐证的时刻被丢掉——而它恰恰是最该放行的说法。
+        # 扫全句在这里是安全的：分档**不决定 /stop 发不发**（那由分类器按末子句判据决定），
+        # 只决定「要不要状态佐证」。`我说了停止搜索，然后他就走了` 在分类器那层就是 None，
+        # 根本走不到这里。
+        if any(_clause_hits(clause, _STOP_ADDRESSED) for clause in clauses):
             return "addressed"
-        if _clause_hits(command_clause, _STOP_AMBIGUOUS):
+        if _clause_hits(_command_clause(clauses), _STOP_AMBIGUOUS):
             return "ambiguous"
         return None
 

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -948,7 +948,7 @@ class OpenClawAdapter:
             return {"is_magic_intent": False, "command": None, "source": "rule"}
 
         # ⚠️ `/clear` 与 `/new` **不再从自由文本触发**，只认字面命令
-        # （`normalize_magic_command` 在本函数最开头就拦掉并提前返回）。
+        # （`parse_typed_magic_command` 在本函数最开头就拦掉并提前返回）。
         # 拿掉的理由是实测出来的三条乘在一起：
         #   · 误触率最高：纯聊天语境的「换话题」说法 6/14 命中，而那 6 条全部指的是
         #     **聊天话题**，不是 agent 会话；中文语料里 `/new` 触发词出现频率是 `/stop`

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -1030,6 +1030,19 @@ class OpenClawAdapter:
         if not text:
             return {"is_magic_intent": False, "command": None, "source": "empty"}
 
+        # ⚠️⚠️ 字面命令在**最前面**判掉，不进 LLM。用户打出 `/stop` 意图毫无歧义，
+        # 让一个小模型来复核它是没有道理的——而在这之前它确实要复核：LLM 那条腿无条件
+        # 先跑，只要它返回一个 dict（哪怕说「不是命令」），规则层就再没机会说话，于是
+        # 打出来的 `/stop` 会被**静默丢弃**。实测：把 LLM 打桩成恒判 not-magic，
+        # `/stop` `stop` `/new` `/clear` `/daemon approve` 五条全丢。
+        #
+        # 这也顺手修掉下面那道自由文本过滤的误伤：`/new` `/clear` 只认字面命令，而
+        # 打出来的字面命令原本也要经 LLM 转一手，回来就被那道过滤当成「自由文本推断」
+        # 一起毙了。现在它根本到不了那一层。
+        literal = OpenClawAdapter.normalize_magic_command(text)
+        if literal:
+            return {"is_magic_intent": True, "command": literal, "source": "literal"}
+
         llm_result = await self._classify_magic_intent_with_llm(text)
         if isinstance(llm_result, dict):
             return _drop_commands_not_inferable_from_free_text(llm_result)

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -842,6 +842,34 @@ class OpenClawAdapter:
             return "/daemon approve"
         return raw if raw in MAGIC_COMMANDS else None
 
+    # ⚠️ 用户**打出来**的 magic command 必须是 `/` 开头、且**裸的**——整条输入就是那个
+    # 命令，前后不带任何东西。这条严格判据只用在「这句用户输入算不算字面命令」的地方；
+    # `normalize_magic_command` 保持宽松，因为它另有一类调用者传的是**内部命令值**
+    # （run_magic_command 的入参、台词查表、解析 LLM 输出的 command 字段），那些地方
+    # 收紧只会误伤。
+    #
+    # 收紧掉的是不带斜杠的裸词 `stop` / `new` / `clear` / `approve`：它们是**普通英文单词**，
+    # 8 个 locale 里那 9 条残留误命中全部来自这里（"Stop" / "Clear" 按钮标签）。
+    _TYPED_MAGIC_COMMANDS = {
+        "/clear": "/clear",
+        "/new": "/new",
+        "/stop": "/stop",
+        "/daemon approve": "/daemon approve",
+        "/approve": "/daemon approve",
+    }
+
+    @staticmethod
+    def parse_typed_magic_command(user_text: Any) -> Optional[str]:
+        """The magic command a user typed verbatim, or None.
+
+        Strict on purpose: leading "/" required, and the whole utterance must be
+        the command — no bare word, no prefix, no trailing text.
+        """  # noqa: DOCSTRING_CJK
+        raw = str(user_text or "").strip()
+        if not raw.startswith("/"):
+            return None
+        return OpenClawAdapter._TYPED_MAGIC_COMMANDS.get(raw.lower())
+
     @staticmethod
     def get_magic_command_feedback(command: str) -> str:
         normalized = OpenClawAdapter.normalize_magic_command(command) or ""
@@ -905,7 +933,7 @@ class OpenClawAdapter:
     @staticmethod
     def _classify_magic_intent_with_rules(user_text: str) -> Dict[str, Any]:
         text = str(user_text or "").strip()
-        normalized = OpenClawAdapter.normalize_magic_command(text)
+        normalized = OpenClawAdapter.parse_typed_magic_command(text)
         if normalized:
             return {"is_magic_intent": True, "command": normalized, "source": "rule"}
 
@@ -1001,7 +1029,7 @@ class OpenClawAdapter:
         must never be gated.
         """  # noqa: DOCSTRING_CJK
         text = str(user_text or "").strip()
-        if not text or OpenClawAdapter.normalize_magic_command(text):
+        if not text or OpenClawAdapter.parse_typed_magic_command(text):
             return None
         clauses = _split_clauses(text)
         if not clauses:
@@ -1039,7 +1067,7 @@ class OpenClawAdapter:
         # 这也顺手修掉下面那道自由文本过滤的误伤：`/new` `/clear` 只认字面命令，而
         # 打出来的字面命令原本也要经 LLM 转一手，回来就被那道过滤当成「自由文本推断」
         # 一起毙了。现在它根本到不了那一层。
-        literal = OpenClawAdapter.normalize_magic_command(text)
+        literal = OpenClawAdapter.parse_typed_magic_command(text)
         if literal:
             return {"is_magic_intent": True, "command": literal, "source": "literal"}
 

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -456,10 +456,10 @@ def _drop_commands_not_inferable_from_free_text(result: Dict[str, Any]) -> Dict[
     if command in _FREE_TEXT_INFERABLE:
         return result
     logger.info(
-        "[OpenClaw] magic intent %r dropped: not inferable from free text",
+        "[OpenClaw] magic intent %r vetoed: not inferable from free text",
         result.get("command"),
     )
-    return {"is_magic_intent": False, "command": None, "source": "free-text-veto"}
+    return None
 
 
 
@@ -1078,7 +1078,12 @@ class OpenClawAdapter:
 
         llm_result = await self._classify_magic_intent_with_llm(text)
         if isinstance(llm_result, dict):
-            return _drop_commands_not_inferable_from_free_text(llm_result)
+            # ⚠️ 被否决之后要**回落规则层**，不能就地判成「不是命令」。LLM 把
+            # `取消这个任务` 错判成 /new 时，否决掉那个破坏性命令是对的，但用户这句
+            # 本来是零-LLM 规则认得的 /stop——就地终结等于连合法的取消一起丢掉。
+            vetoed = _drop_commands_not_inferable_from_free_text(llm_result)
+            if vetoed is not None:
+                return vetoed
         return self._classify_magic_intent_with_rules(text)
 
     async def stop_running(

--- a/tests/unit/test_agent_external_gate.py
+++ b/tests/unit/test_agent_external_gate.py
@@ -56,14 +56,31 @@ class _SpyCU:
 # ── _deterministic_action_signal: the zero-LLM shortcuts the gate must keep ──
 def test_det_signal_magic_word():
     ex = _exec()
-    assert ex._deterministic_action_signal("/clear", openclaw_enabled=True, user_plugin_enabled=False) is True
-    assert ex._deterministic_action_signal("stop", openclaw_enabled=True, user_plugin_enabled=False) is True
-    # natural-language magic commands (zero-LLM rule classifier) count too
-    assert ex._deterministic_action_signal("取消这个任务", openclaw_enabled=True, user_plugin_enabled=False) is True
-    assert ex._deterministic_action_signal("换个话题吧", openclaw_enabled=True, user_plugin_enabled=False) is True
-    assert ex._deterministic_action_signal("随便聊聊", openclaw_enabled=True, user_plugin_enabled=False) is False
+
+    def sig(text, *, openclaw=True):
+        return ex._deterministic_action_signal(
+            text, openclaw_enabled=openclaw, user_plugin_enabled=False
+        )
+
+    # 字面命令：必须 `/` 开头且整条就是命令
+    assert sig("/clear") is True
+    assert sig("/stop") is True
+    assert sig("/daemon approve") is True
+    # ⚠️ 不带斜杠的裸词**不再**是命令：它们是普通英文单词，8 个 locale 里的
+    # "Stop" / "Clear" 按钮标签就是这么被判成命令的。
+    assert sig("stop") is False
+    assert sig("clear") is False
+    # 自由文本里仍然能推断出来的只有 /stop（含明确档与模糊档；要不要状态佐证是
+    # 派单侧的事，跟这道前置闸无关）
+    assert sig("取消这个任务") is True
+    assert sig("停下来") is True
+    # ⚠️ `/new` `/clear` 已从自由文本路径摘掉——用户说「换个话题」九成指的是聊天
+    # 话题，不是要重置 agent 会话。
+    assert sig("换个话题吧") is False
+    assert sig("忘了刚才的事") is False
+    assert sig("随便聊聊") is False
     # magic word is ignored when openclaw is off
-    assert ex._deterministic_action_signal("/clear", openclaw_enabled=False, user_plugin_enabled=False) is False
+    assert sig("/clear", openclaw=False) is False
 
 
 def test_det_signal_plugin_keyword():

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -1186,3 +1186,39 @@ def test_a_running_task_under_another_character_corroborates(wired):
     )
     _dispatch("/stop", task_id="m2", user_text="停下来")
     assert fake.magic_calls == [], "别人的在跑任务不能给我的模糊说法当佐证"
+
+
+def test_a_cross_character_prompt_window_corroborates_an_ambiguous_stop(wired):
+    """⚠️ 佐证的三条路径必须在「角色」这一维上一致，否则留下的口子最难看。
+
+    Active tasks and retirement both treat one sender's characters as a single
+    upstream session (`_build_session_key` opens with ``del role_name``). Leaving
+    only the prompt-window side role-scoped means a prompt raised under character
+    A, rejected with 「停下来」 after switching to B, returns before the ``/stop``
+    block — the stop is dropped *and* A's window survives for a later inferred
+    approval.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    registry = oc._shared.Modules.task_registry
+    _register(registry, "t-other-char", status="completed", lanlan="miku")
+    assert oc._collect_active_openclaw_task_ids() == [], "前提：没有在跑的任务"
+
+    _dispatch("/stop", task_id="m1", user_text="停下来")
+    assert [c[0] for c in fake.magic_calls] == ["/stop"], "跨角色的提示也算佐证"
+    assert registry["t-other-char"][oc._APPROVAL_CONSUMED_KEY] is True
+
+    fake.magic_calls.clear()
+    _dispatch("/daemon approve", task_id="m2")
+    assert fake.magic_calls == [], "被拒绝过的跨角色提示不该还能授权"
+
+
+def test_cross_sender_prompts_never_corroborate(wired):
+    """放宽只到 sender 一层：别人的待批准提示不能给我的模糊说法当佐证。"""  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    _register(
+        oc._shared.Modules.task_registry, "t-other-sender",
+        status="completed", sender="USER_B",
+    )
+
+    _dispatch("/stop", task_id="m1", user_text="停下来")
+    assert fake.magic_calls == []

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -64,6 +64,12 @@ class _FakeOpenClaw:
 
         return OpenClawAdapter.normalize_magic_command(command)
 
+    @staticmethod
+    def stop_trigger_tier(user_text):
+        from brain.openclaw_adapter import OpenClawAdapter
+
+        return OpenClawAdapter.stop_trigger_tier(user_text)
+
     async def run_magic_command(self, command, *, sender_id=None, role_name=None):
         self.magic_calls.append((command, sender_id, role_name))
         return {"success": True, "reply": "收到", "command": command}
@@ -139,6 +145,7 @@ def _register(
     kind="openclaw",
     ended_seconds_ago=1.0,
     session_id="sess-1",
+    reply="发现 3 个重复文件，要删掉吗？",
 ):
     info = {
         "id": task_id,
@@ -149,6 +156,10 @@ def _register(
         "session_id": session_id,
         "start_time": _iso((ended_seconds_ago or 0) + 5),
         "params": {},
+        # ⚠️ 默认带一句**问句**回复。窗口现在要求那条 reply 真的问过问题——只判「有任务
+        # 跑完过」的话，一次「整理完成，共移动 12 个文件」也会给随后随口的「同意」开闸。
+        # 想测「回复不是问句」走 reply=... 显式传。
+        "result": {"reply": reply},
     }
     # ⚠️ 连 queued / running 也带上 end_time，明知生产里它们不会有。
     # 目的是**隔离状态判据**：不带的话，把 running 塞进窗口集合的变异会被
@@ -938,3 +949,80 @@ def test_stop_retires_before_the_cancel_helper_can_raise(wired, monkeypatch):
     assert registry["t-done"][oc._APPROVAL_CONSUMED_KEY] is True, (
         "取消 helper 抛出之前，窗口就该已经作废掉了"
     )
+
+
+def test_a_completion_that_asked_nothing_does_not_open_the_gate(wired):
+    """⚠️ 窗口判的应该是「问过问题」，不是「跑完过任务」。
+
+    Only a reply that actually asked something can be an approval prompt. Opening
+    on any completion means a plain "整理完成，共移动 12 个文件" hands the next
+    casual 同意 a live approval — the task never asked for one.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    _register(
+        oc._shared.Modules.task_registry,
+        "t-done",
+        status="completed",
+        reply="整理完成，共移动 12 个文件。",
+    )
+
+    _dispatch("/daemon approve")
+    assert fake.magic_calls == [], "没问过问题的完成不该开闸"
+
+    # 逃生口：显式敲字面命令仍然豁免
+    _dispatch("/daemon approve", user_text="/daemon approve")
+    assert [c[0] for c in fake.magic_calls] == ["/daemon approve"]
+
+
+@pytest.mark.parametrize(
+    "reply",
+    ["要删掉吗？", "Proceed?", "确认执行这个动作", "是否继续", "需要我删掉嗎"],
+)
+def test_replies_that_can_carry_a_prompt_open_the_gate(wired, reply):
+    """带明确疑问标记的回复才算提示。判据只认标记，不枚举「提示长什么样」。"""  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    _register(oc._shared.Modules.task_registry, "t-done", status="completed", reply=reply)
+
+    _dispatch("/daemon approve")
+    assert [c[0] for c in fake.magic_calls] == ["/daemon approve"], reply
+
+
+def test_stop_needs_a_running_task_when_the_phrasing_is_ambiguous(wired):
+    """⚠️ 「停下来」在角色扮演里可能是对猫娘本人说的，不是要掐后台任务。
+
+    Whole-clause matching kills the narration cases (雨停下来了) but cannot tell
+    these apart — the sentence is identical either way. So this tier asks for
+    corroboration: something must actually be running.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+
+    _dispatch("/stop", user_text="停下来")
+    assert fake.magic_calls == [], "没有在跑的任务时，模糊说法不该派 /stop"
+
+    _register(
+        oc._shared.Modules.task_registry,
+        "t-live",
+        status="running",
+        ended_seconds_ago=None,
+    )
+    _dispatch("/stop", user_text="停下来")
+    assert [c[0] for c in fake.magic_calls] == ["/stop"]
+
+
+@pytest.mark.parametrize(
+    "text", ["取消这个任务", "停止搜索", "算了别查了", "取消這個搜尋", "/stop", "stop"]
+)
+def test_an_addressed_stop_never_needs_corroboration(wired, text):
+    """⚠️ 逃生阀不能焊死。
+
+    registry lies exactly when /stop matters most — a timed-out request is written
+    as ``failed``, a restart empties the registry, TTL drops the entry — and the
+    upstream job may well still be running. The one channel that can stop it is
+    this POST, so phrasings that unambiguously address the agent, and the literal
+    command, must go through with nothing on record.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    assert oc._shared.Modules.task_registry == {}
+
+    _dispatch("/stop", user_text=text)
+    assert [c[0] for c in fake.magic_calls] == ["/stop"], text

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -1222,3 +1222,55 @@ def test_cross_sender_prompts_never_corroborate(wired):
 
     _dispatch("/stop", task_id="m1", user_text="停下来")
     assert fake.magic_calls == []
+
+
+def test_the_retirement_set_is_always_a_superset_of_the_gate_set(wired):
+    """⚠️⚠️ 这是这套过滤器的**总不变量**：作废 ⊇ 开闸，逐维成立。
+
+    Open the gate and you authorize an upstream action; retire and you only mark
+    a record spent. So every dimension the gate narrows on — age, session,
+    character, prompt marker — must be *wider or equal* on the retirement side.
+    Anything the gate can still see but retirement cannot is a window nobody can
+    ever close, which is exactly the shape of the last four defects here.
+
+    A property check rather than a checklist: the registry below spans every
+    dimension at once, so a new filter added to one side and not the other turns
+    this red without anyone remembering to extend a list.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    registry = oc._shared.Modules.task_registry
+
+    _register(registry, "fresh", status="completed")
+    _register(registry, "stale", status="completed",
+              ended_seconds_ago=TASK_REGISTRY_CLEANUP_TTL + 60)
+    _register(registry, "future", status="completed", ended_seconds_ago=-30.0)
+    _register(registry, "no-end", status="completed", ended_seconds_ago=None)
+    _register(registry, "other-char", status="completed", lanlan="miku")
+    _register(registry, "other-session", status="completed", session_id="sess-old")
+    _register(registry, "no-prompt", status="completed", reply="整理完成。")
+    _register(registry, "running", status="running", ended_seconds_ago=None)
+    _register(registry, "failed", status="failed")
+    _register(registry, "cancelled", status="cancelled")
+
+    def _gate(**kw):
+        return set(oc._iter_approval_window_tasks(
+            sender_id="USER_A", exclude_task_id=None, **kw
+        ))
+
+    narrow = _gate(lanlan_name="lan")                      # approve 准入
+    narrow_any_role = _gate(lanlan_name=None)              # /stop 佐证
+    wide = _gate(lanlan_name=None, age_bounded=False,
+                 match_lanlan=False, require_session=False)  # 作废
+
+    assert narrow <= narrow_any_role <= wide, (
+        f"作废必须 ⊇ 开闸：narrow={sorted(narrow)} "
+        f"any_role={sorted(narrow_any_role)} wide={sorted(wide)}"
+    )
+    # 每一维都得真的被某一侧区分开，否则上面的包含关系是空转
+    assert "stale" not in narrow and "stale" in wide, "判龄这一维没起作用"
+    assert "other-session" not in narrow and "other-session" in wide, "session 维没起作用"
+    assert "other-char" not in narrow and "other-char" in narrow_any_role, "角色维没起作用"
+    assert "no-prompt" not in narrow and "no-prompt" in wide, "疑问标记维没起作用"
+    # 非 completed 状态两侧都看不见
+    for task_id in ("running", "failed", "cancelled"):
+        assert task_id not in wide, task_id

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -989,7 +989,7 @@ def test_a_completion_that_asked_nothing_does_not_open_the_gate(wired):
 
 @pytest.mark.parametrize(
     "reply",
-    ["要删掉吗？", "Proceed?", "确认执行这个动作", "是否继续", "需要我删掉嗎"],
+    ["要删掉吗？", "Proceed?", "需要我删掉嗎", "要不要我继续", "删掉这 3 个?"],
 )
 def test_replies_that_can_carry_a_prompt_open_the_gate(wired, reply):
     """带明确疑问标记的回复才算提示。判据只认标记，不枚举「提示长什么样」。"""  # noqa: DOCSTRING_CJK
@@ -1079,3 +1079,47 @@ def test_the_addressed_tier_is_what_carries_the_addressed_cases(wired):
 
     for text in ("取消这个任务", "停止搜索", "算了别查了", "取消這個搜尋"):
         assert OpenClawAdapter.stop_trigger_tier(text) == "addressed", text
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "已确认配置无误。", "確認完成", "已检查是否有重复文件，没有发现。",
+        "整理完成，共移动 12 个文件。", "确认执行完毕", "是否存在的检查已跑完",
+    ],
+)
+def test_a_declarative_confirmation_is_not_a_prompt(wired, reply):
+    """⚠️ 标记是**子串**匹配，所以只能收在陈述句里不会出现的词。
+
+    ``确认`` / ``確認`` / ``是否`` all read naturally in a completion summary —
+    "已确认配置无误", "已检查是否有重复" — so accepting them as prompt markers
+    reopened the window on replies that asked nothing at all, and the next casual
+    同意 went straight upstream.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    _register(oc._shared.Modules.task_registry, "t-done", status="completed", reply=reply)
+
+    _dispatch("/daemon approve")
+    assert fake.magic_calls == [], reply
+
+
+def test_an_ambiguous_stop_is_corroborated_by_a_standing_approval_window(wired):
+    """⚠️ 审批提示出口时**恰恰没有在跑的任务**——窗口是 completed 开的。
+
+    Requiring only a queued/running task made the guard return before the
+    ``/stop`` block, so a 「停下来」 that *rejects* the prompt was dropped **and**
+    left the window standing for a later inferred 同意 to approve the very thing
+    the user just refused.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    registry = oc._shared.Modules.task_registry
+    _register(registry, "t-done", status="completed")
+    assert oc._collect_active_openclaw_task_ids() == [], "前提：没有在跑的任务"
+
+    _dispatch("/stop", task_id="magic-stop", user_text="停下来")
+    assert [c[0] for c in fake.magic_calls] == ["/stop"], "拒绝提示的 /stop 必须发出去"
+    assert registry["t-done"][oc._APPROVAL_CONSUMED_KEY] is True, "而且要把窗口作废掉"
+
+    fake.magic_calls.clear()
+    _dispatch("/daemon approve", task_id="magic-approve")
+    assert fake.magic_calls == [], "被拒绝过的提示不该还能授权"

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -1271,6 +1271,8 @@ def test_the_retirement_set_is_always_a_superset_of_the_gate_set(wired):
     assert "other-session" not in narrow and "other-session" in wide, "session 维没起作用"
     assert "other-char" not in narrow and "other-char" in narrow_any_role, "角色维没起作用"
     assert "no-prompt" not in narrow and "no-prompt" in wide, "疑问标记维没起作用"
+    assert "future" not in narrow and "future" in wide, "判龄**下界**没起作用"
+    assert "no-end" not in narrow and "no-end" in wide, "缺 end_time 的 fail-closed 没起作用"
     # 非 completed 状态两侧都看不见
     for task_id in ("running", "failed", "cancelled"):
         assert task_id not in wide, task_id

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -1123,3 +1123,66 @@ def test_an_ambiguous_stop_is_corroborated_by_a_standing_approval_window(wired):
     fake.magic_calls.clear()
     _dispatch("/daemon approve", task_id="magic-approve")
     assert fake.magic_calls == [], "被拒绝过的提示不该还能授权"
+
+
+def test_a_stale_completion_does_not_corroborate_an_ambiguous_stop(wired):
+    """⚠️ 佐证是**开闸**决策，得用窄判据——用作废那套宽过滤会把分档守卫废掉。
+
+    Terminal entries can sit in the registry indefinitely on this path (cleanup
+    only runs from the capabilities route), so a single hours-old, non-prompt
+    completion would otherwise corroborate every later 停下来 forever.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    registry = oc._shared.Modules.task_registry
+
+    # 超龄
+    _register(registry, "t-stale", status="completed",
+              ended_seconds_ago=oc.TASK_REGISTRY_CLEANUP_TTL + 60)
+    _dispatch("/stop", task_id="m1", user_text="停下来")
+    assert fake.magic_calls == [], "超龄的完成记录不该给模糊说法当佐证"
+
+    # 没问过问题
+    registry.clear()
+    _register(registry, "t-plain", status="completed", reply="整理完成，共移动 12 个文件。")
+    _dispatch("/stop", task_id="m2", user_text="停下来")
+    assert fake.magic_calls == [], "没问过问题的完成记录同样不算佐证"
+
+    # 已经兑现过
+    registry.clear()
+    _register(registry, "t-used", status="completed")
+    registry["t-used"][oc._APPROVAL_CONSUMED_KEY] = True
+    _dispatch("/stop", task_id="m3", user_text="停下来")
+    assert fake.magic_calls == [], "已兑现的窗口不该复活成佐证"
+
+
+def test_a_running_task_under_another_character_corroborates(wired):
+    """⚠️ 上游会话键只认 sender（`_build_session_key` 第一行 `del role_name`）。
+
+    A job running under another character of the same sender is exactly what a
+    「停下来」 can be referring to, and the `/stop` POST lands on that same shared
+    upstream session anyway.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    _register(
+        oc._shared.Modules.task_registry,
+        "t-other-char",
+        status="running",
+        lanlan="miku",
+        ended_seconds_ago=None,
+    )
+
+    _dispatch("/stop", task_id="m1", user_text="停下来")
+    assert [c[0] for c in fake.magic_calls] == ["/stop"]
+
+    # 但跨 sender 仍然不算
+    fake.magic_calls.clear()
+    oc._shared.Modules.task_registry.clear()
+    _register(
+        oc._shared.Modules.task_registry,
+        "t-other-sender",
+        status="running",
+        sender="USER_B",
+        ended_seconds_ago=None,
+    )
+    _dispatch("/stop", task_id="m2", user_text="停下来")
+    assert fake.magic_calls == [], "别人的在跑任务不能给我的模糊说法当佐证"

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -399,7 +399,8 @@ def test_the_proactive_block_is_scoped_to_approve(wired, command):
     """A proactive /stop is a designed feature (see _resolve_openclaw_sender_id)."""
     fake, _ = wired
 
-    _dispatch(command, proactive=True)
+    _dispatch(command, proactive=True,
+              user_text="取消这个任务" if command == "/stop" else command)
 
     assert [c[0] for c in fake.magic_calls] == [command]
 
@@ -633,10 +634,14 @@ def test_the_gate_does_not_leak_to_the_other_magic_commands(wired, command):
     /stop, /new and /clear must still dispatch with an empty registry — /stop in
     particular is how a user halts things, and gating it on "a task is running"
     would make it useless exactly when the registry is out of sync.
+
+    ⚠️ /stop goes in with an **addressed** phrasing: that tier is the designed
+    escape hatch and needs no corroboration. The ambiguous tier is covered by
+    test_stop_needs_a_running_task_when_the_phrasing_is_ambiguous.
     """  # noqa: DOCSTRING_CJK
     fake, emitted = wired
 
-    _dispatch(command)
+    _dispatch(command, user_text="取消这个任务" if command == "/stop" else command)
 
     assert [call[0] for call in fake.magic_calls] == [command]
     assert emitted, f"{command} 应该照常产生 task_result"
@@ -659,7 +664,7 @@ def test_stop_retires_a_standing_approval_window(wired):
         ended_seconds_ago=None,
     )
 
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
     assert [c[0] for c in fake.magic_calls] == ["/stop"]
 
     fake.magic_calls.clear()
@@ -677,7 +682,7 @@ def test_stop_retires_the_window_with_nothing_left_to_cancel(wired):
     fake, _ = wired
     _register(oc._shared.Modules.task_registry, "t-done", status="completed")
 
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
     assert fake.stop_calls == [], "前提：这一轮没有在跑的任务可掐"
     assert oc._shared.Modules.task_registry["t-done"][oc._APPROVAL_CONSUMED_KEY] is True
 
@@ -696,7 +701,7 @@ def test_stop_retires_the_window_even_when_the_upstream_call_fails(wired):
         return {"success": False, "error": "boom", "command": command}
 
     fake.run_magic_command = _fail
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
 
     fake.run_magic_command = _FakeOpenClaw.run_magic_command.__get__(fake)
     fake.magic_calls.clear()
@@ -729,7 +734,7 @@ def test_an_explicitly_typed_approve_survives_stop(wired):
     fake, _ = wired
     _register(oc._shared.Modules.task_registry, "t-done", status="completed")
 
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
     fake.magic_calls.clear()
 
     _dispatch("/daemon approve", task_id="magic-approve", user_text="/daemon approve")
@@ -770,7 +775,7 @@ def test_stop_retires_every_standing_window_not_just_the_first(wired):
     _register(registry, "t-a", status="completed", ended_seconds_ago=3.0)
     _register(registry, "t-b", status="completed", ended_seconds_ago=1.0)
 
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
 
     assert registry["t-a"].get(oc._APPROVAL_CONSUMED_KEY) is True
     assert registry["t-b"].get(oc._APPROVAL_CONSUMED_KEY) is True
@@ -796,7 +801,7 @@ def test_a_proactive_stop_never_retires_the_users_window(wired):
     home = fake.default_sender_id
     _register(oc._shared.Modules.task_registry, "t-done", status="completed", sender=home)
 
-    _dispatch("/stop", task_id="magic-stop", sender=home, proactive=True)
+    _dispatch("/stop", task_id="magic-stop", sender=home, proactive=True, user_text="取消这个任务")
     assert [c[0] for c in fake.magic_calls] == ["/stop"], "主动轮的 /stop 本身照常派发"
     assert oc._APPROVAL_CONSUMED_KEY not in oc._shared.Modules.task_registry["t-done"]
 
@@ -820,7 +825,7 @@ def test_stop_retires_a_window_whose_end_time_is_in_the_future(wired):
     _register(registry, "t-stale", status="completed", ended_seconds_ago=oc.TASK_REGISTRY_CLEANUP_TTL + 30)
     _register(registry, "t-noend", status="completed", ended_seconds_ago=None)
 
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
 
     for task_id in ("t-future", "t-stale", "t-noend"):
         assert registry[task_id].get(oc._APPROVAL_CONSUMED_KEY) is True, task_id
@@ -839,7 +844,7 @@ def test_stop_retires_windows_of_the_senders_other_characters(wired):
     _register(registry, "t-other-char", status="completed", lanlan="miku")
     _register(registry, "t-other-sender", status="completed", sender="USER_B")
 
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
 
     assert registry["t-other-char"].get(oc._APPROVAL_CONSUMED_KEY) is True
     assert registry["t-other-sender"].get(oc._APPROVAL_CONSUMED_KEY) is None, (
@@ -863,7 +868,7 @@ def test_stop_retires_the_window_even_when_the_upstream_call_raises(wired):
         raise RuntimeError("connection reset")
 
     fake.run_magic_command = _boom
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
     assert oc._shared.Modules.task_registry["t-done"][oc._APPROVAL_CONSUMED_KEY] is True
 
     fake.run_magic_command = _FakeOpenClaw.run_magic_command.__get__(fake)
@@ -933,7 +938,7 @@ def test_stop_still_retires_when_the_session_is_unknown(wired):
         raise RuntimeError("session cache unreadable")
 
     fake.peek_persistent_session_id = _boom
-    _dispatch("/stop", task_id="magic-stop")
+    _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
     assert registry["t-done"][oc._APPROVAL_CONSUMED_KEY] is True
 
 
@@ -957,7 +962,7 @@ def test_stop_retires_before_the_cancel_helper_can_raise(wired, monkeypatch):
     # tracker——这个仓库的 pytest 有后台线程/单例泄漏污染后续用例的前科。
     monkeypatch.setattr(oc._task_tracker, "record_completed", _boom)
     with pytest.raises(RuntimeError):
-        _dispatch("/stop", task_id="magic-stop")
+        _dispatch("/stop", task_id="magic-stop", user_text="取消这个任务")
 
     assert registry["t-done"][oc._APPROVAL_CONSUMED_KEY] is True, (
         "取消 helper 抛出之前，窗口就该已经作废掉了"
@@ -989,7 +994,7 @@ def test_a_completion_that_asked_nothing_does_not_open_the_gate(wired):
 
 @pytest.mark.parametrize(
     "reply",
-    ["要删掉吗？", "Proceed?", "需要我删掉嗎", "要不要我继续", "删掉这 3 个?"],
+    ["要删掉吗？", "Proceed?", "需要我删掉嗎", "删掉这 3 个?", "现在删除嗎"],
 )
 def test_replies_that_can_carry_a_prompt_open_the_gate(wired, reply):
     """带明确疑问标记的回复才算提示。判据只认标记，不枚举「提示长什么样」。"""  # noqa: DOCSTRING_CJK
@@ -1041,33 +1046,41 @@ def test_an_addressed_stop_never_needs_corroboration(wired, text):
     assert [c[0] for c in fake.magic_calls] == ["/stop"], text
 
 
-def test_an_unclassified_stop_phrasing_falls_through_to_dispatch(wired):
-    """⚠️ 分不出档的说法走**兜底放行**，这是独立于两档词表的一条判据。
+def test_an_unrecognized_stop_phrasing_still_needs_corroboration(wired):
+    """⚠️ 判据反转：分不出档**不再**免检——那正是 LLM 误判的入口。
 
-    ``stop`` used to sit in the addressed-tier parametrization, where it was
-    green for the wrong reason: it is not a literal command (no slash) and it is
-    in neither tier table, so it rides the ``tier is None`` fallback. Deleting
-    the entire addressed tier would have left that case passing.
+    An earlier revision let ``tier is None`` through as an escape hatch. But
+    ``stop_trigger_tier`` runs on the raw text independently of who classified
+    it, so 停下来 is tiered ambiguous no matter what; None means only "no table
+    knows this phrasing", which is precisely the LLM-misclassification path this
+    guard exists to contain. Leaving it open left a door built specifically to
+    bypass the guard.
 
-    The fallback itself is deliberate — the LLM leg can produce ``/stop`` from
-    phrasings no table knows, and welding those shut would close the escape
-    hatch that exists precisely because the registry lies when it matters most.
+    The escape hatch is the **addressed tier plus the literal command** — both
+    still dispatch with nothing on record.
     """  # noqa: DOCSTRING_CJK
     from brain.openclaw_adapter import OpenClawAdapter
 
     fake, _ = wired
     assert oc._shared.Modules.task_registry == {}
-
-    # 前提：既不是字面命令，也不在任何一档词表里
-    assert OpenClawAdapter.parse_typed_magic_command("stop") is None
-    assert OpenClawAdapter.stop_trigger_tier("stop") is None
     assert OpenClawAdapter.stop_trigger_tier("请把这个停一停") is None
 
-    for text in ("stop", "请把这个停一停"):
-        fake.magic_calls.clear()
-        _dispatch("/stop", user_text=text)
-        assert [c[0] for c in fake.magic_calls] == ["/stop"], text
+    _dispatch("/stop", task_id="m1", user_text="请把这个停一停")
+    assert fake.magic_calls == [], "词表不认识的说法，没有佐证时不该派发"
 
+    # 有佐证就放行
+    _register(oc._shared.Modules.task_registry, "t-live", status="running",
+              ended_seconds_ago=None)
+    _dispatch("/stop", task_id="m2", user_text="请把这个停一停")
+    assert [c[0] for c in fake.magic_calls] == ["/stop"]
+
+    # 明确档与字面命令始终免检
+    fake.magic_calls.clear()
+    oc._shared.Modules.task_registry.clear()
+    for text in ("取消这个任务", "/stop"):
+        fake.magic_calls.clear()
+        _dispatch("/stop", task_id="m3", user_text=text)
+        assert [c[0] for c in fake.magic_calls] == ["/stop"], text
 
 def test_the_addressed_tier_is_what_carries_the_addressed_cases(wired):
     """⚠️ 上面那条兜底会掩盖「明确档被删掉」——所以这里直接打词表。
@@ -1276,3 +1289,47 @@ def test_the_retirement_set_is_always_a_superset_of_the_gate_set(wired):
     # 非 completed 状态两侧都看不见
     for task_id in ("running", "failed", "cancelled"):
         assert task_id not in wide, task_id
+
+
+def test_stop_cancels_the_cross_character_task_it_used_as_corroboration(wired):
+    """⚠️ 因为它放行，就得掐它——否则 UI 继续显示用户刚停掉的工作。
+
+    The upstream `/stop` POST lands on the shared session and stops that job
+    anyway, so leaving the other character's registry entry as ``running`` is the
+    local state telling a lie.
+    """  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    registry = oc._shared.Modules.task_registry
+    _register(registry, "t-other-char", status="running", lanlan="miku",
+              ended_seconds_ago=None)
+
+    _dispatch("/stop", task_id="m1", user_text="停下来")
+
+    assert [c[0] for c in fake.magic_calls] == ["/stop"]
+    assert registry["t-other-char"]["status"] == "cancelled", (
+        "拿它当佐证放行了，就必须把它掐掉"
+    )
+
+
+def test_another_senders_running_task_is_never_cancelled(wired):
+    """放宽只到 sender 一层：别人的任务不能被我的 /stop 掐掉。"""  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    registry = oc._shared.Modules.task_registry
+    _register(registry, "t-mine", status="running", ended_seconds_ago=None)
+    _register(registry, "t-theirs", status="running", sender="USER_B",
+              ended_seconds_ago=None)
+
+    _dispatch("/stop", task_id="m1", user_text="停下来")
+
+    assert registry["t-mine"]["status"] == "cancelled"
+    assert registry["t-theirs"]["status"] == "running", "跨 sender 不该被掐"
+
+
+@pytest.mark.parametrize("reply", ["整理了「要不要删除备份」这个讨论。", "记录了要不要保留的争论"])
+def test_an_embedded_interrogative_phrase_is_not_a_prompt(wired, reply):
+    """⚠️ `要不要` 也会出现在陈述句里——标记是子串匹配，收它同样会顶开窗口。"""  # noqa: DOCSTRING_CJK
+    fake, _ = wired
+    _register(oc._shared.Modules.task_registry, "t-done", status="completed", reply=reply)
+
+    _dispatch("/daemon approve")
+    assert fake.magic_calls == [], reply

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -70,6 +70,12 @@ class _FakeOpenClaw:
 
         return OpenClawAdapter.stop_trigger_tier(user_text)
 
+    @staticmethod
+    def parse_typed_magic_command(user_text):
+        from brain.openclaw_adapter import OpenClawAdapter
+
+        return OpenClawAdapter.parse_typed_magic_command(user_text)
+
     async def run_magic_command(self, command, *, sender_id=None, role_name=None):
         self.magic_calls.append((command, sender_id, role_name))
         return {"success": True, "reply": "收到", "command": command}
@@ -561,11 +567,18 @@ def test_an_explicitly_typed_magic_word_is_never_gated(wired):
     fake, emitted = wired
     assert oc._shared.Modules.task_registry == {}
 
-    for typed in ("/daemon approve", "daemon approve", "/approve", "approve"):
+    for typed in ("/daemon approve", "/approve"):
         fake.magic_calls.clear()
         _dispatch("/daemon approve", user_text=typed)
         assert [c[0] for c in fake.magic_calls] == ["/daemon approve"], typed
     assert emitted
+
+    # ⚠️ 不带斜杠的裸词**不算**亲手打的命令，所以拿不到这条豁免——否则一句英文闲聊
+    # 里的 "approve" 就能绕开整道审批闸。
+    for not_typed in ("approve", "daemon approve", "Approve"):
+        fake.magic_calls.clear()
+        _dispatch("/daemon approve", user_text=not_typed)
+        assert fake.magic_calls == [], not_typed
 
 
 def test_another_senders_task_does_not_open_the_gate(wired):

--- a/tests/unit/test_openclaw_approve_gate.py
+++ b/tests/unit/test_openclaw_approve_gate.py
@@ -1023,7 +1023,7 @@ def test_stop_needs_a_running_task_when_the_phrasing_is_ambiguous(wired):
 
 
 @pytest.mark.parametrize(
-    "text", ["取消这个任务", "停止搜索", "算了别查了", "取消這個搜尋", "/stop", "stop"]
+    "text", ["取消这个任务", "停止搜索", "算了别查了", "取消這個搜尋", "/stop"]
 )
 def test_an_addressed_stop_never_needs_corroboration(wired, text):
     """⚠️ 逃生阀不能焊死。
@@ -1039,3 +1039,43 @@ def test_an_addressed_stop_never_needs_corroboration(wired, text):
 
     _dispatch("/stop", user_text=text)
     assert [c[0] for c in fake.magic_calls] == ["/stop"], text
+
+
+def test_an_unclassified_stop_phrasing_falls_through_to_dispatch(wired):
+    """⚠️ 分不出档的说法走**兜底放行**，这是独立于两档词表的一条判据。
+
+    ``stop`` used to sit in the addressed-tier parametrization, where it was
+    green for the wrong reason: it is not a literal command (no slash) and it is
+    in neither tier table, so it rides the ``tier is None`` fallback. Deleting
+    the entire addressed tier would have left that case passing.
+
+    The fallback itself is deliberate — the LLM leg can produce ``/stop`` from
+    phrasings no table knows, and welding those shut would close the escape
+    hatch that exists precisely because the registry lies when it matters most.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    fake, _ = wired
+    assert oc._shared.Modules.task_registry == {}
+
+    # 前提：既不是字面命令，也不在任何一档词表里
+    assert OpenClawAdapter.parse_typed_magic_command("stop") is None
+    assert OpenClawAdapter.stop_trigger_tier("stop") is None
+    assert OpenClawAdapter.stop_trigger_tier("请把这个停一停") is None
+
+    for text in ("stop", "请把这个停一停"):
+        fake.magic_calls.clear()
+        _dispatch("/stop", user_text=text)
+        assert [c[0] for c in fake.magic_calls] == ["/stop"], text
+
+
+def test_the_addressed_tier_is_what_carries_the_addressed_cases(wired):
+    """⚠️ 上面那条兜底会掩盖「明确档被删掉」——所以这里直接打词表。
+
+    Without this, removing _STOP_ADDRESSED entirely leaves every dispatch test
+    green: those phrasings would simply fall through the same None-tier path.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    for text in ("取消这个任务", "停止搜索", "算了别查了", "取消這個搜尋"):
+        assert OpenClawAdapter.stop_trigger_tier(text) == "addressed", text

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -499,9 +499,6 @@ def test_mood_words_are_not_mistaken_for_artist_names():
 MAGIC_PAIRS = [
     # ⚠️ /clear 的触发词不在这里：它不可逆地清掉上游会话上下文，判据又还是自由文本
     # 子串，所以刻意保持简体。见 test_clear_triggers_stay_simplified_only。
-    ("换个话题", "換個話題"),
-    ("说点别的", "說點別的"),
-    ("重新开始", "重新開始"),
     # 台湾用「搜尋」，所以这一条不是「搜索」的字形转换。
     ("停止搜索", "停止搜尋"),
     ("取消这个任务", "取消這個任務"),
@@ -823,7 +820,6 @@ def test_clause_whitelists_are_script_symmetric():
         _APPROVE_ACTIONS,
         _APPROVE_AFFIRMATIONS,
         _APPROVE_COMPANIONS,
-        _NEW_CLAUSES,
         _STOP_CLAUSES,
     )
 
@@ -837,7 +833,6 @@ def test_clause_whitelists_are_script_symmetric():
         ("approve_affirmations", _APPROVE_AFFIRMATIONS),
         ("approve_companions", _APPROVE_COMPANIONS),
         ("stop", _STOP_CLAUSES),
-        ("new", _NEW_CLAUSES),
     )
 
     # ⚠️ 表外字形必须报错，否则这条守卫在它身上是空转的：_fold 折不出对侧时返回词条
@@ -888,10 +883,11 @@ def test_approve_requires_every_clause_but_stop_and_new_only_the_last():
     # non-final clause is narration, not an imperative, and must not dispatch.
     # ⚠️ 这四条是「末子句」和「任意子句」判据的唯一区分点：换成 any(...) 时只有它们会红。
     assert OpenClawAdapter.rule_magic_command("我还没同意，停止搜索") == "/stop"
-    assert OpenClawAdapter.rule_magic_command("我不同意这个方案，换个话题") == "/new"
+    assert OpenClawAdapter.rule_magic_command("我不同意这个方案，取消这个任务") == "/stop"
     assert OpenClawAdapter.rule_magic_command("停下来，这是我当时唯一的念头") is None
     assert OpenClawAdapter.rule_magic_command("停下來，這是我當時唯一的念頭") is None
-    assert OpenClawAdapter.rule_magic_command("换个话题，他总是这么逃避") is None
+    # ⚠️ `/new` 已从自由文本路径摘除，这里不再有它的对照；末子句判据仍由上面
+    # 那两条 /stop 钉住（换成 any(...) 时「停下来，这是我当时唯一的念头」会红）。
     assert OpenClawAdapter.rule_magic_command("換個話題，他總是這麼逃避") is None
     assert OpenClawAdapter.rule_magic_command("别找了，他说，然后转身走了") is None
     assert OpenClawAdapter.rule_magic_command("重新开始，说起来简单做起来难") is None
@@ -901,43 +897,33 @@ def test_approve_requires_every_clause_but_stop_and_new_only_the_last():
     ("text", "expected"),
     [
         # leading function words stripped
-        ("我们换个话题吧", "/new"), ("我們換個話題吧", "/new"),
         ("请停下来", "/stop"), ("請停下來", "/stop"),
         ("帮我停下来", "/stop"), ("幫我停下來", "/stop"),
         ("那你去执行吧", "/daemon approve"),
         # ⚠️ 第二人称的复数/敬称写法要**整词**排在单字 `你` 前面，否则 `你们停下来`
         # 被 `你` 吃掉首字、剩下 `们停下来`。这条和 `那么`/`快点` 是同一个坑。
         ("你们停下来", "/stop"), ("你們停下來", "/stop"),
-        ("您换个话题吧", "/new"), ("您們換個話題", "/new"),
         ("您去执行吧", "/daemon approve"), ("你们去执行吧", "/daemon approve"),
         # ⚠️ 多字前缀必须整词剥。`那` 排在 `那么` 前面时正则会吃掉首字、留下一个
         # `么` 粘在后面（子句变成「么停下来」），整条判据失效。`快`/`快点` 同理。
-        ("那么停下来吧", "/stop"), ("那麼換個話題吧", "/new"),
-        ("快点停下来", "/stop"), ("快點停下來", "/stop"),
+        ("那么停下来吧", "/stop"), ("快点停下来", "/stop"), ("快點停下來", "/stop"),
         ("快点去执行", "/daemon approve"),
         # 祈使副词：中文祈使句最常见的修饰，闭集缺了它们等于这套口令只认「裸命令」
         ("赶紧停下来", "/stop"), ("馬上取消這個任務", "/stop"),
         ("立刻停止搜尋", "/stop"), ("现在别找了", "/stop"),
-        ("能不能停下来", "/stop"), ("不如換個話題", "/new"),
-        ("干脆换个话题", "/new"), ("还是换个话题吧", "/new"),
-        ("拜託停下來", "/stop"), ("我想取消这个任务", "/stop"),
+        ("能不能停下来", "/stop"), ("拜託停下來", "/stop"), ("我想取消这个任务", "/stop"),
         # ⚠️ `要不要` 必须排在 `要不` 前面，否则被咬成 `要停下来`——这是这套表
         # 第五次栽在「多字词排在它的首字/前缀后面」上（那么·快点·我想·你们·要不要）。
         ("要不要停下来？", "/stop"), ("要不要停下來", "/stop"),
-        ("要不要换个话题", "/new"), ("要不要換個話題", "/new"),
-        ("我想重新开始", "/new"), ("马上去执行", "/daemon approve"),
+        ("马上去执行", "/daemon approve"),
         # trailing particles stripped
-        ("重新开始吧", "/new"), ("重新開始吧", "/new"),
         ("停下来吧", "/stop"), ("停下來吧", "/stop"),
         # 征询/疑问尾：「…好吗 / …行不行」是最常见的礼貌祈使口吻
         ("停下来好吗", "/stop"), ("停下來好嗎", "/stop"),
         ("停下来行不行", "/stop"), ("停下来好不好", "/stop"),
-        ("换个话题好吗", "/new"), ("換個話題好嗎", "/new"),
-        ("换个话题怎么样", "/new"), ("重新開始好嗎", "/new"),
         # ⚠️ 语气词也是简繁两侧的东西：只收繁体「囉」会让同一句话繁体命中简体不命中
         ("停下來囉", "/stop"), ("停下来啰", "/stop"), ("停下来咯", "/stop"),
         ("停下來咯", "/stop"), ("停下来喽", "/stop"),
-        ("说点别的呗", "/new"), ("說點別的唄", "/new"),
         # ...but stripping must not resurrect a misfire
         ("雨停下来了", None), ("我准了假", None), ("比賽即將重新開始", None),
         ("我想重新开始新的人生", None), ("我想让时间停下来", None),
@@ -1023,31 +1009,27 @@ def test_an_affirmative_clause_needs_a_real_command_beside_it(text, expected):
         ("去执行👌", None),
         ("停下来…", "/stop"), ("停下來……", "/stop"), ("停下來——", "/stop"),
         ("別找了…", "/stop"), ("「停下來」", "/stop"), ("“停下来”", "/stop"),
-        ("換個話題…", "/new"), ("换个话题👍", "/new"), ("重新開始……", "/new"),
         # 剥完装饰仍要过白名单——装饰不是万能钥匙
         ("雨停下来了…", None), ("我准了假👌", None), ("比賽即將重新開始……", None),
         # ⚠️ 中文省略号是**句中分隔符**，不只是句尾装饰
         ("同意……去执行", "/daemon approve"), ("同意⋯⋯去执行", "/daemon approve"),
         # 破折号同理，也是句中分隔符
         ("同意——去执行", "/daemon approve"), ("同意—去执行", "/daemon approve"),
-        ("好吧——换个话题", "/new"), ("停下來——別找了", "/stop"),
-        ("好吧……换个话题", "/new"), ("停下來……別找了", "/stop"),
+        ("停下來——別找了", "/stop"),
+        ("停下來……別找了", "/stop"),
         # ⚠️⚠️ approve **只剥句尾装饰**：句首那一格是语义位。`❌去執行` 是「别执行」，
         # `「去執行」` 是在**提及**这个词而不是下令。一律当装饰剥掉就全变成了授权。
         ("❌去執行", None), ("❌去执行", None), ("🚫去執行🚫", None),
         ("🚫去执行", None), ("「去執行」", None), ("「去执行」", None),
         ("『去执行』", None), ("（去执行）", None),
         # /stop 与 /new 后果小，两端照剥
-        ("「停下來」", "/stop"), ("『別找了』", "/stop"), ("（换个话题）", "/new"),
-        # ⚠️ 空白也是分隔符，会把语气词切成独立末子句；末子句判据要往回跳过它们
-        ("停下来 吧", "/stop"), ("停下來 👍", "/stop"), ("换个话题 喵", "/new"),
-        # ⚠️ 剥这段尾巴要试**所有**匹配的词尾并取最长：`_TAIL_TOKENS` 里 `了` 排在
+        ("「停下來」", "/stop"), ("『別找了』", "/stop"), # ⚠️ 空白也是分隔符，会把语气词切成独立末子句；末子句判据要往回跳过它们
+        ("停下来 吧", "/stop"), ("停下來 👍", "/stop"), # ⚠️ 剥这段尾巴要试**所有**匹配的词尾并取最长：`_TAIL_TOKENS` 里 `了` 排在
         # `好了` 前面，只取第一个匹配会把 `好了` 剥成 `好`，于是这段尾巴不被认成
         # 「纯语气词」、反倒被当成命令子句。和 _clause_hits 里那个坑是同一个。
-        ("换个话题 好了", "/new"), ("停下来 好了", "/stop"), ("別找了 好了", "/stop"),
+        ("停下来 好了", "/stop"), ("別找了 好了", "/stop"),
         # 礼貌收尾也是纯语气：`谢谢` 不该被当成命令子句
-        ("停下来谢谢", "/stop"), ("停下來，謝謝", "/stop"), ("换个话题，谢谢", "/new"),
-        ("别找了 谢谢", "/stop"), ("停下来多谢", "/stop"),
+        ("停下来谢谢", "/stop"), ("停下來，謝謝", "/stop"), ("别找了 谢谢", "/stop"), ("停下来多谢", "/stop"),
         ("别找了 吧", "/stop"),
         # ⚠️ 但**不给 approve 用**：那样 `同意 吧` 会变成裸应答被批准（旧实现是 None）。
         # 代价是 `去执行 吧` 也丢了，二选一，选了 fail-closed 那边。
@@ -1124,9 +1106,7 @@ def test_truncated_table_entries_are_not_commands(text):
         # 再也剥不出 `停下来`。换词表顺序解决不了，`行吗` 本身必须收。
         # （approve 侧不能拿来测这个——疑问式对批准是一票否决，见
         # test_a_question_never_approves。）
-        ("停下来行吗", "/stop"), ("停下來行嗎", "/stop"), ("换个话题行吗", "/new"),
-        ("停下来吗", "/stop"), ("停下來嗎", "/stop"), ("换个话题怎么样", "/new"),
-    ],
+        ("停下来行吗", "/stop"), ("停下來行嗎", "/stop"), ("停下来吗", "/stop"), ("停下來嗎", "/stop"), ],
 )
 def test_particles_are_peeled_one_at_a_time(text, expected):
     from brain.openclaw_adapter import OpenClawAdapter
@@ -1145,20 +1125,17 @@ def test_particles_are_peeled_one_at_a_time(text, expected):
         ("去执行吗", "_APPROVE_ACTIONS"), ("去執行嗎", "_APPROVE_ACTIONS"),
         ("去执行行不行", "_APPROVE_ACTIONS"), ("去執行好不好", "_APPROVE_ACTIONS"),
         ("停下来行吗", "_STOP_CLAUSES"), ("停下來行嗎", "_STOP_CLAUSES"),
-        ("换个话题好不好", "_NEW_CLAUSES"),
     ],
 )
 def test_the_lookup_layer_peels_every_matching_tail(clause, table_name):
     from brain.openclaw_adapter import (
         _APPROVE_ACTIONS,
-        _NEW_CLAUSES,
         _STOP_CLAUSES,
         _clause_hits,
     )
 
     tables = {
         "_APPROVE_ACTIONS": _APPROVE_ACTIONS,
-        "_NEW_CLAUSES": _NEW_CLAUSES,
         "_STOP_CLAUSES": _STOP_CLAUSES,
     }
     assert _clause_hits(clause, tables[table_name]), f"{clause} 剥不出 {table_name} 里的条目"
@@ -1402,8 +1379,7 @@ def test_narrow_and_wide_lead_sets_are_disjoint_where_it_matters():
         # 落不到任何白名单条目上（Codex P2）。
         ("同意：去执行", "/daemon approve"), ("沒問題:去執行", "/daemon approve"),
         ("没问题：去执行", "/daemon approve"), ("同意:删吧", "/daemon approve"),
-        ("先说明一下：停下来", "/stop"), ("这样吧：换个话题", "/new"),
-    ],
+        ("先说明一下：停下来", "/stop"), ],
 )
 def test_colons_are_clause_boundaries(text, expected):
     from brain.openclaw_adapter import OpenClawAdapter
@@ -1435,16 +1411,13 @@ def test_decisive_adverbs_still_approve(text):
         # ⚠️ 问号否决**只作用于 approve**：对 /stop 和 /new 而言，
         # 「停下来好吗？」是完全正常的礼貌祈使，不能一并毙掉。
         ("停下来好吗？", "/stop"), ("停下來好嗎？", "/stop"),
-        ("换个话题好吗？", "/new"), ("換個話題好嗎？", "/new"),
         ("能不能停下来？", "/stop"),
         # 无标点的疑问式同理——「能不能停下来」是最常见的礼貌祈使之一
         ("能不能停下来", "/stop"), ("可不可以停下來", "/stop"),
         ("停下来吗", "/stop"), ("停下来行不行", "/stop"),
-        ("换个话题怎么样", "/new"), ("換個話題怎麼樣", "/new"),
         # 试探/提议型对 /stop 和 /new 同样是完全正常的祈使
-        ("要不换个话题", "/new"), ("不如换个话题", "/new"), ("还是换个话题吧", "/new"),
         ("要不停下来", "/stop"), ("不如停下來", "/stop"), ("還是停下來吧", "/stop"),
-        ("干脆换个话题", "/new"), ("乾脆停下來", "/stop"),
+        ("乾脆停下來", "/stop"),
     ],
 )
 def test_the_question_veto_is_scoped_to_approve(text, expected):
@@ -1509,11 +1482,8 @@ def test_stop_triggers_containing_a_negator_are_untouched(text):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("我不同意这个方案，换个话题", "/new"),
-        ("我不同意這個方案，換個話題", "/new"),
         ("我还没同意，停止搜索", "/stop"),
         ("我還沒同意，停止搜尋", "/stop"),
-        ("我不同意，清空聊天记录", "/clear"),
         # 繁体那条不在这里：/clear 的触发词刻意保持简体（见
         # test_destructive_command_triggers_stay_simplified_only），所以
         # 「我不同意，清空聊天記錄」本来就该是 None，不是被否定短语压掉的。
@@ -2813,19 +2783,15 @@ def test_a_traditional_companion_still_cannot_authorize_alone(text):
     [
         # ASCII `-`：Unicode 破折号收了一整排，最常打的那个反而漏了
         ("同意--去执行", "/daemon approve"),
-        ("好吧--换个话题", "/new"),
         ("同意——去执行", "/daemon approve"),
         ("停下来-好吗", "/stop"),
         # 句尾礼貌语：_command_clause 只剥得掉 `了`，剩下的 `拜托` 成了命令子句
         ("停下来，拜托了", "/stop"),
         ("停下來，拜託了", "/stop"),
-        ("换个话题，麻烦了", "/new"),
-        ("換個話題，麻煩了", "/new"),
         ("别找了，拜托了", "/stop"),
         # `_` 在 Python 的 \w 里，所以 \W 剥不掉它
         ("_停下来_", "/stop"),
         ("__停下來__", "/stop"),
-        ("_换个话题_", "/new"),
         ("停下来 _", "/stop"),
         ("**停下来**", "/stop"),
     ],
@@ -2914,19 +2880,15 @@ def test_the_affirmation_narrowing_keeps_every_real_authorization(text):
     ("text", "expected"),
     [
         # 斜杠当分隔符用（聊天里很常见）
-        ("好吧/换个话题", "/new"),
         ("同意/去执行", "/daemon approve"),
         ("停下来/谢谢", "/stop"),
         # 前缀在外、包裹在内：剥完首部虚词还得再剥一次装饰
         ("请「停下来」", "/stop"),
-        ("麻烦（换个话题）", "/new"),
         ("你_停下来_", "/stop"),
         ("請「停下來」", "/stop"),
         # 书面疑问式请求（只进宽表，approve 永远看不到）
         ("能否停下来？", "/stop"),
-        ("可否换个话题", "/new"),
         ("是否可以停下来", "/stop"),
-        ("是否能换个话题", "/new"),
         ("能否停下來", "/stop"),
     ],
 )
@@ -2960,7 +2922,7 @@ def test_the_new_leads_and_separators_do_not_manufacture_approvals(text):
 
 @pytest.mark.parametrize(
     ("text", "expected"),
-    [("/stop", "/stop"), ("/daemon approve", "/daemon approve"), ("/new", "/new")],
+    [("/stop", "/stop"), ("/daemon approve", "/daemon approve"), ],
 )
 def test_literal_magic_words_survive_the_slash_separator(text, expected):
     """⚠️ `/` 成了子句分隔符，但字面命令由 normalize_magic_command 在更早一层拦下。"""  # noqa: DOCSTRING_CJK
@@ -2974,9 +2936,7 @@ def test_literal_magic_words_survive_the_slash_separator(text, expected):
     [
         ("请问能不能停下来？", "/stop"),
         ("請問能不能停下來", "/stop"),
-        ("请问可以换个话题吗", "/new"),
         ("请问停下来", "/stop"),
-        ("請問換個話題", "/new"),
     ],
 )
 def test_the_politest_interrogative_lead_still_reaches_its_command(text, expected):
@@ -6835,3 +6795,78 @@ def test_dao_in_ordinary_words_does_not_break_real_frames():
                  '我想停止播放因为无论唱什么歌都不好听',
                  '帮我停止播放红心歌单'):
         assert is_explicit_music_cancellation(text) is True, text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "换个话题", "換個話題", "换个话题吧", "重新开始", "重新開始", "重新开始吧",
+        "说点别的", "說點別的", "聊点别的", "聊點別的", "重新开个话题",
+        "我们换个话题好不好", "不聊这个了，换个话题", "这局输了，重新开始",
+        "忘了刚才的事", "忘掉刚才的事", "清除聊天记录", "清空聊天记录",
+        "删掉刚才的记录", "清除我们的聊天记录", "忘了刚才的事吧",
+    ],
+)
+def test_new_and_clear_are_unreachable_from_free_text(text):
+    """⚠️ `/new` 与 `/clear` 只认字面命令，自由文本一律不触发。
+
+    Three measured facts multiplied: the highest misfire rate (6 of 14 pure-chat
+    "change topic" phrasings fired, and all six meant the *chat* topic), no local
+    state to gate on at all, and an irreversible effect — ``/new`` overwrites the
+    one pointer to the upstream session in place, after which a later ``/stop``
+    lands on the new session and cannot reach the job still running in the old.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.rule_magic_command(text) is None, text
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/new", "/new"), ("new", "/new"), ("/clear", "/clear"), ("clear", "/clear"),
+        ("/stop", "/stop"), ("stop", "/stop"),
+        ("/daemon approve", "/daemon approve"), ("approve", "/daemon approve"),
+    ],
+)
+def test_the_literal_commands_all_still_resolve(text, expected):
+    """摘掉的是自由文本推断，不是命令本身——四条字面命令必须原样可用。"""  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.rule_magic_command(text) == expected, text
+
+
+@pytest.mark.parametrize(
+    ("text", "tier"),
+    [
+        ("停下来", "ambiguous"), ("停下來", "ambiguous"),
+        ("快停下来", "ambiguous"), ("别找了", "ambiguous"), ("別找了", "ambiguous"),
+        ("取消这个任务", "addressed"), ("取消這個任務", "addressed"),
+        ("停止搜索", "addressed"), ("停止搜尋", "addressed"),
+        ("算了别查了", "addressed"), ("取消这个搜索", "addressed"),
+        ("/stop", None), ("stop", None), ("今天天气真好", None),
+    ],
+)
+def test_stop_phrasings_are_split_into_two_tiers(text, tier):
+    """⚠️ 分档是纯函数：状态在 agent_server，brain 不能伸手去拿。
+
+    The ambiguous tier is the set of imperatives that are word-for-word identical
+    when addressed to the character instead of the agent, so the dispatcher asks
+    for corroboration there. The addressed tier and the literal command never
+    need it — the registry lies exactly when /stop matters most.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.stop_trigger_tier(text) == tier, text
+
+
+def test_the_two_stop_tiers_are_disjoint_and_cover_the_table():
+    """两档必须是对整张表的划分：既不重叠，也不能漏。"""  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import (
+        _STOP_ADDRESSED,
+        _STOP_AMBIGUOUS,
+        _STOP_CLAUSES,
+    )
+
+    assert _STOP_ADDRESSED & _STOP_AMBIGUOUS == frozenset()
+    assert _STOP_ADDRESSED | _STOP_AMBIGUOUS == _STOP_CLAUSES

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -6824,9 +6824,11 @@ def test_new_and_clear_are_unreachable_from_free_text(text):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("/new", "/new"), ("new", "/new"), ("/clear", "/clear"), ("clear", "/clear"),
-        ("/stop", "/stop"), ("stop", "/stop"),
-        ("/daemon approve", "/daemon approve"), ("approve", "/daemon approve"),
+        ("/new", "/new"), ("/clear", "/clear"),
+        ("/stop", "/stop"), ("/daemon approve", "/daemon approve"),
+        ("/approve", "/daemon approve"),
+        # ⚠️ 不带斜杠的裸词已不再是命令，见
+        # test_a_typed_command_rejects_bare_words_and_anything_extra。
     ],
 )
 def test_the_literal_commands_all_still_resolve(text, expected):
@@ -6875,11 +6877,8 @@ def test_the_two_stop_tiers_are_disjoint_and_cover_the_table():
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("/stop", "/stop"), ("stop", "/stop"),
-        ("/new", "/new"), ("new", "/new"),
-        ("/clear", "/clear"), ("clear", "/clear"),
-        ("/daemon approve", "/daemon approve"), ("approve", "/daemon approve"),
-        ("/approve", "/daemon approve"), ("daemon approve", "/daemon approve"),
+        ("/stop", "/stop"), ("/new", "/new"), ("/clear", "/clear"),
+        ("/daemon approve", "/daemon approve"), ("/approve", "/daemon approve"),
     ],
 )
 def test_a_typed_command_never_depends_on_the_llm(text, expected):
@@ -6937,3 +6936,71 @@ def test_the_free_text_veto_still_holds_when_the_llm_misbehaves(text):
 
     assert result.get("command") is None, text
     assert result.get("source") == "free-text-veto"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/stop", "/stop"), ("/new", "/new"), ("/clear", "/clear"),
+        ("/daemon approve", "/daemon approve"), ("/approve", "/daemon approve"),
+        # 大小写与首尾空白不算「后缀」
+        ("/STOP", "/stop"), (" /stop ", "/stop"), ("/Daemon Approve", "/daemon approve"),
+    ],
+)
+def test_a_typed_command_must_be_slash_prefixed_and_bare(text, expected):
+    """⚠️ 用户打出来的 magic command：必须 `/` 开头，且整条输入就是那个命令。"""  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.parse_typed_magic_command(text) == expected, text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # 不带斜杠的裸词 —— 它们是普通英文单词
+        "stop", "new", "clear", "approve", "daemon approve", "Stop", "CLEAR",
+        # 带了别的东西就不是「裸的」
+        "/stop now", "/stop 一下", "/stopp", "/stop!", "/stop.", "请 /stop",
+        "stop/", "/ stop", "//stop", "/openclaw stop", "/qwenpaw stop",
+        "帮我 /stop", "/daemon approve please",
+    ],
+)
+def test_a_typed_command_rejects_bare_words_and_anything_extra(text):
+    """⚠️ 8 个 locale 里残留的 9 条误命中全部来自不带斜杠的 `Stop` / `Clear` 按钮标签。
+
+    Accepting the slashless words meant an English UI string — or an English chat
+    line — counted as a *typed* command, which also handed it the explicit
+    exemption that bypasses the approval gate entirely.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.parse_typed_magic_command(text) is None, text
+    assert OpenClawAdapter.rule_magic_command(text) is None, text
+
+
+def test_no_ui_string_in_any_locale_is_a_magic_command():
+    """⚠️ 8 个 locale 的全部文案：一条命令意图都没有，命中数必须是 0。"""  # noqa: DOCSTRING_CJK
+    import glob
+    import io
+    import json
+
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    def _walk(node, out):
+        if isinstance(node, str):
+            out.append(node)
+        elif isinstance(node, dict):
+            for value in node.values():
+                _walk(value, out)
+        elif isinstance(node, list):
+            for value in node:
+                _walk(value, out)
+
+    strings: list[str] = []
+    for path in sorted(glob.glob("static/locales/*.json")):
+        with io.open(path, encoding="utf-8") as handle:
+            _walk(json.load(handle), strings)
+    assert len(strings) > 30000, "语料没加载到，断言会变成空转"
+
+    hits = [s for s in strings if s.strip() and OpenClawAdapter.rule_magic_command(s.strip())]
+    assert hits == [], f"UI 文案被判成命令：{hits[:8]}"

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -6980,9 +6980,9 @@ def test_a_typed_command_rejects_bare_words_and_anything_extra(text):
 
 def test_no_ui_string_in_any_locale_is_a_magic_command():
     """⚠️ 8 个 locale 的全部文案：一条命令意图都没有，命中数必须是 0。"""  # noqa: DOCSTRING_CJK
-    import glob
     import io
     import json
+    from pathlib import Path
 
     from brain.openclaw_adapter import OpenClawAdapter
 
@@ -6997,7 +6997,11 @@ def test_no_ui_string_in_any_locale_is_a_magic_command():
                 _walk(value, out)
 
     strings: list[str] = []
-    for path in sorted(glob.glob("static/locales/*.json")):
+    # ⚠️ 用 __file__ 锚定，别用相对路径：`cd tests && pytest ...` 时 glob 会是空的，
+    # 断言变成「语料没加载到」的伪失败。同文件的
+    # test_no_magic_command_fires_on_the_projects_own_ui_copy 已经是这个写法。
+    locales_dir = Path(__file__).resolve().parents[2] / "static" / "locales"
+    for path in sorted(locales_dir.glob("*.json")):
         with io.open(path, encoding="utf-8") as handle:
             _walk(json.load(handle), strings)
     assert len(strings) > 30000, "语料没加载到，断言会变成空转"

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -6870,3 +6870,70 @@ def test_the_two_stop_tiers_are_disjoint_and_cover_the_table():
 
     assert _STOP_ADDRESSED & _STOP_AMBIGUOUS == frozenset()
     assert _STOP_ADDRESSED | _STOP_AMBIGUOUS == _STOP_CLAUSES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/stop", "/stop"), ("stop", "/stop"),
+        ("/new", "/new"), ("new", "/new"),
+        ("/clear", "/clear"), ("clear", "/clear"),
+        ("/daemon approve", "/daemon approve"), ("approve", "/daemon approve"),
+        ("/approve", "/daemon approve"), ("daemon approve", "/daemon approve"),
+    ],
+)
+def test_a_typed_command_never_depends_on_the_llm(text, expected):
+    """⚠️⚠️ 打出来的命令必须**保证**到达，不能让小模型有否决权。
+
+    ``classify_magic_intent`` used to await the LLM leg unconditionally, and any
+    dict it returned — including "not a command" — was final, so the rule layer
+    never got a say. A model having an off moment silently swallowed a typed
+    ``/stop`` while the upstream job kept running.
+
+    It also broke the free-text veto added alongside: a typed ``/new`` went out
+    to the LLM, came back, and was killed as if it had been *inferred* from free
+    text. Deciding the literal form before the LLM fixes both and saves a call.
+    """  # noqa: DOCSTRING_CJK
+    import asyncio
+
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    adapter = OpenClawAdapter.__new__(OpenClawAdapter)
+    called = []
+
+    async def _hostile_llm(_self, user_text):
+        called.append(user_text)
+        return {"is_magic_intent": False, "command": None}
+
+    original = OpenClawAdapter._classify_magic_intent_with_llm
+    OpenClawAdapter._classify_magic_intent_with_llm = _hostile_llm
+    try:
+        result = asyncio.run(OpenClawAdapter.classify_magic_intent(adapter, text))
+    finally:
+        OpenClawAdapter._classify_magic_intent_with_llm = original
+
+    assert result.get("command") == expected, text
+    assert called == [], "字面命令不该把它送进 LLM"
+
+
+@pytest.mark.parametrize("text", ["换个话题", "忘了刚才的事", "重新开始", "清除聊天记录"])
+def test_the_free_text_veto_still_holds_when_the_llm_misbehaves(text):
+    """提示词管不住模型：LLM 硬返回 /new 也要被毙掉。"""  # noqa: DOCSTRING_CJK
+    import asyncio
+
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    adapter = OpenClawAdapter.__new__(OpenClawAdapter)
+
+    async def _rogue_llm(_self, user_text):
+        return {"is_magic_intent": True, "command": "/new"}
+
+    original = OpenClawAdapter._classify_magic_intent_with_llm
+    OpenClawAdapter._classify_magic_intent_with_llm = _rogue_llm
+    try:
+        result = asyncio.run(OpenClawAdapter.classify_magic_intent(adapter, text))
+    finally:
+        OpenClawAdapter._classify_magic_intent_with_llm = original
+
+    assert result.get("command") is None, text
+    assert result.get("source") == "free-text-veto"

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -7045,3 +7045,42 @@ def test_a_narrated_addressed_phrase_never_becomes_a_command(text):
     from brain.openclaw_adapter import OpenClawAdapter
 
     assert OpenClawAdapter.rule_magic_command(text) is None, text
+
+
+def test_every_typed_command_key_starts_with_a_slash():
+    """⚠️ `parse_typed_magic_command` 里那句 `startswith("/")` 是**冗余**的防御。
+
+    Mutation testing flagged it as equivalent: every key in the table already
+    starts with "/", so a slashless word misses the lookup anyway. Rather than
+    contrive a test around a redundant guard, pin the premise that makes it
+    redundant — if someone ever adds a slashless alias, this turns red and they
+    have to decide deliberately.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    keys = sorted(OpenClawAdapter._TYPED_MAGIC_COMMANDS)
+    assert keys == ["/approve", "/clear", "/daemon approve", "/new", "/stop"]
+    assert all(k.startswith("/") for k in keys), keys
+    assert all(k == k.lower() for k in keys), "查表前会 lower()，键必须已经是小写"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # 模糊词在**非末**子句，末子句不是命令 → 整句不该被分成模糊档
+        "别找了，我自己来", "停下来，这是我当时唯一的念头", "快停下来，他喊道",
+        "別找了，我自己來",
+    ],
+)
+def test_the_ambiguous_tier_only_reads_the_trailing_clause(text):
+    """⚠️ 明确档扫全句、模糊档只看末子句——这个不对称是有意的。
+
+    Scanning every clause for the ambiguous tier would label a narrated 停下来 as
+    "ambiguous" instead of None. Under the rule path that costs nothing (the
+    classifier already returned None), but on the LLM path it silently flips such
+    an utterance from "no corroboration needed" to "needs corroboration" — a
+    behaviour change nobody asked for, and one no dispatch test would notice.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.stop_trigger_tier(text) is None, text

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -7008,3 +7008,40 @@ def test_no_ui_string_in_any_locale_is_a_magic_command():
 
     hits = [s for s in strings if s.strip() and OpenClawAdapter.rule_magic_command(s.strip())]
     assert hits == [], f"UI 文案被判成命令：{hits[:8]}"
+
+
+@pytest.mark.parametrize(
+    ("text", "tier"),
+    [
+        # 明确档在前、模糊收尾在后 —— 整句仍算「明确」
+        ("取消这个任务，停下来", "addressed"),
+        ("停止搜索，别找了", "addressed"),
+        ("算了别查了，停下来吧", "addressed"),
+        ("取消這個搜尋，停下來", "addressed"),
+        # 只有模糊说法
+        ("停下来", "ambiguous"), ("别找了，停下来", "ambiguous"),
+    ],
+)
+def test_an_addressed_phrase_anywhere_makes_the_whole_utterance_addressed(text, tier):
+    """⚠️ 明确档扫**所有**子句，模糊档只看末子句。
+
+    ``取消这个任务，停下来`` puts the unambiguous cancel first and a colloquial
+    closer last; tiering on the trailing clause alone called it ambiguous, so in
+    exactly the timeout/restart/TTL moments where nothing corroborates, the most
+    deserving phrasing got dropped.
+
+    Scanning every clause is safe here because the tier does **not** decide
+    whether ``/stop`` fires — the classifier already did that on the trailing
+    clause. ``我说了停止搜索，然后他就走了`` is None before this is ever reached.
+    """  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.stop_trigger_tier(text) == tier, text
+
+
+@pytest.mark.parametrize("text", ["我说了停止搜索，然后他就走了", "他让我取消这个任务，我没理"])
+def test_a_narrated_addressed_phrase_never_becomes_a_command(text):
+    """分档扫全句不会把叙述变成命令——分类器那层先按末子句判据否掉了。"""  # noqa: DOCSTRING_CJK
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    assert OpenClawAdapter.rule_magic_command(text) is None, text

--- a/tests/unit/test_zh_tw_input_parity.py
+++ b/tests/unit/test_zh_tw_input_parity.py
@@ -6934,8 +6934,9 @@ def test_the_free_text_veto_still_holds_when_the_llm_misbehaves(text):
     finally:
         OpenClawAdapter._classify_magic_intent_with_llm = original
 
+    # ⚠️ 否决之后会**回落规则层**，所以 source 是 "rule" 而不是 veto 常量——
+    # 关键断言是命令确实没出去，而不是它从哪一层出去的。
     assert result.get("command") is None, text
-    assert result.get("source") == "free-text-veto"
 
 
 @pytest.mark.parametrize(
@@ -7084,3 +7085,34 @@ def test_the_ambiguous_tier_only_reads_the_trailing_clause(text):
     from brain.openclaw_adapter import OpenClawAdapter
 
     assert OpenClawAdapter.stop_trigger_tier(text) is None, text
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [("取消这个任务", "/stop"), ("停止搜索", "/stop"), ("同意，去执行", "/daemon approve")],
+)
+def test_a_vetoed_llm_command_falls_back_to_the_rules(text, expected):
+    """⚠️ 否决破坏性命令，不该连合法的取消一起丢。
+
+    When the LLM ignores its prompt and answers ``/new`` for 取消这个任务, vetoing
+    that is right — but finalizing the veto as "not magic" throws away a command
+    the zero-LLM rules can identify perfectly well. Veto, then fall through.
+    """  # noqa: DOCSTRING_CJK
+    import asyncio
+
+    from brain.openclaw_adapter import OpenClawAdapter
+
+    adapter = OpenClawAdapter.__new__(OpenClawAdapter)
+
+    async def _rogue_llm(_self, user_text):
+        return {"is_magic_intent": True, "command": "/new"}
+
+    original = OpenClawAdapter._classify_magic_intent_with_llm
+    OpenClawAdapter._classify_magic_intent_with_llm = _rogue_llm
+    try:
+        result = asyncio.run(OpenClawAdapter.classify_magic_intent(adapter, text))
+    finally:
+        OpenClawAdapter._classify_magic_intent_with_llm = original
+
+    assert result.get("command") == expected, text
+    assert result.get("source") == "rule"


### PR DESCRIPTION
承接 #2680。那个 PR 把三条命令的**识别**从子串包含收成整子句白名单；这个 PR 处理的是
维护者在 review 里指出的另一件事：**问题不在识别而在状态机**——四条命令的误触率、可用
状态、破坏半径天生不同，不该套同一套判据。

先派了五路实测调查（状态 / 离线成本 / 在线收益 / 逐命令误触率 / 破坏半径），下面每个数字
都是跑出来的，不是读码推断。

## 调查里最反直觉的两条

**规则表在线时省的 LLM 调用是零。** `classify_magic_intent` 是 **LLM 无条件先跑**，只要它
返回一个 dict（**哪怕内容是「不是命令」**）就是终局，规则层再没机会说话：

```python
llm_result = await self._classify_magic_intent_with_llm(text)
if isinstance(llm_result, dict): return llm_result   # ← 判 not-magic 也走这里
return self._classify_magic_intent_with_rules(text)  # ← 只有 LLM 挂了才到
```

推论：**在线时规则误命中并不会真的触发命令**（LLM 会否掉，代价是 2~3 次调用的钱），真正
的误执行只发生在 LLM 腿降级时（配置读失败 / 10s 超时且不重试 / 上游吐非 JSON）。
反方向的漏判则任何时候都是硬损失：规则漏 + external_intent 低 → 命令**静默丢失**。

**OpenClaw 未连接时，误触基本不花钱。** `qwenpaw_available` 是每个分析轮现打的一次 HTTP
健康探测；它为假时 `classify_magic_intent` **整段不跑**（实测喂 6 条命令句，await 数全 0）。
没有 LLM 调用、没有台词、不丢用户的话。

## 改动

### 1. `/new` 与 `/clear`：从自由文本路径整个摘掉，只认字面命令

三条实测事实相乘：

- **误触率最高**：纯聊天语境的「换话题」说法 **6/14** 命中，且那 6 条**全部**指的是聊天
  话题而非 agent 会话；中文语料里 `/new` 触发词频率是 `/stop` 的 **4.3 倍**
  （30 次 vs 7 次 / 304 万字），且 `/new` 的 30 次里 8 次整句成立，`/stop` 是 0 次。
- **零状态可用**：本地没有任何前置条件可查（不像 `/stop` 有「在跑的任务」、approve 有
  「刚完成的任务」），想拦也无从拦起。
- **后果不可逆**：`/new` 就地覆盖指向上游会话的**唯一**指针（无备份、无写回入口）；
  ⚠️ 而且实测出一条跨命令腐蚀——误触 `/new` 之后用户再喊「停下来」，POST 打到的是**新**
  会话，旧会话里真正在跑的活儿**停不下来**，本地却照样标成 cancelled。

删掉 `_NEW_CLAUSES` / `_CLEAR_TRIGGERS` 两张表（留着必被下一个人捡回去用），LLM 提示词
只列两条命令，并加一道**硬过滤**：LLM 那条腿返回 `/new` `/clear` 一律作废——提示词管不住
模型，而这两条的后果不可逆。

### 2. `/stop`：触发词分两档，模糊档要状态佐证

| 档 | 词 | 状态要求 |
|---|---|---|
| 明确指向 agent | 取消这个任务 / 取消这个搜索 / 停止搜索 / 算了别查了 | **无** |
| 日常对话也成立 | 停下来 / 快停下来 / 别找了 | **要有佐证**（见下） |

⚠️ **明确档扫所有子句，模糊档只看末子句。** `取消这个任务，停下来` 把无歧义的取消放在前、
口语收尾放在后，只看末子句会判成模糊，然后在恰恰没有佐证的时刻被丢掉。扫全句在这里安全，
因为**分档不决定 `/stop` 发不发**（分类器已按末子句判据决定过），只决定要不要佐证——
`我说了停止搜索，然后他就走了` 在分类器那层就是 None。

⚠️ **佐证 = 在跑的任务（不按角色收窄）或一个窄条件下有效的审批窗口。**
- 审批提示出口时**恰恰没有 queued/running 任务**（窗口是 completed 开的，两个状态集合互不
  相交），所以只看在跑的任务会让「拒绝提示的那句停下来」被丢掉、窗口还留着给下一句「同意」。
- 但窗口这侧必须用**窄**判据（新鲜 + 同角色 + 同会话 + 带疑问标记 + 未兑现）。终态条目在
  这条路径上可以无限期留着，用作废那套宽过滤的话，**一条几小时前、没问过问题的完成记录**
  就能让之后每一句「停下来」永远放行——分档守卫等于白加。「开闸窄、作废宽」在这里同样成立。
- 在跑的任务那侧则**不按角色收窄**：上游会话键 `_build_session_key` 第一行 `del role_name`，
  同 sender 跨角色共用一个 QwenPaw 会话。跨 sender 仍然不算。

整子句判据挡得掉叙述（`雨停下来了` 不命中），挡不掉用户对**猫娘本人**说的同一句话——
角色扮演里那句话字面完全一样。

⚠️ **逃生阀有意不焊死。** `stop_running` 实测是**纯客户端 no-op**（0 次 HTTP），唯一能让
上游停手的就是那次 `/stop` POST；而 registry 恰恰在最需要它的时刻说谎——请求超时后状态被
写成 `failed`、进程重启后 registry 全空、条目过 TTL 被删，这些时刻上游那个活儿可能还在跑。
把 POST 整个门在 registry 上等于焊死逃生阀。所以只有模糊档要佐证。

分档判定是 brain 侧的**纯函数** `stop_trigger_tier`，状态判定留在 agent_server —— brain
不能伸手去拿 `task_registry`（有 API & layering 门禁）。

### 3. `/daemon approve`：窗口要求那条回复**真的问过问题**

原来只判「5 分钟内有任务跑完过」，于是一次「整理完成，共移动 12 个文件」也会给随后随口
的「同意」开闸。上游那句 reply 就存在 registry 条目的 `result` 里，判一下几乎不要钱。

⚠️ 判据只认**明确的疑问标记**（`？` `?` `吗` `嗎` `要不要`），不枚举「审批提示长什么样」
——后者是开集。曾经还收了 `确认` / `確認` / `是否`，已删：这里是**子串**匹配，而那三个在
陈述句里同样常见（`已确认配置无误` / `確認完成` / `已检查是否有重复`），收了等于让一次
普通的完成回报把窗口顶开。

代价记账：上游若用「是否继续」这类不带问号的问法征询，窗口会误关，用户得手敲字面命令。
方向是 fail-closed。

### 4. 字面命令必须 `/` 开头且**裸的**，且不再经过 LLM

两件事，起因是一个提问：「打出来的 `/stop` 能保证到达吗？」——答案是**不能**。

**洞一（既有）**：字面命令要经 LLM 复核。实测把 LLM 打桩成恒判 not-magic，
`/stop` `stop` `/new` `/clear` `/daemon approve` 五条**全部被静默丢弃**，而上游那个活儿
还在跑。让一个小模型对「用户明确打出的命令」有否决权本来就没道理——改成字面命令在最前面
判掉，根本不进 LLM（顺带省一次调用）。

**洞二（本 PR 前一个提交引入的回归）**：给 LLM 腿加的自由文本过滤，把**打出来**的字面
`/new` 也当成「推断出来的」一起毙了。同一处修法一并解决。

**收紧**：新增 `parse_typed_magic_command`——`/` 开头且整条输入就是那个命令，不认不带斜杠
的裸词、不认任何前后缀。只用在「这句用户输入算不算字面命令」的四处；`normalize_magic_command`
保持宽松不动（它另有一类调用者传的是**内部命令值**，收紧只会误伤）。

⚠️ 这条的收益比表面大：8 个 locale 共 34056 条 UI 文案的残留误命中 **9 → 0**，那 9 条全是
不带斜杠的 `Stop` / `Clear` 按钮标签。而且后果不只是误触发——`explicitly_typed` 一旦成立
就拿到**显式豁免**，整道审批闸被绕过。也就是说改之前，**一句英文闲聊里的 `approve` 可以
在没有任何审批窗口的情况下把 `/daemon approve` 直接发到上游**。

## 数字

对抗集逐命令误命中（分母 = 各组条数）：

| 组 | `origin/main`（#2680 之前） | #2680 合并后 | 本 PR |
|---|---|---|---|
| `/stop` | 22/22 | 0/22 | 0/22 |
| `/new` | 16/16 | 0/16 | 0/16 |
| `/clear` | 3/6 | 3/6 | **0/6** |
| `/daemon approve` | 17/28 | 4/28 | 4/28（全是裸应答，窗口关着时到不了上游） |

- **8 个 locale 共 34056 条 UI 文案：9 → 0**
- 全量新旧差分 122255 条：**简体/中性侧扩面 0、改判到别的命令 0**；召回收窄
  9506 → 10556，增量正好是摘掉的 `/new` `/clear`
- 测试：7163 通过（相关两个文件；已 rebase 到最新 main）

## 行为契约

| 输入 | 结果 |
|---|---|
| `/stop`（整条） | ✅ 保证到达，不经 LLM |
| `/openclaw stop`（文本输入） | ✅ streaming 短路，不经 analyzer |
| `stop` / `/stop now` / `请 /stop` | ❌ 不是命令 |
| 语音「取消这个任务」 | ✅ 直接生效（逃生阀） |
| 语音「停下来」 | 要有在跑的任务 |
| 语音「换个话题」 | ❌ 不再触发 `/new` |
| 语音「同意」 | 要有窗口，且上游那句回复真的问过问题 |

## 已知限制（记账，不修）

- `/openclaw stop` 的短路要求 `openclaw_ready` 为真；不满足时落到 analyzer，而
  `parse_typed_magic_command` 不认这个前缀形态。无害：那条件不成立时 openclaw 本来就不可用。
- approve 的疑问标记判据是这轮唯一一处「靠标记猜上游行为」的地方。上游若换种问法会误关
  窗口，fail-closed。
- 上游 QwenPaw 的「待审批状态」契约（跨仓库）仍是根治手段；本地闸只是近似。第一方代码里
  确实没有任何待审批状态（`pending_approval` / `awaiting_approval` / `approval_state`
  grep 只命中注释本身）。
- 「疑问式/礼貌式变体」这一开集收口到此为止，未收的形态（`停下来行不？` 一类）见 #2680 讨论。

## 回归报告

### 必要性

`/daemon approve` 让上游 QwenPaw daemon **真的执行**一个挂起的高风险动作（删文件之类），
而这条通路从来没校验过「这句话是不是在回答某个待审批提示」。#2680 收窄了识别，但没解决
状态机：`/new` `/clear` 仍能被一句「换个话题」触发且零前置条件，而后果不可逆；字面命令
还要经一个小模型复核，模型判错就静默丢弃。

### 行为变化（前后对比）

| 输入 | 改动前 | 改动后 |
|---|---|---|
| 语音「换个话题」 | `/new`（覆盖上游会话指针，不可逆） | 无事 |
| 语音「忘了刚才的事」 | `/clear` | 无事 |
| 语音「停下来」+ 无在跑任务 | `/stop` 照发 | 静默丢弃 |
| 语音「停下来」+ 有在跑任务 | `/stop` | `/stop`（不变） |
| 语音「取消这个任务」 | `/stop` | `/stop`（不变，逃生阀） |
| 语音「同意」+ 上游回的是「整理完成」 | 放行 | 丢弃（回复没问过问题） |
| 打字 `/stop` + LLM 判 not-magic | **静默丢弃** | 保证到达 |
| 打字 `stop`（无斜杠） | `/stop`，且拿到显式豁免 | 不是命令 |
| UI 文案 "Stop" / "Clear" 被喂进分类器 | 命中 | 不命中 |

### 已知回归（明确记账）

- **语音用户无法再用嘴换 agent 会话或清上下文**。要换得打 `/new` `/clear`。这是本次
  拍板的方向：用户说「换个话题」九成指的是聊天话题，实测 6/14 纯聊天说法会误触。
- **`stop` / `approve` 等不带斜杠的裸词不再是命令**。英文界面用户若习惯直接打 `stop`，
  现在要打 `/stop`。
- **上游用不带疑问标记的说法征询时，「同意」会被丢弃**，用户得手敲 `/daemon approve`。
  疑问标记是开集，这里选了 fail-closed。
- **模糊说法 + 无在跑任务 = 静默丢弃**，屏幕不回字。这与 `/stop` 误触时的现有行为一致
  （两者都不影响正常聊天回复，magic 分支走的是并行的 analyzer）。

### 验证

- 相关测试 7171 通过；`cd tests` 换目录复跑确认路径锚定生效
- **变异验证 15 条，杀死 14**。抓到两处并已补：①「模糊档也扫全句」原本无人能杀——它在
  规则路径上不改变行为，却会在 LLM 路径上把被叙述包着的「停下来」从「不需要佐证」悄悄翻成
  「需要佐证」，任何派单测试都看不见；②唯一存活的那条是**可证等价**的（`startswith("/")`
  在任何输入上都不改变结果，因为表的键全部以 `/` 开头），没有硬凑测试去杀它，而是把使它
  等价的**前提**钉住：键集合等值 + 全部以 `/` 开头 + 全部已是小写
- ⚠️ 另加了一条**总不变量**的属性检查 `test_the_retirement_set_is_always_a_superset_of_the_gate_set`：
  作废集合 ⊇ 开闸集合，逐维成立。写成属性而非清单——registry 一次铺满所有维度，某一侧新加
  过滤而另一侧忘了加就会红。它当场抓到一条我自己埋的（`require_session=False` 只关掉了
  「问不出会话时 fail-closed」那一半，没关掉 session 匹配本身，参数名名不副实）
- 全量新旧差分 122255 条：简体/中性侧扩面 0、改判 0
- 8 个 locale 共 34056 条 UI 文案：9 → 0
- ruff / docstring 禁 CJK 门禁全绿；brain 未引入对 app 的依赖（API & layering）

## 不拆分理由

四处改动是同一个判据的四个面（哪条命令能从自由文本触发、触发要什么状态佐证、字面命令怎么
算），拆开会让每一半的 diff 都读不出取舍；而且 2 和 4 共用 `parse_typed_magic_command`，
3 和 2 共用同一套「开闸窄、作废宽」的过滤器开关。
