### PR TITLE
fix(realtime): 取消不再把未关闭的连接留给没人（#2602 索引 12-14）

### DIFF
--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -413,23 +413,41 @@ class LifecycleMixin:
             self.initial_next_session_context_snapshot_len = 0
 
     async def _cleanup_pending_session_resources(self):
-        """[Hot-swap related] Safely cleans up ONLY PENDING connector and session if they exist AND are not the current main session."""
+        """[Hot-swap related] Safely cleans up ONLY PENDING connector and session if they exist AND are not the current main session.
+
+        The close runs as a task this manager owns and every caller awaits it
+        through ``shield``. Its usual caller is the background prep task's
+        CancelledError handler, and ``_reset_preparation_state`` caps its wait
+        at 2s by cancelling that same task a second time — which, when the
+        close was awaited directly, interrupted it after the reference had
+        already been dropped: nobody left to finish closing the socket, and
+        ``_wait_one`` swallows the timeout so the reset reports success. The
+        cap now bounds only how long the caller waits.
+        """
         # Stop any listener specifically for the pending session (if different from main listener structure)
         # The _listen_for_pending_session_response tasks are short-lived and managed by their callers.
-        if self.pending_session:
-            try:
-                logger.info("🧹 清理pending_session资源...")
-                await self.pending_session.close()
-                logger.info("✅ Pending session已关闭")
-            except Exception as e:
-                logger.error(f"💥 清理pending_session时出错: {e}")
-            finally:
-                self.pending_session = None  # 即使close失败也要清除引用
+        session, self.pending_session = self.pending_session, None
+        if session:
+            task = asyncio.create_task(self._close_detached_pending_session(session))
+            self._pending_session_close_tasks.add(task)
+            task.add_done_callback(self._pending_session_close_tasks.discard)
+            await asyncio.shield(task)
+
+    async def _close_detached_pending_session(self, session):
+        """Close a pending session that no longer has a slot to be cleared from."""
+        try:
+            logger.info("🧹 清理pending_session资源...")
+            await session.close()
+            logger.info("✅ Pending session已关闭")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"💥 清理pending_session时出错: {e}")
 
     async def _init_renew_status(self):
         await self._reset_preparation_state(True)
         self.session_start_time = None
-        await self._cleanup_pending_session_resources()  # close()后再置None，避免泄漏
+        await self._cleanup_pending_session_resources()  # 关闭由 manager 持有，取消也不会丢
         self.is_hot_swap_imminent = False
         # 状态机是 per-manager 的，跨 start_session/end_session 复用同一实例。
         # 若上一轮 proactive 在 PHASE1/PHASE2 中途 WS 断开、PROACTIVE_DONE 来不及

