### PR TITLE
fix(语音): start_session 去重路径补 ack 前重跑路由决策（#2539）

### DIFF
--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -76,6 +76,12 @@ _FRONTEND_START_DEADLINE_SECONDS = 15.0
 # BEFORE the client gives up rather than a second after.
 _CONNECT_TOTAL_BUDGET_SECONDS = 12.0
 
+# Public alias. The dedupe reroute in core/lifecycle.py runs a whole extra
+# connect phase AFTER already spending part of the frontend deadline waiting,
+# so it has to know this ceiling to tell whether its verdict can still land
+# before the client gives up.
+ASR_CONNECT_TOTAL_BUDGET_SECONDS = _CONNECT_TOTAL_BUDGET_SECONDS
+
 
 def _uses_smart_turn_endpointing(provider_policy: Any) -> bool:
     """Honor the endpoint authority independently of transport shape."""

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -804,6 +804,57 @@ class AsrRuntimeMixin:
                 operation_generation=operation_generation,
             )
 
+    async def _rerun_route_for_deduped_start(
+        self,
+        input_mode: str,
+        *,
+        handshake_override=...,
+        resource_optimization_override=...,
+    ) -> None:
+        """Re-decide the microphone route for a deduplicated same-mode start.
+
+        A same-mode start that collides with an in-flight one starts nothing of
+        its own and only re-acks, so it inherits the in-flight start's verdict.
+        That verdict can already be void for THIS requester: a second window
+        claims the voice lease (websocket_router does it synchronously before
+        firing start_session), which invalidates the in-flight ASR start. That
+        start then returns ASR_START_STALE and returns early, leaving the route
+        on the "blocked" placeholder its own teardown installed -- and emitting
+        no status at all, since the stale exit is upstream of every emitter.
+        The ack carries that placeholder, so both windows latch fail-closed and
+        the microphone never opens for the session that did start, with nothing
+        on screen to explain it. Nothing re-decides in-session either: the only
+        other entry is the core-change reconcile.
+
+        Runs while the requester holds the lease and no start is in flight
+        (the caller waits for the count to reach 0), so the fence inside
+        ``_start_independent_asr_if_enabled`` sees a settled, self-consistent
+        state -- and the handshake passed down is this request's own snapshot
+        rather than whatever the shared field holds by now.
+
+        Blocked routes only. A settled native/independent verdict is valid for
+        whoever ends up holding the microphone, and re-running would tear down
+        a healthy provider mid-session for nothing.
+        """
+        if input_mode != "audio":
+            return
+        # The in-flight start's OWN mode is the authority, not this request's:
+        # the dedupe branch treats a missing ``_starting_input_mode`` as a match,
+        # so an audio request can land here against an in-flight text start. Its
+        # route is legitimately blocked for the text session's whole life, and
+        # re-deciding would hand a live microphone to a session that has no
+        # audio path at all.
+        if str(getattr(self, "input_mode", "") or "") != "audio":
+            return
+        self._ensure_asr_runtime_state()
+        if self._asr_route_mode != "blocked":
+            return
+        await self._start_independent_asr_if_enabled(
+            input_mode,
+            handshake_override=handshake_override,
+            resource_optimization_override=resource_optimization_override,
+        )
+
     def _abandon_core_voice_turn(
         self,
         turn_id: str | None = None,

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -540,6 +540,7 @@ class AsrRuntimeMixin:
         preserve_hot_swap_audio: bool = False,
         handshake_override=...,
         resource_optimization_override=...,
+        connect_budget_seconds: float | None = None,
     ) -> None:
         """Resolve the microphone route for one session start.
 
@@ -548,6 +549,17 @@ class AsrRuntimeMixin:
         await. Ellipsis means "not supplied" — the internal re-entry paths
         (hot-swap, device change) have no request of their own and reuse the
         accepted live session's optimization choice.
+
+        ``connect_budget_seconds`` bounds only the PROVIDER CONNECT. A caller
+        working against a deadline (the dedupe reroute) passes what is left of
+        it; when that cannot cover a whole connect-and-retry phase this returns
+        with the route on its blocked placeholder rather than produce a verdict
+        nobody is still listening for. Checked here rather than at the call site
+        on purpose: the cheap outcomes -- independent ASR disabled by handshake
+        or by the persisted setting, or a Core that owns recognition natively --
+        settle on ``native`` without connecting to anything, and gating those on
+        a connect budget would strand a microphone that had nothing to wait for
+        (Codex P2).
         """
         self._ensure_asr_runtime_state()
         operation_generation = self._begin_asr_route_operation()
@@ -738,6 +750,21 @@ class AsrRuntimeMixin:
                 )
             )
             return
