### PR TITLE
fix: 确认云端卡牌锻造扣费

### DIFF
--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -273,6 +273,54 @@ def _relay(r: httpx.Response):
     return r.json()
 
 
+async def _confirm_cloud_forge_debit(
+    *,
+    operation_id: str,
+    credit_id: str,
+    card_id: str,
+) -> dict:
+    """Tell the cloud about a debit only after the local ledger has committed it."""
+    credentials = await asyncio.to_thread(_get_client_credentials)
+    if not credentials:
+        return {"confirmed": False, "detail": "client_not_registered"}
+    client_id, client_proof = credentials
+    url = (
+        f"{_social_base_url()}/api/cards/forge-operations/"
+        f"{operation_id}/debit-confirmation"
+    )
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SEC) as client:
+            response = await client.post(
+                url,
+                json={
+                    "client_id": client_id,
+                    "client_proof": client_proof,
+                    "credit_id": credit_id,
+                    "card_id": card_id,
+                },
+            )
+    except (httpx.HTTPError, OSError):
+        return {"confirmed": False, "detail": "cloud_unreachable"}
+    try:
+        payload = response.json()
+    except (ValueError, TypeError):
+        payload = {}
+    if response.status_code >= 400 or not isinstance(payload, dict):
+        detail = payload.get("detail") if isinstance(payload, dict) else None
+        return {
+            "confirmed": False,
+            "detail": str(detail or f"http_{response.status_code}"),
+        }
+    confirmed = (
+        payload.get("confirmed") is True
+        and str(payload.get("operation_id") or "") == operation_id
+        and str(payload.get("credit_id") or "") == credit_id
+        and str(payload.get("card_id") or "") == card_id
+        and bool(payload.get("confirmed_at"))
+    )
+    return {"confirmed": confirmed}
+
+
 def _origin_port(parsed) -> int | None:
     if parsed.port:
         return parsed.port
