### PR TITLE
docs: prepare Baidu sitemap discovery

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -592,6 +592,8 @@ export default defineConfig({
 
   lastUpdated: true,
   cleanUrls: true,
+  // Baidu consumes this canonical standards-based sitemap.
+  // Keep a single source of truth rather than maintaining crawler-specific copies.
   sitemap: {
     hostname: SITE_ORIGIN,
     transformItems: filterSitemapItems,

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,3 +1,7 @@
+# Baidu Search
+User-agent: Baiduspider
+Allow: /
+
 User-agent: *
 Allow: /
 

--- a/docs/scripts/check-seo-output.mjs
+++ b/docs/scripts/check-seo-output.mjs
@@ -68,12 +68,69 @@ function fail(file, message) {
 }
 
 function robotsGroup(source, userAgent) {
-  const groups = source.split(/\r?\n\s*\r?\n/)
-  return groups.find((group) =>
-    group
-      .split(/\r?\n/)
-      .some((line) => line.trim().toLowerCase() === `user-agent: ${userAgent.toLowerCase()}`),
+  const target = userAgent.toLowerCase()
+  let groupStarted = false
+  let groupHasRules = false
+  let collectingTarget = false
+  let targetGroup = []
+
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*/, '').trim()
+    if (!line) continue
+
+    const separator = line.indexOf(':')
+    if (separator === -1) continue
+    const field = line.slice(0, separator).trim().toLowerCase()
+    const value = line.slice(separator + 1).trim()
+
+    if (field === 'user-agent') {
+      if (groupStarted && groupHasRules) {
+        if (collectingTarget) return targetGroup.join('\n')
+        groupHasRules = false
+        collectingTarget = false
+        targetGroup = []
+      }
+
+      groupStarted = true
+      if (value.toLowerCase() === target) collectingTarget = true
+      if (collectingTarget) targetGroup.push(line)
+      continue
+    }
+
+    if (!groupStarted) continue
+    groupHasRules = true
+    if (collectingTarget) targetGroup.push(line)
+  }
+
+  return collectingTarget ? targetGroup.join('\n') : undefined
+}
+
+function isValidSitemapLastmod(value) {
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(Z|[+-]\d{2}:\d{2}))?$/,
   )
+  if (!match) return false
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, zone] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  if (year === 0 || month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]) {
+    return false
+  }
+
+  if (hourText === undefined) return true
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  const second = secondText === undefined ? 0 : Number(secondText)
+  if (hour > 23 || minute > 59 || second > 59) return false
+  if (zone === 'Z') return true
+
+  const zoneHour = Number(zone.slice(1, 3))
+  const zoneMinute = Number(zone.slice(4, 6))
+  return zoneHour <= 23 && zoneMinute <= 59
 }
 
 function jsonLdNodes(data) {
@@ -157,7 +214,7 @@ if (existsSync(sitemapPath)) {
 
   for (const match of sitemap.matchAll(/<lastmod>([\s\S]*?)<\/lastmod>/g)) {
     const value = match[1].trim()
-    if (Number.isNaN(Date.parse(value))) {
+    if (!isValidSitemapLastmod(value)) {
       fail('sitemap.xml', `contains an invalid lastmod value: ${value}`)
     }
   }

--- a/docs/scripts/check-seo-output.mjs
+++ b/docs/scripts/check-seo-output.mjs
@@ -7,6 +7,9 @@ import {
 
 const DIST_DIR = resolve('.vitepress/dist')
 const PUBLIC_DIR = resolve('public')
+const SITEMAP_URL = `${SITE_ORIGIN}/sitemap.xml`
+const SITEMAP_NAMESPACE = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+const TARGET_SEARCH_CRAWLERS = ['Baiduspider']
 const errors = []
 
 function filesRecursively(directory, extension) {
@@ -64,6 +67,15 @@ function fail(file, message) {
   errors.push(`${file}: ${message}`)
 }
 
+function robotsGroup(source, userAgent) {
+  const groups = source.split(/\r?\n\s*\r?\n/)
+  return groups.find((group) =>
+    group
+      .split(/\r?\n/)
+      .some((line) => line.trim().toLowerCase() === `user-agent: ${userAgent.toLowerCase()}`),
+  )
+}
+
 function jsonLdNodes(data) {
   if (!data || typeof data !== 'object') return []
   return Array.isArray(data['@graph']) ? data['@graph'] : [data]
@@ -87,16 +99,67 @@ if (!existsSync(sitemapPath)) fail('sitemap.xml', 'file is missing')
 
 if (existsSync(robotsPath)) {
   const robots = readFileSync(robotsPath, 'utf8')
-  if (!robots.includes('Sitemap: https://project-neko.online/sitemap.xml')) {
+  if (!robots.includes(`Sitemap: ${SITEMAP_URL}`)) {
     fail('robots.txt', 'does not declare the production sitemap URL')
+  }
+
+  for (const crawler of TARGET_SEARCH_CRAWLERS) {
+    const group = robotsGroup(robots, crawler)
+    if (!group) {
+      fail('robots.txt', `does not declare an explicit ${crawler} policy`)
+      continue
+    }
+    if (!/^Allow:\s*\/$/gim.test(group)) {
+      fail('robots.txt', `${crawler} is not explicitly allowed to crawl the site`)
+    }
+    if (/^Disallow:\s*\/$/gim.test(group)) {
+      fail('robots.txt', `${crawler} is explicitly blocked from the site root`)
+    }
   }
 }
 
 const sitemapUrls = new Set()
 if (existsSync(sitemapPath)) {
   const sitemap = readFileSync(sitemapPath, 'utf8')
-  for (const match of sitemap.matchAll(/<loc>([\s\S]*?)<\/loc>/g)) {
-    sitemapUrls.add(decodeXml(match[1].trim()))
+  if (!new RegExp(`<urlset\\b[^>]*\\bxmlns=["']${SITEMAP_NAMESPACE}["']`, 'i').test(sitemap)) {
+    fail('sitemap.xml', 'does not use the standard sitemap urlset namespace')
+  }
+
+  const locValues = [...sitemap.matchAll(/<loc>([\s\S]*?)<\/loc>/g)].map((match) =>
+    decodeXml(match[1].trim()),
+  )
+
+  for (const value of locValues) {
+    if (sitemapUrls.has(value)) {
+      fail('sitemap.xml', `contains a duplicate URL: ${value}`)
+      continue
+    }
+    sitemapUrls.add(value)
+
+    let url
+    try {
+      url = new URL(value)
+    } catch {
+      fail('sitemap.xml', `contains an invalid absolute URL: ${value}`)
+      continue
+    }
+    if (url.origin !== SITE_ORIGIN || url.protocol !== 'https:') {
+      fail('sitemap.xml', `URL is not canonical HTTPS on ${SITE_ORIGIN}: ${value}`)
+    }
+    if (url.search || url.hash) {
+      fail('sitemap.xml', `URL contains a query string or fragment: ${value}`)
+    }
+  }
+
+  if (![...sitemapUrls].some((url) => url.startsWith(`${SITE_ORIGIN}/zh-CN/`))) {
+    fail('sitemap.xml', 'does not include any Simplified Chinese documentation URLs')
+  }
+
+  for (const match of sitemap.matchAll(/<lastmod>([\s\S]*?)<\/lastmod>/g)) {
+    const value = match[1].trim()
+    if (Number.isNaN(Date.parse(value))) {
+      fail('sitemap.xml', `contains an invalid lastmod value: ${value}`)
+    }
   }
 }
 


### PR DESCRIPTION
## 改动概述 / Summary

- 为文档站显式允许 Baiduspider 抓取，同时保留通用爬虫规则和生产 Sitemap 声明。
- 保持 VitePress 标准 Sitemap 为唯一数据源，不维护搜索引擎专用副本。
- 扩展构建产物校验：检查 Sitemap 命名空间、HTTPS 同源 URL、重复项、查询参数/片段、简体中文页面及 lastmod 有效性。

## 回归报告 / Regression Report

不适用：未修改 app/、main_logic/ 或 memory/。

## 不拆分理由 / Why Not Split

不适用：仅修改 3 个文档站 SEO 相关文件。

## 测试 / Testing

- cd docs && npm run build:check
- 结果：303 个可索引页面、45 个 noindex 页面、1152 个 hreflang 链接，校验通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档与搜索优化**
  - 优化搜索引擎抓取策略，支持百度爬虫访问完整文档内容。
  - 改进站点地图格式，确保链接使用 HTTPS、标准路径且避免重复。
  - 增强站点地图与爬虫规则校验，减少无效参数和配置错误。
  - 补充站点地图更新时间信息，帮助搜索引擎识别文档更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->