### PR TITLE
fix: let music controls receive clicks under tool wheel

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -4396,6 +4396,8 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   --compact-tool-button-size: 38px;
   --compact-tool-fan-hit-outset: 52px;
   --compact-tool-wheel-hover-radius: 116px;
+  --compact-tool-wheel-music-control-cutout-width: 160px;
+  --compact-tool-wheel-music-control-cutout-height: 96px;
   /* Orbit radius = how far the tool icons sit from the arrow center (visual
      only). 45.96px (a straight halving of the original 91.92px) packed the icons
      in too tight, so it's dialed back to 80px. The drag-rotate sensitivity
@@ -4790,10 +4792,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 /* 播放器位于轮盘中心左上方，其控制区会和圆形旋转命中区相交。播放器显示时，
    从命中圆左上挖出固定的控制带，让播放/暂停、音量与静音点击穿透到下层；
    道具按钮保持各自的 pointer-events:auto，不受影响。 */
-.app-shell:has(> #music-player-mount.compact-music-player-mount:not(:empty))
+.app-shell:has(> #music-player-mount.compact-music-player-mount > .music-player-bar:not([hidden]))
   .compact-input-tool-fan[data-compact-input-tool-fan-open="true"]
   .compact-input-tool-fan-hit-region {
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 96px, 160px 96px, 160px 0);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 var(--compact-tool-wheel-music-control-cutout-height), var(--compact-tool-wheel-music-control-cutout-width) var(--compact-tool-wheel-music-control-cutout-height), var(--compact-tool-wheel-music-control-cutout-width) 0);
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-wheel-selection-pointer {

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -4778,11 +4778,22 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] {
   visibility: visible;
-  pointer-events: auto;
+  /* 容器本身没有可见内容，不应形成 232px 方形的透明点击层。实际轮盘事件
+     从命中圆/道具按钮冒泡到该容器；未命中的区域自然穿透给下面的界面。 */
+  pointer-events: none;
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region {
   pointer-events: auto;
+}
+
+/* 播放器位于轮盘中心左上方，其控制区会和圆形旋转命中区相交。播放器显示时，
+   从命中圆左上挖出固定的控制带，让播放/暂停、音量与静音点击穿透到下层；
+   道具按钮保持各自的 pointer-events:auto，不受影响。 */
+.app-shell:has(> #music-player-mount.compact-music-player-mount:not(:empty))
+  .compact-input-tool-fan[data-compact-input-tool-fan-open="true"]
+  .compact-input-tool-fan-hit-region {
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 96px, 160px 96px, 160px 0);
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-wheel-selection-pointer {

--- a/static/app/app-react-chat-window/geometry-and-messages.js
+++ b/static/app/app-react-chat-window/geometry-and-messages.js
@@ -397,6 +397,8 @@
     var COMPACT_TOOL_FAN_CIRCLE_SLICE_COUNT = 18;
     var COMPACT_TOOL_AVATAR_CHOICE_FLOAT_PADDING_X = 6;
     var COMPACT_TOOL_AVATAR_CHOICE_FLOAT_PADDING_Y = 12;
+    var COMPACT_TOOL_FAN_MUSIC_CONTROL_CUTOUT_WIDTH = 160;
+    var COMPACT_TOOL_FAN_MUSIC_CONTROL_CUTOUT_HEIGHT = 96;
 
     function readCompactToolFanPixelVar(style, name, fallback) {
         var rawValue = style ? style.getPropertyValue(name) : '';
@@ -432,6 +434,58 @@
             });
         }
         return slices;
+    }
+
+    function getCompactToolFanMusicControlCutoutRect(element, parentRect) {
+        if (!element || !parentRect || typeof element.closest !== 'function') return null;
+        var appShell = element.closest('.app-shell');
+        if (!appShell || typeof appShell.querySelector !== 'function') return null;
+        var musicBar = appShell.querySelector(
+            '#music-player-mount.compact-music-player-mount > .music-player-bar:not([hidden])'
+        );
+        if (!musicBar || !musicBar.parentNode || musicBar.parentNode.parentNode !== appShell) return null;
+        var style = window.getComputedStyle ? window.getComputedStyle(element) : null;
+        var cutoutWidth = readCompactToolFanPixelVar(
+            style,
+            '--compact-tool-wheel-music-control-cutout-width',
+            COMPACT_TOOL_FAN_MUSIC_CONTROL_CUTOUT_WIDTH
+        );
+        var cutoutHeight = readCompactToolFanPixelVar(
+            style,
+            '--compact-tool-wheel-music-control-cutout-height',
+            COMPACT_TOOL_FAN_MUSIC_CONTROL_CUTOUT_HEIGHT
+        );
+        return {
+            left: parentRect.left,
+            top: parentRect.top,
+            width: cutoutWidth,
+            height: cutoutHeight,
+            right: parentRect.left + cutoutWidth,
+            bottom: parentRect.top + cutoutHeight
+        };
+    }
+
+    function subtractCompactRect(rect, cutoutRect) {
+        var sourceRect = I.normalizeCompactDomRect(rect);
+        var overlap = intersectCompactRects(sourceRect, cutoutRect);
+        if (!sourceRect) return [];
+        if (!overlap) return [sourceRect];
+        return [
+            { left: sourceRect.left, top: sourceRect.top, right: sourceRect.right, bottom: overlap.top },
+            { left: sourceRect.left, top: overlap.bottom, right: sourceRect.right, bottom: sourceRect.bottom },
+            { left: sourceRect.left, top: overlap.top, right: overlap.left, bottom: overlap.bottom },
+            { left: overlap.right, top: overlap.top, right: sourceRect.right, bottom: overlap.bottom }
+        ].map(function (piece) {
+            if (piece.right <= piece.left || piece.bottom <= piece.top) return null;
+            return {
+                left: piece.left,
+                top: piece.top,
+                width: piece.right - piece.left,
+                height: piece.bottom - piece.top,
+                right: piece.right,
+                bottom: piece.bottom
+            };
+        }).filter(Boolean);
     }
 
     function expandCompactRect(rect, expandX, expandTop, expandBottom) {
@@ -493,6 +547,12 @@
         var items = [];
         if (parentRect) {
             var nativeRects = buildCompactToolFanCircleSliceRects(parentRect, element) || [parentRect];
+            var musicControlCutoutRect = getCompactToolFanMusicControlCutoutRect(element, parentRect);
+            if (musicControlCutoutRect) {
+                nativeRects = nativeRects.reduce(function (cutoutNativeRects, nativeRect) {
+                    return cutoutNativeRects.concat(subtractCompactRect(nativeRect, musicControlCutoutRect));
+                }, []);
+            }
             nativeRects.forEach(function (nativeRect, index) {
                 items.push({
                     id: index === 0 ? 'toolFan:native' : 'toolFan:native:' + index,

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1866,8 +1866,8 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: none !important;
 }
 
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell:has(> #music-player-mount.compact-music-player-mount:not(:empty)) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region {
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 96px, 160px 96px, 160px 0);
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell:has(> #music-player-mount.compact-music-player-mount > .music-player-bar:not([hidden])) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 var(--compact-tool-wheel-music-control-cutout-height), var(--compact-tool-wheel-music-control-cutout-width) var(--compact-tool-wheel-music-control-cutout-height), var(--compact-tool-wheel-music-control-cutout-width) 0);
 }
 
 #react-chat-window-root {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1849,6 +1849,23 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     z-index: 100003 !important;
 }
 
+/* 轮盘容器本身是透明的；保留按钮和圆形旋转区的交互，其余区域（特别是与紧凑播放器
+   重叠的左上控制带）必须点击穿透。这里覆盖上面的宿主通用 pointer-events 规则。 */
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] {
+    pointer-events: none !important;
+}
+
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .avatar-tool-quickbar,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .avatar-tool-quickbar * {
+    pointer-events: auto !important;
+}
+
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell:has(> #music-player-mount.compact-music-player-mount:not(:empty)) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 96px, 160px 96px, 160px 0);
+}
+
 #react-chat-window-root {
     width: 100%;
     height: 100%;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1713,9 +1713,7 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) [data-compact-geometry-owner="surface"],
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) [data-compact-geometry-owner="surface"] *,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton *,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"],
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] * {
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton * {
     pointer-events: auto;
 }
 
@@ -1856,10 +1854,16 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
 }
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item:not([data-compact-tool-wheel-slot="hidden"]):not([data-compact-tool-wheel-slot="hidden-forward"]):not([data-compact-tool-wheel-slot="hidden-backward"]),
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .avatar-tool-quickbar,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .avatar-tool-quickbar * {
     pointer-events: auto !important;
+}
+
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden"],
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden-forward"],
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden-backward"] {
+    pointer-events: none !important;
 }
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell:has(> #music-player-mount.compact-music-player-mount:not(:empty)) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region {

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1045,6 +1045,8 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
 
     assert "position: absolute;" in fan_block
     assert "--compact-tool-wheel-hover-radius: 116px;" in fan_block
+    assert "--compact-tool-wheel-music-control-cutout-width: 160px;" in fan_block
+    assert "--compact-tool-wheel-music-control-cutout-height: 96px;" in fan_block
     assert "--compact-tool-wheel-orbit-radius: 80px;" in fan_block
     assert "--compact-tool-fan-focus-x: var(--compact-tool-wheel-hover-radius);" in fan_block
     assert "--compact-tool-fan-focus-y: var(--compact-tool-wheel-hover-radius);" in fan_block
@@ -1068,6 +1070,18 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     assert ".compact-input-tool-wheel-charge" in styles
     assert "width: calc(var(--compact-tool-wheel-hover-radius) * 2);" in styles
     assert '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region' in styles
+    assert '.app-shell:has(> #music-player-mount.compact-music-player-mount > .music-player-bar:not([hidden]))' in styles
+    assert "var(--compact-tool-wheel-music-control-cutout-width)" in styles
+    assert "var(--compact-tool-wheel-music-control-cutout-height)" in styles
+    assert "function getCompactToolFanMusicControlCutoutRect(element, parentRect)" in script
+    assert "#music-player-mount.compact-music-player-mount > .music-player-bar:not([hidden])" in script
+    assert "function subtractCompactRect(rect, cutoutRect)" in script
+    assert "COMPACT_TOOL_FAN_MUSIC_CONTROL_CUTOUT_WIDTH = 160;" in script
+    assert "COMPACT_TOOL_FAN_MUSIC_CONTROL_CUTOUT_HEIGHT = 96;" in script
+    assert "--compact-tool-wheel-music-control-cutout-width" in script
+    assert "--compact-tool-wheel-music-control-cutout-height" in script
+    assert "nativeRects = nativeRects.reduce" in collector_block
+    assert "subtractCompactRect(nativeRect, musicControlCutoutRect)" in collector_block
     assert '.compact-input-tool-fan[data-compact-tool-wheel-charge-active="true"] .compact-input-tool-wheel-charge' in styles
     assert "conic-gradient(" in styles
     assert "--compact-tool-wheel-charge-first-angle" in styles
@@ -2669,6 +2683,11 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
         "    pointer-events: none !important;\n"
         "}"
     )
