### PR TITLE
test(hybrid_recall): 补上三个 setUp 漏掉的 tmpdir 清理

### DIFF
--- a/tests/unit/test_hybrid_recall.py
+++ b/tests/unit/test_hybrid_recall.py
@@ -229,6 +229,7 @@ class TestHybridRecallE2E(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
         # Write a fake facts_archive.json — _aload_archive_facts reads it
         # directly via fact_store._facts_archive_path().
         self.archive_path = os.path.join(self.tmpdir, "facts_archive.json")
@@ -454,6 +455,7 @@ class TestRecallByTime(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
         self.archive_path = os.path.join(self.tmpdir, "facts_archive.json")
         with open(self.archive_path, "w", encoding="utf-8") as f:
             json.dump([], f)
@@ -537,6 +539,7 @@ class TestArchiveHalfCommitOverlap(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
         self.archive_path = os.path.join(self.tmpdir, "facts_archive.json")
 
     def _write_archive(self, rows):


### PR DESCRIPTION
## 问题

`tests/unit/test_hybrid_recall.py` 里三个测试类在 `setUp` 调了 `tempfile.mkdtemp()` 但从来不清理：

- `TestHybridRecallE2E`
- `TestRecallByTime`
- `TestArchiveHalfCommitOverlap`

跑一遍这个文件会在系统临时目录留下 **20 个**残留目录（每个 test method 一个）。

## 改动

照 #2707 里 `_ArchiveTmpCase.asyncSetUp` 已有的写法，在每个 `mkdtemp()` 后补一行：

```python
self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
```

`import shutil` 在 #2707 已经加过了，本 PR 不动 import。

## 验证

泄漏计数（改前 20，改后 0）：

```
python -c "import glob,os,subprocess,tempfile; t=tempfile.gettempdir(); b=set(glob.glob(os.path.join(t,'tmp*'))); subprocess.run(['python','-m','pytest','tests/unit/test_hybrid_recall.py','-q'],capture_output=True); a=set(glob.glob(os.path.join(t,'tmp*'))); print('leaked:', len([p for p in (a-b) if os.path.isdir(p)]))"
leaked: 0
```

测试全通过：

```
python -m pytest tests/unit/test_hybrid_recall.py -q
58 passed in 1.01s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 改进测试环境清理机制，测试结束后会自动删除临时目录及其内容。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->