+        if (
+            connect_budget_seconds is not None
+            and connect_budget_seconds < ASR_CONNECT_TOTAL_BUDGET_SECONDS
+        ):
+            # Out of budget: leave the route on the blocked placeholder installed
+            # above, which is exactly the state the caller would have re-acked
+            # without re-deciding at all.
+            logger.info(
+                "[%s] independent ASR connect skipped: %.2fs of budget left,"
+                " under the %.1fs connect ceiling",
+                self.lanlan_name,
+                connect_budget_seconds,
+                ASR_CONNECT_TOTAL_BUDGET_SECONDS,
+            )
+            return
         start_kwargs: dict[str, object] = {
             "route_key": core_type,
             "resource_optimization_enabled": resolved_optimization_value,
@@ -846,26 +873,18 @@ class AsrRuntimeMixin:
         that does match, so skipping here loses nothing.
 
         ``remaining_deadline_seconds`` is what is left of the frontend's start
-        deadline. A re-decision runs a whole connect-and-retry phase whose
-        ceiling is ASR_CONNECT_TOTAL_BUDGET_SECONDS, so starting one without
-        room for it would push the re-ack past the point where the client gives
-        up -- and its timeout fires end_session, tearing down the session that
-        did start (Codex P2). Out of budget, the caller's bare re-ack is the
-        better trade: it is the pre-existing behaviour, and it still reaches the
-        requester in time.
+        deadline, handed down as the connect budget. A connect-and-retry phase
+        can run to ASR_CONNECT_TOTAL_BUDGET_SECONDS, so starting one without room
+        for it would push the re-ack past the point where the client gives up --
+        and its timeout fires end_session, tearing down the session that did
+        start (Codex P2). Out of budget the bare re-ack is the better trade: it
+        is the pre-existing behaviour, and it still reaches the requester in
+        time. The budget stops the CONNECT only, never the cheap native
+        outcomes -- see _start_independent_asr_if_enabled.
         """
         if input_mode != "audio":
             return
         self._ensure_asr_runtime_state()
-        if remaining_deadline_seconds < ASR_CONNECT_TOTAL_BUDGET_SECONDS:
-            logger.info(
-                "[%s] dedupe reroute skipped: %.2fs left of the start deadline,"
-                " under the %.1fs connect budget",
-                self.lanlan_name,
-                remaining_deadline_seconds,
-                ASR_CONNECT_TOTAL_BUDGET_SECONDS,
-            )
-            return
         if self._voice_lease_connection_id != lease_connection_id:
             logger.info(
                 "[%s] dedupe reroute skipped: voice lease moved on during the wait",
@@ -886,6 +905,7 @@ class AsrRuntimeMixin:
             input_mode,
             handshake_override=handshake_override,
             resource_optimization_override=resource_optimization_override,
+            connect_budget_seconds=remaining_deadline_seconds,
         )
 
     def _abandon_core_voice_turn(

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -18,6 +18,7 @@ from websockets import exceptions as web_exceptions
 
 from main_logic.asr_client import get_asr_core_capabilities
 from main_logic.asr_client.runtime import (
+    ASR_CONNECT_TOTAL_BUDGET_SECONDS,
     AsrRuntimeCallbacks,
     AsrStartStatus,
     IndependentAsrRuntime,
@@ -808,6 +809,8 @@ class AsrRuntimeMixin:
         self,
         input_mode: str,
         *,
+        lease_connection_id: str,
+        remaining_deadline_seconds: float,
         handshake_override=...,
         resource_optimization_override=...,
     ) -> None:
@@ -826,17 +829,48 @@ class AsrRuntimeMixin:
         on screen to explain it. Nothing re-decides in-session either: the only
         other entry is the core-change reconcile.
 
-        Runs while the requester holds the lease and no start is in flight
-        (the caller waits for the count to reach 0), so the fence inside
-        ``_start_independent_asr_if_enabled`` sees a settled, self-consistent
-        state -- and the handshake passed down is this request's own snapshot
-        rather than whatever the shared field holds by now.
+        Runs while no start is in flight (the caller waits for the count to
+        reach 0), so the fence inside ``_start_independent_asr_if_enabled`` sees
+        a settled, self-consistent state -- and the handshake passed down is
+        this request's own snapshot rather than whatever the shared field holds
+        by now.
 
         Blocked routes only. A settled native/independent verdict is valid for
         whoever ends up holding the microphone, and re-running would tear down
         a healthy provider mid-session for nothing.
+
+        ``lease_connection_id`` is the caller's pre-wait snapshot: the wait is
+        seconds long, and a THIRD audio start claiming the microphone during it
+        would otherwise get its route configured from this superseded window's
+        handshake (Codex P2). The new holder runs this same path with a snapshot
+        that does match, so skipping here loses nothing.
+
+        ``remaining_deadline_seconds`` is what is left of the frontend's start
+        deadline. A re-decision runs a whole connect-and-retry phase whose
+        ceiling is ASR_CONNECT_TOTAL_BUDGET_SECONDS, so starting one without
+        room for it would push the re-ack past the point where the client gives
+        up -- and its timeout fires end_session, tearing down the session that
+        did start (Codex P2). Out of budget, the caller's bare re-ack is the
+        better trade: it is the pre-existing behaviour, and it still reaches the
+        requester in time.
         """
         if input_mode != "audio":
+            return
+        self._ensure_asr_runtime_state()
+        if remaining_deadline_seconds < ASR_CONNECT_TOTAL_BUDGET_SECONDS:
+            logger.info(
+                "[%s] dedupe reroute skipped: %.2fs left of the start deadline,"
+                " under the %.1fs connect budget",
+                self.lanlan_name,
+                remaining_deadline_seconds,
+                ASR_CONNECT_TOTAL_BUDGET_SECONDS,
+            )
+            return
+        if self._voice_lease_connection_id != lease_connection_id:
+            logger.info(
+                "[%s] dedupe reroute skipped: voice lease moved on during the wait",
+                self.lanlan_name,
+            )
             return
         # The in-flight start's OWN mode is the authority, not this request's:
         # the dedupe branch treats a missing ``_starting_input_mode`` as a match,
@@ -846,7 +880,6 @@ class AsrRuntimeMixin:
         # audio path at all.
         if str(getattr(self, "input_mode", "") or "") != "audio":
             return
-        self._ensure_asr_runtime_state()
         if self._asr_route_mode != "blocked":
             return
         await self._start_independent_asr_if_enabled(

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -906,6 +906,12 @@ class LifecycleMixin:
             # 跳过、在 in-flight 还没真正起好时就误发 started 假阳性（Codex P1）。
             # 等待上限绑前端的 start_session 超时：超过它再补发 ack 已无意义
             # （前端早已 reject + end_session），故以它为窗口上界兼防挂安全阀。
+            #
+            # 快照本请求进入时的 voice lease 身份：等待可能长达十几秒，期间第三个
+            # audio start 抢走麦克风是可能的，那时替它重跑路由会用**本请求**（已经
+            # 被顶掉的那个窗口）的 handshake 去配新持有者的路由。新持有者自己也会
+            # 走这条路径、且它的快照对得上，所以这里跳过不丢东西（Codex P2）。
+            _lease_at_request = getattr(self, "_voice_lease_connection_id", "")
             _waited = 0.0
             while self._starting_session_count > 0 and _waited < FRONTEND_START_SESSION_TIMEOUT_SECONDS:
                 await asyncio.sleep(0.05)
@@ -927,6 +933,10 @@ class LifecycleMixin:
                 # 带的是本请求方真正成立的路由（详见 _rerun_route_for_deduped_start）。
                 await self._rerun_route_for_deduped_start(
                     input_mode,
+                    lease_connection_id=_lease_at_request,
+                    remaining_deadline_seconds=(
+                        FRONTEND_START_SESSION_TIMEOUT_SECONDS - _waited
+                    ),
                     handshake_override=handshake_override,
                     resource_optimization_override=resource_optimization_override,
                 )

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -916,6 +916,11 @@ class LifecycleMixin:
             # 被顶掉的那个窗口）的 handshake 去配新持有者的路由。新持有者自己也会
             # 走这条路径、且它的快照对得上，所以这里跳过不丢东西（Codex P2）。
             _lease_at_request = getattr(self, "_voice_lease_connection_id", "")
+            # 墙钟基准，供下面算「前端 deadline 还剩多少」。不能拿 _waited
+            # 当依据：它按标称 50ms 累加，事件循环一卡（或 sleep 超发）真实
+            # 时间会甩开它好几秒，于是预算被高估、放行一次最长 12s 的 ASR
+            # connect，补发的 ack 仍然赶在前端超时之后（Codex P2）。
+            _wait_started = time.monotonic()
             _waited = 0.0
             while self._starting_session_count > 0 and _waited < FRONTEND_START_SESSION_TIMEOUT_SECONDS:
                 await asyncio.sleep(0.05)
@@ -935,11 +940,18 @@ class LifecycleMixin:
                 # blocked 占位上且不发任何 status，结果两个窗口都 fail-closed latch
                 # 住、麦克风在本会话内再也打不开。先重跑一次决策再补 ack，让 ack
                 # 带的是本请求方真正成立的路由（详见 _rerun_route_for_deduped_start）。
+                # 麦克风是不是还归本请求方。重跑之前取：重跑若 fail-closed 会
+                # revoke lease 把这个字段清空，那时再判就分不清「被别人抢走」和
+                # 「自己刚放弃」了。
+                _lease_moved = (
+                    getattr(self, "_voice_lease_connection_id", "") != _lease_at_request
+                )
                 await self._rerun_route_for_deduped_start(
                     input_mode,
                     lease_connection_id=_lease_at_request,
                     remaining_deadline_seconds=(
-                        FRONTEND_START_SESSION_TIMEOUT_SECONDS - _waited
+                        FRONTEND_START_SESSION_TIMEOUT_SECONDS
+                        - (time.monotonic() - _wait_started)
                     ),
                     handshake_override=handshake_override,
                     resource_optimization_override=resource_optimization_override,
@@ -949,8 +961,18 @@ class LifecycleMixin:
                 # 就不在任何一条投递面上了（self.websocket 可能是更新的窗口）。
                 # 那样它会一直等到 15s 超时，而超时发的 end_session 会把刚起来的
                 # 会话撕掉。本请求那把 ws 是已知的，直接定向送一份（Codex P2）。
+                #
+                # lease 已易主时，ack 里的路由只能报 blocked。此刻 _asr_route_mode
+                # 是**新持有者**的裁决，可能已经 settle 成 native/independent；
+                # 照报会让本请求方（已经被顶掉的那个窗口）看到一条健康路由、
+                # 开麦，而服务端的 voice identity 归新持有者，它之后的每一帧
+                # PCM 都会被当 stale 丢掉——又一个"开着麦说给空气听"（Codex P2）。
+                # 报 blocked 让它 fail-closed 收口：UI 干净、可重试。
                 await self.send_session_started(
-                    input_mode, request_id=request_id, also_notify=websocket
+                    input_mode,
+                    request_id=request_id,
+                    also_notify=websocket,
+                    microphone_route_override="blocked" if _lease_moved else None,
                 )
         elif user_initiated and _allow_cross_mode_restart:
             # 跨模式撞车，且这是用户显式启动：典型是 proactive（主动搭话 /

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -940,12 +940,6 @@ class LifecycleMixin:
                 # blocked 占位上且不发任何 status，结果两个窗口都 fail-closed latch
                 # 住、麦克风在本会话内再也打不开。先重跑一次决策再补 ack，让 ack
                 # 带的是本请求方真正成立的路由（详见 _rerun_route_for_deduped_start）。
-                # 麦克风是不是还归本请求方。重跑之前取：重跑若 fail-closed 会
-                # revoke lease 把这个字段清空，那时再判就分不清「被别人抢走」和
-                # 「自己刚放弃」了。
-                _lease_moved = (
-                    getattr(self, "_voice_lease_connection_id", "") != _lease_at_request
-                )
                 await self._rerun_route_for_deduped_start(
                     input_mode,
                     lease_connection_id=_lease_at_request,
@@ -961,6 +955,14 @@ class LifecycleMixin:
                 # 就不在任何一条投递面上了（self.websocket 可能是更新的窗口）。
                 # 那样它会一直等到 15s 超时，而超时发的 end_session 会把刚起来的
                 # 会话撕掉。本请求那把 ws 是已知的，直接定向送一份（Codex P2）。
+                #
+                # 麦克风是不是还归本请求方，要在重跑**之后**判：重跑内部会 await
+                # 整个 provider connect（最长 12s），第三个窗口在那期间抢走麦
+                # 并把路由 settle 成健康值是可能的，重跑前的快照看不到（Codex P2）。
+                # lease 为空不算易主——那是本次 fail-closed 自己 revoke 的，路由
+                # 此刻本就是 blocked，照报即可。
+                _lease_now = getattr(self, "_voice_lease_connection_id", "")
+                _lease_moved = bool(_lease_now) and _lease_now != _lease_at_request
                 #
                 # lease 已易主时，ack 里的路由只能报 blocked。此刻 _asr_route_mode
                 # 是**新持有者**的裁决，可能已经 settle 成 native/independent；

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -918,6 +918,18 @@ class LifecycleMixin:
             # 故一律不发。也**不**发 session_failed——in-flight 可能仍在跑/或其
             # 失败路径已通知前端，过早发 failed 会被前端当终态打断本会成功的启动。
             if self._starting_session_count == 0 and self.session and self.is_active:
+                # 补发的 ack 带的是 in-flight 那次 start 的路由裁决（见
+                # send_session_started），而这条路径本身从不重跑决策。裁决对本
+                # 请求方可能已经作废：本请求抢 voice lease 会 invalidate in-flight
+                # 的 ASR start，那次 start 于是 ASR_START_STALE 早退、把路由留在
+                # blocked 占位上且不发任何 status，结果两个窗口都 fail-closed latch
+                # 住、麦克风在本会话内再也打不开。先重跑一次决策再补 ack，让 ack
+                # 带的是本请求方真正成立的路由（详见 _rerun_route_for_deduped_start）。
+                await self._rerun_route_for_deduped_start(
+                    input_mode,
+                    handshake_override=handshake_override,
+                    resource_optimization_override=resource_optimization_override,
+                )
                 await self.send_session_started(input_mode)
         elif user_initiated and _allow_cross_mode_restart:
             # 跨模式撞车，且这是用户显式启动：典型是 proactive（主动搭话 /

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -694,6 +694,7 @@ class LifecycleMixin:
         _allow_cross_mode_restart=True,
         handshake_override=_HANDSHAKE_OVERRIDE_UNSET,
         resource_optimization_override=_HANDSHAKE_OVERRIDE_UNSET,
+        request_id=None,
     ):
         # user_initiated：True 仅由 websocket_router 的 start_session action 传入，
         # 标记"用户显式点击启动"。跨模式撞车时只有用户显式请求才会等 in-flight
@@ -741,6 +742,7 @@ class LifecycleMixin:
             websocket, new, input_mode,
             user_initiated=user_initiated,
             _allow_cross_mode_restart=_allow_cross_mode_restart,
+            request_id=request_id,
             handshake_override=session_handshake_override,
             resource_optimization_override=(
                 session_resource_optimization_handshake_override
@@ -834,6 +836,7 @@ class LifecycleMixin:
                     input_mode,
                     llm_result,
                     _diag_start,
+                    request_id=request_id,
                     handshake_override=session_handshake_override,
                     resource_optimization_override=(
                         session_resource_optimization_handshake_override
@@ -874,6 +877,7 @@ class LifecycleMixin:
         *,
         user_initiated,
         _allow_cross_mode_restart,
+        request_id,
         handshake_override,
         resource_optimization_override,
     ):
@@ -940,7 +944,14 @@ class LifecycleMixin:
                     handshake_override=handshake_override,
                     resource_optimization_override=resource_optimization_override,
                 )
-                await self.send_session_started(input_mode)
+                # ``also_notify``：重跑若 fail-closed 会 revoke lease，把
+                # _voice_lease_connection_id 和 voice socket 一起清掉，本请求方
+                # 就不在任何一条投递面上了（self.websocket 可能是更新的窗口）。
+                # 那样它会一直等到 15s 超时，而超时发的 end_session 会把刚起来的
+                # 会话撕掉。本请求那把 ws 是已知的，直接定向送一份（Codex P2）。
+                await self.send_session_started(
+                    input_mode, request_id=request_id, also_notify=websocket
+                )
         elif user_initiated and _allow_cross_mode_restart:
             # 跨模式撞车，且这是用户显式启动：典型是 proactive（主动搭话 /
             # greeting）自起的 text 会话还在飞，而用户此刻点了"开始语音对话"
@@ -1004,6 +1015,7 @@ class LifecycleMixin:
                     input_mode,
                     user_initiated=True,
                     _allow_cross_mode_restart=False,
+                    request_id=request_id,
                     handshake_override=handshake_override,
                     resource_optimization_override=resource_optimization_override,
                 )
@@ -1592,6 +1604,7 @@ class LifecycleMixin:
         next_context_count,
         diag_start,
         *,
+        request_id=None,
         handshake_override=...,
         resource_optimization_override=...,
     ):
@@ -1630,8 +1643,10 @@ class LifecycleMixin:
             self.set_goodbye_silent(False)
 
         logger.info(f"[语音会话诊断] 即将通知前端 session_started (start_session 总耗时: {time.time() - diag_start:.2f}秒)")
-        # 通知前端 session 已成功启动
-        await self.send_session_started(input_mode)
+        # 通知前端 session 已成功启动。带上本次 start 的 request_id：别的窗口
+        # 若也有 start 在等，它据此认出这条不是回应自己的，从而不会用一条属于
+        # 别人的 ack 收口自己的 promise（详见 send_session_started）。
+        await self.send_session_started(input_mode, request_id=request_id)
 
         # 在 queued context 写入 session 前保持输入闸门关闭；否则第一条
         # 缓存/并发用户输入可能抢在上下文前面进入模型。

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -377,18 +377,26 @@ class NotifyMixin:
             return None
         return socket
 
-    async def _send_to_voice_owner(self, payload: dict) -> None:
-        """Best-effort push to the voice-lease holder; never raises."""
+    async def _send_to_voice_owner(self, payload: dict):
+        """Best-effort push to the voice-lease holder; never raises.
+
+        Returns the socket it actually reached, or None. Callers that need to
+        avoid a second copy must dedupe against THIS, not against a fresh
+        ``_voice_owner_socket()`` read: the send below is an await, and a lease
+        takeover inside it makes the second read a DIFFERENT socket, leaving the
+        one that just got the payload absent from the "already sent" set.
+        """
 
         socket = self._voice_owner_socket()
         if socket is None:
-            return
+            return None
         try:
             await socket.send_text(json.dumps(payload))
         except WebSocketDisconnect:
             pass
         except Exception as e:
             logger.error(f"💥 WS Send To Voice Owner Error: {e}")
+        return socket
 
     async def send_status(self, message: str):
         """Send a status message to the frontend. message should be a JSON string {"code": "XXX", "details": {...}}, translated by the frontend via i18next."""
@@ -550,11 +558,19 @@ class NotifyMixin:
             # ASR mixin should keep today's behaviour, not have every audio
             # start refuse the microphone.
             payload["microphone_route"] = route_mode
+        # The sockets this call actually delivered to, recorded as it goes. Every
+        # membership below has to be answered from here rather than by re-reading
+        # self.websocket / _voice_owner_socket(): both can point somewhere else
+        # by the time the addressed send runs, and a socket that already got the
+        # payload would then look unserved (CodeRabbit).
+        delivered_to = []
+        display_socket = self.websocket
         try:
-            if self.websocket and hasattr(self.websocket, 'client_state') and self.websocket.client_state == self.websocket.client_state.CONNECTED:
+            if display_socket and hasattr(display_socket, 'client_state') and display_socket.client_state == display_socket.client_state.CONNECTED:
                 data = json.dumps(payload)
                 try:
-                    await self.websocket.send_text(data)
+                    await display_socket.send_text(data)
+                    delivered_to.append(display_socket)
                 except WebSocketDisconnect:
                     # Isolated for the same reason as
                     # send_session_ended_by_server: the CONNECTED check and the
@@ -606,7 +622,9 @@ class NotifyMixin:
                 # isRecording true (which a game STT gate requires), releasing
                 # the game lease and closing hardware the text entry never
                 # meant to touch.
-                await self._send_to_voice_owner(dict(payload))
+                owner_socket = await self._send_to_voice_owner(dict(payload))
+                if owner_socket is not None:
+                    delivered_to.append(owner_socket)
             if also_notify is not None:
                 # Addressed delivery for a requester that neither plane is
                 # guaranteed to reach (Codex P2). The dedupe re-ack is the case:
@@ -617,17 +635,7 @@ class NotifyMixin:
                 # its promise until the 15s timeout, and that timeout's end_session
                 # tears down the session that just started.
                 await self._send_to_socket_if_new(
-                    also_notify,
-                    dict(payload),
-                    (
-                        self.websocket,
-                        # Mirrors the guard above: with a game owner the fan-out
-                        # never ran, so the lease socket has NOT been served and
-                        # must not be treated as already covered.
-                        self._voice_owner_socket()
-                        if getattr(self, "_voice_lease_owner", "none") != "game"
-                        else None,
-                    ),
+                    also_notify, dict(payload), delivered_to
                 )
         except WebSocketDisconnect:
             # Client disconnected mid-send; this push is best-effort.

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -495,6 +495,7 @@ class NotifyMixin:
         *,
         request_id: str | None = None,
         also_notify=None,
+        microphone_route_override: str | None = None,
     ): # 通知前端session已启动
         # Carry the SETTLED microphone route on the ack itself (Codex P2).
         #
@@ -534,7 +535,16 @@ class NotifyMixin:
         payload = {"type": "session_started", "input_mode": input_mode}
         if request_id:
             payload["request_id"] = request_id
-        route_mode = str(getattr(self, "_asr_route_mode", "") or "")
+        #
+        # ``microphone_route_override`` exists for one caller: the dedupe re-ack
+        # whose requester has since LOST the voice lease. The live route belongs
+        # to the new holder by then and may well be healthy, but reporting it
+        # would open a microphone on a window whose PCM the server now discards
+        # as superseded. It overrides rather than suppresses so the requester
+        # still gets an ack and settles its start instead of hanging.
+        route_mode = str(
+            microphone_route_override or getattr(self, "_asr_route_mode", "") or ""
+        )
         if route_mode:
             # Omitted when unknown rather than defaulted: a manager without the
             # ASR mixin should keep today's behaviour, not have every audio

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -506,11 +506,13 @@ class NotifyMixin:
         #
         # Qualifying the ack fixes every emitter at once: the ordinary one in
         # _start_session_activate, the in-flight dedupe re-ack in