--- a/main_logic/core/manager.py
+++ b/main_logic/core/manager.py
@@ -166,6 +166,12 @@ class LLMSessionManager(
         self._session_turn_count = 0  # 当前 session 的用户输入轮次计数
         self.pending_connector = None
         self.pending_session = None
+        # Closing a detached pending session is owned here, not by whoever
+        # happened to ask for it: that caller is a background prep task the
+        # reset path cancels — twice, once on entry and again when its 2s wait
+        # expires — and the second cancel used to land inside the close.
+        # Holding the task also keeps it from being garbage collected.
+        self._pending_session_close_tasks: set = set()
         self.pending_use_tts = None
         self.is_hot_swap_imminent = False
         self.tts_handler_task = None

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -114,7 +114,7 @@ class _AudioMixin:
         Callers outside a connection teardown pass nothing and are unaffected.
         """
         async with self._audio_processing_lock:
-            if generation is not None and self._connection_generation != generation:
+            if generation is not None and not self._still_owns_connection(generation):
                 logger.info(
                     "Audio processor close: a replacement connection adopted it; leaving it alone"
                 )

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -103,9 +103,22 @@ class _AudioMixin:
                 except Exception as exc:
                     logger.error(f"Error toggling audio noise reduction: {exc}")
 
-    async def _close_audio_processor(self) -> None:
-        """Quiesce executor processing before releasing RNNoise/soxr state."""
+    async def _close_audio_processor(self, generation=None) -> None:
+        """Quiesce executor processing before releasing RNNoise/soxr state.
+
+        ``generation`` names the connection whose processor this is. Waiting
+        for the lock is an await like any other, so a replacement can attach
+        during it — and because connect() only builds a processor when the
+        field is empty, the replacement adopts this very one. Releasing it
+        afterwards would leave the live connection resampling through nothing.
+        Callers outside a connection teardown pass nothing and are unaffected.
+        """
         async with self._audio_processing_lock:
+            if generation is not None and self._connection_generation != generation:
+                logger.info(
+                    "Audio processor close: a replacement connection adopted it; leaving it alone"
+                )
+                return
             processor = self._audio_processor
             if processor is None:
                 return

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -133,6 +133,14 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self.on_repetition_detected = on_repetition_detected
         self.extra_event_handlers = extra_event_handlers or {}
         self._bg_tasks: set = set()  # 防止 fire-and-forget 任务被 GC 回收
+        # Teardown owns the socket it detached, so a cancelled caller cannot
+        # strand it. Both close paths run as one task per connection and every
+        # caller awaits it through a shield: cancelling the caller stops the
+        # waiting, never the closing, and a retry re-awaits the same task
+        # instead of finding ``self.ws`` already None and returning happy.
+        # Reset by connect(), because the client object outlives a connection.
+        self._close_task = None
+        self._failed_transport_close_task = None
 
         # Track current response state
         self._current_response_id = None

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -141,6 +141,13 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # Reset by connect(), because the client object outlives a connection.
         self._close_task = None
         self._failed_transport_close_task = None
+        self._gemini_close_task = None
+        # Bumped when a replacement connection attaches. A teardown that
+        # outlived its caller compares it after every await: the socket it
+        # detached is still its own to close, but client-wide state (silence
+        # scalars, the shared audio processor, the Gemini session) belongs to
+        # whoever attached last.
+        self._connection_generation = 0
 
         # Track current response state
         self._current_response_id = None

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -225,7 +225,7 @@ class _GeminiMixin:
 
             # 设置 ws 为 session，用于兼容性检查
             self.ws = self._gemini_session
-            self._rearm_teardown_ownership()
+            self._on_connection_attached()
             self._fatal_error_occurred = False
             self._gemini_user_transcript = ""
             self._gemini_user_transcript_after_interrupt = False
@@ -400,45 +400,66 @@ class _GeminiMixin:
             logger.error("Gemini send_tool_response failed: %s", e)
 
     async def _close_gemini(self) -> None:
-        """Close Gemini Live API session."""
-        if self._gemini_context_manager:
-            try:
-                await self._gemini_context_manager.__aexit__(None, None, None)
-            except asyncio.CancelledError:
-                # The SDK context exit did NOT run to completion. Clearing the
-                # references here — as an unconditional ``finally`` did — is
-                # what makes it unrecoverable: the next _close_gemini() sees
-                # ``_gemini_context_manager`` already None, skips the exit
-                # entirely, and the SDK session is left with no owner. Keep
-                # them so a retry can finish the exit.
-                raise
-            except Exception as e:
-                logger.error(f"Error closing Gemini session: {e}")
-            # A raised (non-cancel) exit is still an exit that ran to its own
-            # conclusion; the SDK has no second attempt to offer, so its
-            # references are dropped exactly as before.
+        """Close Gemini Live API session.
+
+        An async context manager is one-shot: a ``__aexit__()`` interrupted by
+        a cancel cannot be resumed by calling it again — the cleanup generator
+        has already been unwound, and the second call returns or raises without
+        redoing what was interrupted. So the exit must not be interrupted in
+        the first place. It runs as a task this client owns and every caller
+        awaits it through ``shield``, which matters because a caller here can
+        genuinely be cancelled: besides ``close()``, the Gemini proactive
+        quarantine in ``_responses.py`` calls this from a fired task.
+        """
+        if not self._gemini_context_manager:
+            return
+        await self._own_teardown("_gemini_close_task", self._close_gemini_impl)
+
+    async def _close_gemini_impl(self) -> None:
+        context = self._gemini_context_manager
+        session = self._gemini_session
+        if context is None:
+            return
+        try:
+            await context.__aexit__(None, None, None)
+        except Exception as e:
+            # A raised exit is still an exit that ran to its own conclusion —
+            # the references are dropped below either way, as before.
+            logger.error(f"Error closing Gemini session: {e}")
+
+        if self._gemini_context_manager is not context:
+            # A replacement session attached while the SDK exit ran. Its
+            # references — and the client-wide state below — are not ours to
+            # clear; ours was the context we just exited.
+            logger.info(
+                "Gemini close: a replacement session attached; leaving its state alone"
+            )
+            return
+
+        self._gemini_context_manager = None
+        if self._gemini_session is session:
             self._gemini_session = None
-            self._gemini_context_manager = None
+        if self.ws is session:
             self.ws = None
 
-            # 重置静默超时相关状态（与普通close()保持一致）
-            self._silence_timeout_triggered = False
-            self._last_speech_time = None
-            self._silence_reset_pending = False
-            self._last_silence_clear_speech_time = 0.0
-            self._last_local_loud_time = 0.0
-            self._client_vad_active = False
-            self._client_vad_last_speech_time = 0.0
-            self._speech_detect_start = 0.0
-            self._rnnoise_vad_active = False
-            self._user_recent_activity_time = 0.0
-            self._ai_recent_activity_time = 0.0
+        # 重置静默超时相关状态（与普通close()保持一致）
+        self._silence_timeout_triggered = False
+        self._last_speech_time = None
+        self._silence_reset_pending = False
+        self._last_silence_clear_speech_time = 0.0
+        self._last_local_loud_time = 0.0
+        self._client_vad_active = False
+        self._client_vad_last_speech_time = 0.0
+        self._speech_detect_start = 0.0
+        self._rnnoise_vad_active = False
+        self._user_recent_activity_time = 0.0
+        self._ai_recent_activity_time = 0.0
 
-            # 重置音频处理器状态
-            if self._audio_processor is not None:
-                self._audio_processor.reset()
+        # 重置音频处理器状态
+        if self._audio_processor is not None:
+            self._audio_processor.reset()
 
-            logger.info("Gemini Live API session closed")
+        logger.info("Gemini Live API session closed")
 
     async def _handle_messages_gemini(self) -> None:
         """Handle messages from Gemini Live API."""

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -413,11 +413,16 @@ class _GeminiMixin:
         """
         if not self._gemini_context_manager:
             return
-        await self._own_teardown("_gemini_close_task", self._close_gemini_impl)
+        await self._own_teardown("_gemini_close_task", self._detach_for_gemini_close)
 
-    async def _close_gemini_impl(self) -> None:
-        context = self._gemini_context_manager
-        session = self._gemini_session
+    def _detach_for_gemini_close(self):
+        """Seize the context to exit, synchronously (see ``_own_teardown``)."""
+
+        return self._close_gemini_impl(
+            self._gemini_context_manager, self._gemini_session
+        )
+
+    async def _close_gemini_impl(self, context, session) -> None:
         if context is None:
             return
         try:

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -403,31 +403,41 @@ class _GeminiMixin:
         if self._gemini_context_manager:
             try:
                 await self._gemini_context_manager.__aexit__(None, None, None)
+            except asyncio.CancelledError:
+                # The SDK context exit did NOT run to completion. Clearing the
+                # references here — as an unconditional ``finally`` did — is
+                # what makes it unrecoverable: the next _close_gemini() sees
+                # ``_gemini_context_manager`` already None, skips the exit
+                # entirely, and the SDK session is left with no owner. Keep
+                # them so a retry can finish the exit.
+                raise
             except Exception as e:
                 logger.error(f"Error closing Gemini session: {e}")
-            finally:
-                self._gemini_session = None
-                self._gemini_context_manager = None
-                self.ws = None
+            # A raised (non-cancel) exit is still an exit that ran to its own
+            # conclusion; the SDK has no second attempt to offer, so its
+            # references are dropped exactly as before.
+            self._gemini_session = None
+            self._gemini_context_manager = None
+            self.ws = None
 
-                # 重置静默超时相关状态（与普通close()保持一致）
-                self._silence_timeout_triggered = False
-                self._last_speech_time = None
-                self._silence_reset_pending = False
-                self._last_silence_clear_speech_time = 0.0
-                self._last_local_loud_time = 0.0
-                self._client_vad_active = False
-                self._client_vad_last_speech_time = 0.0
-                self._speech_detect_start = 0.0
-                self._rnnoise_vad_active = False
-                self._user_recent_activity_time = 0.0
-                self._ai_recent_activity_time = 0.0
+            # 重置静默超时相关状态（与普通close()保持一致）
+            self._silence_timeout_triggered = False
+            self._last_speech_time = None
+            self._silence_reset_pending = False
+            self._last_silence_clear_speech_time = 0.0
+            self._last_local_loud_time = 0.0
+            self._client_vad_active = False
+            self._client_vad_last_speech_time = 0.0
+            self._speech_detect_start = 0.0
+            self._rnnoise_vad_active = False
+            self._user_recent_activity_time = 0.0
+            self._ai_recent_activity_time = 0.0
 
-                # 重置音频处理器状态
-                if self._audio_processor is not None:
-                    self._audio_processor.reset()
+            # 重置音频处理器状态
+            if self._audio_processor is not None:
+                self._audio_processor.reset()
 
-                logger.info("Gemini Live API session closed")
+            logger.info("Gemini Live API session closed")
 
     async def _handle_messages_gemini(self) -> None:
         """Handle messages from Gemini Live API."""

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -225,6 +225,7 @@ class _GeminiMixin:
 
             # 设置 ws 为 session，用于兼容性检查
             self.ws = self._gemini_session
+            self._rearm_teardown_ownership()
             self._fatal_error_occurred = False
             self._gemini_user_transcript = ""
             self._gemini_user_transcript_after_interrupt = False

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -146,15 +146,6 @@ class _TransportMixin:
         # because 'connection-scoped' should be true by construction.
         self._idless_quarantine = False
 
-        # Same lifetime, for a different reason: a close task closes the socket
-        # it detached, so it is finished with THIS connection's socket the
-        # moment the next one is established. Keeping the finished (or even
-        # still-running) task would make the new connection's close a no-op.
-        # An unfinished predecessor is unaffected — it already owns the old
-        # socket outright and nothing here cancels it.
-        self._close_task = None
-        self._failed_transport_close_task = None
-
         # ``close()`` releases RNNoise/soxr state. The client object is reused
         # across sessions, so recreate that session-owned processor on demand.
         if self._audio_processor is None:
@@ -191,6 +182,7 @@ class _TransportMixin:
         # end_session 协程挂住数百毫秒~数秒（Qwen 回 CLOSE 帧偶尔很慢），
         # 超时后 websockets 内部会 transport.abort() 强制关闭。
         self.ws = await websockets.connect(url, additional_headers=headers, close_timeout=0.5)
+        self._rearm_teardown_ownership()
         # Do not reopen the arbiter until the replacement transport exists.
         # A failed reconnect must leave the prior shutdown state intact.
         self._response_arbiter.reset_connection_state()
@@ -2052,6 +2044,26 @@ class _TransportMixin:
             )
             logger.error(f"Error in message handling: {str(e)}")
             raise
