### PR TITLE
持久化界面语言并同步当前角色偏好

### DIFF
--- a/main_routers/config_router/__init__.py
+++ b/main_routers/config_router/__init__.py
@@ -63,6 +63,7 @@ from .preferences import (  # noqa: F401
 from .language import (  # noqa: F401
     get_steam_language,
     get_user_language_api,
+    set_ui_language_api,
 )
 from .core_config import (  # noqa: F401
     get_core_config_api,

--- a/main_routers/config_router/language.py
+++ b/main_routers/config_router/language.py
@@ -18,10 +18,60 @@
 Split out of the former monolithic ``main_routers/config_router.py``.
 """
 
+import asyncio
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
 from ._shared import logger, router
 
 from ..shared_state import ensure_steamworks
-from utils.preferences import aload_ui_language_override
+from ..shared_state import get_config_manager
+from ..system_router._shared import _validate_local_mutation_request
+from utils.preferences import (
+    aload_ui_language_override,
+    asave_ui_language_override,
+)
+
+
+_UI_LANGUAGE_SYNC_LOCK = asyncio.Lock()
+
+
+async def _rollback_ui_language(previous_language: str | None) -> bool:
+    """Best-effort rollback that never hides the original sync failure."""
+    try:
+        return bool(await asave_ui_language_override(previous_language))
+    except Exception:
+        logger.exception("界面语言回滚异常")
+        return False
+
+
+def _ui_language_sync_failure_payload(
+    *,
+    error: str,
+    normalized: str,
+    previous_ui_language: str | None,
+    rollback_succeeded: bool,
+    character_name: str | None = None,
+    conversation_sync: dict | None = None,
+) -> dict:
+    """Describe both persisted sides when UI rollback could not be completed."""
+    payload = {
+        "success": False,
+        "error": error,
+        "language": normalized,
+        "character_name": character_name,
+        "conversation_sync": conversation_sync,
+        "ui_language": previous_ui_language if rollback_succeeded else normalized,
+        "ui_language_rollback_succeeded": rollback_succeeded,
+    }
+    if not rollback_succeeded:
+        payload.update({
+            "partial_success": True,
+            "partial_persistence": True,
+            "error": f"{error}，且界面语言回滚失败",
+        })
+    return payload
 
 
 @router.get("/steam_language")
@@ -183,3 +233,106 @@ async def get_user_language_api():
             "error": str(e),
             "language": "zh"  # 默认中文
         }
+
+
+async def _persist_ui_language_and_sync(normalized: str):
+    """Serialize one UI write, character sync, and any compensating rollback."""
+    previous_ui_language = await aload_ui_language_override()
+    if not await asave_ui_language_override(normalized):
+        return JSONResponse(
+            {"success": False, "error": "保存界面语言失败"},
+            status_code=500,
+        )
+
+    try:
+        config_manager = get_config_manager()
+        characters = await config_manager.aload_characters()
+        current_name = str(characters.get("当前猫娘") or "").strip()
+        conversation_sync = None
+        if current_name and current_name in (characters.get("猫娘") or {}):
+            from ..characters_router.language_preference import (
+                apply_character_language_preference,
+            )
+
+            conversation_sync = await apply_character_language_preference(
+                current_name,
+                normalized,
+            )
+            if conversation_sync.get("success") is not True:
+                # The memory-server write happens before best-effort context
+                # isolation.  If it committed, rolling back only the UI value
+                # would split the two settings again.  Keep both languages in
+                # sync and surface the isolation failure as a partial warning.
+                locale_was_synced = (
+                    conversation_sync.get("partial_success") is True
+                    and conversation_sync.get("language") == normalized
+                )
+                if not locale_was_synced:
+                    rollback_succeeded = await _rollback_ui_language(
+                        previous_ui_language,
+                    )
+                    return JSONResponse(
+                        _ui_language_sync_failure_payload(
+                            error=conversation_sync.get("error")
+                            or "同步语言偏好失败",
+                            normalized=normalized,
+                            previous_ui_language=previous_ui_language,
+                            rollback_succeeded=rollback_succeeded,
+                            character_name=current_name,
+                            conversation_sync=conversation_sync,
+                        ),
+                        status_code=500,
+                    )
+
+        return {
+            "success": True,
+            "language": normalized,
+            "character_name": current_name or None,
+            "partial_success": bool(
+                conversation_sync and conversation_sync.get("partial_success")
+            ),
+            "conversation_sync": conversation_sync,
+        }
+    except Exception:
+        rollback_succeeded = await _rollback_ui_language(previous_ui_language)
+        logger.exception("同步界面语言和语言偏好失败")
+        return JSONResponse(
+            _ui_language_sync_failure_payload(
+                error="同步语言设置失败",
+                normalized=normalized,
+                previous_ui_language=previous_ui_language,
+                rollback_succeeded=rollback_succeeded,
+            ),
+            status_code=503,
+        )
+
+
+@router.put("/ui-language")
+async def set_ui_language_api(request: Request):
+    """Persist the desktop UI locale and sync the current character preference."""
+    from utils.language_utils import (
+        is_supported_language_code,
+        normalize_language_code,
+    )
+
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = None
+    validation_error = _validate_local_mutation_request(
+        request,
+        payload=payload if isinstance(payload, dict) else None,
+    )
+    if validation_error is not None:
+        return validation_error
+
+    language = payload.get("language") if isinstance(payload, dict) else None
+    if not is_supported_language_code(language):
+        return JSONResponse(
+            {"success": False, "error": "不支持的语言"},
+            status_code=400,
+        )
+
+    normalized = normalize_language_code(language, format="full")
+    async with _UI_LANGUAGE_SYNC_LOCK:
+        return await _persist_ui_language_and_sync(normalized)

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -1433,22 +1433,29 @@
         return v == null ? '' : String(v);
     }
 
+    function getLiveRendererLanguage() {
+        try {
+            if (window.i18next && window.i18next.language) return window.i18next.language;
+            if (window.i18n && window.i18n.language) return window.i18n.language;
+            return localStorage.getItem('i18nextLng') || navigator.language || 'en';
+        } catch (_) {
+            return 'en';
+        }
+    }
+
     function getConversationLanguageForCurrentCharacter() {
         try {
             // Once the server preference has been hydrated, it is authoritative for
             // this session even when a previous localStorage write failed.
             if (S.conversationLanguageHydrated === true) {
                 if (S.conversationLanguage) return S.conversationLanguage;
-                if (window.i18next && window.i18next.language) return window.i18next.language;
-                if (window.i18n && window.i18n.language) return window.i18n.language;
-                return localStorage.getItem('i18nextLng') || navigator.language || 'en';
+                return getLiveRendererLanguage();
             }
             if (typeof window.getConversationLanguagePreference === 'function') {
                 return window.getConversationLanguagePreference(getWebSocketLanlanName() || '');
             }
             if (S.conversationLanguage) return S.conversationLanguage;
-            if (window.i18next && window.i18next.language) return window.i18next.language;
-            return localStorage.getItem('i18nextLng') || navigator.language || 'en';
+            return getLiveRendererLanguage();
         } catch (_) {
             return S.conversationLanguage || 'en';
         }
@@ -1480,6 +1487,19 @@
             return Promise.resolve(fallback);
         }
 
+        var explicitAtStart = '';
+        var preferenceRevisionAtStart = null;
+        try {
+            if (typeof window.getExplicitConversationLanguagePreference === 'function') {
+                explicitAtStart = window.getExplicitConversationLanguagePreference(characterName) || '';
+            }
+        } catch (_) { /* continue with server hydration */ }
+        try {
+            if (typeof window.getConversationLanguagePreferenceRevision === 'function') {
+                preferenceRevisionAtStart = window.getConversationLanguagePreferenceRevision(characterName);
+            }
+        } catch (_) { /* retain the value-only fence below */ }
+
         var request = fetch('/api/characters/character/' + encodeURIComponent(characterName) + '/language-preference', {
             cache: 'no-store'
         }).then(function (response) {
@@ -1491,7 +1511,7 @@
                 ? payload.language.trim()
                 : '';
             return {
-                language: explicitLanguage || payload.effective_language || fallback,
+                language: explicitLanguage,
                 explicitLanguage: explicitLanguage
             };
         }).catch(function (error) {
@@ -1501,9 +1521,62 @@
 
         function applyHydratedConversationLanguage(hydrated) {
             var resolved = hydrated || {};
-            var language = resolved.language || fallback;
-            if (S._conversationLanguageHydrationId !== hydrationId) return language;
             var degraded = !!(resolved.requestFailed || resolved.timedOut);
+            // A successful empty response proves only that there is no durable
+            // character preference. Its backend effective_language can lag a
+            // URL/localStorage hot switch in this renderer, so resolve the live
+            // renderer locale at application time instead of replaying that
+            // process-level fallback over a newer UI update.
+            var language = resolved.explicitLanguage || (
+                degraded
+                    ? (resolved.language || fallback)
+                    : getLiveRendererLanguage()
+            );
+            if (S._conversationLanguageHydrationId !== hydrationId) return language;
+            var currentExplicit = '';
+            var currentExplicitResolved = false;
+            var preferenceRevisionChanged = false;
+            var localPreferenceOwnsResult = false;
+            try {
+                if (typeof window.getExplicitConversationLanguagePreference === 'function') {
+                    currentExplicit = window.getExplicitConversationLanguagePreference(characterName) || '';
+                    currentExplicitResolved = true;
+                }
+            } catch (_) { /* a newer revision still fences the stale response */ }
+            try {
+                if (
+                    preferenceRevisionAtStart !== null
+                    && typeof window.getConversationLanguagePreferenceRevision === 'function'
+                ) {
+                    preferenceRevisionChanged = (
+                        window.getConversationLanguagePreferenceRevision(characterName)
+                        !== preferenceRevisionAtStart
+                    );
+                }
+            } catch (_) { /* retain the value-only fence below */ }
+            // A revision change covers same-page dispatch:false writes and clears,
+            // including those that win before the timeout. Never let a degraded
+            // result mark that newer state untrusted or let a late response replace it.
+            if (preferenceRevisionChanged) {
+                language = currentExplicitResolved && currentExplicit
+                    ? currentExplicit
+                    : getLiveRendererLanguage();
+                resolved = {
+                    language: language,
+                    explicitLanguage: currentExplicitResolved ? currentExplicit : ''
+                };
+                degraded = false;
+                localPreferenceOwnsResult = true;
+            } else if (!degraded && currentExplicit && currentExplicit !== explicitAtStart) {
+                // Shared storage can expose a newer explicit value before this
+                // document receives its storage event. An unchanged startup cache
+                // must not override a fresh authoritative empty response.
+                resolved = {
+                    language: currentExplicit,
+                    explicitLanguage: currentExplicit
+                };
+                language = currentExplicit;
+            }
             var effectiveConversationLanguage = resolved.explicitLanguage || '';
             if (degraded) {
                 try {
@@ -1527,13 +1600,19 @@
             S.conversationLanguageHydrated = true;
             // Only mirror an explicit character preference into the local cache.
             // effective_language is a UI/global fallback and must remain dynamic.
-            if (resolved.explicitLanguage && typeof window.setConversationLanguagePreference === 'function') {
+            if (
+                !localPreferenceOwnsResult
+                && resolved.explicitLanguage
+                && typeof window.setConversationLanguagePreference === 'function'
+            ) {
                 window.setConversationLanguagePreference(
                     resolved.explicitLanguage,
                     characterName,
                     { dispatch: false, source: 'server' }
                 );
             } else if (
+                !localPreferenceOwnsResult
+                &&
                 !resolved.requestFailed
                 && !resolved.timedOut
                 && typeof window.clearConversationLanguagePreference === 'function'
@@ -1543,9 +1622,13 @@
                     source: 'server'
                 });
             }
-            if (resolved.explicitLanguage) {
+            if (!localPreferenceOwnsResult && resolved.explicitLanguage) {
                 _syncLanguageToBackend(resolved.explicitLanguage);
-            } else if (!resolved.requestFailed && !resolved.timedOut) {
+            } else if (
+                !localPreferenceOwnsResult
+                && !resolved.requestFailed
+                && !resolved.timedOut
+            ) {
                 _syncClearedLanguageToBackend(language, characterName);
             }
             _sendGreetingCheckIfReady();

--- a/static/js/character_card_manager/card-form-and-actions.js
+++ b/static/js/character_card_manager/card-form-and-actions.js
@@ -84,10 +84,32 @@ function _isCharacterLanguageHydrationCurrent(select, hydrationId) {
     return select.dataset.languageHydrationId === hydrationId;
 }
 
+function _setCharacterLanguageDurableEvidence(select, language) {
+    const normalizedLanguage = String(language || '').trim();
+    if (
+        normalizedLanguage
+        && !CHARACTER_LANGUAGE_OPTIONS.some(option => option.code === normalizedLanguage)
+    ) {
+        // An invalid non-empty server value does not prove that the character
+        // has no durable preference. Keep the state unknown instead of making
+        // the displayed fallback eligible for an overwrite.
+        delete select.dataset.durableLanguagePreference;
+        return;
+    }
+    select.dataset.durableLanguagePreference = normalizedLanguage;
+}
+
+function _canPersistDisplayedCharacterLanguage(select, language) {
+    return select.dataset.durableLanguagePreference === ''
+        && select.value === language
+        && CHARACTER_LANGUAGE_OPTIONS.some(option => option.code === language);
+}
+
 function _applyCharacterLanguagePreferenceEvent(select, selectUi, language) {
     _nextCharacterLanguageHydrationId(select);
     select.value = language;
     select.dataset.previousValue = language;
+    _setCharacterLanguageDurableEvidence(select, language);
     select.dataset.i18nTitle = 'character.languagePreferenceDescription';
     select.title = _characterLanguageT(
         'character.languagePreferenceDescription',
@@ -138,6 +160,7 @@ async function _hydrateCharacterLanguagePreference(name, select, selectUi) {
             return;
         }
         const language = payload.language || payload.effective_language;
+        _setCharacterLanguageDurableEvidence(select, payload.language);
         if (!payload.language && typeof window.clearConversationLanguagePreference === 'function') {
             // A successful empty response is authoritative even if a malformed
             // effective fallback cannot be shown by the control.
@@ -202,6 +225,7 @@ async function _saveCharacterLanguagePreference(name, select, selectUi) {
         );
         if (durableSave && payload.language === language) {
             select.dataset.previousValue = language;
+            select.dataset.durableLanguagePreference = language;
             _cacheCharacterLanguagePreference(name, language, 'character-card-manager');
         }
         if (partialSave) {
@@ -258,6 +282,9 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     }
     if (previousForm && previousForm._languageSelectCleanup) {
         previousForm._languageSelectCleanup();
+    }
+    if (previousForm && previousForm._localeChangeHandler) {
+        window.removeEventListener('localechange', previousForm._localeChangeHandler);
     }
     if (previousForm && previousForm._characterPersonalityUpdateHandler) {
         window.removeEventListener('neko:character-personality-updated', previousForm._characterPersonalityUpdateHandler);
@@ -446,6 +473,10 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
         languageSelect.dataset.previousValue = languageSelect.value;
         languageField.appendChild(languageSelect);
         const languageSelectUi = _panelCreateVoiceSelectUi(languageSelect);
+        languageSelectUi.setOnReselect(function (language) {
+            if (!_canPersistDisplayedCharacterLanguage(languageSelect, language)) return;
+            void _saveCharacterLanguagePreference(name, languageSelect, languageSelectUi);
+        });
         languageSelect.addEventListener('change', function () {
             void _saveCharacterLanguagePreference(name, languageSelect, languageSelectUi);
         });
@@ -501,6 +532,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
         textareaEl.placeholder = (window.t && typeof window.t === 'function')
             ? window.t('character.detailDescriptionPlaceholder')
             : '可输入详细描述';
+        textareaEl.dataset.i18nPlaceholder = 'character.detailDescriptionPlaceholder';
         textareaEl.value = cat[k];
         fr.appendChild(textareaEl);
         wrapper.appendChild(fr);
@@ -613,6 +645,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
         textareaEl.placeholder = (window.t && typeof window.t === 'function')
             ? window.t('character.detailDescriptionPlaceholder')
             : '可输入详细描述';
+        textareaEl.dataset.i18nPlaceholder = 'character.detailDescriptionPlaceholder';
         fr.appendChild(textareaEl);
         wrapper.appendChild(fr);
 
@@ -701,6 +734,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     const personalityWrapper = document.createElement('div');
     personalityWrapper.className = 'field-row-wrapper personality-row';
     const personalityLabel = document.createElement('label');
+    personalityLabel.dataset.i18n = 'character.personalitySetting';
     personalityLabel.textContent = window.t ? window.t('character.personalitySetting') : '人格设定';
     personalityLabel.style.fontSize = '1rem';
     personalityWrapper.appendChild(personalityLabel);
@@ -719,6 +753,9 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     personalitySummary.textContent = personalitySelection.hasOverride
         ? personalitySelection.displayName
         : (window.t ? window.t('character.personalityUseDefault') : '跟随角色卡默认设定');
+    if (!personalitySelection.hasOverride) {
+        personalitySummary.dataset.i18n = 'character.personalityUseDefault';
+    }
     personalityRow.appendChild(personalitySummary);
     personalityWrapper.appendChild(personalityRow);
 
@@ -726,7 +763,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     personalitySelectBtn.type = 'button';
     personalitySelectBtn.className = 'btn sm row-action-btn personality-select-action';
     personalitySelectBtn.dataset.testid = 'character-personality-select';
-    personalitySelectBtn.innerHTML = '<img src="/static/icons/character_icon.png" alt="" class="personality-icon"> <span>'
+    personalitySelectBtn.innerHTML = '<img src="/static/icons/character_icon.png" alt="" class="personality-icon"> <span data-i18n="character.personalitySelect">'
         + (window.t ? window.t('character.personalitySelect') : '选择人格') + '</span>';
     personalitySelectBtn.disabled = !!isNew;
     personalitySelectBtn.addEventListener('click', async function () {
@@ -747,7 +784,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     personalityClearBtn.type = 'button';
     personalityClearBtn.className = 'btn sm delete row-action-btn personality-clear-action';
     personalityClearBtn.dataset.testid = 'character-personality-clear';
-    personalityClearBtn.innerHTML = '<img src="/static/icons/roload_icon.png" alt="" class="restore-icon"> <span>'
+    personalityClearBtn.innerHTML = '<img src="/static/icons/roload_icon.png" alt="" class="restore-icon"> <span data-i18n="character.personalityClear">'
         + (window.t ? window.t('character.personalityClear') : '恢复默认') + '</span>';
     personalityClearBtn.disabled = !personalitySelection.hasOverride;
     personalityClearBtn.addEventListener('click', async function () {
@@ -804,6 +841,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     const voiceWrapper = document.createElement('div');
     voiceWrapper.className = 'field-row-wrapper voice-row';
     const voiceLabel = document.createElement('label');
+    voiceLabel.dataset.i18n = 'character.voiceSetting';
     voiceLabel.textContent = window.t ? window.t('character.voiceSetting') : '音色设定';
     voiceLabel.style.fontSize = '1rem';
     voiceWrapper.appendChild(voiceLabel);
@@ -828,6 +866,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     voiceSelect.style.alignSelf = 'stretch';
     const defaultOption = document.createElement('option');
     defaultOption.value = '';
+    defaultOption.dataset.i18n = 'character.voiceNotSet';
     defaultOption.textContent = window.t ? window.t('character.voiceNotSet') : '未指定音色';
     voiceSelect.appendChild(defaultOption);
     voiceRow.appendChild(voiceSelect);
@@ -894,7 +933,8 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     saveButton.id = 'save-button';
     saveButton.className = 'btn sm settings-save-action';
     if (!isNew) saveButton.style.display = 'none';
-    saveButton.innerHTML = '<img src="/static/icons/set_on.png" alt="" class="save-icon"> <span>'
+    const saveButtonI18nKey = isNew ? 'character.confirmNewCatgirl' : 'character.saveChanges';
+    saveButton.innerHTML = '<img src="/static/icons/set_on.png" alt="" class="save-icon"> <span data-i18n="' + saveButtonI18nKey + '">'
         + (isNew
             ? (window.t ? window.t('character.confirmNewCatgirl') : '确认新猫娘')
             : (window.t ? window.t('character.saveChanges') : '保存修改'))
@@ -907,7 +947,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     cancelButton.id = 'cancel-button';
     cancelButton.className = 'btn sm settings-cancel-action';
     if (!isNew) cancelButton.style.display = 'none';
-    cancelButton.innerHTML = '<img src="/static/icons/close_button.png" alt="" class="cancel-icon"> <span>'
+    cancelButton.innerHTML = '<img src="/static/icons/close_button.png" alt="" class="cancel-icon"> <span data-i18n="character.cancel">'
         + (window.t ? window.t('character.cancel') : '取消') + '</span>';
     cancelButton.onclick = function () {
         if (saveButton) saveButton.style.display = 'none';
@@ -976,13 +1016,50 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
         });
     }
 
-    // 加载音色列表
-    const voicesLoadPromise = _loadPanelVoices(voiceSelect, String(cat['voice_id'] || '').trim()).then(() => {
-        voiceSelectUi.refresh();
-    }, () => {
-        voiceSelectUi.refresh();
-    });
+    const refreshVoiceCatalog = function (selectedVoiceId) {
+        const refreshSequence = (form._voiceLocaleRefreshSequence || 0) + 1;
+        form._voiceLocaleRefreshSequence = refreshSequence;
+        voiceSelectUi.setDisabled(true);
+        return _loadPanelVoices(voiceSelect, selectedVoiceId).then(() => {
+            if (form._voiceLocaleRefreshSequence !== refreshSequence || !form.isConnected) return;
+            voiceSelectUi.refresh();
+            voiceSelectUi.setDisabled(false);
+        }, () => {
+            if (form._voiceLocaleRefreshSequence !== refreshSequence || !form.isConnected) return;
+            voiceSelectUi.refresh();
+            voiceSelectUi.setDisabled(false);
+        });
+    };
+
+    // Keep unsaved edits in place while rebuilding locale-dependent voice labels.
+    const voicesLoadPromise = refreshVoiceCatalog(String(cat['voice_id'] || '').trim());
     form._voicesLoadPromise = voicesLoadPromise;
+
+    form._lastRenderedLocale = String(window.i18n && window.i18n.language || '');
+    form._localeChangeHandler = function () {
+        const currentLocale = String(window.i18n && window.i18n.language || '');
+        if (currentLocale && currentLocale === form._lastRenderedLocale) return;
+        form._lastRenderedLocale = currentLocale;
+
+        form.querySelectorAll('[data-character-field-name]').forEach(label => {
+            _panelSetFieldLabel(label, label.dataset.characterFieldName || '');
+        });
+        form.querySelectorAll('.setting-field-delete').forEach(_panelConfigureFieldDeleteButton);
+
+        const currentPersonality = readCharacterPersonalitySelection(cat);
+        if (currentPersonality.hasOverride) {
+            delete personalitySummary.dataset.i18n;
+            personalitySummary.textContent = currentPersonality.displayName;
+        } else {
+            personalitySummary.dataset.i18n = 'character.personalityUseDefault';
+            personalitySummary.textContent = window.t
+                ? window.t('character.personalityUseDefault')
+                : '跟随角色卡默认设定';
+        }
+
+        form._voicesLoadPromise = refreshVoiceCatalog(voiceSelect.value);
+    };
+    window.addEventListener('localechange', form._localeChangeHandler);
 
     form._previousVoiceId = String(cat['voice_id'] || '').trim();
     form._live2dModel = live2dPath;
@@ -1040,6 +1117,7 @@ function _panelAttachProfileNameLimiter(input) {
 // label 设置（支持i18n + 超长title提示）
 function _panelSetFieldLabel(labelEl, key) {
     const MAX_LABEL_LEN = 8;
+    labelEl.dataset.characterFieldName = key;
     let displayText = key;
     if (window.t && typeof window.t === 'function') {
         const profileLabelKey = 'characterProfile.labels.' + key;
@@ -1055,6 +1133,7 @@ function _panelSetFieldLabel(labelEl, key) {
         }
     }
     labelEl.textContent = displayText;
+    labelEl.removeAttribute('title');
     if (displayText.length > MAX_LABEL_LEN) {
         labelEl.title = displayText;
     }
@@ -1065,6 +1144,7 @@ function _panelConfigureFieldDeleteButton(button) {
         ? window.t('character.deleteField')
         : '删除设定';
     button.removeAttribute('title');
+    button.dataset.i18nAria = 'character.deleteField';
     button.setAttribute('aria-label', deleteText);
     button.innerHTML = '<img src="/static/icons/delete.png" alt="" class="delete-icon" aria-hidden="true">';
 }
@@ -1373,9 +1453,12 @@ function _panelCreateVoiceSelectUi(selectEl) {
         }
     }
 
+    let onReselect = null;
+
     function selectOptionValue(value) {
         if (selectEl.value === value) {
             closeDropdown(true);
+            if (typeof onReselect === 'function') onReselect(value);
             return;
         }
         selectEl.value = value;
@@ -1486,8 +1569,12 @@ function _panelCreateVoiceSelectUi(selectEl) {
         container,
         refresh,
         setDisabled,
+        setOnReselect(handler) {
+            onReselect = typeof handler === 'function' ? handler : null;
+        },
         destroy() {
             closeDropdown();
+            onReselect = null;
             selectEl.removeEventListener('change', syncSelectionState);
             document.removeEventListener('click', handleDocumentClick);
             document.removeEventListener('keydown', handleDocumentKeydown);
@@ -1510,6 +1597,7 @@ async function _loadPanelVoices(selectEl, currentVoiceId) {
             while (selectEl.firstChild) selectEl.removeChild(selectEl.firstChild);
             const defaultOption = document.createElement('option');
             defaultOption.value = '';
+            defaultOption.dataset.i18n = 'character.voiceNotSet';
             defaultOption.textContent = window.t ? window.t('character.voiceNotSet') : '未指定音色';
             selectEl.appendChild(defaultOption);
 

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -433,6 +433,125 @@ def test_character_card_manager_voice_dropdown_prefers_clone_prefix(
 
 
 @pytest.mark.frontend
+def test_character_language_fallback_can_be_pinned_by_reselecting_it(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const originalFetch = window.fetch.bind(window);
+            const saves = [];
+            window.getConversationLanguagePreference = () => '';
+            window.getExplicitConversationLanguagePreference = () => '';
+            window.clearConversationLanguagePreference = () => {};
+            window.setConversationLanguagePreference = () => {};
+            window.nekoLocalMutationSecurity = {
+                getMutationHeaders: async () => ({ 'X-CSRF-Token': 'test-token' })
+            };
+            window.fetch = async (input, init = {}) => {
+                const url = typeof input === 'string' ? input : input.url;
+                const path = new URL(url, window.location.origin).pathname;
+                if (path === '/api/characters/character/Mimi/language-preference') {
+                    if ((init.method || 'GET').toUpperCase() === 'PUT') {
+                        saves.push(JSON.parse(init.body));
+                        return new Response(JSON.stringify({
+                            success: true,
+                            language: 'ja'
+                        }), {
+                            status: 200,
+                            headers: { 'Content-Type': 'application/json' }
+                        });
+                    }
+                    return new Response(JSON.stringify({
+                        success: true,
+                        language: '',
+                        effective_language: 'ja'
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/voices') {
+                    return new Response(JSON.stringify({
+                        voices: {}, free_voices: {}, native_voices: {}
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/custom_tts_voices') {
+                    return new Response(JSON.stringify({ success: true, voices: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return originalFetch(input, init);
+            };
+
+            const host = document.createElement('div');
+            document.body.appendChild(host);
+            buildCatgirlDetailForm('Mimi', {}, false, host);
+
+            const select = host.querySelector('[data-testid="character-language-preference"]');
+            const customSelect = host.querySelector('.language-preference-custom-select');
+            for (let attempt = 0; attempt < 50; attempt += 1) {
+                if (!select.disabled && select.dataset.durableLanguagePreference === '') break;
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+
+            const optionValues = Array.from(select.options).map(option => option.value);
+            const before = {
+                value: select.value,
+                durable: select.dataset.durableLanguagePreference,
+                saves: saves.length,
+                disabled: select.disabled
+            };
+            customSelect.querySelector('.voice-select-header').click();
+            customSelect.querySelector('.voice-select-option.selected').click();
+            for (let attempt = 0; attempt < 50 && saves.length < 1; attempt += 1) {
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+            for (let attempt = 0; attempt < 50 && select.disabled; attempt += 1) {
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+
+            // Once the same value is durable, selecting it again is a no-op.
+            customSelect.querySelector('.voice-select-header').click();
+            customSelect.querySelector('.voice-select-option.selected').click();
+            await new Promise(resolve => setTimeout(resolve, 20));
+
+            return {
+                before,
+                after: {
+                    value: select.value,
+                    durable: select.dataset.durableLanguagePreference,
+                    saves,
+                    disabled: select.disabled
+                },
+                optionValues
+            };
+        }
+        """
+    )
+
+    assert state["optionValues"] == [
+        "zh-CN", "zh-TW", "en", "ja", "ko", "ru", "es", "pt"
+    ]
+    assert state["before"] == {
+        "value": "ja", "durable": "", "saves": 0, "disabled": False
+    }
+    assert state["after"] == {
+        "value": "ja",
+        "durable": "ja",
+        "saves": [{"language": "ja"}],
+        "disabled": False,
+    }
+
+
+@pytest.mark.frontend
 def test_character_card_manager_voice_dropdown_groups_by_provider_source(
     mock_page: Page,
     running_server: str,

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -120,6 +120,12 @@ def test_ui_language_override_uses_raw_global_preference_only(tmp_path):
     with patch.object(preferences, "_config_manager", cm):
         assert preferences.load_ui_language_override() == "zh-TW"
         assert "uiLanguage" not in preferences.load_global_conversation_settings()
+        assert preferences.save_ui_language_override("ja") is True
+        assert preferences.load_ui_language_override() == "ja"
+        assert preferences.load_global_conversation_settings()["userLanguage"] == "en"
+        assert preferences.save_ui_language_override(None) is True
+        assert preferences.load_ui_language_override() is None
+        assert preferences.load_global_conversation_settings()["userLanguage"] == "en"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_language_preferences.py
+++ b/tests/unit/test_language_preferences.py
@@ -12,6 +12,7 @@ import pytest
 
 from main_routers.characters_router import language_preference as preference_router
 from main_routers.characters_router import crud as characters_crud
+from main_routers.config_router import language as config_language_router
 from main_routers.system_router import _shared as system_router_shared
 from main_logic import cross_server
 from main_logic.core.lifecycle import LifecycleMixin
@@ -28,6 +29,16 @@ LANGUAGE_LISTENERS_START_ANCHOR = (
 LANGUAGE_LISTENERS_END_ANCHOR = (
     "window.addEventListener('neko:new-user-icebreaker-ended'"
 )
+
+
+def _allow_ui_language_mutation(monkeypatch):
+    monkeypatch.setattr(
+        config_language_router,
+        "_validate_local_mutation_request",
+        lambda *_args, **_kwargs: None,
+    )
+
+
 def _slice_between(source: str, start_anchor: str, end_anchor: str, label: str) -> str:
     start = source.find(start_anchor)
     assert start >= 0, f"{label} 起始锚点已失效，请同步更新测试"
@@ -1362,7 +1373,7 @@ def test_conversation_language_hydration_timeout_and_late_response_runtime(node_
     ).read_text(encoding="utf-8")
     slices = {
         "RESOLVERS": _slice_between(
-            websocket_source, "function getConversationLanguageForCurrentCharacter()",
+            websocket_source, "function getLiveRendererLanguage()",
             HYDRATION_START_ANCHOR, "conversation language resolvers",
         ),
         "HYDRATION": _slice_between(
@@ -1388,6 +1399,7 @@ def test_conversation_language_hydration_timeout_and_late_response_runtime(node_
         """
         const assert = require('node:assert/strict');
         let fallback = 'en', cached = '', untrusted = false, character = 'Mimi';
+        const preferenceRevisions = new Map();
         const S = {
           _conversationLanguageHydrationId: 0,
           _conversationLanguageClearPending: null,
@@ -1400,12 +1412,15 @@ def test_conversation_language_hydration_timeout_and_late_response_runtime(node_
           addEventListener(type, callback) { listeners[type] = callback; },
           setConversationLanguagePreference(language, characterName, options) {
             untrusted = false;
+            preferenceRevisions.set(characterName, (preferenceRevisions.get(characterName) || 0) + 1);
             events.push({ type: 'cache', language, characterName, options });
           },
           clearConversationLanguagePreference(characterName, options) {
             untrusted = false;
+            preferenceRevisions.set(characterName, (preferenceRevisions.get(characterName) || 0) + 1);
             events.push({ type: 'clear-cache', characterName, options });
           },
+          getConversationLanguagePreferenceRevision: name => preferenceRevisions.get(name) || 0,
           getConversationLanguagePreference: () => fallback,
           getCachedConversationLanguagePreference: () => cached,
           getExplicitConversationLanguagePreference: () => untrusted ? '' : cached,
@@ -1610,6 +1625,77 @@ def test_conversation_language_hydration_timeout_and_late_response_runtime(node_
           assert.deepEqual(kinds().slice(-3), ['cache', 'sync', 'greeting']);
           cached = '';
 
+          // A successful empty response uses the renderer locale that is live
+          // when it applies, not the backend's stale effective fallback.
+          resetEvents();
+          task = start('Renderer', 'en');
+          const rendererFetch = fetches.at(-1);
+          fallback = 'ja';
+          rendererFetch.resolve(response({
+            success: true, language: '', effective_language: 'ru'
+          }));
+          assert.equal(await task, 'ja');
+          assert.deepEqual(state(), ['', '']);
+          assert.equal(events.at(-2).payload.render_language, 'ja');
+
+          // Shared storage can expose a newer explicit value before this
+          // document receives its storage event. Preserve only values that
+          // appeared while the request was in flight.
+          resetEvents();
+          cached = '';
+          task = start('SiblingWrite', 'en');
+          const siblingFetch = fetches.at(-1);
+          cached = 'ja';
+          siblingFetch.resolve(response({
+            success: true, language: '', effective_language: 'ru'
+          }));
+          assert.equal(await task, 'ja');
+          assert.deepEqual(state(), ['ja', 'ja']);
+          assert.deepEqual(kinds(), ['cache', 'sync', 'greeting']);
+
+          resetEvents();
+          cached = 'ko';
+          task = start('StartupCache', 'en');
+          fetches.at(-1).resolve(response({
+            success: true, language: '', effective_language: 'ru'
+          }));
+          assert.equal(await task, 'en');
+          assert.deepEqual(state(), ['', '']);
+          assert.deepEqual(kinds(), ['clear-cache', 'socket-send', 'greeting']);
+
+          resetEvents();
+          cached = 'ko';
+          task = start('RevisionClear', 'en');
+          window.clearConversationLanguagePreference('RevisionClear', {
+            dispatch: false, source: 'server'
+          });
+          cached = '';
+          resetEvents();
+          fetches.at(-1).resolve(response({ success: true, language: 'ko' }));
+          assert.equal(await task, 'en');
+          assert.deepEqual(state(), ['', '']);
+          assert.deepEqual(kinds(), ['greeting']);
+
+          resetEvents();
+          cached = 'ja';
+          task = start('RevisionTimeout', 'en');
+          window.setConversationLanguagePreference('ja', 'RevisionTimeout', {
+            dispatch: false, source: 'server'
+          });
+          resetEvents();
+          assert.equal(await timeout(task), 'ja');
+          assert.equal(untrusted, false);
+          assert.deepEqual(state(), ['ja', 'ja']);
+          assert.deepEqual(kinds(), ['greeting']);
+          await resolveLate(fetches.length - 1, {
+            success: true, language: 'ko'
+          });
+          assert.equal(untrusted, false);
+          assert.deepEqual(state(), ['ja', 'ja']);
+          assert.deepEqual(kinds(), ['greeting', 'greeting']);
+          cached = '';
+          character = 'Mimi';
+
           resetEvents();
           fallback = 'pt';
           listeners.storage({
@@ -1659,6 +1745,22 @@ def test_conversation_language_hydration_timeout_and_late_response_runtime(node_
     for marker, source in slices.items():
         harness = harness.replace(f"__{marker}__", source)
     _assert_node_ok(node_path, harness)
+
+
+@pytest.mark.unit
+def test_character_form_retranslates_locale_dependent_content():
+    source = (
+        PROJECT_ROOT
+        / "static/js/character_card_manager/card-form-and-actions.js"
+    ).read_text(encoding="utf-8")
+
+    assert "window.removeEventListener('localechange', previousForm._localeChangeHandler)" in source
+    assert "window.addEventListener('localechange', form._localeChangeHandler)" in source
+    assert "form._voiceLocaleRefreshSequence !== refreshSequence" in source
+    assert "form._voicesLoadPromise = refreshVoiceCatalog(voiceSelect.value);" in source
+    assert "data-i18n=\"character.personalitySelect\"" in source
+    assert "data-i18n=\"character.personalityClear\"" in source
+    assert "defaultOption.dataset.i18n = 'character.voiceNotSet'" in source
 
 
 @pytest.mark.unit
@@ -1950,3 +2052,199 @@ async def test_memory_barrier_timeout_keeps_late_cleanup_armed():
         "Mimi",
     )
     assert calls == ["clear", "clear"]
+
+
+class _UiLanguageRequest:
+    base_url = "http://localhost:48911/"
+    method = "PUT"
+    url = SimpleNamespace(path="/api/config/ui-language")
+
+    def __init__(self, language="ja", headers=None):
+        self.language = language
+        self.headers = headers or {}
+
+    async def json(self):
+        return {"language": self.language}
+
+
+def _ui_payload(result):
+    return result if isinstance(result, dict) else json.loads(result.body)
+
+
+def _install_ui_language_runtime(
+    monkeypatch,
+    *,
+    apply_language,
+    save_language,
+    previous="en",
+    current="Mimi",
+):
+    class ConfigManager:
+        async def aload_characters(self):
+            characters = {current: {}} if current else {}
+            return {"当前猫娘": current, "猫娘": characters}
+
+    async def load_language():
+        return previous
+
+    monkeypatch.setattr(config_language_router, "aload_ui_language_override", load_language)
+    monkeypatch.setattr(config_language_router, "asave_ui_language_override", save_language)
+    monkeypatch.setattr(config_language_router, "get_config_manager", lambda: ConfigManager())
+    monkeypatch.setattr(
+        preference_router,
+        "apply_character_language_preference",
+        apply_language,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ui_language_mutation_requires_local_request_auth(monkeypatch):
+    saved = []
+
+    async def save_language(language):
+        saved.append(language)
+        return True
+
+    async def apply_language(_name, language):
+        return {"success": True, "language": language}
+
+    _install_ui_language_runtime(
+        monkeypatch,
+        apply_language=apply_language,
+        save_language=save_language,
+        current="",
+    )
+    monkeypatch.setattr(system_router_shared, "AUTOSTART_CSRF_TOKEN", "token")
+    monkeypatch.setattr(
+        system_router_shared,
+        "AUTOSTART_ALLOWED_ORIGINS",
+        ("http://localhost:48911",),
+    )
+
+    denied = await config_language_router.set_ui_language_api(_UiLanguageRequest())
+    assert denied.status_code == 403
+    assert saved == []
+
+    accepted = await config_language_router.set_ui_language_api(
+        _UiLanguageRequest(headers={
+            "X-CSRF-Token": "token",
+            "origin": "http://localhost:48911",
+        })
+    )
+    assert accepted["success"] is True
+    assert accepted["language"] == "ja"
+    assert saved == ["ja"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "status", "saved", "ui_language", "partial"),
+    [
+        ("partial", None, ["ja"], None, False),
+        ("rollback", 500, ["ja", "en"], "en", False),
+        ("rollback_false", 500, ["ja", "en"], "ja", True),
+        ("exception", 503, ["ja", "en"], "ja", True),
+    ],
+)
+async def test_ui_language_sync_reports_durable_outcome(
+    monkeypatch,
+    mode,
+    status,
+    saved,
+    ui_language,
+    partial,
+):
+    _allow_ui_language_mutation(monkeypatch)
+    save_calls = []
+
+    async def save_language(language):
+        save_calls.append(language)
+        if len(save_calls) > 1 and mode == "rollback_false":
+            return False
+        if len(save_calls) > 1 and mode == "exception":
+            raise OSError("disk unavailable")
+        return True
+
+    async def apply_language(_name, language):
+        if mode == "partial":
+            return {
+                "success": False,
+                "partial_success": True,
+                "language": language,
+                "error": "recent context cleanup failed",
+            }
+        if mode == "exception":
+            raise RuntimeError("memory server unavailable")
+        return {"success": False, "error": "character sync failed"}
+
+    _install_ui_language_runtime(
+        monkeypatch,
+        apply_language=apply_language,
+        save_language=save_language,
+    )
+    result = await config_language_router.set_ui_language_api(_UiLanguageRequest())
+    payload = _ui_payload(result)
+
+    assert (getattr(result, "status_code", None)) == status
+    assert save_calls == saved
+    if mode == "partial":
+        assert payload["success"] is True
+        assert payload["partial_success"] is True
+        assert payload["conversation_sync"]["language"] == "ja"
+    else:
+        assert payload["success"] is False
+        assert payload["ui_language"] == ui_language
+        assert payload["ui_language_rollback_succeeded"] is (not partial)
+        assert payload.get("partial_persistence", False) is partial
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ui_language_sync_serializes_rollback_before_newer_write(monkeypatch):
+    _allow_ui_language_mutation(monkeypatch)
+    current = {"value": "en"}
+    saved = []
+    first_sync_started = asyncio.Event()
+    release_first_sync = asyncio.Event()
+
+    async def load_language():
+        return current["value"]
+
+    async def save_language(language):
+        saved.append(language)
+        current["value"] = language
+        return True
+
+    async def apply_language(_name, language):
+        if language == "ja":
+            first_sync_started.set()
+            await release_first_sync.wait()
+            return {"success": False, "error": "sync failed"}
+        return {"success": True, "language": language}
+
+    _install_ui_language_runtime(
+        monkeypatch,
+        apply_language=apply_language,
+        save_language=save_language,
+    )
+    monkeypatch.setattr(config_language_router, "aload_ui_language_override", load_language)
+
+    first = asyncio.create_task(
+        config_language_router.set_ui_language_api(_UiLanguageRequest("ja"))
+    )
+    await asyncio.wait_for(first_sync_started.wait(), timeout=1)
+    second = asyncio.create_task(
+        config_language_router.set_ui_language_api(_UiLanguageRequest("ko"))
+    )
+    await asyncio.sleep(0)
+    assert saved == ["ja"]
+    assert not second.done()
+
+    release_first_sync.set()
+    first_result, second_result = await asyncio.gather(first, second)
+    assert getattr(first_result, "status_code", None) == 500
+    assert second_result["language"] == "ko"
+    assert saved == ["ja", "en", "ko"]
+    assert current["value"] == "ko"

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -610,6 +610,60 @@ def load_ui_language_override() -> Optional[str]:
     return None
 
 
+def save_ui_language_override(language: Optional[str]) -> bool:
+    """Persist the optional UI locale without mixing it into conversation settings.
+
+    ``uiLanguage`` deliberately lives beside the global conversation entry rather
+    than inside its validated settings payload.  This keeps UI copy selection
+    independent from the per-character prompt locale while still making the
+    desktop tray choice available to every renderer on the next navigation.
+    Passing ``None`` removes the manual override.
+    """
+    try:
+        assert_cloudsave_writable(
+            _config_manager,
+            operation="save",
+            target="user_preferences.json",
+        )
+        _config_manager.ensure_config_directory()
+        normalized = str(language or "").strip() or None
+        with _locked_preferences_store():
+            data = _load_preferences_data_for_write_unlocked()
+            global_index = -1
+            for index, pref in enumerate(data):
+                if (
+                    isinstance(pref, dict)
+                    and pref.get("model_path") == GLOBAL_CONVERSATION_KEY
+                ):
+                    global_index = index
+                    break
+
+            global_pref = data[global_index].copy() if global_index >= 0 else {
+                "model_path": GLOBAL_CONVERSATION_KEY,
+            }
+            if normalized is None:
+                global_pref.pop("uiLanguage", None)
+            else:
+                global_pref["uiLanguage"] = normalized
+
+            if global_index >= 0:
+                data[global_index] = global_pref
+            else:
+                data.append(global_pref)
+            _save_user_preferences_unlocked(data)
+        return True
+    except MaintenanceModeError:
+        raise
+    except Exception as e:
+        print(f"保存 UI 语言覆盖失败: {e}")
+        return False
+
+
+async def asave_ui_language_override(language: Optional[str]) -> bool:
+    """Async wrapper for ``save_ui_language_override``."""
+    return await asyncio.to_thread(save_ui_language_override, language)
+
+
 async def aload_ui_language_override() -> Optional[str]:
     """Async wrapper for ``load_ui_language_override``."""
     return await asyncio.to_thread(load_ui_language_override)


### PR DESCRIPTION
## 改动概述

- 在全局偏好中独立持久化 `uiLanguage`，不混入全局对话设置；旧配置无此字段时继续沿用 Steam、系统区域与现有 i18n 回退。
- 新增受 CSRF token 与 Origin 校验保护的界面语言写接口；一次事务内持久化 UI 语言并同步当前角色偏好。
- 角色同步失败时回滚 UI 语言；回滚失败或角色偏好已保存但上下文隔离部分失败时，返回真实的部分持久化状态。
- WebSocket 成功水合为空时，在应用结果的时刻读取当前 renderer locale，避免后端旧 effective fallback 覆盖刚发生的界面热切换。
- 跨窗口共享存储先于 storage 事件可见时，用因果快照保护请求期间出现的新明确偏好；启动前已有的旧缓存仍可被服务端 authoritative empty 清除。
- 角色卡界面在 `localechange` 后原地刷新字段、人格式样、按钮与声音目录，同时保留未保存编辑，并用序列号阻止较早声音请求覆盖较新 locale。
- 当控件显示无持久化证据的界面 fallback 时，重新选择同一项会明确保存；已有持久偏好时重复选择仍是 no-op。

## 回归报告 / Regression Report

- 改动与必要性：在配置路由中新增受 CSRF/Origin 校验保护的界面语言写接口，并把 `uiLanguage` 持久化与当前角色明确偏好同步放进同一事务；前端同时处理 WebSocket 水合和跨窗口界面刷新。
- 改动前后：改动前界面语言不独立持久化，热切换或角色同步失败可能留下 UI 与角色偏好不一致；改动后旧配置仍沿用原回退，新配置可持久保存，角色同步失败会回滚，并如实报告部分持久化状态。
- 潜在回归与验证：重点覆盖 CSRF/Origin、保存与回滚失败、WebSocket 水合竞态、跨窗口因果快照、未保存编辑和声音请求乱序。重基到最新 `main` 后，语言事务、运行时优先级、云存档及角色卡真实浏览器回归共 189 passed；Ruff、两份 JavaScript `node --check` 和 `git diff --check` 均通过。

## 不拆分理由 / Why Not Split

#2708 已合并，本分支已重基到其合并后的最新 `main`。当前 PR 严格只剩 1 个提交、8 个文件（`+825 -23`）。这 8 个文件共同组成 UI 语言事务：配置持久化、写接口、WebSocket 水合、角色卡热刷新与对应回归必须同步落地，继续拆分会留下保存/回滚或水合链路只实现一半的中间状态。

## 后续

PC #426 依赖本 PR；本 PR 合并后再更新其基线。