-        # _start_session_handle_inflight (which re-acks WITHOUT re-running the
-        # route decision), and the stale-start case above that no status-based
-        # fix can reach. Suppressing the ack instead would be worse -- the
-        # dedupe re-ack exists precisely so the requester is not stranded on its
-        # 15s timeout, whose end_session tears down the session that did start.
+        # _start_session_handle_inflight (which re-decides a blocked route
+        # first, via _rerun_route_for_deduped_start, precisely so the route it
+        # reports here is the requester's own), and the stale-start case above
+        # that no status-based fix can reach. Suppressing the ack instead would
+        # be worse -- the dedupe re-ack exists precisely so the requester is not
+        # stranded on its 15s timeout, whose end_session tears down the session
+        # that did start.
         payload = {"type": "session_started", "input_mode": input_mode}
         route_mode = str(getattr(self, "_asr_route_mode", "") or "")
         if route_mode:

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -550,9 +550,14 @@ class NotifyMixin:
         # would open a microphone on a window whose PCM the server now discards
         # as superseded. It overrides rather than suppresses so the requester
         # still gets an ack and settles its start instead of hanging.
-        route_mode = str(
-            microphone_route_override or getattr(self, "_asr_route_mode", "") or ""
-        )
+        #
+        # It applies to ``also_notify`` ONLY, never to the fan-out (Codex P2).
+        # "This route is unusable" is true of the superseded requester, not of
+        # the session: the new lease holder is on the very same fan-out, and a
+        # window with no start pending latches any blocked verdict it sees --
+        # so broadcasting the override would fail-close the microphone of the
+        # window that legitimately owns it.
+        route_mode = str(getattr(self, "_asr_route_mode", "") or "")
         if route_mode:
             # Omitted when unknown rather than defaulted: a manager without the
             # ASR mixin should keep today's behaviour, not have every audio
@@ -564,10 +569,27 @@ class NotifyMixin:
         # by the time the addressed send runs, and a socket that already got the
         # payload would then look unserved (CodeRabbit).
         delivered_to = []
+
+        def _addressed(base: dict) -> dict:
+            # The requester's copy, carrying the override when there is one.
+            copy = dict(base)
+            if microphone_route_override:
+                copy["microphone_route"] = microphone_route_override
+            return copy
+
         display_socket = self.websocket
         try:
             if display_socket and hasattr(display_socket, 'client_state') and display_socket.client_state == display_socket.client_state.CONNECTED:
-                data = json.dumps(payload)
+                # The requester can BE the display socket (it is simply the
+                # newest connection), and then this is its only copy -- so the
+                # override has to travel on this plane too when it is the one
+                # carrying it. Every other window on this plane gets the real
+                # route.
+                data = json.dumps(
+                    _addressed(payload)
+                    if also_notify is not None and display_socket is also_notify
+                    else payload
+                )
                 try:
                     await display_socket.send_text(data)
                     delivered_to.append(display_socket)
@@ -635,7 +657,7 @@ class NotifyMixin:
                 # its promise until the 15s timeout, and that timeout's end_session
                 # tears down the session that just started.
                 await self._send_to_socket_if_new(
-                    also_notify, dict(payload), delivered_to
+                    also_notify, _addressed(payload), delivered_to
                 )
         except WebSocketDisconnect:
             # Client disconnected mid-send; this push is best-effort.

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -641,6 +641,10 @@ class NotifyMixin:
         try:
             await socket.send_text(json.dumps(payload))
         except WebSocketDisconnect:
+            # The CONNECTED check above and this send are separated by an await,
+            # so the requester can disconnect in between. A window that is gone
+            # has no start left to settle -- swallow it like the sibling planes
+            # do, rather than fail an ack the other windows still need.
             pass
         except Exception as e:
             logger.error(f"💥 WS Send Addressed Ack Error: {e}")

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -489,7 +489,13 @@ class NotifyMixin:
         except Exception as e:
             logger.error(f"💥 WS Send Session Preparing Error: {e}")
     
-    async def send_session_started(self, input_mode: str): # 通知前端session已启动
+    async def send_session_started(
+        self,
+        input_mode: str,
+        *,
+        request_id: str | None = None,
+        also_notify=None,
+    ): # 通知前端session已启动
         # Carry the SETTLED microphone route on the ack itself (Codex P2).
         #
         # The route verdict otherwise travels only as an ASR_INDEPENDENT_*
@@ -513,7 +519,21 @@ class NotifyMixin:
         # be worse -- the dedupe re-ack exists precisely so the requester is not
         # stranded on its 15s timeout, whose end_session tears down the session
         # that did start.
+        #
+        # ``request_id`` names WHICH start this acks. Without it an ack is
+        # anonymous, and a window with its own start pending settles on the
+        # first same-mode ack that reaches it -- including one fanned out for
+        # somebody else's start. That is exactly what happens when a second
+        # window claims the microphone mid-start: the claim moves the voice
+        # socket, so the in-flight start's ack lands on the claimant, whose
+        # frontend clears its timeout, resolves, reads the blocked route it
+        # carries and aborts its microphone flow outright. The claimant's own
+        # ack -- the one carrying the re-decided route -- arrives to a flow that
+        # has already given up. Tagging the ack lets the frontend ignore acks
+        # that are not answering its request.
         payload = {"type": "session_started", "input_mode": input_mode}
+        if request_id:
+            payload["request_id"] = request_id
         route_mode = str(getattr(self, "_asr_route_mode", "") or "")
         if route_mode:
             # Omitted when unknown rather than defaulted: a manager without the
@@ -577,12 +597,54 @@ class NotifyMixin:
                 # the game lease and closing hardware the text entry never
                 # meant to touch.
                 await self._send_to_voice_owner(dict(payload))
+            if also_notify is not None:
+                # Addressed delivery for a requester that neither plane is
+                # guaranteed to reach (Codex P2). The dedupe re-ack is the case:
+                # its own re-decision can fail closed, and _fail_closed_voice_route
+                # REVOKES the lease -- clearing _voice_lease_connection_id and the
+                # voice socket -- before this ack goes out. With a newer window as
+                # self.websocket, the requester is then on neither plane, sits on
+                # its promise until the 15s timeout, and that timeout's end_session
+                # tears down the session that just started.
+                await self._send_to_socket_if_new(
+                    also_notify,
+                    dict(payload),
+                    (
+                        self.websocket,
+                        # Mirrors the guard above: with a game owner the fan-out
+                        # never ran, so the lease socket has NOT been served and
+                        # must not be treated as already covered.
+                        self._voice_owner_socket()
+                        if getattr(self, "_voice_lease_owner", "none") != "game"
+                        else None,
+                    ),
+                )
         except WebSocketDisconnect:
             # Client disconnected mid-send; this push is best-effort.
             pass
         except Exception as e:
             logger.error(f"💥 WS Send Session Started Error: {e}")
-    
+
+    async def _send_to_socket_if_new(self, socket, payload: dict, already_sent) -> None:
+        """Best-effort push to ``socket`` unless it already got this payload.
+
+        Identity comparison, not equality: the planes above hold the very same
+        socket objects, and a second copy of an ack is not harmless -- the
+        frontend's start resolver is one-shot but the handler around it runs
+        again in full (microphone teardown, composer visibility).
+        """
+        if socket is None or any(socket is sent for sent in already_sent):
+            return
+        state = getattr(socket, "client_state", None)
+        if state is None or state != socket.client_state.CONNECTED:
+            return
+        try:
+            await socket.send_text(json.dumps(payload))
+        except WebSocketDisconnect:
+            pass
+        except Exception as e:
+            logger.error(f"💥 WS Send Addressed Ack Error: {e}")
+
     async def send_session_failed(self, input_mode: str): # 通知前端session启动失败
         """Notify the frontend that session start failed, so it hides the preparing banner and resets state"""
         payload = {"type": "session_failed", "input_mode": input_mode}

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -862,11 +862,24 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                         message.get("voice_input_resource_optimization_enabled")
                     )
                 input_type = message.get("input_type", "audio")
+                # 前端每次 start_session 自带的请求标识，原样回带进
+                # session_started。多窗口下 ack 会经 voice-lease fan-out 到达
+                # 不是本请求方的窗口，标识就是接收方判断「这条是不是回应我」
+                # 的唯一依据（详见 core/notify.py send_session_started）。
+                request_id = message.get("request_id")
+                if isinstance(request_id, str):
+                    request_id = request_id.strip()[:128] or None
+                else:
+                    request_id = None
                 if input_type in _SESSION_INPUT_TYPES:
                     if is_game_route_active(lanlan_name):
                         if input_type in _TEXT_SESSION_INPUT_TYPES:
                             logger.info("[%s] game route active: acknowledging text entry without starting ordinary text session", lanlan_name)
-                            _fire_task(session_manager[lanlan_name].send_session_started("text"))
+                            _fire_task(
+                                session_manager[lanlan_name].send_session_started(
+                                    "text", request_id=request_id
+                                )
+                            )
                             continue
                         if input_type == "audio":
                             logger.info("[%s] game route active: starting ordinary realtime as STT provider for game voice", lanlan_name)
@@ -880,6 +893,7 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                                     message.get("new_session", False),
                                     "audio",
                                     user_initiated=True,
