### PR TITLE
fix(qq): 开放平台群 id 兜底 group_openid，防协议改键后群消息全丢

### DIFF
--- a/plugin/plugins/qq_auto_reply/qq_open_plat.py
+++ b/plugin/plugins/qq_auto_reply/qq_open_plat.py
@@ -667,7 +667,12 @@ class QQOpenPlatformConnection(QQConnectionBase):
 
         if event_type == "GROUP_AT_MESSAGE_CREATE":
             content = str(data.get("content") or "")
-            group_id = str(data.get("group_id") or "")
+            # 该通道的群标识本就是 openid（见 display_name_service 的说明），
+            # 平台按 v2 语义可能挂在 group_openid 而不是 group_id。顺序不能反：
+            # group_id 有值时必须继续用它，否则群 subject_id 会整体换键，而
+            # memory/scopes.py 是字节相等匹配、无别名，存量 scoped 群记忆会一次
+            # 性失联。只在原键为空时兜底，才能既零行为变化又挡住全量丢消息。
+            group_id = str(data.get("group_id") or data.get("group_openid") or "")
             mentioned_ids: list[str] = []
             mentions_all = False
             # 检查 @ 目标（content 中 <@!id> 格式）

--- a/tests/unit/test_qq_open_plat_convert_event.py
+++ b/tests/unit/test_qq_open_plat_convert_event.py
@@ -1,0 +1,82 @@
+"""Group-id key fallback in the QQ Open Platform event converter.
+
+``_convert_event`` used to read only ``group_id``. The channel's group
+identifier is in fact an openid, and the v2 payload may carry it under
+``group_openid`` instead; when that happens ``group_id`` is the empty
+string, the backlog writer drops the message outright, and the group
+subject degrades to ``qq::`` which the scope validator rejects.
+
+The fallback order is the load-bearing part: ``group_id`` must keep
+winning when present. Flipping it would re-key every group subject_id,
+and scope matching is byte equality with no aliasing, so all existing
+scoped group memories would be orphaned in one shot.
+"""
+
+import pytest
+
+from plugin.plugins.qq_auto_reply.qq_open_plat import QQOpenPlatformConnection
+
+
+def _connection() -> QQOpenPlatformConnection:
+    conn = QQOpenPlatformConnection.__new__(QQOpenPlatformConnection)
+    conn._self_id = "bot-self"
+    return conn
+
+
+def _group_payload(**group_keys) -> dict:
+    payload = {
+        "id": "msg-1",
+        "content": "<@!bot-self> zaima",
+        "author": {"id": "user-1", "username": "neko"},
+    }
+    payload.update(group_keys)
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("group_keys", "expected"),
+    [
+        # Today's protocol: the original key is present and still wins.
+        ({"group_id": "G-plain"}, "G-plain"),
+        # v2 semantics: only the openid key is sent.
+        ({"group_openid": "G-openid"}, "G-openid"),
+        # Both present — pins the priority so a later refactor can't flip it.
+        ({"group_id": "G-plain", "group_openid": "G-openid"}, "G-plain"),
+        # Present but empty is the same as absent for the fallback.
+        ({"group_id": "", "group_openid": "G-openid"}, "G-openid"),
+    ],
+)
+def test_convert_event_group_id_prefers_group_id_then_group_openid(group_keys, expected):
+    msg = _connection()._convert_event("GROUP_AT_MESSAGE_CREATE", _group_payload(**group_keys))
+
+    assert msg is not None
+    assert msg["message_type"] == "group"
+    assert msg["group_id"] == expected
+
+
+def test_convert_event_group_id_empty_when_neither_key_present():
+    # Neither key → empty string, i.e. the pre-existing discard path
+    # (backlog_service returns early on a falsy group_id). The fallback
+    # must not invent an id out of some other field.
+    msg = _connection()._convert_event("GROUP_AT_MESSAGE_CREATE", _group_payload())
+
+    assert msg is not None
+    assert msg["group_id"] == ""
+
+
+def test_convert_event_private_message_keeps_group_id_empty():
+    # The C2C branch has no group at all; a stray group key on the payload
+    # must not leak into the private message's group_id.
+    msg = _connection()._convert_event(
+        "C2C_MESSAGE_CREATE",
+        {
+            "id": "msg-2",
+            "content": "hi",
+            "author": {"id": "user-1", "username": "neko"},
+            "group_openid": "G-openid",
+        },
+    )
+
+    assert msg is not None
+    assert msg["message_type"] == "private"
+    assert msg["group_id"] == ""


### PR DESCRIPTION
## 问题

