### PR TITLE
fix(realtime): TTS done 记账与 __interrupt__ 同步落地 + 会话锁不得跨挂起（#2619）

### DIFF
--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -321,7 +321,23 @@ class TtsRuntimeMixin:
         regardless of ``use_tts``, so a Realtime native voice session
         (``use_tts=False``) can still have a live worker that needs
         interrupting on ``interrupt_audio``.
+
+        The two TTS-done flags are reset here, before the first ``await``,
+        because clearing the pipeline is what invalidates them — see the
+        comment on the reset itself.
         """
+        # 这两个 flag 是"本轮 done sentinel 已排队"的唯一记账，而下面的
+        # ``__interrupt__`` 一入队就把那个 sentinel 作废了。所以 reset 属于
+        # interrupt 的同一步，必须落在函数的第一个 await（下面的 sleep）之前：
+        # 从函数入口到 put("__interrupt__") 全是同步语句，取消无从投递，两者因此
+        # 原子。放在 await 之后（历史写法：由各调用方在 await 返回后各自清）取消
+        # 落在 sleep 上就会留下"worker 已被中断、记账还说已排队"的残留态，下一轮
+        # ``_request_tts_done_locked`` 因此 early-return "already"，flush sentinel
+        # 永远进不了队 —— 正是 handle_new_message 那两行清零本来要防的后果。
+        # 调用方在本函数返回后的重复清零保留不动：那是给 sleep 窗口内被并发
+        # 置回 True 的情况兜底，与这里要修的取消残留是两件事。
+        self._tts_done_queued_for_turn = False
+        self._tts_done_pending_until_ready = False
         if self.tts_thread and self.tts_thread.is_alive():
             while not self.tts_response_queue.empty():
                 try:

--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -365,6 +365,14 @@ class TtsRuntimeMixin:
                     break
         async with self.tts_cache_lock:
             self.tts_pending_chunks.clear()
+            # 再清一次 queued：上面那 20ms 里并发路径（finish_proactive_delivery
+            # 等）可能看到 False、排了自己的 sentinel 并把它置回 True。那个
+            # sentinel 排在 __interrupt__ 之后、本轮后续文本之前，本来就已作废；
+            # 而记账留 True 会让后续文本的 done 请求 early-return "already"，
+            # 重试那一轮因此发不出句尾 sentinel。handle_new_message 一族靠调用方
+            # 返回后的重复清零兜住了这一点，丢弃/takeover 两条路径没有，所以兜底
+            # 收进这里，让五个调用方拿到同一个保证。
+            self._tts_done_queued_for_turn = False
             self._tts_done_pending_until_ready = False
             self._reset_tts_replay_state()
             # Drop only queued-but-unconfirmed TTS text. Already-confirmed

--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -322,22 +322,28 @@ class TtsRuntimeMixin:
         (``use_tts=False``) can still have a live worker that needs
         interrupting on ``interrupt_audio``.
 
-        The two TTS-done flags are reset here, before the first ``await``,
-        because clearing the pipeline is what invalidates them — see the
-        comment on the reset itself.
+        The two TTS-done flags are NOT reset together, because they are not
+        paired with the same thing — see the comments at each reset.
         """
-        # 这两个 flag 是"本轮 done sentinel 已排队"的唯一记账，而下面的
-        # ``__interrupt__`` 一入队就把那个 sentinel 作废了。所以 reset 属于
-        # interrupt 的同一步，必须落在函数的第一个 await（下面的 sleep）之前：
-        # 从函数入口到 put("__interrupt__") 全是同步语句，取消无从投递，两者因此
-        # 原子。放在 await 之后（历史写法：由各调用方在 await 返回后各自清）取消
-        # 落在 sleep 上就会留下"worker 已被中断、记账还说已排队"的残留态，下一轮
-        # ``_request_tts_done_locked`` 因此 early-return "already"，flush sentinel
-        # 永远进不了队 —— 正是 handle_new_message 那两行清零本来要防的后果。
+        # ``_tts_done_queued_for_turn`` 的对偶是下面的 ``__interrupt__``：一入队
+        # 就把上一轮那个 done sentinel 作废，而这个 flag 是"本轮 sentinel 已排队"
+        # 的唯一记账。所以清零属于 interrupt 的同一步，必须落在函数的第一个
+        # await（下面的 sleep）之前：从函数入口到 put("__interrupt__") 全是同步
+        # 语句，取消无从投递，两者因此原子。放在 await 之后（历史写法：由各调用方
+        # 在 await 返回后各自清）取消落在 sleep 上就会留下"worker 已被中断、记账
+        # 还说已排队"的残留态，下一轮 ``_request_tts_done_locked`` 因此
+        # early-return "already"，flush sentinel 永远进不了队 —— 正是
+        # handle_new_message 那两行清零本来要防的后果。
+        #
+        # ``_tts_done_pending_until_ready`` 不能跟着挪上来：它的对偶是
+        # ``tts_pending_chunks``（"这批文本还没刷出去，done 要等它们之后再补发"），
+        # 两者一起在函数末尾的 tts_cache_lock 段里清。单把 flag 提前、chunks 留在
+        # 原地，取消落在 sleep 上就撕成另一个方向的半套态：worker 就绪后
+        # ``_flush_tts_pending_chunks`` 会把陈旧 chunks 重新入队，却因为 flag 已是
+        # False 而跳过它们的 done 补发，合成器一直不 flush。所以它留在下面不动。
         # 调用方在本函数返回后的重复清零保留不动：那是给 sleep 窗口内被并发
         # 置回 True 的情况兜底，与这里要修的取消残留是两件事。
         self._tts_done_queued_for_turn = False
-        self._tts_done_pending_until_ready = False
         if self.tts_thread and self.tts_thread.is_alive():
             while not self.tts_response_queue.empty():
                 try:

--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -66,6 +66,9 @@ class TurnMixin:
         # 重置音频重采样器状态（新轮次音频不应与上轮次连续）
         self.audio_resampler.clear()
         await self._clear_tts_pipeline()
+        # 权威的清零已经在 _clear_tts_pipeline 入口、与 __interrupt__ 入队同步
+        # 完成（取消落在它内部的 sleep 上也不会留下半套态）。这里保留一次重复
+        # 清零，兜底那 ~20ms 窗口内被并发路径重新置 True 的情况。
         self._tts_done_queued_for_turn = False  # 新轮次重置 TTS 结束信号标记
         self._tts_done_pending_until_ready = False
         # 新一轮开始：清空上一轮 AI 文本累加器（即使上轮 turn end 已清过，
@@ -110,6 +113,20 @@ class TurnMixin:
         Resetting ``audio_resampler`` is safe because the next turn's audio
         is a fresh stream — keeping stale soxr state would only risk a
         boundary artefact at turn 2's first frame.
