### PR TITLE
i18n(#2500 第2步 A/C1/B): 请求级路由 + proactive 查表收口 + 游戏一族翻全码

### DIFF
--- a/config/prompts/_locale.py
+++ b/config/prompts/_locale.py
@@ -40,13 +40,16 @@ Three axes cover every prompt module's needs:
 
     Every prompt dict under config/prompts/ now carries a ``'zh-TW'`` template
     (issue #2500 step 1), so template coverage is no longer what gates the flag.
-    The two template-selecting ``False`` callers — ``prompts_minigame_common``
-    and ``prompts_proactive._normalize_prompt_language`` — are waiting on issue
-    #2500 step 2 instead: their call sites still pass a SHORT language code,
-    which collapses Traditional before it ever reaches this function. Flip a
-    module to ``True`` in the same change that switches its callers to the full
-    locale — flipping earlier is a no-op, and switching the callers first without
-    flipping hands Traditional users a resolver that silently drops the script.
+    ``prompts_minigame_common`` flipped to ``True`` in issue #2500 step 2, in the
+    same change that moved its game-route call sites to the full locale. That
+    pairing is the rule: flipping earlier is a no-op, because the callers' SHORT
+    code has already collapsed the script before it reaches this function, and
+    switching the callers first without flipping hands Traditional users a
+    resolver that silently drops it.
+
+    ``prompts_proactive._normalize_prompt_language`` is the one template-selecting
+    ``False`` left, waiting on its own call-site flip in
+    ``main_logic/proactive_chat/service.py``.
 
     ``prompts_directives._trim_term`` passes ``False`` for an
     unrelated reason and stays that way: it is picking a *particle table family*,

--- a/config/prompts/prompts_badminton.py
+++ b/config/prompts/prompts_badminton.py
@@ -35,11 +35,12 @@ BADMINTON_QUICK_LINE_KEYS = frozenset({
 def normalize_badminton_prompt_locale(language: Any) -> str:
     """Normalize a language code to a FULL badminton quick-lines key.
 
-    Keeps ``zh-CN`` and ``zh-TW`` apart, unlike
-    ``prompts_minigame_common._normalize_prompt_lang``, which collapses every
-    Chinese variant to ``zh``. Both schemes stay separate on purpose: this
-    module's quick-lines tables are keyed by full locale, and collapsing them
-    would regress the Traditional Chinese fallbacks that PR #2000 added.
+    Spells Simplified Chinese ``zh-CN``, where
+    ``prompts_minigame_common._normalize_prompt_lang`` spells it ``zh``. Both keep
+    ``zh-TW`` as its own key since issue #2500 step 2, so that is now the only
+    difference. The two schemes stay separate because this module's quick-lines
+    tables are keyed by full locale and the other module's are not — respelling
+    either one would just break its own tables.
 
     See docs/contributing/developer-notes.md #7 and PR #2000.
     """
@@ -839,10 +840,11 @@ Regras:
 - Se não precisar de controle, não escreva JSON.
 """
 
-# SHORT-locale table: keyed by zh (short-locale scheme via _localized_template
-# / _normalize_prompt_lang). Contrast with BADMINTON_QUICK_LINES_PROMPTS above,
-# which keeps zh-CN / zh-TW apart. See docs/contributing/developer-notes.md #7
-# and PR #2000 before unifying the two schemes.
+# SHORT-locale table: Simplified Chinese keyed as zh (short-locale scheme via
+# _localized_template / _normalize_prompt_lang). Contrast with
+# BADMINTON_QUICK_LINES_PROMPTS above, which keys it zh-CN. Both schemes keep
+# zh-TW. See docs/contributing/developer-notes.md #7 and PR #2000 before
+# unifying the two schemes.
 BADMINTON_SYSTEM_PROMPTS = {
     "zh": BADMINTON_SYSTEM_PROMPT,
     "zh-TW": _BADMINTON_SYSTEM_PROMPT_ZH_TW,
@@ -1335,9 +1337,11 @@ def get_badminton_duel_difficulty_control_prompt(lang: str | None = None) -> str
     """Return the duel-only difficulty-control addendum for the badminton prompt.
 
     Uses ``normalize_badminton_prompt_locale`` (the FULL-locale scheme) rather
-    than ``_normalize_prompt_lang``: the latter collapses every Chinese variant
-    to ``zh``, which would make the ``zh-TW`` entry unreachable data while still
-    reading as compliant to the static ``check_prompt_zh_tw`` gate.
+    than ``_normalize_prompt_lang`` because this table keys Simplified Chinese as
+    ``zh-CN``. Both normalizers keep ``zh-TW`` since issue #2500 step 2; before
+    that, ``_normalize_prompt_lang`` collapsed it and would have left the
+    ``zh-TW`` entry unreachable data while still reading as compliant to the
+    static ``check_prompt_zh_tw`` gate.
     """
     prompt_lang = normalize_badminton_prompt_locale(lang)
     return (

--- a/config/prompts/prompts_card_assist.py
+++ b/config/prompts/prompts_card_assist.py
@@ -35,7 +35,26 @@ router strips fences + matching quote pairs before returning.
 
 from __future__ import annotations
 
+from config.prompts._locale import normalize_prompt_locale
 from config.prompts.prompts_sys import _loc
+
+
+def normalize_card_assist_locale(lang: str | None) -> str:
+    """Normalize a locale to a key of this module's prompt dicts.
+
+    Public on purpose, same reason as ``prompts_proactive.normalize_mini_game_invite_locale``:
+    the consumer is ``main_routers.card_assist_router`` and the tables live here, so
+    "which key scheme do these dicts use" stays answerable next to the dicts.
+
+    This module's dicts carry only ``zh`` / ``zh-TW`` / ``en`` -- the assistant's
+    prompt is authored in Chinese and English, and the other locales get the English
+    prompt plus an explicit output-language directive appended by the router
+    (``_output_language_directive``). So anything that is not a Chinese variant
+    resolves to ``en`` here rather than to its own short code, which would only reach
+    ``_loc``'s missing-key warning and land on ``en`` anyway.
+    """
+    key = normalize_prompt_locale(lang, default="en", simplified="zh", keep_traditional=True)
+    return key if key in ("zh", "zh-TW") else "en"
 
 
 # Canonical catgirl card field keys (Chinese keys are what's stored in
@@ -383,6 +402,15 @@ CARD_ASSIST_CHAT_ADVICE_ONLY_DIRECTIVE = {
 }
 
 
+# 兜底文案：LLM 既没回话也没给动作时，聊天框不能空着。跟本模块其余 dict 一样只写
+# zh / zh-TW / en —— 其它 locale 的助手回复本来就是英文。
+CARD_ASSIST_CHAT_EMPTY_REPLY_FALLBACK = {
+    "zh": "（嗯…我没想好怎么回，能再说一遍喵？）",
+    "zh-TW": "（嗯…我沒想好怎麼回，可以再說一次喵？）",
+    "en": "(Hmm... I'm not sure how to reply — could you say that again?)",
+}
+
+
 def get_card_assist_clarify_prompt(lang: str = "zh") -> str:
     return _loc(CARD_ASSIST_CLARIFY_PROMPT, lang)
 
@@ -401,3 +429,7 @@ def get_card_assist_chat_system_prompt(lang: str = "zh") -> str:
 
 def get_card_assist_chat_advice_only_directive(lang: str = "zh") -> str:
     return _loc(CARD_ASSIST_CHAT_ADVICE_ONLY_DIRECTIVE, lang)
+
+
+def get_card_assist_chat_empty_reply_fallback(lang: str = "zh") -> str:
+    return _loc(CARD_ASSIST_CHAT_EMPTY_REPLY_FALLBACK, lang)

--- a/config/prompts/prompts_galgame.py
+++ b/config/prompts/prompts_galgame.py
@@ -24,7 +24,21 @@ It localizes directly through prompts_sys._loc instead.
 """
 from __future__ import annotations
 
+from config.prompts._locale import normalize_prompt_locale
 from config.prompts.prompts_sys import _loc
+
+
+def normalize_galgame_locale(lang: str | None) -> str:
+    """Normalize a locale to a key of this module's prompt dicts, which include zh-TW.
+
+    Public on purpose, same reason as ``prompts_proactive.normalize_mini_game_invite_locale``:
+    the consumer is ``main_routers.galgame_router`` and the tables live here.
+
+    Every dict below carries all eight NEKO_CORE_LOCALES with Simplified Chinese
+    keyed as ``zh``, so this is the plain full-locale scheme -- ``keep_traditional``
+    stays on and nothing is filtered out.
+    """
+    return normalize_prompt_locale(lang, default='en', simplified='zh', keep_traditional=True)
 
 
 # {lanlan_name} = catgirl display name; {master_name} = chat partner display name.

--- a/config/prompts/prompts_icebreaker.py
+++ b/config/prompts/prompts_icebreaker.py
@@ -263,7 +263,8 @@ def _prompt_lang_from_data(data: dict[str, Any]) -> str:
 
     ``keep_traditional=True`` because this module's dicts do carry 'zh-TW'
     templates — hence the hand-rolled Traditional branch this used to have on
-    top of ``_normalize_prompt_lang``, which collapses zh-TW to zh.
+    top of ``_normalize_prompt_lang``, which collapsed zh-TW to zh until issue
+    #2500 step 2.
 
     Note this is the one prompt-layer normalizer whose input can be a raw HTTP
     request body value (``i18n_language`` / ``language``), with no upstream

--- a/config/prompts/prompts_minigame_common.py
+++ b/config/prompts/prompts_minigame_common.py
@@ -16,15 +16,16 @@
 """Shared helpers for minigame prompt modules (soccer, badminton).
 
 config/prompts deliberately keeps two locale-key schemes side by side. This
-module's ``_normalize_prompt_lang`` produces SHORT keys (every Chinese variant
-collapses to ``zh``) for soccer plus every system/pregame prompt; badminton
-quick-lines use FULL keys (``normalize_badminton_prompt_locale``), which keep
-``zh-CN`` and ``zh-TW`` apart.
+module's ``_normalize_prompt_lang`` keys Simplified Chinese as the short ``zh``
+for soccer plus every system/pregame prompt; badminton quick-lines use FULL keys
+(``normalize_badminton_prompt_locale``), which key it as ``zh-CN``. Since issue
+#2500 step 2 both schemes keep ``zh-TW`` as its own key — they now differ only
+in how they spell Simplified Chinese.
 
-Both now delegate to ``config.prompts._locale.normalize_prompt_locale`` and
-differ only in the keyword arguments they pass. The schemes themselves are
-still separate on purpose: collapsing badminton's full locales back to short
-would regress its Traditional Chinese fallbacks.
+Both delegate to ``config.prompts._locale.normalize_prompt_locale`` and differ
+only in the keyword arguments they pass. The schemes themselves stay separate
+because the two families of tables are keyed differently, not because either
+loses the script.
 
 See docs/contributing/developer-notes.md #7, PR #2000, and issue #2500.
 """
@@ -34,7 +35,7 @@ from config.prompts.prompts_sys import _loc
 
 
 def _normalize_prompt_lang(lang: str | None) -> str:
-    """Normalize a language code to a SHORT prompt-dict key.
+    """Normalize a language code to a prompt-dict key: a SHORT code, or ``zh-TW``.
 
     ``default="zh"`` is intentional and not a copy of the other prompt modules:
     the soccer/game module hardcodes Chinese-flavored helpers (e.g. the fullwidth
@@ -42,16 +43,20 @@ def _normalize_prompt_lang(lang: str | None) -> str:
     parameter at all), so the module-internal default is Chinese while the
     cross-module fallback (``resolve_global_language``) stays English.
 
-    ``keep_traditional=False`` even though every dict reached through this
-    normalizer now carries a ``'zh-TW'`` template (issue #2500 step 1). Flipping
-    it here would change nothing on its own: the callers still hand over a SHORT
-    code, which collapses Traditional upstream of this function. The flip belongs
-    to step 2 of issue #2500 — switching the call sites from
-    ``get_global_language()`` to ``get_global_language_full()`` — and has to land
-    in the same change, or Traditional users get Simplified from a normalizer
-    that claims to keep the script.
+    ``keep_traditional=True`` as of issue #2500 step 2. Every dict reached through
+    this normalizer carries a ``'zh-TW'`` template (step 1), and the game-route
+    call sites now hand over a FULL locale, so Traditional survives the whole way
+    down. The two halves had to land together: the flag alone changes nothing when
+    the callers pass a SHORT code that already collapsed the script, and the call
+    sites alone would hand Traditional users a normalizer that drops it.
+
+    Three tables are read as ``.get(key) or table["en"]`` rather than through
+    ``_loc``, so a ``zh-TW`` key they lack would fall to ENGLISH, not to Simplified
+    (``SOCCER_``/``BADMINTON_PREGAME_CONTEXT_FORMATTER_LABELS`` and every table
+    behind ``prompts_minigame_route._labels``). Adding a table here without a
+    ``zh-TW`` row is therefore a regression, not a soft fallback.
     """
-    return normalize_prompt_locale(lang, default="zh", simplified="zh", keep_traditional=False)
+    return normalize_prompt_locale(lang, default="zh", simplified="zh", keep_traditional=True)
 
 
 def _localized_template(templates: dict[str, str], lang: str | None) -> str:

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -3224,7 +3224,7 @@ def get_proactive_format_sections(
         [MEME]  = attach a meme image (triggers sending an image)
         [PASS]  = skip this proactive chat
     """
-    lang = _normalize_prompt_language(lang)
+    lang_key = _normalize_prompt_language(lang)
 
     # ── i18n 素材片段 ──────────────────────────────────────────────
     _material_labels = {
@@ -3312,7 +3312,7 @@ def get_proactive_format_sections(
     }
 
     # ── 动态拼接 source_instruction ────────────────────────────────
-    labels = _material_labels.get(lang, _material_labels["en"])
+    labels = _material_labels.get(lang_key, _material_labels["en"])
     available = []
     if has_screen:
         available.append(labels["screen"])
@@ -3334,14 +3334,14 @@ def get_proactive_format_sections(
             "ru": ", ",
             "es": ", ",
             "pt": ", ",
-        }.get(lang, ", ")
+        }.get(lang_key, ", ")
         mat_str = joiner.join(available)
         source_instruction = _combine_template.get(
-            lang, _combine_template["en"]
+            lang_key, _combine_template["en"]
         ).format(materials=mat_str)
-        source_instruction += _skip_if_boring.get(lang, _skip_if_boring["en"])
+        source_instruction += _skip_if_boring.get(lang_key, _skip_if_boring["en"])
     else:
-        source_instruction = _none_instruction.get(lang, _none_instruction["en"])
+        source_instruction = _none_instruction.get(lang_key, _none_instruction["en"])
 
     # ── 动态拼接 output_format_section ─────────────────────────────
     #
@@ -3483,15 +3483,15 @@ def get_proactive_format_sections(
 
     if effect_tags:
         # 有副作用 tag 时：[CHAT] + 各有副作用 tag + [PASS]
-        td = _tag_desc.get(lang, _tag_desc["en"])
-        header = _of_header.get(lang, _of_header["en"])
+        td = _tag_desc.get(lang_key, _tag_desc["en"])
+        header = _of_header.get(lang_key, _of_header["en"])
         tag_lines = [f"  {td['CHAT']}"]
         for t in effect_tags:
             tag_lines.append(f"  {td[t]}")
 
         # 选一个有副作用的 tag 作为示例（优先 MEME > MUSIC > WEB，后添加的优先）
         example_tag = effect_tags[-1]
-        examples = _of_example.get(lang, _of_example["en"])
+        examples = _of_example.get(lang_key, _of_example["en"])
         example_text = examples.get(example_tag, examples["CHAT"])
 
         output_format_section = (
@@ -3499,7 +3499,7 @@ def get_proactive_format_sections(
         )
     else:
         # 完全没有副作用 tag：不需要标签系统
-        output_format_section = _of_none.get(lang, _of_none["en"])
+        output_format_section = _of_none.get(lang_key, _of_none["en"])
 
     return source_instruction, output_format_section
 
@@ -3728,14 +3728,21 @@ MEME_TOPIC_NO_KEYWORD = {
 
 
 def get_meme_topic_line(lang: str, *, keyword: str, title: str, source: str) -> str:
-    """Assemble the meme topic line; includes the keyword when non-empty (describing the meme content), otherwise falls back to generic wording."""
+    """Assemble the meme topic line; includes the keyword when non-empty (describing the meme content), otherwise falls back to generic wording.
+
+    ``lang`` goes through ``_normalize_prompt_language`` like every other template
+    lookup in this module. It was the last pair reaching ``_loc`` with the caller's
+    raw value, which made the module's locale handling depend on which function you
+    happened to land in -- see the module note above ``_normalize_prompt_language``.
+    """
+    lang_key = _normalize_prompt_language(lang)
     # 先归一化空白：纯空白关键词（"   "）应视为无关键词，否则会误走带关键词模板。
     normalized_keyword = " ".join((keyword or "").split())
     if normalized_keyword:
-        return _loc(MEME_TOPIC_WITH_KEYWORD, lang).format(
+        return _loc(MEME_TOPIC_WITH_KEYWORD, lang_key).format(
             keyword=normalized_keyword, title=title, source=source
         )
-    return _loc(MEME_TOPIC_NO_KEYWORD, lang).format(title=title, source=source)
+    return _loc(MEME_TOPIC_NO_KEYWORD, lang_key).format(title=title, source=source)
 
 # ---------- Realtime 语音模式主动搭话文本触发（无视觉） ----------
 REALTIME_PROACTIVE_GENERAL_TRIGGER_PROMPTS = {

--- a/main_logic/omni_offline_client/_streaming.py
+++ b/main_logic/omni_offline_client/_streaming.py
@@ -247,7 +247,8 @@ class _StreamingMixin:
         the main model in the persona's voice, so the small model only needs to keep
         the existing tone and shorten the tail, not re-enact the persona. Language is
         detected from ``tail`` (the prefix may be very short; the tail is more
-        informative).
+        informative), with the session locale breaking the Simplified / Traditional
+        tie the detector cannot see.
         """
         if not (tail and tail.strip()):
             return None
@@ -273,9 +274,16 @@ class _StreamingMixin:
             return None
 
         try:
-            from utils.language_utils import detect_language, normalize_language_code
-            detected = detect_language(tail) or 'zh'
-            lang = normalize_language_code(detected, format='short') or 'zh'
+            from utils.language_utils import detect_prompt_language
+            # detect_language alone reports script families, so a Traditional tail
+            # comes back as 'zh' and the zh-TW row of LONG_RESPONSE_TAIL_SUMMARY_PROMPT
+            # is unreachable. detect_prompt_language refines that with the session's
+            # own locale, which is the only signal separating the two (issue #2500 step 2).
+            ui_language = None
+            provider = getattr(self, "_user_language_provider", None)
+            if provider:
+                ui_language = provider()
+            lang = detect_prompt_language(tail, default='zh', ui_language=ui_language) or 'zh'
         except Exception:
             lang = 'zh'
 

--- a/main_routers/card_assist_router.py
+++ b/main_routers/card_assist_router.py
@@ -43,12 +43,14 @@ from fastapi.responses import JSONResponse
 from config import CHARACTER_RESERVED_FIELDS
 from config.prompts.prompts_card_assist import (
     get_card_assist_chat_advice_only_directive,
+    get_card_assist_chat_empty_reply_fallback,
     get_card_assist_chat_system_prompt,
     get_card_assist_clarify_prompt,
     get_card_assist_generate_prompt,
     get_card_assist_refine_field_prompt,
+    normalize_card_assist_locale,
 )
-from utils.language_utils import get_global_language
+from utils.language_utils import get_global_language_full
 from utils.logger_config import get_module_logger
 
 from .shared_state import get_config_manager
@@ -88,22 +90,27 @@ _LLM_TIMEOUT_SECONDS = 60.0
 _ACTION_RECOVERY_SPLIT_MAX_FIELDS = 32
 
 def _resolve_language(payload_locale: str | None) -> str:
-    """Map a frontend locale (e.g. 'zh-CN', 'en-US') to the short prompt
-    language code ('zh' / 'en'). Falls back to the global language setting.
+    """Map a frontend locale (e.g. 'zh-CN', 'en-US') to a card-assist prompt
+    language key ('zh' / 'zh-TW' / 'en'). Falls back to the global language setting.
 
-    Prompt is currently only authored in zh & en; ja/ko/ru/pt/es get the en
+    Prompt is currently authored in zh, zh-TW & en; ja/ko/ru/pt/es get the en
     prompt (target field keys still pull the locale's own template — see
-    `_resolve_locale_code` + `_load_template_keys_for_locale`)."""
+    `_resolve_locale_code` + `_load_template_keys_for_locale`).
+
+    The global fallback reads `get_global_language_full()`, not the short getter:
+    the short one collapses Traditional to 'zh', which would leave every 'zh-TW'
+    template in `prompts_card_assist` unreachable for a Traditional user who did
+    not send a locale in the payload (issue #2500 step 2)."""
     if payload_locale:
         code = payload_locale.strip().lower()
         if code.startswith("zh"):
-            return "zh"
+            return normalize_card_assist_locale(code)
         if code.startswith("en"):
             return "en"
     try:
-        glob = (get_global_language() or "").strip().lower()
+        glob = (get_global_language_full() or "").strip().lower()
         if glob.startswith("zh"):
-            return "zh"
+            return normalize_card_assist_locale(glob)
     except Exception:
         pass
     return "en"
@@ -126,6 +133,11 @@ _SUPPORTED_LOCALE_FILES = {
 def _resolve_locale_code(payload_locale: str | None) -> str:
     """Pick the closest matching `config/characters/<x>.json` filename for
     the payload locale. Falls back to the global language setting, then `en`.
+
+    Like `_resolve_language`, the global fallback has to be the full code: the
+    short getter answers 'zh' for a Traditional user, which maps to the
+    Simplified `zh-CN.json` template and skips the `zh-TW` output-language
+    directive below (issue #2500 step 2).
     """
     if payload_locale:
         code = payload_locale.strip().lower()
@@ -136,7 +148,7 @@ def _resolve_locale_code(payload_locale: str | None) -> str:
         if primary in _SUPPORTED_LOCALE_FILES:
             return _SUPPORTED_LOCALE_FILES[primary]
     try:
-        glob = (get_global_language() or "").strip().lower()
+        glob = (get_global_language_full() or "").strip().lower()
         if glob in _SUPPORTED_LOCALE_FILES:
             return _SUPPORTED_LOCALE_FILES[glob]
         primary = glob.split("-", 1)[0]
@@ -147,11 +159,12 @@ def _resolve_locale_code(payload_locale: str | None) -> str:
     return "en"
 
 
-# `_resolve_locale_code` 的输出（角色卡模板文件名）→ (英文名, 本地名)。prompt 目前只写了
-# zh / en 两版（见 _resolve_language），ja/ko/ru/pt/es 会落到 en、zh-TW 会落到简中。这些
-# locale 如果不显式要求输出语言，助手就会用英文 / 简中提问、并把字段值也填成英文 / 简中
-# （Codex #3331696257）。所以对这些 locale 追加一条输出语言指示。en / zh-CN 与基础 prompt
-# 语言一致，不在表里（返回空指示）。
+# `_resolve_locale_code` 的输出（角色卡模板文件名）→ (英文名, 本地名)。prompt 目前写了
+# zh / zh-TW / en 三版（见 _resolve_language），ja/ko/ru/pt/es 会落到 en。这些 locale
+# 如果不显式要求输出语言，助手就会用英文提问、并把字段值也填成英文（Codex #3331696257）。
+# 所以对这些 locale 追加一条输出语言指示。en / zh-CN 与基础 prompt 语言一致，不在表里
+# （返回空指示）。zh-TW 现在虽然有了自己的 prompt 版本，仍留在表里：基础 prompt 只约束
+# 助手怎么想，这条指示约束它把字段值写成什么字，两者不互相取代。
 _LOCALE_OUTPUT_LANGUAGE: dict[str, tuple[str, str]] = {
     "zh-TW": ("Traditional Chinese", "繁體中文"),
     "ja": ("Japanese", "日本語"),
@@ -1709,8 +1722,12 @@ def _build_action_recovery_prompt(
     This is intentionally not a replacement for the companion persona prompt:
     the original reply stays visible to the user. This pass only recovers the
     structured actions the UI protocol needs.
+
+    Traditional Chinese shares the Simplified branch: this prompt is machinery
+    the user never sees, and the reply's own language is pinned separately by
+    ``_output_language_directive`` off ``locale_code``, which does keep zh-TW.
     """
-    if lang == "zh":
+    if lang.startswith("zh"):
         prompt = f"""你是角色卡动作恢复器，不要扮演角色，不要回复用户。
 
 用户原话：
@@ -2061,8 +2078,7 @@ async def chat(request: Request):
 
     if not reply and not actions:
         # LLM 既没回话也没动作 —— 给前端一个兜底文案，不然聊天框就僵住了。
-        reply = ("（嗯…我没想好怎么回，能再说一遍喵？）" if lang == "zh"
-                 else "(Hmm... I'm not sure how to reply — could you say that again?)")
+        reply = get_card_assist_chat_empty_reply_fallback(lang)
 
     response_payload = {
         "success": True,

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -42,10 +42,11 @@ from config.prompts.prompts_galgame import (
     get_galgame_dialogue_footer,
     get_galgame_dialogue_header,
     get_galgame_option_generation_prompt,
+    normalize_galgame_locale,
 )
 from config.prompts.prompts_sys import _loc
 from utils.file_utils import robust_json_loads
-from utils.language_utils import detect_language, normalize_language_code
+from utils.language_utils import detect_prompt_language
 from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm_async
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
@@ -64,16 +65,30 @@ GALGAME_OPTION_LABELS = ("A", "B", "C")
 
 
 def _resolve_language(text_sample: str, request_lang: str | None) -> str:
-    """Pick the best 'short' language code for the prompt."""
+    """Pick the prompt-dict key for the prompt: a short code, or 'zh-TW'.
+
+    Every dict in ``prompts_galgame`` is keyed by the eight core locales with a
+    ``zh-TW`` row of its own, so the request language is resolved at FULL width
+    (issue #2500 step 2). ``format='short'`` used to collapse Traditional into
+    Simplified here, which left those rows unreachable.
+
+    The detection branch cannot just be normalized the same way: ``detect_language``
+    reports script families, so Traditional and Simplified both come back as 'zh'
+    no matter what the user typed. ``detect_prompt_language`` is the pair that
+    refines a Chinese detection with the caller's own locale, which is the only
+    signal that separates the two.
+    """
     if request_lang:
         try:
-            return normalize_language_code(request_lang, format='short') or 'en'
+            return normalize_galgame_locale(request_lang)
         except Exception:
             # Bad language tag from the client — fall through to text-based detection.
             pass
     try:
         if text_sample.strip():
-            return normalize_language_code(detect_language(text_sample), format='short') or 'en'
+            # request_lang is unusable by the time we get here, so detect_prompt_language
+            # falls back to the process-wide full locale for the Chinese refinement.
+            return detect_prompt_language(text_sample, default='en', ui_language=request_lang)
     except Exception:
         # detect_language can choke on emoji-only / very short strings — default to en.
         pass

--- a/main_routers/game_router/game_context.py
+++ b/main_routers/game_router/game_context.py
@@ -435,7 +435,9 @@ def _build_game_context_organizer_payload(
 async def _run_game_context_organizer_ai(state: dict, snapshot: list[dict]) -> dict:
     """Summarize older in-game context and extract observable signals."""
     char_info = _get_game_route_summary_llm_info(str(state.get("lanlan_name") or ""))
-    language = char_info.get("user_language")
+    # 全码：organizer 的 system/user prompt、formatter labels 和 dialog memory line
+    # 都走 minigame 的 locale 表，短码会把繁体塌成 zh（issue #2500 第 2 步）。
+    language = char_info.get("user_language_full") or char_info.get("user_language")
     payload = _build_game_context_organizer_payload(state, snapshot, language)
     system_prompt = get_game_context_organizer_system_prompt(language)
     user_prompt = get_game_context_organizer_user_prompt(language).format(

--- a/main_routers/game_router/pregame.py
+++ b/main_routers/game_router/pregame.py
@@ -491,7 +491,11 @@ async def _run_soccer_pregame_context_ai(
         neko_initiated=neko_initiated,
         neko_invite_text=neko_invite_text,
         prompt_template=get_soccer_pregame_context_prompt(
-            prompt_locale or char_info.get("user_language")
+            # 兜底腿也要全码：prompt_locale 为空时才走到这里，短码会把繁体塌成 zh
+            # （issue #2500 第 2 步）。与本文件下面两处 `or user_language_full` 同形。
+            prompt_locale
+            or char_info.get("user_language_full")
+            or char_info.get("user_language")
         ),
         extra_payload={"gameType": "soccer"},
     )

--- a/main_routers/game_router/runtime.py
+++ b/main_routers/game_router/runtime.py
@@ -55,7 +55,6 @@ from .char_info import (
     _get_character_info,
     _get_current_character_info,
     _get_game_route_summary_llm_info,
-    _resolve_game_prompt_language,
     _resolve_game_prompt_locale,
 )
 from .game_context import (
@@ -161,6 +160,7 @@ from .session_pool import (  # noqa: F401
     _build_game_prompt,
     _close_and_remove_session,
     _game_session_create_locks,
+    _entry_prompt_locale,
     _game_session_key,
     _game_sessions,
     _get_or_create_session,
@@ -327,7 +327,7 @@ def _reset_game_session_text_history_for_turn(entry: dict, route_state: dict | N
     from utils.llm_client import SystemMessage
 
     instructions = str(entry.get("instructions") or getattr(session, "_instructions", "") or "")
-    language = entry.get("user_language") if isinstance(entry, dict) else None
+    language = _entry_prompt_locale(entry)
     history = [SystemMessage(content=instructions)] if instructions else []
     history.extend(_build_game_recent_history_messages(route_state, language))
     session._instructions = instructions
@@ -747,7 +747,7 @@ async def _run_game_chat(
                     event,
                     route_state,
                     lanlan_prompt=str(entry.get("lanlan_prompt") or ""),
-                    language=str(entry.get("user_language") or ""),
+                    language=_entry_prompt_locale(entry),
                 )
                 if anger_pressure_cap:
                     event = dict(event)
@@ -760,7 +760,7 @@ async def _run_game_chat(
                         event,
                         route_state,
                         lanlan_prompt=str(entry.get("lanlan_prompt") or ""),
-                        language=str(entry.get("user_language") or ""),
+                        language=_entry_prompt_locale(entry),
                     )
                     if anger_pressure_cap:
                         event = dict(event)
@@ -774,7 +774,7 @@ async def _run_game_chat(
                 event_payload = _json.dumps(llm_visible_event, ensure_ascii=False)
             else:
                 event_payload = str(llm_visible_event)
-            event_text = get_game_chat_event_user_prompt(entry.get("user_language")).format(event=event_payload)
+            event_text = get_game_chat_event_user_prompt(_entry_prompt_locale(entry)).format(event=event_payload)
 
             llm_started_at = time.perf_counter()
             try:
@@ -1051,7 +1051,7 @@ async def game_chat(game_type: str, request: Request):
     event = data.get('event', {})
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     # 把请求体里的 i18n 真值同步进 mgr.user_language，让本次 game_chat → _run_game_chat
-    # → _get_character_info 链上 _resolve_game_prompt_language 拿到的 user_language
+    # → _get_character_info 链上 _resolve_game_prompt_locale 拿到的 user_language_full
     # 与前端 i18n 保持一致，而不是被早期 start_session 覆盖回去的全局缓存值。
     _absorb_request_language(data, lanlan_name)
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
@@ -2386,7 +2386,9 @@ async def game_realtime_context(game_type: str, request: Request):
 
     # 直接把 data 传进去，让请求体里的 i18n_language 走第一层优先级（兼带回写
     # mgr.user_language），与其他 soccer 端点的 _absorb_request_language 调用同形。
-    language = _resolve_game_prompt_language(lanlan_name, data=data)
+    # 取全码而非短码：下游 get_compact_realtime_context_texts 走 minigame 的
+    # locale 表，短码会把繁体塌成 zh（issue #2500 第 2 步）。
+    language = _resolve_game_prompt_locale(lanlan_name, data)
     text = _compact_realtime_context_text(game_type, data, language)
     session_id = str((data.get("state") or {}).get("sessionId") or data.get("session_id") or "")
     _log_game_debug_material(
@@ -2706,13 +2708,23 @@ async def game_quick_lines(game_type: str, request: Request):
         except Exception:
             current_name = ""
         requested_name = _resolve_lanlan_name(data.get("lanlan_name") or current_name)
-        # quick-lines 是 soccer 流程里第一个 LLM 端点：接住 _absorb_request_language
-        # 的返回值，避免在 SessionManager 还没 ready / mgr 拿不到的窗口下，char_info 的
-        # user_language 仍 stale 在全局缓存的旧值（首批 quick lines 落英文）。
-        request_language = _absorb_request_language(data, requested_name)
-        request_language_full = _extract_request_language_full(data) if _is_badminton_game_type(game_type) else None
+        # quick-lines 是 soccer 流程里第一个 LLM 端点：请求体里的语言要直接用，而不是
+        # 只信 char_info —— SessionManager 还没 ready / mgr 拿不到的窗口下，char_info 的
+        # user_language 仍 stale 在全局缓存的旧值（首批 quick lines 落英文）。这里调
+        # _absorb_request_language 只为它的回写副作用（把真值同步进 mgr.user_language）；
+        # 本次要用的值由下面的 _extract_request_language_full 从同一个请求体取，取全码。
+        _absorb_request_language(data, requested_name)
+        # 全码，且不再只给 badminton 算：soccer 的 quick-lines 表自 #2706 起也有
+        # zh-TW 行，短码会把它塌掉。这个门原本无害，是因为 soccer 侧的 normalizer
+        # 当时本来就塌繁体；#2500 第 2 步把它翻成保留字形之后，这个门就成了繁中
+        # 用户开局第一批台词落简体的唯一原因。
+        request_language_full = _extract_request_language_full(data)
         char_info = _get_character_info(requested_name)
-        language = request_language_full or request_language or char_info.get("user_language")
+        language = (
+            request_language_full
+            or char_info.get("user_language_full")
+            or char_info.get("user_language")
+        )
         fallback_language = language
         cache_key = ""
         if _is_badminton_game_type(game_type):

--- a/main_routers/game_router/runtime.py
+++ b/main_routers/game_router/runtime.py
@@ -56,9 +56,15 @@ from .char_info import (
     _get_current_character_info,
     _get_game_route_summary_llm_info,
     _resolve_game_prompt_language,
+    _resolve_game_prompt_locale,
 )
 from .game_context import (
     _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT,
+    # 被 ``_run_soccer_passive_guard_ai`` 用着，但拆 runtime.py 上帝文件（#2270）时
+    # 漏在了这条 import 外面。端点那层的 ``except Exception`` 把 NameError 吞成
+    # ``{"ok": false, "reason": "exception"}``，所以 soccer 被动守卫一直静默退化成
+    # observe_more，没人看见。
+    _build_game_context_prompt_payload,
     _game_context_recent_dialogues,
 )
 from .memory_policy import (
@@ -950,7 +956,11 @@ def _normalize_passive_guard_result(value: Any, *, stage: Any, prompt_type: str)
 async def _run_soccer_passive_guard_ai(data: Dict[str, Any], lanlan_name: str) -> Dict[str, Any]:
     route_state = _find_game_route_state_for_session("soccer", str(data.get("session_id") or ""), lanlan_name)
     char_info = _get_game_route_summary_llm_info(lanlan_name)
-    language = _absorb_request_language(data, lanlan_name) or char_info.get("user_language")
+    # 全码：短码会把 zh-TW 塌成 zh，让 soccer prompt 的繁体模板变成够不到的死数据
+    # （#2500 第 2 步）。``_resolve_game_prompt_locale`` 是 ``_absorb_request_language``
+    # 那条优先级链的全码孪生——请求体 > mgr.user_language > 全局缓存，并且同样在请求体
+    # 带 i18n 真值时回写 mgr.user_language。
+    language = _resolve_game_prompt_locale(lanlan_name, data) or char_info.get("user_language_full")
     stage = data.get("stage")
     prompt_type = str(data.get("promptType") or "surrender").strip()
 

--- a/main_routers/game_router/session_pool.py
+++ b/main_routers/game_router/session_pool.py
@@ -38,7 +38,7 @@ import asyncio
 import re
 import time
 import uuid
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from config.prompts.prompts_soccer import get_soccer_system_prompt
 from config.prompts.prompts_badminton import (
     get_badminton_duel_difficulty_control_prompt,
@@ -86,6 +86,25 @@ def _get_session_create_lock(key: str) -> asyncio.Lock:
     if lock is None:
         lock = _game_session_create_locks.setdefault(key, asyncio.Lock())
     return lock
+
+
+def _entry_prompt_locale(entry: Any) -> str:
+    """The session entry's locale for prompt-template selection: FULL, keeping zh-TW.
+
+    Entries carry the same short/full pair ``_get_character_info`` produces. Every
+    consumer of this value hands it to a ``config.prompts`` accessor, and those
+    select templates by locale key, so the full code is the one they need: the
+    short ``user_language`` collapses Traditional into ``zh`` and makes the
+    ``zh-TW`` row of every minigame table unreachable (issue #2500 step 2).
+
+    ``or`` rather than a plain lookup because an entry built before the full field
+    existed -- or one a test hand-rolls -- still carries only the short code, and
+    the Simplified template is a better answer there than ``None``. Same idiom as
+    ``_refresh_game_session_instructions`` below and ``pregame``.
+    """
+    if not isinstance(entry, dict):
+        return ""
+    return str(entry.get("user_language_full") or entry.get("user_language") or "")
 
 
 def _build_game_prompt(
@@ -338,6 +357,10 @@ async def _build_and_register_game_session(
         'lanlan_name': char_info['lanlan_name'],
         'lanlan_prompt': char_info.get('lanlan_prompt') or '',
         'user_language': char_info.get('user_language'),
+        # 与 char_info 同形的短码/全码成对字段。读 prompt locale 一律走
+        # ``_entry_prompt_locale``，别直接读 ``user_language``（那是短码，会把
+        # 繁体塌成 zh，让 minigame 表的 zh-TW 行够不到 —— issue #2500 第 2 步）。
+        'user_language_full': char_info.get('user_language_full'),
         'source': _infer_service_source(
             char_info.get('base_url', ''),
             char_info.get('model', ''),
@@ -377,6 +400,7 @@ async def _refresh_game_session_instructions(
     lanlan_name = str(lanlan_name or entry.get("lanlan_name") or "").strip()
     char_info = _get_character_info(lanlan_name)
     entry["user_language"] = char_info.get("user_language")
+    entry["user_language_full"] = char_info.get("user_language_full")
     if postgame_snapshot is not None:
         pre_game_context = postgame_snapshot.get("pre_game_context")
         game_context = postgame_snapshot.get("game_context")

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1458,9 +1458,10 @@ def test_badminton_duel_difficulty_addendum_is_localized_per_full_locale():
 
     Asserted on the getter, which is the layer that has to keep zh-CN and zh-TW
     apart. ``_normalize_prompt_lang`` (the short-locale scheme the rest of this
-    module's tables use) collapses every Chinese variant to ``zh``; routing this
-    table through it would leave the zh-TW entry unreachable while still reading
-    as compliant to the static ``check_prompt_zh_tw`` gate.
+    module's tables use) spells Simplified Chinese ``zh``, so routing this table
+    through it would miss its ``zh-CN`` row. Until issue #2500 step 2 it also
+    collapsed zh-TW, which would have left that entry unreachable while still
+    reading as compliant to the static ``check_prompt_zh_tw`` gate.
     """
     get = prompts_badminton.get_badminton_duel_difficulty_control_prompt
 

--- a/tests/unit/test_proactive_prompt_locale_uniformity.py
+++ b/tests/unit/test_proactive_prompt_locale_uniformity.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""Every template lookup in prompts_proactive goes through one normalizer (issue #2500).
+
+The module resolves ~45 template lookups. All but one pair already ran the caller's
+language through ``_normalize_prompt_language`` (or one of its two siblings) before
+indexing a dict; ``get_meme_topic_line`` handed ``_loc`` the caller's raw value.
+
+That inconsistency is invisible today because the callers pass SHORT codes, which
+the normalizer leaves alone. It stops being invisible the moment step 2 flips those
+callers to full locales: the raw-value function would answer Traditional while every
+normalized one still answered Simplified (``keep_traditional=False``), mixing both
+scripts inside a single turn. Folding the last pair onto the shared path is what
+makes the later ``keep_traditional`` flip atomic.
+
+The guard below is derived from the module's own AST rather than from a list of
+function names — a list would silently stop covering whatever gets added next,
+which is how this pair survived in the first place.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import itertools
+
+import pytest
+
+from config.prompts import prompts_proactive as P
+
+# ``_resolve_proactive_locale(fmt="short")``'s full value range: everything a caller
+# can hand these functions today.
+CALLER_REACHABLE_LOCALES = ("zh", "en", "ja", "ko", "ru", "es", "pt")
+
+# The names that turn a caller's language into a prompt-dict key in this module.
+NORMALIZER_NAMES = frozenset({
+    "_normalize_prompt_language",
+    "_normalize_startup_greeting_language",
+    "normalize_mini_game_invite_locale",
+    "normalize_prompt_locale",
+})
+
+# Parameter names that carry a caller-supplied, not-yet-normalized language.
+RAW_LANGUAGE_PARAMS = frozenset({"lang", "language"})
+
+
+def _module_tree():
+    return ast.parse(inspect.getsource(P))
+
+
+def _lookup_key_nodes(node):
+    """Key expressions of the three lookup shapes this module uses."""
+    if isinstance(node, ast.Subscript):
+        yield node.slice
+    elif isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "get" and node.args:
+            yield node.args[0]
+        elif isinstance(func, ast.Name) and func.id == "_loc" and len(node.args) >= 2:
+            yield node.args[1]
+
+
+def _raw_language_lookups():
+    """Every place a raw language parameter is used directly as a lookup key.
+
+    A parameter stops counting as raw once the function reassigns that same name
+    from a normalizer, which is the ``lang = _normalize_prompt_language(lang)``
+    shape the module used before this change.
+    """
+    offenders = []
+    for fn in (n for n in ast.walk(_module_tree()) if isinstance(n, ast.FunctionDef)):
+        params = {a.arg for a in fn.args.args + fn.args.kwonlyargs} & RAW_LANGUAGE_PARAMS
+        if not params:
+            continue
+        laundered = set()
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                func = node.value.func
+                called = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+                if called in NORMALIZER_NAMES:
+                    laundered |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+        still_raw = params - laundered
+        if not still_raw:
+            continue
+        for node in ast.walk(fn):
+            for key in _lookup_key_nodes(node):
+                if isinstance(key, ast.Name) and key.id in still_raw:
+                    offenders.append((fn.name, node.lineno, key.id))
+    return sorted(offenders)
+
+
+def test_no_template_lookup_uses_a_raw_language_parameter():
+    offenders = _raw_language_lookups()
+    assert offenders == [], (
+        "these lookups index a prompt dict with the caller's raw language, so they "
+        "will disagree with the rest of the module once the callers move to full "
+        "locales: " + "; ".join(f"{fn}() L{ln} key={key}" for fn, ln, key in offenders)
+    )
+
+
+def test_the_guard_can_actually_fail():
+    """The AST guard is worth nothing if its shapes do not match real code.
+
+    Runs the same detector over a snippet written in the shape the module used
+    before this change, and requires it to be flagged.
+    """
+    tree = ast.parse(
+        "def f(lang):\n"
+        "    return _loc(D, lang)\n"
+    )
+    fn = tree.body[0]
+    keys = [
+        key.id
+        for node in ast.walk(fn)
+        for key in _lookup_key_nodes(node)
+        if isinstance(key, ast.Name)
+    ]
+    assert "lang" in keys
+
+
+# ── 行为面：今天零变化，C2 之后才会动 ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("lang", CALLER_REACHABLE_LOCALES)
+@pytest.mark.parametrize("keyword", ["", "   ", "猫咪"])
+def test_meme_topic_line_is_unchanged_for_every_locale_callers_can_pass(lang, keyword):
+    """Normalizing is a no-op on the short codes, which is why this commit ships alone.
+
+    ``_normalize_prompt_language`` is the identity on all seven, so routing the
+    lookup through it cannot move the output.
+    """
+    assert P._normalize_prompt_language(lang) == lang
+    direct = P._loc(P.MEME_TOPIC_NO_KEYWORD if not keyword.strip() else P.MEME_TOPIC_WITH_KEYWORD, lang)
+    built = P.get_meme_topic_line(lang, keyword=keyword, title="T", source="S")
+    assert built == direct.format(
+        **({"keyword": keyword.strip(), "title": "T", "source": "S"} if keyword.strip()
+           else {"title": "T", "source": "S"})
+    )
+
+
+@pytest.mark.parametrize("lang", CALLER_REACHABLE_LOCALES)
+def test_format_sections_are_unchanged_for_every_locale_callers_can_pass(lang):
+    for flags in itertools.product([False, True], repeat=4):
+        kwargs = dict(zip(("has_screen", "has_web", "has_music", "has_meme"), flags))
+        assert (
+            P.get_proactive_format_sections(lang=lang, **kwargs)
+            == P.get_proactive_format_sections(lang=P._normalize_prompt_language(lang), **kwargs)
+        )
+
+
+def test_the_whole_module_answers_one_script_for_a_traditional_locale():
+    """The point of the refactor: no function disagrees with the others.
+
+    ``keep_traditional`` is still ``False``, so the whole module answers Simplified
+    for ``zh-TW`` -- deliberately, and as one unit. Before, ``get_meme_topic_line``
+    was the single function answering Traditional, which is exactly the mixed-script
+    turn a later flip has to avoid.
+    """
+    meme_line = P.get_meme_topic_line("zh-TW", keyword="", title="T", source="S")
+    assert meme_line == P.get_meme_topic_line("zh", keyword="", title="T", source="S")
+    assert meme_line == P._loc(P.MEME_TOPIC_NO_KEYWORD, "zh").format(title="T", source="S")
+
+    source_instruction, _ = P.get_proactive_format_sections(
+        has_screen=True, has_web=False, has_music=False, has_meme=False, lang="zh-TW"
+    )
+    simplified, _ = P.get_proactive_format_sections(
+        has_screen=True, has_web=False, has_music=False, has_meme=False, lang="zh"
+    )
+    assert source_instruction == simplified
+
+
+@pytest.mark.parametrize("full_locale, short_key", [("zh-CN", "zh"), ("zh-TW", "zh")])
+def test_full_locales_resolve_without_falling_through_loc(full_locale, short_key, capsys):
+    """After step 2's caller flip, Simplified arrives as ``zh-CN``, not ``zh``.
+
+    ``_loc`` would answer that with a missing-key warning and a fallback. Going
+    through the normalizer first means the key is always one the dicts carry.
+    """
+    line = P.get_meme_topic_line(full_locale, keyword="", title="T", source="S")
+    assert line == P.get_meme_topic_line(short_key, keyword="", title="T", source="S")
+    assert "Unexpected lang code" not in capsys.readouterr().out

--- a/tests/unit/test_proactive_prompt_locale_uniformity.py
+++ b/tests/unit/test_proactive_prompt_locale_uniformity.py
@@ -42,8 +42,8 @@ NORMALIZER_NAMES = frozenset({
 RAW_LANGUAGE_PARAMS = frozenset({"lang", "language"})
 
 
-def _module_tree():
-    return ast.parse(inspect.getsource(P))
+def _module_tree(source: str | None = None):
+    return ast.parse(source if source is not None else inspect.getsource(P))
 
 
 def _lookup_key_nodes(node):
@@ -58,7 +58,7 @@ def _lookup_key_nodes(node):
             yield node.args[1]
 
 
-def _raw_language_lookups():
+def _raw_language_lookups(source: str | None = None):
     """Every place a raw language parameter is used directly as a lookup key.
 
     A parameter stops counting as raw once the function reassigns that same name
@@ -66,7 +66,7 @@ def _raw_language_lookups():
     shape the module used before this change.
     """
     offenders = []
-    for fn in (n for n in ast.walk(_module_tree()) if isinstance(n, ast.FunctionDef)):
+    for fn in (n for n in ast.walk(_module_tree(source)) if isinstance(n, ast.FunctionDef)):
         params = {a.arg for a in fn.args.args + fn.args.kwonlyargs} & RAW_LANGUAGE_PARAMS
         if not params:
             continue
@@ -99,21 +99,24 @@ def test_no_template_lookup_uses_a_raw_language_parameter():
 def test_the_guard_can_actually_fail():
     """The AST guard is worth nothing if its shapes do not match real code.
 
-    Runs the same detector over a snippet written in the shape the module used
-    before this change, and requires it to be flagged.
+    Calls ``_raw_language_lookups`` itself. The first version re-implemented the
+    inner walk inline, so it validated a COPY of the detector rather than the
+    detector -- an empty sweep from the real one would still have read green.
     """
-    tree = ast.parse(
-        "def f(lang):\n"
-        "    return _loc(D, lang)\n"
+    before = "def get_meme_topic_line(lang):\n    return _loc(D, lang)\n"
+    assert _raw_language_lookups(before), "detector missed the pre-change shape"
+
+    # 归一化之后必须不再报，否则这条守卫会把修好的代码也判红。
+    after = (
+        "def get_meme_topic_line(lang):\n"
+        "    lang_key = _normalize_prompt_language(lang)\n"
+        "    return _loc(D, lang_key)\n"
     )
-    fn = tree.body[0]
-    keys = [
-        key.id
-        for node in ast.walk(fn)
-        for key in _lookup_key_nodes(node)
-        if isinstance(key, ast.Name)
-    ]
-    assert "lang" in keys
+    assert _raw_language_lookups(after) == []
+
+    # 另外两种查表形状也要认得，否则改写成 .get / [] 就能绕过守卫。
+    assert _raw_language_lookups("def f(lang):\n    return D.get(lang, D['en'])\n")
+    assert _raw_language_lookups("def f(language):\n    return D[language]\n")
 
 
 # ── 行为面：今天零变化，C2 之后才会动 ────────────────────────────────────────
@@ -136,14 +139,69 @@ def test_meme_topic_line_is_unchanged_for_every_locale_callers_can_pass(lang, ke
     )
 
 
+# 每个 locale 在 source_instruction 里独有的字面片段。手写而不是从模块里取：
+# 这些片段住在 get_proactive_format_sections 的函数体内部（局部 dict），拿不到，
+# 而"从被测对象自己推导期望值"恰恰是下面这条测试要避开的东西。
+_SOURCE_INSTRUCTION_MARKERS = {
+    "zh": "你可以结合",
+    "en": "You may combine",
+    "ja": "組み合わせて",
+    "ko": "결합하여",
+    "ru": "комбинировать",
+    "es": "Puedes combinar",
+    "pt": "Você pode combinar",
+}
+
+# 素材名走的是另一张表（_material_labels），必须单独钉：只钉上面那张的话，把
+# 素材名表整个换成英文仍然全绿 —— 这是变异跑出来的，不是推理出来的。
+_MATERIAL_LABEL_MARKERS = {
+    "zh": "屏幕内容",
+    "en": "screen content",
+    "ja": "画面の内容",
+    "ko": "화면 내용",
+    "ru": "содержимое экрана",
+    "es": "contenido de pantalla",
+    "pt": "conteúdo da tela",
+}
+
+
 @pytest.mark.parametrize("lang", CALLER_REACHABLE_LOCALES)
-def test_format_sections_are_unchanged_for_every_locale_callers_can_pass(lang):
+def test_format_sections_select_that_locales_own_text(lang):
+    """An independent oracle, not the function compared against itself.
+
+    The first version asserted ``f(lang) == f(_normalize_prompt_language(lang))``.
+    Since the sibling test pins the normalizer as the identity on exactly these
+    seven codes, that was ``f(x) == f(x)`` -- green even if the function returned
+    a constant, or English for everyone. Assert the locale's own wording instead.
+    """
+    marker = _SOURCE_INSTRUCTION_MARKERS[lang]
+    seen = set()
     for flags in itertools.product([False, True], repeat=4):
         kwargs = dict(zip(("has_screen", "has_web", "has_music", "has_meme"), flags))
-        assert (
-            P.get_proactive_format_sections(lang=lang, **kwargs)
-            == P.get_proactive_format_sections(lang=P._normalize_prompt_language(lang), **kwargs)
+        source_instruction, output_format_section = P.get_proactive_format_sections(lang=lang, **kwargs)
+        assert source_instruction and output_format_section
+        if any(flags):
+            assert marker in source_instruction, (
+                f"{lang} did not select its own source_instruction wording"
+            )
+        if kwargs["has_screen"]:
+            assert _MATERIAL_LABEL_MARKERS[lang] in source_instruction, (
+                f"{lang} did not select its own material label"
+            )
+        seen.add((source_instruction, output_format_section))
+    # 16 种素材组合不能全塌成同一段文案，否则 has_* 分支根本没起作用。
+    assert len(seen) > 1
+
+
+def test_every_locale_gets_distinct_format_sections():
+    """No locale silently rides another's text -- the failure a self-comparison hides."""
+    rendered = {
+        lang: P.get_proactive_format_sections(
+            has_screen=True, has_web=True, has_music=False, has_meme=False, lang=lang
         )
+        for lang in CALLER_REACHABLE_LOCALES
+    }
+    assert len(set(rendered.values())) == len(rendered), "有 locale 拿到了别人的文案"
 
 
 def test_the_whole_module_answers_one_script_for_a_traditional_locale():
@@ -165,6 +223,12 @@ def test_the_whole_module_answers_one_script_for_a_traditional_locale():
         has_screen=True, has_web=False, has_music=False, has_meme=False, lang="zh"
     )
     assert source_instruction == simplified
+    # 单靠上面那条相等断言是空的：归一化器把 'zh-TW' 和 'zh' 映到同一个键，两边
+    # 本来就是同一次调用，任何确定性实现都能过 —— 包括"所有人都拿英文"。所以还要
+    # 钉住内容确实是简体那一行，且不是繁体、不是英文。
+    assert _MATERIAL_LABEL_MARKERS["zh"] in source_instruction      # 屏幕内容
+    assert "螢幕內容" not in source_instruction                      # 繁体写法
+    assert _MATERIAL_LABEL_MARKERS["en"] not in source_instruction  # screen content
 
 
 @pytest.mark.parametrize("full_locale, short_key", [("zh-CN", "zh"), ("zh-TW", "zh")])

--- a/tests/unit/test_prompt_locale_normalizer.py
+++ b/tests/unit/test_prompt_locale_normalizer.py
@@ -44,6 +44,11 @@ PROMPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "config" / "prompts"
 # The six module normalizers collapse to four distinct behaviors. chara, memory
 # and avatar_interaction share one column: same default, same simplified key,
 # both keeping zh-TW.
+#
+# Since issue #2500 step 2 the minigame column keeps zh-TW too, so it now differs
+# from traditional_aware only in its empty-input default ('zh' vs 'en'). proactive
+# is the one column still collapsing Traditional, waiting on its own call-site
+# flip in main_logic/proactive_chat/service.py.
 COLUMNS = ("proactive", "minigame", "traditional_aware", "badminton")
 
 MODULE_NORMALIZERS = {
@@ -72,21 +77,21 @@ EXPECTED = {
     "ja": ("ja", "ja", "ja", "ja"),
     "ko": ("ko", "ko", "ko", "ko"),
     "zh-CN": ("zh", "zh", "zh", "zh-CN"),
-    "zh-TW": ("zh", "zh", "zh-TW", "zh-TW"),
+    "zh-TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
     "ru": ("ru", "ru", "ru", "ru"),
     "pt": ("pt", "pt", "pt", "pt"),
     "es": ("es", "es", "es", "es"),
     # Short Chinese and its spellings.
     "zh": ("zh", "zh", "zh", "zh-CN"),
-    "zh-Hant": ("zh", "zh", "zh-TW", "zh-TW"),
+    "zh-Hant": ("zh", "zh-TW", "zh-TW", "zh-TW"),
     "zh-Hans": ("zh", "zh", "zh", "zh-CN"),
-    "zh-HK": ("zh", "zh", "zh-TW", "zh-TW"),
-    "zh-hant-TW": ("zh", "zh", "zh-TW", "zh-TW"),
+    "zh-HK": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "zh-hant-TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
     # Case, underscore and surrounding whitespace must not change the answer.
-    "ZH-TW": ("zh", "zh", "zh-TW", "zh-TW"),
-    "zh_TW": ("zh", "zh", "zh-TW", "zh-TW"),
-    "  zh-TW  ": ("zh", "zh", "zh-TW", "zh-TW"),
-    "zh-tw": ("zh", "zh", "zh-TW", "zh-TW"),
+    "ZH-TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "zh_TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "  zh-TW  ": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "zh-tw": ("zh", "zh-TW", "zh-TW", "zh-TW"),
     # Region subtags.
     "en-US": ("en", "en", "en", "en"),
     "ja-JP": ("ja", "ja", "ja", "ja"),
@@ -98,7 +103,7 @@ EXPECTED = {
     # Steam store language codes. Every module resolves these now; before the
     # collapse only minigame and badminton did, and the rest fell to English.
     "schinese": ("zh", "zh", "zh", "zh-CN"),
-    "tchinese": ("zh", "zh", "zh-TW", "zh-TW"),
+    "tchinese": ("zh", "zh-TW", "zh-TW", "zh-TW"),
     "english": ("en", "en", "en", "en"),
     "japanese": ("ja", "ja", "ja", "ja"),
     "koreana": ("ko", "ko", "ko", "ko"),
@@ -108,7 +113,7 @@ EXPECTED = {
     "latam": ("es", "es", "es", "es"),
     "portuguese": ("pt", "pt", "pt", "pt"),
     "brazilian": ("pt", "pt", "pt", "pt"),
-    "TChinese": ("zh", "zh", "zh-TW", "zh-TW"),
+    "TChinese": ("zh", "zh-TW", "zh-TW", "zh-TW"),
     # Empty input takes the per-module default; the minigame and badminton
     # modules intentionally default to Chinese rather than English.
     "": ("en", "zh", "en", "zh-CN"),

--- a/tests/unit/test_zh_tw_minigame_full_locale_migration.py
+++ b/tests/unit/test_zh_tw_minigame_full_locale_migration.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+"""The rest of the minigame family stops collapsing the locale (issue #2500 step 2).
+
+The first pass migrated only the soccer passive guard. An audit of the whole family
+(transitive closure over the four minigame prompt modules, then every call site's
+locale source in main_routers/game_router/) found five more root producers still
+handing over a SHORT code, so every zh-TW row behind them stayed unreachable data:
+
+  1. /api/{game_type}/realtime-context  — _resolve_game_prompt_language
+  2. /api/soccer/quick-lines            — request_language_full was computed for badminton only
+  3. session entry entry["user_language"] — recent-history labels, anger-cap copy, chat event prompt
+  4. context organizer                  — char_info["user_language"]
+  5. soccer pregame fallback leg        — char_info["user_language"]
+
+None of the five was a regression: a SHORT code in meant the normalizer collapsed
+it exactly as before. They were simply not migrated.
+
+Two guards, deliberately different in shape, because neither alone covers the family:
+the AST scan is precise but sees one assignment hop, and the producer invariants are
+coarse but cross function boundaries. Both are validated against the pre-migration
+shape rather than merely asserted to pass.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import pathlib
+
+import pytest
+
+import utils.llm_client as llm_client_module
+from config.prompts.prompts_minigame_route import (
+    get_game_chat_event_user_prompt,
+    get_game_context_organizer_system_prompt,
+)
+from main_routers.game_router import game_context as gr_game_context
+from main_routers.game_router import session_pool as gr_session_pool
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+GAME_ROUTER_DIR = REPO_ROOT / "main_routers" / "game_router"
+
+# Sources that yield a FULL locale. Any of these in the expression makes it
+# compliant -- `full or short` is a deliberate degrade (an entry built before the
+# field existed still has only the short code), not a collapse of the script.
+_FULL_PRODUCERS = (
+    "user_language_full",
+    "_resolve_game_prompt_locale",
+    "_extract_request_language_full",
+    "_archive_prompt_language",
+    "_entry_prompt_locale",
+    "prompt_locale",
+)
+_SHORT_PRODUCERS = ("_resolve_game_prompt_language", "_absorb_request_language")
+
+
+def _minigame_accessor_names() -> set[str]:
+    """Public accessors reaching ``_normalize_prompt_lang``, via AST transitive closure.
+
+    Discovered rather than listed: a hand-written list only covers the functions
+    that existed the day it was written.
+    """
+    reaching = {"_normalize_prompt_lang", "_localized_template", "_labels"}
+    trees = {
+        name: ast.parse((REPO_ROOT / "config" / "prompts" / f"{name}.py").read_text(encoding="utf-8"))
+        for name in (
+            "prompts_soccer",
+            "prompts_badminton",
+            "prompts_minigame_route",
+            "prompts_minigame_common",
+        )
+    }
+    for _ in range(6):
+        for tree in trees.values():
+            for fn in ast.walk(tree):
+                if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                called = {
+                    node.func.id
+                    for node in ast.walk(fn)
+                    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                }
+                if called & reaching:
+                    reaching.add(fn.name)
+    return {name for name in reaching if not name.startswith("_")}
+
+
+def _is_short_only(expr_src: str) -> bool:
+    if any(marker in expr_src for marker in _FULL_PRODUCERS):
+        return False
+    if any(marker in expr_src for marker in _SHORT_PRODUCERS):
+        return True
+    index = 0
+    while True:
+        index = expr_src.find("user_language", index)
+        if index < 0:
+            return False
+        if not expr_src[index:].startswith("user_language_full"):
+            return True
+        index += 1
+
+
+def _short_only_lookups(root: pathlib.Path) -> list[str]:
+    """Locale arguments handed to a minigame accessor from a short-only source."""
+    accessors = _minigame_accessor_names()
+    offenders: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            assigns: dict[str, str] = {}
+            for node in ast.walk(fn):
+                if (
+                    isinstance(node, ast.Assign)
+                    and len(node.targets) == 1
+                    and isinstance(node.targets[0], ast.Name)
+                ):
+                    assigns[node.targets[0].id] = ast.get_source_segment(src, node.value) or ""
+            for node in ast.walk(fn):
+                if not (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id in accessors
+                ):
+                    continue
+                args = list(node.args) + [
+                    kw.value for kw in node.keywords if kw.arg in (None, "lang", "language")
+                ]
+                for arg in args:
+                    arg_src = ast.get_source_segment(src, arg) or ""
+                    resolved = assigns.get(arg_src, arg_src) if isinstance(arg, ast.Name) else arg_src
+                    if _is_short_only(resolved):
+                        flat = " ".join(resolved.split())[:70]
+                        offenders.append(f"{path.name}:{node.lineno} {node.func.id}(<- {flat})")
+    return sorted(set(offenders))
+
+
+def test_no_minigame_prompt_lookup_is_fed_by_a_short_only_source():
+    """Auto-discovered, not a checklist.
+
+    LIMIT, stated so a green is not read as more than it is: this resolves one
+    hop (a local assignment in the same function). A locale arriving as a plain
+    parameter and passed straight on is invisible here -- those paths are pinned
+    by ``test_short_locale_producers_are_gone_from_the_prompt_paths`` instead.
+    """
+    offenders = _short_only_lookups(GAME_ROUTER_DIR)
+    assert offenders == [], (
+        "these hand a minigame prompt accessor a SHORT-only locale, so every zh-TW "
+        "row behind them stays unreachable: " + "; ".join(offenders)
+    )
+
+
+def test_the_ast_guard_can_actually_fail(tmp_path):
+    """A guard whose shapes do not match real code is worth nothing.
+
+    Feeds the detector the exact shape runtime.py carried before this change.
+    """
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "def f(entry):\n"
+        "    return get_game_chat_event_user_prompt(entry.get('user_language'))\n",
+        encoding="utf-8",
+    )
+    assert _short_only_lookups(tmp_path), "detector failed to flag a known-bad shape"
+
+
+def test_the_accessor_discovery_is_not_empty():
+    """An empty accessor set would make the scan above vacuously green."""
+    accessors = _minigame_accessor_names()
+    assert len(accessors) >= 20
+    assert "get_soccer_quick_lines_prompt" in accessors
+    assert "get_game_chat_event_user_prompt" in accessors
+
+
+def test_short_locale_producers_are_gone_from_the_prompt_paths():
+    """Covers the cross-function pass-through the AST scan cannot see.
+
+    ``_resolve_game_prompt_language`` and a bare ``entry["user_language"]`` were the
+    two short-only producers reaching minigame prompts through a parameter hop
+    (realtime-context; recent-history labels and the anger-cap copy). Both have a
+    full-code twin now, so neither belongs on these paths. ``char_info.py`` is
+    excluded on purpose: it is where the SHORT field is legitimately produced.
+    """
+    callers = [
+        path.name
+        for path in sorted(GAME_ROUTER_DIR.glob("*.py"))
+        if path.name != "char_info.py"
+        and "_resolve_game_prompt_language(" in path.read_text(encoding="utf-8")
+    ]
+    assert callers == [], (
+        f"these still call the SHORT resolver instead of _resolve_game_prompt_locale: {callers}"
+    )
+
+    runtime_src = (GAME_ROUTER_DIR / "runtime.py").read_text(encoding="utf-8")
+    assert 'entry.get("user_language")' not in runtime_src, (
+        "runtime.py reads the entry's SHORT locale directly; use _entry_prompt_locale"
+    )
+    assert "_extract_request_language_full(data) if _is_badminton" not in runtime_src, (
+        "quick-lines computes the full locale for badminton only, so soccer's zh-TW "
+        "quick-lines rows stay unreachable behind that gate"
+    )
+
+
+def test_every_entry_write_site_sets_the_full_locale():
+    """``_entry_prompt_locale`` is only as good as what the entry actually carries.
+
+    Found by mutation: dropping ``user_language_full`` from the entry dict left the
+    whole suite green, because every other test here hands the helper a hand-rolled
+    entry. Both write sites -- construction and refresh -- are pinned here, and the
+    count is asserted so a third one added later cannot quietly skip the field.
+    """
+    src = (GAME_ROUTER_DIR / "session_pool.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    short_writes, full_writes = [], []
+    for node in ast.walk(tree):
+        # entry["user_language"] = ... / entry["user_language_full"] = ...
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "entry"
+                    and isinstance(target.slice, ast.Constant)
+                ):
+                    if target.slice.value == "user_language":
+                        short_writes.append(node.lineno)
+                    elif target.slice.value == "user_language_full":
+                        full_writes.append(node.lineno)
+        # {'user_language': ..., 'user_language_full': ...}
+        if isinstance(node, ast.Dict):
+            keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
+            if "user_language" in keys:
+                short_writes.append(node.lineno)
+                if "user_language_full" in keys:
+                    full_writes.append(node.lineno)
+
+    assert short_writes, "no entry write site found -- the scan stopped matching the code"
+    assert len(full_writes) == len(short_writes), (
+        "every place session_pool writes the entry's short locale must write the full "
+        f"one too; short at lines {sorted(short_writes)}, full at {sorted(full_writes)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "entry, expected",
+    [
+        ({"user_language": "zh", "user_language_full": "zh-TW"}, "zh-TW"),
+        ({"user_language": "zh", "user_language_full": "zh-CN"}, "zh-CN"),
+        # 老 entry（建于该字段存在之前）退回短码，而不是 None。
+        ({"user_language": "zh"}, "zh"),
+        ({"user_language": "zh", "user_language_full": None}, "zh"),
+        ({}, ""),
+        (None, ""),
+    ],
+)
+def test_entry_prompt_locale_prefers_the_full_code(entry, expected):
+    assert gr_session_pool._entry_prompt_locale(entry) == expected
+
+
+def test_entry_prompt_locale_reaches_the_traditional_template():
+    """Returning 'zh-TW' is not the point -- selecting the Traditional row is.
+
+    Asserted through ``get_game_context_organizer_system_prompt`` rather than
+    ``get_game_chat_event_user_prompt``: the latter is one of the paired
+    above/below input watermarks, which are deliberately the SAME Chinese string
+    in all eight locales (they mark a data-block boundary for the model, they are
+    not copy), so it can never tell the two scripts apart. See the note above
+    ``PREGAME_CONTEXT_INPUT_WATERMARK`` in prompts_minigame_common.
+    """
+    entry = {"user_language": "zh", "user_language_full": "zh-TW"}
+    locale = gr_session_pool._entry_prompt_locale(entry)
+    traditional = get_game_context_organizer_system_prompt(locale)
+    assert traditional == get_game_context_organizer_system_prompt("zh-TW")
+    assert traditional != get_game_context_organizer_system_prompt("zh")
+
+    # 水印表照旧逐 locale 相同 —— 这是有意的，不是没翻。
+    assert get_game_chat_event_user_prompt("zh-TW") == get_game_chat_event_user_prompt("zh")
+
+
+class _FakeResult:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def ainvoke(self, messages):
+        self._sink.append(messages)
+        return _FakeResult('{"rollingSummary":"x","signals":{}}')
+
+
+def test_context_organizer_uses_the_traditional_prompt(monkeypatch):
+    """End-to-end through the real ``_run_game_context_organizer_ai`` body."""
+    sink: list = []
+    monkeypatch.setattr(
+        gr_game_context,
+        "_get_game_route_summary_llm_info",
+        lambda *a, **k: {
+            "model": "m",
+            "base_url": "http://localhost",
+            "api_key": "k",
+            "provider_type": "openai",
+            "api_type": "openai",
+            "user_language": "zh",
+            "user_language_full": "zh-TW",
+        },
+    )
+
+    async def _fake_create(*args, **kwargs):
+        return _FakeLLM(sink)
+
+    monkeypatch.setattr(llm_client_module, "create_chat_llm_async", _fake_create)
+
+    state = {"lanlan_name": "Lan", "game_type": "soccer", "session_id": "s1"}
+    asyncio.run(gr_game_context._run_game_context_organizer_ai(state, []))
+
+    assert sink, "LLM 没被调用，说明前置分支提前返回了"
+    system_text = sink[0][0].content
+    assert system_text == get_game_context_organizer_system_prompt("zh-TW")
+    assert system_text != get_game_context_organizer_system_prompt("zh")
+
+
+def test_context_organizer_stays_simplified_for_a_simplified_session(monkeypatch):
+    sink: list = []
+    monkeypatch.setattr(
+        gr_game_context,
+        "_get_game_route_summary_llm_info",
+        lambda *a, **k: {
+            "model": "m",
+            "base_url": "http://localhost",
+            "api_key": "k",
+            "provider_type": "openai",
+            "api_type": "openai",
+            "user_language": "zh",
+            "user_language_full": "zh-CN",
+        },
+    )
+
+    async def _fake_create(*args, **kwargs):
+        return _FakeLLM(sink)
+
+    monkeypatch.setattr(llm_client_module, "create_chat_llm_async", _fake_create)
+
+    state = {"lanlan_name": "Lan", "game_type": "soccer", "session_id": "s1"}
+    asyncio.run(gr_game_context._run_game_context_organizer_ai(state, []))
+    assert sink[0][0].content == get_game_context_organizer_system_prompt("zh")

--- a/tests/unit/test_zh_tw_minigame_prompt_locale.py
+++ b/tests/unit/test_zh_tw_minigame_prompt_locale.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import pathlib
 from types import SimpleNamespace
 
 import pytest
@@ -28,13 +29,29 @@ from config.prompts.prompts_minigame_common import _normalize_prompt_lang
 from main_routers.game_router import char_info as gr_char_info
 from main_routers.game_router import runtime as gr_runtime
 
-# 走 _normalize_prompt_lang 的四个模块。
-MINIGAME_PROMPT_MODULES = (
-    "config.prompts.prompts_soccer",
-    "config.prompts.prompts_badminton",
-    "config.prompts.prompts_minigame_route",
-    "config.prompts.prompts_minigame_common",
-)
+PROMPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "config" / "prompts"
+
+
+def _minigame_prompt_modules() -> tuple[str, ...]:
+    """Every config/prompts module on ``_normalize_prompt_lang``, found via imports.
+
+    This was a hardcoded 4-tuple while the docstring below claimed discovery --
+    exactly the checklist-gap failure it warns about. A fifth module importing the
+    helper would be skipped silently by the coverage guard, and a missing zh-TW row
+    there costs a Traditional user ENGLISH, not Simplified (the three
+    ``.get(k) or table["en"]`` consumers).
+    """
+    found = ["config.prompts.prompts_minigame_common"]
+    for path in sorted(PROMPTS_DIR.glob("prompts_*.py")):
+        if path.stem == "prompts_minigame_common":
+            continue
+        src = path.read_text(encoding="utf-8")
+        if "prompts_minigame_common import" in src or "from config.prompts.prompts_minigame_common" in src:
+            found.append(f"config.prompts.{path.stem}")
+    return tuple(found)
+
+
+MINIGAME_PROMPT_MODULES = _minigame_prompt_modules()
 
 
 @pytest.mark.parametrize(
@@ -88,6 +105,20 @@ def test_every_minigame_table_carries_a_traditional_row(module_name, attr, table
 def test_the_coverage_check_actually_found_tables():
     """A zero-table sweep would make the parametrized test vacuously green."""
     assert len(_chinese_tables()) >= 20
+
+
+def test_the_module_discovery_finds_every_minigame_consumer():
+    """The module list is discovered from imports, so a fifth module cannot slip past.
+
+    Pinned by name as well as by count: discovery returning a short list is the
+    same silent-hole failure as the hand-written tuple this replaced.
+    """
+    assert set(MINIGAME_PROMPT_MODULES) == {
+        "config.prompts.prompts_minigame_common",
+        "config.prompts.prompts_soccer",
+        "config.prompts.prompts_badminton",
+        "config.prompts.prompts_minigame_route",
+    }
 
 
 def test_soccer_prompts_differ_by_script():

--- a/tests/unit/test_zh_tw_minigame_prompt_locale.py
+++ b/tests/unit/test_zh_tw_minigame_prompt_locale.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""The minigame prompt chain keeps Traditional Chinese end to end (issue #2500 step 2).
+
+Two halves that only work together, which is why they ship in one commit:
+
+* ``prompts_minigame_common._normalize_prompt_lang`` now passes
+  ``keep_traditional=True``. On its own that changes nothing — a caller handing
+  over a SHORT code has already collapsed the script upstream.
+* ``_run_soccer_passive_guard_ai`` now resolves the FULL locale. On its own that
+  changes nothing either — the normalizer would have collapsed it right back.
+
+The zh-TW coverage test below is not decoration. Three consumers read these
+tables as ``.get(key) or table["en"]`` rather than through ``_loc``, so a table
+missing a ``zh-TW`` row does not fall back to Simplified — it falls back to
+ENGLISH. Widening the normalizer is only safe while that coverage holds.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+import utils.llm_client as llm_client_module
+from config.prompts import prompts_soccer
+from config.prompts.prompts_minigame_common import _normalize_prompt_lang
+from main_routers.game_router import char_info as gr_char_info
+from main_routers.game_router import runtime as gr_runtime
+
+# 走 _normalize_prompt_lang 的四个模块。
+MINIGAME_PROMPT_MODULES = (
+    "config.prompts.prompts_soccer",
+    "config.prompts.prompts_badminton",
+    "config.prompts.prompts_minigame_route",
+    "config.prompts.prompts_minigame_common",
+)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("zh-TW", "zh-TW"),
+        ("zh-Hant", "zh-TW"),
+        ("zh-HK", "zh-TW"),
+        ("tchinese", "zh-TW"),
+        ("zh-CN", "zh"),
+        ("zh", "zh"),
+        ("schinese", "zh"),
+        ("en", "en"),
+        ("ja", "ja"),
+        (None, "zh"),
+        ("", "zh"),
+    ],
+)
+def test_minigame_normalizer_keeps_the_script(raw, expected):
+    assert _normalize_prompt_lang(raw) == expected
+
+
+def _chinese_tables():
+    """Every locale table in the minigame modules, discovered from the modules.
+
+    Discovered rather than listed: a hand-written list stops covering whatever is
+    added next, and for the three ``.get(key) or table["en"]`` consumers the cost
+    of a miss is an English prompt for a Traditional user, not a Simplified one.
+    """
+    found = []
+    for module_name in MINIGAME_PROMPT_MODULES:
+        module = importlib.import_module(module_name)
+        for attr in dir(module):
+            value = getattr(module, attr)
+            if isinstance(value, dict) and "zh" in value and "en" in value:
+                found.append((module_name, attr, value))
+    return found
+
+
+@pytest.mark.parametrize(
+    "module_name, attr, table",
+    [pytest.param(m, a, t, id=f"{m.rsplit('.', 1)[-1]}.{a}") for m, a, t in _chinese_tables()],
+)
+def test_every_minigame_table_carries_a_traditional_row(module_name, attr, table):
+    assert "zh-TW" in table, (
+        f"{module_name}.{attr} has no zh-TW row; _normalize_prompt_lang now emits "
+        "'zh-TW', and the .get(key) or table['en'] consumers would answer ENGLISH"
+    )
+
+
+def test_the_coverage_check_actually_found_tables():
+    """A zero-table sweep would make the parametrized test vacuously green."""
+    assert len(_chinese_tables()) >= 20
+
+
+def test_soccer_prompts_differ_by_script():
+    traditional = prompts_soccer.get_soccer_passive_guard_system_prompt("zh-TW")
+    simplified = prompts_soccer.get_soccer_passive_guard_system_prompt("zh-CN")
+    assert traditional == prompts_soccer.SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS["zh-TW"]
+    assert simplified == prompts_soccer.SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS["zh"]
+    assert traditional != simplified
+
+
+# ── 端到端：soccer 被动守卫端点 ────────────────────────────────────────────
+
+
+class _FakeResult:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def ainvoke(self, messages):
+        self._sink.append(messages)
+        return _FakeResult('{"classification":"ordinary","confidence":0.5}')
+
+
+def _run_passive_guard(monkeypatch, *, session_language, request_body=None):
+    """Drive the real ``_run_soccer_passive_guard_ai`` and capture its prompts."""
+    sink: list = []
+
+    manager = SimpleNamespace(user_language=session_language, _user_language_explicit=True)
+    monkeypatch.setattr(gr_char_info, "get_session_manager", lambda: {"Lan": manager})
+    monkeypatch.setattr(gr_char_info, "get_global_language_full", lambda: "en")
+    monkeypatch.setattr(gr_runtime, "_find_game_route_state_for_session", lambda *a, **k: None)
+    monkeypatch.setattr(
+        gr_runtime,
+        "_get_game_route_summary_llm_info",
+        lambda *a, **k: {
+            "model": "m",
+            "base_url": "http://localhost",
+            "api_key": "k",
+            "provider_type": "openai",
+            "user_language": "en",
+            "user_language_full": "en",
+        },
+    )
+
+    async def _fake_create(*args, **kwargs):
+        return _FakeLLM(sink)
+
+    monkeypatch.setattr(llm_client_module, "create_chat_llm_async", _fake_create)
+
+    data = dict(request_body or {})
+    data.setdefault("session_id", "s1")
+    data.setdefault("stage", 9)
+    asyncio.run(gr_runtime._run_soccer_passive_guard_ai(data, "Lan"))
+    assert sink, "LLM 没被调用"
+    return sink[0][0].content
+
+
+def test_passive_guard_prompt_is_traditional_for_a_traditional_session(monkeypatch):
+    system_text = _run_passive_guard(monkeypatch, session_language="zh-TW")
+    assert system_text == prompts_soccer.SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS["zh-TW"]
+    assert system_text != prompts_soccer.SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS["zh"]
+
+
+def test_passive_guard_prompt_stays_simplified_for_a_simplified_session(monkeypatch):
+    system_text = _run_passive_guard(monkeypatch, session_language="zh-CN")
+    assert system_text == prompts_soccer.SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS["zh"]
+
+
+def test_passive_guard_request_body_locale_wins_over_the_session(monkeypatch):
+    """The request body's i18n truth is the top priority, same as every other
+    soccer endpoint."""
+    system_text = _run_passive_guard(
+        monkeypatch,
+        session_language="zh-CN",
+        request_body={"i18n_language": "zh-TW"},
+    )
+    assert system_text == prompts_soccer.SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS["zh-TW"]

--- a/tests/unit/test_zh_tw_request_locale_routing.py
+++ b/tests/unit/test_zh_tw_request_locale_routing.py
@@ -17,6 +17,7 @@ land on the Simplified row rather than following Traditional through the new bra
 from __future__ import annotations
 
 import asyncio
+import pathlib
 
 import pytest
 
@@ -96,6 +97,37 @@ def test_card_assist_empty_reply_fallback_has_a_traditional_line():
     assert traditional != simplified
     assert traditional != english
     assert "喵" in traditional
+
+    # 光测 accessor 不够：上面三条在 router 仍写 `lang == "zh"` 时也全绿，因为它们
+    # 根本没碰 router。先把 resolver→accessor 那一段链钉住：
+    with language_context("zh-TW"):
+        lang = card_assist_router._resolve_language(None)
+    assert get_card_assist_chat_empty_reply_fallback(lang) == traditional
+    with language_context("zh-CN"):
+        lang = card_assist_router._resolve_language(None)
+    assert get_card_assist_chat_empty_reply_fallback(lang) == simplified
+
+
+def test_chat_endpoint_picks_the_fallback_through_the_locale_table():
+    """The last link: ``chat()`` must select that line via the table, not a ternary.
+
+    STRUCTURAL on purpose, and the limit is worth stating. Driving ``chat()`` end
+    to end needs the CSRF guard, a Request, and an LLM stub, and the branch under
+    test is one assignment deep inside it. The behavioural half above pins
+    resolver -> accessor; this half pins that the router actually reaches for the
+    accessor. Verified by mutation: restoring the ``lang == "zh"`` ternary passed
+    every behavioural assertion in this file and is caught only here.
+    """
+    src = (
+        pathlib.Path(card_assist_router.__file__).read_text(encoding="utf-8")
+    )
+    assert "get_card_assist_chat_empty_reply_fallback(lang)" in src, (
+        "chat() no longer takes the empty-reply line from the locale table"
+    )
+    assert 'if lang == "zh"' not in src, (
+        "a `lang == \"zh\"` equality test drops 'zh-TW' into the non-Chinese branch; "
+        "compare the script family or go through the locale table"
+    )
 
 
 def test_card_assist_action_recovery_prompt_stays_chinese_for_traditional():

--- a/tests/unit/test_zh_tw_request_locale_routing.py
+++ b/tests/unit/test_zh_tw_request_locale_routing.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+"""Traditional Chinese reaches the request-scoped prompt routers (issue #2500 step 2).
+
+Issue #2500 step 1 backfilled a ``zh-TW`` row into every prompt dict. That alone
+changes nothing: these three call sites derived their locale through a SHORT code,
+which collapses Traditional into Simplified before the template lookup ever happens,
+so the new rows stayed unreachable data. This file pins the flipped behaviour.
+
+Each test drives the real resolver and then asserts on the template it selects,
+not just on the code it returns: a locale key that no dict is keyed by would pass
+a code-only assertion while still handing the user the Simplified template.
+
+The Simplified half of every test is not filler — it is the regression guard.
+Widening a resolver to emit ``zh-TW`` is only correct if ``zh-CN`` / ``zh`` still
+land on the Simplified row rather than following Traditional through the new branch.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from config.prompts.prompts_card_assist import (
+    CARD_ASSIST_CLARIFY_PROMPT,
+    get_card_assist_chat_empty_reply_fallback,
+    get_card_assist_clarify_prompt,
+)
+from config.prompts.prompts_galgame import (
+    GALGAME_FALLBACK_OPTIONS,
+    GALGAME_OPTION_GENERATION_PROMPT,
+    get_galgame_fallback_options,
+)
+from config.prompts.prompts_response import (
+    LONG_RESPONSE_TAIL_SUMMARY_PROMPT,
+)
+from main_logic.omni_offline_client import _streaming
+from main_routers import card_assist_router, galgame_router
+from utils.language_utils import language_context
+
+# 繁体独有写法，用来证明拿到的确实是 zh-TW 那一行而不是简体行。
+TRADITIONAL_TAIL = "我剛剛講的那個計畫，其實還有一些細節沒有講完，你要不要聽聽看？"
+SIMPLIFIED_TAIL = "我刚刚讲的那个计划，其实还有一些细节没有讲完，你要不要听听看？"
+
+
+# ── card-assist：请求体没带 locale 时的全局兜底 ─────────────────────────────
+#
+# 带 locale 的路径本来就分得清繁简（payload 里就是 'zh-TW'）。塌掉的是兜底那一支：
+# 它读的是短码 getter，繁中用户在那里被当成简中。
+
+def test_card_assist_falls_back_to_traditional_when_payload_has_no_locale():
+    with language_context("zh-TW"):
+        assert card_assist_router._resolve_language(None) == "zh-TW"
+        # 角色卡模板文件名同样要跟着走，否则字段 key 还是简中那套。
+        assert card_assist_router._resolve_locale_code(None) == "zh-TW"
+
+    prompt = get_card_assist_clarify_prompt("zh-TW")
+    assert prompt == CARD_ASSIST_CLARIFY_PROMPT["zh-TW"]
+    assert prompt != CARD_ASSIST_CLARIFY_PROMPT["zh"]
+
+
+def test_card_assist_simplified_fallback_is_unchanged():
+    with language_context("zh-CN"):
+        assert card_assist_router._resolve_language(None) == "zh"
+        assert card_assist_router._resolve_locale_code(None) == "zh-CN"
+    with language_context("en"):
+        assert card_assist_router._resolve_language(None) == "en"
+        assert card_assist_router._resolve_locale_code(None) == "en"
+
+
+@pytest.mark.parametrize(
+    "payload_locale, expected",
+    [
+        ("zh-TW", "zh-TW"),
+        ("zh-Hant", "zh-TW"),
+        ("zh-HK", "zh-TW"),
+        ("zh-CN", "zh"),
+        ("zh", "zh"),
+        ("en-US", "en"),
+    ],
+)
+def test_card_assist_payload_locale_keeps_the_script(payload_locale, expected):
+    # 全局设成英文，确保结果只可能来自 payload 而不是兜底。
+    with language_context("en"):
+        assert card_assist_router._resolve_language(payload_locale) == expected
+
+
+def test_card_assist_empty_reply_fallback_has_a_traditional_line():
+    """`lang` can now be 'zh-TW', and the fallback line must not fall to English.
+
+    This guards the shape that leaves ``lang == "zh"`` in place: a Traditional
+    user would take the else branch and get English rather than any Chinese.
+    """
+    traditional = get_card_assist_chat_empty_reply_fallback("zh-TW")
+    simplified = get_card_assist_chat_empty_reply_fallback("zh")
+    english = get_card_assist_chat_empty_reply_fallback("en")
+    assert traditional != simplified
+    assert traditional != english
+    assert "喵" in traditional
+
+
+def test_card_assist_action_recovery_prompt_stays_chinese_for_traditional():
+    """The recovery prompt is internal machinery, so both scripts sharing the
+    Simplified version is deliberate.
+
+    What this guards is "do not fall to English": an ``lang == "zh"`` equality
+    check drops 'zh-TW' into the English branch.
+    """
+    kwargs = dict(
+        locale_code="zh-TW",
+        user_instruction="把性格改得更活泼一点",
+        current_card_text="{}",
+        target_keys_text="性格",
+        assistant_reply="好呀",
+    )
+    traditional = card_assist_router._build_action_recovery_prompt(lang="zh-TW", **kwargs)
+    simplified = card_assist_router._build_action_recovery_prompt(lang="zh", **kwargs)
+    english = card_assist_router._build_action_recovery_prompt(lang="en", **kwargs)
+    assert traditional == simplified
+    assert traditional != english
+
+
+# ── galgame：请求语言 + 文本检测 ────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "request_lang, expected",
+    [
+        ("zh-TW", "zh-TW"),
+        ("tchinese", "zh-TW"),
+        ("zh-CN", "zh"),
+        ("schinese", "zh"),
+        ("ja", "ja"),
+        ("en", "en"),
+    ],
+)
+def test_galgame_request_language_keeps_the_script(request_lang, expected):
+    with language_context("en"):
+        assert galgame_router._resolve_language("", request_lang) == expected
+
+
+def test_galgame_detection_refines_chinese_with_the_session_locale():
+    """``detect_language`` cannot separate the scripts; both report 'zh'.
+
+    Flipping ``format`` to full is therefore not enough on its own -- the
+    detection branch could never reach zh-TW. The session's own locale is what
+    actually decides.
+    """
+    with language_context("zh-TW"):
+        assert galgame_router._resolve_language(TRADITIONAL_TAIL, None) == "zh-TW"
+    with language_context("zh-CN"):
+        # 同一段繁体文本，简中会话仍然拿简体模板 —— 检测器本来就分不出，
+        # 会话 locale 才是判据。
+        assert galgame_router._resolve_language(TRADITIONAL_TAIL, None) == "zh"
+    with language_context("zh-TW"):
+        # 非中文检测结果不看会话 locale。
+        assert galgame_router._resolve_language("hello there my friend", None) == "en"
+
+
+def test_galgame_traditional_locale_selects_the_traditional_templates():
+    with language_context("zh-TW"):
+        lang = galgame_router._resolve_language("", "zh-TW")
+    assert lang == "zh-TW"
+    assert get_galgame_fallback_options(lang) == GALGAME_FALLBACK_OPTIONS["zh-TW"]
+    assert get_galgame_fallback_options(lang) != GALGAME_FALLBACK_OPTIONS["zh"]
+    assert GALGAME_OPTION_GENERATION_PROMPT[lang] != GALGAME_OPTION_GENERATION_PROMPT["zh"]
+
+
+# ── 长回复收尾摘要（TTS）：_summarize_tail_for_tts ──────────────────────────
+
+
+class _FakeResult:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def ainvoke(self, messages):
+        self._sink.append(messages)
+        return _FakeResult("好的。")
+
+
+class _StreamingStub(_streaming._StreamingMixin):
+    """Carries only the one attribute ``_summarize_tail_for_tts`` actually reads."""
+
+    def __init__(self, ui_language):
+        self._user_language_provider = (lambda: ui_language) if ui_language else None
+
+
+class _FakeConfigManager:
+    async def aget_model_api_config(self, model_type, *, core_config=None):
+        assert model_type == "emotion"
+        return {
+            "api_key": "k",
+            "model": "m",
+            "base_url": "http://localhost",
+            "provider_type": "openai",
+        }
+
+
+def _run_tail_summary(monkeypatch, *, ui_language, tail):
+    """Run the real ``_summarize_tail_for_tts`` and capture the system prompt it built."""
+    import utils.config_manager as config_manager_module
+
+    sink: list = []
+    monkeypatch.setattr(
+        config_manager_module, "get_config_manager", lambda: _FakeConfigManager()
+    )
+
+    async def _fake_create(*args, **kwargs):
+        return _FakeLLM(sink)
+
+    monkeypatch.setattr(_streaming, "create_chat_llm_async", _fake_create)
+    monkeypatch.setattr(_streaming, "set_call_type", lambda *_a, **_kw: None)
+
+    stub = _StreamingStub(ui_language)
+    asyncio.run(stub._summarize_tail_for_tts("前面已经播过的部分。", tail))
+    assert sink, "LLM 没被调用，说明前置配置分支提前返回了"
+    return sink[0][0].content
+
+
+def test_tail_summary_uses_the_traditional_prompt_for_a_traditional_session(monkeypatch):
+    system_text = _run_tail_summary(
+        monkeypatch, ui_language="zh-TW", tail=TRADITIONAL_TAIL
+    )
+    assert system_text == LONG_RESPONSE_TAIL_SUMMARY_PROMPT["zh-TW"]["system"]
+    assert system_text != LONG_RESPONSE_TAIL_SUMMARY_PROMPT["zh"]["system"]
+
+
+def test_tail_summary_keeps_simplified_sessions_on_the_simplified_prompt(monkeypatch):
+    system_text = _run_tail_summary(
+        monkeypatch, ui_language="zh-CN", tail=SIMPLIFIED_TAIL
+    )
+    assert system_text == LONG_RESPONSE_TAIL_SUMMARY_PROMPT["zh"]["system"]
+
+
+def test_tail_summary_without_a_session_locale_follows_the_global_one(monkeypatch):
+    """With no ``_user_language_provider``, fall back to the process-wide FULL
+    locale rather than the short code."""
+    with language_context("zh-TW"):
+        system_text = _run_tail_summary(
+            monkeypatch, ui_language=None, tail=TRADITIONAL_TAIL
+        )
+    assert system_text == LONG_RESPONSE_TAIL_SUMMARY_PROMPT["zh-TW"]["system"]


### PR DESCRIPTION
issue #2500 第 2 步的第一批：把低风险调用点从短码改成全码。

第 1 步（#2706）已经把全部 222 个 prompt dict 补上 `zh-TW` 模板，`check_prompt_zh_tw.py --count` 是 0。但调用侧还传短码，`normalize_language_code(..., format='short')` 把 `zh-TW` 塌成 `'zh'`，繁中用户拿到的仍然是简体模板——补的那 222 条一条都没被用上。这个 PR 翻其中三块互不相关的子系统的传参。

三个 commit，各自独立可 review：

| commit | 子系统 | 性质 |
| --- | --- | --- |
| A | card-assist / galgame / 长回复收尾摘要 | 请求级路由翻全码 |
| C1 | proactive 模板查表 | 纯重构，对可达输入零行为变化 |
| B | 游戏一族（soccer / badminton / minigame route） | normalizer + 调用点，必须同 commit |
| D | minigame 一族剩下 5 组消费者 | Codex review 后补，把 B 收干净 |
| E | 测试修正 | 对抗 review 抓出两条假绿，只动测试不动实现 |

---

## 回归报告

### 段 1 —— commit A：请求级路由翻全码

**改了什么**

- `main_routers/card_assist_router.py`
  - `_resolve_language` / `_resolve_locale_code` 的全局兜底从 `get_global_language()` 换成 `get_global_language_full()`。
  - `_resolve_language` 的 zh 分支改用新的 `normalize_card_assist_locale`（`config/prompts/prompts_card_assist.py`，跟 `normalize_mini_game_invite_locale` 同样放在表旁边导出）分繁简。请求体带 locale 的那条路径同样保留字形。
- `main_routers/galgame_router.py` `_resolve_language`
  - 请求语言分支改用 `normalize_galgame_locale`（全码）。
  - 检测分支**不是**照抄——`detect_language` 报的是字形族，繁简都回 `'zh'`，只把 `format` 翻成 `'full'` 那条分支永远够不到 `zh-TW`（简中还会变成 `'zh-CN'`，撞上 `_loc` 的缺键警告）。改用 `detect_prompt_language`，它用会话 locale 给中文检测做细分。
- `main_logic/omni_offline_client/_streaming.py` `_summarize_tail_for_tts`
  - 同样是"从文本检测语言"的形态，改用 `detect_prompt_language` + 会话的 `_user_language_provider`。

**必要性**：这三处是繁中用户实际会碰到的入口。card-assist 是角色卡 AI 助手的四个端点，galgame 是对话选项生成，`_streaming` 是长回复的 TTS 收尾摘要。

**繁中前后对比**（全局语言 = 繁中、请求体没带 locale）

| 位置 | 改前 | 改后 |
| --- | --- | --- |
| `card_assist._resolve_language(None)` | `'zh'`（简体 prompt） | `'zh-TW'` |
| `card_assist._resolve_locale_code(None)` | `'zh-CN'`（简中角色卡模板） | `'zh-TW'` |
| `card_assist._resolve_language('zh-TW')` | `'zh'` | `'zh-TW'` |
| `galgame._resolve_language('', 'zh-TW')` | `'zh'` | `'zh-TW'` |
| `galgame._resolve_language(繁体文本, None)` | `'zh'` | `'zh-TW'` |
| `_summarize_tail_for_tts`（会话 `zh-TW`） | `LONG_RESPONSE_TAIL_SUMMARY_PROMPT['zh']` | `[...]['zh-TW']` |

简中 / 英文 / 日文侧逐条验过不变（`zh-CN` → `'zh'` / `'zh-CN'`，`en` → `'en'` / `'en'`）。

**潜在回归**

1. **`lang` 现在可能是 `'zh-TW'`，两处 `lang == "zh"` 相等判断会让繁中掉进英文分支。** 这是本 commit 自己引进的风险，两处都处理了：
   - 聊天空回复兜底文案（原来是 router 里的内联三元）挪进 `prompts_card_assist`，补 `zh-TW` 行；
   - `_build_action_recovery_prompt` 改成字形族判断（`lang.startswith("zh")`）。那段 prompt 是给模型看的内部机械件，繁简共用简体版是有意的；回复本身的输出语言另由 `_output_language_directive` 按 `locale_code` 钉住，那条本来就认 `zh-TW`。
2. **`_LOCALE_OUTPUT_LANGUAGE` 里的 `zh-TW` 保留没删**：基础 prompt 只约束助手怎么想，这条指示约束它把字段值写成什么字，两者不互相取代。
3. `card_assist` 的 dict 只有 `zh` / `zh-TW` / `en` 三键，`normalize_card_assist_locale` 因此把非中文一律收成 `'en'`——否则 `ja` 之类只会撞 `_loc` 的缺键警告再落回 `en`，结果一样但多一行噪声。

**关于原方案里的 `_streaming.py`**：原计划说"按路径和内容都没搜到"。它存在，路径是 `main_logic/omni_offline_client/_streaming.py`（`git grep` 会被 `tts_client/_registry_meta.py` 里一堆 `input_streaming` / `output_streaming` 字段淹掉）。已纳入。

---

### 段 2 —— commit C1：proactive 模板查表统一走归一化器（零行为变化）

**改了什么**

`config/prompts/prompts_proactive.py` 里 ~45 处模板查表，收口到 `_normalize_prompt_language`：

- `get_meme_topic_line`（2 处）—— 真正绕过归一化器的就是这一对，把调用方的裸 `lang` 直接喂给 `_loc`。加一行归一化。
- `get_proactive_format_sections`（9 处）—— **原方案说这 9 处"直接用传进来的裸 lang"，实测不是**：这个函数开头本来就有 `lang = _normalize_prompt_language(lang)`，只是把结果重新绑回 `lang` 这个名字。所以是纯改名 `lang` → `lang_key`，让"这里到底归一化了没有"能从名字看出来。

所以真实的绕过是 **2 处不是 11 处**。改动本身照做，理由不变。用 AST 走了一遍全模块确认没有第三处（护栏测试就是这个 AST 检查，见下）。

**零行为变化的证据**

对照 `origin/main` 的同一个模块逐条比对，输入集 = `_resolve_proactive_locale(fmt="short")` 今天能产生的全部 7 个短码 × 16 种素材组合 × 3 种关键词形态：

```
[今天调用侧能传的 7 个短码] compared=133 mismatches=0
```

`_normalize_prompt_language` 在这 7 个短码上是恒等映射，所以经不经它结果一样。

同一份脚本换成 C2 之后的输入集（8 个全码），差异只出现在 `zh-TW` 的 3 条上：

```
[C2 之后的 8 个全码]        compared=152 mismatches=3
   ('meme_topic_line', 'zh-TW', ...)  ×3

  before: "發現一張很有意思的[梗圖]：'T'（來自 S）"
  after : "发现一个很有意思的[表情包]：'T'（来自 S）"
```

**这正是必须先做 C1 的原因**：`zh-TW` 行已经存在（#2706），改前 `get_meme_topic_line` 是全模块唯一一个在 `zh-TW` 上返回繁体的函数，另外 43 处被 `keep_traditional=False` 压着返回简体。C2 一旦把调用侧翻成全码，同一轮对话里就会繁简混着出。收口之后 45 处走同一条路径，C2 翻 `keep_traditional` 才是原子的。

顺带：C2 之后简中会以 `'zh-CN'` 传进来，改前那条路径会打 `WARNING: Unexpected lang code zh-CN`，现在不会了。

**潜在回归**：对今天的调用侧没有。`zh-TW` 上的那 3 条差异今天到不了（调用侧传的是短码），而且方向是"从全模块唯一的例外回到全模块一致"。

---

### 段 3 —— commit B：游戏一族（两半必须同 commit）

**改了什么**

- `config/prompts/prompts_minigame_common.py:54` `_normalize_prompt_lang` 的 `keep_traditional` → `True`。
- `main_routers/game_router/runtime.py` `_run_soccer_passive_guard_ai` 的语言取值：`_absorb_request_language(...)`（短码）→ `_resolve_game_prompt_locale(lanlan_name, data)`（全码）。

`_resolve_game_prompt_locale` 是 `_absorb_request_language` 那条优先级链的全码孪生：请求体 > `mgr.user_language` > 全局缓存，并且同样在请求体带 i18n 真值时回写 `mgr.user_language`。

**⚠️ 更正一处原方案的说法**：原方案（和本 PR body 的第一版）说"`session_pool`/`pregame`/`archive` 本来就走全码，翻完这两处这条链就通了"。**不准确** —— Codex 指出还有别的消费者在塌。完整审计和收尾见下面的段 4。

**为什么必须同一个 commit**：只翻 `keep_traditional` 而调用点还传短码，字形在上游就塌掉了；只翻调用点而 normalizer 还塌，也一样。逐半 revert 验过——各自单独 revert 都能让新测试变红。

**繁中前后对比**（会话 `user_language='zh-TW'`，走 `/api/soccer/passive-guard`）

| | 改前 | 改后 |
| --- | --- | --- |
| `_normalize_prompt_lang('zh-TW')` | `'zh'` | `'zh-TW'` |
| passive-guard 的 SystemMessage | `SOCCER_PASSIVE_GUARD_SYSTEM_PROMPTS['zh']` | `[...]['zh-TW']` |
| 请求体 `i18n_language='zh-TW'`、会话简中 | 简体 | 繁体（请求体优先） |

简中会话（`zh-CN`）仍然拿 `['zh']`，逐条验过。

**潜在回归 —— 这条最关键**

翻 `keep_traditional` 会让 `_normalize_prompt_lang` 的**每一个**消费者开始收到 `'zh-TW'`，不只是 soccer passive guard。其中三个消费点读表是 `.get(key) or table["en"]` 而**不是** `_loc`：

- `SOCCER_PREGAME_CONTEXT_FORMATTER_LABELS`
- `BADMINTON_PREGAME_CONTEXT_FORMATTER_LABELS`
- `prompts_minigame_route._labels` 背后的全部表

对这三个来说，缺 `zh-TW` 键**掉英文而不是掉简体**。翻之前审过：走这个 normalizer 的四个模块里 29 张 locale 表全都有 `zh-TW` 行。新增测试把这条覆盖做成了自动发现的护栏（从模块 `dir()` 里扫，不是手写清单），加一条"扫到的表数 >= 20"防止空扫变成假绿。

另外把四处已经变成谎话的注释/docstring 更新了：`prompts_badminton`（3 处）、`prompts_icebreaker`（1 处）、`config/prompts/_locale.py` 的 `keep_traditional` 说明、`tests/unit/test_badminton_improvement_contract.py` 的一段 docstring。`tests/unit/test_prompt_locale_normalizer.py` 的四列契约表里 minigame 那一列的 10 行跟着翻（它是这次行为改动的 spec 表，不是被动改绿）。

**⚠️ 顺带修一个不相干的既有 bug**

`_build_game_context_prompt_payload` 在拆 `runtime.py` 上帝文件（#2270）时漏在 `from .game_context import (...)` 外面，`_run_soccer_passive_guard_ai` 每次调用都抛 `NameError`。端点那层的 `except Exception` 把它吞成 `{"ok": false, "reason": "exception", "recommendedAction": "observe_more"}`，所以 soccer 被动守卫从 #2270 起就一直静默退化成 observe_more，没人看见。

在 `origin/main` 上确认过：该名字在 `runtime.py:957` 被用，既没 import 也没在文件里定义。

不修就没法给 commit B 写行为测试（函数进不去第 3 行），所以补上了这行 import。这跟 i18n 无关，reviewer 单独看这一处即可。

---

### 段 4 —— commit D：minigame 一族剩下 5 组也翻全码（Codex review 后补）

**为什么有这一段**：commit B 只翻了 soccer passive guard。Codex 指出同族还有消费者在塌短码。顺着做了完整审计 —— 对四个 minigame prompt 模块做 AST 传递闭包拿到 28 个到达 `_normalize_prompt_lang` 的公开 accessor，再回溯 `main_routers/game_router/` 里每个调用点的 `language` 根来源：

| 根来源 | 消费者 | 改前 | 改后 |
| --- | --- | --- | --- |
| `_archive_prompt_language(archive)` | `archive.py` ×6、`postgame.py` ×3 | ✅ 全码 | ✅ |
| `char_info["user_language_full"]` | `session_pool.py:303/397`、`pregame.py:512/581` 主支 | ✅ 全码 | ✅ |
| `_resolve_game_prompt_locale(...)` | passive guard | ✅ 全码（commit B） | ✅ |
| `_resolve_game_prompt_language(...)` | `/api/{game_type}/realtime-context` | ❌ 塌 | ✅ 换成 `_resolve_game_prompt_locale` |
| `_absorb_request_language(...)` soccer 支 | `/api/soccer/quick-lines` | ❌ 塌 | ✅ 去掉 badminton 门 |
| session entry `entry["user_language"]` | 近期历史标签、anger cap 文案、game chat 事件 prompt | ❌ 塌 | ✅ 加 `user_language_full` 字段 + `_entry_prompt_locale` 收口 |
| `char_info["user_language"]` | context organizer / formatter labels / dialog memory line | ❌ 塌 | ✅ full 优先 |
| `char_info["user_language"]` 兜底腿 | `pregame.py:494` | ❌ 塌 | ✅ full 优先 |

**quick-lines 那个门值得单独说**：`request_language_full` 原本只给 badminton 算。这在 commit B 之前是无害的 —— soccer 侧的 normalizer 本来就塌繁体，算不算全码没区别。commit B 把 normalizer 翻成保留字形之后，这个门就成了繁中用户**开局第一批台词落简体**的唯一原因。这是本 PR 自己制造的一处"翻了一半"，收掉是对的。

**这 5 组不是回归**：传短码时 normalizer 照旧塌，行为与合并前逐字节相同。它们是"还没迁"，`zh-TW` 行对它们是够不到的死数据。

**繁中前后对比**

| 位置 | 改前 | 改后 |
| --- | --- | --- |
| `_entry_prompt_locale({"user_language":"zh","user_language_full":"zh-TW"})` | 读到 `'zh'` | `'zh-TW'` |
| context organizer 的 SystemMessage（会话 zh-TW） | `[...]['zh']` | `[...]['zh-TW']` |
| soccer quick-lines（请求体 `i18n_language='zh-TW'`） | 简体 | 繁体 |

**潜在回归**

1. `entry` 加了字段，但**读取全部收口到 `_entry_prompt_locale`**，它用 `full or short`，所以建于该字段存在之前的 entry（以及手搓 entry 的测试）退回短码而不是 `None`。
2. `entry["user_language"]` 语义**没变**（仍是短码），只是加了个孪生字段 —— 没有静默改写既有字段含义。审计确认这个字段在 `main_routers/game_router/runtime.py` 之外没有任何读者；`archive` / route state 的同名字段是另一个命名空间，本来就存全码。
3. 顺带删掉 `runtime.py` 里已经悬空的 `_resolve_game_prompt_language` import（`char_info` 仍导出，`__init__` 和 `gr_patch_all` 都直接从那边拿），并修掉旁边指向它的注释。

**顺带澄清一个虚惊**：写行为测试时发现 `GAME_CHAT_EVENT_USER_PROMPTS` 的 `zh-TW` 行与 `zh` 逐字节相同，一度以为是 #2706 补了个没转换的副本。查下来不是 —— 那是成对的 `======以下为/以上为======` 输入水印，**有意逐 locale 保留同一段中文**（见 `prompts_minigame_common.PREGAME_CONTEXT_INPUT_WATERMARK` 的注释），八个 locale 全都一样。顺手用 OpenCC 把 `config/prompts/` 全扫了一遍：449 对 `zh`/`zh-TW` 字符串里 424 对真的翻译过，25 对逐字节相同，其中 23 对本来就不含繁简有别的字，剩下 2 对就是这两张水印表。**#2706 的补齐是干净的，没有未转换的副本。**（附带说明 `scripts/check_prompt_zh_tw.py` 只查键存不存在、不查内容是不是繁体 —— 这次扫描等于替它补了一次人工核对。）

---

## 测试

三个子系统各一个新文件，每条都是**行为**测试（驱动真实解析器 + 断言选中的模板，不只断言返回的 code）：

- `tests/unit/test_zh_tw_request_locale_routing.py`（21 条）—— 段 1
- `tests/unit/test_proactive_prompt_locale_uniformity.py`（33 条）—— 段 2，含 AST 护栏 + 「零行为变化」断言
- `tests/unit/test_zh_tw_minigame_prompt_locale.py`（45 条）—— 段 3，含 29 张表的自动发现覆盖护栏
- `tests/unit/test_zh_tw_minigame_full_locale_migration.py`（14 条）—— 段 4，两种形状的守卫 + entry 写入点成对性

段 4 的守卫刻意做成两种形状，因为单独哪一种都盖不全这一族：**AST 扫描**精确但只解析函数内一跳赋值；**生产者不变量**粗但能跨函数边界，盖住 realtime-context 和 entry 那两条参数透传路径。两者都对迁移前的形状验证过（分别报 5 处 / 3 条），不是只断言"现在是绿的"。这个限制写在测试的 docstring 里，免得把绿读成比它实际更强的保证。

每个文件都做过变异验证：

| 变异 | 结果 |
| --- | --- |
| revert 三个调用点（段 1） | 11 failed / 10 passed（红的都是繁中断言，绿的是简中回归护栏） |
| revert `prompts_proactive.py`（段 2） | 4 failed |
| revert `keep_traditional` 那一半（段 3） | 7 failed |
| revert 调用点那一半（段 3） | 3 failed |
| revert `runtime.py`（段 4） | 2 failed |
| revert `game_context.py`（段 4） | 2 failed |
| 从 entry dict 删掉 `user_language_full`（段 4） | 1 failed |
| 从 refresh 删掉 `user_language_full`（段 4） | 1 failed |
| `_combine_template` 恒取英文（commit E 修完后） | 6 failed |
| `_material_labels` 恒取英文（commit E 修完后） | 7 failed |
| `get_meme_topic_line` 去掉归一化（commit E 修完后） | 3 failed |
| 恢复 card-assist 的 `lang == "zh"` 三元（commit E 修完后） | 1 failed |

上面后四条在 commit E 之前**全部是绿的**——这正是对抗 review 抓出来的问题。

最后两条是**先跑出假绿才补上的**：第一次写完段 4，把 `user_language_full` 从 entry 里删掉时全套仍然全绿——因为其余测试都喂手搓 entry，没人验真实写入点。补了 `test_every_entry_write_site_sets_the_full_locale`（AST 扫两个写入点并断言成对数量相等）之后才红。

### 对抗 review：抓出两条假绿（commit E）

开完 PR 之后我对这个 diff 起了一轮对抗 review（5 个维度独立找 → 去重 → 每条派一个专门**反驳**它的 agent）。9 条发现里 6 条被驳倒（其中 4 条是因为 finder 读的是 commit D 之前的版本），**2 条扛住了反驳——两条都是我自己新加的测试的问题，不是实现的问题**：

**P1 · `test_format_sections_*` 是 `f(x)==f(x)`。** 断言比的是 `get_proactive_format_sections(lang)` 和 `get_proactive_format_sections(_normalize_prompt_language(lang))`，而兄弟测试恰好钉死了那 7 个短码上归一化器是恒等映射——两边是同一次调用。反驳者把 `_material_labels` / `_none_instruction` / `_tag_desc` / `_of_header` 四处全改成硬编码英文（等于所有非英语用户的主动搭话指令整段变英文），整个文件仍然 33 passed，而且**在 `origin/main` 上也一样绿**——它压根不是回归守卫。同一条反驳还指出 `test_the_whole_module_answers_one_script_for_a_traditional_locale` 的后半段同样退化。

**P2 · 空回复兜底测试根本没碰 router。** docstring 说它守的是 `lang == "zh"` 那个相等判断，但三条断言全在调 accessor。反驳者把 router 里的三元表达式恢复回去，全绿。

两条都修了，改法和验证在上面的表里。P2 我**第一次还修错了**：补的是 resolver→accessor 那段链，变异照样全绿；真正差的是 router 里那一行赋值。

反驳者另外给了两条对我有利的更正，一并记下：`test_no_template_lookup_uses_a_raw_language_parameter` 是**有效**守卫（把 5 处 `lang_key` 逐个改回裸 `lang`，AST 检测器全部报出）；`test_meme_topic_line_is_unchanged` 也**不是**自比较（它用 `_loc(dict, lang).format(...)` 独立重建期望值）。

⚠️ **一个操作教训**：这轮 review 的 agent 有写权限，跟我在同一个工作树里并发跑 `uv run python -c` 做验证，导致我这边一次 pytest 出现 24 条瞬时失败（单独跑全过）。反驳者自己也记了这一点（"a sibling process was concurrently mutating the shared worktree, so I avoided disk"）。结论：对抗验证要么隔离工作树，要么别在它跑的时候信本地测试结果。

验收命令：

```
uv run python -m pytest tests/unit -q                                → 27470 passed, 274 skipped
uv run ruff check main_routers/ config/prompts/                      → All checks passed
uv run python scripts/check_docstring_no_cjk.py --base origin/main   → clean
uv run python scripts/check_prompt_zh_tw.py --count                  → 0
```

---

## 不在本 PR 范围

**C2（proactive 的原子翻转）** —— `main_logic/proactive_chat/service.py:1254` 翻全码（`_resolve_proactive_locale` 已经有 `fmt="full"` 参数）+ `prompts_proactive.py:1549` 的 `keep_traditional` 翻 `True`，那两处必须在同一个 commit、单独一个 PR。本 PR 一个字都没动它们。C1 就是给它铺路的。

顺带一提，`service.py:2057/2058` 还有两处直接 `_loc(MEME_SECTION_HEADER, proactive_lang)`，绕开了 `prompts_proactive` 的模块归一化器。`_loc` 能吃 `zh-TW`（有键）也能吃 `zh-CN`（缺键→警告→回落简体），所以 C2 落地时要顺手看一眼，别漏成第三种行为。

**plugin 侧 6 个调用点**（本轮不动，列出来免得后面静默漏掉）：

| 文件 | 行 |
| --- | --- |
| `plugin/plugins/bilibili_danmaku/__init__.py` | 743 / 751 |
| `plugin/plugins/bilibili_dm/__init__.py` | 1123 / 1130 |
| `plugin/plugins/qq_auto_reply/__init__.py` | 1304 / 1306 |
| `plugin/plugins/qq_auto_reply/session_instruction_service.py` | 140（同文件已经 import 了 `get_global_language_full`） |
| `plugin/plugins/wechat_integration/__init__.py` | 561 / 588 |
| `plugin/plugins/game_agent_minecraft/prompts.py` | 78 / 80 |

**`app/agent_server/api_runtime.py` 的 agent lang 缺陷** —— 另一个 PR 在做，跟繁中无关。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
