### PR TITLE
fix(agent): 任务分析把当前语言传下去，别再让所有非英语用户跑英文 prompt

### DIFF
--- a/app/agent_server/api_runtime.py
+++ b/app/agent_server/api_runtime.py
@@ -410,11 +410,19 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
         enriched_messages = _task_tracker.inject(redacted_messages, lanlan_name)
 
         # 一步完成：分析 + 执行
+        #
+        # lang 必须显式传：analyzer 的全部频道描述和系统提示都走 _loc(..., lang)
+        # （task_executor 里的 _assess_unified_channels / _assess_user_plugin /
+        # _stage1_llm_coarse_screen），漏传会落到 analyze_and_execute 的默认值
+        # "en"，让日/韩/俄/西/葡/中文用户全都拿到英文 prompt。
+        # 语言来源跟 agent_server 其他 i18n 消费者（channels/*.py 的结果播报）一致：
+        # _rp_lang(None) → get_global_language()，返回短码 zh/en/ja/ko/ru/es/pt。
         result = await Modules.task_executor.analyze_and_execute(
             messages=enriched_messages,
             lanlan_name=lanlan_name,
             agent_flags=Modules.agent_flags,
             conversation_id=conversation_id,
+            lang=_rp_lang(None),
             external_intent=external_intent,
             proactive=proactive,
         )

--- a/app/agent_server/api_runtime.py
+++ b/app/agent_server/api_runtime.py
@@ -231,7 +231,40 @@ async def _handle_voice_transcript_request(event: Dict[str, Any]) -> None:
         )
 
 
-def _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id) -> None:
+def _resolve_analyze_lang(session_language: Optional[str]) -> str:
+    """Language for the analyzer's prompts: session locale first, process global as fallback.
+
+    ``session_language`` rides the analyze_request event (see
+    ``main_logic/agent_event_bus.publish_analyze_request_reliably``) and carries the
+    frontend i18n truth as a full code (``zh-CN`` / ``zh-TW`` / ``ja`` …). It wins
+    because this process cannot see it any other way: agent_server talks to
+    main_server over ZeroMQ and its own ``get_global_language()`` only derives
+    NEKO_LANGUAGE / Steam / system locale, which is simply wrong whenever the user's
+    UI language differs from the machine's.
+
+    Unvalidated input is fenced out first: ``normalize_language_code`` silently maps
+    anything unrecognized to ``'en'``, so a garbage value would look like a
+    deliberate English choice and beat the (correct) fallback.
+
+    Returns a SHORT code. Every agent prompt dict in ``config/prompts/prompts_agent.py``
+    is keyed by ``zh / en / ja / ko / ru / es / pt`` plus ``zh-TW``; a full ``zh-CN``
+    has no key there and would take ``_loc``'s fallback path with a warning. Traditional
+    Chinese therefore resolves to ``zh`` here, matching every other subsystem that reads
+    ``get_global_language()`` — switching the agent prompts to full codes belongs to the
+    zh-TW migration (issue #2500).
+    """
+    if session_language:
+        try:
+            from utils.language_utils import is_supported_language_code, normalize_language_code
+            if is_supported_language_code(session_language):
+                return normalize_language_code(str(session_language), format='short')
+            logger.debug("[AgentAnalyze] ignoring unsupported session language: %r", session_language)
+        except Exception:
+            logger.debug("[AgentAnalyze] session language normalize failed", exc_info=True)
+    return _rp_lang(None)
+
+
+def _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id, session_language=None) -> None:
     """Throttled proactive-analyze path controlled by AGENT_PROACTIVE_ANALYZE_ENABLED.
 
     A proactive turn has no new user input, so the ordinary user-turn dedupe
@@ -269,7 +302,7 @@ def _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id
     logger.info("[AgentAnalyze] proactive analyze accepted (%d/%d, lanlan=%s)", used + 1, cap, lanlan_name)
     _create_tracked_task(_background_analyze_and_plan(
         messages, lanlan_name, conversation_id=conversation_id,
-        external_intent=None, proactive=True,
+        external_intent=None, proactive=True, session_language=session_language,
     ))
 
 
@@ -317,13 +350,19 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
         if isinstance(messages, list) and messages:
             lanlan_key = _normalize_lanlan_key(lanlan_name)
             conversation_id = event.get("conversation_id")
+            # Live session locale from main_server (full code, e.g. 'zh-TW').
+            # Absent → _resolve_analyze_lang falls back to this process's global.
+            session_language = event.get("language")
             # Proactive (self-initiated, no fresh user input) turn: opt-in,
             # separate throttled path. The ordinary user-turn dedupe below would
             # always drop these (the latest user message is a stale prior turn,
             # so its fingerprint matches), so proactive routing is mandatory, not
             # an optimization.
             if event.get("proactive"):
-                _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id)
+                _handle_proactive_analyze(
+                    messages, lanlan_name, lanlan_key, conversation_id,
+                    session_language=session_language,
+                )
                 return
             # Consume only new user turn. Assistant turn_end without new user input should be ignored.
             fp = _build_analyze_event_fingerprint(event)
@@ -344,11 +383,11 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
             external_intent = event.get("external_intent")
             _create_tracked_task(_background_analyze_and_plan(
                 messages, lanlan_name, conversation_id=conversation_id,
-                external_intent=external_intent,
+                external_intent=external_intent, session_language=session_language,
             ))
 
 
-async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None, proactive: bool = False):
+async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None, proactive: bool = False, session_language: Optional[str] = None):
     """
     [Simplified] Uses DirectTaskExecutor to do everything in one step: analyze the conversation + decide the execution method + execute the task
 
@@ -374,10 +413,10 @@ async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_na
         Modules.analyze_lock = asyncio.Lock()
 
     async with Modules.analyze_lock:
