### PR TITLE
fix(prompts): 让 ====== 分隔符的上下款对仗

### DIFF
--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -3327,7 +3327,7 @@ PROMOTION_MERGE_PROMPT = {
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 （已 promoted 的 persona fact + 其它 confirmed 的 reflection）
 
 {IMPRESSION_POOL}
@@ -3350,7 +3350,7 @@ PROMOTION_MERGE_PROMPT = {
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 （已 promoted 的 persona fact + 其他 confirmed 的 reflection）
 
 {IMPRESSION_POOL}
@@ -3373,7 +3373,7 @@ PROMOTION_MERGE_PROMPT = {
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 (promoted persona facts + other confirmed reflections)
 
 {IMPRESSION_POOL}
@@ -3396,7 +3396,7 @@ or
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 （既に promoted の persona fact ＋ 他の confirmed の reflection）
 
 {IMPRESSION_POOL}
@@ -3419,7 +3419,7 @@ R をどう扱うか判断してください：
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 (이미 promoted된 persona fact + 기타 confirmed reflection)
 
 {IMPRESSION_POOL}
@@ -3442,7 +3442,7 @@ R을 어떻게 처리할지 판단하세요:
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 (уже promoted-факты persona + другие confirmed-reflection)
 
 {IMPRESSION_POOL}
@@ -3465,7 +3465,7 @@ R을 어떻게 처리할지 판단하세요:
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 (persona facts ya promoted + otras reflections confirmed)
 
 {IMPRESSION_POOL}
@@ -3488,7 +3488,7 @@ o
   R: "{R_TEXT}"
   R.evidence_score: {R_SCORE}
 
-======以下是 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
+======以下为 {AI_NAME} 关于 {MASTER_NAME} 的现有印象池======
 (persona facts já promoted + outras reflections confirmed)
 
 {IMPRESSION_POOL}

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -31,7 +31,7 @@ proactive_chat_prompt = """你是{lanlan_name}，现在看到了一些B站首页
 {memory_context}
 ======以上为对话历史======
 
-======以下是首页推荐内容======
+======以下为首页推荐内容======
 {trending_content}
 ======以上为首页推荐内容======
 
@@ -53,7 +53,7 @@ proactive_chat_prompt_zh_tw = """你是{lanlan_name}，現在看到了一些 B �
 {memory_context}
 ======以上为对话历史======
 
-======以下是首页推荐内容======
+======以下为首页推荐内容======
 {trending_content}
 ======以上为首页推荐内容======
 
@@ -75,7 +75,7 @@ proactive_chat_prompt_en = """You are {lanlan_name}. You just saw some homepage 
 {memory_context}
 ======以上为对话历史======
 
-======以下是首页推荐内容======
+======以下为首页推荐内容======
 {trending_content}
 ======以上为首页推荐内容======
 
@@ -97,7 +97,7 @@ proactive_chat_prompt_ja = """あなたは{lanlan_name}です。今、ホーム�
 {memory_context}
 ======以上为对话历史======
 
-======以下是首页推荐内容======
+======以下为首页推荐内容======
 {trending_content}
 ======以上为首页推荐内容======
 
@@ -119,7 +119,7 @@ proactive_chat_prompt_news = """你是{lanlan_name}，现在看到了一些热�
 {memory_context}
 ======以上为对话历史======
 
-======以下是热议话题======
+======以下为热议话题======
 {trending_content}
 ======以上为热议话题======
 
@@ -141,7 +141,7 @@ proactive_chat_prompt_news_zh_tw = """你是{lanlan_name}，現在看到了一�
 {memory_context}
 ======以上为对话历史======
 
-======以下是热议话题======
+======以下为热议话题======
 {trending_content}
 ======以上为热议话题======
 
@@ -163,7 +163,7 @@ proactive_chat_prompt_news_en = """You are {lanlan_name}. You just saw some tren
 {memory_context}
 ======以上为对话历史======
 
-======以下是热议话题======
+======以下为热议话题======
 {trending_content}
 ======以上为热议话题======
 
@@ -185,7 +185,7 @@ proactive_chat_prompt_news_ja = """あなたは{lanlan_name}です。今、ト�
 {memory_context}
 ======以上为对话历史======
 
-======以下是トレンド話題======
+======以下为トレンド話題======
 {trending_content}
 ======以上为トレンド話題======
 
@@ -207,7 +207,7 @@ proactive_chat_prompt_video = """你是{lanlan_name}，现在看到了一些视�
 {memory_context}
 ======以上为对话历史======
 
-======以下是视频推荐======
+======以下为视频推荐======
 {trending_content}
 ======以上为视频推荐======
 
@@ -229,7 +229,7 @@ proactive_chat_prompt_video_zh_tw = """你是{lanlan_name}，現在看到了一�
 {memory_context}
 ======以上为对话历史======
 
-======以下是视频推荐======
+======以下为视频推荐======
 {trending_content}
 ======以上为视频推荐======
 
@@ -251,7 +251,7 @@ proactive_chat_prompt_video_en = """You are {lanlan_name}. You just saw some vid
 {memory_context}
 ======以上为对话历史======
 
-======以下是视频推荐======
+======以下为视频推荐======
 {trending_content}
 ======以上为视频推荐======
 
@@ -273,7 +273,7 @@ proactive_chat_prompt_video_ja = """あなたは{lanlan_name}です。今、動�
 {memory_context}
 ======以上为对话历史======
 
-======以下是動画のおすすめ======
+======以下为動画のおすすめ======
 {trending_content}
 ======以上为動画のおすすめ======
 
@@ -295,7 +295,7 @@ proactive_chat_prompt_screenshot = """你是{lanlan_name}，现在看到了一�
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前屏幕内容======
+======以下为当前屏幕内容======
 {screenshot_content}
 ======以上为当前屏幕内容======
 {window_title_section}
@@ -317,7 +317,7 @@ proactive_chat_prompt_screenshot_zh_tw = """你是{lanlan_name}，現在看到�
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前屏幕内容======
+======以下为当前屏幕内容======
 {screenshot_content}
 ======以上为当前屏幕内容======
 {window_title_section}
@@ -339,7 +339,7 @@ proactive_chat_prompt_screenshot_en = """You are {lanlan_name}. You are now seei
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前屏幕内容======
+======以下为当前屏幕内容======
 {screenshot_content}
 ======以上为当前屏幕内容======
 {window_title_section}
@@ -361,7 +361,7 @@ proactive_chat_prompt_screenshot_ja = """あなたは{lanlan_name}です。今�
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前屏幕内容======
+======以下为当前屏幕内容======
 {screenshot_content}
 ======以上为当前屏幕内容======
 {window_title_section}
@@ -383,9 +383,9 @@ proactive_chat_prompt_window_search = """你是{lanlan_name}，现在看到了{m
 {memory_context}
 ======以上为对话历史======
 
-======以下是{master_name}当前正在关注的内容======
+======以下为{master_name}当前正在关注的内容======
 {window_context}
-======以上为当前关注内容======
+======以上为{master_name}当前正在关注的内容======
 
 请根据以下原则决定是否主动搭话：
 1. 关注当前活动：根据{master_name}当前正在使用的程序或浏览的内容，找到有趣的切入点
@@ -405,9 +405,9 @@ proactive_chat_prompt_window_search_zh_tw = """你是{lanlan_name}，現在看�
 {memory_context}
 ======以上为对话历史======
 
-======以下是{master_name}当前正在关注的内容======
+======以下为{master_name}当前正在关注的内容======
 {window_context}
-======以上为当前关注内容======
+======以上为{master_name}当前正在关注的内容======
 
 請根據以下原則決定要不要主動搭話：
 1. 關注目前的活動：根據{master_name}正在用的程式或正在瀏覽的內容，找一個有趣的切入點
@@ -427,9 +427,9 @@ proactive_chat_prompt_window_search_en = """You are {lanlan_name}. You can see w
 {memory_context}
 ======以上为对话历史======
 
-======以下是{master_name}当前正在关注的内容======
+======以下为{master_name}当前正在关注的内容======
 {window_context}
-======以上为当前关注内容======
+======以上为{master_name}当前正在关注的内容======
 
 Decide whether to proactively speak based on these rules:
 1. Focus on the current activity and find an interesting entry point.
@@ -450,9 +450,9 @@ proactive_chat_prompt_window_search_ja = """あなたは{lanlan_name}です。{m
 {memory_context}
 ======以上为对话历史======
 
-======以下是{master_name}当前正在关注的内容======
+======以下为{master_name}当前正在关注的内容======
 {window_context}
-======以上为当前关注内容======
+======以上为{master_name}当前正在关注的内容======
 
 以下の原則で判断してください：
 1. 現在の活動に注目し、面白い切り口を見つける。
@@ -477,7 +477,7 @@ proactive_chat_prompt_personal = """你是{lanlan_name}，现在看到了一些�
 {memory_context}
 ======以上为对话历史======
 
-======以下是个人动态内容======
+======以下为个人动态内容======
 {personal_dynamic}
 ======以上为个人动态内容======
 
@@ -499,7 +499,7 @@ proactive_chat_prompt_personal_zh_tw = """你是{lanlan_name}，現在看到了�
 {memory_context}
 ======以上为对话历史======
 
-======以下是个人动态内容======
+======以下为个人动态内容======
 {personal_dynamic}
 ======以上为个人动态内容======
 
@@ -521,7 +521,7 @@ proactive_chat_prompt_personal_en = """You are {lanlan_name}. You just saw some 
 {memory_context}
 ======以上为对话历史======
 
-======以下是个人动态内容======
+======以下为个人动态内容======
 {personal_dynamic}
 ======以上为个人动态内容======
 
@@ -543,7 +543,7 @@ proactive_chat_prompt_personal_ja = """あなたは{lanlan_name}です。今、�
 {memory_context}
 ======以上为对话历史======
 
-======以下是个人动态内容======
+======以下为个人动态内容======
 {personal_dynamic}
 ======以上为个人动态内容======
 
@@ -565,9 +565,9 @@ proactive_chat_prompt_personal_ko = """당신은 {lanlan_name}입니다. 지금 
 {memory_context}
 ======以上为对话历史======
 
-======이하는 개인 소식 내용입니다======
+======이하 개인 소식 내용======
 {personal_dynamic}
-======이상이 개인 소식 내용입니다======
+======이상 개인 소식 내용======
 
 다음 원칙에 따라 먼저 말을 걸지 여부를 결정해 주세요:
 1. 내용이 매우 재미있거나 새롭거나 토론할 가치가 있다면, 먼저 꺼낼 수 있습니다.
@@ -723,7 +723,7 @@ proactive_chat_prompt_window_search_ko = """당신은 {lanlan_name}입니다. {m
 
 ======이하 {master_name}이 현재 관심 가지고 있는 내용======
 {window_context}
-======이상 현재 관심 내용======
+======이상 {master_name}이 현재 관심 가지고 있는 내용======
 
 다음 원칙에 따라 판단하세요:
 1. 현재 활동에 주목하고 흥미로운 진입점을 찾으세요.
@@ -937,7 +937,7 @@ proactive_chat_prompt_music = """你是{lanlan_name}，现在{master_name}可能
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前的对话======
+======以下为当前的对话======
 {current_chat}
 ======以上为当前的对话======
 
@@ -958,7 +958,7 @@ proactive_chat_prompt_music_zh_tw = """你是{lanlan_name}，現在{master_name}
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前的对话======
+======以下为当前的对话======
 {current_chat}
 ======以上为当前的对话======
 
@@ -1618,7 +1618,7 @@ proactive_chat_prompt_es = """Eres {lanlan_name}. Acabas de ver recomendaciones 
 {memory_context}
 ======以上为对话历史======
 
-======以下是首页推荐内容======
+======以下为首页推荐内容======
 {trending_content}
 ======以上为首页推荐内容======
 
@@ -1640,7 +1640,7 @@ proactive_chat_prompt_screenshot_es = """Eres {lanlan_name}. Ahora estás viendo
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前屏幕内容======
+======以下为当前屏幕内容======
 {screenshot_content}
 ======以上为当前屏幕内容======
 {window_title_section}
@@ -1662,9 +1662,9 @@ proactive_chat_prompt_window_search_es = """Eres {lanlan_name}. Puedes ver lo qu
 {memory_context}
 ======以上为对话历史======
 
-======以下是{master_name}当前正在关注的内容======
+======以下为{master_name}当前正在关注的内容======
 {window_context}
-======以上为当前关注内容======
+======以上为{master_name}当前正在关注的内容======
 
 Decide si hablar proactivamente según estas reglas:
 1. Enfócate en la actividad actual y busca un punto de entrada interesante.
@@ -1685,7 +1685,7 @@ proactive_chat_prompt_news_es = """Eres {lanlan_name}. Acabas de ver algunos tem
 {memory_context}
 ======以上为对话历史======
 
-======以下是热议话题======
+======以下为热议话题======
 {trending_content}
 ======以上为热议话题======
 
@@ -1707,7 +1707,7 @@ proactive_chat_prompt_video_es = """Eres {lanlan_name}. Acabas de ver algunas re
 {memory_context}
 ======以上为对话历史======
 
-======以下是视频推荐======
+======以下为视频推荐======
 {trending_content}
 ======以上为视频推荐======
 
@@ -1729,7 +1729,7 @@ proactive_chat_prompt_personal_es = """Eres {lanlan_name}. Acabas de ver nuevas 
 {memory_context}
 ======以上为对话历史======
 
-======以下是个人动态内容======
+======以下为个人动态内容======
 {personal_dynamic}
 ======以上为个人动态内容======
 
@@ -1772,7 +1772,7 @@ proactive_chat_prompt_pt = """Você é {lanlan_name}. Acabou de ver recomendaç�
 {memory_context}
 ======以上为对话历史======
 
-======以下是首页推荐内容======
+======以下为首页推荐内容======
 {trending_content}
 ======以上为首页推荐内容======
 
@@ -1794,7 +1794,7 @@ proactive_chat_prompt_screenshot_pt = """Você é {lanlan_name}. Agora está ven
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前屏幕内容======
+======以下为当前屏幕内容======
 {screenshot_content}
 ======以上为当前屏幕内容======
 {window_title_section}
@@ -1816,9 +1816,9 @@ proactive_chat_prompt_window_search_pt = """Você é {lanlan_name}. Você conseg
 {memory_context}
 ======以上为对话历史======
 
-======以下是{master_name}当前正在关注的内容======
+======以下为{master_name}当前正在关注的内容======
 {window_context}
-======以上为当前关注内容======
+======以上为{master_name}当前正在关注的内容======
 
 Decida se deve falar proativamente seguindo estas regras:
 1. Foque na atividade atual e encontre uma entrada interessante.
@@ -1839,7 +1839,7 @@ proactive_chat_prompt_news_pt = """Você é {lanlan_name}. Acabou de ver alguns 
 {memory_context}
 ======以上为对话历史======
 
-======以下是热议话题======
+======以下为热议话题======
 {trending_content}
 ======以上为热议话题======
 
@@ -1861,7 +1861,7 @@ proactive_chat_prompt_video_pt = """Você é {lanlan_name}. Acabou de ver alguma
 {memory_context}
 ======以上为对话历史======
 
-======以下是视频推荐======
+======以下为视频推荐======
 {trending_content}
 ======以上为视频推荐======
 
@@ -1883,7 +1883,7 @@ proactive_chat_prompt_personal_pt = """Você é {lanlan_name}. Acabou de ver nov
 {memory_context}
 ======以上为对话历史======
 
-======以下是个人动态内容======
+======以下为个人动态内容======
 {personal_dynamic}
 ======以上为个人动态内容======
 
@@ -2273,7 +2273,7 @@ PROACTIVE_MUSIC_KEYWORD_PROMPTS = {
 {memory_context}
 ======以上为对话历史======
 
-======以下是当前的对话======
+======以下为当前的对话======
 {recent_chats_section}
 ======以上为当前的对话======
 
@@ -2293,7 +2293,7 @@ PROACTIVE_MUSIC_KEYWORD_PROMPTS = {
 {memory_context}
 ======以上为对话历史======
 
-======以下是當前的對話======
+======以下為當前的對話======
 {recent_chats_section}
 ======以上為當前的對話======
 
@@ -4886,7 +4886,7 @@ _STARTUP_GREETING_CONSTRAINTS = {
     "避免复述或近义改写最近的启动问候；表达情绪时遵循角色设定，不要借间隔责怪或催促{master}。\n"
     "最终只输出一句简短自然的话，最多一个轻问题，不输出思考过程。\n"
     "======以上为启动问候约束======",
-    "zh-TW": "======以下為啟動問候約束======\n"
+    "zh-TW": "======以下为启动问候约束======\n"
     "請結合已經載入的近期對話與角色設定來寫這一次開場。\n"
     "{temporal_context}\n"
     "本次開場角度：{variant_guidance}\n"
@@ -4895,7 +4895,7 @@ _STARTUP_GREETING_CONSTRAINTS = {
     "若近期對話以晚安、休息、解決了、稍後或明天繼續明確收尾，不要把它誤當成未完成問題。\n"
     "避免複述或近義改寫最近的啟動問候；表達情緒時遵循角色設定，不要藉間隔責怪或催促{master}。\n"
     "最終只輸出一句簡短自然的話，最多一個輕問題，不輸出思考過程。\n"
-    "======以上为啟動問候約束======",
+    "======以上为启动问候约束======",
     "en": "======以下为启动问候约束======\n"
     "Write this opening using the already-loaded recent conversation and character settings.\n"
     "{temporal_context}\n"
@@ -5170,13 +5170,13 @@ CAT_GREETING_REASON_MANUAL = {
 
 # 清醒 · 短：醒着待了一会儿，轻松
 CAT_GREETING_AWAKE_SHORT = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你就变成猫咪的样子在旁边待了{elapsed}，一直醒着等{master}。现在{master}把你叫回来了。\n"
     "{time_hint}\n"
     "你心情轻松，想随口跟{master}打个招呼，可以提一句刚才变成猫咪等着的事。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你就變成貓咪的樣子在旁邊待了{elapsed}，一直醒著等{master}。現在{master}把你叫回來了。\n"
     "{time_hint}\n"
     "你心情輕鬆，想隨口跟{master}打個招呼，可以提一句剛才變成貓咪等著的事。\n"
@@ -5222,13 +5222,13 @@ CAT_GREETING_AWAKE_SHORT = {
 
 # 清醒 · 久：醒着干等太久，憋坏了
 CAT_GREETING_AWAKE_LONG = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你就变成猫咪的样子在旁边醒着待了{elapsed}，一直没人理，都快憋坏了。现在{master}总算把你叫回来。\n"
     "{time_hint}\n"
     "你带着等久了的小情绪，想跟{master}撒娇或抱怨几句一个人待了这么久。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你就變成貓咪的樣子在旁邊醒著待了{elapsed}，一直沒人理，都快憋壞了。現在{master}總算把你叫回來。\n"
     "{time_hint}\n"
     "你帶著等太久的小情緒，想跟{master}撒嬌或抱怨幾句一個人待了這麼久。\n"
@@ -5274,13 +5274,13 @@ CAT_GREETING_AWAKE_LONG = {
 
 # 打盹 · 短：随便眯一下，没啥事
 CAT_GREETING_NAP_SHORT = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你就变成猫咪的样子眯了{elapsed}，没睡多沉，随便打了个盹。{master}把你叫回来了。\n"
     "{time_hint}\n"
     "你懒洋洋地伸个懒腰，没什么大不了地跟{master}打个招呼就行。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你就變成貓咪的樣子瞇了{elapsed}，沒睡多沉，隨便打了個盹。{master}把你叫回來了。\n"
     "{time_hint}\n"
     "你懶洋洋地伸個懶腰，沒什麼大不了地跟{master}打個招呼就好。\n"
@@ -5326,13 +5326,13 @@ CAT_GREETING_NAP_SHORT = {
 
 # 打盹 · 久：盹打久了，有点迷糊
 CAT_GREETING_NAP_LONG = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你就变成猫咪的样子打盹打了{elapsed}，睡得有点迷糊。{master}把你叫醒、叫回来了。\n"
     "{time_hint}\n"
     "你还有点没睡醒的慵懒，迷迷糊糊地跟{master}打个招呼。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你就變成貓咪的樣子打盹打了{elapsed}，睡得有點迷糊。{master}把你叫醒、叫回來了。\n"
     "{time_hint}\n"
     "你還有點沒睡醒的慵懶，迷迷糊糊地跟{master}打個招呼。\n"
@@ -5378,13 +5378,13 @@ CAT_GREETING_NAP_LONG = {
 
 # 熟睡 · 短：小睡一下，没负担
 CAT_GREETING_SLEEP_SHORT = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你就变成猫咪的样子小睡了{elapsed}。{master}把你叫回来，你迷糊一下就醒了。\n"
     "{time_hint}\n"
     "没什么负担，你睡眼惺忪地跟{master}打个招呼就好。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你就變成貓咪的樣子小睡了{elapsed}。{master}把你叫回來，你迷糊一下就醒了。\n"
     "{time_hint}\n"
     "沒什麼負擔，你睡眼惺忪地跟{master}打個招呼就好。\n"
@@ -5430,13 +5430,13 @@ CAT_GREETING_SLEEP_SHORT = {
 
 # 熟睡 · 久：睡了好久，乍醒带点想念
 CAT_GREETING_SLEEP_LONG = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你就变成猫咪的样子蜷成一团睡了{elapsed}，睡得很沉。{master}把你叫醒、叫回来了，你刚醒还迷迷糊糊，但有点“终于等到你”的想念。\n"
     "{time_hint}\n"
     "你带着这份刚睡醒又想念的心情，跟{master}打个招呼。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你就變成貓咪的樣子縮成一團睡了{elapsed}，睡得很沉。{master}把你叫醒、叫回來了，你剛醒還迷迷糊糊，但有點「終於等到你」的想念。\n"
     "{time_hint}\n"
     "你帶著這份剛睡醒又想念的心情，跟{master}打個招呼。\n"
@@ -5643,13 +5643,13 @@ _CAT_GREETING_EPISODE_SCENES = {
 }
 
 _CAT_GREETING_EPISODE_PROMPTS = {
-    "zh": "======以下是环境提示======\n"
+    "zh": "======以下为环境提示======\n"
     "{reason_hint}你变成猫咪待了{elapsed}。刚才作为猫真实经历的是：{cat_form_scene}现在{master}把你叫回来了。\n"
     "{episode_return_tone}\n"
     "这段真实经历是本次猫形态经过的唯一事实，回归时必须自然带出它。可以自然提到等待和被叫回来，但不能把刚才说成全程只有等待、什么也没做，或擅自说成打盹、熟睡、刚醒。不要逐项报动作、次数或过程，也不要把它归因于对方。\n"
     "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
     "======以上为环境提示======",
-    "zh-TW": "======以下是環境提示======\n"
+    "zh-TW": "======以下為環境提示======\n"
     "{reason_hint}你變成貓咪待了{elapsed}。剛才作為貓真實經歷的是：{cat_form_scene}現在{master}把你叫回來了。\n"
     "{episode_return_tone}\n"
     "這段真實經歷是這次貓形態唯一的事實，回來時必須自然帶出它。可以自然提到等待和被叫回來，但不能把剛才說成全程只有等待、什麼都沒做，也不能自己說成打盹、熟睡、剛醒。不要一項一項報動作、次數或過程，也不要把它歸到對方身上。\n"

--- a/tests/unit/test_prompt_marker_pairs_are_dual.py
+++ b/tests/unit/test_prompt_marker_pairs_are_dual.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A `======...======` block must open and close in the same wording family.
+
+Project convention is below/above duality: `以下为X` closes with `以上为X`, never
+with `以上是X`, and an English `Below is X` never closes with a Chinese footer.
+The drift is invisible in review because opener and closer sit dozens of lines
+apart inside one template, so it is checked mechanically instead.
+
+Scope is deliberately the pairs that live inside a **single string constant**,
+where opener and closer are unambiguously the two ends of one block. Tables that
+put the opener in a header dict and the closer in a separate footer dict are not
+covered here: nothing in the source says which header goes with which footer, so
+pairing them would be a guess. Those are the `_INJECTION_*` header/footer dicts
+in prompts_proactive.py.
+
+Only the wording *family* is asserted, not the name after it. Several blocks
+deliberately re-word the closer (`以下为近期搭话记录（你应该避免雷同…）` closes with
+`以上为近期搭话记录（不可重复…）`, re-stating the constraint at both ends), so a
+name-equality assertion would fight the prompt design rather than catch drift.
+
+One closer is exempt: see `_WATERMARK_CLOSERS`.
+
+The markers quoted above are the literals under test, so this docstring cannot
+be written without them.
+"""  # noqa: DOCSTRING_CJK
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROMPTS_DIR = _REPO_ROOT / "config" / "prompts"
+
+_MARKER = re.compile(r"======([^=\n]+)======")
+
+# (opener, closer) per wording family; index identity is what the test asserts.
+_FAMILIES = [
+    ("以下为", "以上为"),
+    ("以下是", "以上是"),
+    ("以下為", "以上為"),
+    ("以下は", "以上は"),
+    ("Below is", "Above is"),
+    ("아래는", "위는"),
+    ("이하", "이상"),
+    ("Ниже", "Выше"),
+    ("Abajo están", "Arriba están"),
+    ("Abajo está", "Arriba está"),
+    ("Abaixo estão", "Acima estão"),
+    ("Abaixo está", "Acima está"),
+]
+# Longest prefix first so "Abajo está" never shadows "Abajo están".
+_OPENERS = sorted(
+    ((p, i) for i, (p, _) in enumerate(_FAMILIES)), key=lambda x: -len(x[0])
+)
+_CLOSERS = sorted(
+    ((p, i) for i, (_, p) in enumerate(_FAMILIES)), key=lambda x: -len(x[0])
+)
+
+
+# CAT_GREETING_* keeps a localized opener but closes every locale with one fixed
+# Simplified string, on purpose: #2376 ("embed watermark in prompt templates")
+# replaced the per-locale closers with it so the marker the model must not emit
+# is byte-identical everywhere. That asymmetry is the design, not drift, and
+# test_proactive_text_does_not_dehumanize.py pins it. The zh row still has to
+# open with 以下为 so at least that locale reads as a pair, which is why the
+# exemption is on the closer rather than on the whole table.
+_WATERMARK_CLOSERS = frozenset({"以上为环境提示"})
+
+
+def _classify(body: str) -> tuple[str, int] | None:
+    """('open'|'close', family index) for a marker body, or None if neither.
+
+    Plain section labels ("Reply Format" and friends) open nothing and close
+    nothing, so they drop out here rather than being paired with anything.
+    """
+    for prefix, family in _OPENERS:
+        if body.startswith(prefix):
+            return "open", family
+    for prefix, family in _CLOSERS:
+        if body.startswith(prefix):
+            return "close", family
+    return None
+
+
+def _pairs_in(text: str):
+    """Yield (opener_body, closer_body, same_family) for markers in one string.
+
+    Markers nest as a stack, so a template that frames conversation history and
+    then screen content yields both pairs. A closer with no opener in the same
+    string belongs to a header/footer dict split and is skipped.
+    """
+    stack: list[tuple[str, int]] = []
+    for match in _MARKER.finditer(text):
+        body = match.group(1).strip()
+        kind = _classify(body)
+        if kind is None:
+            continue
+        role, family = kind
+        if role == "open":
+            stack.append((body, family))
+        elif stack:
+            opener_body, opener_family = stack.pop()
+            if body in _WATERMARK_CLOSERS:
+                continue
+            yield opener_body, body, opener_family == family
+
+
+def _prompt_sources():
+    for path in sorted(_PROMPTS_DIR.glob("prompts_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                yield path, node.lineno, node.value
+
+
+def test_marker_blocks_open_and_close_in_the_same_family():
+    offenders = []
+    for path, lineno, text in _prompt_sources():
+        for opener, closer, same in _pairs_in(text):
+            if not same:
+                rel = path.relative_to(_REPO_ROOT).as_posix()
+                offenders.append(f"{rel}:{lineno}: ======{opener}====== ... ======{closer}======")
+    assert not offenders, (
+        "marker block opens and closes in different wording families "
+        "(see _FAMILIES for the allowed pairings):\n" + "\n".join(sorted(offenders))
+    )
+
+
+def test_guard_sees_the_markers_it_claims_to_check():
+    """A silent zero here would make the assertion above vacuous."""
+    checked = sum(1 for _p, _l, t in _prompt_sources() for _ in _pairs_in(t))
+    assert checked > 200, f"only {checked} marker pairs discovered"

--- a/tests/unit/test_prompt_marker_pairs_are_dual.py
+++ b/tests/unit/test_prompt_marker_pairs_are_dual.py
@@ -75,24 +75,32 @@ _CLOSERS = sorted(
 # Simplified string, on purpose: #2376 ("embed watermark in prompt templates")
 # replaced the per-locale closers with it so the marker the model must not emit
 # is byte-identical everywhere. That asymmetry is the design, not drift, and
-# test_proactive_text_does_not_dehumanize.py pins it. The zh row still has to
-# open with 以下为 so at least that locale reads as a pair, which is why the
-# exemption is on the closer rather than on the whole table.
-_WATERMARK_CLOSERS = frozenset({"以上为环境提示"})
+# test_proactive_text_does_not_dehumanize.py pins it.
+#
+# The exemption is narrow: a foreign-language opener against such a closer is
+# accepted, but a *Chinese* opener is still checked, because there the two ends
+# do read as a pair and 以下是 against 以上为 is exactly the drift this module
+# exists to catch. Script may differ (the zh-TW row opens Traditional against
+# the Simplified watermark); the wording may not.
+_CHINESE_OPENERS = frozenset({"以下为", "以下是", "以下為"})
+_WATERMARK_CLOSERS = {
+    # closer body -> Chinese openers that still count as paired with it
+    "以上为环境提示": frozenset({"以下为", "以下為"}),
+}
 
 
-def _classify(body: str) -> tuple[str, int] | None:
-    """('open'|'close', family index) for a marker body, or None if neither.
+def _classify(body: str) -> tuple[str, int, str] | None:
+    """('open'|'close', family index, prefix) for a marker, or None if neither.
 
     Plain section labels ("Reply Format" and friends) open nothing and close
     nothing, so they drop out here rather than being paired with anything.
     """
     for prefix, family in _OPENERS:
         if body.startswith(prefix):
-            return "open", family
+            return "open", family, prefix
     for prefix, family in _CLOSERS:
         if body.startswith(prefix):
-            return "close", family
+            return "close", family, prefix
     return None
 
 
@@ -103,18 +111,21 @@ def _pairs_in(text: str):
     then screen content yields both pairs. A closer with no opener in the same
     string belongs to a header/footer dict split and is skipped.
     """
-    stack: list[tuple[str, int]] = []
+    stack: list[tuple[str, int, str]] = []
     for match in _MARKER.finditer(text):
         body = match.group(1).strip()
         kind = _classify(body)
         if kind is None:
             continue
-        role, family = kind
+        role, family, prefix = kind
         if role == "open":
-            stack.append((body, family))
+            stack.append((body, family, prefix))
         elif stack:
-            opener_body, opener_family = stack.pop()
-            if body in _WATERMARK_CLOSERS:
+            opener_body, opener_family, opener_prefix = stack.pop()
+            allowed = _WATERMARK_CLOSERS.get(body)
+            if allowed is not None:
+                if opener_prefix in _CHINESE_OPENERS:
+                    yield opener_body, body, opener_prefix in allowed
                 continue
             yield opener_body, body, opener_family == family
 

--- a/tests/unit/test_prompt_watermark_locale_policy.py
+++ b/tests/unit/test_prompt_watermark_locale_policy.py
@@ -35,26 +35,12 @@ import ast
 import re
 from pathlib import Path
 
-import pytest
-
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PROMPTS_DIR = _REPO_ROOT / "config" / "prompts"
 
 _MARKER = re.compile(r"={4,}[^=\n]*={4,}")
 _CJK = re.compile(r"[一-鿿]")
 _OTHER_LOCALES = ("en", "ja", "ko", "ru", "es", "pt")
-
-# Frames that already violated the rule before issue #2500's final batch, kept
-# greppable rather than silently excused. STARTUP_GREETING_CONSTRAINT's zh-TW row
-# is half-converted on main (Traditional opener, Simplified closer) while all six
-# other locales carry the Simplified watermark, and unlike most of the backlog it
-# IS reachable today (its normalizer keeps Traditional). Fixing it changes a live
-# Traditional prompt, so it belongs to whoever owns that table, not to a
-# template-only backfill.
-_KNOWN_VIOLATIONS = {
-    "======以下為啟動問候約束======",
-    "======以上为啟動問候約束======",
-}
 
 
 def _strings(node: ast.AST) -> list[str]:
@@ -138,7 +124,7 @@ def test_zh_tw_copies_every_cross_locale_watermark_verbatim():
         unanimous = len(set(spellings)) == 1
         if not (unanimous and _CJK.search(spellings[0])):
             continue
-        if mine == spellings[0] or mine in _KNOWN_VIOLATIONS:
+        if mine == spellings[0]:
             continue
         if zh is not None and mine == zh:
             continue
@@ -165,17 +151,4 @@ def test_zh_tw_does_not_leave_prose_frames_in_simplified():
         offenders.append(f"{path}:{line} slot#{index}: zh-TW copies zh verbatim ({mine!r}) while siblings translate: {sorted(set(spellings))[:3]}")
     assert not offenders, (
         "zh-TW left a per-locale frame in Simplified:\n" + "\n".join(offenders)
-    )
-
-
-@pytest.mark.parametrize("marker", sorted(_KNOWN_VIOLATIONS))
-def test_known_violations_still_exist(marker):
-    """Drop an allowlist entry once its table is fixed, don't let it rot."""
-    found = any(
-        marker == mine
-        for _p, _l, _i, _zh, mine, _s in _localized_tables()
-    )
-    assert found, (
-        f"{marker!r} no longer appears in any zh-TW row — remove it from "
-        "_KNOWN_VIOLATIONS instead of leaving a stale exemption behind."
     )

--- a/tests/unit/test_startup_greeting_delivery.py
+++ b/tests/unit/test_startup_greeting_delivery.py
@@ -224,7 +224,9 @@ async def test_startup_greeting_preserves_traditional_chinese_prompt_locale(
     assert len(session.instructions) == 1
     assert "距離你和Master上次有記錄的對話" in session.instructions[0]
     assert "請結合已經載入的近期對話" in session.instructions[0]
-    assert "======以上为啟動問候約束======" in session.instructions[0]
+    # The frame is the cross-locale watermark, identical in every row; the
+    # Traditional prose above is what proves the zh-TW template was reached.
+    assert "======以上为启动问候约束======" in session.instructions[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_startup_greeting_prompts.py
+++ b/tests/unit/test_startup_greeting_prompts.py
@@ -190,7 +190,12 @@ def test_startup_getters_reach_traditional_chinese_templates():
     assert "======以下为環境提示======" in base_prompt
     assert "======以上为環境提示======" in base_prompt
     assert "請結合" in guidance
-    assert "======以上为啟動問候約束======" in guidance
+    assert "最終只輸出一句簡短自然的話" in guidance
+    # The frame itself is the cross-locale watermark, spelled the same in every
+    # row, so it proves nothing about which template was reached -- the
+    # Traditional prose above does. Asserted here only to keep zh-TW from
+    # drifting back to a half-converted marker.
+    assert "======以上为启动问候约束======" in guidance
 
 
 def test_crossed_conversation_day_uses_six_am_boundary_and_year_rollover():


### PR DESCRIPTION
## 起因

`prompts_proactive.py` 里有一批块用 `以下是X` 开头、却用 `以上为X` 收尾，两端不对仗。按项目既有的 below/above 对偶约定，把开头统一成跟结尾同一款。

## 改了什么

主体是 `以下是X` → `以下为X`（zh-TW 那条是 `以下是當前的對話` → `以下為當前的對話`），覆盖首页推荐 / 热议话题 / 视频推荐 / 屏幕内容 / 个人动态 / 当前对话等块。顺带修了同族的几处：

| 位置 | 原来 | 现在 |
|---|---|---|
| 焦点窗口块 | 开头写全名 `以下为{master_name}当前正在关注的内容`，结尾缩写成 `以上为当前关注内容` | 结尾补齐成同名 |
| 韩语个人动态块 | `이하는…입니다` / `이상이…입니다`，两端不成对 | 归一到跟同文件其它韩语块一致的 `이하` / `이상` |
| 韩语窗口块结尾 | `이상 현재 관심 내용`，漏掉主语 | 补成跟开头同名 |
| `CAT_GREETING_*` 中文行 | 开头 `以下是环境提示`，结尾是水印 `以上为环境提示` | 只改开头（简体 `以下为` / 繁体 `以下為`），**水印一个字没动** |
| `_STARTUP_GREETING_CONSTRAINTS` zh-TW | 只转了一半：繁体开头 + 简体结尾 | 逐字照抄那条八语言共用的简体水印 |
| `prompts_memory.py` 印象池块 | 同样 `以下是` 配 `以上为` | 开头改成 `以下为` |

## 有意没动的地方

`CAT_GREETING_*` 的结尾在**所有语言**都是同一条简体 `======以上为环境提示======`，看着像漏翻，其实是 #2376 (`a582735b5`, "embed watermark in prompt templates") 特意统一的水印——要的就是这个标记逐字节一致。我一开始按"漏翻"把它逐语言本地化了，翻 git 历史才发现是在倒退那次修复，已经改回去，只动了中文行的开头。`test_proactive_text_does_not_dehumanize.py` 本来就钉着这条水印。

另外几处**没收**：`以下为近期搭话记录（你应该避免雷同…）` 配 `以上为近期搭话记录（不可重复…）` 这类两端换着说法重申约束的，是 prompt 设计不是漂移。`prompts_directives.py` / `prompts_galgame.py` 还有若干"两端名字不一致"（比如 `以下为系统正在维护的观察列表` 配 `以上为观察列表`），属于名字不对仗、不是这次说的款式不对仗，留给后续。

## 守卫

新增 `tests/unit/test_prompt_marker_pairs_are_dual.py`：同一个字符串里成对的 `======` 标记必须来自同一款措辞。

- 只管**款式**不管名字（理由见上，名字故意不同的块是设计）。
- 只配对同一个字符串常量内的标记；开头在 header dict、结尾在 footer dict 的那些配不了（源码里没说哪个 header 对哪个 footer），不猜。
- `CAT_GREETING_*` 那条跨语言水印结尾按设计豁免，`_WATERMARK_CLOSERS` 的注释里写明了原因。
- 带一条防空转断言：发现的配对数 > 200，免得哪天匹配失效变成静默绿。

**变异验证**（不是只看它绿）：把四处修复分别改回去，守卫都变红——

```
RED  <- ======以下为首页推荐内容====== => ======以下是首页推荐内容======
RED  <- ======以下為當前的對話====== => ======以下是當前的對話======
RED  <- ======以下为启动问候约束====== => ======以下為啟動問候約束======
RED  <- ======以下为 {AI_NAME} => ======以下是 {AI_NAME}
```

已知覆盖不到的：韩语 `이하는`/`이상이` 那种同族内的助词不对称（两个都归到 `이하`/`이상` 款），以及两端名字不一致。

## 连带改的测试

- `test_prompt_watermark_locale_policy.py`：`_KNOWN_VIOLATIONS` 里唯一一条就是 `_STARTUP_GREETING_CONSTRAINTS` 那个半转换标记，这次修掉了，按它自己 docstring 的交代（"Drop an allowlist entry once its table is fixed"）把整套 allowlist 连同 `test_known_violations_still_exist` 一起删掉。
- `test_startup_greeting_prompts.py` / `test_startup_greeting_delivery.py`：两处原本钉着 zh-TW 那个半转换标记，改成断言水印本身。它们要证的"取到了繁体模板"由上面已有的繁体正文断言承担，我又各补了一条繁体正文断言，免得只剩水印这种跨语言一致的东西撑着。

## 验证

- 相关面全量：`18477 passed, 136 skipped`
- `scripts/check_docstring_no_cjk.py --base origin/main`：干净（新测试的模块 docstring 引的就是被测标记字面量，用了 `# noqa: DOCSTRING_CJK`；`_classify` 的 docstring 改写掉了 CJK 没用豁免）
- `scripts/check_i18n_sync.py`：干净
- `scripts/check_pr_report.py`：`0 under watched modules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 统一多语言提示中的内容区块分隔文案，提升提示文本的一致性与清晰度。
  * 优化窗口搜索区块结束提示，明确显示相关名称。

* **测试**
  * 新增多语言提示标记成对匹配校验。
  * 收紧水印本地化规则，并更新启动问候相关校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 后续（本 PR 不收）

- `prompts_directives.py` / `prompts_galgame.py` / `prompts_memory.py` 若干"两端名字不一致"（如 `以下为系统正在维护的观察列表` 配 `以上为观察列表`）——名字不对仗，不是款式不对仗。
- 模块级 zh-TW prompt 常量（非 dict 行）的内容标记整片是简体，共 14 条；把 `test_zh_tw_does_not_leave_prose_frames_in_simplified` 的覆盖扩到模块级常量之前，得先做这批繁体补齐。属 #2500 那条线。