+
+    def _rearm_teardown_ownership(self) -> None:
+        """Hand the teardown latches to the connection that just attached.
+
+        A close task closes the socket it detached, so it is finished with the
+        previous connection's socket the moment a replacement is installed —
+        and a latched finished task would make the new connection's close a
+        no-op. Rearming has to happen where the socket is assigned, not at the
+        top of connect(): a close landing in the connect await window would
+        otherwise run to completion against no socket at all, and the
+        replacement would attach behind an already-finished latch that every
+        later close() just re-awaits. No await between the assignment and this
+        call, so no third party can observe the pair half-applied.
+
+        An unfinished predecessor is unaffected — it already owns the old
+        socket outright and nothing here cancels it.
+        """
+
+        self._close_task = None
+        self._failed_transport_close_task = None
 
     async def _own_teardown(self, slot: str, factory):
         """Await a teardown that this client owns, not the caller.

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -182,7 +182,7 @@ class _TransportMixin:
         # end_session 协程挂住数百毫秒~数秒（Qwen 回 CLOSE 帧偶尔很慢），
         # 超时后 websockets 内部会 transport.abort() 强制关闭。
         self.ws = await websockets.connect(url, additional_headers=headers, close_timeout=0.5)
-        self._rearm_teardown_ownership()
+        self._on_connection_attached()
         # Do not reopen the arbiter until the replacement transport exists.
         # A failed reconnect must leave the prior shutdown state intact.
         self._response_arbiter.reset_connection_state()
@@ -2045,25 +2045,32 @@ class _TransportMixin:
             logger.error(f"Error in message handling: {str(e)}")
             raise
 
-    def _rearm_teardown_ownership(self) -> None:
-        """Hand the teardown latches to the connection that just attached.
+    def _on_connection_attached(self) -> None:
+        """Mark a replacement connection as live and hand it the teardown latches.
 
         A close task closes the socket it detached, so it is finished with the
         previous connection's socket the moment a replacement is installed —
         and a latched finished task would make the new connection's close a
-        no-op. Rearming has to happen where the socket is assigned, not at the
-        top of connect(): a close landing in the connect await window would
+        no-op. This has to happen where the socket is assigned, not at the top
+        of connect(): a close landing in the connect await window would
         otherwise run to completion against no socket at all, and the
         replacement would attach behind an already-finished latch that every
         later close() just re-awaits. No await between the assignment and this
         call, so no third party can observe the pair half-applied.
 
-        An unfinished predecessor is unaffected — it already owns the old
-        socket outright and nothing here cancels it.
+        The generation bump is the other half. An unfinished predecessor is not
+        cancelled — it owns the retired socket and must finish closing it — but
+        everything else it would touch (the silence scalars connect() just
+        primed, the shared audio processor, the Gemini session) is client-wide
+        state that now belongs to the replacement. Teardowns compare the
+        generation after each await and keep their hands off what is no longer
+        theirs.
         """
 
+        self._connection_generation += 1
         self._close_task = None
         self._failed_transport_close_task = None
+        self._gemini_close_task = None
 
     async def _own_teardown(self, slot: str, factory):
         """Await a teardown that this client owns, not the caller.
@@ -2134,22 +2141,40 @@ class _TransportMixin:
         await self._own_teardown("_close_task", self._close_impl)
 
     async def _close_impl(self) -> None:
+        # Snapshot the connection this teardown belongs to, and detach what it
+        # is going to release, BEFORE the first await. The teardown outlives
+        # its caller by design, so connect() is free to attach a replacement
+        # while this one is parked in the arbiter shutdown — after that point
+        # anything read off the client can already be the replacement's.
+        generation = self._connection_generation
         ws, self.ws = self.ws, None
+        silence_check_task, self._silence_check_task = self._silence_check_task, None
+
         response_arbiter = getattr(self, "_response_arbiter", None)
         if response_arbiter is not None:
             await response_arbiter.shutdown("realtime client closed")
 
         # 取消静默检测任务
-        if self._silence_check_task:
-            self._silence_check_task.cancel()
+        if silence_check_task:
+            silence_check_task.cancel()
             try:
-                await self._silence_check_task
+                await silence_check_task
             except asyncio.CancelledError:
                 pass
             except Exception as e:
                 logger.error(f"Error cancelling silence check task: {e}")
-            finally:
-                self._silence_check_task = None
+
+        if self._connection_generation != generation:
+            # A replacement attached while this teardown ran. Everything below
+            # is client-wide — the silence scalars connect() has just primed,
+            # the audio processor the new connection is already feeding, the
+            # Gemini session it installed — and none of it is ours to release.
+            # The retired socket still is.
+            logger.info(
+                "Realtime close: a replacement connection attached; releasing only the retired socket"
+            )
+            await self._release_retired_socket(ws)
+            return
 
         # 重置静默超时相关状态
         self._silence_timeout_triggered = False
@@ -2173,6 +2198,16 @@ class _TransportMixin:
             await self._close_gemini()
             return
 
+        await self._release_retired_socket(ws)
+
+    async def _release_retired_socket(self, ws) -> None:
+        """Physically close the socket a teardown detached."""
+
+        if self._is_gemini:
+            # A Gemini session is released through the context manager that
+            # opened it, not here — and once a replacement has attached, that
+            # context manager went with the connection which owned it.
+            return
         if ws:
             try:
                 # 连接时已设 close_timeout=0.5s：远端超时未回 CLOSE 帧时，

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -146,6 +146,15 @@ class _TransportMixin:
         # because 'connection-scoped' should be true by construction.
         self._idless_quarantine = False
 
+        # Same lifetime, for a different reason: a close task closes the socket
+        # it detached, so it is finished with THIS connection's socket the
+        # moment the next one is established. Keeping the finished (or even
+        # still-running) task would make the new connection's close a no-op.
+        # An unfinished predecessor is unaffected — it already owns the old
+        # socket outright and nothing here cancels it.
+        self._close_task = None
+        self._failed_transport_close_task = None
+
         # ``close()`` releases RNNoise/soxr state. The client object is reused
         # across sessions, so recreate that session-owned processor on demand.
         if self._audio_processor is None:
@@ -2044,9 +2053,43 @@ class _TransportMixin:
             logger.error(f"Error in message handling: {str(e)}")
             raise
 
+    async def _own_teardown(self, slot: str, factory):
+        """Await a teardown that this client owns, not the caller.
+
+        Both close paths detach ``self.ws`` first and only then await the
+        arbiter shutdown — deliberately, so no ticket can outlive the socket.
+        That ordering also means a cancel landing in the middle takes the only
+        reference to a still-open socket with it: ``self.ws`` is already None,
+        so a retry closes nothing and reports success. Every real canceller is
+        internal (a hot-swap final task cancelled by a concurrent
+        start/end_session), so this is reachable without anyone injecting one.
+
+        Running the teardown as a task the client holds, and awaiting it
+        through ``shield``, separates the two: the caller's cancel stops the
+        waiting, the closing continues, and a later caller awaits the same
+        task rather than a fresh one against an emptied field.
+        """
+
+        task = getattr(self, slot, None)
+        if task is None:
+            task = asyncio.create_task(factory())
+            setattr(self, slot, task)
+        await asyncio.shield(task)
+
     async def _close_failed_transport(self, reason: str) -> None:
         """Fail response tickets and atomically detach the failed socket."""
 
+        # Latched before the task starts: callers check this flag to stop
+        # sending on a socket that is on its way out, and a scheduling gap
+        # before the task's first line must not be a window where they still
+        # think the transport is healthy.
+        self._fatal_error_occurred = True
+        await self._own_teardown(
+            "_failed_transport_close_task",
+            lambda: self._close_failed_transport_impl(reason),
+        )
+
+    async def _close_failed_transport_impl(self, reason: str) -> None:
         self._fatal_error_occurred = True
         ws, self.ws = self.ws, None
         response_arbiter = getattr(self, "_response_arbiter", None)
@@ -2076,6 +2119,9 @@ class _TransportMixin:
 
     async def close(self) -> None:
         """Close the WebSocket connection."""
+        await self._own_teardown("_close_task", self._close_impl)
+
+    async def _close_impl(self) -> None:
         ws, self.ws = self.ws, None
         response_arbiter = getattr(self, "_response_arbiter", None)
         if response_arbiter is not None:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -2072,7 +2072,7 @@ class _TransportMixin:
         self._failed_transport_close_task = None
         self._gemini_close_task = None
 
-    async def _own_teardown(self, slot: str, factory):
+    async def _own_teardown(self, slot: str, detach):
         """Await a teardown that this client owns, not the caller.
 
         Both close paths detach ``self.ws`` first and only then await the
@@ -2087,11 +2087,21 @@ class _TransportMixin:
         through ``shield``, separates the two: the caller's cancel stops the
         waiting, the closing continues, and a later caller awaits the same
         task rather than a fresh one against an emptied field.