@@ -2048,7 +2096,18 @@ async def commit_credit_endpoint(
     except (ValueError, LookupError, RuntimeError) as exc:
         error = _credit_error(exc)
         return JSONResponse({"detail": error.detail}, status_code=error.status_code, headers=cors)
-    return JSONResponse(result, headers=cors)
+    confirmation = await _confirm_cloud_forge_debit(
+        operation_id=operation_id,
+        credit_id=credit_id,
+        card_id=str(payload.get("card_id") or ""),
+    )
+    return JSONResponse(
+        {
+            **result,
+            "debit_confirmed": confirmation.get("confirmed") is True,
+        },
+        headers=cors,
+    )
 
 
 @router.delete("/credits/{credit_id}/reservations/{operation_id}", summary="云端明确失败后释放本机券预占")

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -322,7 +322,7 @@ async def _confirm_cloud_forge_debit(
     try:
         payload = response.json()
     except (ValueError, TypeError):
-        payload = {}
+        payload = None
     if not 200 <= response.status_code < 300 or not isinstance(payload, dict):
         detail = payload.get("detail") if isinstance(payload, dict) else None
         return {

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -284,20 +284,38 @@ async def _confirm_cloud_forge_debit(
     if not credentials:
         return {"confirmed": False, "detail": "client_not_registered"}
     client_id, client_proof = credentials
+    base_url = _social_base_url()
+    try:
+        parsed_base_url = urlparse(base_url)
+        base_hostname = parsed_base_url.hostname
+        if parsed_base_url.scheme == "https" and base_hostname:
+            send_client_proof = True
+        elif (
+            parsed_base_url.scheme == "http"
+            and base_hostname
+            and base_hostname.lower() in _LOOPBACK_HOSTS
+        ):
+            send_client_proof = False
+        else:
+            return {"confirmed": False, "detail": "invalid_cloud_base_url"}
+    except ValueError:
+        return {"confirmed": False, "detail": "invalid_cloud_base_url"}
     url = (
-        f"{_social_base_url()}/api/cards/forge-operations/"
+        f"{base_url}/api/cards/forge-operations/"
         f"{operation_id}/debit-confirmation"
     )
+    request_payload = {
+        "client_id": client_id,
+        "credit_id": credit_id,
+        "card_id": card_id,
+    }
+    if send_client_proof:
+        request_payload["client_proof"] = client_proof
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SEC) as client:
             response = await client.post(
                 url,
-                json={
-                    "client_id": client_id,
-                    "client_proof": client_proof,
-                    "credit_id": credit_id,
-                    "card_id": card_id,
-                },
+                json=request_payload,
             )
     except (httpx.HTTPError, OSError):
         return {"confirmed": False, "detail": "cloud_unreachable"}
@@ -305,7 +323,7 @@ async def _confirm_cloud_forge_debit(
         payload = response.json()
     except (ValueError, TypeError):
         payload = {}
-    if response.status_code >= 400 or not isinstance(payload, dict):
+    if not 200 <= response.status_code < 300 or not isinstance(payload, dict):
         detail = payload.get("detail") if isinstance(payload, dict) else None
         return {
             "confirmed": False,

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -967,6 +967,13 @@ def test_refreshed_desktop_bearer_keeps_same_owner_reservation(
     from main_logic import forge_credit_ledger
 
     monkeypatch.setenv("NEKO_USER_DATA_DIR", str(tmp_path))
+    confirmation_calls = []
+
+    async def confirm_cloud_debit(**_kwargs):
+        confirmation_calls.append(_kwargs)
+        return {"confirmed": True}
+
+    monkeypatch.setattr(C, "_confirm_cloud_forge_debit", confirm_cloud_debit)
     _write_v2_desktop_session(
         tmp_path,
         monkeypatch,
@@ -1033,6 +1040,20 @@ def test_refreshed_desktop_bearer_keeps_same_owner_reservation(
     assert committed.status_code == commit_replay.status_code == 200
     assert committed.json()["committed"] is True
     assert commit_replay.json()["committed"] is True
+    assert committed.json()["debit_confirmed"] is True
+    assert commit_replay.json()["debit_confirmed"] is True
+    assert confirmation_calls == [
+        {
+            "operation_id": operation_id,
+            "credit_id": credit_id,
+            "card_id": card_id,
+        },
+        {
+            "operation_id": operation_id,
+            "credit_id": credit_id,
+            "card_id": card_id,
+        },
+    ]
 
 
 def test_card_drop_capabilities_are_exact_origin_and_no_store(client):

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -345,7 +345,7 @@ async def test_confirm_cloud_forge_debit_omits_proof_for_local_http(monkeypatch)
         card_id="card-id",
     )
 
-    assert result == {"confirmed": False}
+    assert result == {"confirmed": False, "detail": "http_204"}
     assert captured["json"] == {
         "client_id": "client-id",
         "credit_id": "credit-id",

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -8,6 +8,7 @@ import threading
 from pathlib import Path
 
 import pytest
+import httpx
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
@@ -237,6 +238,119 @@ def test_card_drop_client_id_fails_closed_when_fresh_default_cannot_be_saved(
     monkeypatch.setattr(config_manager, "get_config_manager", lambda: FakeConfigManager())
 
     assert C._get_client_id() is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_cloud_forge_debit_rejects_redirect_response(monkeypatch):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "https://community.example")
+    monkeypatch.setattr(
+        C,
+        "_get_client_credentials",
+        lambda: ("client-id", "client-proof"),
+    )
+
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, json):
+            return httpx.Response(
+                302,
+                json={
+                    "confirmed": True,
+                    "operation_id": "operation-id",
+                    "credit_id": "credit-id",
+                    "card_id": "card-id",
+                    "confirmed_at": "now",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+    monkeypatch.setattr(C.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await C._confirm_cloud_forge_debit(
+        operation_id="operation-id",
+        credit_id="credit-id",
+        card_id="card-id",
+    )
+
+    assert result == {"confirmed": False, "detail": "http_302"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cloud_base_url",
+    [
+        "http://community.example",
+        "ftp://community.example",
+        "https:///missing-host",
+        "https://[::1",
+    ],
+)
+async def test_confirm_cloud_forge_debit_rejects_unsafe_cloud_base_url(
+    monkeypatch, cloud_base_url,
+):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", cloud_base_url)
+    monkeypatch.setattr(
+        C,
+        "_get_client_credentials",
+        lambda: ("client-id", "client-proof"),
+    )
+
+    result = await C._confirm_cloud_forge_debit(
+        operation_id="operation-id",
+        credit_id="credit-id",
+        card_id="card-id",
+    )
+
+    assert result == {"confirmed": False, "detail": "invalid_cloud_base_url"}
+
+
+@pytest.mark.asyncio
+async def test_confirm_cloud_forge_debit_omits_proof_for_local_http(monkeypatch):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://localhost:48911")
+    monkeypatch.setattr(
+        C,
+        "_get_client_credentials",
+        lambda: ("client-id", "client-proof"),
+    )
+    captured = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, json):
+            captured["url"] = url
+            captured["json"] = json
+            return httpx.Response(204, json=None, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(C.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await C._confirm_cloud_forge_debit(
+        operation_id="operation-id",
+        credit_id="credit-id",
+        card_id="card-id",
+    )
+
+    assert result == {"confirmed": False}
+    assert captured["json"] == {
+        "client_id": "client-id",
+        "credit_id": "credit-id",
+        "card_id": "card-id",
+    }
 
 
 def test_packaged_facts_module_exposes_shared_entrypoints():


### PR DESCRIPTION
## 变更说明

- 在本地卡牌锻造扣费提交后向云端确认扣费结果。
- 云端确认仅接受 2xx 响应，并校验操作、信用和卡牌标识。
- HTTPS 云端地址才携带真实 client_proof；本地 loopback HTTP 开发地址不携带真实凭据，其他不安全地址直接拒绝。
- 补充首次提交、幂等重放、302 响应、危险地址和本地 HTTP 凭据保护测试。

## 回归报告

- 变更原因：服务端 PR #135 要求云端在领取卡牌前验证本地扣费回执，客户端必须可靠区分确认成功和失败。
- 变更前：任意非 4xx 响应都可能继续进入确认字段校验，且配置为不安全地址时会发送真实 client_proof。
- 变更后：只有 HTTP 2xx 且字段完整匹配才返回确认成功；HTTPS 才发送真实 proof，loopback HTTP 不发送 proof，其他地址 fail closed。
- 潜在回归：本地 HTTP 开发环境不会获得云端确认，需要使用 HTTPS 或由服务端提供对应开发模式；相关行为已覆盖单元测试。

## 不拆分理由

本次修改与原 PR 的云端扣费确认调用属于同一安全契约，拆分会使客户端在服务端回执上线期间处于不一致状态。

## 测试

- `uv run pytest tests/unit/test_card_drop_session_facts.py -q`（77 passed）
- `uv run ruff check main_routers/card_drop_router.py tests/unit/test_card_drop_session_facts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 本地消费提交成功后，系统会自动向云端确认扣款，确保本地与云端状态一致。
  * 提交结果新增扣款确认状态，便于及时了解云端是否确认成功。
* **稳定性改进**
  * 增强了对客户端未注册、网络异常、无效地址、重定向及字段不完整等情况的处理，避免异常响应影响消费流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->