### PR TITLE
test(tokenize): 钉住降级 token 计数是真实计数的上界（#2574）

### DIFF
--- a/tests/unit/test_evidence_render_budget.py
+++ b/tests/unit/test_evidence_render_budget.py
@@ -176,23 +176,31 @@ _HIGH_ENTROPY_SAMPLES = [
 
 
 def _real_encoder():
-    """真实 tiktoken encoder；数据文件取不到就跳过——这几条断言的参照系
-    就是它，没有它测的就不是同一件事。必须在打 fallback 补丁**之前**调，
-    否则 `import tiktoken` 拿到的是 MagicMock。"""
+    """The genuine tiktoken encoder — the reference these assertions are
+    measured against. Skip when the encoding data file is unavailable:
+    without it we would be comparing the heuristic to itself.
+
+    Must be called *before* the fallback patch goes in, or `import
+    tiktoken` hands back the MagicMock.
+    """
     try:
         import tiktoken
-        return tiktoken.get_encoding(PERSONA_RENDER_ENCODING)
+        enc = tiktoken.get_encoding(PERSONA_RENDER_ENCODING)
     except Exception as e:  # noqa: BLE001
         pytest.skip(f"tiktoken encoding data unavailable: {e}")
+    return enc
 
 
 @pytest.fixture
 def force_heuristic(monkeypatch):
-    """让 `_get_encoder` 必然失败，把 utils.tokenize 整个模块压到降级分支，
-    并把打补丁前抓到的真实 encoder yield 出来做参照系。
+    """Force `_get_encoder` to fail so every counter in `utils.tokenize`
+    takes the heuristic branch, and yield the real encoder captured before
+    the patch as the reference.
 
-    退出时清 `_ENCODERS`：该缓存把失败也缓存下来（正是它让降级不会每次
-    重试磁盘 IO），不清的话同进程后续用例全被钉死在降级形态。"""
+    Clears `_ENCODERS` on the way out: that cache stores the *failure* too
+    (which is what keeps the fallback from retrying disk IO on every call),
+    so leaving it would pin the rest of the process into fallback mode.
+    """
     real_enc = _real_encoder()
 
     from utils.tokenize import _reset_fallback_warned_for_tests
@@ -209,12 +217,15 @@ def force_heuristic(monkeypatch):
 
 @pytest.mark.parametrize("text", _HIGH_ENTROPY_SAMPLES)
 def test_heuristic_never_undercounts_real_tokens(text):
-    """降级计数必须 ≥ 真实 tiktoken 计数——#2574 的核心不变量。
+    """The heuristic count must be >= the real tiktoken count — #2574's
+    core invariant.
 
-    直接调 `_count_tokens_heuristic`，不需要打 fallback 补丁，所以同一个
-    用例里两边都能拿到真值。反过来（高估多少）不设上限：字节权重对 CJK
-    约 3 倍、对英文约 4 倍，那是降级形态下**少渲染**，是有意选择的方向
-    （见 utils/tokenize.py 模块 docstring），不是回归。
+    Calls `_count_tokens_heuristic` directly, so no fallback patch is
+    needed and both numbers are available in the same test. The other
+    direction (how much it over-estimates) is deliberately unbounded: byte
+    weights run ~3x for CJK and ~4x for latin, which means rendering
+    *less* in fallback mode — the chosen trade-off (see the `utils
+    /tokenize.py` module docstring), not a regression.
     """
     from utils.tokenize import _count_tokens_heuristic
 
@@ -230,8 +241,9 @@ def test_heuristic_never_undercounts_real_tokens(text):
 @pytest.mark.parametrize("text", _HIGH_ENTROPY_SAMPLES)
 @pytest.mark.parametrize("budget", [1, 5, 20])
 def test_heuristic_truncate_output_fits_real_budget(force_heuristic, text, budget):
-    """降级形态下 `truncate_to_tokens` 的输出，用真实 tokenizer 量也必须
-    在预算内。单条召回（L21 每条 400）靠的就是这一层。"""
+    """In fallback mode, what `truncate_to_tokens` returns must still fit
+    the budget when measured with the real tokenizer. This is the layer
+    the per-entry recall cap (L21, 400 tokens each) rests on."""
     from utils.tokenize import truncate_to_tokens
 
     enc = force_heuristic
@@ -244,15 +256,25 @@ def test_heuristic_truncate_output_fits_real_budget(force_heuristic, text, budge
 
 @pytest.mark.parametrize("budget", [40, 120, 2200])
 def test_heuristic_line_budget_holds_against_real_tokenizer(force_heuristic, budget):
-    """降级形态下 `take_lines_within_token_budget` 的产物（含 join 用的
-    分隔符），用真实 tokenizer 量也必须在预算内。
+    """In fallback mode, what `take_lines_within_token_budget` emits —
+    including the separator it will be joined with — must still fit the
+    budget when measured with the real tokenizer.
 
-    2200 是 #2563 给 L21 召回整段定的预算，issue 实测在旧启发式下真实
-    token 能到它的 2.5–2.7 倍；40 / 120 是让裁剪真的发生的紧预算。
+    2200 is the L21 recall-block budget from #2563, the one #2574 measured
+    at 2.5-2.7x over under the old heuristic; 40 / 120 are tight enough
+    that trimming actually happens.
 
-    唯一豁免是「首行必留」——调用方按相关性排过序，宁可超一点也要出一
-    条，见 `take_lines_within_token_budget` 的 docstring。"""
-    from utils.tokenize import take_lines_within_token_budget
+    The single exemption is the always-keep-the-first-line rule, and it
+    only covers a first line that genuinely does not fit. So the cut is
+    also asserted to be *tight*: whatever was dropped first must be
+    something that really would have overflowed. Without that, an
+    implementation that returned only the first line no matter the budget
+    would satisfy every "within budget" assertion here. (The keep/drop
+    semantics themselves are covered in
+    `tests/unit/test_recall_render_token_budget.py`; this test only owns
+    the heuristic-vs-real half.)
+    """
+    from utils.tokenize import _count_tokens_heuristic, take_lines_within_token_budget
 
     enc = force_heuristic
     separator = "\n"
@@ -263,11 +285,21 @@ def test_heuristic_line_budget_holds_against_real_tokenizer(force_heuristic, bud
     assert dropped == len(_HIGH_ENTROPY_SAMPLES) - len(kept)
 
     real = len(enc.encode(separator.join(kept), disallowed_special=()))
-    if len(kept) == 1:
-        return  # 首行必留，本来就允许单条超预算
-    assert real <= budget, (
-        f"降级整段预算被突破：留了 {len(kept)} 行，真实 {real} > {budget}"
-    )
+    # 留了两行以上，就没有任何理由超预算；只留一行时豁免（首行必留）。
+    if len(kept) > 1:
+        assert real <= budget, (
+            f"降级整段预算被突破：留了 {len(kept)} 行，真实 {real} > {budget}"
+        )
+
+    if dropped:
+        # 裁剪点必须紧贴预算：把下一条加回来一定得超。这条按启发式（也就
+        # 是降级形态下调用方实际用的那把尺）量，因为它钉的是"什么时候停"，
+        # 不是"停下来那一刻真实是多少"。
+        with_next = separator.join(kept + [_HIGH_ENTROPY_SAMPLES[len(kept)]])
+        assert _count_tokens_heuristic(with_next) > budget, (
+            f"裁剪提前收手：留了 {len(kept)} 行、丢了 {dropped} 行，但加上"
+            f"下一条才 {_count_tokens_heuristic(with_next)} ≤ {budget}"
+        )
 
 
 # ── PersonaManager._score_trim_entries ─────────────────────────────

--- a/tests/unit/test_evidence_render_budget.py
+++ b/tests/unit/test_evidence_render_budget.py
@@ -15,11 +15,13 @@ Covers:
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from config import PERSONA_RENDER_ENCODING
 from utils.tokenize import count_tokens
 
 
@@ -138,6 +140,134 @@ def test_heuristic_floor_for_short_non_empty_text(monkeypatch):
     assert count_tokens("ok") >= 1
     assert count_tokens("") == 0
     _reset_fallback_warned_for_tests()
+
+
+# ── 降级计数是上界，不是估算（#2574） ────────────────────────────────
+#
+# #2574 报的是老启发式（非 CJK 约 0.25 token/char）在打包形态下系统性
+# 低估：URL / base64 / 代码片段这类高熵文本实测真实 token 能到预算的
+# 2.5–2.7 倍，而且整条链路没有任何告警。修法是把权重换成 UTF-8 字节
+# 长度（#2626）——BPE 的每个 token 至少映射 1 字节，merge 只会让 token
+# 更少，所以字节数是真实 token 数的**严格上界**。
+#
+# 这条上界性质是整个修复的立论基础，但此前没有测试直接钉住它：现有用
+# 例只覆盖了 warning 一次性、空串和短串下限。下面三条按「计数 → 单条
+# 截断 → 整段预算」把这条不变量在每一层各钉一遍，用的就是 issue 点名
+# 的那几类高熵样本。
+
+# issue 点名的三类高熵文本，加上 CJK / 混合 / 组合字符等边界形态。
+_HIGH_ENTROPY_SAMPLES = [
+    # URL：老启发式最惨的一类，标点和路径段几乎每个字符都自成 token
+    "https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/utils/tokenize.py#L112",
+    # base64：没有任何可 merge 的自然语言词块
+    "aGVsbG8gd29ybGQgdGhpcyBpcyBiYXNlNjQgcGFkZGluZyBkYXRhIQ==",
+    # 代码片段
+    "def _heuristic_char_weight(c): return float(len(c.encode('utf-8')))",
+    # 纯 CJK：字节权重在这里最保守（3 字节/字 vs 真实约 1 token/字）
+    "主人今天心情不错，说想吃辣条",
+    # 中英混排 + URL
+    "主人发了个链接 https://example.com/a?b=1&c=2 说让我看看",
+    # emoji（4 字节）与组合字符
+    "辣条好吃🌶️🔥 café é",
+    # 短串：max(1, ...) 下限的那一头
+    "ok",
+    "a",
+]
+
+
+def _real_encoder():
+    """真实 tiktoken encoder；数据文件取不到就跳过——这几条断言的参照系
+    就是它，没有它测的就不是同一件事。必须在打 fallback 补丁**之前**调，
+    否则 `import tiktoken` 拿到的是 MagicMock。"""
+    try:
+        import tiktoken
+        return tiktoken.get_encoding(PERSONA_RENDER_ENCODING)
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"tiktoken encoding data unavailable: {e}")
+
+
+@pytest.fixture
+def force_heuristic(monkeypatch):
+    """让 `_get_encoder` 必然失败，把 utils.tokenize 整个模块压到降级分支，
+    并把打补丁前抓到的真实 encoder yield 出来做参照系。
+
+    退出时清 `_ENCODERS`：该缓存把失败也缓存下来（正是它让降级不会每次
+    重试磁盘 IO），不清的话同进程后续用例全被钉死在降级形态。"""
+    real_enc = _real_encoder()
+
+    from utils.tokenize import _reset_fallback_warned_for_tests
+
+    fake_tiktoken = MagicMock()
+    fake_tiktoken.get_encoding.side_effect = RuntimeError(
+        "encoding file missing — packaging bug simulation"
+    )
+    monkeypatch.setitem(sys.modules, 'tiktoken', fake_tiktoken)
+    _reset_fallback_warned_for_tests()
+    yield real_enc
+    _reset_fallback_warned_for_tests()
+
+
+@pytest.mark.parametrize("text", _HIGH_ENTROPY_SAMPLES)
+def test_heuristic_never_undercounts_real_tokens(text):
+    """降级计数必须 ≥ 真实 tiktoken 计数——#2574 的核心不变量。
+
+    直接调 `_count_tokens_heuristic`，不需要打 fallback 补丁，所以同一个
+    用例里两边都能拿到真值。反过来（高估多少）不设上限：字节权重对 CJK
+    约 3 倍、对英文约 4 倍，那是降级形态下**少渲染**，是有意选择的方向
+    （见 utils/tokenize.py 模块 docstring），不是回归。
+    """
+    from utils.tokenize import _count_tokens_heuristic
+
+    enc = _real_encoder()
+    real = len(enc.encode(text, disallowed_special=()))
+    heuristic = _count_tokens_heuristic(text)
+    assert heuristic >= real, (
+        f"降级计数低估了真实 token：{text!r} 启发式 {heuristic} < 真实 "
+        f"{real}——#2574 的预算突破就是这么来的"
+    )
+
+
+@pytest.mark.parametrize("text", _HIGH_ENTROPY_SAMPLES)
+@pytest.mark.parametrize("budget", [1, 5, 20])
+def test_heuristic_truncate_output_fits_real_budget(force_heuristic, text, budget):
+    """降级形态下 `truncate_to_tokens` 的输出，用真实 tokenizer 量也必须
+    在预算内。单条召回（L21 每条 400）靠的就是这一层。"""
+    from utils.tokenize import truncate_to_tokens
+
+    enc = force_heuristic
+    out = truncate_to_tokens(text, budget)
+    real = len(enc.encode(out, disallowed_special=())) if out else 0
+    assert real <= budget, (
+        f"降级截断的输出超预算：{text!r} → {out!r} 真实 {real} > {budget}"
+    )
+
+
+@pytest.mark.parametrize("budget", [40, 120, 2200])
+def test_heuristic_line_budget_holds_against_real_tokenizer(force_heuristic, budget):
+    """降级形态下 `take_lines_within_token_budget` 的产物（含 join 用的
+    分隔符），用真实 tokenizer 量也必须在预算内。
+
+    2200 是 #2563 给 L21 召回整段定的预算，issue 实测在旧启发式下真实
+    token 能到它的 2.5–2.7 倍；40 / 120 是让裁剪真的发生的紧预算。
+
+    唯一豁免是「首行必留」——调用方按相关性排过序，宁可超一点也要出一
+    条，见 `take_lines_within_token_budget` 的 docstring。"""
+    from utils.tokenize import take_lines_within_token_budget
+
+    enc = force_heuristic
+    separator = "\n"
+    kept, dropped = take_lines_within_token_budget(
+        _HIGH_ENTROPY_SAMPLES, budget, separator=separator,
+    )
+    assert kept, "非零预算下至少要留一行"
+    assert dropped == len(_HIGH_ENTROPY_SAMPLES) - len(kept)
+
+    real = len(enc.encode(separator.join(kept), disallowed_special=()))
+    if len(kept) == 1:
+        return  # 首行必留，本来就允许单条超预算
+    assert real <= budget, (
+        f"降级整段预算被突破：留了 {len(kept)} 行，真实 {real} > {budget}"
+    )
 
 
 # ── PersonaManager._score_trim_entries ─────────────────────────────


### PR DESCRIPTION
## 改动概述 / Summary

Closes #2574。

#2574 报的是打包形态下 token 预算被系统性突破：tiktoken 编码数据缺失时计数降级到启发式，老公式对非 CJK 按 0.25 token/char 估，URL / base64 / 代码片段这类高熵文本实测真实 token 能到预算的 2.5–2.7 倍，且开发环境测不出来。

**issue 列的四个方向，三个其实已经落地了**，只是没人回来把 issue 关掉：

| 方向 | 状态 |
| --- | --- |
| 1. 调启发式 + bump 版本 | ✅ #2626 把权重换成 UTF-8 字节长度，`_HEURISTIC_VERSION` → `"v2"` |
| 2. 只给召回段加安全系数 | ⛔ 主动放弃，见下 |
| 3. 编码数据打进产物 | ✅ `build-desktop{,-linux}.yml` warm + `--include-data-dir`，`launcher_core/bootstrap.py` frozen 下 setdefault `TIKTOKEN_CACHE_DIR`，打包后空目录直接 `::error::` |
| 4. 降级时告警 | ✅ 一次性 latch，#936 就在，已有用例 |

方向 1 之所以够用：BPE 的每个 token 至少映射 1 字节，merge 只会让 token 更少，所以**字节数是真实 token 数的严格上界**。降级形态现在的偏差方向反过来了——不是突破预算，而是浪费预算（英文约 4 倍、中文约 3 倍的高估，也就是只能塞进 1/3～1/4 的内容）。这是 `utils/tokenize.py` 模块 docstring 里写明的取舍（"favors safety over prompt utilization"）。

方向 2 主动放弃：issue 自己就指出它会让同一个仓库里出现两套 token 语义，1+3 落地后没有必要。

**缺的是测试。** "字节数是上界"这条性质是整个修复的立论基础，但此前没有任何用例直接钉住它——现有的只覆盖了 warning 一次性、空串、短串下限和缓存指纹隔离。也就是说公式要是被改回去（或者哪天有人"优化"成按字符估），CI 全绿，而问题只在分发形态下复发，跟当初一样测不出来。

本 PR 按「计数 → 单条截断 → 整段预算」三层各钉一遍，样本用 issue 点名的 URL / base64 / 代码片段，外加 CJK、中英混排、emoji + 组合字符：

- `test_heuristic_never_undercounts_real_tokens` — `_count_tokens_heuristic(s) >= len(enc.encode(s))`
- `test_heuristic_truncate_output_fits_real_budget` — 降级下 `truncate_to_tokens` 的输出，用真实 tokenizer 量仍在预算内（L21 每条 400 靠这一层）
- `test_heuristic_line_budget_holds_against_real_tokenizer` — 降级下 `take_lines_within_token_budget` 的产物（含 join 分隔符）用真实 tokenizer 量仍在预算内；2200 就是 #2563 给 L21 召回整段定的那个数。豁免"首行必留"，那是 docstring 里写明的前进保证。

新增的 `force_heuristic` fixture 在打补丁**前**抓真实 encoder 做参照系（打完补丁 `import tiktoken` 拿到的是 MagicMock），退出时清 `_ENCODERS`——该缓存把失败也缓存下来，不清会把同进程后续用例钉死在降级形态。

顺带把 issue 最后那句"在口径定下来之前，所有『预算 = 硬上限』的表述都应该理解成『非降级形态下的硬上限』"更新一下：现在正好反过来，**降级形态下预算是硬上限（高估），非降级形态下是精确值**。

## 回归报告 / Regression Report

不适用——纯新增测试，未触碰 `app/`、`main_logic/`、`memory/`，生产代码零改动。

## 不拆分理由 / Why Not Split

不适用（1 个文件，且是测试文件）。

## 测试 / Testing

**先证明这几条测试真的能抓到当初那个 bug**：把 `utils/tokenize.py` 的 `_heuristic_char_weight` 临时改回 #2626 前的 `1.5 if is_cjk_char(c) else 0.25` 公式，新增用例 **12 条失败**——issue 点名的 URL / base64 / 代码片段三类样本在三层里全中，emoji + 组合字符那条也中：

```
FAILED test_heuristic_never_undercounts_real_tokens[https://github.com/...tokenize.py#L112]
FAILED test_heuristic_never_undercounts_real_tokens[aGVsbG8gd29ybGQ...==]
FAILED test_heuristic_never_undercounts_real_tokens[def _heuristic_char_weight(c): ...]
FAILED test_heuristic_never_undercounts_real_tokens[辣条好吃🌶️🔥 café é]
FAILED test_heuristic_truncate_output_fits_real_budget[1|5|20 × 3 样本]
FAILED test_heuristic_line_budget_holds_against_real_tokenizer[40]
FAILED test_heuristic_line_budget_holds_against_real_tokenizer[120]
    AssertionError: 降级整段预算被突破：留了 8 行，真实 125 > 120
```

改回来后：

- `tests/unit/test_evidence_render_budget.py` — 52 passed
- 相邻套件 `test_evidence_token_cache.py` / `test_recall_render_token_budget.py` / `test_memory_render_token_budget.py` — 118 passed
- 顺序无关：`--randomly-seed` 7 / 991 / 20260805 三个顺序均通过（fixture 会碰 `sys.modules` 和 `_ENCODERS`，专门验过不泄漏）
- ruff 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增多种文本类型的 Token 计数准确性验证，涵盖 URL、Base64、代码、中文、Emoji、组合字符及混合文本。
  * 增加文本截断和整体预算控制测试，确保在真实分词器下不超出设定限制。
  * 覆盖降级计数路径及首行必须保留的特殊场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->