+
+        ``detach`` is a plain function — called HERE, synchronously, before the
+        task exists. A coroutine's body does not run at ``create_task`` time,
+        so a detach written inside the teardown would be scheduled, not
+        performed: a connect() parked one await away can attach its
+        replacement and clear the latch first, and the teardown then wakes up
+        and closes the brand-new socket it finds in ``self.ws``. Detaching in
+        the caller's own step keeps the seizure exactly where it used to be,
+        back when close() was an ordinary coroutine. ``detach`` returns the
+        coroutine to run, with everything it seized already bound.
         """
 
         task = getattr(self, slot, None)
         if task is None:
-            task = asyncio.create_task(factory())
+            task = asyncio.create_task(detach())
             setattr(self, slot, task)
         await asyncio.shield(task)
 
@@ -2105,12 +2115,15 @@ class _TransportMixin:
         self._fatal_error_occurred = True
         await self._own_teardown(
             "_failed_transport_close_task",
-            lambda: self._close_failed_transport_impl(reason),
+            lambda: self._detach_for_failed_transport(reason),
         )
 
-    async def _close_failed_transport_impl(self, reason: str) -> None:
-        self._fatal_error_occurred = True
+    def _detach_for_failed_transport(self, reason: str):
         ws, self.ws = self.ws, None
+        return self._close_failed_transport_impl(reason, ws)
+
+    async def _close_failed_transport_impl(self, reason: str, ws) -> None:
+        self._fatal_error_occurred = True
         response_arbiter = getattr(self, "_response_arbiter", None)
         if response_arbiter is not None:
             await response_arbiter.shutdown(reason)
@@ -2138,18 +2151,38 @@ class _TransportMixin:
 
     async def close(self) -> None:
         """Close the WebSocket connection."""
-        await self._own_teardown("_close_task", self._close_impl)
+        await self._own_teardown("_close_task", self._detach_for_close)
 
-    async def _close_impl(self) -> None:
-        # Snapshot the connection this teardown belongs to, and detach what it
-        # is going to release, BEFORE the first await. The teardown outlives
-        # its caller by design, so connect() is free to attach a replacement
-        # while this one is parked in the arbiter shutdown — after that point
-        # anything read off the client can already be the replacement's.
+    def _detach_for_close(self):
+        """Seize this connection's resources, then hand them to the teardown.
+
+        Synchronous on purpose (see ``_own_teardown``), and it takes everything
+        the teardown will release in one uninterrupted step: the teardown
+        outlives its caller by design, so connect() is free to attach a
+        replacement while it is parked in the arbiter shutdown, and anything
+        re-read off the client after that point can already be the
+        replacement's. The Gemini context comes along for the same reason —
+        ``_connect_gemini()`` overwrites the field, and the retired SDK
+        connection would have no one left to exit it.
+        """
+
         generation = self._connection_generation
         ws, self.ws = self.ws, None
         silence_check_task, self._silence_check_task = self._silence_check_task, None
+        gemini_context = self._gemini_context_manager
+        gemini_close_task = self._gemini_close_task
+        return self._close_impl(
+            generation, ws, silence_check_task, gemini_context, gemini_close_task
+        )
 
+    async def _close_impl(
+        self,
+        generation,
+        ws,
+        silence_check_task,
+        gemini_context,
+        gemini_close_task,
+    ) -> None:
         response_arbiter = getattr(self, "_response_arbiter", None)
         if response_arbiter is not None:
             await response_arbiter.shutdown("realtime client closed")
@@ -2169,11 +2202,11 @@ class _TransportMixin:
             # is client-wide — the silence scalars connect() has just primed,
             # the audio processor the new connection is already feeding, the
             # Gemini session it installed — and none of it is ours to release.
-            # The retired socket still is.
+            # What we seized still is.
             logger.info(
-                "Realtime close: a replacement connection attached; releasing only the retired socket"
+                "Realtime close: a replacement connection attached; releasing only the retired connection"
             )
-            await self._release_retired_socket(ws)
+            await self._release_retired_connection(ws, gemini_context, gemini_close_task)
             return
 
         # 重置静默超时相关状态
@@ -2191,22 +2224,37 @@ class _TransportMixin:
 
         # Wait for any executor-owned chunk to finish before releasing the
         # session's RNNoise native state and soxr streaming buffers.
-        await self._close_audio_processor()
+        await self._close_audio_processor(generation)
 
         # Gemini uses different cleanup
         if self._is_gemini:
             await self._close_gemini()
             return
 
-        await self._release_retired_socket(ws)
+        await self._release_retired_connection(ws, gemini_context, gemini_close_task)
 
-    async def _release_retired_socket(self, ws) -> None:
-        """Physically close the socket a teardown detached."""
+    async def _release_retired_connection(
+        self,
+        ws,
+        gemini_context=None,
+        gemini_close_task=None,
+    ) -> None:
+        """Physically release the connection a teardown seized."""
 
         if self._is_gemini:
             # A Gemini session is released through the context manager that
-            # opened it, not here — and once a replacement has attached, that
-            # context manager went with the connection which owned it.
+            # opened it, not by closing a socket. On the replacement path that
+            # context is no longer reachable from the client — connect()
+            # overwrote the field — so the reference we seized is the only one
+            # left, and dropping it would leave the SDK connection open with
+            # nobody to exit it.
+            if gemini_close_task is not None:
+                # Already being exited by an in-flight teardown of its own
+                # (the proactive quarantine close); awaiting it is how we avoid
+                # a second __aexit__ on the same one-shot context.
+                await asyncio.shield(gemini_close_task)
+            elif gemini_context is not None:
+                await self._close_gemini_impl(gemini_context, ws)
             return
         if ws:
             try:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -2072,6 +2072,21 @@ class _TransportMixin:
         self._failed_transport_close_task = None
         self._gemini_close_task = None
 
+    def _still_owns_connection(self, generation) -> bool:
+        """Whether the connection a teardown seized is still the client's.
+
+        The rule this expresses has to hold at EVERY await boundary inside a
+        teardown, not just the first: the teardown outlives its caller by
+        design, so a replacement can attach during any one of them, and from
+        that moment the client's shared state (the arbiter, the fatal flag, the
+        silence scalars, the audio processor, the Gemini session) is the
+        replacement's. What the teardown seized up front stays its own to
+        release; everything else it must leave alone. Any await added below is
+        a new place to ask this.
+        """
+
+        return self._connection_generation == generation
+
     async def _own_teardown(self, slot: str, detach):
         """Await a teardown that this client owns, not the caller.
 
@@ -2119,24 +2134,34 @@ class _TransportMixin:
         )
 
     def _detach_for_failed_transport(self, reason: str):
+        generation = self._connection_generation
         ws, self.ws = self.ws, None
-        return self._close_failed_transport_impl(reason, ws)
+        return self._close_failed_transport_impl(reason, generation, ws)
 
-    async def _close_failed_transport_impl(self, reason: str, ws) -> None:
-        self._fatal_error_occurred = True
-        response_arbiter = getattr(self, "_response_arbiter", None)
-        if response_arbiter is not None:
-            await response_arbiter.shutdown(reason)
-        await self._abort_failed_transport(reason, ws)
+    async def _close_failed_transport_impl(self, reason: str, generation, ws) -> None:
+        # The fatal flag is the retired connection's, and the wrapper has
+        # already set it. Re-asserting it here would re-condemn a replacement
+        # that attached in between — connect() clears the flag on purpose, and
+        # a live connection marked fatal rejects every later send.
+        if self._still_owns_connection(generation):
+            response_arbiter = getattr(self, "_response_arbiter", None)
+            if response_arbiter is not None:
+                # Shared across connections, and connect() has already reopened
+                # it for the replacement. Shutting it down now would fail the
+                # new connection's tickets over a socket that is fine.
+                await response_arbiter.shutdown(reason)
+        await self._abort_failed_transport(reason, ws, generation)
 
     async def _abort_failed_transport(
         self,
         reason: str,
         ws=_ATTACHED_TRANSPORT,
+        generation=None,
     ) -> None:
         """Detach, when needed, and physically close a failed raw WebSocket."""
 
-        self._fatal_error_occurred = True
+        if generation is None or self._still_owns_connection(generation):
+            self._fatal_error_occurred = True
         if ws is _ATTACHED_TRANSPORT:
             ws, self.ws = self.ws, None
         if ws is not None:
@@ -2184,7 +2209,12 @@ class _TransportMixin:
         gemini_close_task,
     ) -> None:
         response_arbiter = getattr(self, "_response_arbiter", None)
-        if response_arbiter is not None:
+        if response_arbiter is not None and self._still_owns_connection(generation):
+            # The arbiter is shared across connections, not owned by one. If a
+            # replacement attached between the caller's seizure and this task's
+            # first line, connect() has already reopened it — shutting it down
+            # here would fail the live connection's tickets while its socket
+            # stays perfectly healthy.
             await response_arbiter.shutdown("realtime client closed")
 
         # 取消静默检测任务