-        await _do_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id, external_intent=external_intent, proactive=proactive)
+        await _do_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id, external_intent=external_intent, proactive=proactive, session_language=session_language)
 
 
-async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None, proactive: bool = False):
+async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None, proactive: bool = False, session_language: Optional[str] = None):
     """Inner implementation, always called under analyze_lock."""
     try:
         if not Modules.analyzer_enabled:
@@ -415,14 +454,14 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
         # （task_executor 里的 _assess_unified_channels / _assess_user_plugin /
         # _stage1_llm_coarse_screen），漏传会落到 analyze_and_execute 的默认值
         # "en"，让日/韩/俄/西/葡/中文用户全都拿到英文 prompt。
-        # 语言来源跟 agent_server 其他 i18n 消费者（channels/*.py 的结果播报）一致：
-        # _rp_lang(None) → get_global_language()，返回短码 zh/en/ja/ko/ru/es/pt。
+        # 取值优先 session locale（随 analyze_request 事件从 main_server 带过来的
+        # 前端 i18n 真值），取不到才回落本进程全局值——见 _resolve_analyze_lang。
         result = await Modules.task_executor.analyze_and_execute(
             messages=enriched_messages,
             lanlan_name=lanlan_name,
             agent_flags=Modules.agent_flags,
             conversation_id=conversation_id,
-            lang=_rp_lang(None),
+            lang=_resolve_analyze_lang(session_language),
             external_intent=external_intent,
             proactive=proactive,
         )

--- a/main_logic/agent_event_bus.py
+++ b/main_logic/agent_event_bus.py
@@ -483,6 +483,7 @@ async def publish_analyze_request_reliably(
     conversation_id: Optional[str] = None,
     external_intent: Optional[float] = None,
     proactive: bool = False,
+    language: Optional[str] = None,
 ) -> bool:
     """Reliably publish analyze_request: carries event_id + ack, with short retries.
 
@@ -495,6 +496,14 @@ async def publish_analyze_request_reliably(
     ``proactive`` marks a self-initiated (no fresh user input) turn. The agent
     routes these through a separate throttled path instead of the user-turn
     dedupe; omitted (not set) for ordinary user turns.
+
+    ``language`` is the live session locale (the frontend i18n truth held in
+    ``session_manager[...].user_language``, a full code like ``zh-TW``). The agent
+    runs in its own process, so it cannot see that value — its own
+    ``get_global_language()`` only derives NEKO_LANGUAGE / Steam / system locale,
+    which is wrong whenever the UI language differs. It rides this payload so the
+    analyzer's prompts follow the language the user is actually reading. Omitted
+    (``None``) → the agent falls back to its process-global value.
     """
     event_id = uuid.uuid4().hex
     sent_at = time.perf_counter()
@@ -516,6 +525,12 @@ async def publish_analyze_request_reliably(
         # agent's user-turn path is byte-for-byte unchanged when disabled.
         if proactive:
             event["proactive"] = True
+        # Live session locale; omitted when unknown so the agent keeps its
+        # process-global fallback. Not part of the analyze dedupe fingerprint
+        # (that hashes messages + trigger only), so adding it cannot change
+        # which turns get analyzed.
+        if language:
+            event["language"] = language
 
         loop = asyncio.get_running_loop()
         waiter: asyncio.Future = loop.create_future()

--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -1077,6 +1077,9 @@ class TurnMixin:
                 ack_timeout_s=0.8,
                 retries=1,
                 conversation_id=uuid4().hex,
+                # Session locale (full code) so the agent process prompts in the
+                # UI language instead of its own Steam/system locale.
+                language=getattr(self, "user_language", None),
             )
         except Exception as exc:
             logger.warning("[%s] openclaw magic command publish failed: %s", self.lanlan_name, exc)

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -60,7 +60,7 @@ emoji_pattern2 = re.compile("["
 emotion_pattern = re.compile('<(.*?)>')
 
 
-async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None, had_user_input: bool = True) -> bool:
+async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None, had_user_input: bool = True, language: str | None = None) -> bool:
     """Publish analyze request via EventBus with ack/retry.
 
     ``had_user_input`` is False for a proactive turn (lanlan spoke with no fresh
@@ -68,6 +68,12 @@ async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str,
     re-ran, and the "latest user message" here is a stale prior turn) and are
     marked ``proactive=True`` so the agent routes them through its throttled
     proactive path instead of the user-turn dedupe (which would drop them).
+
+    ``language`` is the live session locale, taken from the same
+    ``_current_user_language()`` provider that already feeds the memory-server
+    calls and the agent task-result rendering. The agent process cannot read the
+    session's ``user_language`` on its own, so its analyzer prompts would
+    otherwise follow the machine's Steam/system locale instead of the UI language.
     """
     try:
         # Optional optimization hint: the cheap pre-gate signal the master-emotion
@@ -103,6 +109,7 @@ async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str,
             conversation_id=conversation_id,
             external_intent=external_intent,
             proactive=not had_user_input,