+
+        On the write order and cancellation (#2619): the flags are cleared
+        before the ``async with self.lock`` that rotates the sid, which looks
+        like it could be cancelled half-applied. It cannot. No holder of
+        ``self.lock`` anywhere in this package suspends while holding it, so
+        the lock is never observed held, so this acquire always takes the
+        uncontended fast path and never yields — and a cancellation therefore
+        lands either before this method is entered or after it has returned,
+        never between these writes. That property is the whole reason this
+        shape is safe, so it is enforced rather than assumed: see
+        CORE_LOCK_NO_AWAIT in ``scripts/check_core_contracts.py``. Adding an
+        ``await`` inside any of those blocks makes the lock contendable and
+        makes this window real; move the awaited work out of the block
+        instead of reordering the writes here.
         """
         if self._takeover_active:
             return

--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -66,9 +66,11 @@ class TurnMixin:
         # 重置音频重采样器状态（新轮次音频不应与上轮次连续）
         self.audio_resampler.clear()
         await self._clear_tts_pipeline()
-        # 权威的清零已经在 _clear_tts_pipeline 入口、与 __interrupt__ 入队同步
-        # 完成（取消落在它内部的 sleep 上也不会留下半套态）。这里保留一次重复
-        # 清零，兜底那 ~20ms 窗口内被并发路径重新置 True 的情况。
+        # _tts_done_queued_for_turn 的权威清零已经在 _clear_tts_pipeline 入口、
+        # 与 __interrupt__ 入队同步完成（取消落在它内部的 sleep 上也不会留下
+        # "worker 已中断、记账还说已排队"的残留）。这里保留一次重复清零，兜底那
+        # ~20ms 窗口内被并发路径重新置 True 的情况；pending_until_ready 则由
+        # _clear_tts_pipeline 末尾与 tts_pending_chunks 成对清，这里同样是兜底。
         self._tts_done_queued_for_turn = False  # 新轮次重置 TTS 结束信号标记
         self._tts_done_pending_until_ready = False
         # 新一轮开始：清空上一轮 AI 文本累加器（即使上轮 turn end 已清过，

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1234,21 +1234,28 @@ class _TransportMixin:
         last step — there is nothing behind it for a slow hook to starve. That
         is NOT the same as being uncancellable, and an earlier version of this
         comment claimed it was: the arbiter bounds the whole notification, so
-        the rotation can still be cancelled at its only await, taking the
-        session lock. Today that leaves the host half-rotated — the TTS flags
-        say a fresh turn while the speech id still says the old one — because
-        ``rotate_speech_id_for_response_done`` writes those flags before it
-        takes the lock.
+        the rotation can be cancelled. What it cannot do is land half-applied.
+        Its only await is taking the session lock, and no holder of that lock
+        suspends while holding it, so the lock is never observed held and that
+        acquire always takes the uncontended fast path without yielding — the
+        cancellation therefore arrives before the rotation is entered or after
+        it has returned. A second version of this comment claimed the opposite
+        (TTS flags saying a fresh turn while the speech id still said the old
+        one); measured, that state is not reachable while the lock invariant
+        holds, and the invariant is now enforced by CORE_LOCK_NO_AWAIT in
+        ``scripts/check_core_contracts.py`` rather than left to convention
+        (#2619).
 
-        Measured, that state is repaired by the next turn's terminal, which
-        rotates unconditionally; it is not the permanent silence the earlier
-        comment described. It also is not this path's to fix: the rotation has
-        two other callers that are cancelled just as ordinarily and with no
-        escape hatch involved
+        This still is not the path to shield the rotation from. The rotation
+        has two other callers cancelled just as ordinarily and with no escape
+        hatch involved
         ([_responses.py](main_logic/omni_realtime_client/_responses.py) and
         [proactive.py](main_logic/core/proactive.py), both inside
-        fire-and-forget tasks), so making the rotation all-or-nothing belongs
-        in the rotation itself. Tracked separately.
+        fire-and-forget tasks), and shielding here measurably reopens the hole
+        ``_turn_epoch`` closed: a detached rotation takes the lock after the
+        epoch has already moved and overwrites the new session's speech id,
+        which ``lifecycle.py``'s lock-free write cannot be FIFO-ordered
+        against.
 
         ``on_sid_rotate`` is conditional because providers WITH server VAD
         rotate the speech id from ``speech_stopped`` instead; firing here too

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -101,6 +101,16 @@ VOICE_INPUT_LAYERING
     processing, routers, or arbitrary utility modules. ASR runtime code emits
     neutral callbacks and cannot import the Core-owned Registry in reverse.
 
+CORE_LOCK_NO_AWAIT
+    No ``async with self.lock`` block holds a suspension point. Twelve of
+    those blocks write ``current_speech_id``, eight of them writing the two
+    TTS done flags in the same block. Because no holder suspends, the lock is
+    never observed held, every acquire takes the uncontended fast path, and
+    no acquire is a cancellation point — which is what makes those paired
+    writes atomic (#2619). The first ``await`` inside any of these blocks
+    makes the lock contendable and reopens a torn "flags say the new turn,
+    speech id still says the old one" state at every one of them.
+
 VOICE_IDENTITY_LAYERING
     The in-memory speaker identity domain owns only model identity, normalized
     references, and profiles. Its package initializer is inert; its domain
@@ -937,6 +947,135 @@ def check_fail_closed_chokepoint(core_dir: Path) -> list[Violation]:
             core_dir / "asr_runtime.py", 1, 0, "VOICE_FAIL_CLOSED_CHOKEPOINT",
             f"{CHOKEPOINT}() is gone from main_logic/core — it is the only sanctioned caller "
             f"of {sorted(REVOKE_HELPERS)}, so its removal makes this gate vacuous"))
+    return violations
+
+
+def _statements_in_critical_section(body: list[ast.stmt]):
+    """Yield every node a critical section actually executes.
+
+    Nested ``def`` / ``async def`` / ``lambda`` bodies are skipped: code
+    defined inside the block runs when the closure is called, not while the
+    lock is held, so an ``await`` in there is not a suspension of this
+    critical section. Descending into them would make the gate fire on
+    something that is fine.
+    """
+
+    stack: list[ast.AST] = list(body)
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Violation]:
+    """CORE_LOCK_NO_AWAIT — the session lock is never held across a suspension.
+
+    Every ``async with self.lock`` block in the package holds only
+    synchronous statements. That is not a style preference, it is what makes
+    the speech-id rotations atomic, and it holds by induction: if no holder
+    ever suspends while holding the lock, no other task can ever observe it
+    held, so ``await self.lock.acquire()`` always takes the uncontended fast
+    path and never yields — which means cancellation cannot be delivered
+    between taking the lock and the writes inside it.
+
+    #2619 read the same code the other way round and proposed reordering the
+    writes in ``rotate_speech_id_for_response_done`` to close a torn-state
+    window. Measured, that window does not exist while this contract holds:
+    the acquire never suspends, so the rotation either runs whole or does not
+    start. The first ``await`` added inside any of these blocks is what would
+    make the window real — for that rotation and for the eight other blocks
+    that write ``current_speech_id`` alongside both TTS done flags. So the
+    invariant is the fix, and this gate is what keeps it true.
+
+    The check is deliberately package-wide rather than pinned to the rotation
+    sites: the property is a property of the lock, and one careless holder
+    anywhere is enough to lose it everywhere.
+    """
+
+    def suspension_kind(node: ast.AST) -> str | None:
+        # ``yield`` counts: it turns the holder into an async generator and
+        # hands control back to whoever drives it, which can abandon or throw
+        # into the generator while the lock is still held.
+        if isinstance(node, ast.Await):
+            return "await"
+        if isinstance(node, ast.AsyncFor):
+            return "async for"
+        if isinstance(node, ast.AsyncWith):
+            return "nested async with"
+        if isinstance(node, (ast.Yield, ast.YieldFrom)):
+            return "yield"
+        # ``[x async for x in y]`` carries no AsyncFor node of its own.
+        if isinstance(node, ast.comprehension) and node.is_async:
+            return "async comprehension"
+        return None
+
+    def is_session_lock(item: ast.withitem) -> bool:
+        expr = item.context_expr
+        return (
+            isinstance(expr, ast.Attribute)
+            and expr.attr == "lock"
+            and isinstance(expr.value, ast.Name)
+            and expr.value.id == "self"
+        )
+
+    violations: list[Violation] = []
+    blocks_seen = 0
+    for path in sorted(core_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        tree = parse(path)
+        for block in ast.walk(tree):
+            if not isinstance(block, ast.AsyncWith):
+                continue
+            if not any(is_session_lock(item) for item in block.items):
+                continue
+            blocks_seen += 1
+            for node in _statements_in_critical_section(block.body):
+                kind = suspension_kind(node)
+                if kind is None:
+                    continue
+                violations.append(Violation(
+                    path, getattr(node, "lineno", block.lineno),
+                    getattr(node, "col_offset", block.col_offset),
+                    "CORE_LOCK_NO_AWAIT",
+                    f"'{kind}' inside the 'async with self.lock' block opened at line "
+                    f"{block.lineno} — the session lock must never be held across a "
+                    f"suspension. While it is not, the lock is never contended, so every "
+                    f"acquire takes the fast path, no acquire is a cancellation point, and "
+                    f"the sid+TTS-flag writes inside these blocks are atomic (#2619). One "
+                    f"suspension here makes the lock contendable and reopens that torn "
+                    f"state at every one of these blocks, not just this one. Do the awaited "
+                    f"work before or after the block"))
+                break  # one report per block; the first suspension is the defect
+    if not blocks_seen:
+        violations.append(Violation(
+            core_dir / "turn.py", 1, 0, "CORE_LOCK_NO_AWAIT",
+            "no 'async with self.lock' block left in main_logic/core — either the session "
+            "lock moved or the rotations stopped taking it; this gate is now vacuous, so "
+            "update it instead of letting it go dark"))
+    # The no-suspension argument assumes a plain asyncio.Lock: a reentrant or
+    # threading primitive would make 'never observed held' false for reasons
+    # this AST cannot see.
+    manager_tree = parse(manager_path)
+    declares_asyncio_lock = any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(t, ast.Attribute) and t.attr == "lock"
+            and isinstance(t.value, ast.Name) and t.value.id == "self"
+            for t in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and dotted_node_path(node.value.func) == "asyncio.Lock"
+        for node in ast.walk(manager_tree)
+    )
+    if not declares_asyncio_lock:
+        violations.append(Violation(
+            manager_path, 1, 0, "CORE_LOCK_NO_AWAIT",
+            "self.lock is no longer bound to asyncio.Lock() in manager.py — the atomicity "
+            "this gate protects rests on the uncontended-acquire fast path of that exact "
+            "primitive; re-derive the contract before swapping it"))
     return violations
 
 
@@ -1821,6 +1960,7 @@ def run(root: Path) -> list[Violation]:
     violations: list[Violation] = []
     violations.extend(check_voice_identity_contracts(root))
     violations.extend(check_fail_closed_chokepoint(core_dir))
+    violations.extend(check_session_lock_atomicity(core_dir, manager_path))
     init_tree = parse(init_path)
     facade_names = facade_top_level_names(init_tree)
     facade_owners = facade_owner_modules(init_tree)

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1369,7 +1369,12 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
                 break  # one report per block; the first suspension is the defect
     if not blocks_seen:
         violations.append(Violation(
-            core_dir / "turn.py", 1, 0, "CORE_LOCK_NO_AWAIT",
+            # Anchored on the package initializer, not on whichever module
+            # happens to hold a rotation today: this violation fires exactly
+            # when the package changed shape, so naming a module that may
+            # itself have been renamed or deleted would render as a bare
+            # absolute path. ``run()`` hard-fails if this file is missing.
+            core_dir / "__init__.py", 1, 0, "CORE_LOCK_NO_AWAIT",
             "no 'async with self.lock' block left in main_logic/core — either the session "
             "lock moved or the rotations stopped taking it; this gate is now vacuous, so "
             "update it instead of letting it go dark"))

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1030,8 +1030,17 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             and expr.value.id == "self"
         )
 
+    def is_self_lock_attr(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "lock"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        )
+
     violations: list[Violation] = []
     blocks_seen = 0
+    manager_bindings: list[tuple[ast.AST, ast.expr | None]] = []
     for path in sorted(core_dir.glob("*.py")):
         if path.name == "__init__.py":
             continue
@@ -1051,23 +1060,23 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             for item in node.items
             if is_session_lock(item)
         }
-        # manager.py binds the attribute once; that assignment target is the
-        # only non-``async with`` mention the package is allowed to carry.
-        bind_targets: set[int] = {
-            id(target)
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Assign)
-            for target in node.targets
-            if isinstance(target, ast.Attribute) and target.attr == "lock"
-            and isinstance(target.value, ast.Name) and target.value.id == "self"
-        } if path == manager_path else set()
+        # manager.py binds the attribute; that assignment target is the only
+        # non-``async with`` mention the package is allowed to carry. Every
+        # binding is collected — not just the first — because the primitive
+        # check below has to see a rebind that a later statement performs.
+        if path == manager_path:
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Assign):
+                    manager_bindings.extend(
+                        (target, node.value)
+                        for target in node.targets
+                        if is_self_lock_attr(target)
+                    )
+                elif isinstance(node, ast.AnnAssign) and is_self_lock_attr(node.target):
+                    manager_bindings.append((node.target, node.value))
+        bind_targets = {id(target) for target, _ in manager_bindings}
         for node in ast.walk(tree):
-            if not (
-                isinstance(node, ast.Attribute)
-                and node.attr == "lock"
-                and isinstance(node.value, ast.Name)
-                and node.value.id == "self"
-            ):
+            if not is_self_lock_attr(node):
                 continue
             if id(node) in sanctioned or id(node) in bind_targets:
                 continue
@@ -1084,6 +1093,25 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             if not any(is_session_lock(item) for item in block.items):
                 continue
             blocks_seen += 1
+            # ``async with self.lock, other:`` enters ``other`` while the
+            # session lock is already held, and on the way out awaits its
+            # ``__aexit__`` before the lock is released — two suspensions the
+            # body scan below never sees, because neither is in the body. So
+            # the session lock has to be the LAST item. An item BEFORE it is
+            # fine: the lock is not yet held on the way in, and is already
+            # released on the way out.
+            lock_index = next(
+                i for i, item in enumerate(block.items) if is_session_lock(item)
+            )
+            for trailing in block.items[lock_index + 1:]:
+                violations.append(Violation(
+                    path, trailing.context_expr.lineno, trailing.context_expr.col_offset,
+                    "CORE_LOCK_NO_AWAIT",
+                    "context manager entered after self.lock in the same 'async with' — "
+                    "its __aenter__ (and its __aexit__ on the way out) run while the "
+                    "session lock is held, which is a suspension the lock must never "
+                    "span (#2619). Put it in its own block before the lock, or make "
+                    "self.lock the last item"))
             for node in _statements_in_critical_section(block.body):
                 kind = suspension_kind(node)
                 if kind is None:
@@ -1109,25 +1137,36 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             "update it instead of letting it go dark"))
     # The no-suspension argument assumes a plain asyncio.Lock: a reentrant or
     # threading primitive would make 'never observed held' false for reasons
-    # this AST cannot see.
-    manager_tree = parse(manager_path)
-    declares_asyncio_lock = any(
-        isinstance(node, ast.Assign)
-        and any(
-            isinstance(t, ast.Attribute) and t.attr == "lock"
-            and isinstance(t.value, ast.Name) and t.value.id == "self"
-            for t in node.targets
-        )
-        and isinstance(node.value, ast.Call)
-        and dotted_node_path(node.value.func) == "asyncio.Lock"
-        for node in ast.walk(manager_tree)
-    )
-    if not declares_asyncio_lock:
+    # this AST cannot see. Checking that SOME binding is asyncio.Lock() is not
+    # enough — a later ``self.lock = OtherLock()`` would leave the first
+    # binding intact for the check to find while the attribute the code
+    # actually takes is the second. So exactly one binding is required, and
+    # that one is the one validated.
+    if len(manager_bindings) != 1:
+        found = ", ".join(
+            f"line {getattr(target, 'lineno', '?')}" for target, _ in manager_bindings
+        ) or "none"
         violations.append(Violation(
-            manager_path, 1, 0, "CORE_LOCK_NO_AWAIT",
-            "self.lock is no longer bound to asyncio.Lock() in manager.py — the atomicity "
-            "this gate protects rests on the uncontended-acquire fast path of that exact "
-            "primitive; re-derive the contract before swapping it"))
+            manager_path,
+            getattr(manager_bindings[0][0], "lineno", 1) if manager_bindings else 1, 0,
+            "CORE_LOCK_NO_AWAIT",
+            f"self.lock must be bound exactly once in manager.py, found "
+            f"{len(manager_bindings)} ({found}) — with more than one binding the "
+            f"primitive check cannot tell which object the package actually takes, and "
+            f"a rebind to a suspending lock would pass while an earlier asyncio.Lock() "
+            f"line satisfies the check"))
+    else:
+        value = manager_bindings[0][1]
+        if not (
+            isinstance(value, ast.Call)
+            and dotted_node_path(value.func) == "asyncio.Lock"
+        ):
+            violations.append(Violation(
+                manager_path, getattr(manager_bindings[0][0], "lineno", 1), 0,
+                "CORE_LOCK_NO_AWAIT",
+                "self.lock is no longer bound to asyncio.Lock() in manager.py — the "
+                "atomicity this gate protects rests on the uncontended-acquire fast path "
+                "of that exact primitive; re-derive the contract before swapping it"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1145,7 +1145,7 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         return None
 
     def is_lock_attr(node: ast.AST) -> bool:
-        """Any ``<expr>.lock``, whatever the receiver.
+        """Any reach for the ``lock`` attribute, however it is spelled.
 
         Deliberately NOT pinned to a literal ``self`` receiver: ``owner =
         self`` followed by ``async with owner.lock:`` acquires the same
@@ -1154,9 +1154,34 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         direction — and measured, it costs nothing: the package contains no
         ``.lock`` acquisition with any other receiver, and manager.py's
         binding is the only non-``async with`` mention at all.
+
+        The literal reflective spellings count too — ``getattr(x, "lock")``
+        and ``x.__dict__["lock"]`` reach the same object while carrying no
+        ``Attribute`` node named ``lock`` for a syntax-only match to see.
+        Same reasoning as ``check_fail_closed_chokepoint``'s ``called_name``
+        in this file: a gate a one-line rewrite defeats is not a gate. A
+        computed name (``getattr(x, name)``) is out of reach of any AST check
+        and is not claimed to be covered.
         """
 
-        return isinstance(node, ast.Attribute) and node.attr == "lock"
+        if isinstance(node, ast.Attribute):
+            return node.attr == "lock"
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "lock"
+        ):
+            return True
+        return (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "__dict__"
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value == "lock"
+        )
 
     def is_session_lock(item: ast.withitem) -> bool:
         return is_lock_attr(item.context_expr)

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -956,6 +956,13 @@ def check_fail_closed_chokepoint(core_dir: Path) -> list[Violation]:
 def _statements_in_critical_section(body: list[ast.stmt]):
     """Yield every node a critical section actually executes.
 
+    A generator expression is deferred the same way, with one eager part:
+    measured, ``(await work(x) async for x in src())`` evaluates NOTHING at
+    creation, while ``(x for x in await get())`` does evaluate the outermost
+    iterable there. So only ``generators[0].iter`` is walked for those. List,
+    set and dict comprehensions are NOT deferred — measured, they run their
+    element expression immediately — and stay fully walked.
+
     A nested ``def`` / ``async def`` / ``lambda`` splits into two halves that
     run at different times, and only the body is deferred:
 
@@ -976,6 +983,12 @@ def _statements_in_critical_section(body: list[ast.stmt]):
     while stack:
         node = stack.pop()
         yield node
+        if isinstance(node, ast.GeneratorExp):
+            # Everything but the outermost iterable runs at consumption time,
+            # which is necessarily after the block has exited.
+            if node.generators:
+                stack.append(node.generators[0].iter)
+            continue
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             # ``Lambda.body`` is one expression; the others hold a statement
             # list. Compare by identity — AST nodes have no ``__eq__``, and
@@ -1240,6 +1253,26 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             for item in node.items
             if is_session_lock(item)
         }
+        # The module can stay the real stdlib one while its ``Lock`` attribute
+        # is replaced: ``asyncio.Lock = OtherLock`` leaves both the name check
+        # and the ``asyncio.Lock()`` spelling intact while the manager builds
+        # an arbitrary primitive. Same family as the reflective writes above —
+        # the swap happens where the checker was only reading spelling.
+        for node in ast.walk(tree):
+            targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                targets = list(node.targets)
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                targets = [node.target]
+            for target in targets:
+                if dotted_node_path(target) == "asyncio.Lock":
+                    violations.append(Violation(
+                        path, node.lineno, node.col_offset, "CORE_LOCK_NO_AWAIT",
+                        "asyncio.Lock is reassigned — the primitive check validates the "
+                        "spelling 'asyncio.Lock()' and that 'asyncio' means the standard "
+                        "library, but neither survives the attribute itself being "
+                        "replaced; the manager would then build an arbitrary lock whose "
+                        "acquire may suspend (#2619)"))
         # manager.py binds the attribute; that assignment target is the only
         # non-``async with`` mention the package is allowed to carry. Every
         # binding is collected — not just the first — because the primitive

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1037,8 +1037,19 @@ def _name_binding_sites(tree: ast.AST, name: str) -> list[ast.AST]:
             ):
                 sites.append(node)
         elif isinstance(node, ast.AnnAssign):
-            # A bare ``x: T`` declares a type and binds nothing.
-            if node.value is not None and name in _assignment_target_names(node.target):
+            if name not in _assignment_target_names(node.target):
+                pass
+            elif node.value is not None:
+                sites.append(node)
+            elif isinstance(node.target, ast.Name):
+                # A valueless annotation binds no VALUE but does affect scope:
+                # ``asyncio: object`` anywhere in a function makes the name
+                # local for that whole function, so a later ``asyncio.Lock()``
+                # raises UnboundLocalError rather than reaching the module.
+                # Either way the name no longer means the import, so it counts.
+                # (An ATTRIBUTE annotation — ``self.lock: asyncio.Lock`` — has
+                # no such effect and is handled where lock bindings are
+                # collected, not here.)
                 sites.append(node)
         elif isinstance(node, (ast.AugAssign, ast.NamedExpr)):
             if name in _assignment_target_names(node.target):
@@ -1158,9 +1169,11 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
     blocks_seen = 0
     manager_bindings: list[tuple[ast.AST, ast.expr | None]] = []
     annotation_only: list[ast.AST] = []
-    for path in sorted(core_dir.glob("*.py")):
-        if path.name == "__init__.py":
-            continue
+    # rglob, and no ``__init__.py`` exemption: a holder in the facade or in a
+    # subpackage is inside the package whose invariant this enforces. The flat
+    # layout is enforced separately by CORE_MIXIN_SHAPE, but this gate must not
+    # depend on that one still being there to be complete.
+    for path in sorted(p for p in core_dir.rglob("*.py") if "__pycache__" not in p.parts):
         tree = parse(path)
         # Every sanctioned mention of the lock is the context expression of an
         # ``async with``. Manual ``await self.lock.acquire()`` ... ``release()``

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -994,6 +994,69 @@ def _statements_in_critical_section(body: list[ast.stmt]):
         stack.extend(ast.iter_child_nodes(node))
 
 
+def _name_binding_sites(tree: ast.AST, name: str) -> list[ast.AST]:
+    """Return every node that binds ``name``, in any scope, by any syntax.
+
+    Written as an enumeration of BINDINGS rather than of ways-to-rebind: the
+    latter is open-ended (import-as, assignment, parameter, loop target,
+    ``with ... as``, ``except ... as``, comprehension, walrus, ``match``
+    capture, a def or class of that name …) and a checker built by listing
+    them stays one form behind whoever is looking. Scope is deliberately
+    ignored — any binding of the name anywhere in the module is enough to
+    make a spelling-based check on it unsound.
+
+    Models ordinary binding syntax only, not reflective mutation through
+    ``globals()`` / ``exec`` / attribute writes on the module object.
+    """
+
+    sites: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            sites.extend(
+                node for alias in node.names
+                if (alias.asname or alias.name.split(".")[0]) == name
+            )
+        elif isinstance(node, ast.ImportFrom):
+            sites.extend(
+                node for alias in node.names
+                if (alias.asname or alias.name) == name
+            )
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == name:
+                sites.append(node)
+        elif isinstance(node, ast.arg):
+            if node.arg == name:
+                sites.append(node)
+        elif isinstance(node, ast.Assign):
+            if any(
+                name in _assignment_target_names(target) for target in node.targets
+            ):
+                sites.append(node)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+            if name in _assignment_target_names(node.target):
+                sites.append(node)
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            if name in _assignment_target_names(node.target):
+                sites.append(node)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            if any(
+                item.optional_vars is not None
+                and name in _assignment_target_names(item.optional_vars)
+                for item in node.items
+            ):
+                sites.append(node)
+        elif isinstance(node, ast.ExceptHandler):
+            if node.name == name:
+                sites.append(node)
+        elif isinstance(node, ast.comprehension):
+            if name in _assignment_target_names(node.target):
+                sites.append(node)
+        elif isinstance(node, ast.match_case):
+            if name in _match_pattern_binding_names(node.pattern):
+                sites.append(node)
+    return sites
+
+
 def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Violation]:
     """CORE_LOCK_NO_AWAIT — the session lock is never held across a suspension.
 