@@ -2197,7 +2227,7 @@ class _TransportMixin:
             except Exception as e:
                 logger.error(f"Error cancelling silence check task: {e}")
 
-        if self._connection_generation != generation:
+        if not self._still_owns_connection(generation):
             # A replacement attached while this teardown ran. Everything below
             # is client-wide — the silence scalars connect() has just primed,
             # the audio processor the new connection is already feeding, the
@@ -2225,6 +2255,17 @@ class _TransportMixin:
         # Wait for any executor-owned chunk to finish before releasing the
         # session's RNNoise native state and soxr streaming buffers.
         await self._close_audio_processor(generation)
+
+        if not self._still_owns_connection(generation):
+            # Waiting for the audio lock is an await like any other, and this
+            # is the last one before the release below reads the client again:
+            # ``_close_gemini()`` would exit the replacement's context — the
+            # session a successful reconnect just installed.
+            logger.info(
+                "Realtime close: a replacement connection attached; releasing only the retired connection"
+            )
+            await self._release_retired_connection(ws, gemini_context, gemini_close_task)
+            return
 
         # Gemini uses different cleanup
         if self._is_gemini:

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -84,6 +84,9 @@ def _make_swap_manager():
     mgr.session = None
     mgr.message_handler_task = None
     mgr.pending_session = None
+    # Production sets this in __init__; the pending-session close is a task the
+    # manager owns so a cancelled caller cannot strand an open socket.
+    mgr._pending_session_close_tasks = set()
     mgr.background_preparation_task = None
     mgr.final_swap_task = None
     mgr.pending_session_warmed_up_event = None

--- a/tests/unit/test_realtime_close_ownership.py
+++ b/tests/unit/test_realtime_close_ownership.py
@@ -158,6 +158,45 @@ async def test_connect_rearms_close_ownership_for_the_new_socket():
     second.close.assert_awaited_once_with()
 
 
+@pytest.mark.asyncio
+async def test_close_inside_the_connect_window_does_not_latch_the_new_socket_shut():
+    """Rearming at the top of connect() would leave the replacement socket
+    behind a finished teardown: a close landing in the connect await window
+    runs to completion against no socket, and every later close() just
+    re-awaits that finished task."""
+    client = _make_client()
+
+    async def _shutdown(reason):
+        return None
+
+    client._response_arbiter.shutdown = _shutdown
+
+    attached = AsyncMock()
+    connecting = asyncio.Event()
+    resume = asyncio.Event()
+
+    async def _slow_connect(*args, **kwargs):
+        connecting.set()
+        await resume.wait()
+        return attached
+
+    with patch("websockets.connect", new=_slow_connect):
+        connect_task = asyncio.create_task(
+            client.connect(instructions="hi", native_audio=True)
+        )
+        await asyncio.wait_for(connecting.wait(), timeout=5)
+        # An end_session racing the reconnect: nothing is attached yet, so this
+        # close has no socket of its own to close.
+        await asyncio.wait_for(client.close(), timeout=5)
+
+        resume.set()
+        await asyncio.wait_for(connect_task, timeout=5)
+
+    assert client.ws is attached
+    await asyncio.wait_for(client.close(), timeout=5)
+    attached.close.assert_awaited_once_with()
+
+
 # ── Gemini SDK context exit ──────────────────────────────────────────
 
 

--- a/tests/unit/test_realtime_close_ownership.py
+++ b/tests/unit/test_realtime_close_ownership.py
@@ -316,6 +316,66 @@ async def test_audio_processor_is_not_released_after_a_replacement_adopts_it():
     assert client._audio_processor is processor
 
 
+@pytest.mark.asyncio
+async def test_retired_teardown_does_not_shut_the_replacements_arbiter_down():
+    """The arbiter is shared across connections, and connect() reopens it. A
+    teardown scheduled just before the reconnect attached must not shut it down
+    again — the replacement's socket would stay healthy while every ticket on
+    it fails."""
+    client = _make_client()
+    retired_ws = _FakeWs()
+    client.ws = retired_ws
+    shutdown_calls = []
+
+    async def _shutdown(reason):
+        shutdown_calls.append(reason)
+
+    client._response_arbiter.shutdown = _shutdown
+
+    closing = asyncio.create_task(client.close())
+    # One step: close() seizes the retired socket and schedules its teardown,
+    # which has not run a single line yet.
+    await asyncio.sleep(0)
+    assert client.ws is None, "fixture check: the seizure must have happened"
+
+    # The reconnect wins that gap: it attaches and reopens the arbiter.
+    client.ws = AsyncMock()
+    client._on_connection_attached()
+    await asyncio.wait_for(closing, timeout=5)
+
+    assert shutdown_calls == []
+    assert retired_ws.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_retired_failed_transport_does_not_recondemn_the_replacement():
+    """connect() clears the fatal flag on purpose. A retired fatal teardown
+    re-asserting it would make the live connection reject every later send."""
+    client = _make_client()
+    retired_ws = _FakeWs()
+    client.ws = retired_ws
+    shutdown_calls = []
+
+    async def _shutdown(reason):
+        shutdown_calls.append(reason)
+
+    client._response_arbiter.shutdown = _shutdown
+
+    failing = asyncio.create_task(client._close_failed_transport("transport failed"))
+    await asyncio.sleep(0)
+    assert client.ws is None, "fixture check: the seizure must have happened"
+
+    # The reconnect attaches and clears the fatal flag, as connect() does.
+    client.ws = AsyncMock()
+    client._fatal_error_occurred = False
+    client._on_connection_attached()
+    await asyncio.wait_for(failing, timeout=5)
+
+    assert client._fatal_error_occurred is False
+    assert shutdown_calls == []
+    assert retired_ws.close_calls == 1
+
+
 # ── Gemini SDK context exit ──────────────────────────────────────────
 
 
@@ -431,6 +491,46 @@ async def test_retired_gemini_context_is_exited_even_after_a_reconnect():
     assert replacement_context.exit_calls == 0
     assert client._gemini_context_manager is replacement_context
     assert client._gemini_session is replacement_session
+    assert client.ws is replacement_session
+
+
+@pytest.mark.asyncio
+async def test_replacement_attaching_during_the_audio_lock_keeps_its_gemini_session():
+    """The audio lock is the last await before the release reads the client
+    again, so a replacement attaching there must not have its freshly installed
+    session exited."""
+    client = _make_client()
+    client._is_gemini = True
+    retired_context = _GatedGeminiContext()
+    retired_session = object()
+    client._gemini_context_manager = retired_context
+    client._gemini_session = retired_session
+    client.ws = retired_session
+    client._audio_processor = MagicMock()
+
+    async def _shutdown(reason):
+        return None
+
+    client._response_arbiter.shutdown = _shutdown
+
+    await client._audio_processing_lock.acquire()
+    closing = asyncio.create_task(client.close())
+    await _settle()
+
+    replacement_context = _GatedGeminiContext()
+    replacement_session = object()
+    client._gemini_context_manager = replacement_context
+    client._gemini_session = replacement_session
+    client.ws = replacement_session
+    client._on_connection_attached()
+    client._audio_processing_lock.release()
+
+    retired_context.release.set()
+    await asyncio.wait_for(closing, timeout=5)
+
+    assert replacement_context.exit_calls == 0
+    assert retired_context.exit_calls == 1
+    assert client._gemini_context_manager is replacement_context
     assert client.ws is replacement_session
 
 