+    visible_music_tool_fan_cutout_rule = (
+        f'{compact_surface_prefix} #react-chat-window-root .app-shell:has(> #music-player-mount.compact-music-player-mount > .music-player-bar:not([hidden])) .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region {{\n'
+        "    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 var(--compact-tool-wheel-music-control-cutout-height), var(--compact-tool-wheel-music-control-cutout-width) var(--compact-tool-wheel-music-control-cutout-height), var(--compact-tool-wheel-music-control-cutout-width) 0);\n"
+        "}"
+    )
     compact_music_interactive_rule = (
         f'{compact_surface_prefix} #music-player-mount,\n'
         f'{compact_surface_prefix} #music-player-mount * {{\n'
@@ -2717,6 +2736,7 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     assert tool_fan_passthrough_rule in styles
     assert visible_tool_fan_interactive_rule in styles
     assert hidden_tool_fan_slots_rule in styles
+    assert visible_music_tool_fan_cutout_rule in styles
     assert compact_music_interactive_rule in styles
     assert compact_music_hidden_rule in styles
     assert history_passthrough_rule in styles

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -2645,10 +2645,28 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
         f'{compact_surface_prefix} [data-compact-geometry-owner="surface"],\n'
         f'{compact_surface_prefix} [data-compact-geometry-owner="surface"] *,\n'
         f'{compact_surface_prefix} #reactChatWindowMinimizeButton,\n'
-        f'{compact_surface_prefix} #reactChatWindowMinimizeButton *,\n'
-        f'{compact_surface_prefix} .compact-input-tool-fan[data-compact-input-tool-fan-open="true"],\n'
-        f'{compact_surface_prefix} .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] * {{\n'
+        f'{compact_surface_prefix} #reactChatWindowMinimizeButton * {{\n'
         "    pointer-events: auto;\n"
+        "}"
+    )
+    tool_fan_passthrough_rule = (
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] {{\n'
+        "    pointer-events: none !important;\n"
+        "}"
+    )
+    visible_tool_fan_interactive_rule = (
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-fan-hit-region,\n'
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item:not([data-compact-tool-wheel-slot="hidden"]):not([data-compact-tool-wheel-slot="hidden-forward"]):not([data-compact-tool-wheel-slot="hidden-backward"]),\n'
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .avatar-tool-quickbar,\n'
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .avatar-tool-quickbar * {{\n'
+        "    pointer-events: auto !important;\n"
+        "}"
+    )
+    hidden_tool_fan_slots_rule = (
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden"],\n'
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden-forward"],\n'
+        f'{compact_surface_prefix} #react-chat-window-root .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden-backward"] {{\n'
+        "    pointer-events: none !important;\n"
         "}"
     )
     compact_music_interactive_rule = (
@@ -2696,6 +2714,9 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     )
 
     assert broad_surface_rule in styles
+    assert tool_fan_passthrough_rule in styles
+    assert visible_tool_fan_interactive_rule in styles
+    assert hidden_tool_fan_slots_rule in styles
     assert compact_music_interactive_rule in styles
     assert compact_music_hidden_rule in styles
     assert history_passthrough_rule in styles
@@ -2708,6 +2729,9 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     assert styles.index(history_passthrough_rule) < styles.index(meme_passthrough_rule)
     assert styles.index(meme_passthrough_rule) < styles.index(meme_close_interactive_rule)
     assert styles.index(meme_close_interactive_rule) < styles.index(history_interactive_rule)
+    assert styles.index(broad_surface_rule) < styles.index(tool_fan_passthrough_rule)
+    assert styles.index(tool_fan_passthrough_rule) < styles.index(visible_tool_fan_interactive_rule)
+    assert styles.index(visible_tool_fan_interactive_rule) < styles.index(hidden_tool_fan_slots_rule)
     assert ".compact-export-history-scroll,\n" in history_passthrough_rule
 
 


### PR DESCRIPTION
## 改动概述 / Summary

- 修复 Compact 工具轮盘展开时，透明固定命中区域拦截音乐播放器控制按钮点击的问题。
- 轮盘容器的非交互区域改为点击穿透；保留道具按钮与圆形旋转区的交互。
- 播放器显示时，从圆形旋转命中区裁出与播放器控制区重叠的左上区域。
- Closes #2684

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：仅修改 2 个样式文件，属于同一交互修复。

## 测试 / Testing

- `npm.cmd run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化紧凑聊天模式下工具轮盘的点击区域，透明区域不再阻挡底层控件操作。
  * 播放器显示时，播放、音量和静音控制可正常点击，同时不影响工具按钮交互。
  * 隐藏工具项不再响应点击，最小化按钮与快捷工具栏的交互更加准确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->