### PR TITLE
fix(test)：删掉 R11 测试里两处函数内重复的 import json

### DIFF
--- a/tests/unit/test_qq_open_platform_identity_scope.py
+++ b/tests/unit/test_qq_open_platform_identity_scope.py
@@ -587,8 +587,6 @@ IMPLEMENTATION_DETAIL = (
 
 
 def test_the_probe_copy_describes_no_implementation_detail():
-    import json
-
     for path in _locale_files():
         catalogue = json.loads(path.read_text(encoding="utf-8"))
         for key in PROBE_KEYS:
@@ -603,8 +601,6 @@ def test_the_probe_copy_describes_no_implementation_detail():
 def test_the_probe_hint_tells_the_reader_what_to_do():
     # A switch nobody knows how to act on is a switch nobody uses.  Every
     # locale must name the action (@ the bot) and where the result shows up.
-    import json
-
     for path in _locale_files():
         catalogue = json.loads(path.read_text(encoding="utf-8"))
         hint = catalogue["ui.openplat.config.identity_probe_hint"]


### PR DESCRIPTION
## 背景

#2711 最后一轮给身份取证开关加两条文案守卫时，我在两个新测试函数里写了 `import json`——而同一个 PR 前面刚按 github-code-quality 的同一条规则清理过这个文件。守卫本身没问题，只是 import 写重了。

模块顶部第 27 行已经 `import json`，两处函数内的重复导入直接删掉。

## 影响

纯清理，无行为变化。`tests/unit/test_qq_open_platform_identity_scope.py` 57 passed。

## 说明

这本该在 #2711 里修掉，但 lint 反馈到达时 PR 已经合并（squash 成 `ae638dd04`），所以单独开这一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 清理测试代码中的重复导入，测试逻辑和断言保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->