+            language=language,
         )
         if sent:
             logger.debug(
@@ -1188,6 +1195,7 @@ async def run_sync_connector(
                                                 messages=recent,
                                                 conversation_id=uuid.uuid4().hex,
                                                 had_user_input=_turn_had_user_input,
+                                                language=_current_user_language(),
                                             )
                                             if sent:
                                                 logger.debug(f"[{lanlan_name}] analyze_request dispatch success (turn_end), messages={len(recent)}")
@@ -1288,6 +1296,7 @@ async def run_sync_connector(
                                                 trigger="session_end",
                                                 messages=recent,
                                                 conversation_id=uuid.uuid4().hex,
+                                                language=_current_user_language(),
                                                 # session_end is terminal — never treated as proactive
                                                 # (had_user_input defaults True), so it always takes the
                                                 # ordinary user-turn path.

--- a/tests/unit/test_agent_analyze_language.py
+++ b/tests/unit/test_agent_analyze_language.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The analyzer call site must hand the current language down to the executor.
+
+``DirectTaskExecutor.analyze_and_execute`` declares ``lang: str = "en"`` and
+feeds it to every ``_loc(...)`` lookup that builds the agent's channel
+descriptions and system prompts.  ``_do_analyze_and_plan`` used to omit the
+argument, so the default silently won and Japanese / Korean / Russian /
+Spanish / Portuguese / Chinese users all got English prompts — the localized
+templates in ``config/prompts/prompts_agent.py`` were never reachable.
+
+These tests are pinned at the **call site**: a test that only exercises
+``analyze_and_execute`` with an explicit ``lang`` cannot catch a caller that
+forgets to pass it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any, Optional
+
+import pytest
+
+from config.prompts.prompts_agent import (
+    CHANNEL_DESC_BROWSER_USE,
+    UNIFIED_CHANNEL_SYSTEM_PROMPT,
+)
+from config.prompts.prompts_sys import _loc
+from utils.language_utils import language_context
+
+# Scripts that prove the prompt really is in the target language rather than
+# English.  Deliberately independent of the template wording: rephrasing a
+# template must not silently turn these assertions into no-ops.
+_SCRIPT_PROBES = {
+    "ja": re.compile(r"[぀-ヿ]"),   # hiragana / katakana
+    "ru": re.compile(r"[Ѐ-ӿ]"),   # Cyrillic
+    "ko": re.compile(r"[가-힣]"),   # hangul syllables
+    "zh": re.compile(r"[一-鿿]"),   # CJK ideographs
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_env_language_override(monkeypatch: pytest.MonkeyPatch):
+    """``language_context`` yields to ``NEKO_LANGUAGE``; keep it out of the way."""
+    monkeypatch.delenv("NEKO_LANGUAGE", raising=False)
+
+
+class _CapturingExecutor:
+    """Stands in for ``Modules.task_executor`` and records the kwargs it got."""
+
+    def __init__(self):
+        self.kwargs: Optional[dict[str, Any]] = None
+
+    async def analyze_and_execute(self, **kwargs):
+        self.kwargs = kwargs
+        return None
+
+
+def _run_analyze(monkeypatch: pytest.MonkeyPatch, executor: Any, ui_language: str) -> None:
+    """Drive ``_do_analyze_and_plan`` once with ``ui_language`` selected."""
+    from app.agent_server import api_runtime
+    from app.agent_server._shared import Modules
+
+    monkeypatch.setattr(Modules, "task_executor", executor, raising=False)
+    monkeypatch.setattr(Modules, "analyzer_enabled", True, raising=False)
+    monkeypatch.setattr(
+        Modules,
+        "agent_flags",
+        {
+            "computer_use_enabled": False,
+            "browser_use_enabled": False,
+            "user_plugin_enabled": True,
+            "openclaw_enabled": False,
+            "openfang_enabled": False,
+        },
+        raising=False,
+    )
+
+    messages = [{"role": "user", "content": "帮我打开浏览器搜索一下天气"}]
+    with language_context(ui_language):
+        asyncio.run(api_runtime._do_analyze_and_plan(messages, "喵喵"))
+
+
+# ---------------------------------------------------------------------------
+# 1. The call site passes lang — the default must never win
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ui_language, expected_lang",
+    [
+        ("ja", "ja"),
+        ("ko", "ko"),
+        ("ru", "ru"),
+        ("es", "es"),
+        ("pt", "pt"),
+        ("zh-CN", "zh"),
+        # Short code by design: zh-TW resolves to 'zh' here, same as every other
+        # subsystem that reads get_global_language().  Switching the agent
+        # prompts to full codes belongs to the zh-TW migration (issue #2500),
+        # not to this fix — flip this expectation there.
+        ("zh-TW", "zh"),
+        ("en", "en"),
+    ],
+)
+def test_do_analyze_and_plan_passes_current_language(
+    monkeypatch: pytest.MonkeyPatch, ui_language: str, expected_lang: str
+):
+    executor = _CapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language)
+
+    assert executor.kwargs is not None, "analyze_and_execute was never called"
+    # Explicit membership check, not .get(): relying on the "en" default is the
+    # bug this test exists for, and .get() would paper over it for en users.
+    assert "lang" in executor.kwargs, (
+        "_do_analyze_and_plan must pass lang explicitly; otherwise "
+        "analyze_and_execute's lang='en' default silently wins"
+    )
+    assert executor.kwargs["lang"] == expected_lang
+
+
+def test_default_lang_is_english_so_omitting_it_would_be_a_regression():
+    """Guards the premise of the test above.
+
+    If the default ever stops being ``"en"``, "the caller forgot to pass lang"
+    would no longer show up as English, and the assertions above would be
+    testing something weaker than they claim.
+    """
+    import inspect
+
+    from brain.task_executor import DirectTaskExecutor
+
+    sig = inspect.signature(DirectTaskExecutor.analyze_and_execute)
+    assert sig.parameters["lang"].default == "en"
+
+
+# ---------------------------------------------------------------------------
+# 2. End-to-end: the lang that reaches the executor selects the prompt template
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, content: str):
+        self.content = content
+        self.calls: list[list[dict[str, str]]] = []
+
+    async def ainvoke(self, messages):
+        self.calls.append(list(messages))
+        return _FakeResponse(self.content)
+
+
+class _PromptCapturingExecutor:
+    """Feeds the received ``lang`` into the real unified-channel assembly.
+
+    This closes the loop: the language selected in the UI must end up choosing
+    the actual system prompt string the agent LLM is called with, not just some
+    keyword in transit.
+    """
+
+    def __init__(self):
+        self.system_prompt: Optional[str] = None
+        self.lang: Optional[str] = None
+
+    async def analyze_and_execute(self, **kwargs):
+        from brain.task_executor import DirectTaskExecutor
+
+        self.lang = kwargs.get("lang")
+
+        executor = object.__new__(DirectTaskExecutor)
+        fake_llm = _FakeLLM("{}")
+        executor._get_llm = lambda **_kw: fake_llm
+        executor._retrieve_relevant_corrections = lambda *a, **kw: []
+        executor._build_correction_lessons_block = lambda _lessons: ""
+
+        await executor._assess_unified_channels(
+            "LATEST_USER_REQUEST: 打开浏览器搜天气",
+            browser_available=True,
+            lang=self.lang,
+        )
+        self.system_prompt = fake_llm.calls[0][0]["content"]
+        return None
+
+
+def _expected_unified_prompt(lang: str) -> str:
+    return _loc(UNIFIED_CHANNEL_SYSTEM_PROMPT, lang).format(
+        channels_block=_loc(CHANNEL_DESC_BROWSER_USE, lang),
+        keys_json='["browser_use"]',
+        json_fields=(
+            '  "browser_use": {"can_execute": boolean, '
+            '"task_description": "brief description", "reason": "why"},'
+        ),
+    )
+
+
+@pytest.mark.parametrize("ui_language", ["ja", "ru", "ko", "zh-CN"])
+def test_agent_system_prompt_follows_ui_language(
+    monkeypatch: pytest.MonkeyPatch, ui_language: str
+):
+    executor = _PromptCapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language)
+
+    assert executor.system_prompt, "unified assessment never built a system prompt"
+    short = "zh" if ui_language.startswith("zh") else ui_language
+
+    # Exact template selection …
+    assert executor.system_prompt == _expected_unified_prompt(short)
+    # … and it is not the English one we used to always send.
+    assert executor.system_prompt != _expected_unified_prompt("en")
+    # … and it really is written in that language, independent of wording.
+    assert _SCRIPT_PROBES[short].search(executor.system_prompt), (
+        f"{short} system prompt carries no {short} script — "
+        "looks like an English template leaked through"
+    )
+
+
+def test_english_ui_still_gets_the_english_prompt(monkeypatch: pytest.MonkeyPatch):
+    """The fix must not shift English users onto a different template."""
+    executor = _PromptCapturingExecutor()
+    _run_analyze(monkeypatch, executor, "en")
+
+    assert executor.system_prompt == _expected_unified_prompt("en")
+
+
+# ---------------------------------------------------------------------------
+# 3. Every localized agent template is reachable through the short code
+# ---------------------------------------------------------------------------
+
+
+def test_short_codes_resolve_to_distinct_localized_templates():
+    """``_loc`` must return a real per-language template for all 7 short codes.
+
+    A missing key falls back to English inside ``_loc``, which is exactly the
+    failure mode this PR fixes — catch it here instead of at runtime.
+    """
+    english = _loc(UNIFIED_CHANNEL_SYSTEM_PROMPT, "en")
+    for short in ("zh", "ja", "ko", "ru", "es", "pt"):
+        assert _loc(UNIFIED_CHANNEL_SYSTEM_PROMPT, short) != english
+        assert _loc(CHANNEL_DESC_BROWSER_USE, short) != _loc(CHANNEL_DESC_BROWSER_USE, "en")