`plugin/plugins/qq_auto_reply/qq_open_plat.py` 的 `_convert_event` 在群消息分支只读一个键：

```python
group_id = str(data.get("group_id") or "")
```

而 `group_openid` **全仓零命中**（`git grep group_openid` 只在 `docs/design/speaker-trust-entity-semantics.md` 的分析里出现，代码零处）。仓库自己其实已经知道这条通道的群标识是 openid —— `display_name_service.py` 的类 docstring 里逐字写着「group_id 是 openid，拿不到人类可读群名」。

若平台按 v2 语义把群标识挂在 `group_openid` 而不是 `group_id`，`group_id` 恒为空串，连锁后果：

1. `backlog_service.py` 的 `if not group_id: return` 直接吞掉消息 —— **群消息连 backlog 都不落**，静默全丢；
2. 群 subject 退化成 `qq::`，被 `memory/scopes.py` 的「group_participant subject_id 必须恰好 3 段非空」校验拒掉；
3. 发送路径 POST 到 `/v2/groups//messages`。

## 改动

```python
group_id = str(data.get("group_id") or data.get("group_openid") or "")
```

**这是防御性兜底：当前协议下行为完全不变，仅在平台改用 openid 键时才生效，避免群消息全丢。** 两种协议假设下都正确，不需要线上取证就能合。

### 顺序不能反（本 PR 唯一的坑）

必须 `group_id` 优先、`group_openid` 兜底。如果写成 `group_openid or group_id`，而今天 `group_id` 是有值的，那群 subject_id 会从 `qq:<group_id>:...` 整体换成 `qq:<group_openid>:...` —— `memory/scopes.py` 的 `entry_matches_subject` 是**字节相等**判定、无别名无规范化，于是**全部存量 scoped 群记忆和 persona section 一次性变成不可达孤儿**。

只在原键为空时兜底，才能同时做到「原键有值 ⇒ 零行为变化」和「原键为空 ⇒ 修掉一次全量丢消息」。

## 范围

- 只动 `qq_open_plat.py` 的事件转换路径。已 grep 确认同文件内**没有**其它读群标识的地方：`data.get("group_id")` 全文件仅此一处，其余 `group_id` 都是发送侧函数的形参（由调用方传入，不读事件 payload）。
- 没动 `message_dispatcher.py` 的 admin bootstrap。

## 测试

`_convert_event` 此前**零测试覆盖**。新增 `tests/unit/test_qq_open_plat_convert_event.py`，6 条：

| 用例 | 期望 |
| --- | --- |
| 只有 `group_id` | 取 `group_id`（今天的协议，行为不变） |
| 只有 `group_openid` | 取 `group_openid`（兜底生效） |
| 两者都有 | 取 `group_id`（**钉死优先级**，防后人手滑翻转） |
| `group_id: ""` + `group_openid` 有值 | 取 `group_openid`（空串等同缺失） |
| 两者都无 | 空串，走既有丢弃路径，不从别的字段编 id |
| 私聊 payload 带 `group_openid` | `group_id` 仍为 `""`，不漏进私聊分支 |

变异验证（两个变异都被抓住，不是空跑）：

- 变异 A：翻成 `group_openid or group_id` → 「两者都有」用例红。
- 变异 B：删掉兜底退回 `data.get("group_id") or ""` → 「只有 openid」+「空串兜底」两条红。

无跨用例顺序依赖（本仓已接 pytest-randomly）。

## 顺带发现，本 PR 不改

`_convert_event` 开头对 `author` 有一组**对称的键名假设**，同样存疑：

```python
author = data.get("author", {})
user_id = str(author.get("id") or "")
user_nickname = str(author.get("username") or "") or None
```

`author.id` / `author.username` 是频道（guild）消息的形态；C2C / 群 v2 事件按文档给的是 `author.user_openid` / `author.member_openid`，且不带 `username`。若果真如此，`user_id` 也会恒空。

**但这条和群 id 那条不同，不能照抄同样的修法**：`user_id` 参与 speaker/trust 的身份键，而 `user_openid` 与 `member_openid` 是两个不同粒度的标识（前者跨群唯一、后者每群每人一个），兜底顺序怎么排会直接决定身份是否跨群合并 —— 这需要先取证真实 payload，属于另一个独立问题。这里只报告，不顺手改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化群聊消息识别：当群组标识缺失时，自动使用备用群组标识，确保消息归属信息完整。
  * 保持私聊消息的群组标识为空，避免错误继承群聊信息。

* **Tests**
  * 补充多种群组标识存在、为空或缺失场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->