### PR TITLE
test(settings): 钉住 #2540 启动期 ASR 合并的收敛行为（复查结论：缺陷已由 #2573 修掉）

### DIFF
--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -3115,6 +3115,275 @@ def test_cross_window_asr_flip_authoritative_over_pending_get_harness():
     assert "HARNESS_OK" in result.stdout
 
 
+def test_boot_get_converges_on_a_peer_asr_flip_it_did_not_witness_harness():
+    # Issue #2540 (residual 2 of #2345): window A's boot GET merged the stale
+    # server value onto independentAsrEnabled just because the key was not in
+    # _dirtySettingsKeys, and A then stayed on that value. The sibling test
+    # above only covers the flip arriving DURING the in-flight GET, where the
+    # flip gate marks the key dirty. Pin the two interleavings it does not
+    # reach -- the flip already sitting in the boot snapshot, and the flip
+    # arriving after the merge already landed -- so the decision-tuple ordering
+    # that makes both converge cannot silently regress into dirty-mark-only
+    # gating again.
+    harness = textwrap.dedent(
+        """
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+
+        const source = fs.readFileSync(__APP_SETTINGS_PATH__, 'utf8');
+
+        function assert(cond, msg) {
+          if (!cond) throw new Error('ASSERT: ' + msg);
+        }
+
+        function makeContext(bootSnapshot) {
+          const postCalls = [];
+          const getCalls = [];
+          const listeners = [];
+          const store = Object.create(null);
+          if (bootSnapshot) {
+            store['project_neko_settings'] = JSON.stringify(bootSnapshot);
+          }
+          const sandbox = {
+            console: { log() {}, warn() {}, error() {} },
+            CustomEvent: class {
+              constructor(type) { this.type = type; }
+            },
+            setInterval() { return 0; },
+            clearInterval() {},
+            setTimeout(fn, ms) {
+              const t = setTimeout(fn, ms);
+              if (t && typeof t.unref === 'function') t.unref();
+              return t;
+            },
+            clearTimeout,
+            localStorage: {
+              getItem(key) {
+                return Object.prototype.hasOwnProperty.call(store, key)
+                  ? store[key]
+                  : null;
+              },
+              setItem(key, value) { store[key] = value; },
+              removeItem(key) { delete store[key]; },
+            },
+            document: { getElementById() { return null; } },
+            fetch(url, opts) {
+              return new Promise((resolve, reject) => {
+                if (opts && opts.method === 'POST') {
+                  postCalls.push({ url, body: opts.body, resolve, reject });
+                } else {
+                  getCalls.push({ url, resolve, reject });
+                }
+              });
+            },
+          };
+          sandbox.window = {
+            appState: {
+              independentAsrEnabled: false,
+              independentAsrActive: true,
+              voiceChatActive: true,
+              voiceInputLifecycleState: 'active',
+              voiceSessionStartEpoch: 10,
+              voiceSettingsPendingUntilEpoch: null,
+              pendingVoiceRouteIndependentAsr: null,
+              settingsHydrated: false,
+            },
+            appConst: {},
+            appUtils: { mapRenderQualityToFollowPerf() { return 'medium'; } },
+            addEventListener(type, fn) { listeners.push({ type, fn }); },
+            removeEventListener() {},
+            dispatchEvent() {},
+          };
+          vm.createContext(sandbox);
+          vm.runInContext(source, sandbox);
+          const storage = listeners.filter((entry) => entry.type === 'storage');
+          assert(storage.length === 1, 'module must register exactly one storage listener');
+          return {
+            postCalls,
+            getCalls,
+            S: sandbox.window.appState,
+            fireStorage(value) {
+              storage[0].fn({
+                key: 'project_neko_settings',
+                newValue: JSON.stringify(value),
+              });
+            },
+            postedAsrValues() {
+              return postCalls.map((call) => {
+                try { return JSON.parse(call.body).independentAsrEnabled; }
+                catch (_) { return undefined; }
+              });
+            },
+          };
+        }
+
+        const tick = () => new Promise((resolve) => setImmediate(resolve));
+        const NOW = Date.now();
+        // The peer toggled a second ago; the server snapshot this window is
+        // about to read still carries the decision from a minute ago.
+        const PEER_WRITE_ID = NOW - 1000;
+        const SERVER_DECISION_ID = NOW - 60000;
+
+        function peerFlipSnapshot(writeId, value) {
+          return {
+            independentAsrEnabled: value,
+            _sharedWriteMeta: {
+              writeId,
+              writerId: 'peerwindow',
+              changedKeys: ['independentAsrEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              pendingRecovery: false,
+              asrDecision: { writeId, writerId: 'peerwindow', value },
+            },
+          };
+        }
+
+        function resolveStaleGet(getCall, options) {
+          const withDecision = !(options && options.withoutDecisions);
+          const body = {
+            success: true,
+            revision: 7,
+            settings: { independentAsrEnabled: false },
+            telemetryBranch: null,
+          };
+          if (withDecision) {
+            body.decisions = {
+              independentAsrEnabled: {
+                writeId: SERVER_DECISION_ID,
+                writerId: 'serverside',
+                value: false,
+              },
+            };
+          }
+          getCall.resolve({
+            ok: true,
+            headers: {
+              get(header) {
+                return header === 'ETag' ? '"conversation-settings-7"' : null;
+              },
+            },
+            json: async () => body,
+          });
+        }
+
+        async function main() {
+          // Scenario 1: the peer's flip reached localStorage before this window
+          // loaded, so no storage event ever announces it and the key is not
+          // dirty here. The restored decision tuple must still outrank the
+          // server's older one.
+          const ctx = makeContext(peerFlipSnapshot(PEER_WRITE_ID, true));
+          assert(ctx.S.independentAsrEnabled === true, 'boot must load the peer flip');
+          assert(ctx.getCalls.length === 1, 'boot must issue the settings GET');
+          resolveStaleGet(ctx.getCalls[0]);
+          await tick();
+          await tick();
+          await tick();
+          assert(
+            ctx.S.independentAsrEnabled === true,
+            'the stale boot GET must not overwrite a non-dirty key the peer already decided'
+          );
+          assert(
+            ctx.postedAsrValues().every((value) => value !== false),
+            'the stale value must not be POSTed back over the peer decision'
+          );
+
+          // Scenario 1 negative: the SAME shape with a decision OLDER than the
+          // server's is a genuine hydration, not a conflict -- the merge must
+          // still apply the server value, or scenario 1 would pass vacuously.
+          const stale = makeContext(
+            peerFlipSnapshot(SERVER_DECISION_ID - 1000, true)
+          );
+          assert(stale.S.independentAsrEnabled === true, 'boot must load the local value');
+          resolveStaleGet(stale.getCalls[0]);
+          await tick();
+          await tick();
+          await tick();
+          assert(
+            stale.S.independentAsrEnabled === false,
+            'a local decision older than the server tuple must still hydrate from the server'
+          );
+
+          // Scenario 2: the merge lands first and the peer's flip only arrives
+          // afterwards. Adopting the server tuple must not pin this window.
+          const late = makeContext(null);
+          resolveStaleGet(late.getCalls[0]);
+          await tick();
+          await tick();
+          await tick();
+          assert(
+            late.S.independentAsrEnabled === false,
+            'the clean boot must merge the server value'
+          );
+          late.fireStorage(peerFlipSnapshot(NOW, true));
+          assert(
+            late.S.independentAsrEnabled === true,
+            'a peer flip newer than the adopted server tuple must win after the merge'
+          );
+
+          // Scenario 3: a server with no decisions block at all carries no
+          // ordering evidence, so it must never displace a restored local one.
+          const legacyServer = makeContext(peerFlipSnapshot(PEER_WRITE_ID, true));
+          resolveStaleGet(legacyServer.getCalls[0], { withoutDecisions: true });
+          await tick();
+          await tick();
+          await tick();
+          assert(
+            legacyServer.S.independentAsrEnabled === true,
+            'a decision-less server snapshot must not overwrite a restored local decision'
+          );
+
+          console.log('HARNESS_OK');
+          process.exitCode = 0;
+        }
+
+        main().catch((err) => {
+          console.error(err && err.stack ? err.stack : String(err));
+          process.exitCode = 1;
+        });
+        """
+    ).replace("__APP_SETTINGS_PATH__", json.dumps(str(APP_SETTINGS_PATH)))
+
+    result = _run_settings_node_harness(harness)
+    assert result.returncode == 0, (
+        "boot-GET convergence harness failed\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "HARNESS_OK" in result.stdout
+
+
+def test_boot_merge_orders_asr_on_the_decision_tuple_not_only_the_dirty_mark():
+    # Structural half of the #2540 pin. The behavioural harness above can only
+    # observe the outcome; this asserts the boot path actually keeps the two
+    # inputs the issue said were conflated -- "I never changed this key" and
+    # "I never had an authoritative value for it" -- separate.
+    settings_source = APP_SETTINGS_PATH.read_text(encoding="utf-8")
+
+    load_fn = _block_after(settings_source, "function loadSettings() {")
+    # The boot snapshot restores the decision tuple, so a flip a peer wrote
+    # before this window loaded is still ordered against the server's.
+    assert "bootMeta.asrDecision" in load_fn
+    assert "_adoptAsrDecisionTuple(" in load_fn
+    assert "const bootDecision = bootMeta.asrDecision || bootMeta;" in load_fn
+
+    # The field-level merge skips the ASR key on decision ordering, which is
+    # evaluated INDEPENDENTLY of _dirtySettingsKeys.
+    assert (
+        "if (key === 'independentAsrEnabled' && preserveLocalAsrDecision) continue;"
+        in load_fn
+    )
+    preserve = load_fn.split("const preserveLocalAsrDecision =", 1)[1].split(
+        ";", 1
+    )[0]
+    assert "_lastAsrDecision" in preserve
+    assert "_asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)" in preserve
+    # A server snapshot with no decision tuple carries no ordering evidence:
+    # the local decision must win rather than the absence counting as newer.
+    assert "!serverAsrDecision" in preserve
+    assert "_dirtySettingsKeys" not in preserve
+
+
 def test_shared_settings_writes_carry_explicit_change_metadata():
     # Codex P2 (follow-up): saveSettings() writes independentAsrEnabled into
     # EVERY localStorage snapshot, so the receiving window could not tell a real


### PR DESCRIPTION
## 改动概述 / Summary

复查 #2540（#2345 残留 2）的结论 + 对应回归钉。**只动测试，不动实现。**

**复查结论：issue 描述的缺陷已经不存在了。** #2573 为 ASR 引入了 `(writeId, writerId, value)` 决策元组的全序，并让启动期合并按 `preserveLocalAsrDecision` 给较新的本地决策让路——这正好是 issue「建议方向」里的第二条（让合并走 `asrDecision` 的 writeId 比较，而不是只看 dirty 标记）。我用 node harness 把 issue 描述的各个交错都跑了一遍，窗口 A 都能收敛。

但现有回归只覆盖**一种**交错：翻转发生在 GET 在途期间（`test_cross_window_asr_flip_authoritative_over_pending_get_harness`）。那条路径靠翻转闸把 key 标成 dirty，恰好绕开了 issue 说的「非 dirty」这个前提条件——也就是说 #2540 真正的形态目前没有任何钉子看着。本 PR 补上。

新增两条：

- **行为钉**（node harness，驱动真实模块）
  - 翻转在本窗口加载前就已落进 localStorage：没有任何 storage 事件宣告它，key 也不在 `_dirtySettingsKeys` 里，陈旧 GET 仍不得覆盖；
  - 合并先落地、对端翻转后到：仍须收敛到对端的值（不会被已采纳的服务端元组钉死）；
  - 服务端快照完全没有 `decisions` 时不得顶掉已恢复的本地决策；
  - 反向用例：本地决策比服务端元组**旧**时必须照常从服务端水合——否则前几条会被一个「无脑保留本地值」的实现空过。
- **结构钉**：启动期合并对 ASR 的让路条件只看决策元组定序，不得退回只看 `_dirtySettingsKeys`。

## 已知边界 / Known Boundary

复查中找到一处仍能复现 #2540 症状的窄路径，**本 PR 不处理**：若服务端持有的决策元组 writeId 比对端真实翻转还新，窗口 A 采纳它之后会永久拒绝对端那次翻转。能造出这种元组的只有两条来源——`utils/preferences.py` 的 `_next_legacy_asr_decision`（无决策头的写入由服务端时钟补铸，即旧版本客户端）和 cloudsave 从时钟更快的机器带回来的元组。要根治得放弃 (writeId, writerId) 这套挂钟全序、换真正的逻辑时钟，那是 #2573 已经定下的设计取舍，不该在一条回归 PR 里翻案。若认为值得追，建议单开 issue。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/`（本 PR 只改 `tests/`）。

## 不拆分理由 / Why Not Split

不适用：只改 1 个文件。

## 测试 / Testing

- `uv run pytest tests/unit/test_app_websocket_static.py -q` → 76 passed
- `uv run ruff check tests/unit/test_app_websocket_static.py`
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main`
- 变异验证（改实现 → 看是否变红）：
  - 去掉合并里的 `preserveLocalAsrDecision` 让路 → 两条钉子均红
  - 同时去掉启动快照里两条决策恢复分支 → 行为钉红（只去掉其中一条不红，另一条会兜住，符合预期）
  - 把让路改成无条件保留本地值 → 结构钉红

## 关联 / Related

复查 #2540。合并后建议关掉 #2540（保留上面「已知边界」那条作为单独跟踪项，若要跟的话）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