--- a/tests/unit/test_agent_analyze_language.py
+++ b/tests/unit/test_agent_analyze_language.py
@@ -22,9 +22,16 @@ argument, so the default silently won and Japanese / Korean / Russian /
 Spanish / Portuguese / Chinese users all got English prompts — the localized
 templates in ``config/prompts/prompts_agent.py`` were never reachable.
 
-These tests are pinned at the **call site**: a test that only exercises
-``analyze_and_execute`` with an explicit ``lang`` cannot catch a caller that
-forgets to pass it.
+Where the language comes from matters as much as passing it.  agent_server is a
+separate process talking to main_server over ZeroMQ, so its own
+``get_global_language()`` only derives NEKO_LANGUAGE / Steam / system locale — it
+cannot see the frontend i18n truth the session holds in ``user_language``.  The
+analyze_request event therefore carries the session locale, and
+``_resolve_analyze_lang`` prefers it, falling back to the process global.
+
+These tests are pinned at the **call site** at every hop (event → handler →
+executor): a test that only exercises ``analyze_and_execute`` with an explicit
+``lang`` cannot catch a caller that forgets to pass it.
 """
 
 from __future__ import annotations
@@ -70,9 +77,7 @@ class _CapturingExecutor:
         return None
 
 
-def _run_analyze(monkeypatch: pytest.MonkeyPatch, executor: Any, ui_language: str) -> None:
-    """Drive ``_do_analyze_and_plan`` once with ``ui_language`` selected."""
-    from app.agent_server import api_runtime
+def _install_agent_modules(monkeypatch: pytest.MonkeyPatch, executor: Any) -> None:
     from app.agent_server._shared import Modules
 
     monkeypatch.setattr(Modules, "task_executor", executor, raising=False)
@@ -90,9 +95,30 @@ def _run_analyze(monkeypatch: pytest.MonkeyPatch, executor: Any, ui_language: st
         raising=False,
     )
 
+
+def _run_analyze(
+    monkeypatch: pytest.MonkeyPatch,
+    executor: Any,
+    ui_language: str,
+    session_language: Optional[str] = None,
+) -> None:
+    """Drive ``_do_analyze_and_plan`` once.
+
+    ``ui_language`` is what this process's global language resolves to;
+    ``session_language`` is what rode the analyze_request event from main_server
+    (``None`` = the event carried none, so the global is the only source).
+    """
+    from app.agent_server import api_runtime
+
+    _install_agent_modules(monkeypatch, executor)
+
     messages = [{"role": "user", "content": "帮我打开浏览器搜索一下天气"}]
     with language_context(ui_language):
-        asyncio.run(api_runtime._do_analyze_and_plan(messages, "喵喵"))
+        asyncio.run(
+            api_runtime._do_analyze_and_plan(
+                messages, "喵喵", session_language=session_language,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -255,3 +281,217 @@ def test_short_codes_resolve_to_distinct_localized_templates():
     for short in ("zh", "ja", "ko", "ru", "es", "pt"):
         assert _loc(UNIFIED_CHANNEL_SYSTEM_PROMPT, short) != english
         assert _loc(CHANNEL_DESC_BROWSER_USE, short) != _loc(CHANNEL_DESC_BROWSER_USE, "en")
+
+
+# ---------------------------------------------------------------------------
+# 4. Session locale beats the agent process's own locale
+# ---------------------------------------------------------------------------
+
+
+def test_session_language_wins_over_process_global(monkeypatch: pytest.MonkeyPatch):
+    """The frontend UI language is the truth; the machine's locale is the fallback.
+
+    A user on a Chinese Windows / Steam who runs the UI in English must get English
+    analyzer prompts — the process global would say ``zh``.
+    """
+    executor = _CapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language="zh-CN", session_language="en")
+
+    assert executor.kwargs["lang"] == "en"
+
+
+def test_session_language_wins_in_the_other_direction(monkeypatch: pytest.MonkeyPatch):
+    """Symmetric case: English machine, Japanese UI → Japanese prompts."""
+    executor = _PromptCapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language="en", session_language="ja")
+
+    assert executor.lang == "ja"
+    assert executor.system_prompt == _expected_unified_prompt("ja")
+    assert _SCRIPT_PROBES["ja"].search(executor.system_prompt)
+
+
+def test_session_language_is_short_normalized(monkeypatch: pytest.MonkeyPatch):
+    """The event carries a full code; the prompt lookup needs the short one.
+
+    ``prompts_agent.py`` has no ``zh-CN`` key, so forwarding the full code
+    verbatim would take ``_loc``'s fallback path and log a warning on every turn.
+    """
+    executor = _CapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language="en", session_language="zh-CN")
+    assert executor.kwargs["lang"] == "zh"
+
+    executor = _CapturingExecutor()
+    # Same short-code decision as the global path: zh-TW folds to 'zh' until the
+    # #2500 migration switches the agent prompts to full codes.
+    _run_analyze(monkeypatch, executor, ui_language="en", session_language="zh-TW")
+    assert executor.kwargs["lang"] == "zh"
+
+
+@pytest.mark.parametrize("garbage", ["undefined", "null", "estonian", "", "  ", "xx-YY"])
+def test_garbage_session_language_falls_back_to_the_global(
+    monkeypatch: pytest.MonkeyPatch, garbage: str
+):
+    """``normalize_language_code`` maps anything unrecognized to 'en'.
+
+    Without an upfront validity fence, a corrupted ``localStorage`` value would
+    look like a deliberate English choice and beat the correct global fallback.
+    """
+    executor = _CapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language="ja", session_language=garbage)
+
+    assert executor.kwargs["lang"] == "ja"
+
+
+def test_missing_session_language_falls_back_to_the_global(monkeypatch: pytest.MonkeyPatch):
+    """Events published before this field existed (or with no session truth yet)."""
+    executor = _CapturingExecutor()
+    _run_analyze(monkeypatch, executor, ui_language="ru", session_language=None)
+
+    assert executor.kwargs["lang"] == "ru"
+
+
+# ---------------------------------------------------------------------------
+# 5. The event → handler hop: the language must survive it
+# ---------------------------------------------------------------------------
+
+
+def _drive_session_event(monkeypatch: pytest.MonkeyPatch, event: dict[str, Any]) -> dict[str, Any]:
+    """Feed one analyze_request into ``_on_session_event``, capture the plan kwargs."""
+    from app.agent_server import api_runtime
+    from app.agent_server._shared import Modules
+
+    _install_agent_modules(monkeypatch, _CapturingExecutor())
+    # A fresh fingerprint table, or the dedupe drops the event.
+    monkeypatch.setattr(Modules, "last_user_turn_fingerprint", {}, raising=False)
+    monkeypatch.setattr(Modules, "last_proactive_assistant_fingerprint", {}, raising=False)
+    monkeypatch.setattr(Modules, "proactive_analyze_count", {}, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_plan(messages, lanlan_name, **kwargs):
+        captured.update(kwargs)
+        captured["called"] = True
+
+    monkeypatch.setattr(api_runtime, "_background_analyze_and_plan", _fake_plan)
+
+    async def _go():
+        await api_runtime._on_session_event(event)
+        # _create_tracked_task schedules; give it one loop turn to run.
+        await asyncio.sleep(0)
+
+    asyncio.run(_go())
+    return captured
+
+
+def test_event_language_reaches_the_analyze_plan(monkeypatch: pytest.MonkeyPatch):
+    captured = _drive_session_event(
+        monkeypatch,
+        {
+            "event_type": "analyze_request",
+            "lanlan_name": "喵喵",
+            "trigger": "turn_end",
+            "language": "ja",
+            "messages": [{"role": "user", "content": "打开浏览器"}],
+        },
+    )
+
+    assert captured.get("called"), "_background_analyze_and_plan was never scheduled"
+    assert captured.get("session_language") == "ja"
+
+
+def test_event_language_reaches_the_proactive_path(monkeypatch: pytest.MonkeyPatch):
+    """The proactive branch returns early — it needs the same wiring, separately."""
+    captured = _drive_session_event(
+        monkeypatch,
+        {
+            "event_type": "analyze_request",
+            "lanlan_name": "喵喵",
+            "trigger": "turn_end",
+            "proactive": True,
+            "language": "ru",
+            "messages": [
+                {"role": "user", "content": "早"},
+                {"role": "assistant", "content": "我刚看到一条新闻"},
+            ],
+        },
+    )
+
+    assert captured.get("called"), "proactive analyze was never scheduled"
+    assert captured.get("session_language") == "ru"
+
+
+# ---------------------------------------------------------------------------
+# 6. The publisher side: every call site must hand the session locale over
+# ---------------------------------------------------------------------------
+
+
+def test_publisher_puts_the_language_on_the_event(monkeypatch: pytest.MonkeyPatch):
+    from main_logic import agent_event_bus as bus
+
+    published: list[dict[str, Any]] = []
+
+    class _Bridge:
+        owner_loop = None
+        owner_thread_id = None
+
+        async def publish_analyze_request(self, event):
+            published.append(event)
+            return False  # stop after the first attempt; we only inspect the payload
+
+    async def _go(language):
+        published.clear()
+        monkeypatch.setattr(bus, "_main_bridge_ref", _Bridge(), raising=False)
+        import threading
+
+        _Bridge.owner_loop = asyncio.get_running_loop()
+        _Bridge.owner_thread_id = threading.get_ident()
+        await bus.publish_analyze_request_reliably(
+            lanlan_name="喵喵",
+            trigger="turn_end",
+            messages=[{"role": "user", "content": "x"}],
+            retries=0,
+            language=language,
+        )
+        return published[0] if published else None
+
+    with_lang = asyncio.run(_go("zh-TW"))
+    assert with_lang is not None and with_lang.get("language") == "zh-TW"
+
+    # Omitted when unknown, like conversation_id / external_intent / proactive —
+    # the agent then keeps its process-global fallback.
+    without = asyncio.run(_go(None))
+    assert without is not None and "language" not in without
+
+
+def test_every_analyze_publish_call_site_passes_a_language():
+    """Auto-discovered: a new publish site that forgets ``language`` fails here.
+
+    This is the same defect class the PR fixes — a caller silently falling back to
+    a default — so the guard discovers call sites instead of listing them.
+    """
+    import ast
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    targets = {
+        "publish_analyze_request_reliably",
+        "_publish_analyze_request_with_fallback",
+    }
+    checked = 0
+    offenders: list[str] = []
+
+    for path in sorted((repo_root / "main_logic").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name not in targets:
+                continue
+            checked += 1
+            if not any(kw.arg == "language" for kw in node.keywords):
+                offenders.append(f"{path.relative_to(repo_root).as_posix()}:{node.lineno}")
+
+    assert checked >= 3, f"found only {checked} publish call sites — did the API get renamed?"
+    assert not offenders, f"analyze publish call sites missing language=: {offenders}"


### PR DESCRIPTION
## 改动概述 / Summary

agent 的任务分析对**所有非英语用户**都在跑英文 prompt。

`DirectTaskExecutor.analyze_and_execute()` 的签名里有 `lang: str = "en"`（`brain/task_executor.py:1838`），而唯一的生产调用点 `app/agent_server/api_runtime.py` 的 `_do_analyze_and_plan()` 从来没传过它。于是 `lang` 恒为 `"en"`，一路喂给：

- `_assess_unified_channels()` → `_loc(UNIFIED_CHANNEL_SYSTEM_PROMPT, lang)`、`_loc(CHANNEL_DESC_QWENPAW / OPENFANG / BROWSER_USE / COMPUTER_USE, lang)`
- `_assess_user_plugin()` → `_loc(USER_PLUGIN_SYSTEM_PROMPT, lang)`
- `_stage1_llm_coarse_screen()` → `_loc(USER_PLUGIN_COARSE_SCREEN_PROMPT, lang)`

也就是 **agent 的全部频道描述和系统提示**。`config/prompts/prompts_agent.py` 里 zh / zh-TW / ja / ko / ru / es / pt 七套模板一次都没被取到过。

修法两层：

1. 调用点把语言传下去。
2. 语言取**会话真值**（前端 i18n 语言），随 analyze_request 事件从 main_server 带到 agent 进程；取不到才回落 agent 进程自己的全局值。

> 这**不是** issue #2500（繁体中文）的一部分。#2500 关心的是繁中拿到简体，这一条是七种语言全拿英文。

## 回归报告 / Regression Report

### 改动了什么

| 文件 | 改动 |
| --- | --- |
| `app/agent_server/api_runtime.py` | 新增 `_resolve_analyze_lang()`；`analyze_request` 事件读 `language` 并一路传到 `analyze_and_execute(lang=...)`（含 proactive 支路） |
| `main_logic/agent_event_bus.py` | `publish_analyze_request_reliably` 新增可选 `language`，非空时写进事件 |
| `main_logic/cross_server.py` | `_publish_analyze_request_with_fallback` 透传 `language`；turn_end / session_end 两个发布点传 `_current_user_language()` |
| `main_logic/core/turn.py` | openclaw magic command 发布点传 `self.user_language` |
| `tests/unit/test_agent_analyze_language.py` | 新增，29 个用例 |

### 理由 / 必要性

**第一层：默认值不是判断。** `lang` 的默认值 `"en"` 是"调用方没给"的兜底，不是"用户是英语用户"的判断。调用点漏传，默认值就静默变成了全体用户的实际语言。

**第二层：语言得取对。** 第一版用的是 `_rp_lang(None)` → `get_global_language()`，跟同包其他 i18n 消费者（`channels/*.py` 的结果播报）一致。Codex 指出这个来源不够（[P1 comment](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2718#discussion_r3725156811)），核实下来成立：

- agent_server 是**独立进程**，跟 main_server 走 ZeroMQ（`app/main_server/character_runtime.py:305`）。
- 它自己的 `get_global_language()` 只能推 `NEKO_LANGUAGE` > Steam > 系统 locale。
- 前端 i18n 真值在 `session_manager[lanlan_name].user_language`（`main_routers/websocket_router.py:797`），`publish_analyze_request_reliably` 不带它。
- 所以 UI 语言 ≠ 机器语言时（中文系统 + 英文 UI、英文系统 + 日文 UI），拿到的是错的。

`main_logic/core/lifecycle.py:1057-1063` 那段注释记的正是这个坑的另一面（"Steam=zh / 系统=en 时正确的 'zh-CN' 被全局缓存打回 'en'"）——会话值是真值，全局缓存是兜底。所以这版改成把会话语言随事件带过去。

事件里放 **full code**（`zh-CN` / `zh-TW`，无损），消费侧用之前先过 `is_supported_language_code` 再短码归一。这道栅栏是必须的：`normalize_language_code` 对无法识别的输入**静默回落 `'en'`**，不挡的话 corrupted `localStorage` 里的 `'undefined'` / `'estonian'` 会伪装成"用户选了英文"，把正确的兜底顶掉（`set_user_language` 里已有同款栅栏，同一个理由）。

**为什么最终传短码。** `prompts_agent.py` 七个 dict 的 key 集合是 `en/es/ja/ko/pt/ru/zh/zh-TW` —— **没有 `zh-CN`**。直接把全码递给 `_loc` 的话，简中用户每次分析都会打一条 `WARNING: Unexpected lang code zh-CN` 再 fallback 回 `zh`，白绕一圈。短码取值域 `{zh,en,ja,ko,ru,es,pt}` 全部命中。繁中在这里折成 `zh`，与其他读 `get_global_language()` 的子系统一致；agent 的繁中模板留给 #2500 第 2 步统一切（测试里钉死了这条预期，到时候直接看得到）。

### 改动前后的表现对比

受影响的是**除英语外的全部 7 种支持语言**。下表是实测（`_loc(UNIFIED_CHANNEL_SYSTEM_PROMPT, lang)` 取到的首行）：

| UI 语言 | 修前 `lang` | 修前实际拿到的 system prompt | 修后 `lang` | 修后实际拿到的 system prompt |
| --- | --- | --- | --- | --- |
| 简体中文 zh-CN | `en` | `You are an agentic automation assessment agent, give…` | `zh` | `你是一个agentic automation assessment agent, 根据用户的最新请求，判…` |
| 繁体中文 zh-TW | `en` | `You are an agentic automation assessment agent, give…` | `zh` | `你是一个agentic automation assessment agent, 根据用户的最新请求，判…`（简中模板，同其他子系统；#2500 第 2 步再切繁中） |
| 日本語 ja | `en` | `You are an agentic automation assessment agent, give…` | `ja` | `あなたはagentic automation assessment agent, ユーザーの最新リクエス…` |
| 한국어 ko | `en` | `You are an agentic automation assessment agent, give…` | `ko` | `당신은 agentic automation assessment agent, 사용자의 최신 요청에…` |
| Русский ru | `en` | `You are an agentic automation assessment agent, give…` | `ru` | `Вы agentic automation assessment agent, на основе по…` |
| Español es | `en` | `You are an agentic automation assessment agent, give…` | `es` | `Eres un agentic automation assessment agent. Dada la…` |
| Português pt | `en` | `You are an agentic automation assessment agent, give…` | `pt` | `Você é um agentic automation assessment agent. Dada …` |
| English en | `en` | `You are an agentic automation assessment agent, give…` | `en` | 不变 |

UI 语言与机器语言不一致时（第二层解决的那部分）：

| 场景 | 修前 | 第一版（进程全局） | 本版（会话真值） |
| --- | --- | --- | --- |
| 中文系统 / 英文 UI | `en`（碰巧对） | `zh`（错） | `en` ✅ |
| 英文系统 / 日文 UI | `en`（错） | `en`（错） | `ja` ✅ |
| 事件不带 language（旧发布点 / 会话真值还没建立） | `en` | 进程全局 | 进程全局（兜底不变） |

同一条 `lang` 也同时修好了频道描述（`CHANNEL_DESC_*`）、插件系统提示（`USER_PLUGIN_SYSTEM_PROMPT`）和插件粗筛提示（`USER_PLUGIN_COARSE_SCREEN_PROMPT`）—— 它们共用这一个参数。

### 其余 `lang: str = "en"` 默认值：逐个查过，都不动

按要求没有顺手改默认值（改了会让"漏传"从英文变成"跟随全局"，是另一种静默行为变化）。四处默认值的调用点全查了，生产链路上都是显式传参：

| 默认值所在 | 生产调用点 | 是否显式传 |
| --- | --- | --- |
| `_assess_unified_channels` (`:1148`) | `task_executor.py:2084` | ✅ `lang=lang` |
| `_stage1_llm_coarse_screen` (`:1386`) | `task_executor.py:1517` | ✅ `lang=lang` |
| `_assess_user_plugin` (`:1426`) | `task_executor.py:2079` | ✅ `lang=lang` |
| `_analyze_and_execute_inner` (`:1937`) | `task_executor.py:1860` | ✅ `lang=lang` |
| `analyze_and_execute` (`:1838`) | `api_runtime.py:413` | ❌ 本 PR 修的就是这一处 |

整条链上只有最外面这一个口子漏了，堵上之后默认值在生产路径上不再被取到（只剩测试里显式用它）。`brain/task_executor.py` 本 PR 一行没动。

### 潜在回归点

- **影响链路**：`analyze_request` → `_do_analyze_and_plan` → `analyze_and_execute` → 统一渠道评估 / 插件评估两路 LLM 调用的 system prompt。只改 prompt 语言，不改任何判定逻辑、渠道优先级、JSON schema——四个占位符和输出格式要求在每种语言的模板里都是同一套。
- **事件契约**：`language` 是可选 key，与 `conversation_id` / `external_intent` / `proactive` 同形，缺省即回落旧行为。**不进 analyze 去重指纹**——`_build_analyze_event_fingerprint` 只哈希 messages + trigger（+ magic command 的 event_id），所以加这个字段不可能改变"哪些轮会被分析"。ack / retry 协议不受影响。
- **脏值**：`is_supported_language_code` 栅栏挡在前面，无法识别的值走兜底而不是被 `normalize_language_code` 静默变成 `'en'`（有 6 个参数化用例覆盖）。
- **`_loc` fallback**：短码取值域全部命中 dict key，不触发 fallback、不打 WARNING。
- **异常兜底**：`_resolve_analyze_lang` 整段 try/except，归一化炸了也只是回落 `_rp_lang(None)`，不会让分析流程失败。

### 已知的同族问题，本 PR 不收

`channels/computer_use.py:168`、`browser_use.py:158`、`openfang.py:146` 的任务结果播报（猫娘实际念出来的那句话）也在用 `_rp_lang(None)`，同样看不到会话语言。这是 **本 PR 之前就存在**的问题，且要改的话得给 5 个 channel 的 `dispatch()` 签名都加参数、动的是 TTS 会念出来的用户可见文案，回归面跟本 PR 完全不同。留作独立 PR，这里只把 analyzer prompt 这条链修干净。

## 不拆分理由 / Why Not Split

不适用（计入上限的文件 4 个）。

## 测试 / Testing

新增 `tests/unit/test_agent_analyze_language.py`（29 passed）。测试**打在每一跳的调用点上**——只测被调方收到 lang 会怎样，是抓不到"调用方忘了传"这类缺陷的：

1. `test_do_analyze_and_plan_passes_current_language[8 参数化]` —— 真跑 `_do_analyze_and_plan`，`Modules.task_executor` 换成记录 kwargs 的替身，断言 `"lang" in kwargs`（用 `in` 而不是 `.get()`：靠默认值正是这个 bug，`.get()` 会把 en 用户的情况糊过去）且值等于当前语言。
2. `test_default_lang_is_english_so_omitting_it_would_be_a_regression` —— 钉住上一条的前提：默认值确实是 `"en"`。默认值哪天变了，"忘了传"就不再表现为英文，上面的断言会弱于它的主张。
3. `test_agent_system_prompt_follows_ui_language[ja / ru / ko / zh-CN]` —— 端到端闭环：调用点收到的 lang 直接喂进真实的 `_assess_unified_channels`，捕获实际送给 LLM 的 system prompt，三重断言：等于该语言模板的渲染结果 / 不等于英文渲染结果 / 文本里真含该语言的字符（假名、西里尔、谚文、汉字）。第三条独立于模板措辞——改写模板不会把它悄悄变成空断言。
4. `test_session_language_wins_over_process_global` / `..._in_the_other_direction` —— Codex 举的两个方向都覆盖：中文机器 + 英文 UI → `en`；英文机器 + 日文 UI → `ja`（且真取到日语模板）。
5. `test_session_language_is_short_normalized` —— `zh-CN` / `zh-TW` 都折成 `zh`；短码这个决定被钉住。
6. `test_garbage_session_language_falls_back_to_the_global[6 参数化]` —— `undefined` / `null` / `estonian` / 空 / 空白 / `xx-YY` 一律回落全局，不被 `normalize_language_code` 静默变成 `en`。
7. `test_event_language_reaches_the_analyze_plan` / `..._the_proactive_path` —— 真喂一条 analyze_request 进 `_on_session_event`，断言 `event["language"]` 到达了 `_background_analyze_and_plan`。proactive 是提前 return 的独立支路，单独钉一条。
8. `test_publisher_puts_the_language_on_the_event` —— 发布侧：带 language 时进事件、为 None 时不进（保持旧行为）。
9. `test_every_analyze_publish_call_site_passes_a_language` —— **AST 自动发现**：扫 `main_logic/**/*.py` 里所有 `publish_analyze_request_reliably` / `_publish_analyze_request_with_fallback` 的调用，逐个要求带 `language=`。不是清单式枚举，以后新加的发布点漏传会红。
10. `test_english_ui_still_gets_the_english_prompt` / `test_short_codes_resolve_to_distinct_localized_templates` —— 英文用户不被挪走；6 个非英语短码在 `_loc` 下都能取到与英文不同的模板。

**变异验证**（8 条，全部被杀）：

| 变异 | 结果 |
| --- | --- |
| 撤掉调用点的 `lang=`（回到缺陷现状） | 12 failed ✅ |
| `lang` 改用全码 `get_global_language_full()` | 2 failed（`zh-CN` / `zh-TW`）✅ |
| `_resolve_analyze_lang` 去掉 `is_supported_language_code` 栅栏 | 5 failed ✅ |
| `_resolve_analyze_lang` 改 `format='full'` | 1 failed ✅ |
| `_on_session_event` 不传 `session_language` | 1 failed ✅ |
| proactive 支路不传 `session_language` | 1 failed ✅ |
| `agent_event_bus` 不写 `event["language"]` | 1 failed ✅ |
| `cross_server` / `turn.py` 发布点漏 `language=` | AST 守卫 failed ✅ |

**命令**：

- `uv run python -m pytest tests/unit -q -k "agent or task_executor or language"` → **600 passed, 27074 deselected**
- `uv run ruff check app/agent_server/api_runtime.py main_logic/agent_event_bus.py main_logic/cross_server.py main_logic/core/turn.py tests/unit/test_agent_analyze_language.py` → All checks passed（唯一 warning 是 `cross_server.py:837` 一条既有的 `# noqa` 格式提示，本 PR 未触碰该行）
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main` → 通过
- `tests/test_agent_rewrite_regression.py` 有 11 条 failed，已在 `origin/main` 上原样复现（同样 11 failed / 152 passed），与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
