### PR TITLE
i18n(#2500 第2步 C2): 主动搭话一族原子翻转 keep_traditional + 三处源头塌陷

### DIFF
--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -1536,17 +1536,31 @@ proactive_generate_ru = """Ваша роль:
 def _normalize_prompt_language(lang: str) -> str:
     """Normalize a language code for the module's general prompt dictionaries.
 
-    Traditional Chinese still collapses to ``zh`` here, but no longer for lack of
-    templates — issue #2500 step 1 backfilled a ``'zh-TW'`` row into every
-    dictionary in this module. What is missing is step 2: the callers reaching
-    these tables still pass a SHORT code, so Traditional is already gone by the
-    time it arrives. Flipping ``keep_traditional`` belongs with that call-site
-    migration, not before it.
+    Traditional Chinese now survives as ``zh-TW``: issue #2500 step 1 backfilled a
+    ``'zh-TW'`` row into every dictionary in this module, and step 2 migrated the
+    callers off short codes, so the script is still present by the time it arrives
+    here. The three normalizers below are therefore identical today; they stay
+    separate so that a table which later diverges can be retuned on its own.
 
-    ``_normalize_startup_greeting_language`` and ``normalize_mini_game_invite_locale``
-    stay separate because their callers *do* hand over a full locale today.
+    ``normalize_proactive_prompt_locale`` is the public face of this function, for
+    consumers that index this module's tables directly instead of going through a
+    getter.
     """
-    return normalize_prompt_locale(lang, default="en", simplified="zh", keep_traditional=False)
+    return normalize_prompt_locale(lang, default="en", simplified="zh", keep_traditional=True)
+
+
+def normalize_proactive_prompt_locale(lang: str) -> str:
+    """Normalize a locale to a key of this module's prompt dicts.
+
+    Public on purpose, same reason as ``normalize_mini_game_invite_locale``: several
+    consumers in ``main_logic`` resolve a locale long before they reach a getter,
+    and a few index the tables (``MUSIC_SEARCH_RESULT_TEXTS``,
+    ``RECENT_PROACTIVE_TIME_LABELS``, ...) with a plain ``dict.get``. Those lookups
+    need the key scheme this module actually uses — ``zh`` / ``zh-TW`` — which is
+    neither a short code (``zh`` loses the script) nor a full locale (``zh-CN`` is
+    not a key here and would silently fall through to English).
+    """
+    return _normalize_prompt_language(lang)
 
 
 def _normalize_startup_greeting_language(lang: str) -> str:

--- a/config/prompts/prompts_sys.py
+++ b/config/prompts/prompts_sys.py
@@ -56,6 +56,23 @@ def _loc(d: dict, lang: str) -> str:
     return d["en"]
 
 
+def normalize_sys_prompt_locale(lang: str | None) -> str:
+    """Normalize a locale to a key of this module's prompt dicts.
+
+    Public on purpose, same reason as ``prompts_proactive.normalize_mini_game_invite_locale``:
+    callers in ``main_logic`` resolve a locale long before they reach ``_loc``, and
+    ``_loc`` cannot repair what arrived broken — it only *reports* an unexpected key
+    and then falls back, so a short code (``zh``) and a full locale (``zh-CN``) both
+    render Simplified without an error. This returns the scheme the tables here
+    actually use: ``zh`` / ``zh-TW``.
+    """
+    from config.prompts._locale import normalize_prompt_locale
+
+    return normalize_prompt_locale(
+        lang, default="en", simplified="zh", keep_traditional=True
+    )
+
+
 
 # ---------- Agent 结果解析器 i18n ----------
 

--- a/main_logic/conversation_turns.py
+++ b/main_logic/conversation_turns.py
@@ -23,9 +23,12 @@ def _privacy_mode_active() -> bool:
 
 
 def normalize_turn_language(language: str | None = None) -> str:
+    # ⚠️ 兜底必须取 full。format='full' 只能保住已有的字形，救不回已经丢掉的：
+    # get_global_language() 返回短码，繁中在这里之前就成了 zh，format='full'
+    # 再把它扩成 zh-CN（issue #2500）。显式传进来的 language 照旧优先。
     try:
-        from utils.language_utils import get_global_language, normalize_language_code
-        source = language if language else get_global_language()
+        from utils.language_utils import get_global_language_full, normalize_language_code
+        source = language if language else get_global_language_full()
         return normalize_language_code(source, format='full') or 'en'
     except Exception:
         return 'en'

--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -27,7 +27,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
+from utils.language_utils import normalize_language_code, get_global_language_full
 from utils.logger_config import get_module_logger
 
 

--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -27,7 +27,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from utils.language_utils import normalize_language_code, get_global_language
+from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
 from utils.logger_config import get_module_logger
 
 
@@ -180,7 +180,11 @@ def _load_locale_messages(locale_code: str) -> dict:
 
 
 def _get_chat_locale_text(language: str | None, key: str, fallback: str) -> str:
-    raw_lang = language or get_global_language()
+    # ⚠️ 兜底必须取 full。下面的 format='full' 只能保住已有的字形，救不回
+    # 已经丢掉的：get_global_language() 返回短码，繁中在进这个函数之前就成了
+    # zh，format='full' 再把它扩成 zh-CN，static/locales/zh-TW.json 永远读不到
+    # （issue #2500）。显式传进来的 language 照旧优先。
+    raw_lang = language or get_global_language_full()
     try:
         lang_full = normalize_language_code(raw_lang, format='full')
     except Exception:

--- a/main_logic/core/callback_render.py
+++ b/main_logic/core/callback_render.py
@@ -32,6 +32,7 @@ from config.prompts.prompts_sys import (
     CONTEXT_SUMMARY_TASK_HEADER, CONTEXT_SUMMARY_TASK_FOOTER,
     CONTEXT_SUMMARY_EVENT_HEADER, CONTEXT_SUMMARY_EVENT_FOOTER,
     RESULT_PARSER_PHRASES,
+    normalize_sys_prompt_locale,
 )
 
 from ._shared import logger
@@ -171,10 +172,19 @@ def _build_callback_instruction(
     group can pick the right outer template and (for task_result+active)
     slot in the right status/action phrases. Event templates ignore
     status/action — the concept doesn't apply to passive event streams.
+    ``lang`` is normalized to a prompt-dict key *here* rather than at the call
+    sites. Every template this renders (SYSTEM_NOTIFICATION_*, SOURCE_DESCRIPTORS,
+    TASK_STATUS_PHRASES, ...) carries a ``zh-TW`` row, and ``_loc`` degrades a
+    stray tag (``zh_TW`` / ``zh-Hant`` / ``zh-CN``) *silently* to the Simplified
+    row — a wrong-script notification, not an error, so nothing downstream would
+    ever notice. Four call sites feed this function; normalizing once here is the
+    only shape a fifth one cannot get wrong (issue #2500).
     """
     if not callbacks:
         return ""
     from collections import OrderedDict
+
+    lang = normalize_sys_prompt_locale(lang)
 
     grouped: "OrderedDict[tuple, list]" = OrderedDict()
     for cb in callbacks:

--- a/main_logic/core/greeting.py
+++ b/main_logic/core/greeting.py
@@ -46,7 +46,7 @@ from config.prompts.prompts_avatar_interaction import (
     _sanitize_avatar_interaction_text_context,
 )
 from utils.config_manager import get_config_manager
-from utils.language_utils import normalize_language_code, get_global_language
+from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
 from uuid import uuid4
 from ._shared import (
     logger,
@@ -767,12 +767,17 @@ class GreetingMixin:
         # tier → 行为：cat1=清醒 / cat2=打盹 / cat3=熟睡。
         behavior = {"cat1": "awake", "cat2": "nap", "cat3": "sleep"}.get(str(tier or "").strip().lower(), "awake")
 
-        _lang = normalize_language_code(self.user_language, format='short')
         from config.prompts.prompts_proactive import (
             CAT_GREETING_SILENT_BELOW_SECONDS,
             get_cat_greeting_episode_prompt, get_cat_greeting_episode_scene,
             get_cat_greeting_prompt,
             get_cat_greeting_reason_hint,
+            normalize_proactive_prompt_locale,
+        )
+        # 猫咪问候的四张表都在 prompts_proactive（有 zh-TW 行）；短码会把 zh-TW
+        # 折成 zh，那些行永远取不到（issue #2500）。
+        _lang = normalize_proactive_prompt_locale(
+            self.user_language or get_global_language_full()
         )
         from utils.time_format import format_elapsed as _format_elapsed
         episode_scene = get_cat_greeting_episode_scene(episode, _lang)
@@ -899,7 +904,10 @@ class GreetingMixin:
             await self.state.fire(SessionEvent.PROACTIVE_DONE)
 
     async def trigger_new_character_greeting(self) -> None:
-        from config.prompts.prompts_proactive import get_new_character_greeting_prompt
+        from config.prompts.prompts_proactive import (
+            get_new_character_greeting_prompt,
+            normalize_proactive_prompt_locale,
+        )
         from utils.new_character_greeting_state import has_pending, remove_pending
 
         config_manager = get_config_manager()
@@ -915,7 +923,11 @@ class GreetingMixin:
             logger.info("[%s] trigger_new_character_greeting: voice session active/starting, skipping", self.lanlan_name)
             return
 
-        _lang = normalize_language_code(getattr(self, 'user_language', '') or '', format='short') or get_global_language()
+        # 同 trigger_cat_greeting：破冰问候模板也在 prompts_proactive，要 prompt
+        # key 才留得住 zh-TW。空 user_language 才回落全局语言（issue #2500）。
+        _lang = normalize_proactive_prompt_locale(
+            getattr(self, 'user_language', '') or get_global_language_full()
+        )
         template = get_new_character_greeting_prompt(_lang)
 
         if self._is_voice_session_active_or_starting():

--- a/main_logic/core/greeting.py
+++ b/main_logic/core/greeting.py
@@ -46,7 +46,7 @@ from config.prompts.prompts_avatar_interaction import (
     _sanitize_avatar_interaction_text_context,
 )
 from utils.config_manager import get_config_manager
-from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
+from utils.language_utils import normalize_language_code, get_global_language_full
 from uuid import uuid4
 from ._shared import (
     logger,

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -2098,7 +2098,8 @@ class LifecycleMixin:
             selected = selected_all[len(_extras):]
             if not selected:
                 return [], ""
-            _lang = normalize_language_code(self.user_language, format='short')
+            # 与 proactive 三条投递路径同口径：字形留到渲染函数再归一化。
+            _lang = normalize_language_code(self.user_language, format='full')
             rendered = _build_callback_instruction(
                 selected,
                 lang=_lang,

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -36,7 +36,7 @@ from main_logic.proactive_delivery import (
     resolve_callback_delivery_ack,
 )
 from config import ANTI_REPEAT_EXEMPT_SOURCE_TAGS
-from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
+from utils.language_utils import normalize_language_code, get_global_language_full
 from uuid import uuid4
 from ._shared import _VOICE_PROACTIVE_ACK_GRACE_S, logger, _proactive_expected_sid
 from .callback_render import _build_callback_instruction, _select_callbacks_within_token_budget

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -36,7 +36,7 @@ from main_logic.proactive_delivery import (
     resolve_callback_delivery_ack,
 )
 from config import ANTI_REPEAT_EXEMPT_SOURCE_TAGS
-from utils.language_utils import normalize_language_code, get_global_language
+from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
 from uuid import uuid4
 from ._shared import _VOICE_PROACTIVE_ACK_GRACE_S, logger, _proactive_expected_sid
 from .callback_render import _build_callback_instruction, _select_callbacks_within_token_budget
@@ -721,7 +721,9 @@ class ProactiveMixin:
                     )
                     return False
 
-                _lang = normalize_language_code(self.user_language, format='short')
+                # ⚠️ 不能砍成短码：_build_callback_instruction 的模板有 zh-TW 行，
+                # 短码在这里就把字形丢了，归一化器再也救不回来（issue #2500）。
+                _lang = normalize_language_code(self.user_language, format='full')
                 voice_snapshot = [
                     cb for cb in proactive_cbs
                     if not cb.get(DELIVERY_RETRACTED_KEY)
@@ -1330,7 +1332,8 @@ class ProactiveMixin:
             for _cb in active_callbacks:
                 if isinstance(_cb, dict):
                     _proactive_images.extend(_cb.get("media_images") or [])
-            _lang = normalize_language_code(self.user_language, format='short')
+            # 同 trigger_agent_callbacks：字形要留到 _build_callback_instruction。
+            _lang = normalize_language_code(self.user_language, format='full')
             instruction = _build_callback_instruction(
                 active_callbacks,
                 lang=_lang,
@@ -2546,7 +2549,10 @@ class ProactiveMixin:
         )
         delivered_to_prompt = False
         try:
-            _lang = normalize_language_code(getattr(self, 'user_language', '') or '', format='short') or get_global_language()
+            # 同上；user_language 为空时才回落全局语言（此前回落的是短码）。
+            _lang = normalize_language_code(
+                getattr(self, 'user_language', '') or get_global_language_full(), format='full'
+            )
             rendered = _build_callback_instruction(
                 callbacks_snapshot,
                 lang=_lang,

--- a/main_logic/proactive_chat/service.py
+++ b/main_logic/proactive_chat/service.py
@@ -43,6 +43,7 @@ from config.prompts.prompts_proactive import (
     get_screen_img_hint,
     get_screen_section_footer,
     get_screen_section_header,
+    normalize_proactive_prompt_locale,
 )
 from config.prompts.prompts_sys import _loc
 from main_logic.omni_realtime_client import OmniRealtimeClient
@@ -283,13 +284,27 @@ def _resolve_proactive_locale(
     keeps proactive invite copy and Phase 1-2 LLM output aligned with the live
     session whenever frontend i18n has already reported the user's language.
 
-    ``fmt="full"`` keeps the script: a short code has no room for one, so ``zh-TW``
-    and ``zh-CN`` both come out ``zh``. That is fine for consumers that only need a
-    language family, but it makes a ``zh-TW`` row in a prompt dict unreachable data.
-    Pass ``fmt="full"`` wherever the result ends up indexing such a dict — the one
-    precedence chain stays shared either way, which is the point of the parameter
-    rather than a second resolver (issue #2500).
+    Three output shapes, one precedence chain — which is the point of the parameter
+    rather than a second resolver (issue #2500):
+
+    - ``fmt="short"`` — a language family (``zh``). No room for a script, so
+      ``zh-TW`` and ``zh-CN`` both come out ``zh``.
+    - ``fmt="full"`` — a BCP-47 locale (``zh-CN`` / ``zh-TW``). This is the key
+      scheme of ``static/locales/*.json``.
+    - ``fmt="prompt"`` — a prompt-dict key (``zh`` / ``zh-TW``). This is the key
+      scheme of every table in ``config/prompts``, and it is NOT the same as
+      ``full``: those tables have no ``zh-CN`` row, so a full locale misses and
+      degrades Simplified users to English on the plain ``dict.get`` lookups
+      (``MUSIC_SEARCH_RESULT_TEXTS``, ``RECENT_PROACTIVE_TIME_LABELS``,
+      ``WORK_BREAK_GENERIC_WORK_LABEL``, ...). Use this wherever the result ends
+      up indexing a prompt dict; it keeps ``zh-TW`` reachable without stranding
+      ``zh-CN``.
     """
+    def _normalize(value: str) -> str:
+        if fmt == "prompt":
+            return normalize_proactive_prompt_locale(value)
+        return normalize_language_code(value, format=fmt)
+
     request_lang = next(
         (value for value in _command_language_candidates(data) if value),
         None,
@@ -299,14 +314,16 @@ def _resolve_proactive_locale(
     # ``normalize_language_code`` 对未识别值默认回退 ``'en'``——必须先用公共白名单
     # 挡掉，否则 proactive 邀请文案会被静默短路成英文，错过本应命中的 session 真值。
     if request_lang and is_supported_language_code(request_lang):
-        normalized = normalize_language_code(request_lang, format=fmt)
+        normalized = _normalize(request_lang)
         if normalized:
             return normalized
     session_lang = getattr(mgr, "user_language", None)
     if session_lang:
-        normalized = normalize_language_code(session_lang, format=fmt)
+        normalized = _normalize(session_lang)
         if normalized:
             return normalized
+    if fmt == "prompt":
+        return normalize_proactive_prompt_locale(get_global_language_full()) or "en"
     if fmt == "full":
         return get_global_language_full() or "en"
     return get_global_language() or "en"
@@ -739,9 +756,12 @@ async def handle_proactive_chat(
             )
         ):
             try:
-                _break_lang = _resolve_proactive_locale(command, mgr)
-                # 邀请按钮 label 走 prompt dict（有 zh-TW 行），必须留住字形；
-                # break reminder 的其余消费点还在短码方案上，保持不动。
+                # break reminder 的消费点全是 prompt dict（休息提醒模板、
+                # WORK_BREAK_* 兜底 label、_loc 出来的分隔符），一律要 prompt
+                # key 而不是短码，否则 zh-TW 行取不到（issue #2500）。
+                _break_lang = _resolve_proactive_locale(command, mgr, fmt="prompt")
+                # 邀请按钮 label 经 normalize_mini_game_invite_locale 二次归一，
+                # full locale 在那边同样收敛到 zh-TW，故保持 full 不动。
                 _break_invite_lang = _resolve_proactive_locale(
                     command, mgr, fmt="full"
                 )
@@ -1251,7 +1271,9 @@ async def handle_proactive_chat(
 
         raw_memory_context = ""
         try:
-            proactive_lang = _resolve_proactive_locale(command, mgr)
+            # fmt="prompt"：proactive_lang 一路喂到 Phase 1/2 模板、屏幕/外部/
+            # 音乐/表情包分节、近期搭话记录、action note——全是 prompt dict。
+            proactive_lang = _resolve_proactive_locale(command, mgr, fmt="prompt")
         except Exception:
             proactive_lang = "zh"
         topic_hook_lang = _resolve_topic_hook_locale(

--- a/tests/unit/test_collapsed_locale_sources_zh_tw.py
+++ b/tests/unit/test_collapsed_locale_sources_zh_tw.py
@@ -153,6 +153,20 @@ def test_callback_instruction_leaves_other_locales_alone(spelling):
 CALLBACK_MODULES = ("main_logic.core.proactive", "main_logic.core.lifecycle")
 
 
+def _callee_name(node: ast.Call) -> str:
+    """调用名，属性式与裸名一视同仁。
+
+    ⚠️ 只认 ``ast.Name`` 会漏 ``callback_render._build_callback_instruction(...)``
+    这种属性式调用——那是个纯粹合法的重构，却会让守卫看不见那个调用点。
+    """  # noqa: DOCSTRING_CJK
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
 def _tree(module_name: str) -> ast.Module:
     import importlib
 
@@ -173,8 +187,7 @@ def _functions_rendering_callbacks(tree: ast.Module) -> list:
             continue
         if any(
             isinstance(call, ast.Call)
-            and isinstance(call.func, ast.Name)
-            and call.func.id == "_build_callback_instruction"
+            and _callee_name(call) == "_build_callback_instruction"
             for call in ast.walk(node)
         ):
             out.append(node)
@@ -187,8 +200,7 @@ def _lang_arg_names(tree: ast.Module) -> set[str]:
     for node in ast.walk(tree):
         if not (
             isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "_build_callback_instruction"
+            and _callee_name(node) == "_build_callback_instruction"
         ):
             continue
         for kw in node.keywords:
@@ -210,8 +222,7 @@ def _short_format_assignments(tree: ast.Module) -> list[int]:
             for call in ast.walk(node.value):
                 if not (
                     isinstance(call, ast.Call)
-                    and isinstance(call.func, ast.Name)
-                    and call.func.id == "normalize_language_code"
+                    and _callee_name(call) == "normalize_language_code"
                 ):
                     continue
                 if any(
@@ -237,8 +248,7 @@ def test_all_four_callback_call_sites_are_accounted_for():
                 node
                 for node in ast.walk(_tree(m))
                 if isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id == "_build_callback_instruction"
+                and _callee_name(node) == "_build_callback_instruction"
             ]
         )
         for m in CALLBACK_MODULES

--- a/tests/unit/test_collapsed_locale_sources_zh_tw.py
+++ b/tests/unit/test_collapsed_locale_sources_zh_tw.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+"""Locale *sources* that had already collapsed before the lookup (issue #2500 step 2).
+
+Three places looked correct on inspection and were not. Each ran a
+``format='full'`` normalization — the right call for its consumer — over a source
+that was **already** a short code, so Traditional had been destroyed one line
+earlier and ``full`` merely re-expanded ``zh`` into ``zh-CN``:
+
+* ``_shared._get_chat_locale_text`` — reads ``static/locales/*.json`` (``zh-CN`` /
+  ``zh-TW`` keys), fell back to ``get_global_language()``.
+* ``conversation_turns.normalize_turn_language`` — same shape.
+* ``callback_render._build_callback_instruction`` — four call sites, all shortening
+  to ``zh`` before handing the locale over.
+
+⚠️ These are *not* fixed by changing the ``format`` argument. ``format='full'``
+cannot recover a script that is already gone; the fix is at the source. A test
+that only pins the ``format`` argument would stay green through the bug, which is
+why every case below drives the real function and compares rendered output.
+"""  # noqa: DOCSTRING_CJK
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+
+import pytest
+
+from config.prompts.prompts_sys import (
+    SYSTEM_NOTIFICATION_TASK_ACTIVE,
+    normalize_sys_prompt_locale,
+)
+from main_logic import conversation_turns
+from main_logic.core import _shared
+from main_logic.core.callback_render import _build_callback_instruction
+
+TRADITIONAL_SPELLINGS = ("zh-TW", "zh-tw", "zh_TW", "zh-Hant", "zh-Hant-TW", "tchinese")
+SIMPLIFIED_SPELLINGS = ("zh", "zh-CN", "zh_CN", "zh-Hans", "schinese")
+LOCALES_DIR = pathlib.Path(_shared.__file__).resolve().parents[2] / "static" / "locales"
+
+
+def _locale_chat_value(locale_code: str, key: str) -> str:
+    data = json.loads((LOCALES_DIR / f"{locale_code}.json").read_text(encoding="utf-8"))
+    return data["chat"][key]
+
+
+# ── 1. _get_chat_locale_text 的兜底源 ────────────────────────
+def test_chat_locale_text_precondition_the_two_rows_differ():
+    """空断言陷阱：两份 JSON 若哪天同文，下面的断言就永远为真。"""  # noqa: DOCSTRING_CJK
+    assert _locale_chat_value("zh-TW", "title") != _locale_chat_value("zh-CN", "title")
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_chat_locale_text_falls_back_to_the_traditional_global(spelling, monkeypatch):
+    monkeypatch.setattr(_shared, "get_global_language_full", lambda: spelling)
+    assert _shared._get_chat_locale_text(None, "title", "FB") == _locale_chat_value(
+        "zh-TW", "title"
+    )
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_chat_locale_text_still_falls_back_to_simplified(spelling, monkeypatch):
+    monkeypatch.setattr(_shared, "get_global_language_full", lambda: spelling)
+    assert _shared._get_chat_locale_text(None, "title", "FB") == _locale_chat_value(
+        "zh-CN", "title"
+    )
+
+
+def test_chat_locale_text_still_prefers_an_explicit_language(monkeypatch):
+    """兜底改了，显式入参的优先级不能跟着变。"""  # noqa: DOCSTRING_CJK
+    monkeypatch.setattr(_shared, "get_global_language_full", lambda: "zh-TW")
+    assert _shared._get_chat_locale_text("ja", "title", "FB") == _locale_chat_value(
+        "ja", "title"
+    )
+
+
+def test_chat_locale_text_unknown_key_still_returns_the_fallback(monkeypatch):
+    monkeypatch.setattr(_shared, "get_global_language_full", lambda: "zh-TW")
+    assert _shared._get_chat_locale_text(None, "no_such_key_here", "FB") == "FB"
+
+
+# ── 2. normalize_turn_language 的兜底源 ─────────────────────
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_turn_language_falls_back_to_the_traditional_global(spelling, monkeypatch):
+    import utils.language_utils as lu
+
+    monkeypatch.setattr(lu, "get_global_language_full", lambda: spelling)
+    assert conversation_turns.normalize_turn_language() == "zh-TW"
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_turn_language_still_falls_back_to_simplified(spelling, monkeypatch):
+    import utils.language_utils as lu
+
+    monkeypatch.setattr(lu, "get_global_language_full", lambda: spelling)
+    assert conversation_turns.normalize_turn_language() == "zh-CN"
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_turn_language_still_prefers_an_explicit_language(spelling, monkeypatch):
+    import utils.language_utils as lu
+
+    monkeypatch.setattr(lu, "get_global_language_full", lambda: "ja")
+    assert conversation_turns.normalize_turn_language(spelling) == "zh-TW"
+
+
+# ── 3. callback 指令：渲染函数就地归一化 ─────────────────────
+CALLBACKS = [
+    {
+        "origin": "task_result",
+        "status": "completed",
+        "source_kind": "plugin",
+        "source_name": "x",
+        "result": "ok",
+    }
+]
+
+
+def _rendered(lang: str) -> str:
+    return _build_callback_instruction(
+        CALLBACKS, lang=lang, lanlan_name="N", master_name="M"
+    )
+
+
+def test_callback_precondition_the_two_rows_differ():
+    assert SYSTEM_NOTIFICATION_TASK_ACTIVE["zh-TW"] != SYSTEM_NOTIFICATION_TASK_ACTIVE["zh"]
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_callback_instruction_renders_traditional(spelling):
+    """渲染函数自己归一化，所以连 ``zh_TW`` / ``zh-Hant`` 这些拼法也接得住。"""  # noqa: DOCSTRING_CJK
+    assert _rendered(spelling) == _rendered("zh-TW")
+    assert _rendered(spelling) != _rendered("zh")
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_callback_instruction_still_renders_simplified(spelling):
+    """⚠️ ``zh-CN`` 也在这张清单里：它是 ``format='full'`` 的产物，而
+    prompts_sys 的表没有 ``zh-CN`` 行。"""  # noqa: DOCSTRING_CJK
+    assert _rendered(spelling) == _rendered("zh")
+
+
+@pytest.mark.parametrize("spelling", ("en", "ja", "ko", "ru", "es", "pt"))
+def test_callback_instruction_leaves_other_locales_alone(spelling):
+    assert normalize_sys_prompt_locale(spelling) == spelling
+    assert _rendered(spelling) != _rendered("en") or spelling == "en"
+
+
+# ── 4. 调用点：自动发现，不是列清单 ──────────────────────────
+# ⚠️ 第 3 节测的是渲染函数，它已经就地归一化了——把调用点改回 ``format='short'``，
+# 第 3 节**照样全绿**，因为字形是在调用点丢的，函数里救不回来。所以这里 walk 一遍
+# 两个 mixin 的 AST，找出所有喂 _build_callback_instruction 的变量，回溯它的赋值。
+CALLBACK_MODULES = ("main_logic.core.proactive", "main_logic.core.lifecycle")
+
+
+def _tree(module_name: str) -> ast.Module:
+    import importlib
+
+    mod = importlib.import_module(module_name)
+    return ast.parse(pathlib.Path(inspect.getsourcefile(mod)).read_text(encoding="utf-8"))
+
+
+def _functions_rendering_callbacks(tree: ast.Module) -> list:
+    """含 _build_callback_instruction 调用的函数。
+
+    ⚠️ 必须按函数定界。``_lang`` 这个名字在这两个模块里被七八个互不相干的
+    消费点共用（prompt_ephemeral、context summary、pending extra replies…），
+    全模块按变量名匹配会把那些还没迁移的路径一起算进来。
+    """  # noqa: DOCSTRING_CJK
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if any(
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "_build_callback_instruction"
+            for call in ast.walk(node)
+        ):
+            out.append(node)
+    return out
+
+
+def _lang_arg_names(tree: ast.Module) -> set[str]:
+    """喂给 _build_callback_instruction 的 ``lang=`` 变量名。"""  # noqa: DOCSTRING_CJK
+    names = set()
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_build_callback_instruction"
+        ):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "lang" and isinstance(kw.value, ast.Name):
+                names.add(kw.value.id)
+    return names
+
+
+def _short_format_assignments(tree: ast.Module) -> list[int]:
+    """渲染回调的函数里，哪些 ``lang=`` 变量是被 ``format='short'`` 赋的值。"""  # noqa: DOCSTRING_CJK
+    offenders = []
+    for func in _functions_rendering_callbacks(tree):
+        names = _lang_arg_names(func)
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id in names for t in node.targets):
+                continue
+            for call in ast.walk(node.value):
+                if not (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "normalize_language_code"
+                ):
+                    continue
+                if any(
+                    kw.arg == "format" and getattr(kw.value, "value", None) == "short"
+                    for kw in call.keywords
+                ):
+                    offenders.append(node.lineno)
+    return offenders
+
+
+@pytest.mark.parametrize("module_name", CALLBACK_MODULES)
+def test_the_callback_call_site_walk_finds_something(module_name):
+    """空断言陷阱：AST 匹配写错时下面那条会 vacuously 通过。"""  # noqa: DOCSTRING_CJK
+    tree = _tree(module_name)
+    assert _lang_arg_names(tree), f"{module_name} 里没找到 lang= 调用点"
+    assert _functions_rendering_callbacks(tree), f"{module_name} 里没定位到渲染函数"
+
+
+def test_all_four_callback_call_sites_are_accounted_for():
+    total = sum(
+        len(
+            [
+                node
+                for node in ast.walk(_tree(m))
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "_build_callback_instruction"
+            ]
+        )
+        for m in CALLBACK_MODULES
+    )
+    assert total == 4, f"调用点数量变了（{total}），复核一遍是不是有新路径漏了归一化"
+
+
+@pytest.mark.parametrize("module_name", CALLBACK_MODULES)
+def test_no_callback_call_site_shortens_the_locale(module_name):
+    offenders = _short_format_assignments(_tree(module_name))
+    assert not offenders, (
+        f"{module_name} 这些行还在把 locale 砍成短码，字形到不了渲染函数：{offenders}"
+    )

--- a/tests/unit/test_proactive_locale_zh_tw.py
+++ b/tests/unit/test_proactive_locale_zh_tw.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+"""Traditional-Chinese reachability for the whole proactive family (issue #2500 step 2 C2).
+
+Step 1 backfilled a ``zh-TW`` row into every dictionary in ``prompts_proactive``.
+Those rows were unreachable data until now: ``_normalize_prompt_language`` ran with
+``keep_traditional=False``, and every caller resolved its locale with
+``format="short"``, so Traditional was already gone twice over before a lookup
+happened. This file pins the flip and — more importantly — the call sites, because
+the flip alone is worthless if a caller still hands over ``zh``.
+
+Three things are asserted, and each is useless without the others:
+
+1. the normalizer keeps the script (``keep_traditional=True``),
+2. every proactive entry point hands it a locale that still has one, and
+3. **one turn renders one locale** — the invariant that made the flip have to be
+   atomic. A later patch that adds a lookup bypassing the normalizer, or "cleans
+   up" one call site back to the short code, would leave Traditional users reading
+   half-Simplified copy. Test 3 is the one that catches it.
+
+⚠️ There is a fourth assertion that looks redundant and is not: the Simplified
+guard. The obvious way to keep the script is ``format="full"``, which yields
+``zh-CN`` — and ``zh-CN`` is not a key in *any* of these tables. That mistake keeps
+every Traditional test green while quietly degrading the majority Simplified path
+to English on the plain ``dict.get`` lookups. See
+``test_simplified_never_degrades_to_english``.
+"""  # noqa: DOCSTRING_CJK
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from config.prompts.prompts_activity import (
+    WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME,
+    WORK_BREAK_GENERIC_WORK_LABEL,
+)
+from config.prompts.prompts_proactive import (
+    CAT_GREETING_REASON_AUTO,
+    MEME_SECTION_HEADER,
+    MUSIC_SEARCH_RESULT_TEXTS,
+    NEW_CHARACTER_GREETING_PROMPT,
+    PROACTIVE_MUSIC_UNKNOWN_TRACK,
+    RECENT_PROACTIVE_CHANNEL_LABELS,
+    RECENT_PROACTIVE_TIME_LABELS,
+    SCREEN_SECTION_HEADER,
+    _normalize_prompt_language,
+    get_cat_greeting_reason_hint,
+    get_new_character_greeting_prompt,
+    get_proactive_music_unknown_track_name,
+    get_screen_section_header,
+    normalize_proactive_prompt_locale,
+)
+from config.prompts.prompts_sys import _loc
+from main_logic.proactive_chat import service
+
+TRADITIONAL_SPELLINGS = ("zh-TW", "zh-tw", "zh_TW", "zh-Hant", "zh-Hant-TW", "tchinese")
+SIMPLIFIED_SPELLINGS = ("zh", "zh-CN", "zh_CN", "zh-Hans", "schinese")
+OTHER_LOCALES = ("en", "ja", "ko", "ru", "es", "pt")
+
+
+def _mgr(user_language):
+    return SimpleNamespace(user_language=user_language)
+
+
+# ── 1. 归一化器留住字形 ──────────────────────────────────────
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_every_traditional_spelling_survives_the_normalizer(spelling):
+    assert _normalize_prompt_language(spelling) == "zh-TW"
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_simplified_spellings_still_collapse_to_the_simplified_key(spelling):
+    """``zh-CN`` must come out ``zh``: it is the *simplified* key of these tables,
+    and ``zh-CN`` itself is not a key anywhere in ``config/prompts``."""
+    assert _normalize_prompt_language(spelling) == "zh"
+
+
+@pytest.mark.parametrize("spelling", OTHER_LOCALES)
+def test_other_locales_are_untouched_by_the_flip(spelling):
+    assert _normalize_prompt_language(spelling) == spelling
+
+
+@pytest.mark.parametrize("spelling", ("estonian", "undefined", "", None))
+def test_garbage_degrades_to_english_not_to_a_crash(spelling):
+    assert _normalize_prompt_language(spelling) == "en"
+
+
+def test_public_normalizer_is_the_same_function():
+    """The public face must not drift from the private one — consumers that index
+    the tables directly have to land on exactly the getters' key scheme."""
+    for spelling in TRADITIONAL_SPELLINGS + SIMPLIFIED_SPELLINGS + OTHER_LOCALES:
+        assert normalize_proactive_prompt_locale(spelling) == _normalize_prompt_language(
+            spelling
+        )
+
+
+# ── 2. 解析器把字形送到位 ────────────────────────────────────
+@pytest.mark.parametrize("source", ("request", "session", "global"))
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_prompt_format_preserves_traditional_from_every_source(source, spelling, monkeypatch):
+    if source == "request":
+        data, mgr = {"language": spelling}, _mgr(None)
+    elif source == "session":
+        data, mgr = {}, _mgr(spelling)
+    else:
+        data, mgr = {}, _mgr(None)
+        monkeypatch.setattr(service, "get_global_language_full", lambda: spelling)
+
+    assert service._resolve_proactive_locale(data, mgr, fmt="prompt") == "zh-TW"
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_short_format_still_collapses_it(spelling):
+    """前提守卫：短码方案确实会毁掉字形。这条一旦变绿，上面那些测试就
+    不再证明任何东西了——它们会在没修调用点的情况下照样通过。"""  # noqa: DOCSTRING_CJK
+    resolved = service._resolve_proactive_locale({}, _mgr(spelling))
+    assert resolved == "zh", resolved
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_prompt_format_yields_the_simplified_key_not_a_full_locale(spelling):
+    """⚠️ ``fmt="full"`` 会给出 ``zh-CN``，那不是任何 prompt 表的键。"""  # noqa: DOCSTRING_CJK
+    assert service._resolve_proactive_locale({}, _mgr(spelling), fmt="prompt") == "zh"
+
+
+@pytest.mark.parametrize("spelling", OTHER_LOCALES)
+def test_prompt_format_leaves_other_locales_alone(spelling):
+    assert service._resolve_proactive_locale({}, _mgr(spelling), fmt="prompt") == spelling
+
+
+def test_request_language_still_wins_over_the_session():
+    resolved = service._resolve_proactive_locale({"language": "ja"}, _mgr("zh-TW"), fmt="prompt")
+    assert resolved == "ja"
+
+
+def test_garbage_request_language_still_falls_through_to_the_session():
+    """白名单守卫早于本次改动，必须活下来：否则 localStorage 一坏，
+    文案就被短路成英文，而 session 里明明有真值。"""  # noqa: DOCSTRING_CJK
+    resolved = service._resolve_proactive_locale(
+        {"language": "estonian"}, _mgr("zh-TW"), fmt="prompt"
+    )
+    assert resolved == "zh-TW", resolved
+
+
+# ── 3. 四条路径各自拿到 zh-TW 模板 ───────────────────────────
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_proactive_chat_copy_renders_traditional(spelling):
+    """主动搭话文案：屏幕分节 header 走 {master} 占位符展开，是整条
+    Phase 2 prompt 里最容易被漏掉字形的一段。"""  # noqa: DOCSTRING_CJK
+    lang = service._resolve_proactive_locale({}, _mgr(spelling), fmt="prompt")
+    assert get_screen_section_header("博士", lang) == SCREEN_SECTION_HEADER["zh-TW"].format(
+        master="博士"
+    )
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_break_reminder_copy_renders_traditional(spelling):
+    """休息邀请：这两张表在 prompts_activity，用的是裸 ``dict.get``——
+    键错了不会报错，只会静默变英文。"""  # noqa: DOCSTRING_CJK
+    from main_logic.proactive_chat.break_reminders import _resolve_break_reminder_label
+
+    lang = service._resolve_proactive_locale({}, _mgr(spelling), fmt="prompt")
+    assert _resolve_break_reminder_label(None, lang, WORK_BREAK_GENERIC_WORK_LABEL) == (
+        WORK_BREAK_GENERIC_WORK_LABEL["zh-TW"]
+    )
+    for game_type, per_lang in WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME.items():
+        assert per_lang.get(lang) == per_lang["zh-TW"], game_type
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_new_character_greeting_renders_traditional(spelling):
+    """破冰问候。"""  # noqa: DOCSTRING_CJK
+    assert get_new_character_greeting_prompt(
+        normalize_proactive_prompt_locale(spelling)
+    ) == NEW_CHARACTER_GREETING_PROMPT["zh-TW"]
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_cat_greeting_renders_traditional(spelling):
+    """猫咪问候：与破冰问候同族，同一个 mixin、同样的短码来源。"""  # noqa: DOCSTRING_CJK
+    assert get_cat_greeting_reason_hint(
+        True, normalize_proactive_prompt_locale(spelling)
+    ) == CAT_GREETING_REASON_AUTO["zh-TW"]
+
+
+# ── 4. 同一轮里所有文案同一个 locale ─────────────────────────
+# ⚠️ 这条是 C1 收口的存在理由。上面每条路径单独测都可能是绿的，而用户看到的是
+# 一整轮混排。以后谁再加一处绕过归一化器的查表，这里会红。
+def _one_turn_renderings(lang: str) -> dict[str, str]:
+    """一轮主动搭话里真实会拼进 prompt 的若干片段，覆盖三种查表风格：
+    getter / ``_loc`` / 裸 ``dict.get``。"""  # noqa: DOCSTRING_CJK
+    return {
+        "screen_header": get_screen_section_header("博士", lang),
+        "meme_header": _loc(MEME_SECTION_HEADER, lang),
+        "music_unknown_track": get_proactive_music_unknown_track_name(lang),
+        "music_search_title": MUSIC_SEARCH_RESULT_TEXTS.get(
+            lang, MUSIC_SEARCH_RESULT_TEXTS["en"]
+        )["title"],
+        "recent_time_label": RECENT_PROACTIVE_TIME_LABELS.get(
+            lang, RECENT_PROACTIVE_TIME_LABELS["en"]
+        )["m"],
+        "recent_channel_label": RECENT_PROACTIVE_CHANNEL_LABELS.get(
+            lang, RECENT_PROACTIVE_CHANNEL_LABELS["en"]
+        )["vision"],
+    }
+
+
+def _expected_for_key(key: str, row: str) -> str:
+    return {
+        "screen_header": SCREEN_SECTION_HEADER[row].format(master="博士"),
+        "meme_header": MEME_SECTION_HEADER[row],
+        "music_unknown_track": PROACTIVE_MUSIC_UNKNOWN_TRACK[row],
+        "music_search_title": MUSIC_SEARCH_RESULT_TEXTS[row]["title"],
+        "recent_time_label": RECENT_PROACTIVE_TIME_LABELS[row]["m"],
+        "recent_channel_label": RECENT_PROACTIVE_CHANNEL_LABELS[row]["vision"],
+    }[key]
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_one_turn_is_entirely_traditional(spelling):
+    lang = service._resolve_proactive_locale({}, _mgr(spelling), fmt="prompt")
+    rendered = _one_turn_renderings(lang)
+    # 断言取值相等而不是"含某个繁体字"：包含式断言挡不住一半模板回落简体。
+    assert rendered == {k: _expected_for_key(k, "zh-TW") for k in rendered}
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_one_turn_is_entirely_simplified(spelling):
+    lang = service._resolve_proactive_locale({}, _mgr(spelling), fmt="prompt")
+    rendered = _one_turn_renderings(lang)
+    assert rendered == {k: _expected_for_key(k, "zh") for k in rendered}
+
+
+def test_simplified_never_degrades_to_english():
+    """⚠️ 这条专门挡 ``fmt="full"``。
+
+    ``full`` 给出的是 ``zh-CN``，而这些表一个 ``zh-CN`` 键都没有——裸 ``dict.get``
+    会直接落到 ``en``。繁中那一侧的测试全绿，简中用户却看到英文。
+    """  # noqa: DOCSTRING_CJK
+    lang = service._resolve_proactive_locale({}, _mgr("zh-CN"), fmt="prompt")
+    english = {k: _expected_for_key(k, "en") for k in _one_turn_renderings(lang)}
+    rendered = _one_turn_renderings(lang)
+    offenders = [k for k, v in rendered.items() if v == english[k]]
+    assert not offenders, f"简中被降级成英文的片段：{offenders}"
+
+
+def test_full_format_would_have_broken_simplified():
+    """前提守卫：证明上一条测的不是空气。``fmt="full"`` 确实会打穿简中。
+
+    如果哪天 ``full`` 也开始返回 ``zh``（或这些表补了 ``zh-CN`` 行），这条会红，
+    提醒把上一条的理由重写——而不是让它退化成一条永远为真的断言。
+    """  # noqa: DOCSTRING_CJK
+    full = service._resolve_proactive_locale({}, _mgr("zh-CN"), fmt="full")
+    assert full == "zh-CN"
+    assert MUSIC_SEARCH_RESULT_TEXTS.get(full) is None
+    assert RECENT_PROACTIVE_TIME_LABELS.get(full) is None
+
+
+# ── 5. 调用点：自动发现，不是列清单 ──────────────────────────
+# ⚠️ 上面全部是"归一化器和表各自没问题"。真正让 zh-TW 到达用户的是调用点：
+# 把 ``fmt="prompt"`` 删掉，第 1/3/4 节里很多条还是绿的（表本身没变）。所以这里
+# walk 一遍 service.py 的 AST，检查**每一个**调用点都显式给了 fmt。
+def _service_tree() -> ast.Module:
+    path = pathlib.Path(inspect.getsourcefile(service))
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _resolver_calls() -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(_service_tree())
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_resolve_proactive_locale"
+    ]
+
+
+def test_the_call_site_walk_finds_something():
+    """空断言陷阱：AST 匹配写错时下面那条会 vacuously 通过。"""  # noqa: DOCSTRING_CJK
+    assert len(_resolver_calls()) >= 4
+
+
+def test_no_call_site_relies_on_the_short_default():
+    """短码默认值留着是函数契约的一部分，但没有调用点该再用它——
+    proactive 一族的消费点如今全是 prompt dict。"""  # noqa: DOCSTRING_CJK
+    offenders = [
+        node.lineno
+        for node in _resolver_calls()
+        if not any(kw.arg == "fmt" for kw in node.keywords)
+    ]
+    assert not offenders, f"这些调用点还在吃短码默认值：service.py:{offenders}"
+
+
+GREETING_ENTRYPOINTS = ("trigger_cat_greeting", "trigger_new_character_greeting")
+
+
+def _greeting_function(name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    from main_logic.core import greeting as greeting_mod
+
+    tree = ast.parse(
+        pathlib.Path(inspect.getsourcefile(greeting_mod)).read_text(encoding="utf-8")
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"greeting.py 里找不到 {name}——入口改名了，这条守卫已失效")
+
+
+@pytest.mark.parametrize("name", GREETING_ENTRYPOINTS)
+def test_greeting_entrypoints_do_not_shorten_the_locale(name):
+    """⚠️ 上面两条问候测试喂的是已归一化的 locale，测的是 getter 不是调用点：
+    把 greeting.py 改回 ``format='short'``，那两条照样绿。这里盯调用点。"""  # noqa: DOCSTRING_CJK
+    offenders = [
+        node.lineno
+        for node in ast.walk(_greeting_function(name))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "normalize_language_code"
+        and any(
+            kw.arg == "format" and getattr(kw.value, "value", None) == "short"
+            for kw in node.keywords
+        )
+    ]
+    assert not offenders, f"{name} 还在把 locale 砍成短码：greeting.py:{offenders}"
+
+
+@pytest.mark.parametrize("name", GREETING_ENTRYPOINTS)
+def test_greeting_entrypoints_normalize_through_the_prompt_normalizer(name):
+    callees = {
+        node.func.id
+        for node in ast.walk(_greeting_function(name))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "normalize_proactive_prompt_locale" in callees, (
+        f"{name} 没走 prompt key 归一化器，zh-TW 行取不到"
+    )
+
+
+def test_prompt_dict_consumers_ask_for_the_prompt_format():
+    """``_break_lang`` / ``proactive_lang`` 是喂 prompt 表的两条主干。"""  # noqa: DOCSTRING_CJK
+    wanted = {"_break_lang", "proactive_lang"}
+    seen: dict[str, str] = {}
+    for node in ast.walk(_service_tree()):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        if not (isinstance(call.func, ast.Name) and call.func.id == "_resolve_proactive_locale"):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id in wanted:
+                fmt = next((kw.value for kw in call.keywords if kw.arg == "fmt"), None)
+                seen[target.id] = getattr(fmt, "value", None)
+    assert seen == {name: "prompt" for name in wanted}, seen

--- a/tests/unit/test_proactive_locale_zh_tw.py
+++ b/tests/unit/test_proactive_locale_zh_tw.py
@@ -263,6 +263,21 @@ def test_full_format_would_have_broken_simplified():
 # ⚠️ 上面全部是"归一化器和表各自没问题"。真正让 zh-TW 到达用户的是调用点：
 # 把 ``fmt="prompt"`` 删掉，第 1/3/4 节里很多条还是绿的（表本身没变）。所以这里
 # walk 一遍 service.py 的 AST，检查**每一个**调用点都显式给了 fmt。
+def _callee_name(node: ast.Call) -> str:
+    """调用名，属性式与裸名一视同仁。
+
+    ⚠️ 只认 ``ast.Name`` 会漏：``service._resolve_proactive_locale(...)`` /
+    ``prompts_proactive.normalize_proactive_prompt_locale(...)`` 都是 ``ast.Attribute``，
+    一个纯粹合法的重构会让守卫误红（或者更糟，漏掉一个真调用点）。
+    """  # noqa: DOCSTRING_CJK
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
 def _service_tree() -> ast.Module:
     path = pathlib.Path(inspect.getsourcefile(service))
     return ast.parse(path.read_text(encoding="utf-8"))
@@ -273,8 +288,7 @@ def _resolver_calls() -> list[ast.Call]:
         node
         for node in ast.walk(_service_tree())
         if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "_resolve_proactive_locale"
+        and _callee_name(node) == "_resolve_proactive_locale"
     ]
 
 
@@ -297,16 +311,50 @@ def test_no_call_site_relies_on_the_short_default():
 GREETING_ENTRYPOINTS = ("trigger_cat_greeting", "trigger_new_character_greeting")
 
 
-def _greeting_function(name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+def _greeting_tree() -> ast.Module:
     from main_logic.core import greeting as greeting_mod
 
-    tree = ast.parse(
+    return ast.parse(
         pathlib.Path(inspect.getsourcefile(greeting_mod)).read_text(encoding="utf-8")
     )
+
+
+def _named_function(tree: ast.Module, name: str):
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
             return node
-    raise AssertionError(f"greeting.py 里找不到 {name}——入口改名了，这条守卫已失效")
+    return None
+
+
+def _greeting_scope(name: str) -> list:
+    """入口函数，**外加**它在本模块里调到的辅助函数（追一层）。
+
+    ⚠️ 只 walk 入口函数体是有缝的：把 locale 解析挪进一个私有 helper
+    （``_resolve_greeting_lang()``），短码就藏到守卫看不见的地方了。追一层把这条缝
+    堵上——同时也让「必须调归一化器」那条不会因为纯粹的抽取重构而误红。
+    """  # noqa: DOCSTRING_CJK
+    tree = _greeting_tree()
+    entry = _named_function(tree, name)
+    assert entry is not None, f"greeting.py 里找不到 {name}——入口改名了，这条守卫已失效"
+
+    scope = [entry]
+    for node in ast.walk(entry):
+        if not isinstance(node, ast.Call):
+            continue
+        helper = _named_function(tree, _callee_name(node))
+        if helper is not None and helper is not entry:
+            scope.append(helper)
+    return scope
+
+
+def _calls_in(scope: list) -> list[ast.Call]:
+    return [node for func in scope for node in ast.walk(func) if isinstance(node, ast.Call)]
+
+
+@pytest.mark.parametrize("name", GREETING_ENTRYPOINTS)
+def test_the_greeting_scope_walk_finds_something(name):
+    """空断言陷阱：作用域解析写错时，下面两条会 vacuously 通过。"""  # noqa: DOCSTRING_CJK
+    assert _calls_in(_greeting_scope(name)), f"{name} 作用域里一个调用都没扫到"
 
 
 @pytest.mark.parametrize("name", GREETING_ENTRYPOINTS)
@@ -315,10 +363,8 @@ def test_greeting_entrypoints_do_not_shorten_the_locale(name):
     把 greeting.py 改回 ``format='short'``，那两条照样绿。这里盯调用点。"""  # noqa: DOCSTRING_CJK
     offenders = [
         node.lineno
-        for node in ast.walk(_greeting_function(name))
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "normalize_language_code"
+        for node in _calls_in(_greeting_scope(name))
+        if _callee_name(node) == "normalize_language_code"
         and any(
             kw.arg == "format" and getattr(kw.value, "value", None) == "short"
             for kw in node.keywords
@@ -329,11 +375,7 @@ def test_greeting_entrypoints_do_not_shorten_the_locale(name):
 
 @pytest.mark.parametrize("name", GREETING_ENTRYPOINTS)
 def test_greeting_entrypoints_normalize_through_the_prompt_normalizer(name):
-    callees = {
-        node.func.id
-        for node in ast.walk(_greeting_function(name))
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-    }
+    callees = {_callee_name(node) for node in _calls_in(_greeting_scope(name))}
     assert "normalize_proactive_prompt_locale" in callees, (
         f"{name} 没走 prompt key 归一化器，zh-TW 行取不到"
     )
@@ -347,7 +389,7 @@ def test_prompt_dict_consumers_ask_for_the_prompt_format():
         if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
             continue
         call = node.value
-        if not (isinstance(call.func, ast.Name) and call.func.id == "_resolve_proactive_locale"):
+        if _callee_name(call) != "_resolve_proactive_locale":
             continue
         for target in node.targets:
             if isinstance(target, ast.Name) and target.id in wanted:

--- a/tests/unit/test_proactive_prompt_locale_uniformity.py
+++ b/tests/unit/test_proactive_prompt_locale_uniformity.py
@@ -207,14 +207,17 @@ def test_every_locale_gets_distinct_format_sections():
 def test_the_whole_module_answers_one_script_for_a_traditional_locale():
     """The point of the refactor: no function disagrees with the others.
 
-    ``keep_traditional`` is still ``False``, so the whole module answers Simplified
-    for ``zh-TW`` -- deliberately, and as one unit. Before, ``get_meme_topic_line``
-    was the single function answering Traditional, which is exactly the mixed-script
-    turn a later flip has to avoid.
+    C2 flipped ``keep_traditional`` to ``True`` together with every call site, so
+    the whole module now answers Traditional for ``zh-TW`` -- and, still, as one
+    unit. That uniformity is the invariant, not the script: before the collapse
+    ``get_meme_topic_line`` was the single function answering Traditional while the
+    rest answered Simplified, which is exactly the mixed-script turn this pins shut.
     """
     meme_line = P.get_meme_topic_line("zh-TW", keyword="", title="T", source="S")
-    assert meme_line == P.get_meme_topic_line("zh", keyword="", title="T", source="S")
-    assert meme_line == P._loc(P.MEME_TOPIC_NO_KEYWORD, "zh").format(title="T", source="S")
+    assert meme_line != P.get_meme_topic_line("zh", keyword="", title="T", source="S")
+    assert meme_line == P._loc(P.MEME_TOPIC_NO_KEYWORD, "zh-TW").format(
+        title="T", source="S"
+    )
 
     source_instruction, _ = P.get_proactive_format_sections(
         has_screen=True, has_web=False, has_music=False, has_meme=False, lang="zh-TW"
@@ -222,22 +225,24 @@ def test_the_whole_module_answers_one_script_for_a_traditional_locale():
     simplified, _ = P.get_proactive_format_sections(
         has_screen=True, has_web=False, has_music=False, has_meme=False, lang="zh"
     )
-    assert source_instruction == simplified
-    # 单靠上面那条相等断言是空的：归一化器把 'zh-TW' 和 'zh' 映到同一个键，两边
-    # 本来就是同一次调用，任何确定性实现都能过 —— 包括"所有人都拿英文"。所以还要
-    # 钉住内容确实是简体那一行，且不是繁体、不是英文。
-    assert _MATERIAL_LABEL_MARKERS["zh"] in source_instruction      # 屏幕内容
-    assert "螢幕內容" not in source_instruction                      # 繁体写法
+    assert source_instruction != simplified
+    # 钉住内容确实是繁体那一行，且不是简体、不是英文——单看"两边不等"是空的，
+    # "所有人都拿英文"也能让它不等。
+    assert "螢幕內容" in source_instruction                          # 繁体写法
+    assert _MATERIAL_LABEL_MARKERS["zh"] not in source_instruction  # 屏幕内容
     assert _MATERIAL_LABEL_MARKERS["en"] not in source_instruction  # screen content
 
 
-@pytest.mark.parametrize("full_locale, short_key", [("zh-CN", "zh"), ("zh-TW", "zh")])
-def test_full_locales_resolve_without_falling_through_loc(full_locale, short_key, capsys):
+@pytest.mark.parametrize(
+    "full_locale, expected_key", [("zh-CN", "zh"), ("zh-TW", "zh-TW")]
+)
+def test_full_locales_resolve_without_falling_through_loc(full_locale, expected_key, capsys):
     """After step 2's caller flip, Simplified arrives as ``zh-CN``, not ``zh``.
 
     ``_loc`` would answer that with a missing-key warning and a fallback. Going
-    through the normalizer first means the key is always one the dicts carry.
+    through the normalizer first means the key is always one the dicts carry —
+    and, since C2, ``zh-TW`` resolves to its own row rather than the Simplified one.
     """
     line = P.get_meme_topic_line(full_locale, keyword="", title="T", source="S")
-    assert line == P.get_meme_topic_line(short_key, keyword="", title="T", source="S")
+    assert line == P.get_meme_topic_line(expected_key, keyword="", title="T", source="S")
     assert "Unexpected lang code" not in capsys.readouterr().out

--- a/tests/unit/test_proactive_text_does_not_dehumanize.py
+++ b/tests/unit/test_proactive_text_does_not_dehumanize.py
@@ -361,7 +361,10 @@ def test_cat_greeting_episode_scene_rejects_invalid_combinations_and_uses_englis
     assert get_cat_greeting_episode_scene({'kind': 'rested'}, 'fr-FR') == english
     zh = get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh')
     assert get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-CN') == zh
-    assert get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-TW') == zh
+    # 自 #2500 C2 起繁中走自己那一行，不再折成简体。
+    traditional = get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-TW')
+    assert traditional != zh
+    assert get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-Hant') == traditional
 
 
 def test_cat_greeting_episode_scene_is_not_labeled_as_optional_background() -> None:

--- a/tests/unit/test_proactive_text_does_not_dehumanize.py
+++ b/tests/unit/test_proactive_text_does_not_dehumanize.py
@@ -363,6 +363,9 @@ def test_cat_greeting_episode_scene_rejects_invalid_combinations_and_uses_englis
     assert get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-CN') == zh
     # 自 #2500 C2 起繁中走自己那一行，不再折成简体。
     traditional = get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-TW')
+    # 空断言陷阱：查不到 kind 时函数返回 ''，那样 '' != zh 与 '' == '' 两条都成立，
+    # 繁中用户拿到空文案而测试全绿。必须先钉住它非空。
+    assert traditional, 'zh-TW 缺少 rested 场景行，繁中会拿到空文案'
     assert traditional != zh
     assert get_cat_greeting_episode_scene({'kind': 'rested'}, 'zh-Hant') == traditional
 

--- a/tests/unit/test_prompt_locale_normalizer.py
+++ b/tests/unit/test_prompt_locale_normalizer.py
@@ -36,23 +36,25 @@ from config.prompts.prompts_badminton import normalize_badminton_prompt_locale
 from config.prompts.prompts_chara import _normalize_lang
 from config.prompts.prompts_memory import _normalize_memory_prompt_lang
 from config.prompts.prompts_minigame_common import _normalize_prompt_lang
-from config.prompts.prompts_proactive import _normalize_prompt_language
-from config.prompts.prompts_sys import _loc
+from config.prompts.prompts_proactive import (
+    _normalize_prompt_language,
+    normalize_proactive_prompt_locale,
+)
+from config.prompts.prompts_sys import _loc, normalize_sys_prompt_locale
 
 PROMPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "config" / "prompts"
 
-# The six module normalizers collapse to four distinct behaviors. chara, memory
-# and avatar_interaction share one column: same default, same simplified key,
-# both keeping zh-TW.
+# The module normalizers collapse to three distinct behaviors. chara, memory,
+# avatar_interaction, proactive and sys share one column: same default, same
+# simplified key, all keeping zh-TW.
 #
 # Since issue #2500 step 2 the minigame column keeps zh-TW too, so it now differs
 # from traditional_aware only in its empty-input default ('zh' vs 'en'). proactive
-# is the one column still collapsing Traditional, waiting on its own call-site
-# flip in main_logic/proactive_chat/service.py.
-COLUMNS = ("proactive", "minigame", "traditional_aware", "badminton")
+# was the last column still collapsing Traditional; C2 flipped it together with its
+# call sites, so it folded into traditional_aware and is asserted as a peer below.
+COLUMNS = ("minigame", "traditional_aware", "badminton")
 
 MODULE_NORMALIZERS = {
-    "proactive": _normalize_prompt_language,
     "minigame": _normalize_prompt_lang,
     "traditional_aware": _normalize_lang,
     "badminton": normalize_badminton_prompt_locale,
@@ -62,6 +64,9 @@ MODULE_NORMALIZERS = {
 TRADITIONAL_AWARE_PEERS = (
     _normalize_memory_prompt_lang,
     _avatar_interaction_locale,
+    _normalize_prompt_language,
+    normalize_proactive_prompt_locale,
+    normalize_sys_prompt_locale,
 )
 
 # _avatar_interaction_locale resolves empty input through
@@ -70,67 +75,67 @@ TRADITIONAL_AWARE_PEERS = (
 # test_avatar_empty_input_falls_back_to_global_language pins that path instead.
 AVATAR_RESOLVER_INPUTS = {"", None}
 
-# input -> (proactive, minigame, traditional_aware, badminton)
+# input -> (minigame, traditional_aware, badminton)
 EXPECTED = {
     # The eight runtime locales.
-    "en": ("en", "en", "en", "en"),
-    "ja": ("ja", "ja", "ja", "ja"),
-    "ko": ("ko", "ko", "ko", "ko"),
-    "zh-CN": ("zh", "zh", "zh", "zh-CN"),
-    "zh-TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "ru": ("ru", "ru", "ru", "ru"),
-    "pt": ("pt", "pt", "pt", "pt"),
-    "es": ("es", "es", "es", "es"),
+    "en": ("en", "en", "en"),
+    "ja": ("ja", "ja", "ja"),
+    "ko": ("ko", "ko", "ko"),
+    "zh-CN": ("zh", "zh", "zh-CN"),
+    "zh-TW": ("zh-TW", "zh-TW", "zh-TW"),
+    "ru": ("ru", "ru", "ru"),
+    "pt": ("pt", "pt", "pt"),
+    "es": ("es", "es", "es"),
     # Short Chinese and its spellings.
-    "zh": ("zh", "zh", "zh", "zh-CN"),
-    "zh-Hant": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "zh-Hans": ("zh", "zh", "zh", "zh-CN"),
-    "zh-HK": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "zh-hant-TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "zh": ("zh", "zh", "zh-CN"),
+    "zh-Hant": ("zh-TW", "zh-TW", "zh-TW"),
+    "zh-Hans": ("zh", "zh", "zh-CN"),
+    "zh-HK": ("zh-TW", "zh-TW", "zh-TW"),
+    "zh-hant-TW": ("zh-TW", "zh-TW", "zh-TW"),
     # Case, underscore and surrounding whitespace must not change the answer.
-    "ZH-TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "zh_TW": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "  zh-TW  ": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "zh-tw": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "ZH-TW": ("zh-TW", "zh-TW", "zh-TW"),
+    "zh_TW": ("zh-TW", "zh-TW", "zh-TW"),
+    "  zh-TW  ": ("zh-TW", "zh-TW", "zh-TW"),
+    "zh-tw": ("zh-TW", "zh-TW", "zh-TW"),
     # Region subtags.
-    "en-US": ("en", "en", "en", "en"),
-    "ja-JP": ("ja", "ja", "ja", "ja"),
-    "ko-KR": ("ko", "ko", "ko", "ko"),
-    "ru-RU": ("ru", "ru", "ru", "ru"),
-    "es-MX": ("es", "es", "es", "es"),
-    "pt-BR": ("pt", "pt", "pt", "pt"),
-    "en_US": ("en", "en", "en", "en"),
+    "en-US": ("en", "en", "en"),
+    "ja-JP": ("ja", "ja", "ja"),
+    "ko-KR": ("ko", "ko", "ko"),
+    "ru-RU": ("ru", "ru", "ru"),
+    "es-MX": ("es", "es", "es"),
+    "pt-BR": ("pt", "pt", "pt"),
+    "en_US": ("en", "en", "en"),
     # Steam store language codes. Every module resolves these now; before the
     # collapse only minigame and badminton did, and the rest fell to English.
-    "schinese": ("zh", "zh", "zh", "zh-CN"),
-    "tchinese": ("zh", "zh-TW", "zh-TW", "zh-TW"),
-    "english": ("en", "en", "en", "en"),
-    "japanese": ("ja", "ja", "ja", "ja"),
-    "koreana": ("ko", "ko", "ko", "ko"),
-    "korean": ("ko", "ko", "ko", "ko"),
-    "russian": ("ru", "ru", "ru", "ru"),
-    "spanish": ("es", "es", "es", "es"),
-    "latam": ("es", "es", "es", "es"),
-    "portuguese": ("pt", "pt", "pt", "pt"),
-    "brazilian": ("pt", "pt", "pt", "pt"),
-    "TChinese": ("zh", "zh-TW", "zh-TW", "zh-TW"),
+    "schinese": ("zh", "zh", "zh-CN"),
+    "tchinese": ("zh-TW", "zh-TW", "zh-TW"),
+    "english": ("en", "en", "en"),
+    "japanese": ("ja", "ja", "ja"),
+    "koreana": ("ko", "ko", "ko"),
+    "korean": ("ko", "ko", "ko"),
+    "russian": ("ru", "ru", "ru"),
+    "spanish": ("es", "es", "es"),
+    "latam": ("es", "es", "es"),
+    "portuguese": ("pt", "pt", "pt"),
+    "brazilian": ("pt", "pt", "pt"),
+    "TChinese": ("zh-TW", "zh-TW", "zh-TW"),
     # Empty input takes the per-module default; the minigame and badminton
     # modules intentionally default to Chinese rather than English.
-    "": ("en", "zh", "en", "zh-CN"),
-    "   ": ("en", "zh", "en", "zh-CN"),
+    "": ("zh", "en", "zh-CN"),
+    "   ": ("zh", "en", "zh-CN"),
     # Unrecognized *non-empty* input is a different case from empty: it always
     # resolves to English, never to the module default.
-    "xx": ("en", "en", "en", "en"),
-    "klingon": ("en", "en", "en", "en"),
-    "-zh": ("en", "en", "en", "en"),
-    "fr": ("en", "en", "en", "en"),
+    "xx": ("en", "en", "en"),
+    "klingon": ("en", "en", "en"),
+    "-zh": ("en", "en", "en"),
+    "fr": ("en", "en", "en"),
     # "esperanto" must not be read as Spanish: matching is exact or
     # "<locale>-" prefixed, never a bare startswith.
-    "esperanto": ("en", "en", "en", "en"),
+    "esperanto": ("en", "en", "en"),
     # Known wart, pinned so a change is deliberate: a tag merely beginning with
     # "zh" still reads as Chinese. Harmless while the runtime locale set is
     # NEKO_CORE_LOCALES, none of which collide.
-    "zh-": ("zh", "zh", "zh", "zh-CN"),
+    "zh-": ("zh", "zh", "zh-CN"),
 }
 
 


### PR DESCRIPTION
issue #2500 第 2 步的 C2：主动搭话一族的原子翻转。

前置 A / C1 / B 在 #2721 合并，agent 语言缺陷在 #2718 合并。C1 把
`prompts_proactive.py` 的 45 处查表全部收口到 `_normalize_prompt_language`（裸 `lang`
已归零），所以现在翻 `keep_traditional` 才是原子的——这正是 C1 存在的意义。

## 回归报告

### 第一段：原子翻转（commit 1）

**改了什么。** `prompts_proactive._normalize_prompt_language` 的 `keep_traditional`
从 `False` 翻成 `True`，同时把所有会走到这些表的调用点一起改掉。

**为什么必须同一个 commit。** 只翻一半会让繁中用户在**同一轮对话**里繁简混着出：
Phase 2 prompt 的屏幕分节是繁体，同一段里的音乐搜索标题却是简体。

**⚠️ 这里刻意没有用 `fmt="full"`。** issue 原本的写法是给调用点补 `fmt="full"`，
实测会引进一个比原缺陷更严重的回归：`normalize_language_code(x, format='full')` 对
`zh` / `zh-CN` 产出的是 **`zh-CN`**，而 `config/prompts` 下**没有任何一张表有
`zh-CN` 行**（键是 `zh` / `zh-TW`）。这条路径上有五处裸 `dict.get`：

| 表 | 消费点 |
|---|---|
| `MUSIC_SEARCH_RESULT_TEXTS` | `music_recommendation.py:80` |
| `RECENT_PROACTIVE_TIME_LABELS` / `_CHANNEL_LABELS` | `state.py:453-454` |
| `WORK_BREAK_GENERIC_WORK_LABEL` | `break_reminders.py:93` |
| `WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME` | `break_reminders.py:238` |

`.get('zh-CN', ...['en'])` 全部直接落到英文。也就是说 `fmt="full"` 会让繁中侧测试
全绿、**简中用户看到英文**——而且不报错。所以 `_resolve_proactive_locale` 新增的是
第三种模式 `fmt="prompt"`，产出 prompt 表真正的键（`zh` / `zh-TW`），繁中留得住、
简中不掉队。`test_simplified_never_degrades_to_english` + 其前提守卫钉住这条。

**改动清单。**

- `prompts_proactive._normalize_prompt_language`：`keep_traditional` `False` → `True`
- 新增公开的 `normalize_proactive_prompt_locale`（与既有 `normalize_mini_game_invite_locale`
  同例），给绕过 getter、直接索引这些表的消费点用
- `_resolve_proactive_locale` 新增 `fmt="prompt"`；一条 precedence chain 不变
- `service.py:742` `_break_lang`、`service.py:1254` `proactive_lang` 改吃 `fmt="prompt"`
- `greeting.py:918` 破冰问候、`greeting.py:770` 猫咪问候改走 prompt key 归一化器；
  `user_language` 为空时才回落 `get_global_language_full()`

**⚠️ 比 issue 清单多改了一处：`greeting.py:770`（猫咪问候）。** 它不在 issue 列的
五处里，但它同样喂 `prompts_proactive`（`get_cat_greeting_prompt` / `_episode_prompt` /
`_episode_scene` / `_reason_hint` 四个 getter）、同样是短码源，落在原子集内。漏掉它，
翻转就是不完整的——破冰问候繁体、猫咪问候简体。

**⚠️ 少改了一处：`service.py:745` `_break_invite_lang` 已经是 `fmt="full"`**（issue
把它列进了待改清单）。它经 `normalize_mini_game_invite_locale` 二次归一，full locale
在那边同样收敛到 `zh-TW`，所以保持不动；只更新了它上面那条已经说谎的注释。

**前后对比（`user_language = zh-TW`）。**

| 路径 | before | after |
|---|---|---|
| 主动搭话 / 屏幕分节 | `======以下为博士的屏幕======` | `======以下為博士的螢幕======` |
| 音乐搜索结果标题 | `【音乐搜索结果】` | `【音樂搜尋結果】` |
| 近期搭话时间标签 | `{}分钟前` | `{}分鐘前` |
| 休息邀请兜底 label | `手头上的活` | `手邊的事` |
| 破冰问候 | `======以下是环境提示======` | `======以下是環境提示======` |
| 猫咪问候 reason | `刚才{master}忙着没顾上你，` | `剛才{master}忙著沒空理你，` |
| callback 指令 | `[系统通知] 来自插件「x」的任务已完成` | `[系統通知] 來自外掛「x」的任務已完成` |

简中对照（`user_language = zh-CN` → resolved `zh`）：`【音乐搜索结果】` / `{}分钟前`，
不变。

### 第二段：源头已塌（commit 2）

这三处代码**看着是对的**，扫一眼很容易放过去：都跑了一次 `format='full'`——对它们
各自的消费点而言是正确的调用——但**源头**已经是短码，繁中在进这个函数之前就成了
`zh`，`format='full'` 只是把它再扩成 `zh-CN`。修法是换兜底源，不动 `format` 参数。

- `_shared.py:183` `_get_chat_locale_text`：读 `static/locales/*.json`（`zh-CN` /
  `zh-TW` 键），兜底 `get_global_language()` → `get_global_language_full()`。此前繁中
  永远读不到 `zh-TW.json`
- `conversation_turns.py:28` `normalize_turn_language`：同形，同修法
- `callback_render._build_callback_instruction`：**四个**调用点全在砍短码
  （`proactive.py` 724 / 1333 / 2549、`lifecycle.py` 2101）。归一化挪进渲染函数里做
  一次（与 `_render_mini_game_invite_line` 同例），调用点改传 full——这是第五个调用点
  也弄不错的形状。`prompts_sys` 新增公开的 `normalize_sys_prompt_locale`

两处显式 `language` 入参的优先级不变，只改兜底那一支。

**⚠️ 关于 `proactive.py:2549`。** issue 说它「落在 prompts_proactive 上」——实际它经
`_build_callback_instruction` 落在 **`prompts_sys`** 上，而且有三个形态完全相同的兄弟
调用点。单修 2549 会造成新的不一致：drain 路径繁体、语音/文本/热切换三条路径简体。
所以四处一起修。

**潜在回归。**

- 非中文 locale：`fmt="prompt"` 与 `fmt="short"` 对 en/ja/ko/ru/es/pt 输出完全相同
  （`normalize_prompt_locale` 对它们是恒等），无行为变化。已测
- 简中：resolved 仍是 `zh`，所有表命中原来那一行。已测（含专门的降级守卫）
- garbage / 空输入：`is_supported_language_code` 白名单守卫与空输入默认值都未改动，
  已回归测试
- 显式 `language` 入参优先级：未改动，已回归测试
- `_loc` 的 `WARNING: Unexpected lang code` 不会新增——`prompt` key 一定是表里有的键

## ⚠️ `prompts_directives.py:230` 的 `keep_traditional=False` 是设计，不是欠账

**别当债去翻。** 它在 `_trim_term` 里选**尾词表的语族**，而 `_TRIM_TRAIL_TOKENS_BY_LOCALE`
只有 `zh` / `ja` / `ko` 三个键——繁简共用同一套 trim token，塌成 `zh` 是正确行为。
翻了它会让繁体走进 `_TRIM_TRAIL_FALLBACK_LOCALES` 回落分支，尾词反而剥不掉。

这是生产代码里仅剩的两处 `keep_traditional=False` 之一，另一处（prompts_proactive）
才是真欠账，本 PR 已清。

## 不在本轮范围

都要先判断「传短码是不是有意的」再动，本 PR 不碰：

- `main_logic/activity/tracker.py:1182`
- `main_routers/config_router/language.py:168`
- `main_routers/game_router/session_pool.py:138`（变量名就叫 `short_language`）
- plugin 侧 6 处：`bilibili_danmaku` / `bilibili_dm` / `qq_auto_reply` ×2 /
  `wechat_integration` / `game_agent_minecraft`

审计过程中另外发现的、属于 **prompts_sys 那一批**（不是 proactive 一族）：

- `lifecycle.py` 1393 / 2276 / 2344、`notify.py` 139 / 284 —— 渲染的是 context summary /
  pending extra replies / 通知，与 callback 指令是不同模板，整批一起迁比零敲更安全
- `omni_realtime_client/_responses.py:48` —— 手搓的 `.split("-", 1)[0]` 短码化，而且
  `.lower()` 之后连 `zh-TW` 键都对不上；`REALTIME_PROACTIVE_*_TRIGGER_PROMPTS` 的
  `zh-TW` 行目前是死数据

## 验收

```
uv run python -m pytest tests/unit -q
  → 27677 passed, 274 skipped, 2 failed
```

两条 failed 是**本地环境**导致、与本 PR 无关，已用 `git stash` 验证在不带本 PR 改动时
同样红：`test_phase4b_boundaries::test_legacy_detector_and_evaluation_paths_do_not_exist`
与 `test_campplus_distribution_contracts::test_legacy_voice_identity_and_model_locations_are_absent`
——它们扫文件系统禁止路径，本机 checkout 里有个**未被 git 跟踪**的 `tools/voice_eval/`
残留目录。CI 上是干净的。

```
uv run ruff check main_logic/ config/prompts/ tests/unit/     → All checks passed
uv run python scripts/check_docstring_no_cjk.py --base origin/main → 0
uv run python scripts/check_prompt_zh_tw.py --count            → 0
```

**新增测试。**

- `tests/unit/test_proactive_locale_zh_tw.py`（103 条）——归一化器 / 解析器 / 四条路径
  各自的 zh-TW 渲染 / **同一轮全同 locale** / 简中不降级 / 调用点 AST walk
- `tests/unit/test_collapsed_locale_sources_zh_tw.py`（54 条）——三处源头塌陷，每条都
  驱动真实函数比对渲染结果，另加按函数定界的调用点 walk

**变异验证。** 十处变异逐个跑过，全部转红后恢复：翻转还原、`fmt="prompt"`→`fmt="full"`、
`fmt="prompt"`→默认短码、两个问候调用点还原、两处兜底源还原、渲染函数内归一化删除、
两个 callback 调用点还原。

⚠️ 调用点 walk 必须**按函数定界**：`_lang` 这个名字在 `proactive.py` / `lifecycle.py`
里被七八个互不相干的消费点共用，按模块匹配会把尚未迁移的路径一起算进来（第一版就是
这么误报的）。

**顺带更新三个钉住旧行为的测试**（都是期望值翻转，不是放宽断言）：

- `test_prompt_locale_normalizer`：`proactive` 列翻转后与 `traditional_aware` 完全同
  行为，折进该列当 peer（顺带把 `normalize_sys_prompt_locale` 也纳进去）
- `test_proactive_prompt_locale_uniformity`：不变量是「全模块同一个字形」，不是「字形
  必须是简体」；期望值翻成繁体，断言改成 `!=` 简体 **并且**钉住繁体那一行（避免退化成
  「大家都拿英文也能过」）
- `test_proactive_text_does_not_dehumanize`：猫咪 episode scene 同理

## 不拆分理由

不适用（计数文件未超限），但说明一下两个 commit 的边界：commit 1 是**必须原子**的
行为变化（拆开会让繁中用户同一轮里繁简混排），commit 2 的三处缺陷彼此独立、也不依赖
commit 1，单独 revert 任意一个都不会让另一个出错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持繁体中文（`zh-TW`）使用独立的本地化提示词和文案。
  * 统一主动提示、系统提示、问候语及回调内容的区域语言识别。
  * 增强语言回退逻辑，优先保留完整区域语言信息。

* **错误修复**
  * 修复繁体中文可能错误降级为简体中文或英文的问题。
  * 修复主动聊天及回调场景中的语言模板选择不一致问题。

* **测试**
  * 增加繁体中文本地化、语言回退及文案渲染的全面测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->