@@ -1205,44 +1268,46 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
                 "atomicity this gate protects rests on the uncontended-acquire fast path "
                 "of that exact primitive; re-derive the contract before swapping it"))
         else:
-            # ``asyncio.Lock`` is matched by spelling, so the name has to mean
-            # the standard library. ``import custom_locks as asyncio`` or a
-            # plain ``asyncio = custom_locks`` would satisfy the spelling
-            # while binding an entirely different primitive.
+            # ``asyncio.Lock`` is matched by SPELLING, so the name has to mean
+            # the standard library. Rather than enumerate the ways it could
+            # mean something else (``import custom_locks as asyncio``, a plain
+            # ``asyncio = custom_locks``, a parameter named ``asyncio``, a
+            # loop target, a ``with ... as`` …), require the name to have
+            # exactly one binding in manager.py and require that binding to be
+            # a plain ``import asyncio``. That is closed under binding syntax
+            # instead of chasing forms one at a time.
             manager_tree = parse(manager_path)
-            for node in ast.walk(manager_tree):
-                rebind_line = None
-                if isinstance(node, ast.Import):
-                    rebind_line = next(
-                        (node.lineno for a in node.names
-                         if (a.asname or a.name) == "asyncio" and a.name != "asyncio"),
-                        None,
-                    )
-                elif isinstance(node, ast.ImportFrom):
-                    rebind_line = next(
-                        (node.lineno for a in node.names
-                         if (a.asname or a.name) == "asyncio"),
-                        None,
-                    )
-                elif isinstance(node, ast.Assign):
-                    rebind_line = next(
-                        (node.lineno for t in node.targets
-                         if isinstance(t, ast.Name) and t.id == "asyncio"),
-                        None,
-                    )
-                elif (
-                    isinstance(node, (ast.AnnAssign, ast.AugAssign))
-                    and isinstance(node.target, ast.Name)
-                    and node.target.id == "asyncio"
-                ):
-                    rebind_line = node.lineno
-                if rebind_line is not None:
-                    violations.append(Violation(
-                        manager_path, rebind_line, 0, "CORE_LOCK_NO_AWAIT",
-                        "the name 'asyncio' is rebound in manager.py — the primitive "
-                        "check matches the spelling 'asyncio.Lock()', so aliasing or "
-                        "shadowing the module lets a lock with different suspension "
-                        "semantics pass as the standard-library one (#2619)"))
+            bindings = _name_binding_sites(manager_tree, "asyncio")
+
+            def binds_the_stdlib_package(node: ast.AST) -> bool:
+                # ``import asyncio`` and ``import asyncio.subprocess`` both
+                # bind the top-level name to the same stdlib package, so both
+                # are the guarantee this check wants; anything with an
+                # ``asname`` or any other syntax is not.
+                return isinstance(node, ast.Import) and any(
+                    alias.asname is None
+                    and (alias.name == "asyncio" or alias.name.startswith("asyncio."))
+                    for alias in node.names
+                )
+
+            plain_import = bool(bindings) and all(
+                binds_the_stdlib_package(node) for node in bindings
+            )
+            if not plain_import:
+                where = ", ".join(
+                    f"line {getattr(b, 'lineno', '?')}" for b in bindings
+                ) or "nowhere"
+                violations.append(Violation(
+                    manager_path,
+                    getattr(bindings[0], "lineno", 1) if bindings else 1, 0,
+                    "CORE_LOCK_NO_AWAIT",
+                    f"the name 'asyncio' must be bound in manager.py only by a plain "
+                    f"'import asyncio' — found {len(bindings)} binding(s) "
+                    f"({where}). The primitive check matches the spelling "
+                    f"'asyncio.Lock()', so any other binding of that name (alias import, "
+                    f"assignment, parameter, loop target, with/except capture …) lets a "
+                    f"lock with different suspension semantics pass as the "
+                    f"standard-library one (#2619)"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1125,6 +1125,19 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
     an external holder can only arise from new code reaching into the
     attribute directly. Measured today: no production module outside the
     package references a manager's ``.lock`` at all.
+
+    Second known boundary: the ``asyncio`` binding check is scope- and
+    control-flow-blind. It requires every binding of the name to be a plain
+    ``import asyncio``, but does not work out which one reaches the
+    ``self.lock`` assignment — a module-level import plus a conditional
+    ``import asyncio`` inside ``__init__`` satisfies it. That is deliberate:
+    the local import makes the name local for the whole method, so the
+    un-taken branch raises ``UnboundLocalError`` at ``asyncio.Lock()``
+    (measured). The failure is a crash at construction, not a lock with
+    different suspension semantics slipping through — unlike the shadowing
+    forms above, which run fine and only the gate cannot see. Deciding it
+    properly needs reaching-definition analysis at the assignment, which is a
+    dataflow pass this syntax-level gate does not want to become.
     """
 
     def suspension_kind(node: ast.AST) -> str | None:

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1194,16 +1194,16 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         claimed to be covered.
         """
 
-        REFLECTIVE = {
-            "getattr", "setattr",
-            "object.__getattribute__", "object.__setattr__",
-        }
+        return is_lock_read(node) or is_lock_write(node)
+
+    def is_lock_read(node: ast.AST) -> bool:
+        """A reach for the attribute that yields the lock object."""
 
         if isinstance(node, ast.Attribute):
             return node.attr == "lock"
         if (
             isinstance(node, ast.Call)
-            and dotted_node_path(node.func) in REFLECTIVE
+            and dotted_node_path(node.func) in {"getattr", "object.__getattribute__"}
             and len(node.args) >= 2
             and isinstance(node.args[1], ast.Constant)
             and node.args[1].value == "lock"
@@ -1217,8 +1217,30 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             and node.slice.value == "lock"
         )
 
+    def is_lock_write(node: ast.AST) -> bool:
+        """A reflective call that REPLACES the attribute."""
+
+        return (
+            isinstance(node, ast.Call)
+            and dotted_node_path(node.func) in {"setattr", "object.__setattr__"}
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "lock"
+        )
+
     def is_session_lock(item: ast.withitem) -> bool:
-        return is_lock_attr(item.context_expr)
+        """Reads only — a write is never an acquisition.
+
+        Both spellings have to be recognised by the form check, but only a
+        READ can be the thing an ``async with`` acquires. Letting a write
+        qualify here sanctioned the setter itself: ``async with setattr(self,
+        "lock", OtherLock()): pass`` was recorded as a lock acquisition and
+        reported nothing, even though the swap already happened by the time
+        entering ``None`` raises TypeError — which the surrounding code is
+        free to catch.
+        """
+
+        return is_lock_read(item.context_expr)
 
     def is_self_lock_attr(node: ast.AST) -> bool:
         return (

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1258,7 +1258,10 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         # and the ``asyncio.Lock()`` spelling intact while the manager builds
         # an arbitrary primitive. Same family as the reflective writes above —
         # the swap happens where the checker was only reading spelling.
-        for node in ast.walk(tree):
+        # Reflective writes count the same as direct ones, for the same reason
+        # they do on the lock attribute itself: catching one spelling and not
+        # the other is not a gate, it is a speed bump.
+        def replaces_asyncio_lock(node: ast.AST) -> bool:
             targets: list[ast.expr] = []
             if isinstance(node, ast.Assign):
                 targets = list(node.targets)
@@ -1266,13 +1269,34 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
                 targets = [node.target]
             for target in targets:
                 if dotted_node_path(target) == "asyncio.Lock":
-                    violations.append(Violation(
-                        path, node.lineno, node.col_offset, "CORE_LOCK_NO_AWAIT",
-                        "asyncio.Lock is reassigned — the primitive check validates the "
-                        "spelling 'asyncio.Lock()' and that 'asyncio' means the standard "
-                        "library, but neither survives the attribute itself being "
-                        "replaced; the manager would then build an arbitrary lock whose "
-                        "acquire may suspend (#2619)"))
+                    return True
+                # ``asyncio.__dict__["Lock"] = X``
+                if (
+                    isinstance(target, ast.Subscript)
+                    and dotted_node_path(target.value) == "asyncio.__dict__"
+                    and isinstance(target.slice, ast.Constant)
+                    and target.slice.value == "Lock"
+                ):
+                    return True
+            # ``setattr(asyncio, "Lock", X)`` / ``object.__setattr__(...)``
+            return (
+                isinstance(node, ast.Call)
+                and dotted_node_path(node.func) in {"setattr", "object.__setattr__"}
+                and len(node.args) >= 2
+                and dotted_node_path(node.args[0]) == "asyncio"
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == "Lock"
+            )
+
+        for node in ast.walk(tree):
+            if replaces_asyncio_lock(node):
+                violations.append(Violation(
+                    path, node.lineno, node.col_offset, "CORE_LOCK_NO_AWAIT",
+                    "asyncio.Lock is replaced — the primitive check validates the "
+                    "spelling 'asyncio.Lock()' and that 'asyncio' means the standard "
+                    "library, but neither survives the attribute itself being "
+                    "replaced; the manager would then build an arbitrary lock whose "
+                    "acquire may suspend (#2619)"))
         # manager.py binds the attribute; that assignment target is the only
         # non-``async with`` mention the package is allowed to carry. Every
         # binding is collected — not just the first — because the primitive

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -956,11 +956,20 @@ def check_fail_closed_chokepoint(core_dir: Path) -> list[Violation]:
 def _statements_in_critical_section(body: list[ast.stmt]):
     """Yield every node a critical section actually executes.
 
-    Nested ``def`` / ``async def`` / ``lambda`` bodies are skipped: code
-    defined inside the block runs when the closure is called, not while the
-    lock is held, so an ``await`` in there is not a suspension of this
-    critical section. Descending into them would make the gate fire on
-    something that is fine.
+    A nested ``def`` / ``async def`` / ``lambda`` splits into two halves that
+    run at different times, and only the body is deferred:
+
+    * the BODY runs when the closure is called, which is necessarily after
+      the block has exited, so an ``await`` in there is not a suspension of
+      this critical section and flagging it would be a false positive;
+    * the DEFINITION-TIME parts — decorators, default values, annotations —
+      are evaluated right here, while the lock is held. ``async def
+      later(x=await self.flush())`` parses, and the default is evaluated at
+      def time (measured), so skipping the whole node would let a real
+      suspension through.
+
+    So the body is skipped and everything else about the definition is still
+    walked.
     """
 
     stack: list[ast.AST] = list(body)
@@ -968,6 +977,19 @@ def _statements_in_critical_section(body: list[ast.stmt]):
         node = stack.pop()
         yield node
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # ``Lambda.body`` is one expression; the others hold a statement
+            # list. Compare by identity — AST nodes have no ``__eq__``, and
+            # two structurally identical children must not collapse.
+            deferred = (
+                {id(node.body)}
+                if isinstance(node, ast.Lambda)
+                else {id(stmt) for stmt in node.body}
+            )
+            stack.extend(
+                child
+                for child in ast.iter_child_nodes(node)
+                if id(child) not in deferred
+            )
             continue
         stack.extend(ast.iter_child_nodes(node))
 
@@ -1067,6 +1089,21 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         if path == manager_path:
             for node in ast.walk(tree):
                 if isinstance(node, ast.Assign):
+                    if not any(is_self_lock_attr(t) for t in node.targets):
+                        continue
+                    # ``self.other_lock = self.lock = asyncio.Lock()`` binds
+                    # ONE object to two names. The gate deliberately ignores
+                    # non-session locks, so the second name would then be a
+                    # sanctioned handle on the session lock that may be held
+                    # across awaits. One target only.
+                    if len(node.targets) != 1:
+                        violations.append(Violation(
+                            path, node.lineno, node.col_offset, "CORE_LOCK_NO_AWAIT",
+                            "the self.lock binding must have exactly one target — a "
+                            "chained assignment aliases the same lock object under "
+                            "another name, and every other lock name is allowed to be "
+                            "held across awaits, so the alias becomes a way to suspend "
+                            "while holding the session lock (#2619)"))
                     manager_bindings.extend(
                         (target, node.value)
                         for target in node.targets
@@ -1156,17 +1193,56 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             f"a rebind to a suspending lock would pass while an earlier asyncio.Lock() "
             f"line satisfies the check"))
     else:
-        value = manager_bindings[0][1]
+        target, value = manager_bindings[0]
+        line = getattr(target, "lineno", 1)
         if not (
             isinstance(value, ast.Call)
             and dotted_node_path(value.func) == "asyncio.Lock"
         ):
             violations.append(Violation(
-                manager_path, getattr(manager_bindings[0][0], "lineno", 1), 0,
-                "CORE_LOCK_NO_AWAIT",
+                manager_path, line, 0, "CORE_LOCK_NO_AWAIT",
                 "self.lock is no longer bound to asyncio.Lock() in manager.py — the "
                 "atomicity this gate protects rests on the uncontended-acquire fast path "
                 "of that exact primitive; re-derive the contract before swapping it"))
+        else:
+            # ``asyncio.Lock`` is matched by spelling, so the name has to mean
+            # the standard library. ``import custom_locks as asyncio`` or a
+            # plain ``asyncio = custom_locks`` would satisfy the spelling
+            # while binding an entirely different primitive.
+            manager_tree = parse(manager_path)
+            for node in ast.walk(manager_tree):
+                rebind_line = None
+                if isinstance(node, ast.Import):
+                    rebind_line = next(
+                        (node.lineno for a in node.names
+                         if (a.asname or a.name) == "asyncio" and a.name != "asyncio"),
+                        None,
+                    )
+                elif isinstance(node, ast.ImportFrom):
+                    rebind_line = next(
+                        (node.lineno for a in node.names
+                         if (a.asname or a.name) == "asyncio"),
+                        None,
+                    )
+                elif isinstance(node, ast.Assign):
+                    rebind_line = next(
+                        (node.lineno for t in node.targets
+                         if isinstance(t, ast.Name) and t.id == "asyncio"),
+                        None,
+                    )
+                elif (
+                    isinstance(node, (ast.AnnAssign, ast.AugAssign))
+                    and isinstance(node.target, ast.Name)
+                    and node.target.id == "asyncio"
+                ):
+                    rebind_line = node.lineno
+                if rebind_line is not None:
+                    violations.append(Violation(
+                        manager_path, rebind_line, 0, "CORE_LOCK_NO_AWAIT",
+                        "the name 'asyncio' is rebound in manager.py — the primitive "
+                        "check matches the spelling 'asyncio.Lock()', so aliasing or "
+                        "shadowing the module lets a lock with different suspension "
+                        "semantics pass as the standard-library one (#2619)"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1023,7 +1023,11 @@ def _name_binding_sites(tree: ast.AST, name: str) -> list[ast.AST]:
         elif isinstance(node, ast.ImportFrom):
             sites.extend(
                 alias for alias in node.names
-                if (alias.asname or alias.name) == name
+                # ``from x import *`` can bind ANY name the module exports,
+                # including this one, and nothing in the AST says which. It
+                # counts as a binding of every name — unknown, so not the
+                # sanctioned one.
+                if alias.name == "*" or (alias.asname or alias.name) == name
             )
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             if node.name == name:
@@ -1363,9 +1367,9 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
                     f"'import asyncio' — found {len(bindings)} binding(s) "
                     f"({where}). The primitive check matches the spelling "
                     f"'asyncio.Lock()', so any other binding of that name (alias import, "
-                    f"assignment, parameter, loop target, with/except capture …) lets a "
-                    f"lock with different suspension semantics pass as the "
-                    f"standard-library one (#2619)"))
+                    f"wildcard import, assignment, parameter, loop target, with/except "
+                    f"capture …) lets a lock with different suspension semantics pass as "
+                    f"the standard-library one (#2619)"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1011,14 +1011,18 @@ def _name_binding_sites(tree: ast.AST, name: str) -> list[ast.AST]:
 
     sites: list[ast.AST] = []
     for node in ast.walk(tree):
+        # The ``ast.alias`` is returned, not the containing import: one
+        # statement can carry several, and ``import asyncio, vendor as
+        # asyncio`` must not be judged by whichever alias happens to look
+        # right — Python leaves the name bound to the LAST one.
         if isinstance(node, ast.Import):
             sites.extend(
-                node for alias in node.names
+                alias for alias in node.names
                 if (alias.asname or alias.name.split(".")[0]) == name
             )
         elif isinstance(node, ast.ImportFrom):
             sites.extend(
-                node for alias in node.names
+                alias for alias in node.names
                 if (alias.asname or alias.name) == name
             )
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -1032,7 +1036,11 @@ def _name_binding_sites(tree: ast.AST, name: str) -> list[ast.AST]:
                 name in _assignment_target_names(target) for target in node.targets
             ):
                 sites.append(node)
-        elif isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+        elif isinstance(node, ast.AnnAssign):
+            # A bare ``x: T`` declares a type and binds nothing.
+            if node.value is not None and name in _assignment_target_names(node.target):
+                sites.append(node)
+        elif isinstance(node, (ast.AugAssign, ast.NamedExpr)):
             if name in _assignment_target_names(node.target):
                 sites.append(node)
         elif isinstance(node, (ast.For, ast.AsyncFor)):
@@ -1087,6 +1095,21 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
     The check is deliberately package-wide rather than pinned to the rotation
     sites: the property is a property of the lock, and one careless holder
     anywhere is enough to lose it everywhere.
+
+    Known boundary: the scan covers ``main_logic/core`` only. A holder
+    OUTSIDE the package — ``async with manager.lock: await ...`` somewhere
+    that was handed a manager — would make the lock contendable just the
+    same, and this gate would not see it. That gap is not closed here
+    because the cheap closure is not sound: matching ``.lock`` repo-wide
+    collides with unrelated locks that legitimately suspend under
+    themselves (measured: ``plugin/plugins/neko_live/core/pipeline_session.py``
+    holds a per-uid ``entry.lock`` by design), and demanding an allowlist
+    entry from unrelated code makes the gate about the wrong thing. What IS
+    closed is the leak path: core cannot hand the lock out, because every
+    ``.lock`` mention there must be an ``async with`` context expression, so
+    an external holder can only arise from new code reaching into the
+    attribute directly. Measured today: no production module outside the
+    package references a manager's ``.lock`` at all.
     """
 
     def suspension_kind(node: ast.AST) -> str | None:
@@ -1106,14 +1129,22 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
             return "async comprehension"
         return None
 
+    def is_lock_attr(node: ast.AST) -> bool:
+        """Any ``<expr>.lock``, whatever the receiver.
+
+        Deliberately NOT pinned to a literal ``self`` receiver: ``owner =
+        self`` followed by ``async with owner.lock:`` acquires the same
+        object, and resolving aliases properly is dataflow analysis. Matching
+        the attribute name alone over-approximates instead, which is the safe
+        direction — and measured, it costs nothing: the package contains no
+        ``.lock`` acquisition with any other receiver, and manager.py's
+        binding is the only non-``async with`` mention at all.
+        """
+
+        return isinstance(node, ast.Attribute) and node.attr == "lock"
+
     def is_session_lock(item: ast.withitem) -> bool:
-        expr = item.context_expr
-        return (
-            isinstance(expr, ast.Attribute)
-            and expr.attr == "lock"
-            and isinstance(expr.value, ast.Name)
-            and expr.value.id == "self"
-        )
+        return is_lock_attr(item.context_expr)
 
     def is_self_lock_attr(node: ast.AST) -> bool:
         return (
@@ -1126,6 +1157,7 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
     violations: list[Violation] = []
     blocks_seen = 0
     manager_bindings: list[tuple[ast.AST, ast.expr | None]] = []
+    annotation_only: list[ast.AST] = []
     for path in sorted(core_dir.glob("*.py")):
         if path.name == "__init__.py":
             continue
@@ -1173,17 +1205,27 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
                         if is_self_lock_attr(target)
                     )
                 elif isinstance(node, ast.AnnAssign) and is_self_lock_attr(node.target):
-                    manager_bindings.append((node.target, node.value))
+                    if node.value is None:
+                        # ``self.lock: asyncio.Lock`` with no value is a type
+                        # declaration; it neither assigns nor replaces the
+                        # attribute, so it is exempt from the form check
+                        # without counting as a binding.
+                        annotation_only.append(node.target)
+                    else:
+                        manager_bindings.append((node.target, node.value))
         bind_targets = {id(target) for target, _ in manager_bindings}
+        bind_targets.update(id(target) for target in annotation_only)
         for node in ast.walk(tree):
-            if not is_self_lock_attr(node):
+            if not is_lock_attr(node):
                 continue
             if id(node) in sanctioned or id(node) in bind_targets:
                 continue
             violations.append(Violation(
                 path, node.lineno, node.col_offset, "CORE_LOCK_NO_AWAIT",
-                "self.lock referenced outside an 'async with self.lock' block — the "
-                "session lock may only be taken as a context manager. Manual "
+                "a '.lock' attribute is referenced outside an 'async with' block — the "
+                "session lock may only be taken as a context manager, and the receiver "
+                "is not required to be literally 'self' because an alias reaches the "
+                "same object. Manual "
                 "acquire()/release() (or passing the lock elsewhere) can hold it across "
                 "an await without presenting a block for this gate to check, which makes "
                 "the lock contendable and reopens the torn sid/TTS-flag state (#2619)"))
@@ -1283,11 +1325,14 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
                 # ``import asyncio`` and ``import asyncio.subprocess`` both
                 # bind the top-level name to the same stdlib package, so both
                 # are the guarantee this check wants; anything with an
-                # ``asname`` or any other syntax is not.
-                return isinstance(node, ast.Import) and any(
-                    alias.asname is None
-                    and (alias.name == "asyncio" or alias.name.startswith("asyncio."))
-                    for alias in node.names
+                # ``asname`` or any other syntax is not. Judged per ALIAS —
+                # judging the containing statement let ``import asyncio,
+                # vendor as asyncio`` pass on the strength of its first alias
+                # while Python bound the name to the second.
+                return (
+                    isinstance(node, ast.alias)
+                    and node.asname is None
+                    and (node.name == "asyncio" or node.name.startswith("asyncio."))
                 )
 
             plain_import = bool(bindings) and all(

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -109,7 +109,10 @@ CORE_LOCK_NO_AWAIT
     no acquire is a cancellation point — which is what makes those paired
     writes atomic (#2619). The first ``await`` inside any of these blocks
     makes the lock contendable and reopens a torn "flags say the new turn,
-    speech id still says the old one" state at every one of them.
+    speech id still says the old one" state at every one of them. The lock
+    must also be taken ONLY as a context manager — manual
+    ``acquire()``/``release()`` would hold it across awaits while presenting
+    no block for the shape check to see.
 
 VOICE_IDENTITY_LAYERING
     The in-memory speaker identity domain owns only model identity, normalized
@@ -989,6 +992,13 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
     that write ``current_speech_id`` alongside both TTS done flags. So the
     invariant is the fix, and this gate is what keeps it true.
 
+    Two halves, because a shape check alone is defeatable. The reachable
+    shape — no suspension inside any ``async with self.lock`` block — is only
+    meaningful if every acquisition IS such a block, so the lock is also
+    required to appear nowhere else: manual ``acquire()``/``release()`` holds
+    it across arbitrary awaits while presenting no block to inspect.
+    ``manager.py``'s binding assignment is the single exemption.
+
     The check is deliberately package-wide rather than pinned to the rotation
     sites: the property is a property of the lock, and one careless holder
     anywhere is enough to lose it everywhere.
@@ -1026,6 +1036,48 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         if path.name == "__init__.py":
             continue
         tree = parse(path)
+        # Every sanctioned mention of the lock is the context expression of an
+        # ``async with``. Manual ``await self.lock.acquire()`` ... ``release()``
+        # would hold it across arbitrary awaits while presenting no AsyncWith
+        # node for the scan below to inspect — the one rewrite that defeats
+        # this gate without tripping it. So the reachable-shape check is
+        # paired with a form check: any other reference to ``self.lock`` is
+        # rejected outright, which also covers handing the lock to a helper
+        # that awaits under it.
+        sanctioned: set[int] = {
+            id(item.context_expr)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncWith)
+            for item in node.items
+            if is_session_lock(item)
+        }
+        # manager.py binds the attribute once; that assignment target is the
+        # only non-``async with`` mention the package is allowed to carry.
+        bind_targets: set[int] = {
+            id(target)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Attribute) and target.attr == "lock"
+            and isinstance(target.value, ast.Name) and target.value.id == "self"
+        } if path == manager_path else set()
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Attribute)
+                and node.attr == "lock"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "self"
+            ):
+                continue
+            if id(node) in sanctioned or id(node) in bind_targets:
+                continue
+            violations.append(Violation(
+                path, node.lineno, node.col_offset, "CORE_LOCK_NO_AWAIT",
+                "self.lock referenced outside an 'async with self.lock' block — the "
+                "session lock may only be taken as a context manager. Manual "
+                "acquire()/release() (or passing the lock elsewhere) can hold it across "
+                "an await without presenting a block for this gate to check, which makes "
+                "the lock contendable and reopens the torn sid/TTS-flag state (#2619)"))
         for block in ast.walk(tree):
             if not isinstance(block, ast.AsyncWith):
                 continue

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1168,21 +1168,29 @@ def check_session_lock_atomicity(core_dir: Path, manager_path: Path) -> list[Vio
         ``.lock`` acquisition with any other receiver, and manager.py's
         binding is the only non-``async with`` mention at all.
 
-        The literal reflective spellings count too — ``getattr(x, "lock")``
-        and ``x.__dict__["lock"]`` reach the same object while carrying no
-        ``Attribute`` node named ``lock`` for a syntax-only match to see.
-        Same reasoning as ``check_fail_closed_chokepoint``'s ``called_name``
-        in this file: a gate a one-line rewrite defeats is not a gate. A
-        computed name (``getattr(x, name)``) is out of reach of any AST check
-        and is not claimed to be covered.
+        The literal reflective spellings count too — ``getattr(x, "lock")``,
+        ``setattr(x, "lock", …)`` and ``x.__dict__["lock"]`` reach the same
+        attribute while carrying no ``Attribute`` node named ``lock`` for a
+        syntax-only match to see. Reads and WRITES both: a reflective write
+        replaces the primitive itself, which the exact-once binding check
+        would never notice, and then a perfectly clean-looking ``async with
+        self.lock:`` runs on a lock whose acquire may suspend. Same reasoning
+        as ``check_fail_closed_chokepoint``'s ``called_name`` in this file: a
+        gate a one-line rewrite defeats is not a gate. A computed name
+        (``getattr(x, name)``) is out of reach of any AST check and is not
+        claimed to be covered.
         """
+
+        REFLECTIVE = {
+            "getattr", "setattr",
+            "object.__getattribute__", "object.__setattr__",
+        }
 
         if isinstance(node, ast.Attribute):
             return node.attr == "lock"
         if (
             isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "getattr"
+            and dotted_node_path(node.func) in REFLECTIVE
             and len(node.args) >= 2
             and isinstance(node.args[1], ast.Constant)
             and node.args[1].value == "lock"

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2181,26 +2181,38 @@ def test_lock_gate_still_flags_eager_comprehensions(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "swap",
+    [
+        pytest.param("asyncio.Lock = OtherLock", id="direct"),
+        pytest.param('setattr(asyncio, "Lock", OtherLock)', id="setattr"),
+        pytest.param('object.__setattr__(asyncio, "Lock", OtherLock)', id="object-setattr"),
+        pytest.param('asyncio.__dict__["Lock"] = OtherLock', id="dunder-dict"),
+    ],
+)
 def test_lock_gate_rejects_replacing_asyncio_lock_itself(
     contract_checker,
     tmp_path: Path,
+    swap: str,
 ) -> None:
     """The module can stay stdlib while its ``Lock`` attribute is swapped.
 
-    Both the name check and the ``asyncio.Lock()`` spelling survive that,
-    so neither notices the manager building an arbitrary primitive.
+    Both the name check and the ``asyncio.Lock()`` spelling survive that, so
+    neither notices the manager building an arbitrary primitive. Direct and
+    reflective spellings alike — catching one and not the other is a speed
+    bump, not a gate.
     """
 
     source = _CLEAN_PROBE + (
         "\n"
         "    def swap(self):\n"
-        "        asyncio.Lock = OtherLock\n"
+        f"        {swap}\n"
     )
 
     violations = _lock_violations(contract_checker, tmp_path, source)
 
     assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
-    assert "asyncio.Lock is reassigned" in violations[0].message
+    assert "asyncio.Lock is replaced" in violations[0].message
 
 
 @pytest.mark.unit

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2218,6 +2218,9 @@ def test_lock_gate_rejects_a_chained_binding_that_aliases_the_lock(
         # Not an import at all: the caller supplies the module.
         pytest.param("import asyncio\n", "self, asyncio", id="parameter"),
         pytest.param("import asyncio\n", "self, *, asyncio=custom_locks", id="kwonly-parameter"),
+        # A star import can bind any name the other module exports, and
+        # nothing in the AST says which — unknown, so not the sanctioned one.
+        pytest.param("import asyncio\nfrom vendor_locks import *\n", "self", id="wildcard-import"),
     ],
 )
 def test_lock_gate_rejects_shadowing_the_asyncio_name(

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2101,6 +2101,109 @@ def test_lock_gate_reports_one_violation_per_block_not_per_suspension(
 
 
 @pytest.mark.unit
+def test_lock_gate_ignores_a_generator_expression_body_under_the_lock(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """A generator expression body runs at consumption, not at creation.
+
+    Measured: ``(await work(x) async for x in src())`` evaluates nothing when
+    it is built, so the block never suspends and flagging it is a false
+    positive — and a gate that rejects harmless code teaches people to route
+    around it.
+    """
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        "            self._pending = (await self.work(x) async for x in self.src())\n"
+    )
+
+    assert _lock_violations(contract_checker, tmp_path, source) == []
+
+
+@pytest.mark.unit
+def test_lock_gate_still_sees_the_eager_outermost_iterable(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """The one part of a generator expression that IS evaluated at creation.
+
+    Measured: ``(x for x in await get())`` runs ``await get()`` immediately,
+    so skipping the whole node would hide a real suspension.
+    """
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        "            self._pending = (x for x in await self.get())\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "comprehension",
+    [
+        pytest.param("[await self.one(x) for x in self.batch]", id="list"),
+        pytest.param("{await self.one(x) for x in self.batch}", id="set"),
+        pytest.param("{x: await self.one(x) for x in self.batch}", id="dict"),
+    ],
+)
+def test_lock_gate_still_flags_eager_comprehensions(
+    contract_checker,
+    tmp_path: Path,
+    comprehension: str,
+) -> None:
+    """Only GENERATOR expressions are deferred; the other three run now."""
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        f"            self._rows = {comprehension}\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+
+
+@pytest.mark.unit
+def test_lock_gate_rejects_replacing_asyncio_lock_itself(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """The module can stay stdlib while its ``Lock`` attribute is swapped.
+
+    Both the name check and the ``asyncio.Lock()`` spelling survive that,
+    so neither notices the manager building an arbitrary primitive.
+    """
+
+    source = _CLEAN_PROBE + (
+        "\n"
+        "    def swap(self):\n"
+        "        asyncio.Lock = OtherLock\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "asyncio.Lock is reassigned" in violations[0].message
+
+
+@pytest.mark.unit
 def test_lock_gate_ignores_awaits_in_closures_defined_inside_the_block(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2471,6 +2471,7 @@ def test_lock_gate_rejects_an_annotated_rebind_too(
     "acquisition",
     [
         pytest.param('getattr(self, "lock")', id="getattr"),
+        pytest.param('object.__getattribute__(self, "lock")', id="getattribute"),
         pytest.param('self.__dict__["lock"]', id="dunder-dict"),
     ],
 )
@@ -2497,6 +2498,42 @@ def test_lock_gate_sees_the_lock_reached_reflectively(
     assert violations
     assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
     assert any("must never be held across a suspension" in v.message for v in violations)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "write",
+    [
+        pytest.param('setattr(self, "lock", OtherLock())', id="setattr"),
+        pytest.param('object.__setattr__(self, "lock", OtherLock())', id="object-setattr"),
+        pytest.param('self.__dict__["lock"] = OtherLock()', id="dunder-dict-write"),
+    ],
+)
+def test_lock_gate_sees_the_lock_replaced_reflectively(
+    contract_checker,
+    tmp_path: Path,
+    write: str,
+) -> None:
+    """A reflective WRITE swaps the primitive the whole contract rests on.
+
+    The exact-once binding check in manager.py would still see only the
+    original ``self.lock = asyncio.Lock()``, and every later ``async with
+    self.lock:`` would look clean while running on a lock whose acquire can
+    suspend. Catching reads but not writes would be the same inconsistency
+    this gate criticised elsewhere.
+    """
+
+    source = _CLEAN_PROBE + (
+        "\n"
+        "    def swap(self):\n"
+        f"        {write}\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert violations
+    assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
+    assert any("outside an 'async with' block" in v.message for v in violations)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -1975,3 +1975,241 @@ def test_voice_identity_contract_rejects_model_assets_inside_domain_package(
         "found models/speaker.onnx"
         in messages
     )
+
+
+# ── CORE_LOCK_NO_AWAIT ──────────────────────────────────────────────────
+#
+# The gate exists because the atomicity of every ``current_speech_id`` +
+# TTS-done-flag write rests on one property of ``self.lock``: no holder ever
+# suspends, so the lock is never observed held, so ``acquire()`` always takes
+# the uncontended fast path and is therefore not a cancellation point (#2619).
+# These tests pin what makes that property checkable.
+
+
+def _lock_core_dir(
+    tmp_path: Path,
+    probe_source: str,
+    manager_source: str | None = None,
+) -> tuple[Path, Path]:
+    """A minimal core package: manager.py binding the lock plus one probe module."""
+
+    core = tmp_path / "core"
+    core.mkdir()
+    (core / "__init__.py").write_text("", encoding="utf-8")
+    manager = core / "manager.py"
+    manager.write_text(
+        manager_source
+        if manager_source is not None
+        else (
+            '"""m."""\n\n'
+            "import asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock = asyncio.Lock()\n"
+        ),
+        encoding="utf-8",
+    )
+    (core / "probe.py").write_text(probe_source, encoding="utf-8")
+    return core, manager
+
+
+def _lock_violations(contract_checker, tmp_path: Path, probe_source: str, **kw):
+    core, manager = _lock_core_dir(tmp_path, probe_source, **kw)
+    return contract_checker.check_session_lock_atomicity(core, manager)
+
+
+_CLEAN_PROBE = (
+    '"""m."""\n\n'
+    "class ProbeMixin:\n"
+    '    """m."""\n\n'
+    "    async def rotate(self):\n"
+    "        await self.prepare()\n"
+    "        async with self.lock:\n"
+    "            self.current_speech_id = new_id()\n"
+    "            self._tts_done_queued_for_turn = False\n"
+    "        await self.announce()\n"
+)
+
+
+@pytest.mark.unit
+def test_lock_gate_accepts_a_critical_section_with_no_suspension(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """Awaits before and after the block are exactly the sanctioned shape."""
+
+    assert _lock_violations(contract_checker, tmp_path, _CLEAN_PROBE) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "statement",
+    [
+        # The plain form: this is what would make the rotation tearable.
+        "await self.flush()",
+        "value = await self.flush()",
+        # ...and the spellings that suspend without an ``await`` statement of
+        # their own, each of which an Await-only scan walks straight past.
+        "async for item in self.stream():\n                pass",
+        "async with self.other_lock:\n                pass",
+        "self.rows = [x async for x in self.stream()]",
+        "self.rows = [await self.one(x) for x in self.batch]",
+        "yield self.current_speech_id",
+    ],
+)
+def test_lock_gate_rejects_every_suspension_spelling(
+    contract_checker,
+    tmp_path: Path,
+    statement: str,
+) -> None:
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        f"            {statement}\n"
+        "            self.current_speech_id = new_id()\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "async with self.lock" in violations[0].message
+
+
+@pytest.mark.unit
+def test_lock_gate_reports_one_violation_per_block_not_per_suspension(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """The defect is the block, not each await in it — three awaits, one report."""
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        "            await self.a()\n"
+        "            await self.b()\n"
+        "            await self.c()\n"
+    )
+
+    assert len(_lock_violations(contract_checker, tmp_path, source)) == 1
+
+
+@pytest.mark.unit
+def test_lock_gate_ignores_awaits_in_closures_defined_inside_the_block(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """A coroutine DEFINED under the lock does not RUN under it.
+
+    Flagging this would be a false positive: the closure body executes when
+    someone awaits the returned object, which by definition is after the
+    ``async with`` has exited.
+    """
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        "            async def later():\n"
+        "                await self.flush()\n"
+        "            self._deferred = later\n"
+    )
+
+    assert _lock_violations(contract_checker, tmp_path, source) == []
+
+
+@pytest.mark.unit
+def test_lock_gate_ignores_other_locks(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """Only ``self.lock`` carries the contract.
+
+    ``self.tts_cache_lock`` and friends are ordinary locks whose holders may
+    await; widening the rule to every attribute named ``*lock`` would fail the
+    package on code that is fine.
+    """
+
+    source = _CLEAN_PROBE + (
+        "\n"
+        "    async def flush(self):\n"
+        "        async with self.tts_cache_lock:\n"
+        "            await self.drain()\n"
+    )
+
+    assert _lock_violations(contract_checker, tmp_path, source) == []
+
+
+@pytest.mark.unit
+def test_lock_gate_fails_loudly_when_no_lock_block_is_left(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """A gate that silently matches nothing is worse than no gate."""
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        self.current_speech_id = new_id()\n"
+    )
+
+    messages = [v.message for v in _lock_violations(contract_checker, tmp_path, source)]
+
+    assert any("vacuous" in m for m in messages)
+
+
+@pytest.mark.unit
+def test_lock_gate_rejects_swapping_the_lock_primitive(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """The fast-path argument is specific to ``asyncio.Lock``.
+
+    A reentrant or threading primitive would break "never observed held" for
+    reasons no AST walk over the critical sections can see, so the binding
+    itself is part of the contract.
+    """
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import threading\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock = threading.RLock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "asyncio.Lock()" in violations[0].message
+
+
+@pytest.mark.unit
+def test_lock_gate_holds_on_the_real_core_package(contract_checker) -> None:
+    """The contract this gate encodes is true of the tree today.
+
+    Not a tautology with the synthetic cases above: this is the measurement
+    #2619's premise turns on. If it ever fails, the torn-state window that
+    issue described becomes real and the rotation sites need revisiting.
+    """
+
+    core_dir = PROJECT_ROOT / "main_logic" / "core"
+    violations = contract_checker.check_session_lock_atomicity(
+        core_dir, core_dir / "manager.py"
+    )
+
+    assert violations == [], "\n".join(v.render(PROJECT_ROOT) for v in violations)

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2652,6 +2652,45 @@ def test_lock_gate_sees_the_lock_replaced_reflectively(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "write",
+    [
+        pytest.param('setattr(self, "lock", OtherLock())', id="setattr"),
+        pytest.param('object.__setattr__(self, "lock", OtherLock())', id="object-setattr"),
+    ],
+)
+def test_lock_gate_never_sanctions_a_write_as_an_acquisition(
+    contract_checker,
+    tmp_path: Path,
+    write: str,
+) -> None:
+    """A setter in context-expression position is still a swap, not a take.
+
+    Recognising both spellings for the form check is right; treating a WRITE
+    as the thing an ``async with`` acquires is not — it recorded the setter
+    as a sanctioned acquisition and reported nothing. Entering ``None`` does
+    raise TypeError, but the swap has already happened by then and the
+    surrounding code is free to catch it.
+    """
+
+    source = _CLEAN_PROBE + (
+        "\n"
+        "    async def sneaky(self):\n"
+        "        try:\n"
+        f"            async with {write}:\n"
+        "                pass\n"
+        "        except TypeError:\n"
+        "            pass\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert violations
+    assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
+    assert any("outside an 'async with' block" in v.message for v in violations)
+
+
+@pytest.mark.unit
 def test_lock_gate_sees_the_lock_taken_through_an_alias_of_self(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2127,6 +2127,122 @@ def test_lock_gate_ignores_awaits_in_closures_defined_inside_the_block(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("definition", "why"),
+    [
+        pytest.param(
+            "            async def later(x=await self.flush()):\n"
+            "                return x\n",
+            "default values are evaluated at def time",
+            id="awaited-default",
+        ),
+        pytest.param(
+            "            @self.deco(await self.flush())\n"
+            "            def later():\n"
+            "                pass\n",
+            "decorator expressions are evaluated at def time",
+            id="awaited-decorator",
+        ),
+        pytest.param(
+            "            self._f = lambda x=await self.flush(): x\n",
+            "a lambda default is evaluated at def time too",
+            id="awaited-lambda-default",
+        ),
+    ],
+)
+def test_lock_gate_still_sees_definition_time_awaits_in_nested_defs(
+    contract_checker,
+    tmp_path: Path,
+    definition: str,
+    why: str,
+) -> None:
+    """Only the deferred BODY of a nested def is exempt, not its setup.
+
+    Measured: ``async def later(x=await flush())`` parses, and the default
+    runs at definition time — i.e. right here, with the lock held. Skipping
+    the whole node would let that through.
+    """
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock:\n"
+        f"{definition}"
+        "            self.current_speech_id = new_id()\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"], why
+
+
+@pytest.mark.unit
+def test_lock_gate_rejects_a_chained_binding_that_aliases_the_lock(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """One object, two names — and the second name is not gate-checked.
+
+    Other lock attributes are intentionally allowed to be held across awaits,
+    so an alias of the session lock under another name is a way to suspend
+    while holding it.
+    """
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.other_lock = self.lock = asyncio.Lock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "exactly one target" in violations[0].message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "rebind",
+    [
+        pytest.param("import custom_locks as asyncio\n", id="import-as"),
+        pytest.param("from vendor import locks as asyncio\n", id="from-import-as"),
+        pytest.param("import asyncio\nasyncio = custom_locks\n", id="plain-rebind"),
+    ],
+)
+def test_lock_gate_rejects_shadowing_the_asyncio_name(
+    contract_checker,
+    tmp_path: Path,
+    rebind: str,
+) -> None:
+    """The primitive is matched by spelling, so the name must mean stdlib."""
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            f"{rebind}\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock = asyncio.Lock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "rebound" in violations[0].message
+
+
+@pytest.mark.unit
 def test_lock_gate_ignores_other_locks(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2351,7 +2351,7 @@ def test_lock_gate_rejects_taking_the_lock_outside_a_context_manager(
     assert violations, "the manual form must not walk past the gate"
     assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
     assert all(
-        "outside an 'async with self.lock' block" in v.message for v in violations
+        "outside an 'async with' block" in v.message for v in violations
     )
 
 
@@ -2461,6 +2461,94 @@ def test_lock_gate_rejects_an_annotated_rebind_too(
 
     assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
     assert "exactly once" in violations[0].message
+
+
+@pytest.mark.unit
+def test_lock_gate_sees_the_lock_taken_through_an_alias_of_self(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """``owner = self`` then ``async with owner.lock:`` is the same object.
+
+    Resolving aliases properly is dataflow analysis; matching the attribute
+    name whatever the receiver over-approximates instead, which is the safe
+    direction. Measured, it costs nothing on the real package: it holds no
+    ``.lock`` acquisition with any receiver other than ``self``.
+    """
+
+    # Built on the clean probe so the package still holds a real
+    # ``async with self.lock`` block: without one the non-vacuity guard fires
+    # and the test would pass for the wrong reason.
+    source = _CLEAN_PROBE + (
+        "\n"
+        "    async def sneaky(self):\n"
+        "        owner = self\n"
+        "        async with owner.lock:\n"
+        "            await self.flush()\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert violations
+    assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
+    assert any("must never be held across a suspension" in v.message for v in violations)
+
+
+@pytest.mark.unit
+def test_lock_gate_rejects_a_compound_import_whose_last_alias_shadows(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """One import statement, two aliases — Python keeps the last one.
+
+    Judging the containing statement let this pass on the strength of its
+    first alias while the name was actually bound to the second.
+    """
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import asyncio, custom_locks as asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock = asyncio.Lock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "only by a plain 'import asyncio'" in violations[0].message
+
+
+@pytest.mark.unit
+def test_lock_gate_does_not_count_a_valueless_annotation_as_a_binding(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """``self.lock: asyncio.Lock`` declares a type and assigns nothing.
+
+    It cannot change the runtime primitive, so counting it as a second
+    binding would fail the contract on a harmless type declaration — and a
+    gate that rejects harmless code teaches people to route around it.
+    """
+
+    assert _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock: asyncio.Lock\n"
+            "        self.lock = asyncio.Lock()\n"
+        ),
+    ) == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2149,6 +2149,55 @@ def test_lock_gate_ignores_other_locks(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "manual",
+    [
+        # The rewrite that holds the lock across an await while presenting no
+        # AsyncWith node at all — a shape-only gate walks straight past it.
+        "        await self.lock.acquire()\n"
+        "        await self.flush()\n"
+        "        self.lock.release()\n",
+        # Same escape, one indirection further out.
+        "        held = self.lock\n"
+        "        async with held:\n"
+        "            await self.flush()\n",
+        # Handing it to something that may await under it.
+        "        await self._helper_that_awaits(self.lock)\n",
+    ],
+)
+def test_lock_gate_rejects_taking_the_lock_outside_a_context_manager(
+    contract_checker,
+    tmp_path: Path,
+    manual: str,
+) -> None:
+    source = (
+        _CLEAN_PROBE
+        + "\n"
+        + "    async def sneaky(self):\n"
+        + manual
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    # One report per illegal mention, so the acquire/release pair yields two.
+    assert violations, "the manual form must not walk past the gate"
+    assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
+    assert all(
+        "outside an 'async with self.lock' block" in v.message for v in violations
+    )
+
+
+@pytest.mark.unit
+def test_lock_gate_allows_the_one_binding_assignment_in_manager(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """``self.lock = asyncio.Lock()`` is the single sanctioned non-block mention."""
+
+    assert _lock_violations(contract_checker, tmp_path, _CLEAN_PROBE) == []
+
+
+@pytest.mark.unit
 def test_lock_gate_fails_loudly_when_no_lock_block_is_left(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2524,6 +2524,76 @@ def test_lock_gate_rejects_a_compound_import_whose_last_alias_shadows(
 
 
 @pytest.mark.unit
+def test_lock_gate_counts_a_bare_local_annotation_of_the_module_name(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """``asyncio: object`` in a function makes the NAME local for that scope.
+
+    Unlike an attribute annotation, this one changes what the later
+    ``asyncio.Lock()`` resolves to — measured, it raises UnboundLocalError
+    rather than reaching the module — so the name no longer means the import
+    and the primitive claim no longer holds.
+    """
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        asyncio: object\n"
+            "        self.lock = asyncio.Lock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "only by a plain 'import asyncio'" in violations[0].message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "relative",
+    [
+        pytest.param("__init__.py", id="facade-initializer"),
+        pytest.param("helpers/session.py", id="subpackage-module"),
+    ],
+)
+def test_lock_gate_scans_every_module_in_the_package(
+    contract_checker,
+    tmp_path: Path,
+    relative: str,
+) -> None:
+    """A holder in the facade or a subpackage is still inside the package.
+
+    ``glob('*.py')`` is non-recursive and the initializer used to be skipped
+    outright, so a holder in either place was never parsed.
+    """
+
+    core, manager = _lock_core_dir(tmp_path, _CLEAN_PROBE)
+    holder = core / relative
+    holder.parent.mkdir(parents=True, exist_ok=True)
+    holder.write_text(
+        '"""m."""\n\n'
+        "class SneakyMixin:\n"
+        '    """m."""\n\n'
+        "    async def hold(self):\n"
+        "        async with self.lock:\n"
+        "            await self.work()\n",
+        encoding="utf-8",
+    )
+
+    violations = contract_checker.check_session_lock_atomicity(core, manager)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "must never be held across a suspension" in violations[0].message
+
+
+@pytest.mark.unit
 def test_lock_gate_does_not_count_a_valueless_annotation_as_a_binding(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2210,19 +2210,28 @@ def test_lock_gate_rejects_a_chained_binding_that_aliases_the_lock(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "rebind",
+    ("preamble", "signature"),
     [
-        pytest.param("import custom_locks as asyncio\n", id="import-as"),
-        pytest.param("from vendor import locks as asyncio\n", id="from-import-as"),
-        pytest.param("import asyncio\nasyncio = custom_locks\n", id="plain-rebind"),
+        pytest.param("import custom_locks as asyncio\n", "self", id="import-as"),
+        pytest.param("from vendor import locks as asyncio\n", "self", id="from-import-as"),
+        pytest.param("import asyncio\nasyncio = custom_locks\n", "self", id="plain-rebind"),
+        # Not an import at all: the caller supplies the module.
+        pytest.param("import asyncio\n", "self, asyncio", id="parameter"),
+        pytest.param("import asyncio\n", "self, *, asyncio=custom_locks", id="kwonly-parameter"),
     ],
 )
 def test_lock_gate_rejects_shadowing_the_asyncio_name(
     contract_checker,
     tmp_path: Path,
-    rebind: str,
+    preamble: str,
+    signature: str,
 ) -> None:
-    """The primitive is matched by spelling, so the name must mean stdlib."""
+    """The primitive is matched by spelling, so the name must mean stdlib.
+
+    Checked as "exactly one binding, and it is a plain ``import asyncio``"
+    rather than as a list of rebinding forms — the list of ways to bind a
+    name is open-ended, so a checker built from it stays one form behind.
+    """
 
     violations = _lock_violations(
         contract_checker,
@@ -2230,16 +2239,50 @@ def test_lock_gate_rejects_shadowing_the_asyncio_name(
         _CLEAN_PROBE,
         manager_source=(
             '"""m."""\n\n'
-            f"{rebind}\n\n"
+            f"{preamble}\n\n"
             "class LLMSessionManager:\n"
             '    """m."""\n\n'
-            "    def __init__(self):\n"
+            f"    def __init__({signature}):\n"
             "        self.lock = asyncio.Lock()\n"
         ),
     )
 
     assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
-    assert "rebound" in violations[0].message
+    assert "only by a plain 'import asyncio'" in violations[0].message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "imports",
+    [
+        pytest.param("import asyncio\n", id="plain"),
+        pytest.param("import asyncio\nimport os\n", id="alongside-others"),
+        # A submodule import still binds the top-level name to the same stdlib
+        # package, so it is the same guarantee; rejecting it would be a false
+        # positive that pushes people to work around the gate.
+        pytest.param("import asyncio\nimport asyncio.subprocess\n", id="submodule"),
+    ],
+)
+def test_lock_gate_accepts_the_plain_asyncio_import(
+    contract_checker,
+    tmp_path: Path,
+    imports: str,
+) -> None:
+    """The sanctioned shape must stay accepted."""
+
+    assert _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            f"{imports}\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock = asyncio.Lock()\n"
+        ),
+    ) == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2188,6 +2188,114 @@ def test_lock_gate_rejects_taking_the_lock_outside_a_context_manager(
 
 
 @pytest.mark.unit
+def test_lock_gate_rejects_a_context_manager_entered_after_the_lock(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """``async with self.lock, other:`` suspends twice with the lock held.
+
+    ``other.__aenter__`` runs after the lock is taken, and its ``__aexit__``
+    runs before the lock is released — neither is in the block body, so the
+    body scan alone never sees them.
+    """
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.lock, self.tts_cache_lock:\n"
+        "            self.current_speech_id = new_id()\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "entered after self.lock" in violations[0].message
+
+
+@pytest.mark.unit
+def test_lock_gate_allows_a_context_manager_entered_before_the_lock(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """The other order is genuinely safe, so it must not be rejected.
+
+    On the way in the lock is not held yet; on the way out it is released
+    first (``__aexit__`` runs in reverse). Nothing suspends under it.
+    """
+
+    source = (
+        '"""m."""\n\n'
+        "class ProbeMixin:\n"
+        '    """m."""\n\n'
+        "    async def rotate(self):\n"
+        "        async with self.tts_cache_lock, self.lock:\n"
+        "            self.current_speech_id = new_id()\n"
+    )
+
+    assert _lock_violations(contract_checker, tmp_path, source) == []
+
+
+@pytest.mark.unit
+def test_lock_gate_rejects_a_second_binding_that_swaps_the_primitive(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """A rebind must not hide behind an earlier, valid-looking binding.
+
+    Checking that SOME binding is ``asyncio.Lock()`` lets a later
+    ``self.lock = OtherLock()`` through: the first line still satisfies the
+    primitive check while the object the code actually takes is the second.
+    """
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self, reentrant=False):\n"
+            "        self.lock = asyncio.Lock()\n"
+            "        if reentrant:\n"
+            "            self.lock = OtherLock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "exactly once" in violations[0].message
+
+
+@pytest.mark.unit
+def test_lock_gate_rejects_an_annotated_rebind_too(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    """``self.lock: X = Y`` is an AnnAssign, a different node than Assign."""
+
+    violations = _lock_violations(
+        contract_checker,
+        tmp_path,
+        _CLEAN_PROBE,
+        manager_source=(
+            '"""m."""\n\n'
+            "import asyncio\n\n\n"
+            "class LLMSessionManager:\n"
+            '    """m."""\n\n'
+            "    def __init__(self):\n"
+            "        self.lock = asyncio.Lock()\n"
+            "        self.lock: object = OtherLock()\n"
+        ),
+    )
+
+    assert [v.code for v in violations] == ["CORE_LOCK_NO_AWAIT"]
+    assert "exactly once" in violations[0].message
+
+
+@pytest.mark.unit
 def test_lock_gate_allows_the_one_binding_assignment_in_manager(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2467,6 +2467,39 @@ def test_lock_gate_rejects_an_annotated_rebind_too(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "acquisition",
+    [
+        pytest.param('getattr(self, "lock")', id="getattr"),
+        pytest.param('self.__dict__["lock"]', id="dunder-dict"),
+    ],
+)
+def test_lock_gate_sees_the_lock_reached_reflectively(
+    contract_checker,
+    tmp_path: Path,
+    acquisition: str,
+) -> None:
+    """These carry no ``Attribute`` named ``lock`` for a syntax match to see.
+
+    Same standard the fail-closed chokepoint gate in this script already
+    holds itself to: a gate a one-line rewrite defeats is not a gate.
+    """
+
+    source = _CLEAN_PROBE + (
+        "\n"
+        "    async def sneaky(self):\n"
+        f"        async with {acquisition}:\n"
+        "            await self.flush()\n"
+    )
+
+    violations = _lock_violations(contract_checker, tmp_path, source)
+
+    assert violations
+    assert {v.code for v in violations} == {"CORE_LOCK_NO_AWAIT"}
+    assert any("must never be held across a suspension" in v.message for v in violations)
+
+
+@pytest.mark.unit
 def test_lock_gate_sees_the_lock_taken_through_an_alias_of_self(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2148,21 +2148,30 @@ def test_lock_gate_ignores_other_locks(
     assert _lock_violations(contract_checker, tmp_path, source) == []
 
 
+# The three rewrites that hold the lock across an await while presenting no
+# ``async with self.lock`` block for a shape-only scan to inspect. Kept as
+# named constants rather than inline list entries: adjacent string literals
+# inside a list are how a missing comma silently merges two cases into one.
+_MANUAL_ACQUIRE_RELEASE = (
+    "        await self.lock.acquire()\n"
+    "        await self.flush()\n"
+    "        self.lock.release()\n"
+)
+_ALIASED_THEN_ENTERED = (
+    "        held = self.lock\n"
+    "        async with held:\n"
+    "            await self.flush()\n"
+)
+_HANDED_TO_A_HELPER = "        await self._helper_that_awaits(self.lock)\n"
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "manual",
     [
-        # The rewrite that holds the lock across an await while presenting no
-        # AsyncWith node at all — a shape-only gate walks straight past it.
-        "        await self.lock.acquire()\n"
-        "        await self.flush()\n"
-        "        self.lock.release()\n",
-        # Same escape, one indirection further out.
-        "        held = self.lock\n"
-        "        async with held:\n"
-        "            await self.flush()\n",
-        # Handing it to something that may await under it.
-        "        await self._helper_that_awaits(self.lock)\n",
+        pytest.param(_MANUAL_ACQUIRE_RELEASE, id="manual-acquire-release"),
+        pytest.param(_ALIASED_THEN_ENTERED, id="aliased-then-entered"),
+        pytest.param(_HANDED_TO_A_HELPER, id="handed-to-a-helper"),
     ],
 )
 def test_lock_gate_rejects_taking_the_lock_outside_a_context_manager(

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -2822,9 +2822,12 @@ def test_lock_gate_fails_loudly_when_no_lock_block_is_left(
         "        self.current_speech_id = new_id()\n"
     )
 
-    messages = [v.message for v in _lock_violations(contract_checker, tmp_path, source)]
+    violations = _lock_violations(contract_checker, tmp_path, source)
 
-    assert any("vacuous" in m for m in messages)
+    assert any("vacuous" in v.message for v in violations)
+    # This violation fires exactly when the package changed shape, so it must
+    # not point at a module that may have been renamed away with it.
+    assert all(v.path.exists() for v in violations), [str(v.path) for v in violations]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_realtime_sid_rotation_atomicity.py
+++ b/tests/unit/test_realtime_sid_rotation_atomicity.py
@@ -45,11 +45,23 @@ pytestmark = pytest.mark.unit
 
 
 class _FakeQueue:
+    """Records puts, and signals the moment ``__interrupt__`` is enqueued.
+
+    That signal is what the interrupt-window tests synchronise on. Sleeping
+    for a fraction of the 20ms wait would be a wall-clock bet: under CI load
+    the wake-up can land after the clear has already finished, and cancelling
+    a completed task is a no-op, so the test would fail for a scheduling
+    reason rather than a real one.
+    """
+
     def __init__(self):
         self.messages = []
+        self.interrupt_enqueued = asyncio.Event()
 
     def put(self, item):
         self.messages.append(item)
+        if item == ("__interrupt__", None):
+            self.interrupt_enqueued.set()
 
     def empty(self):
         return True
@@ -241,12 +253,16 @@ async def test_pipeline_clear_resets_the_done_ledger_with_the_interrupt():
 
 
 async def _cancel_inside_the_interrupt_sleep(mgr):
-    """Start the clear, cancel it during the 20ms wait, assert it got that far."""
+    """Start the clear, cancel it during the 20ms wait, assert it got that far.
+
+    Synchronised on the interrupt being enqueued, not on the clock: the put
+    and the ``await asyncio.sleep(0.02)`` that follows it are one synchronous
+    run, so a waiter woken by that event necessarily resumes while the clear
+    is parked in the sleep — on any machine, under any load.
+    """
 
     task = asyncio.create_task(_clear_pipeline(mgr))
-    # Long enough to get past the interrupt and into the sleep, short enough
-    # to stay inside its 20ms.
-    await asyncio.sleep(0.005)
+    await mgr.tts_request_queue.interrupt_enqueued.wait()
     task.cancel()
     assert isinstance(
         (await asyncio.gather(task, return_exceptions=True))[0],
@@ -296,8 +312,9 @@ async def test_a_done_request_during_the_interrupt_window_cannot_own_the_ledger(
     mgr.tts_thread = _FakeAliveThread()
 
     async def concurrent_done_request():
-        # Land inside the sleep, after the flag was cleared.
-        await asyncio.sleep(0.005)
+        # Land inside the sleep, after the flag was cleared — waited for
+        # deterministically rather than timed.
+        await mgr.tts_request_queue.interrupt_enqueued.wait()
         assert mgr._tts_done_queued_for_turn is False, (
             "test must observe the cleared flag, or it is not reproducing the race"
         )

--- a/tests/unit/test_realtime_sid_rotation_atomicity.py
+++ b/tests/unit/test_realtime_sid_rotation_atomicity.py
@@ -277,6 +277,41 @@ async def test_cancelling_the_pipeline_clear_cannot_strand_the_done_ledger():
 
 
 @pytest.mark.asyncio
+async def test_a_done_request_during_the_interrupt_window_cannot_own_the_ledger():
+    """A concurrent done request must not consume the NEXT turn's entry.
+
+    The 20ms interrupt wait is a window in which another task — proactive
+    delivery finishing, say — can see the freshly cleared flag, enqueue its
+    own sentinel behind ``__interrupt__``, and set the flag back to True.
+    That sentinel is already void (the interrupt precedes it), but a True
+    ledger makes the retry's own done request short-circuit on "already", so
+    the retried utterance never gets a sentinel after its text.
+
+    ``handle_new_message`` and friends survive this because they re-clear
+    after the call returns; the discard and takeover paths do not, which is
+    why the clear now owns that reset itself.
+    """
+
+    mgr = _make_manager()
+    mgr.tts_thread = _FakeAliveThread()
+
+    async def concurrent_done_request():
+        # Land inside the sleep, after the flag was cleared.
+        await asyncio.sleep(0.005)
+        assert mgr._tts_done_queued_for_turn is False, (
+            "test must observe the cleared flag, or it is not reproducing the race"
+        )
+        mgr.tts_request_queue.put((None, None))
+        mgr._tts_done_queued_for_turn = True
+
+    await asyncio.gather(_clear_pipeline(mgr), concurrent_done_request())
+
+    assert mgr._tts_done_queued_for_turn is False, (
+        "the clear must re-take the ledger after its interrupt window"
+    )
+
+
+@pytest.mark.asyncio
 async def test_cancelling_the_pipeline_clear_keeps_deferred_done_with_its_chunks():
     """The other flag must NOT be hoisted alongside — it is paired elsewhere.
 

--- a/tests/unit/test_realtime_sid_rotation_atomicity.py
+++ b/tests/unit/test_realtime_sid_rotation_atomicity.py
@@ -1,0 +1,265 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""#2619: the speech-id rotation and the TTS-done ledger under cancellation.
+
+``rotate_speech_id_for_response_done`` writes two TTS-done flags and then
+rotates ``current_speech_id`` under ``self.lock``, and had no test of any kind.
+The concern was that a cancellation between those writes leaves the host
+saying "new turn" on the flags and "old turn" on the speech id.
+
+What these tests pin:
+
+* the rotation's contract, which nothing covered before;
+* that the torn state is NOT reachable through the real lock, because no
+  holder of ``self.lock`` suspends, so the acquire never yields and is not a
+  cancellation point (the structural half of this lives in
+  ``scripts/check_core_contracts.py::CORE_LOCK_NO_AWAIT``);
+* what the residue WOULD be if that invariant were lost — the counterfactual
+  is the reason the gate exists, so it is asserted rather than described;
+* the window that was genuinely reachable: ``_clear_tts_pipeline`` sends
+  ``__interrupt__`` and then sleeps 20ms, so a cancellation there used to
+  leave an interrupted worker behind a ledger still claiming the done
+  sentinel was queued — which makes the next turn's sentinel unsendable.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+
+import pytest
+
+import main_logic.core as core_module
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.messages = []
+
+    def put(self, item):
+        self.messages.append(item)
+
+    def empty(self):
+        return True
+
+    def get_nowait(self):
+        raise RuntimeError("empty")
+
+
+class _FakeResampler:
+    def __init__(self):
+        self.cleared = 0
+
+    def clear(self):
+        self.cleared += 1
+
+
+class _FakeAliveThread:
+    def is_alive(self):
+        return True
+
+
+class _NullAsyncLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_manager(*, lock=None):
+    """A manager carrying only what the two methods under test touch."""
+
+    mgr = object.__new__(core_module.LLMSessionManager)
+    mgr.lanlan_name = "Lan"
+    mgr.lock = asyncio.Lock() if lock is None else lock
+    mgr.tts_cache_lock = _NullAsyncLock()
+    mgr.audio_resampler = _FakeResampler()
+    mgr.current_speech_id = "sid-old"
+    mgr._takeover_active = False
+    mgr._tts_done_queued_for_turn = True
+    mgr._tts_done_pending_until_ready = True
+    mgr.tts_thread = None
+    mgr.tts_ready = False
+    mgr.tts_request_queue = _FakeQueue()
+    mgr.tts_response_queue = _FakeQueue()
+    mgr.tts_pending_chunks = []
+    mgr._tts_stream_normalizer = core_module.TtsStreamNormalizer()
+    mgr._tts_markdown_stripper = core_module.TtsMarkdownStripper()
+    mgr._tts_bracket_stripper = core_module.TtsBracketStripper()
+    mgr._tts_norm_speech_id = None
+    mgr._tts_replay_done = False
+    mgr._tts_replay_sent_chunks = deque()
+    mgr._tts_replay_audio_emitted = False
+    mgr._pending_ai_voice_echo_text = ""
+    mgr._pending_ai_voice_echo_chunks = deque()
+    mgr._confirmed_ai_voice_echo_audio_speech_ids = set()
+    return mgr
+
+
+_rotate = core_module.LLMSessionManager.rotate_speech_id_for_response_done
+_clear_pipeline = core_module.LLMSessionManager._clear_tts_pipeline
+
+
+def _turn_state(mgr):
+    return (
+        mgr.current_speech_id,
+        mgr._tts_done_queued_for_turn,
+        mgr._tts_done_pending_until_ready,
+    )
+
+
+# ── the rotation's contract (previously untested) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rotation_issues_a_new_sid_and_clears_the_done_ledger():
+    mgr = _make_manager()
+
+    await _rotate(mgr)
+
+    assert mgr.current_speech_id != "sid-old"
+    assert mgr._tts_done_queued_for_turn is False
+    assert mgr._tts_done_pending_until_ready is False
+    assert mgr.audio_resampler.cleared == 1
+
+
+@pytest.mark.asyncio
+async def test_rotation_is_suppressed_under_takeover():
+    """Takeover owns the turn boundary; rotating under it would steal the sid."""
+
+    mgr = _make_manager()
+    mgr._takeover_active = True
+
+    await _rotate(mgr)
+
+    assert _turn_state(mgr) == ("sid-old", True, True)
+    assert mgr.audio_resampler.cleared == 0
+
+
+# ── atomicity through the real lock ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rotation_never_yields_so_no_task_can_observe_it_midway():
+    """The acquire takes the uncontended fast path, so nothing interleaves.
+
+    This is the load-bearing measurement: an observer task that runs on every
+    event-loop pass must not get a single turn between the first write and the
+    last, which is exactly why a cancellation cannot land between them.
+    """
+
+    mgr = _make_manager()
+    observations = []
+
+    async def observer():
+        while True:
+            observations.append(_turn_state(mgr))
+            await asyncio.sleep(0)
+
+    watcher = asyncio.create_task(observer())
+    await asyncio.sleep(0)
+    observations.clear()
+
+    await _rotate(mgr)
+
+    watcher.cancel()
+    # Every sample is either the fully-old state or the fully-new one; a
+    # sample with cleared flags and the old sid would be the #2619 tear.
+    assert all(
+        state == ("sid-old", True, True) or state == _turn_state(mgr)
+        for state in observations
+    ), observations
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_rotation_leaves_it_all_or_nothing():
+    mgr = _make_manager()
+
+    task = asyncio.create_task(_rotate(mgr))
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Cancelled before entry: nothing applied, and nothing half-applied.
+    assert _turn_state(mgr) == ("sid-old", True, True)
+
+
+@pytest.mark.asyncio
+async def test_a_suspending_lock_holder_is_what_would_tear_the_rotation():
+    """The counterfactual the CORE_LOCK_NO_AWAIT gate exists to prevent.
+
+    Held by a suspending holder, the lock becomes contendable, the acquire
+    becomes a real suspension point, and a cancellation there splits the
+    write into exactly the state #2619 described: the flags say a fresh turn,
+    the speech id still says the old one. Nothing in the package holds the
+    lock this way today — the gate is what keeps that true.
+    """
+
+    mgr = _make_manager()
+
+    await mgr.lock.acquire()  # stand in for a holder that awaits mid-section
+    task = asyncio.create_task(_rotate(mgr))
+    await asyncio.sleep(0)  # let it reach the contended acquire
+    task.cancel()
+    mgr.lock.release()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert _turn_state(mgr) == ("sid-old", False, False)
+
+
+# ── the window that was reachable: interrupt vs. the done ledger ────────
+
+
+@pytest.mark.asyncio
+async def test_pipeline_clear_resets_the_done_ledger_with_the_interrupt():
+    mgr = _make_manager()
+    mgr.tts_thread = _FakeAliveThread()
+
+    await _clear_pipeline(mgr)
+
+    assert mgr.tts_request_queue.messages == [("__interrupt__", None)]
+    assert mgr._tts_done_queued_for_turn is False
+    assert mgr._tts_done_pending_until_ready is False
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_pipeline_clear_cannot_strand_the_done_ledger():
+    """Regression: the interrupt and the ledger reset must land together.
+
+    ``_clear_tts_pipeline`` sleeps 20ms waiting for the worker to act on
+    ``__interrupt__``. A cancellation there used to leave the sentinel voided
+    on the worker side but still recorded as queued on the manager side, so
+    the next turn's ``_request_tts_done_locked`` short-circuits on "already"
+    and its flush sentinel never reaches the worker at all.
+    """
+
+    mgr = _make_manager()
+    mgr.tts_thread = _FakeAliveThread()
+
+    task = asyncio.create_task(_clear_pipeline(mgr))
+    # Long enough to get past the interrupt and into the sleep, short enough
+    # to stay inside its 20ms.
+    await asyncio.sleep(0.005)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert mgr.tts_request_queue.messages == [("__interrupt__", None)], (
+        "test must cancel after the interrupt was queued, or it proves nothing"
+    )
+    assert mgr._tts_done_queued_for_turn is False
+    assert mgr._tts_done_pending_until_ready is False

--- a/tests/unit/test_realtime_sid_rotation_atomicity.py
+++ b/tests/unit/test_realtime_sid_rotation_atomicity.py
@@ -190,8 +190,10 @@ async def test_cancelling_the_rotation_leaves_it_all_or_nothing():
 
     task = asyncio.create_task(_rotate(mgr))
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    assert isinstance(
+        (await asyncio.gather(task, return_exceptions=True))[0],
+        asyncio.CancelledError,
+    )
 
     # Cancelled before entry: nothing applied, and nothing half-applied.
     assert _turn_state(mgr) == ("sid-old", True, True)
@@ -215,8 +217,10 @@ async def test_a_suspending_lock_holder_is_what_would_tear_the_rotation():
     await asyncio.sleep(0)  # let it reach the contended acquire
     task.cancel()
     mgr.lock.release()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    assert isinstance(
+        (await asyncio.gather(task, return_exceptions=True))[0],
+        asyncio.CancelledError,
+    )
 
     assert _turn_state(mgr) == ("sid-old", False, False)
 
@@ -236,9 +240,26 @@ async def test_pipeline_clear_resets_the_done_ledger_with_the_interrupt():
     assert mgr._tts_done_pending_until_ready is False
 
 
+async def _cancel_inside_the_interrupt_sleep(mgr):
+    """Start the clear, cancel it during the 20ms wait, assert it got that far."""
+
+    task = asyncio.create_task(_clear_pipeline(mgr))
+    # Long enough to get past the interrupt and into the sleep, short enough
+    # to stay inside its 20ms.
+    await asyncio.sleep(0.005)
+    task.cancel()
+    assert isinstance(
+        (await asyncio.gather(task, return_exceptions=True))[0],
+        asyncio.CancelledError,
+    )
+    assert mgr.tts_request_queue.messages == [("__interrupt__", None)], (
+        "test must cancel after the interrupt was queued, or it proves nothing"
+    )
+
+
 @pytest.mark.asyncio
 async def test_cancelling_the_pipeline_clear_cannot_strand_the_done_ledger():
-    """Regression: the interrupt and the ledger reset must land together.
+    """Regression: the interrupt and the queued-flag reset must land together.
 
     ``_clear_tts_pipeline`` sleeps 20ms waiting for the worker to act on
     ``__interrupt__``. A cancellation there used to leave the sentinel voided
@@ -250,16 +271,30 @@ async def test_cancelling_the_pipeline_clear_cannot_strand_the_done_ledger():
     mgr = _make_manager()
     mgr.tts_thread = _FakeAliveThread()
 
-    task = asyncio.create_task(_clear_pipeline(mgr))
-    # Long enough to get past the interrupt and into the sleep, short enough
-    # to stay inside its 20ms.
-    await asyncio.sleep(0.005)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    await _cancel_inside_the_interrupt_sleep(mgr)
 
-    assert mgr.tts_request_queue.messages == [("__interrupt__", None)], (
-        "test must cancel after the interrupt was queued, or it proves nothing"
-    )
     assert mgr._tts_done_queued_for_turn is False
-    assert mgr._tts_done_pending_until_ready is False
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_pipeline_clear_keeps_deferred_done_with_its_chunks():
+    """The other flag must NOT be hoisted alongside — it is paired elsewhere.
+
+    ``_tts_done_pending_until_ready`` means "these pending chunks still owe a
+    done sentinel", so it belongs with ``tts_pending_chunks``, and the two are
+    cleared together at the end of the clear. Resetting it early would tear
+    the pair in the opposite direction: cancellation during the sleep would
+    drop the flag while leaving the chunks, and once the worker reports ready
+    ``_flush_tts_pending_chunks`` re-enqueues that text with no sentinel
+    behind it, leaving the synthesizer unflushed.
+    """
+
+    mgr = _make_manager()
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_pending_chunks = [("sid-old", "还没刷出去的文本")]
+    mgr._tts_done_pending_until_ready = True
+
+    await _cancel_inside_the_interrupt_sleep(mgr)
+
+    assert mgr._tts_done_pending_until_ready is True
+    assert mgr.tts_pending_chunks == [("sid-old", "还没刷出去的文本")]


### PR DESCRIPTION
Closes #2619。

## 结论先行:issue 的前提反了

#2619 说 `rotate_speech_id_for_response_done` 在锁前写两个 TTS flag、锁内写 sid,取消落在取锁上会留下"flag 说新一轮、sid 还是旧一轮"的半套态,并为"接受 NOT-APPLIED 还是保留 HALF"列了一个需要拍板的取舍。

那个取舍不存在,因为两条分支都到不了:

- `main_logic/core` 里 23 处 `async with self.lock`,**全部不含 await**(AST 核实);`self.lock` 只在 [manager.py:107](main_logic/core/manager.py:107) 定义,全仓没有手动 `acquire()`,也没有 core 之外的使用者。
- 没有任何持锁者会挂起 ⇒ 锁永远不会被别的 task 观察到"已持有" ⇒ `await lock.acquire()` 永远走未争用 fast path、**不产生挂起点** ⇒ 取消只能落在进入 rotate 之前或返回之后。

实测:

```
uncontended:         done=True     state={'flag': False, 'sid': 'new'}   ← 取消晚了,全写完了
contended+cancelled: cancelled=True state={'flag': True,  'sid': 'old'}  ← 只有争用才有窗口
```

issue 自己测出了"未争用时该改动是逐字 no-op",但只当成"改动无害"的论据,没往下推一步:**未争用是恒真的**。

所以本 PR 不动 rotate 的写入顺序。挪进锁修不了不存在的 bug,代价是万一将来锁真被争用,落到的是 issue 自己论证过的更差分支(flag 留 True → 下一轮 flush sentinel 不入队)。

## 改了什么

### 1. 把不变量从"默认成立"变成"有人守着"

新增静态门 **`CORE_LOCK_NO_AWAIT`**([scripts/check_core_contracts.py](scripts/check_core_contracts.py)):`main_logic/core` 里任何 `async with self.lock` 块不得含 `await` / `async for` / 嵌套 `async with` / async 推导 / `yield`。

- 按块报一次,不按每个 await 报。
- 块内定义的闭包**不算**——它不在临界区里执行,flag 它是假阳性。
- 只认 `self.lock`。`tts_cache_lock` 等是普通锁,持有者可以 await。
- 带非空守卫(块全没了就报"gate 已 vacuous"),外加要求 `manager.py` 仍绑 `asyncio.Lock()`——fast path 的论证只对这个原语成立,换成可重入/线程原语就得重新推导。

这道门覆盖的不只是那一处轮换:全包 12 个锁块写 `current_speech_id`,其中 8 个在同一块里同时写两个 TTS flag。属性是**锁的**属性,一个持锁者破坏就全丢,所以门是全包范围而不是钉在轮换点上。

已经在 CI 里跑:[analyze.yml:304](.github/workflows/analyze.yml:304)。

冒烟验证——往 `handle_new_message` 的锁块里插一行 await:

```
main_logic/core/turn.py:85:12  CORE_LOCK_NO_AWAIT  'await' inside the 'async with self.lock' block opened at line 83 — ...
exit: 1
```

### 2. 补齐 `rotate_speech_id_for_response_done` 的测试

此前**零覆盖**,全量 unit 跑一遍它被调用 0 次,"套件全绿"证明不了任何事。新增 [tests/unit/test_realtime_sid_rotation_atomicity.py](tests/unit/test_realtime_sid_rotation_atomicity.py):

- 轮换的契约本身(发新 sid、清两个 flag、清 resampler、takeover 下不动)。
- **不会中途让出**:一个每轮 event loop 都跑的观察者 task,在整个轮换期间拿不到任何一次采样——这就是取消无从投递的直接证据。
- **反事实用例**:手动让一个挂起的持锁者把锁变成可争用,取消就确实撕出 `('sid-old', False, False)`,即 #2619 描述的那个态。把"门"和"它防的东西"之间的因果钉死,而不是写在注释里。

### 3. 修掉同族里唯一真正可达的那个窗口

issue 提到的两个"同族缺口"需要重新定性,两者不是一回事:

- [lifecycle.py:2562-2564](main_logic/core/lifecycle.py:2562) 三行连续、中间无 await,**本来就是原子的**。不持锁在这里无害。
- `handle_new_message` 那条**才是真的**:中间隔着 `await self._clear_tts_pipeline()`,而它里面有 [tts_runtime.py](main_logic/core/tts_runtime.py) 的 `await asyncio.sleep(0.02)` —— 一个实打实 20ms 的挂起窗口,而且走的是 server-VAD 主路径,调用频率远高于 rotate。

取消落在那儿的残留:`__interrupt__` 已入队(上一轮的 done sentinel 已作废),但记账还说 `_tts_done_queued_for_turn=True`。下一轮 `_request_tts_done_locked` 因此 early-return `"already"`,flush sentinel 永远进不了队——正是 `turn.py` 那段中文注释说这两行清零**本来要防的**后果。

**修法是往前挪,不是往后挪。** 这两个 flag 的对偶本来就不是 sid,而是 `__interrupt__`:入队即作废 sentinel,所以清零属于 interrupt 的同一步。`_clear_tts_pipeline` 从函数入口到 `put(("__interrupt__", None))` 全是同步语句,把清零放在开头,两者因此原子,**且两个方向都没有取舍**(不像"挪进锁"那样用不连贯换更差的连贯分支)。

调用方在本函数返回后的重复清零保留不动:那是给 20ms 窗口内被并发置回 True 的情况兜底,与这里修的取消残留是两件事。

顺带修正两处同源缺口:`handle_response_complete` 的 takeover 丢弃路径和 `response_discarded` 的重试路径此前清了管线却不清记账,重试那一轮的句尾 sentinel 发不出去。

### 4. 注释订正

[_transport.py](main_logic/omni_realtime_client/_transport.py) 那段把半套态当既成事实写着,并把"原子化归 rotate 自己管"记为待办。现在写清楚为什么不可达、由谁守着,并保留"为什么这里不能 shield"的实测结论(脱离的 rotation 会在 epoch 变化之后才拿到锁并写入,重新捅开 #2604 堵上的洞)。

## 回归报告

### 改了什么、为什么必要

三块,合起来回答同一个问题:#2619 描述的「sid 轮换被取消会留下半套态」到底存不存在,以及怎么让它以后也不存在。

1. **新增静态门 `CORE_LOCK_NO_AWAIT`**(`scripts/check_core_contracts.py`)。必要性在于:轮换之所以是原子的,靠的是「`main_logic/core` 里 23 处 `async with self.lock` 全部不含 await」这条不变量——没有持锁者挂起,锁就永远不会被观察到「已持有」,`acquire()` 永远走未争用 fast path、不产生挂起点,取消因此无从落在写入之间。这条不变量此前是默认成立、无人看守的,任何人加一行 await 就会让 #2619 描述的缺陷**真的**出现,而且是在全包 8 个同样在锁内写 sid + 两个 flag 的块上同时出现。门分两半:块内不得有挂起点,且 `self.lock` 只能以 async with 形态出现(手动 `acquire()/release()` 能跨 await 持锁却不出示块给形态检查看)。

2. **补齐 `rotate_speech_id_for_response_done` 的测试**。此前零覆盖,全量 unit 跑一遍它被调用 0 次——「套件全绿」对它证明不了任何事。

3. **`_clear_tts_pipeline` 里 `_tts_done_queued_for_turn` 的清零提前**,与 `__interrupt__` 入队同步。这是同族里唯一真正可达的窗口,走 server-VAD 主路径,频率远高于 rotate。

### 前后行为对比

| 场景 | 改前 | 改后 |
|---|---|---|
| `_clear_tts_pipeline` 被取消在 `await asyncio.sleep(0.02)` 上 | `__interrupt__` 已入队(上一轮 sentinel 已作废),但 `_tts_done_queued_for_turn` 仍为 True。下一轮 `_request_tts_done_locked` early-return `"already"`,**flush sentinel 永远进不了队**,句尾音频挂在 buffer 里不 finalize | 该 flag 与 interrupt 同步清零(入口到 `put()` 全是同步语句,取消无从投递),下一轮正常入队 |
| 同上,且此前有 `tts_pending_chunks` + `_tts_done_pending_until_ready=True` | 两者一起保留,worker 就绪后 `_flush_tts_pending_chunks` 重新入队并补发 done | **不变**。该 flag 的对偶是 chunks 而非 interrupt,故**不**跟着提前清(评审第二轮修正,见下) |
| `handle_response_complete` 的 takeover 丢弃 / `response_discarded` 的重试 | 清了管线却不清记账,重试那一轮的句尾 sentinel 发不出去 | 同步清零,重试轮的 sentinel 正常发出 |
| `rotate_speech_id_for_response_done` 被取消 | 全或无(未争用 fast path 无挂起点) | **逐字不变**,本 PR 不动它的写入顺序 |
| 锁段里有人加 await | 静默通过,#2619 的半套态变为真实可达 | CI 报 `CORE_LOCK_NO_AWAIT`,exit 1 |

### 潜在回归与已排除项

- **`_clear_tts_pipeline` 的 5 个调用方语义是否都成立**:逐个核过。3 个(`handle_new_message`、`streaming.py:373`、`turn.py:1678`)本来就在返回后立刻清同样的 flag,提前清对它们是幂等;另 2 个(takeover 丢弃、`response_discarded`)此前不清,现在清——语义上正确(管线已清空,「sentinel 已排队」按定义就是陈旧记账),且修掉了它们各自的潜在缺口。调用方返回后的重复清零一律**保留不动**,兜底 20ms 窗口内被并发置回 True 的情况,因此该并发路径的行为逐字不变。
- **反方向撕裂**(评审 Codex P2 指出,已修):首版把两个 flag 一起提前清。`_tts_done_pending_until_ready` 的对偶是 `tts_pending_chunks`,两者在函数末尾的 `tts_cache_lock` 段里成对清;单把 flag 提前会导致取消时丢 flag 留 chunks,worker 就绪后陈旧文本重新入队却跳过 done 补发。已回退为只提前清 `_tts_done_queued_for_turn`,并新增配对用例钉住。
- **门的假阳性**:块内定义的闭包不算(不在临界区执行),已有用例覆盖;只认 `self.lock`,`tts_cache_lock` 等普通锁的持有者仍可 await。
- **门变哑**:带非空守卫(锁块全没了就报 vacuous),外加要求 `manager.py` 仍绑 `asyncio.Lock()`——fast path 的论证只对这个原语成立。
- **未触及**:`rotate_speech_id_for_response_done` 的写入顺序、`lifecycle.py:2562` 那三行(连续无 await,本来就原子)、`_transport.py` 的 shield 方案(实测会重新捅开 #2604 用 `_turn_epoch` 堵上的洞,已在注释里记录为排除项)。

### 验证

| 项 | 结果 |
|---|---|
| `scripts/check_core_contracts.py` 全仓 | exit 0 |
| 门对注入的块内 await | 正确报 `CORE_LOCK_NO_AWAIT`,exit 1 |
| 门对注入的手动 `acquire()/release()` | 正确报,exit 1 |
| `test_check_core_contracts.py` | 203 → 222 passed |
| `test_realtime_sid_rotation_atomicity.py` | 8 passed |
| **撤掉 `queued_for_turn` 的提前清** | 2 failed —— 原缺陷的回归测试咬得住 |
| **把 `pending_until_ready` 重新提前清** | 1 failed —— 反方向的配对用例也咬得住 |
| arbiter / external_text_turns / proactive_sm / game_route_memory / 两个门文件 | 539 passed |
| openai_tts / audio_stream_queue / proactive_sid_guard / startup_greeting | 235 passed |
| 其余触及改动路径的 unit 文件 | 全绿或与基线逐字一致 |
| `ruff check`(改动文件) | 通过 |
| CI `Unit pytest (Windows)` | 首版提交已 pass |

本机基线上已有的失败(与本 PR 无关,`git stash` 后逐一复现确认):`test_a_turn_starting_during_the_repetition_step_keeps_its_recovery`、`test_tool_calling`(12F/76P,改动前后完全相同)、`test_core_independent_asr`(基线也挂死)。另有若干因本机默认 GBK 编码导致 `read_text()` 失败的用例,`PYTHONUTF8=1` 下全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复语音合成取消后可能残留完成状态的问题，避免过时的完成信号影响后续语音处理。
  * 改善语音会话 ID 轮换与中断流程的一致性，降低并发和取消操作导致的状态异常。
  * 确保待处理音频数据与延迟完成状态在中断期间保持正确关联。

* **测试**
  * 新增并完善语音 ID 轮换、TTS 中断、取消操作及并发场景的覆盖测试。
  * 增加会话锁使用规则的自动检查，提升相关功能的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->