+                                    request_id=request_id,
                                     handshake_override=request_handshake_override,
                                     resource_optimization_override=(
                                         request_optimization_override
@@ -929,6 +943,7 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                             message.get("new_session", False),
                             mode,
                             user_initiated=True,
+                            request_id=request_id,
                             handshake_override=request_handshake_override,
                             resource_optimization_override=(
                                 request_optimization_override

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2266,7 +2266,12 @@
                 if (micStartMustStandDown()) return;
                 S.socket.send(JSON.stringify({
                     action: 'start_session',
-                    input_type: 'audio'
+                    input_type: 'audio',
+                    // Read off OUR owner token, not the shared slot: a start
+                    // that displaced us during ensureWebSocketOpen above would
+                    // otherwise get its id stamped on this stale request, and
+                    // the ack for it would settle a promise it does not answer.
+                    request_id: window.sessionStartRequestId(micStartOwner)
                 }));
 
                 // Timeout (15s)
@@ -2778,7 +2783,8 @@
                 S.socket.send(JSON.stringify({
                     action: 'start_session',
                     input_type: 'text',
-                    new_session: true
+                    new_session: true,
+                    request_id: window.sessionStartRequestId(textStartOwner)
                 }));
 
                 await sessionStartPromise;
@@ -3029,7 +3035,8 @@
                             S.socket.send(JSON.stringify({
                                 action: 'start_session',
                                 input_type: 'text',
-                                new_session: false
+                                new_session: false,
+                                request_id: window.sessionStartRequestId(composerStartOwner)
                             }));
 
                             // Timeout after WebSocket confirms connection

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -158,6 +158,12 @@
         // 不一致（典型是 proactive/greeting 并发自起的 text 会话发来的 ack）时
         // 忽略，避免错误模式的 ack 收口用户的启动 promise / 翻转会话状态。
         _pendingSessionStartMode: null,
+        // 本次 claim 的请求标识，随 start_session 发给后端、由 session_started
+        // 原样带回。多窗口下 ack 会经 voice-lease fan-out 到达不是请求方的窗口
+        // （抢麦的窗口会把 voice socket 换成自己的），标识就是「这条 ack 是不是
+        // 在回应我」的唯一依据——没有它，一条为别人发出的 ack 会收口本窗口的
+        // 启动 promise，而本窗口真正的 ack 到达时它已经放弃了。
+        _pendingSessionStartRequestId: null,
         // 上一次 claim 的模式，释放后依然保留（_pendingSessionStartMode 会被清空）。
         // 用于判断"抢走槽位的那个启动是不是语音启动"——它可能已经 ack 完并释放，
         // 但仍然活着且正在驱动语音 UI，见 supersededByAudioStart。
@@ -318,6 +324,12 @@
     // audio start is very much alive and holding the state the global unwind
     // destroys.
     var lastAudioClaimSeq = 0;
+    // 每次 claim 一个新标识；按 owner 存，发送点只会读到自己那一个——被顶掉的
+    // flow 即使还走到发送，也带的是它自己的标识，后端回的 ack 因此对不上当前
+    // pending，不会误收口。窗口段随机，避免两个窗口的序号撞车。
+    var startRequestIdSeq = 0;
+    var startRequestIdWindowTag = Math.random().toString(36).slice(2, 10);
+    var startRequestIdByOwner = new WeakMap();
 
     window.claimSessionStart = function (mode, resolve, reject) {
         // Whoever we are about to displace can no longer be settled by anything
@@ -338,6 +350,10 @@
         S._pendingSessionStartMode = mode;
         startClaimSeq += 1;
         startClaimSeqByOwner.set(resolve, startClaimSeq);
+        startRequestIdSeq += 1;
+        var requestId = startRequestIdWindowTag + '-' + startRequestIdSeq;
+        startRequestIdByOwner.set(resolve, requestId);
+        S._pendingSessionStartRequestId = requestId;
         if (mode === 'audio') lastAudioClaimSeq = startClaimSeq;
         // After the slot is ours, so anything the displaced flow does on its way
         // out already sees the new owner and stands down against it.
@@ -360,7 +376,18 @@
         S.sessionStartedResolver = null;
         S.sessionStartedRejecter = null;
         S._pendingSessionStartMode = null;
+        S._pendingSessionStartRequestId = null;
         return true;
+    };
+
+    /**
+     * The request id minted for ``owner``'s claim, for the send site to put on
+     * the wire. Read it with your OWN owner token rather than off the shared
+     * state: a flow displaced during its reconnect await would otherwise stamp
+     * the newer start's id onto its own stale start_session.
+     */
+    window.sessionStartRequestId = function (owner) {
+        return (owner && startRequestIdByOwner.get(owner)) || null;
     };
 
     /**
@@ -479,6 +506,7 @@
         S.sessionStartedResolver = null;
         S.sessionStartedRejecter = null;
         S._pendingSessionStartMode = null;
+        S._pendingSessionStartRequestId = null;
     };
 
     // ======================== 工具函数 ========================

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -4008,7 +4008,14 @@
                     // ack 不带标识时按「是我的」处理：后端内部路径（proactive /
                     // greeting / 断线自恢复）不经用户请求、没有标识，而它们撞上
                     // pending 启动的情形本就由上面的模式守卫负责。
-                    var _ackAnswersThisWindow = !S._pendingSessionStartRequestId
+                    //
+                    // 主判据是 resolver 而不是标识本身：清 resolver 的地方有十来处，
+                    // 指望每一处都记得连标识一起清是靠不住的，漏一处就会留下一个陈旧
+                    // 标识，让本窗口从此把所有别人的 ack 都判成「不是我的」，连
+                    // blocked latch 和准备中提示都不再处理（Codex P2）。没有 resolver
+                    // 在等 = 本窗口没有启动在途 = 任何 ack 都按旧行为处理。
+                    var _ackAnswersThisWindow = !S.sessionStartedResolver
+                        || !S._pendingSessionStartRequestId
                         || !response.request_id
                         || response.request_id === S._pendingSessionStartRequestId;
                     if (!_ackAnswersThisWindow) {

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -3258,7 +3258,11 @@
                                     // that follow (codex P2).
                                     await ensureWebSocketOpen();
                                     if (restartMustStandDown()) return;
-                                    S.socket.send(JSON.stringify({ action: 'start_session', input_type: 'audio' }));
+                                    S.socket.send(JSON.stringify({
+                                        action: 'start_session',
+                                        input_type: 'audio',
+                                        request_id: window.sessionStartRequestId(restartStartOwner)
+                                    }));
 
                                     window.sessionTimeoutId = setTimeout(function () {
                                         // Only for the start this timer was armed for.
@@ -3991,6 +3995,26 @@
                         }
                         return;
                     }
+                    // 请求标识守卫：这条 ack 是不是在回应**本窗口**那次启动。
+                    //
+                    // 模式守卫拦不住同模式的串台：抢麦的窗口会把 voice socket 换成
+                    // 自己的，于是别人那次 audio start 的 ack 经 fan-out 落到本窗口。
+                    // 本窗口据此清超时、resolve、按 ack 里的 blocked 路由直接
+                    // abortVoiceStartForBlockedRoute()——而真正回应本窗口的那条 ack
+                    // （带着重跑后的路由）到达时，麦克风流程早就放弃了。
+                    //
+                    // 只 gate「收口」（清超时 + resolve），不 gate 下面的 UI 同步：
+                    // 后端确实起了一个会话，文本框显隐、停麦这些对本窗口照样成立。
+                    // ack 不带标识时按「是我的」处理：后端内部路径（proactive /
+                    // greeting / 断线自恢复）不经用户请求、没有标识，而它们撞上
+                    // pending 启动的情形本就由上面的模式守卫负责。
+                    var _ackAnswersThisWindow = !S._pendingSessionStartRequestId
+                        || !response.request_id
+                        || response.request_id === S._pendingSessionStartRequestId;
+                    if (!_ackAnswersThisWindow) {
+                        console.log('[App] session_started answers another start',
+                            response.request_id, 'pending', S._pendingSessionStartRequestId);
+                    }
                     console.log(window.t('console.sessionStartedReceived'), response.input_mode);
                     S.suppressAssistantStreamUntilNextSession = false;
                     S.isTextSessionActive = response.input_mode === 'text';
@@ -4098,7 +4122,7 @@
                     // 500ms 后才清，贴近 15s deadline 的 ack（如 14.8s，尤其跨模式等待+重启
                     // 链路）会被先一步触发的超时误 reject + end_session，把后端已接受的会话
                     // 打断（Codex P2）。resolve 仍延后做（留时间收尾 UI），但超时此刻就拆。
-                    if (S.sessionStartedResolver && window.sessionTimeoutId) {
+                    if (_ackAnswersThisWindow && S.sessionStartedResolver && window.sessionTimeoutId) {
                         clearTimeout(window.sessionTimeoutId);
                         window.sessionTimeoutId = null;
                     }
@@ -4113,9 +4137,13 @@
                     // and let the queued message go out before the backend has
                     // acknowledged the text session at all (Codex P2). Resolve
                     // only if the slot still holds the very start we acked.
-                    var _ackedResolver = S.sessionStartedResolver;
+                    var _ackedResolver = _ackAnswersThisWindow ? S.sessionStartedResolver : null;
                     setTimeout(function () {
-                        if (typeof window.hideVoicePreparingToast === 'function') window.hideVoicePreparingToast();
+                        // Not gated on the resolver: a window with no pending
+                        // start (chat.html) still has to drop the banner. Gated
+                        // on the request guard, though -- a window still waiting
+                        // for ITS ack must keep showing "preparing".
+                        if (_ackAnswersThisWindow && typeof window.hideVoicePreparingToast === 'function') window.hideVoicePreparingToast();
                         if (!_ackedResolver) return;
                         if (S.sessionStartedResolver === _ackedResolver) {
                             // Still ours: release the shared slot and its timer.
@@ -4126,6 +4154,7 @@
                             S.sessionStartedResolver = null;
                             S.sessionStartedRejecter = null;
                             S._pendingSessionStartMode = null;
+                            S._pendingSessionStartRequestId = null;
                         }
                         // Settle OUR promise either way, INCLUDING when the slot
                         // has moved on (Codex P2). Its timeout was already
@@ -4210,6 +4239,7 @@
                     S.sessionStartedResolver = null;
                     S.sessionStartedRejecter = null;
                     S._pendingSessionStartMode = null;
+                    S._pendingSessionStartRequestId = null;
 
                 // -------- session_ended_by_server --------
                 } else if (response.type === 'session_ended_by_server') {
@@ -4234,6 +4264,7 @@
                     S.sessionStartedResolver = null;
                     S.sessionStartedRejecter = null;
                     S._pendingSessionStartMode = null;
+                    S._pendingSessionStartRequestId = null;
 
                     if (window.sessionTimeoutId) {
                         clearTimeout(window.sessionTimeoutId);

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -4019,7 +4019,7 @@
                     S.suppressAssistantStreamUntilNextSession = false;
                     S.isTextSessionActive = response.input_mode === 'text';
                     S.voiceChatActive = response.input_mode !== 'text';
-                    S.voiceStartPending = false;
+                    if (_ackAnswersThisWindow) S.voiceStartPending = false;
                     // NOTE: the fail-closed latch is deliberately NOT cleared
                     // here. lifecycle.py runs _start_independent_asr_if_enabled
                     // BEFORE send_session_started, so this ack always arrives

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -4043,7 +4043,15 @@
                     // relies on it surviving), and clearing it from an ack
                     // would undo that. Guarded on the field being present so an
                     // older backend keeps exactly today's behaviour.
-                    if (response.input_mode !== 'text'
+                    // Gated on the request guard as well (CodeRabbit): the latch
+                    // is set-only, so a blocked verdict belonging to ANOTHER
+                    // window's start would stick, and this window's own healthy
+                    // ack could not clear it -- the microphone would refuse to
+                    // open even though the route re-decision succeeded. A window
+                    // with no start pending still latches: that is the case with
+                    // no other channel to learn the verdict from.
+                    if (_ackAnswersThisWindow
+                            && response.input_mode !== 'text'
                             && response.microphone_route === 'blocked') {
                         S.voiceInputRouteBlocked = true;
                     }

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -5594,6 +5594,94 @@ def test_blocked_route_latch_blocks_game_exit_microphone_resume():
     assert "S.voiceInputRouteBlocked = false;" not in started_handler
 
 
+def test_every_start_session_send_carries_a_request_id():
+    # #2539 / Codex P2. The ack names the start it answers, and the receiver
+    # ignores acks that name a different one. A send site that forgets the id
+    # gets an anonymous ack back, which every window treats as "mine" -- the
+    # exact failure the id exists to prevent. Discovered rather than listed, so
+    # a NEW send site cannot slip past this.
+    sources = {
+        "app-buttons.js": APP_BUTTONS_PATH.read_text(encoding="utf-8"),
+        "app-websocket.js": APP_WEBSOCKET_PATH.read_text(encoding="utf-8"),
+    }
+    found = 0
+    for name, source in sources.items():
+        cursor = 0
+        while True:
+            at = source.find("action: 'start_session'", cursor)
+            if at == -1:
+                break
+            cursor = at + 1
+            found += 1
+            payload_end = source.index("}", at)
+            payload = source[at:payload_end]
+            assert "request_id: window.sessionStartRequestId(" in payload, (
+                f"{name}: a start_session send at offset {at} carries no request id"
+            )
+    assert found >= 4, "the send sites were not discovered; the search anchor moved"
+
+    # Read off the flow's OWN owner token, never the shared slot: a start
+    # displaced during its reconnect await would otherwise stamp the newer
+    # start's id onto its own stale request.
+    state_source = APP_STATE_PATH.read_text(encoding="utf-8")
+    assert "window.sessionStartRequestId = function (owner) {" in state_source
+    assert "startRequestIdByOwner.get(owner)" in state_source
+
+
+def test_pending_request_id_is_claimed_and_released_with_the_slot():
+    # The id lives and dies with the shared start slot. Left behind after a
+    # release, it would make the NEXT anonymous-or-foreign ack look mismatched
+    # and strand a start that nothing else settles.
+    state_source = APP_STATE_PATH.read_text(encoding="utf-8")
+    websocket_source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+
+    assert "_pendingSessionStartRequestId: null," in state_source
+    claim = state_source.split("window.claimSessionStart = function (", 1)[1].split(
+        "\n    };", 1
+    )[0]
+    assert "S._pendingSessionStartRequestId = requestId;" in claim
+
+    # Every slot teardown clears it. Paired with the mode, which is the field
+    # that already had to be cleared everywhere -- so count against that rather
+    # than list the sites.
+    for source in (state_source, websocket_source):
+        assert source.count("S._pendingSessionStartRequestId = null;") == source.count(
+            "S._pendingSessionStartMode = null;"
+        )
+
+
+def test_session_started_only_settles_the_start_it_answers():
+    # Codex P2. The cross-mode guard cannot catch a SAME-mode ack meant for
+    # another window, and that is the load-bearing case: the window that claims
+    # the microphone mid-start becomes the lease holder, so the in-flight start's
+    # ack is fanned out to it. Without this guard it clears its own timeout,
+    # resolves, reads the blocked route that ack carries and aborts its
+    # microphone flow -- and its real ack, carrying the re-decided route, lands
+    # on a flow that already gave up.
+    websocket_source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+
+    started_handler = websocket_source.split(
+        "S.isTextSessionActive = response.input_mode === 'text';", 1
+    )[0].rsplit("} else if (response.type === 'session_started') {", 1)[1]
+    guard = started_handler.split("var _ackAnswersThisWindow =", 1)[1].split(";", 1)[0]
+    assert "response.request_id === S._pendingSessionStartRequestId" in guard
+    # An ack with no id counts as ours: the internal starts (proactive,
+    # greeting, disconnect recovery) carry no request, and the cross-mode guard
+    # already covers them.
+    assert "!response.request_id" in guard
+    assert "!S._pendingSessionStartRequestId" in guard
+
+    # Settling is what the guard gates -- the timeout clear and the deferred
+    # resolve. The UI sync below it is deliberately NOT gated: the backend did
+    # start a session, so composer visibility and the microphone teardown still
+    # apply to this window.
+    tail = websocket_source.split("var _ackAnswersThisWindow =", 1)[1]
+    timeout_clear = tail.split("clearTimeout(window.sessionTimeoutId);", 1)[0]
+    assert "_ackAnswersThisWindow && S.sessionStartedResolver" in timeout_clear
+    capture = next(l for l in tail.splitlines() if "var _ackedResolver =" in l)
+    assert "_ackAnswersThisWindow ?" in capture
+
+
 def test_session_started_ack_latches_a_blocked_microphone_route():
     # The one clear of the latch that is NOT tied to a route verdict is user
     # intent (app-buttons.js, next to _pendingSessionStartMode = 'audio'). What
@@ -6189,8 +6277,16 @@ def test_deferred_session_start_resolve_is_pinned_to_the_ack_it_belongs_to():
     #     forever, isMicStarting true and the button stuck.
     source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
 
-    capture = "var _ackedResolver = S.sessionStartedResolver;"
-    assert capture in source, "the ack must capture the pending start it belongs to"
+    capture_line = next(
+        l for l in source.splitlines() if "var _ackedResolver =" in l
+    )
+    assert "S.sessionStartedResolver" in capture_line, (
+        "the ack must capture the pending start it belongs to"
+    )
+    # And only when the ack is answering THIS window's request: a same-mode ack
+    # fanned out for somebody else's start must not settle our promise.
+    assert "_ackAnswersThisWindow" in capture_line
+    capture = capture_line.strip()
 
     # The capture has to happen at ack time, i.e. before the deferred callback
     # is scheduled -- capturing inside it would read the same shared slot again

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -5665,6 +5665,11 @@ def test_session_started_only_settles_the_start_it_answers():
     )[0].rsplit("} else if (response.type === 'session_started') {", 1)[1]
     guard = started_handler.split("var _ackAnswersThisWindow =", 1)[1].split(";", 1)[0]
     assert "response.request_id === S._pendingSessionStartRequestId" in guard
+    # Anchored on the resolver first (Codex P2): a dozen places clear the
+    # resolver, and expecting every one of them to also clear the id is exactly
+    # the checklist that goes stale. A window with no start pending must treat
+    # any ack as its own, or a leaked id silently disables the latch forever.
+    assert "!S.sessionStartedResolver" in guard
     # An ack with no id counts as ours: the internal starts (proactive,
     # greeting, disconnect recovery) carry no request, and the cross-mode guard
     # already covers them.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -5702,14 +5702,18 @@ def test_session_started_ack_latches_a_blocked_microphone_route():
     started_handler = websocket_source.split(
         "S.isTextSessionActive = response.input_mode === 'text';", 1
     )[1].split("var _tiaStarted", 1)[0]
-    latch = started_handler.split("if (response.input_mode !== 'text'", 1)[1].split(
-        "}", 1
-    )[0]
+    latch = started_handler.split("S.voiceInputRouteBlocked = true;", 1)[0].rsplit(
+        "if (", 1
+    )[1]
+    # Only for a request this window actually made: the latch is set-only, so a
+    # blocked verdict belonging to another window's start would stick and this
+    # window's own healthy ack could not clear it.
+    assert "_ackAnswersThisWindow" in latch
+    assert "response.input_mode !== 'text'" in latch
     # Set-only, and only on a blocked verdict: the latch is sticky by design
     # (tearDownBlockedVoiceRoute relies on it surviving), and an ack that says
     # native/independent must not clear what a status verdict set.
     assert "response.microphone_route === 'blocked'" in latch
-    assert "S.voiceInputRouteBlocked = true;" in latch
     # Guarded on the field being present, so an older backend that omits it
     # keeps its current behaviour rather than refusing every microphone.
     assert "response.microphone_route !== 'blocked'" not in started_handler

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -5594,6 +5594,39 @@ def test_blocked_route_latch_blocks_game_exit_microphone_resume():
     assert "S.voiceInputRouteBlocked = false;" not in started_handler
 
 
+def test_session_started_ack_latches_a_blocked_microphone_route():
+    # The one clear of the latch that is NOT tied to a route verdict is user
+    # intent (app-buttons.js, next to _pendingSessionStartMode = 'audio'). What
+    # keeps that from opening the microphone onto a dead route is this branch:
+    # the ack carries the settled route (send_session_started in notify.py), so
+    # a still-blocked route re-latches before the start promise settles.
+    #
+    # It is also the only channel that reaches a window which never got an
+    # ASR_INDEPENDENT_* status at all -- a fenced start emits none, which is the
+    # case the backend's dedupe re-decision (#2539) exists to shrink but cannot
+    # remove.
+    websocket_source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+    buttons_source = APP_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    # The clear-on-intent this backstops, in the flow that arms the audio start.
+    assert "S.voiceInputRouteBlocked = false;" in buttons_source
+
+    started_handler = websocket_source.split(
+        "S.isTextSessionActive = response.input_mode === 'text';", 1
+    )[1].split("var _tiaStarted", 1)[0]
+    latch = started_handler.split("if (response.input_mode !== 'text'", 1)[1].split(
+        "}", 1
+    )[0]
+    # Set-only, and only on a blocked verdict: the latch is sticky by design
+    # (tearDownBlockedVoiceRoute relies on it surviving), and an ack that says
+    # native/independent must not clear what a status verdict set.
+    assert "response.microphone_route === 'blocked'" in latch
+    assert "S.voiceInputRouteBlocked = true;" in latch
+    # Guarded on the field being present, so an older backend that omits it
+    # keeps its current behaviour rather than refusing every microphone.
+    assert "response.microphone_route !== 'blocked'" not in started_handler
+
+
 def test_shared_write_metadata_carries_per_key_asr_authority():
     # Codex P2. meta.hydrated is the GLOBAL hydration bit, which any unrelated
     # user edit flips -- so a window whose boot GET never merged could stamp its

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -5680,6 +5680,19 @@ def test_session_started_only_settles_the_start_it_answers():
     assert "_ackAnswersThisWindow && S.sessionStartedResolver" in timeout_clear
     capture = next(l for l in tail.splitlines() if "var _ackedResolver =" in l)
     assert "_ackAnswersThisWindow ?" in capture
+    # voiceStartPending is a start-lifecycle flag, not a session fact:
+    # app-auto-goodbye.js reads it as "a voice start is in flight", so clearing
+    # it on somebody else's ack lets goodbye/idle run through a legitimate mic
+    # start that is still waiting for its own ack (Codex P2).
+    pending_clear = next(
+        l for l in tail.splitlines() if "S.voiceStartPending = false;" in l
+    )
+    assert "_ackAnswersThisWindow" in pending_clear
+    # Session facts stay ungated -- the backend really did start a session.
+    session_facts = next(
+        l for l in tail.splitlines() if "S.voiceChatActive = response.input_mode" in l
+    )
+    assert "_ackAnswersThisWindow" not in session_facts
 
 
 def test_session_started_ack_latches_a_blocked_microphone_route():

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -3231,25 +3231,58 @@ async def test_addressed_ack_dedupes_against_who_actually_got_it():
     assert len(requester.sent) == 1, "the requester must be acked exactly once"
 
 
-async def test_route_override_reports_blocked_over_a_live_healthy_route():
-    # Codex P2. For a requester that LOST the voice lease while it waited, the
-    # live route belongs to the new holder -- and it may well be healthy by
-    # then. Reporting it opens a microphone on a window whose PCM the server
-    # discards as superseded: another mic that is on and reaching nobody.
-    # Override rather than suppress, or the requester hangs to its own timeout.
-    recorder, _chat = _fake_socket_pair()
+async def test_route_override_reaches_only_the_addressed_requester():
+    # Codex P2, twice over. For a requester that LOST the voice lease while it
+    # waited, the live route belongs to the new holder -- and it may well be
+    # healthy by then. Reporting it opens a microphone on a window whose PCM the
+    # server discards as superseded, so that requester needs a blocked verdict
+    # (override rather than suppress, or it hangs to its own timeout).
+    #
+    # But the verdict is true of the REQUESTER, not of the session: the new
+    # holder is on the very same fan-out, and a window with no start pending
+    # latches any blocked route it sees. Broadcasting the override would
+    # fail-close the microphone of the window that legitimately owns it.
+    requester, new_holder = _fake_socket_pair()
     mgr = _make_routable_audio_manager(True)
-    mgr._begin_voice_input_connection("socket-a")
+    mgr._begin_voice_input_connection("socket-c")
     _authorize_core_lease(mgr)
-    mgr._set_voice_input_websocket("socket-a", recorder)
-    mgr.websocket = recorder
+    mgr._set_voice_input_websocket("socket-c", new_holder)
+    mgr.websocket = new_holder
     mgr._set_microphone_route("independent")
 
     await LLMSessionManager.send_session_started(
-        mgr, "audio", request_id="w4-2", microphone_route_override="blocked"
+        mgr,
+        "audio",
+        request_id="w4-2",
+        also_notify=requester,
+        microphone_route_override="blocked",
     )
 
-    assert json.loads(recorder.sent[0])["microphone_route"] == "blocked"
+    assert json.loads(requester.sent[0])["microphone_route"] == "blocked"
+    assert [json.loads(x)["microphone_route"] for x in new_holder.sent] == [
+        "independent"
+    ], "the live route must stay intact for everyone but the requester"
+
+
+async def test_route_override_travels_when_the_requester_is_the_display_socket():
+    # The requester is simply the newest connection often enough, and then the
+    # display plane is its ONLY copy -- the addressed send would dedupe itself
+    # away. The override has to ride that plane in exactly that case.
+    requester, _other = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr.websocket = requester
+    mgr._voice_lease_connection_id = ""
+    mgr._set_microphone_route("independent")
+
+    await LLMSessionManager.send_session_started(
+        mgr,
+        "audio",
+        request_id="w4-3",
+        also_notify=requester,
+        microphone_route_override="blocked",
+    )
+
+    assert [json.loads(x)["microphone_route"] for x in requester.sent] == ["blocked"]
 
 
 async def test_addressed_ack_is_not_a_second_copy_for_the_same_socket():

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -3198,6 +3198,39 @@ async def test_dedupe_ack_reaches_the_requester_after_a_fail_closed_reroute():
     assert [json.loads(x) for x in requester.sent] == [expected]
 
 
+async def test_addressed_ack_dedupes_against_who_actually_got_it():
+    # CodeRabbit. The fan-out's send is an await, and a lease takeover inside it
+    # points _voice_owner_socket() at a DIFFERENT socket. Deduping against a
+    # fresh read would then miss the socket that just got the payload -- the
+    # requester -- and send it a second copy. One ack, one resolver, but the
+    # handler around it runs again in full: microphone teardown, composer
+    # visibility, the lot.
+    requester, chat = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr._begin_voice_input_connection("socket-a")
+    _authorize_core_lease(mgr)
+    mgr._set_voice_input_websocket("socket-a", requester)
+    mgr.websocket = chat
+
+    original_send = requester.send_text
+
+    async def _send_then_lose_the_lease(payload):
+        await original_send(payload)
+        # A third window claims the microphone while this send is in flight.
+        later, _ = _fake_socket_pair()
+        mgr._begin_voice_input_connection("socket-c")
+        _authorize_core_lease(mgr)
+        mgr._set_voice_input_websocket("socket-c", later)
+
+    requester.send_text = _send_then_lose_the_lease
+
+    await LLMSessionManager.send_session_started(
+        mgr, "audio", request_id="w5-1", also_notify=requester
+    )
+
+    assert len(requester.sent) == 1, "the requester must be acked exactly once"
+
+
 async def test_route_override_reports_blocked_over_a_live_healthy_route():
     # Codex P2. For a requester that LOST the voice lease while it waited, the
     # live route belongs to the new holder -- and it may well be healthy by

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -3127,6 +3127,96 @@ async def test_audio_start_ack_is_not_duplicated_for_a_single_window():
     ], "a single window must be acked exactly once"
 
 
+async def test_start_ack_names_the_request_it_answers():
+    # #2539 / Codex P2. An anonymous ack is settled by whichever window receives
+    # it, and the lease fan-out routinely delivers one start's ack to a DIFFERENT
+    # window -- the claimant that took the microphone mid-start. That window's
+    # frontend then clears its timeout, resolves, reads the blocked route the ack
+    # carries and aborts its own microphone flow; its real ack arrives to a flow
+    # that already gave up. The id is what lets the receiver tell the two apart.
+    recorder, chat = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr._begin_voice_input_connection("socket-a")
+    _authorize_core_lease(mgr)
+    mgr._set_voice_input_websocket("socket-a", recorder)
+    mgr.websocket = chat
+
+    await LLMSessionManager.send_session_started(mgr, "audio", request_id="w1-7")
+
+    expected = {
+        "type": "session_started",
+        "input_mode": "audio",
+        "request_id": "w1-7",
+        "microphone_route": "native",
+    }
+    # Both planes carry it, or the plane that reaches the requester is the one
+    # that cannot be recognised.
+    assert [json.loads(x) for x in recorder.sent] == [expected]
+    assert [json.loads(x) for x in chat.sent] == [expected]
+
+
+async def test_start_ack_stays_anonymous_without_a_request_id():
+    # Internal starts (proactive, greeting, the disconnect recovery) carry no
+    # request of their own. The field must be absent rather than null: the
+    # frontend treats an ack with no id as "mine" to keep those paths working,
+    # and a null would have to be special-cased at every reader.
+    recorder, _chat = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr._begin_voice_input_connection("socket-a")
+    _authorize_core_lease(mgr)
+    mgr._set_voice_input_websocket("socket-a", recorder)
+    mgr.websocket = recorder
+
+    await LLMSessionManager.send_session_started(mgr, "audio")
+
+    assert "request_id" not in json.loads(recorder.sent[0])
+
+
+async def test_dedupe_ack_reaches_the_requester_after_a_fail_closed_reroute():
+    # Codex P2. The dedupe re-ack runs a route re-decision first, and that can
+    # fail closed -- which REVOKES the lease, clearing _voice_lease_connection_id
+    # and the voice socket. With a newer window as self.websocket the requester
+    # is then on neither plane: it sits on its promise until the 15s timeout, and
+    # that timeout's end_session tears down the session that just started.
+    requester, chat = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr.websocket = chat
+    # Post-revoke state: no lease identity, no voice socket.
+    mgr._voice_lease_connection_id = ""
+    mgr._set_microphone_route("blocked")
+
+    await LLMSessionManager.send_session_started(
+        mgr, "audio", request_id="w2-3", also_notify=requester
+    )
+
+    expected = {
+        "type": "session_started",
+        "input_mode": "audio",
+        "request_id": "w2-3",
+        "microphone_route": "blocked",
+    }
+    assert [json.loads(x) for x in requester.sent] == [expected]
+
+
+async def test_addressed_ack_is_not_a_second_copy_for_the_same_socket():
+    # The addressed send must stay a no-op when the requester is already on one
+    # of the planes. A duplicate ack is not harmless: the resolver is one-shot
+    # but the handler around it runs again in full -- microphone teardown,
+    # composer visibility, the lot.
+    requester, _chat = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr._begin_voice_input_connection("socket-a")
+    _authorize_core_lease(mgr)
+    mgr._set_voice_input_websocket("socket-a", requester)
+    mgr.websocket = requester
+
+    await LLMSessionManager.send_session_started(
+        mgr, "audio", request_id="w3-1", also_notify=requester
+    )
+
+    assert len(requester.sent) == 1, "the requester must be acked exactly once"
+
+
 async def test_audio_start_ack_does_not_reach_the_game_microphone():
     # Same exemption the text path carries: the galgame gate owns the mic
     # through its built-in consumer route, and a session_started handler that

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -3084,9 +3084,9 @@ async def test_audio_start_ack_carries_the_settled_blocked_route():
     # ack says "started" -- so the microphone opens onto a route that discards
     # every frame, with no status and no recovery path.
     #
-    # Qualifying the ack covers that, and covers the in-flight dedupe re-ack
-    # (_start_session_handle_inflight) which re-acks without re-running the
-    # route decision at all.
+    # Qualifying the ack covers that, and carries the in-flight dedupe re-ack's
+    # verdict too (_start_session_handle_inflight re-decides a blocked route
+    # before re-acking; see test_session_start_guard.py).
     recorder, chat = _fake_socket_pair()
     mgr = _make_routable_audio_manager(True)
     mgr._begin_voice_input_connection("socket-a")

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -3198,6 +3198,27 @@ async def test_dedupe_ack_reaches_the_requester_after_a_fail_closed_reroute():
     assert [json.loads(x) for x in requester.sent] == [expected]
 
 
+async def test_route_override_reports_blocked_over_a_live_healthy_route():
+    # Codex P2. For a requester that LOST the voice lease while it waited, the
+    # live route belongs to the new holder -- and it may well be healthy by
+    # then. Reporting it opens a microphone on a window whose PCM the server
+    # discards as superseded: another mic that is on and reaching nobody.
+    # Override rather than suppress, or the requester hangs to its own timeout.
+    recorder, _chat = _fake_socket_pair()
+    mgr = _make_routable_audio_manager(True)
+    mgr._begin_voice_input_connection("socket-a")
+    _authorize_core_lease(mgr)
+    mgr._set_voice_input_websocket("socket-a", recorder)
+    mgr.websocket = recorder
+    mgr._set_microphone_route("independent")
+
+    await LLMSessionManager.send_session_started(
+        mgr, "audio", request_id="w4-2", microphone_route_override="blocked"
+    )
+
+    assert json.loads(recorder.sent[0])["microphone_route"] == "blocked"
+
+
 async def test_addressed_ack_is_not_a_second_copy_for_the_same_socket():
     # The addressed send must stay a no-op when the requester is already on one
     # of the planes. A duplicate ack is not harmless: the resolver is one-shot

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -6351,7 +6351,7 @@ async def test_session_activation_resolves_asr_before_frontend_ack() -> None:
         side_effect=lambda _mode, **_kwargs: order.append("asr")
     )
     manager.send_session_started = AsyncMock(
-        side_effect=lambda _mode: order.append("started")
+        side_effect=lambda _mode, **_kwargs: order.append("started")
     )
 
     stop = asyncio.Event()

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -5396,6 +5396,93 @@ async def test_core_passes_only_configured_speaker_shadow_factory(
     factory.assert_not_called()
 
 
+async def test_connect_budget_does_not_block_a_free_native_route(
+    monkeypatch,
+) -> None:
+    # Codex P2. The budget bounds the PROVIDER CONNECT, nothing else. A request
+    # whose handshake disables independent ASR settles on native without talking
+    # to anyone, so refusing it over a connect budget would leave the route on
+    # its blocked placeholder and abort a microphone start that had nothing to
+    # wait for.
+    runtime = _Runtime()
+    runtime.core_api_type = "gemini"
+    runtime.input_mode = "audio"
+    monkeypatch.setattr(
+        core_module,
+        "aload_global_conversation_settings",
+        AsyncMock(return_value={"independentAsrEnabled": True}),
+    )
+    start_mock = AsyncMock()
+    monkeypatch.setattr(runtime._asr_runtime, "start", start_mock)
+
+    await runtime._start_independent_asr_if_enabled(
+        "audio",
+        handshake_override=False,
+        connect_budget_seconds=0.0,
+    )
+
+    assert runtime._asr_route_mode == "native"
+    start_mock.assert_not_awaited()
+
+
+async def test_connect_budget_stops_a_connect_it_cannot_finish(
+    monkeypatch,
+) -> None:
+    # The other half: independent ASR IS wanted, so the decision would connect --
+    # and a verdict produced after the frontend's deadline is worse than none,
+    # because the client's timeout tears down the session that did start. Leave
+    # the route on the blocked placeholder, which is what the caller would have
+    # re-acked without re-deciding at all.
+    runtime = _Runtime()
+    runtime.core_api_type = "gemini"
+    runtime.input_mode = "audio"
+    monkeypatch.setattr(
+        core_module,
+        "aload_global_conversation_settings",
+        AsyncMock(return_value={"independentAsrEnabled": True}),
+    )
+    start_mock = AsyncMock()
+    monkeypatch.setattr(runtime._asr_runtime, "start", start_mock)
+
+    await runtime._start_independent_asr_if_enabled(
+        "audio",
+        handshake_override=True,
+        connect_budget_seconds=0.0,
+    )
+
+    assert runtime._asr_route_mode == "blocked"
+    start_mock.assert_not_awaited()
+
+
+async def test_connect_budget_is_opt_in(monkeypatch) -> None:
+    # Every other caller (hot-swap, device change, the ordinary start) passes no
+    # budget and must keep connecting exactly as before.
+    runtime = _Runtime()
+    runtime.core_api_type = "gemini"
+    runtime.input_mode = "audio"
+    monkeypatch.setattr(
+        core_module,
+        "aload_global_conversation_settings",
+        AsyncMock(return_value={"independentAsrEnabled": True}),
+    )
+    async def _ready(**_kwargs):
+        # Epoch read at call time: the teardown that precedes the connect bumps
+        # it, and a result stamped with the pre-call value reads as stale.
+        return AsrStartResult(
+            status=AsrStartStatus.READY,
+            provider="qwen",
+            session_epoch=runtime._capture_ingress_token().session_epoch,
+        )
+
+    start_mock = AsyncMock(side_effect=_ready)
+    monkeypatch.setattr(runtime._asr_runtime, "start", start_mock)
+
+    await runtime._start_independent_asr_if_enabled("audio", handshake_override=True)
+
+    assert runtime._asr_route_mode == "independent"
+    start_mock.assert_awaited_once()
+
+
 async def test_provider_restart_reuses_accepted_session_optimization(
     monkeypatch,
 ) -> None:

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1703,7 +1703,9 @@ def test_start_session_success_path_clears_goodbye_silent_gate():
     normalized_source = re.sub(r"\s+", " ", _read_core_package_source())
     success_marker = "self._session_start_circuit_open = False"
     clear_marker = "if self.is_goodbye_silent(): self.set_goodbye_silent(False)"
-    notify_marker = "await self.send_session_started(input_mode)"
+    # The ack now names the start it answers (#2539), so match the call opener
+    # rather than the whole call: the args are not what this guard is about.
+    notify_marker = "await self.send_session_started(input_mode"
 
     clear_pos = normalized_source.index(clear_marker)
     success_pos = normalized_source.rindex(success_marker, 0, clear_pos)

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -388,6 +388,54 @@ async def test_same_mode_dedupe_reports_the_live_route_while_the_lease_holds():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_same_mode_dedupe_rechecks_the_lease_after_the_reroute():
+    """Codex P2. The reroute itself awaits a whole provider connect (up to 12s),
+    and a third window can claim the microphone inside THAT window and settle
+    the route to a healthy value. A snapshot taken before the reroute cannot see
+    it, so the superseded requester would be handed a healthy route and open a
+    microphone whose frames the server discards."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    async def _redecide_then_lose_the_lease(*_a, **kwargs):
+        calls.append(("redecide", kwargs))
+        # A third window claims the mic while this connect is in flight, and its
+        # own re-decision settles the route.
+        mgr._voice_lease_connection_id = "socket-c"
+        mgr._asr_route_mode = "independent"
+
+    mgr._start_independent_asr_if_enabled = _redecide_then_lose_the_lease
+
+    await _run_dedupe_start(mgr)
+
+    assert [c[0] for c in calls] == ["redecide", "ack"]
+    assert calls[1][2]["microphone_route_override"] == "blocked"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_does_not_call_a_fail_closed_revoke_a_takeover():
+    """A reroute that fails closed revokes the lease itself, emptying the
+    identity. That is this request's OWN outcome, not a takeover: the route is
+    blocked anyway, so the ack should report it rather than override it -- the
+    override exists to hide somebody else's healthy route, not our own failure."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    async def _redecide_then_fail_closed(*_a, **kwargs):
+        calls.append(("redecide", kwargs))
+        mgr._voice_lease_connection_id = ""
+
+    mgr._start_independent_asr_if_enabled = _redecide_then_fail_closed
+
+    await _run_dedupe_start(mgr)
+
+    assert [c[0] for c in calls] == ["redecide", "ack"]
+    assert calls[1][2]["microphone_route_override"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_same_mode_dedupe_measures_the_deadline_on_the_wall_clock(
     monkeypatch,
 ):

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -203,6 +203,8 @@ def _make_deduping_manager(*, route_mode, session_input_mode="audio"):
     mgr = _make_starting_manager(starting_input_mode="audio")
     mgr.input_mode = session_input_mode
     mgr._asr_route_mode = route_mode
+    mgr._voice_lease_connection_id = "socket-b"
+    mgr.lanlan_name = "test"
     # Lazy-init only; the route fields under test are set explicitly above.
     mgr._ensure_asr_runtime_state = lambda: None
     mgr._independent_asr_handshake_override = None
@@ -332,6 +334,50 @@ async def test_same_mode_dedupe_redecides_with_this_requests_handshake():
     assert calls[0][0] == "redecide"
     assert calls[0][1]["handshake_override"] is True
     assert calls[0][1]["resource_optimization_override"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_skips_reroute_when_the_lease_moved_on():
+    """Codex P2. The wait is seconds long, and a THIRD audio start can claim the
+    microphone inside it. Re-deciding then would configure the NEW holder's
+    route from this superseded window's handshake. The new holder walks the same
+    path with a snapshot that matches, so skipping loses nothing -- but the ack
+    still goes out, or this requester hangs to its own timeout."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    async def _third_window_claims_the_microphone():
+        await asyncio.sleep(0.05)
+        mgr._voice_lease_connection_id = "socket-c"
+
+    claim = asyncio.create_task(_third_window_claims_the_microphone())
+    await _run_dedupe_start(mgr)
+    await claim
+
+    assert [name for name, _ in calls] == ["ack"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_skips_reroute_without_room_in_the_deadline(
+    monkeypatch,
+):
+    """Codex P2. The re-decision runs a whole connect-and-retry phase on top of a
+    wait that has already spent part of the frontend's 15s deadline. Starting one
+    without room for it pushes the re-ack past the point where the client gives
+    up -- and the client's timeout fires end_session, tearing down the session
+    that did start. Out of budget, the bare re-ack (the pre-existing behaviour)
+    is the better trade."""
+    monkeypatch.setattr(
+        "main_logic.core.asr_runtime.ASR_CONNECT_TOTAL_BUDGET_SECONDS", 100.0
+    )
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    await _run_dedupe_start(mgr)
+
+    assert [name for name, _ in calls] == ["ack"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -1,10 +1,14 @@
 import asyncio
+import time
 from queue import Queue
 from unittest.mock import AsyncMock
 
 import pytest
 
 from main_logic.core import LLMSessionManager
+from main_logic.core import lifecycle as lifecycle_module
+
+from tests.fake_clock import patch_module_clock
 
 
 def _make_inactive_manager(*, starting_count=1):
@@ -197,6 +201,10 @@ async def test_cross_mode_background_start_does_not_restart():
     assert mgr._starting_session_count == 1
 
 
+# Mutable flag so the patched clock can be flipped from inside the wait loop.
+_stalled = {"on": False}
+
+
 def _make_deduping_manager(*, route_mode, session_input_mode="audio"):
     """Manager pre-positioned at the SAME-mode dedupe branch: an in-flight audio
     start occupies the count, and it has already settled the route to
@@ -357,6 +365,62 @@ async def test_same_mode_dedupe_skips_reroute_when_the_lease_moved_on():
     await claim
 
     assert [c[0] for c in calls] == ["ack"]
+    # And the ack must not report the NEW holder's route (Codex P2). It can well
+    # be healthy by now -- the new holder re-decided it -- and a superseded
+    # window that sees a healthy route opens a microphone whose every frame the
+    # server discards as stale. Report blocked so it fails closed and settles.
+    assert calls[0][2]["microphone_route_override"] == "blocked"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_reports_the_live_route_while_the_lease_holds():
+    """Dual of the above: the requester still owns the microphone, so the ack
+    must carry the real verdict rather than a blanket blocked."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    await _run_dedupe_start(mgr)
+
+    assert calls[-1][0] == "ack"
+    assert calls[-1][2]["microphone_route_override"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_measures_the_deadline_on_the_wall_clock(
+    monkeypatch,
+):
+    """Codex P2. The remaining budget must come from a monotonic clock, not from
+    the loop's nominal 50ms sleep counter: a stalled event loop (or an
+    overshooting sleep) burns seconds of the frontend's 15s timer while the
+    counter barely moves, and an inflated budget then permits a full 12s connect
+    whose ack lands after the client has already given up and sent
+    end_session."""
+    real_monotonic = time.monotonic
+    _stalled["on"] = False
+    # The counter will read ~0.1s of nominal sleep; the wall clock says the
+    # frontend deadline is nearly spent. Scoped to the module under test --
+    # patching stdlib time would hand the fake to every background thread too.
+    patch_module_clock(
+        monkeypatch,
+        lifecycle_module,
+        monotonic=lambda: real_monotonic() + (14.0 if _stalled["on"] else 0.0),
+    )
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    async def _stall_the_loop():
+        await asyncio.sleep(0.05)
+        _stalled["on"] = True
+
+    stall = asyncio.create_task(_stall_the_loop())
+    await _run_dedupe_start(mgr)
+    await stall
+
+    assert [c[0] for c in calls] == ["ack"], (
+        "a budget read off the sleep counter would have permitted the reroute"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -201,10 +201,6 @@ async def test_cross_mode_background_start_does_not_restart():
     assert mgr._starting_session_count == 1
 
 
-# Mutable flag so the patched clock can be flipped from inside the wait loop.
-_stalled = {"on": False}
-
-
 def _make_deduping_manager(*, route_mode, session_input_mode="audio"):
     """Manager pre-positioned at the SAME-mode dedupe branch: an in-flight audio
     start occupies the count, and it has already settled the route to
@@ -446,21 +442,23 @@ async def test_same_mode_dedupe_measures_the_deadline_on_the_wall_clock(
     whose ack lands after the client has already given up and sent
     end_session."""
     real_monotonic = time.monotonic
-    _stalled["on"] = False
+    # Local rather than module-level: a shared mutable would couple this case to
+    # any future one that reuses it, and to test ordering (CodeRabbit).
+    stalled = {"on": False}
     # The counter will read ~0.1s of nominal sleep; the wall clock says the
     # frontend deadline is nearly spent. Scoped to the module under test --
     # patching stdlib time would hand the fake to every background thread too.
     patch_module_clock(
         monkeypatch,
         lifecycle_module,
-        monotonic=lambda: real_monotonic() + (14.0 if _stalled["on"] else 0.0),
+        monotonic=lambda: real_monotonic() + (14.0 if stalled["on"] else 0.0),
     )
     mgr = _make_deduping_manager(route_mode="blocked")
     calls = _record_dedupe_calls(mgr)
 
     async def _stall_the_loop():
         await asyncio.sleep(0.05)
-        _stalled["on"] = True
+        stalled["on"] = True
 
     stall = asyncio.create_task(_stall_the_loop())
     await _run_dedupe_start(mgr)

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -196,6 +196,165 @@ async def test_cross_mode_background_start_does_not_restart():
     assert mgr._starting_session_count == 1
 
 
+def _make_deduping_manager(*, route_mode, session_input_mode="audio"):
+    """Manager pre-positioned at the SAME-mode dedupe branch: an in-flight audio
+    start occupies the count, and it has already settled the route to
+    ``route_mode`` for the session whose mode is ``session_input_mode``."""
+    mgr = _make_starting_manager(starting_input_mode="audio")
+    mgr.input_mode = session_input_mode
+    mgr._asr_route_mode = route_mode
+    # Lazy-init only; the route fields under test are set explicitly above.
+    mgr._ensure_asr_runtime_state = lambda: None
+    mgr._independent_asr_handshake_override = None
+    mgr._voice_input_resource_optimization_handshake_override = None
+    return mgr
+
+
+def _record_dedupe_calls(mgr):
+    """Trace the two dedupe-path effects in call order: the route re-decision
+    and the re-ack. Order is the point -- an ack sent before the re-decision
+    would carry the very verdict the re-decision exists to replace."""
+    calls = []
+
+    async def _redecide(*_a, **kwargs):
+        calls.append(("redecide", kwargs))
+
+    async def _ack(input_mode):
+        calls.append(("ack", input_mode))
+
+    mgr._start_independent_asr_if_enabled = _redecide
+    mgr.send_session_started = _ack
+    return calls
+
+
+async def _run_dedupe_start(mgr, *, request_mode="audio", **kwargs):
+    """Drive a same-mode start into the dedupe wait, then let the in-flight
+    start settle."""
+    task = asyncio.create_task(
+        LLMSessionManager.start_session(
+            mgr, mgr.websocket, False, request_mode, user_initiated=True, **kwargs
+        )
+    )
+    await asyncio.sleep(0.1)
+    mgr._starting_session_count = 0
+    await task
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_redecides_a_blocked_route_before_reacking():
+    """#2539. The dedupe path starts nothing of its own, so it used to re-ack
+    with the in-flight start's verdict. Claiming the voice lease (which this
+    requester did, synchronously, before start_session) invalidates the
+    in-flight ASR start; that start exits ASR_START_STALE, leaves the route on
+    its blocked placeholder and emits no status at all. The ack carries the
+    placeholder, both windows latch fail-closed, and the microphone never opens
+    for the session that did start -- nothing re-decides in-session."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    await _run_dedupe_start(mgr)
+
+    assert [name for name, _ in calls] == ["redecide", "ack"]
+    assert calls[0][1]["handshake_override"] is None
+    assert calls[1][1] == "audio"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_keeps_a_settled_route():
+    """A native/independent verdict is valid for whoever holds the microphone.
+    Re-deciding would tear down a healthy provider mid-session, so only a
+    blocked route is re-run."""
+    for settled in ("native", "independent"):
+        mgr = _make_deduping_manager(route_mode=settled)
+        calls = _record_dedupe_calls(mgr)
+
+        await _run_dedupe_start(mgr)
+
+        assert [name for name, _ in calls] == ["ack"], settled
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_does_not_redecide_against_a_text_session():
+    """The dedupe branch treats a missing _starting_input_mode as a match, so an
+    audio request can land here against an in-flight TEXT start. A text session
+    pins the route to blocked for its whole life; re-deciding would hand a live
+    microphone to a session with no audio path."""
+    mgr = _make_deduping_manager(route_mode="blocked", session_input_mode="text")
+    mgr._starting_input_mode = None
+    calls = _record_dedupe_calls(mgr)
+
+    await _run_dedupe_start(mgr)
+
+    assert [name for name, _ in calls] == ["ack"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_does_not_redecide_for_a_text_request():
+    """Dual of the case above: a TEXT request can land in the same-mode branch
+    against an in-flight AUDIO start (again via a missing _starting_input_mode).
+    Re-deciding on its behalf would open a microphone route for a requester that
+    asked for the keyboard."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    mgr._starting_input_mode = None
+    calls = _record_dedupe_calls(mgr)
+
+    await _run_dedupe_start(mgr, request_mode="text")
+
+    assert [name for name, _ in calls] == ["ack"]
+    assert calls[0][1] == "text"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_redecides_with_this_requests_handshake():
+    """The re-decision belongs to THIS request: it must use the handshake
+    snapshot carried down from its own start_session call, not whatever the
+    shared manager field holds by the time the wait ends (a later request may
+    have overwritten it -- that is why start_session snapshots it at all)."""
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    async def _overwrite_shared_field_during_wait():
+        await asyncio.sleep(0.05)
+        mgr._independent_asr_handshake_override = False
+        mgr._voice_input_resource_optimization_handshake_override = False
+
+    overwrite = asyncio.create_task(_overwrite_shared_field_during_wait())
+    await _run_dedupe_start(
+        mgr, handshake_override=True, resource_optimization_override=True
+    )
+    await overwrite
+
+    assert calls[0][0] == "redecide"
+    assert calls[0][1]["handshake_override"] is True
+    assert calls[0][1]["resource_optimization_override"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_mode_dedupe_skips_both_when_inflight_never_settles(monkeypatch):
+    """Timeout exit: the in-flight start never settles, so the session/is_active
+    it would report may belong to the PREVIOUS session. No ack, and therefore no
+    route re-decision either -- re-deciding would tear down the route of a start
+    that is still running."""
+    monkeypatch.setattr(
+        "main_logic.core.lifecycle.FRONTEND_START_SESSION_TIMEOUT_SECONDS", 0.2
+    )
+    mgr = _make_deduping_manager(route_mode="blocked")
+    calls = _record_dedupe_calls(mgr)
+
+    await LLMSessionManager.start_session(
+        mgr, mgr.websocket, False, "audio", user_initiated=True
+    )
+
+    assert calls == []
+    assert mgr._starting_session_count == 1
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_start_skips_restart_when_torn_down_during_wait():

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -464,31 +464,33 @@ async def test_same_mode_dedupe_measures_the_deadline_on_the_wall_clock(
     await _run_dedupe_start(mgr)
     await stall
 
-    assert [c[0] for c in calls] == ["ack"], (
-        "a budget read off the sleep counter would have permitted the reroute"
+    assert calls[0][0] == "redecide"
+    budget = calls[0][1]["connect_budget_seconds"]
+    assert budget < 2.0, (
+        f"budget {budget} was read off the sleep counter, not the wall clock"
     )
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_same_mode_dedupe_skips_reroute_without_room_in_the_deadline(
-    monkeypatch,
-):
-    """Codex P2. The re-decision runs a whole connect-and-retry phase on top of a
-    wait that has already spent part of the frontend's 15s deadline. Starting one
-    without room for it pushes the re-ack past the point where the client gives
-    up -- and the client's timeout fires end_session, tearing down the session
-    that did start. Out of budget, the bare re-ack (the pre-existing behaviour)
-    is the better trade."""
-    monkeypatch.setattr(
-        "main_logic.core.asr_runtime.ASR_CONNECT_TOTAL_BUDGET_SECONDS", 100.0
-    )
+async def test_same_mode_dedupe_hands_the_remaining_deadline_down_as_a_budget():
+    """Codex P2, twice. The re-decision can run a whole connect-and-retry phase
+    on top of a wait that already spent part of the frontend's 15s deadline, and
+    a re-ack past that deadline is worse than useless: the client's timeout fires
+    end_session and tears down the session that did start.
+
+    The budget travels DOWN rather than gating here, because only the route
+    decision knows whether it is going to connect at all -- a handshake that
+    disables independent ASR settles on native for free, and refusing that over
+    a connect budget would strand a microphone that had nothing to wait for."""
     mgr = _make_deduping_manager(route_mode="blocked")
     calls = _record_dedupe_calls(mgr)
 
     await _run_dedupe_start(mgr)
 
-    assert [c[0] for c in calls] == ["ack"]
+    assert [c[0] for c in calls] == ["redecide", "ack"]
+    budget = calls[0][1]["connect_budget_seconds"]
+    assert 14.0 < budget <= 15.0, budget
 
 
 @pytest.mark.unit

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -156,6 +156,7 @@ async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
         "audio",
         user_initiated=True,
         _allow_cross_mode_restart=False,
+        request_id=None,
         handshake_override=None,
         resource_optimization_override=None,
     )
@@ -221,8 +222,8 @@ def _record_dedupe_calls(mgr):
     async def _redecide(*_a, **kwargs):
         calls.append(("redecide", kwargs))
 
-    async def _ack(input_mode):
-        calls.append(("ack", input_mode))
+    async def _ack(input_mode, **kwargs):
+        calls.append(("ack", input_mode, kwargs))
 
     mgr._start_independent_asr_if_enabled = _redecide
     mgr.send_session_started = _ack
@@ -257,7 +258,7 @@ async def test_same_mode_dedupe_redecides_a_blocked_route_before_reacking():
 
     await _run_dedupe_start(mgr)
 
-    assert [name for name, _ in calls] == ["redecide", "ack"]
+    assert [c[0] for c in calls] == ["redecide", "ack"]
     assert calls[0][1]["handshake_override"] is None
     assert calls[1][1] == "audio"
 
@@ -274,7 +275,7 @@ async def test_same_mode_dedupe_keeps_a_settled_route():
 
         await _run_dedupe_start(mgr)
 
-        assert [name for name, _ in calls] == ["ack"], settled
+        assert [c[0] for c in calls] == ["ack"], settled
 
 
 @pytest.mark.unit
@@ -290,7 +291,7 @@ async def test_same_mode_dedupe_does_not_redecide_against_a_text_session():
 
     await _run_dedupe_start(mgr)
 
-    assert [name for name, _ in calls] == ["ack"]
+    assert [c[0] for c in calls] == ["ack"]
 
 
 @pytest.mark.unit
@@ -306,7 +307,7 @@ async def test_same_mode_dedupe_does_not_redecide_for_a_text_request():
 
     await _run_dedupe_start(mgr, request_mode="text")
 
-    assert [name for name, _ in calls] == ["ack"]
+    assert [c[0] for c in calls] == ["ack"]
     assert calls[0][1] == "text"
 
 
@@ -355,7 +356,7 @@ async def test_same_mode_dedupe_skips_reroute_when_the_lease_moved_on():
     await _run_dedupe_start(mgr)
     await claim
 
-    assert [name for name, _ in calls] == ["ack"]
+    assert [c[0] for c in calls] == ["ack"]
 
 
 @pytest.mark.unit
@@ -377,7 +378,7 @@ async def test_same_mode_dedupe_skips_reroute_without_room_in_the_deadline(
 
     await _run_dedupe_start(mgr)
 
-    assert [name for name, _ in calls] == ["ack"]
+    assert [c[0] for c in calls] == ["ack"]
 
 
 @pytest.mark.unit
@@ -459,6 +460,7 @@ async def test_cross_mode_start_restarts_even_if_inflight_failed_internally():
         "audio",
         user_initiated=True,
         _allow_cross_mode_restart=False,
+        request_id=None,
         handshake_override=None,
         resource_optimization_override=None,
     )

--- a/tests/unit/test_websocket_binary_audio.py
+++ b/tests/unit/test_websocket_binary_audio.py
@@ -80,7 +80,7 @@ class _ProtocolManager:
         self.calls.append(("resource_optimization_handshake", value))
 
     def start_session(self, *_args, **_kwargs):
-        self.calls.append(("start_session", None))
+        self.calls.append(("start_session", _kwargs))
 
         async def _complete() -> None:
             return None
@@ -528,6 +528,70 @@ async def test_start_session_forwards_independent_asr_handshake_before_dispatch(
             strict=True,
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_start_session_forwards_the_request_id_it_was_given(
+    monkeypatch,
+) -> None:
+    # #2539 / Codex P2. The ack has to name the start it answers, or a window
+    # with its own start pending settles on the first same-mode ack that reaches
+    # it -- and the lease fan-out routinely delivers one start's ack to the
+    # window that claimed the microphone mid-start.
+    manager = _ProtocolManager()
+    websocket = _EventWebSocket(
+        [
+            {"action": "start_session", "input_type": "audio", "request_id": "w1-4"},
+            {"action": "start_session", "input_type": "text"},
+            # Not a string, and an empty one: both mean "no request", not a
+            # crash and not an id the frontend could never match.
+            {"action": "start_session", "input_type": "audio", "request_id": 17},
+            {"action": "start_session", "input_type": "audio", "request_id": "   "},
+        ]
+    )
+    _install_protocol_endpoint(
+        monkeypatch,
+        manager=manager,
+        websocket=websocket,
+    )
+
+    await websocket_router.websocket_endpoint(websocket, "Lan")
+
+    assert [
+        kwargs.get("request_id")
+        for name, kwargs in manager.calls
+        if name == "start_session"
+    ] == ["w1-4", None, None, None]
+
+
+@pytest.mark.asyncio
+async def test_start_session_bounds_the_request_id_length(monkeypatch) -> None:
+    # The id is echoed back on every ack for the session's whole start, and it
+    # arrives from the client. Bound it rather than mirror an arbitrary payload.
+    manager = _ProtocolManager()
+    websocket = _EventWebSocket(
+        [
+            {
+                "action": "start_session",
+                "input_type": "audio",
+                "request_id": "x" * 500,
+            },
+        ]
+    )
+    _install_protocol_endpoint(
+        monkeypatch,
+        manager=manager,
+        websocket=websocket,
+    )
+
+    await websocket_router.websocket_endpoint(websocket, "Lan")
+
+    forwarded = next(
+        kwargs["request_id"]
+        for name, kwargs in manager.calls
+        if name == "start_session"
+    )
+    assert forwarded == "x" * 128
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
关闭 #2539。

## 现象

同模式并发 start 撞车时，`_start_session_handle_inflight` 的去重路径只补发一次
`session_started`，从不重跑路由决策，于是它带出去的是 in-flight 那次 start 的裁决。

issue 记录这条时，担心的是「补发的 ack 会让前端清 latch，把仍成立的 blocked 裁决抹掉」。
#2345 合入的版本已经用 issue 里说的「改动面小」那半修掉了这个方向：ack 带上
`microphone_route`，前端 `session_started` 处理器改成 set-only，不再从 ack 清 latch。

但同一条「不重跑决策」现在以对偶形式仍然成立，方向反过来了：

1. 窗口 A 点麦 → `_claim_voice_input_connection()` → `start_session(audio)` 在飞
2. 窗口 B 点麦 → claim 换到 B，`_begin_voice_input_connection` 顺手 `_invalidate_asr_start()`
3. A 的 `_asr_runtime.start()` 返回 `ASR_START_STALE` → 早退。路由停在 blocked 占位上，
   而这个早退点在所有 status 发射点之前——**一条 status 都不发**
4. A 的 activate 发 `session_started(audio, microphone_route=blocked)`；B 的去重路径等落定后
   再补发一条
5. 两个窗口一起 `voiceInputRouteBlocked = true`。真正起来的那个会话麦克风再也打不开，屏幕上
   没有任何解释——会话内也没有别的重决入口（另一条只有 core 变更 reconcile），用户只能
   end_session 从头来

## 改动

### 一、去重路径补 ack 前重跑路由决策

`_rerun_route_for_deduped_start`，四道守卫：

- 本请求是 audio，且 in-flight 起的会话也是 audio（去重分支把 `_starting_input_mode` 缺失
  当同模式匹配，所以两边都要判）
- 当前路由仍是 blocked。已 settle 的 native/independent 不重跑——那种裁决对谁持麦都成立，
  重跑等于把健康的 provider 中途拆了重连
- voice lease 没在等待期间易主。等待可能十几秒，第三个 audio start 抢走麦克风时，替它重跑
  会用本请求（已被顶掉的窗口）的 handshake 去配新持有者的路由；新持有者自己也走这条路径且
  快照对得上，跳过不丢东西
- 前端 deadline 还剩得下一次 connect（`ASR_CONNECT_TOTAL_BUDGET_SECONDS` = 12s）。重跑跑的是
  完整的 connect-and-retry，叠在最长 15s 的等待后面会把 ack 推过 deadline，前端超时发的
  end_session 反过来把刚起来的会话撕掉。剩余量按 `time.monotonic()` 算——等待循环的计数器
  按标称 50ms 累加，事件循环一卡真实时间就甩开它好几秒，预算被高估等于没设

传本请求自己的 handshake 快照，而不是共享字段此刻的值。重跑成功会发
`ASR_INDEPENDENT_READY` / `DISABLED`，前端据此清 latch；随后的 ack 带的是新路由。顺序是
「先重决、后补 ack」，反过来 ack 就还是带旧裁决。

### 二、`session_started` 带请求标识

上面那半只修好了后端的路由，但**前端已经放弃了**：B 抢麦时 router 同步把 voice socket 换成
B 的（`websocket_router.py`），于是 A 那次 start 的 ack 经 fan-out 落到 B。B 前端一看模式对
得上就清超时、500ms 后 resolve，然后按 ack 里的 blocked 路由走
`abortVoiceStartForBlockedRoute()` 直接结束麦克风流程，不重试——后端随后重跑出的 READY 和
补发的 ack 都救不回来。

模式守卫拦不住这种同模式串台，ack 本身也没有任何东西能说明「我在回应谁」。所以：

- 前端每次 claim start 槽位时铸一个请求标识（窗口段随机 + 递增序号），按 owner 存，四个
  `start_session` 发送点都用自己的 owner 取。被顶掉的 flow 即便还走到发送，带的也是自己那个
  标识，回来的 ack 因此对不上当前 pending
- 后端 router 取出该标识（非字符串/空白视为无、长度封顶 128），沿
  `start_session` → `activate` → `send_session_started` 原样带回 ack
- 前端只用「标识匹配」的 ack 收口（清超时 + resolve + 收起准备中提示），**latch 也一并 gate**：
  latch 是 set-only，别人留下的 blocked 本窗口自己的健康 ack 清不掉，重跑成功了照样开不了麦。
  没有 pending 启动的窗口不受影响（守卫对它恒为真），那正是「无从别处得知裁决」的场景。
  UI 同步（文本框显隐、停麦）不 gate——后端确实起了会话，那些对本窗口照样成立
- ack 不带标识时按「是我的」处理：后端内部路径（proactive / greeting / 断线自恢复）没有请求
  标识，它们撞上 pending 启动本就由模式守卫负责

### 三、去重路径的 ack 定向送达请求方

另外，lease 若在等待期间易主，ack 里的路由**只报 blocked**：此刻的 `_asr_route_mode` 是新持有者
的裁决，可能已 settle 成 native/independent；照报会让被顶掉的那个窗口看到健康路由、开麦，而
服务端的 voice identity 归新持有者，它之后每一帧 PCM 都被当 stale 丢掉——又一个"开着麦说给空气
听"。选覆盖而不是不发：不发的话它会干等到 15s 超时，而超时发的 end_session 会把刚起来的会话
撕掉，正是本 PR 在修的那类后果。

重跑若 fail-closed，`_fail_closed_voice_route` 会 revoke lease，把 `_voice_lease_connection_id`
和 voice socket 一起清掉，本请求方就不在任何一条投递面上了（`self.websocket` 可能是更新的
窗口），只能等到 15s 超时、而超时发的 end_session 会把刚起来的会话撕掉。去重路径改为额外向
本请求那把 ws 定向送一份，按 socket 身份去重（重复 ack 不是无害的：resolver 一次性，但外层
处理器会整个再跑一遍）。

去重按**实际投递到的** socket 集合走，边发边记：fan-out 的 send 是个 await，lease 在那期间被抢走
时重新读 `_voice_owner_socket()` 拿到的是新 socket，刚收到 ack 的旧 lease socket（通常就是本请求方）
反而不在集合里。`self.websocket` 同理，也改成先取局部变量再发。

## 回归报告

**改了什么、为什么必要**：见上。核心是一条并发窄路径下麦克风被永久 fail-closed 且无提示、
会话内不自愈；修的过程中又暴露出「ack 是匿名的，谁收到谁收口」这条更普遍的缺陷。

**改动前后行为**：

| | 改动前 | 改动后 |
|---|---|---|
| 同模式去重路径 | 等落定 → 补 ack（带 in-flight 的裁决） | 等落定 →（audio & audio & blocked & lease 未易主 & 预算够时）重跑决策 → 补 ack + 定向送请求方；lease 易主时 ack 只报 blocked |
| `session_started` | 匿名 | 带 `request_id`（无请求来源时不带该字段） |
| 前端收到同模式 ack | 一律收口 | 标识匹配才收口；UI 同步不变 |

非 audio 请求、in-flight 是 text、路由已 settle、lease 已易主、预算不足五种情况下，去重路径
行为与改动前完全一致。

**潜在回归**：

1. blocked 是**正当**裁决时（provider 连不上、settings 不可读的 fail-closed）会多试一次
   provider 连接。代价是一次连接尝试 + 一次幂等的 fail-closed 通知；对用户其实是多一次重试
   机会。只在「同模式并发撞车」这条窄路径上发生
2. 重跑会 `_begin_asr_route_operation()` 涨一次代次。若此刻恰有别的路由操作（如热切换
   reconcile）在跑，两边互相 fence，最坏结果是重跑被 fence 掉、路由留在 blocked——与改动前
   现状相同，不会更糟
3. 请求标识是新契约。若某条用户发起路径漏带标识，它收到的 ack 也不带（后端原样回传），按
   「是我的」处理 → 退回改动前行为，不会卡死。测试用**自动发现**所有 `action: 'start_session'`
   发送点来挡漏带，新增发送点也会被抓到
4. 前后端同步上线，无需兼容旧客户端（已与维护者确认）

**测试**：

- `tests/unit/test_session_start_guard.py` +13（含 lease 在重跑期间易主 → ack 报 blocked、
  fail-closed 清空 lease 不算易主）：重决+顺序、settled 不重决、in-flight text 不重决、
  text 请求不重决、handshake 快照、lease 易主跳过、预算不足跳过、超时退出两件事都不做、
  lease 易主时 ack 报 blocked、lease 在手时报真实路由、预算按墙钟算
- `tests/unit/test_audio_stream_queue.py` +6：ack 带标识、无来源时不带该字段、revoke 后定向送达、
  同一 socket 不重复发、send 期间 lease 易主仍只发一次、路由覆盖压过健康的实时路由
- `tests/unit/test_websocket_binary_audio.py` +2：router 转发标识（含非字符串/空白/超长）
- `tests/unit/test_app_websocket_static.py` +4：前端消费 `microphone_route`、发送点全带标识
  （自动发现）、标识随槽位 claim/release、只让匹配的 ack 收口

变异验证（逐条撤掉实现确认测试变红）：

| 变异 | 结果 |
|---|---|
| 去掉 `_rerun_route_for_deduped_start` 调用 | 2 红 |
| 去掉 blocked-only 守卫 | 1 红 |
| 去掉 in-flight text 守卫 | 1 红 |
| 去掉请求模式守卫 | 1 红 |
| ack 与重决顺序颠倒 | 2 红 |
| 去掉 lease 易主守卫 | 1 红 |
| 去掉 deadline 预算守卫 | 1 红 |
| 删掉前端 latch 分支 | 1 红 |
| 某个发送点漏带 `request_id` | 1 红 |
| resolve 不受标识守卫约束 | 2 红 |
| 预算换回 sleep 计数器 | 1 红 |
| lease 易主时不覆盖路由 | 2 红 |
| lease 判定挪回重跑之前 | 1 红 |
| 空 lease 也算成被抢 | 1 红 |
| 去重换回「重新读一次」 | 1 红 |
| latch 不受标识守卫约束 | 1 红 |

本地：语音/会话/ASR/websocket 相关全部相关测试 3949 passed（另有 2 条与本改动无关的失败，是
本地未入库的 `tools/voice_eval` 目录触发的遗留路径守卫，CI 上不存在）；docstring 禁 CJK 门通过；
三个改动的 JS 文件 `node --check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