--- a/tests/unit/test_realtime_close_ownership.py
+++ b/tests/unit/test_realtime_close_ownership.py
@@ -245,6 +245,77 @@ async def test_teardown_outliving_its_connection_does_not_touch_the_replacement(
     replacement_silence_task.cancel()
 
 
+@pytest.mark.asyncio
+async def test_teardown_seizes_the_socket_before_a_replacement_can_attach():
+    """A coroutine's body does not run at create_task time. If the teardown
+    detached inside the task, a connect() one await away would attach first and
+    the teardown would then close the brand-new socket."""
+    client = _make_client()
+    retired_ws = _FakeWs()
+    client.ws = retired_ws
+
+    async def _shutdown(reason):
+        return None
+
+    client._response_arbiter.shutdown = _shutdown
+
+    replacement = AsyncMock()
+    connecting = asyncio.Event()
+    resume = asyncio.Event()
+
+    async def _slow_connect(*args, **kwargs):
+        connecting.set()
+        await resume.wait()
+        return replacement
+
+    with patch("websockets.connect", new=_slow_connect):
+        connect_task = asyncio.create_task(
+            client.connect(instructions="hi", native_audio=True)
+        )
+        await asyncio.wait_for(connecting.wait(), timeout=5)
+
+        # close() and the pending connect() become runnable in the same tick:
+        # the connect resumes and attaches while the teardown task is merely
+        # scheduled.
+        closing = asyncio.create_task(client.close())
+        resume.set()
+        await asyncio.wait_for(connect_task, timeout=5)
+        await asyncio.wait_for(closing, timeout=5)
+
+    assert retired_ws.close_calls == 1
+    replacement.close.assert_not_awaited()
+    assert client.ws is replacement
+
+
+@pytest.mark.asyncio
+async def test_audio_processor_is_not_released_after_a_replacement_adopts_it():
+    """connect() only builds a processor when the field is empty, so a
+    replacement attaching while the teardown waits for the audio lock adopts
+    this very one."""
+    client = _make_client()
+    client.ws = _FakeWs()
+
+    async def _shutdown(reason):
+        return None
+
+    client._response_arbiter.shutdown = _shutdown
+
+    processor = MagicMock()
+    client._audio_processor = processor
+
+    await client._audio_processing_lock.acquire()
+    closing = asyncio.create_task(client.close())
+    await _settle()
+
+    # The reconnect completes while the teardown is queued on the audio lock.
+    client._on_connection_attached()
+    client._audio_processing_lock.release()
+    await asyncio.wait_for(closing, timeout=5)
+
+    processor.close.assert_not_called()
+    assert client._audio_processor is processor
+
+
 # ── Gemini SDK context exit ──────────────────────────────────────────
 
 
@@ -326,6 +397,41 @@ async def test_gemini_close_leaves_a_replacement_session_alone():
     assert client._gemini_session is replacement_session
     assert client.ws is replacement_session
     assert replacement_context.exit_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retired_gemini_context_is_exited_even_after_a_reconnect():
+    """The retired context is unreachable from the client once
+    ``_connect_gemini()`` overwrites the field, so the reference the teardown
+    seized is the only one that can still exit that SDK connection."""
+    client = _make_client()
+    client._is_gemini = True
+    retired_context = _GatedGeminiContext()
+    retired_session = object()
+    client._gemini_context_manager = retired_context
+    client._gemini_session = retired_session
+    client.ws = retired_session
+    entered, release, _calls = _gate_arbiter_shutdown(client)
+
+    closing = asyncio.create_task(client.close())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+
+    replacement_context = _GatedGeminiContext()
+    replacement_session = object()
+    client._gemini_context_manager = replacement_context
+    client._gemini_session = replacement_session
+    client.ws = replacement_session
+    client._on_connection_attached()
+
+    release.set()
+    retired_context.release.set()
+    await asyncio.wait_for(closing, timeout=5)
+
+    assert retired_context.exit_calls == 1, "the retired SDK connection must still be exited"
+    assert replacement_context.exit_calls == 0
+    assert client._gemini_context_manager is replacement_context
+    assert client._gemini_session is replacement_session
+    assert client.ws is replacement_session
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_realtime_close_ownership.py
+++ b/tests/unit/test_realtime_close_ownership.py
@@ -7,7 +7,8 @@ afterwards, so a cancel landing in between took the only reference with it:
   arbiter shutdown (deliberately — no ticket may outlive the socket);
 - ``_close_failed_transport()`` does the same on the fatal path;
 - ``_close_gemini()`` cleared the SDK context manager in a ``finally``, which
-  runs on cancel too, so a retry found nothing left to exit;
+  runs on cancel too — and an interrupted ``__aexit__()`` cannot be retried
+  anyway, so the exit itself must not be interrupted;
 - ``_cleanup_pending_session_resources()`` cleared ``pending_session`` in a
   ``finally`` while ``_reset_preparation_state`` cancels its caller a *second*
   time when its 2s wait expires — landing inside that very close.
@@ -15,9 +16,13 @@ afterwards, so a cancel landing in between took the only reference with it:
 Every canceller here is internal: a hot-swap final task or background prep
 task cancelled by a concurrent start/end_session. Reported as items 12-14 of
 the #2602 index.
+
+Outliving the caller means a teardown can also outlive its connection, so the
+other half is scope: it releases what it detached, and keeps its hands off the
+client-wide state a replacement connection has since taken over.
 """
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -197,10 +202,57 @@ async def test_close_inside_the_connect_window_does_not_latch_the_new_socket_shu
     attached.close.assert_awaited_once_with()
 
 
+@pytest.mark.asyncio
+async def test_teardown_outliving_its_connection_does_not_touch_the_replacement():
+    """The teardown is explicitly allowed to outlive its caller, so it can also
+    outlive its connection. Everything it reads after its first await —
+    silence-check task, audio processor, silence scalars — is client-wide, and
+    once a replacement has attached none of it is the old teardown's to
+    release. Only the socket it detached still is."""
+    client = _make_client()
+    retired_ws = _FakeWs()
+    client.ws = retired_ws
+    entered, release, _calls = _gate_arbiter_shutdown(client)
+
+    retired_silence_task = asyncio.create_task(asyncio.Event().wait())
+    client._silence_check_task = retired_silence_task
+
+    closing = asyncio.create_task(client.close())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+
+    # A reconnect completes while the old teardown is parked.
+    replacement_ws = _FakeWs()
+    replacement_silence_task = asyncio.create_task(asyncio.Event().wait())
+    replacement_processor = MagicMock()
+    client.ws = replacement_ws
+    client._silence_check_task = replacement_silence_task
+    client._audio_processor = replacement_processor
+    client._last_speech_time = 1234.0
+    client._on_connection_attached()
+
+    release.set()
+    await asyncio.wait_for(closing, timeout=5)
+
+    assert retired_ws.close_calls == 1, "the retired socket is still the teardown's own"
+    assert retired_silence_task.cancelled()
+    assert not replacement_silence_task.done(), "the replacement's silence check must survive"
+    assert client._silence_check_task is replacement_silence_task
+    replacement_processor.close.assert_not_called()
+    assert client._audio_processor is replacement_processor
+    assert client._last_speech_time == 1234.0
+    assert client.ws is replacement_ws
+
+    replacement_silence_task.cancel()
+
+
 # ── Gemini SDK context exit ──────────────────────────────────────────
 
 
 class _GatedGeminiContext:
+    """A context manager that would happily be re-entered — so a test asserting
+    the exit ran once is asserting the production guarantee, not this fake's
+    one-shot behaviour."""
+
     def __init__(self):
         self.entered = asyncio.Event()
         self.release = asyncio.Event()
@@ -213,12 +265,17 @@ class _GatedGeminiContext:
 
 
 @pytest.mark.asyncio
-async def test_cancelled_gemini_exit_keeps_the_references_for_a_retry():
+async def test_cancelled_gemini_caller_does_not_interrupt_the_sdk_exit():
+    """An async context manager is one-shot: an ``__aexit__()`` unwound by a
+    cancel cannot be resumed by calling it again. So the exit must not be
+    interrupted — the cancel has to stop the waiting, not the exiting, and the
+    exit must run exactly once."""
     client = _make_client()
     context = _GatedGeminiContext()
+    session = object()
     client._gemini_context_manager = context
-    client._gemini_session = object()
-    client.ws = client._gemini_session
+    client._gemini_session = session
+    client.ws = session
 
     caller = asyncio.create_task(client._close_gemini())
     await asyncio.wait_for(context.entered.wait(), timeout=5)
@@ -227,18 +284,48 @@ async def test_cancelled_gemini_exit_keeps_the_references_for_a_retry():
     with pytest.raises(asyncio.CancelledError):
         await caller
 
-    # The SDK context exit never completed, so the references are the only way
-    # back to it — dropping them orphans the session for good.
+    # Still parked inside the SDK exit, holding its own references.
+    assert context.exit_calls == 1
     assert client._gemini_context_manager is context
-    assert client._gemini_session is not None
 
+    retry = asyncio.create_task(client._close_gemini())
+    await _settle()
     context.release.set()
-    await asyncio.wait_for(client._close_gemini(), timeout=5)
+    await asyncio.wait_for(retry, timeout=5)
 
-    assert context.exit_calls == 2
+    assert context.exit_calls == 1, "the interrupted exit must be finished, not re-entered"
     assert client._gemini_context_manager is None
     assert client._gemini_session is None
     assert client.ws is None
+
+
+@pytest.mark.asyncio
+async def test_gemini_close_leaves_a_replacement_session_alone():
+    client = _make_client()
+    context = _GatedGeminiContext()
+    retired_session = object()
+    client._gemini_context_manager = context
+    client._gemini_session = retired_session
+    client.ws = retired_session
+
+    closing = asyncio.create_task(client._close_gemini())
+    await asyncio.wait_for(context.entered.wait(), timeout=5)
+
+    # A reconnect completes while the retired session is still exiting.
+    replacement_context = _GatedGeminiContext()
+    replacement_session = object()
+    client._gemini_context_manager = replacement_context
+    client._gemini_session = replacement_session
+    client.ws = replacement_session
+    client._on_connection_attached()
+
+    context.release.set()
+    await asyncio.wait_for(closing, timeout=5)
+
+    assert client._gemini_context_manager is replacement_context
+    assert client._gemini_session is replacement_session
+    assert client.ws is replacement_session
+    assert replacement_context.exit_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_realtime_close_ownership.py
+++ b/tests/unit/test_realtime_close_ownership.py
@@ -1,0 +1,318 @@
+"""Teardown ownership: a cancelled caller must not strand an open connection.
+
+Three teardown paths detached their resource first and awaited the slow part
+afterwards, so a cancel landing in between took the only reference with it:
+
+- ``OmniRealtimeClient.close()`` detaches ``self.ws`` before awaiting the
+  arbiter shutdown (deliberately — no ticket may outlive the socket);
+- ``_close_failed_transport()`` does the same on the fatal path;
+- ``_close_gemini()`` cleared the SDK context manager in a ``finally``, which
+  runs on cancel too, so a retry found nothing left to exit;
+- ``_cleanup_pending_session_resources()`` cleared ``pending_session`` in a
+  ``finally`` while ``_reset_preparation_state`` cancels its caller a *second*
+  time when its 2s wait expires — landing inside that very close.
+
+Every canceller here is internal: a hot-swap final task or background prep
+task cancelled by a concurrent start/end_session. Reported as items 12-14 of
+the #2602 index.
+"""
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import main_logic.core as core_module
+from main_logic.omni_realtime_client import OmniRealtimeClient, TurnDetectionMode
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeWs:
+    def __init__(self):
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+
+
+def _make_client():
+    return OmniRealtimeClient(
+        base_url="wss://example.test/realtime",
+        api_key="sk-test",
+        model="qwen-omni-turbo-realtime",
+        turn_detection_mode=TurnDetectionMode.MANUAL,
+        api_type="qwen",
+    )
+
+
+def _gate_arbiter_shutdown(client):
+    """Park the arbiter shutdown so a cancel lands after the ws was detached."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def _shutdown(reason):
+        calls.append(reason)
+        entered.set()
+        await release.wait()
+
+    client._response_arbiter.shutdown = _shutdown
+    return entered, release, calls
+
+
+async def _settle():
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_still_closes_the_socket_it_detached():
+    client = _make_client()
+    ws = _FakeWs()
+    client.ws = ws
+    entered, release, calls = _gate_arbiter_shutdown(client)
+
+    caller = asyncio.create_task(client.close())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    # The socket is already detached at this point — that is the whole window.
+    assert client.ws is None
+
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    release.set()
+    # The retry a caller would make: it must await the same teardown rather
+    # than see an empty ``self.ws`` and report success over an open socket.
+    await asyncio.wait_for(client.close(), timeout=5)
+
+    assert ws.close_calls == 1
+    assert calls == ["realtime client closed"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_failed_transport_close_still_closes_the_socket():
+    client = _make_client()
+    ws = _FakeWs()
+    client.ws = ws
+    entered, release, calls = _gate_arbiter_shutdown(client)
+
+    caller = asyncio.create_task(client._close_failed_transport("transport failed"))
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    assert client.ws is None
+    # Latched before the teardown task runs: callers gate their sends on it.
+    assert client._fatal_error_occurred is True
+
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    release.set()
+    await asyncio.wait_for(client._close_failed_transport("transport failed"), timeout=5)
+
+    assert ws.close_calls == 1
+    assert calls == ["transport failed"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_close_runs_the_teardown_once():
+    client = _make_client()
+    ws = _FakeWs()
+    client.ws = ws
+    shutdown_calls = []
+
+    async def _shutdown(reason):
+        shutdown_calls.append(reason)
+
+    client._response_arbiter.shutdown = _shutdown
+
+    await client.close()
+    await client.close()
+
+    assert ws.close_calls == 1
+    assert shutdown_calls == ["realtime client closed"]
+
+
+@pytest.mark.asyncio
+async def test_connect_rearms_close_ownership_for_the_new_socket():
+    """The client object outlives a connection, so a finished teardown must not
+    make the NEXT connection's close a no-op."""
+    client = _make_client()
+    first = _FakeWs()
+    client.ws = first
+
+    async def _shutdown(reason):
+        return None
+
+    client._response_arbiter.shutdown = _shutdown
+    await client.close()
+    assert first.close_calls == 1
+
+    second = AsyncMock()
+    with patch("websockets.connect", new_callable=AsyncMock, return_value=second):
+        await client.connect(instructions="hi", native_audio=True)
+
+    assert client.ws is second
+    await client.close()
+    second.close.assert_awaited_once_with()
+
+
+# ── Gemini SDK context exit ──────────────────────────────────────────
+
+
+class _GatedGeminiContext:
+    def __init__(self):
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.exit_calls = 0
+
+    async def __aexit__(self, *exc_info):
+        self.exit_calls += 1
+        self.entered.set()
+        await self.release.wait()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_gemini_exit_keeps_the_references_for_a_retry():
+    client = _make_client()
+    context = _GatedGeminiContext()
+    client._gemini_context_manager = context
+    client._gemini_session = object()
+    client.ws = client._gemini_session
+
+    caller = asyncio.create_task(client._close_gemini())
+    await asyncio.wait_for(context.entered.wait(), timeout=5)
+
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    # The SDK context exit never completed, so the references are the only way
+    # back to it — dropping them orphans the session for good.
+    assert client._gemini_context_manager is context
+    assert client._gemini_session is not None
+
+    context.release.set()
+    await asyncio.wait_for(client._close_gemini(), timeout=5)
+
+    assert context.exit_calls == 2
+    assert client._gemini_context_manager is None
+    assert client._gemini_session is None
+    assert client.ws is None
+
+
+@pytest.mark.asyncio
+async def test_failing_gemini_exit_still_drops_the_references():
+    """A raised (non-cancel) exit ran to its own conclusion; the SDK has no
+    second attempt to offer, so the pre-existing behaviour stands."""
+    client = _make_client()
+
+    class _RaisingContext:
+        async def __aexit__(self, *exc_info):
+            raise RuntimeError("sdk exit failed")
+
+    client._gemini_context_manager = _RaisingContext()
+    client._gemini_session = object()
+
+    await client._close_gemini()
+
+    assert client._gemini_context_manager is None
+    assert client._gemini_session is None
+    assert client.ws is None
+
+
+# ── Pending hot-swap session ─────────────────────────────────────────
+
+
+class _GatedSession:
+    def __init__(self):
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.close_calls = 0
+        self.closed = False
+
+    async def close(self):
+        self.close_calls += 1
+        self.entered.set()
+        await self.release.wait()
+        self.closed = True
+
+
+def _make_prep_manager():
+    mgr = object.__new__(core_module.LLMSessionManager)
+    mgr.pending_session = None
+    mgr._pending_session_close_tasks = set()
+    mgr.background_preparation_task = None
+    mgr.final_swap_task = None
+    mgr.is_preparing_new_session = False
+    mgr._require_context_append_current_delivery = False
+    mgr.summary_triggered_time = None
+    mgr.initial_cache_snapshot_len = 0
+    mgr.initial_next_session_context_snapshot_len = 0
+    mgr.message_cache_for_new_session = []
+    mgr.pending_session_warmed_up_event = None
+    mgr.pending_session_final_prime_complete_event = None
+    mgr.pending_use_tts = None
+    return mgr
+
+
+async def _prep_task_shaped_like_production(mgr):
+    """Same shape as ``_background_prepare_pending_session``: park, and clean
+    the pending session up from the CancelledError handler."""
+    try:
+        await asyncio.Event().wait()
+    except asyncio.CancelledError:
+        await mgr._cleanup_pending_session_resources()
+        raise
+
+
+@pytest.mark.asyncio
+async def test_second_cancel_of_the_cleanup_caller_does_not_abandon_the_close():
+    mgr = _make_prep_manager()
+    session = _GatedSession()
+    mgr.pending_session = session
+
+    prep = asyncio.create_task(_prep_task_shaped_like_production(mgr))
+    await _settle()
+
+    prep.cancel()
+    await asyncio.wait_for(session.entered.wait(), timeout=5)
+    # What _reset_preparation_state's expiring 2s wait does to the very task
+    # that is running the cleanup.
+    prep.cancel()
+    await _settle()
+    assert prep.done()
+
+    session.release.set()
+    await _settle()
+    await _settle()
+
+    assert session.closed, "the close lost its owner when its caller was cancelled"
+    assert session.close_calls == 1
+    assert mgr.pending_session is None
+
+
+@pytest.mark.asyncio
+async def test_reset_preparation_state_timeout_does_not_abandon_the_close():
+    """Production topology: the real reset, the real 2s cap, a close that
+    outlives it. The cap must bound only how long the reset waits."""
+    mgr = _make_prep_manager()
+    session = _GatedSession()
+    mgr.pending_session = session
+
+    prep = asyncio.create_task(_prep_task_shaped_like_production(mgr))
+    mgr.background_preparation_task = prep
+    await _settle()
+
+    await asyncio.wait_for(mgr._reset_preparation_state(), timeout=10)
+
+    assert mgr.background_preparation_task is None
+    assert session.closed is False, "fixture check: the close must still be in flight"
+
+    session.release.set()
+    await _settle()
+    await _settle()
+
+    assert session.closed
+    assert session.close_calls == 1


### PR DESCRIPTION
修 #2602 索引里的第 12、13、14 条（D 组「相邻的 Omni / Gemini / hot-swap 所有权问题」）。本 Issue 的主故障（A.1，缺失 `response.created` 时整轮被 stale filter 丢弃）已由 #2642 的 `_announces_responses` 闩修掉，本 PR 不重复。

## 问题

三条 teardown 都是**先摘除资源、后 await 慢的那半段**，落在中间的 cancel 就把指向仍然打开的连接的唯一引用一并带走：

| 位置 | 摘除什么 | 之后 await 什么 | 取消后果 |
| --- | --- | --- | --- |
| `OmniRealtimeClient.close()` | `self.ws` | arbiter shutdown / audio processor | 旧 socket 永不 close，重试看到 `self.ws is None` 直接报成功 |
| `_close_failed_transport()` | `self.ws` | arbiter shutdown | 同上（致命路径） |
| `_close_gemini()` | `finally` 清 context manager / session | `__aexit__()` | 重试跳过 SDK context exit，session 永久失去 owner |
| `_cleanup_pending_session_resources()` | `finally` 清 `pending_session` | `session.close()` | `_reset_preparation_state` 的 2s 上限到点**第二次** cancel 同一个调用者，正落在这次 close 里；`_wait_one` 又吞掉 timeout，reset 对外仍报成功 |

取消源全部来自仓库内部，不需要任何外部注入：并发的 `start_session` / `end_session` 经 `_reset_preparation_state()` 取消热切换 `final_swap_task`（旧 session 的 close 就在 `_perform_final_swap_sequence()` 里）或后台准备 task。`_close_gemini()` 另有一个独立入口——`_responses.py` 的 Gemini proactive quarantine——同样跑在可被取消的 fired task 上。

## 改法

同一条：**让 teardown 变成对象自己持有的 task，调用方一律通过 `shield` 去 await。** 调用方的 cancel 只停止「等待」，不停止「关闭」；后来的调用者 re-await 同一个 task，而不是对着已经清空的字段跑一遍空转。

- `_own_teardown(slot, factory)`：client 侧两条 close 路径共用；两把 latch 随 `connect()` 复位——同一个 client 对象跨会话复用，已完成的 teardown 不能让下一条连接的 close 变成 no-op。
- `_close_gemini()`：`CancelledError` 分支保留引用后 re-raise；抛别的异常仍然照旧清（SDK 没有第二次机会可给）。
- `_cleanup_pending_session_resources()`：`pending_session` 仍然当场置 None，前进性不变；close 交给 manager 持有的 task，2s 上限从此只约束调用方等多久。

`DetectorRuntime.close()` 早就是这个形状（owned + shield），此处与之对齐，不是新引进的模式。

## 回归报告

**改了什么 / 为什么必要**：见上。这四处的共同后果是 socket / SDK session 泄漏——热切换在生产里由普通会话轮换触发，不是罕见路径；泄漏的旧连接还会继续占用上游配额与本地 fd。

**前后行为对比**：

- 正常（无取消）路径：完全一致——同样的顺序、同样的 arbiter shutdown reason、同样一次 `ws.close()`。已有的 `test_close_detaches_socket_before_awaiting_arbiter_shutdown` / `test_failed_transport_detaches_socket_before_arbiter_shutdown` 未改动仍绿。
- 取消路径：调用方照旧收到 `CancelledError`（行为不变），但 socket / SDK session 现在一定会被关掉；重复调用 close 只会 await 同一个 task，不会重复 close。
- `_cleanup_pending_session_resources` 期间若有 pending session 的 lifecycle 回调打回来，`expected_session is self.pending_session` 现在走「已被别人清掉」分支而不是再清一次——少一次重复 close，方向正确。
- `_fatal_error_occurred` 在 `_close_failed_transport` 里改成进 task 之前就置位，避免调度间隙里调用方还以为传输是健康的。

**潜在回归**：

1. teardown 现在跑在独立 task 上，异常传播路径变了一层。已 review：两条 impl 内部本来就把可预期异常吞掉并记日志，逃出来的异常经 `shield` 原样抛给 await 方，与之前一致；第二个 awaiter 会看到同一个异常（之前是「什么都不做直接返回」，新行为更诚实）。
2. `pending_session` 现在在 close 之前置 None。全部 5 个调用点都已核对：没有任何一个在调用后依赖它仍非空。
3. 若 close 永远挂住，close task 会一直活着（之前是引用被丢弃、task 也不存在）。这正是「有 owner」的代价，也是 Issue 里点名要的形态；manager 侧不再被它阻塞。
4. 手工构造 manager 的测试夹具需要 `_pending_session_close_tasks`（生产 `__init__` 里有）。已给 `test_hot_swap_cancellation.py` 的夹具补上；其余 4 个手工夹具的文件跑过均绿。

## 测试

新增 `tests/unit/test_realtime_close_ownership.py`（8 条）：取消 close / 取消 failed-transport close 后 socket 仍被关闭且重试 await 同一个 task、重复 close 只 teardown 一次、`connect()` 重新武装闩、Gemini 取消保留引用且重试跑完 `__aexit__`、Gemini 非取消异常仍照旧清引用、cleanup 调用者被二次 cancel 不丢 close、以及生产拓扑下真实 `_reset_preparation_state()` 2s 上限到点也不丢 close。

变异验证（逐条撤掉修复 → 对应用例变红）：

| 变异 | 结果 |
| --- | --- |
| `close()` 退回内联 body | 2 failed |
| `_close_failed_transport()` 退回内联 body | 1 failed |
| Gemini 取消分支照旧清引用 | 1 failed |
| cleanup 退回 `finally` 清引用 + 直接 await | 2 failed |
| `connect()` 不复位闩 | 1 failed |

相关面回归：`tests/unit -k "realtime or arbiter or swap or session or close"` → 1312 passed, 5 skipped。

Refs #2602

🤖 Generated with [Claude Code](https://claude.com/claude-code)
