### PR TITLE
refactor(memory): 召回渲染收口到单一入口，护栏改成边界收口（#2588）

### DIFF
--- a/main_logic/core/tool_calling.py
+++ b/main_logic/core/tool_calling.py
@@ -291,109 +291,40 @@ class ToolCallingMixin:
 
     @staticmethod
     def _render_recall_block(results: list, _lang: str) -> str:
-        """Render recall hits as the markdown block the model receives.
+        """Render recall hits through the shared entry point, with a header.
 
         Format: ``1. [事实/关于用户] text  (2026-05-01, 23 天前)``, under an
         i18n overview line.
 
-        tier/entity go through the localized label table (a scoped entry's
-        entity is always its subject.kind, and echoing it raw would push
-        ``[fact/group_chat]`` into a Chinese prompt); the plugin's
-        ``memory_bridge.render_relevant_memory`` shares that table. The
-        memory text itself is never translated. The time anchor prefers
-        when the event actually happened — event_end_at → event_start_at →
-        created_at, the same order as the persona stale block and temporal
-        ``_past_anchor`` — so the model sees when the event happened rather
-        than when the memory was written, plus a localized relative label.
+        No line building happens here. ``memory.recall_render`` is the one
+        place recall results become prompt text — it owns the label table,
+        the time anchor and the token budgets, and it owns them once so
+        this side and the QQ plugin's ``render_relevant_memory`` cannot
+        drift apart (issue #2588; the two used to be hand-written twins).
+        This method supplies the locale and the overview line, which the
+        entry point charges to the same budget because it lands in the same
+        string the model reads.
 
-        Budget mirrors the plugin twin: each entry truncated by tokens
-        (never dropped), the block through the same
-        ``take_lines_within_token_budget``. Entry count here comes from
-        hybrid_recall's fusion cap rather than the plugin's limit=5, so
-        this is the side where the block cap actually binds.
+        Entry count here comes from hybrid_recall's fusion cap rather than
+        the plugin's limit=5, so this is the side where the block cap
+        actually binds.
 
         Deliberately synchronous, and called through ``asyncio.to_thread``
         — see the caller.
         """  # noqa: DOCSTRING_CJK
-        from config import (
-            RECALL_RENDER_ENTRY_MAX_TOKENS,
-            RECALL_RENDER_LINE_OVERHEAD_TOKENS,
-            RECALL_RENDER_TOTAL_MAX_TOKENS,
+        from config import RECALL_RENDER_TOTAL_MAX_TOKENS
+        from memory.recall_render import render_recall_block
+
+        block = render_recall_block(
+            results, _lang,
+            header_template=_loc(RECALL_MEMORY_TOOL_FOUND_HEADER, _lang),
         )
-        from config.prompts.prompts_memory import render_recall_entry_tag
-        from memory.temporal import (
-            time_since_label as _time_label,
-            _parse_iso_safe,
-            to_naive_local,
-        )
-        from utils.tokenize import (
-            count_tokens,
-            take_lines_within_token_budget,
-            truncate_to_tokens,
-        )
-        entry_lines: list[str] = []
-        for i, r in enumerate(results, start=1):
-            tag = render_recall_entry_tag(r.get("tier"), r.get("entity"), _lang)
-            # str() coerce 防 malformed memory entry：facts/reflections.json
-            # 走 JSON 序列化往返，理论上 text / 时间字段应是 str，但 manual
-            # edit / 老格式残留 / 迁移 bug 都可能让它们变 list / int 等
-            # truthy non-string（时间戳尤其常见，老数据可能存 epoch int）。
-            # codex review (2 轮): 不 coerce → .strip() / [:10] crash → 整条
-            # tool call 翻 is_error，模型反而不能正常走。
-            text = truncate_to_tokens(
-                str(r.get("text") or "").strip(),
-                RECALL_RENDER_ENTRY_MAX_TOKENS,
-            )
-            # 锚点取 event_end_at → event_start_at → created_at 里**第一个能
-            # 解析出来**的（不是第一个 truthy 的）：manual edit / 迁移可能让
-            # 高优先级字段是个非空但解析不了的脏值，按 truthiness 选会卡住、
-            # 把本可用的低优先级字段挡掉，渲染出乱码日期（Codex）。
-            # _parse_iso_safe 对 None / int / list 等都安全返回 None。
-            # date_part 和 rel 都从同一个归一后的 datetime 出，口径一致。
-            anchor_dt = None
-            for _cand in (
-                r.get("event_end_at"),
-                r.get("event_start_at"),
-                r.get("created_at"),
-            ):
-                anchor_dt = to_naive_local(_parse_iso_safe(_cand))
-                if anchor_dt is not None:
-                    break
-            date_part = anchor_dt.strftime("%Y-%m-%d") if anchor_dt else ""
-            rel = _time_label(anchor_dt.isoformat(), lang=_lang) if anchor_dt else ""
-            if date_part and rel:
-                time_suffix = f"  ({date_part}, {rel})"
-            elif date_part:
-                time_suffix = f"  ({date_part})"
-            else:
-                time_suffix = ""
-            # 整行再兜一次底（与插件侧对偶）：截断只管 text，而 tag 里的
-            # tier / entity 是未知枚举原样透出的，手改过的 facts.json 能塞
-            # 进任意长的 entity——而整段预算的"至少留一条"规则会无条件留下
-            # 第一行。行上限用「单条 + 行装饰」的口径，正常条目够不着。
-            entry_lines.append(truncate_to_tokens(
-                f"{i}. {tag} {text}{time_suffix}",
-                RECALL_RENDER_ENTRY_MAX_TOKENS + RECALL_RENDER_LINE_OVERHEAD_TOKENS,
-            ))
-        # 首行 i18n 总览也进这个字符串，所以要先从预算里扣掉，否则整段实际
-        # 超预算（ja 的表头就有 14 tok）。用 n=条目总数 估表头开销：最终 n
-        # 只可能更小、位数只可能更少，往大了估是安全方向。
-        header_template = _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, _lang)
-        header_reserve = count_tokens(
-            header_template.format(n=len(entry_lines))
-        ) + count_tokens("\n")
-        kept, dropped = take_lines_within_token_budget(
-            entry_lines, max(0, RECALL_RENDER_TOTAL_MAX_TOKENS - header_reserve),
-        )
-        if dropped:
+        if block.dropped:
             logger.info(
                 "[recall_memory] rendered block over %d tok budget; dropped "
-                "trailing %d entries", RECALL_RENDER_TOTAL_MAX_TOKENS, dropped,
+                "trailing %d entries", RECALL_RENDER_TOTAL_MAX_TOKENS, block.dropped,
             )
-        # 总览按**实际渲染出去的条数**算：报 n=8 却只列 5 条会让模型以为
-        # 剩下三条被自己漏掉了，追着再调一次工具。
-        header = header_template.format(n=len(kept))
-        return "\n".join([header] + kept)
+        return block.text
 
     async def _sync_tools_to_active_session(self, *, raise_on_failure: bool = False) -> None:
         """Sync the registry's current state to all active clients.

--- a/memory/recall_render.py
+++ b/memory/recall_render.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The one place ``/query_memory`` results become prompt text.
+
+Every recall consumer in this repo renders through `render_recall_block`.
+That is the point of the module: recall hits go straight into a prompt and
+a single merged reflection can be thousands of tokens, so the block needs a
+ceiling — and a ceiling that lives in two hand-written twins drifts.
+
+It used to live in two. ``QQMemoryBridge.render_relevant_memory`` and the
+main app's ``recall_memory`` tool handler each built the same
+``1. [fact/user] text  (2026-05-01, 3 months ago)`` line, each applied the
+same two budgets, and issue #2588 measured 12 distinct ways for a third
+renderer — or an edit to either twin — to reach the prompt un-budgeted
+while the structural guards stayed green. Those guards inferred "the budget
+runs" from the SHAPE of the source (does this function call
+``take_lines_within_token_budget``?), and that inference was defeated five
+times running, because "will this call execute, and is its result used" is
+not decidable from an AST.
+
+Collapsing the twins does not make the inference sound; it makes the
+inference unnecessary. There is one render path, it has behavioural tests
+that feed oversized input and measure the tokens that come out, and the
+remaining structural check is a much cruder one that does not need to
+reason about execution: nobody else may call the recall label table, and
+every module that posts to ``/query_memory`` must import this one.
+
+Budget shape (constants in ``config.memory_settings``):
+
+- each entry's TEXT truncated to ``RECALL_RENDER_ENTRY_MAX_TOKENS`` —
+  truncated, never dropped: recall is relevance-ranked, so half of the top
+  hit still beats none of it;
+- each rendered LINE truncated to entry + ``RECALL_RENDER_LINE_OVERHEAD_TOKENS``,
+  because the tier/entity tag echoes unknown enum values verbatim and a
+  hand-edited ``facts.json`` can hold an arbitrarily long ``entity``;
+- the block as a whole through ``take_lines_within_token_budget`` against
+  ``RECALL_RENDER_TOTAL_MAX_TOKENS``, minus the header when the caller asks
+  for one — the header lands in the same string the model reads, so it
+  comes out of the same allowance.
+
+Deliberately synchronous. ``truncate_to_tokens`` encodes the text BEFORE
+truncation and tiktoken degrades quadratically on a chunk the pretokenizer
+cannot split, so every caller hands this to ``asyncio.to_thread`` rather
+than running it on the event loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping as _MappingABC
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class RenderedRecallBlock:
+    """What `render_recall_block` produced, plus what it had to cut.
+
+    ``text`` is the block as the model will see it. ``kept`` / ``dropped``
+    are entry counts for the caller's diagnostics — callers log the drop on
+    their own side, since a missing logger must never cost the user their
+    memory block.
+    """
+
+    text: str
+    kept: int
+    dropped: int
+
+
+def _time_suffix(entry: Mapping[str, Any], lang: str) -> str:
+    """Localized ``  (2026-05-01, 3 months ago)`` for one entry.
+
+    The anchor prefers when the event actually happened —
+    ``event_end_at`` → ``event_start_at`` → ``created_at``, the same order
+    as the persona stale block and temporal ``_past_anchor`` — so the model
+    sees when the event happened rather than when the memory was written.
+
+    First anchor that PARSES, not first that is truthy: a manual edit or a
+    migration can leave a high-priority field non-empty but unparseable,
+    and picking by truthiness would stop there and render a garbage date
+    instead of falling through to a usable lower-priority field.
+    """
+    from memory.temporal import (
+        _parse_iso_safe,
+        time_since_label as _time_label,
+        to_naive_local,
+    )
+
+    anchor_dt = None
+    for candidate in (
+        entry.get("event_end_at"),
+        entry.get("event_start_at"),
+        entry.get("created_at"),
+    ):
+        # _parse_iso_safe returns None for None / int / list, so malformed
+        # persisted values cannot raise out of a render.
+        anchor_dt = to_naive_local(_parse_iso_safe(candidate))
+        if anchor_dt is not None:
+            break
+    if anchor_dt is None:
+        return ""
+    date_part = anchor_dt.strftime("%Y-%m-%d")
+    rel = _time_label(anchor_dt.isoformat(), lang=lang)
+    return f"  ({date_part}, {rel})" if rel else f"  ({date_part})"
+
+
+def render_recall_block(
+    results: Sequence[Mapping[str, Any]] | None,
+    lang: str = "zh",
+    *,
+    header_template: str | None = None,
+) -> RenderedRecallBlock:
+    """Render recall hits as the numbered block the model receives.
+
+    ``header_template`` is an already-localized string with an ``{n}``
+    placeholder (the main app's overview line); pass ``None`` for callers
+    that wrap the block in fixed template text of their own. When present
+    it is charged to the block budget, and it is formatted with the number
+    of entries that SURVIVED the budget — announcing "found 10" above a
+    list of 3 makes the model believe it lost seven results and call the
+    tool again.
+
+    Entries with no text are skipped before numbering, so the visible
+    numbers stay 1..n with no gaps.
+    """
+    from config import (
+        RECALL_RENDER_ENTRY_MAX_TOKENS,
+        RECALL_RENDER_LINE_OVERHEAD_TOKENS,
+        RECALL_RENDER_TOTAL_MAX_TOKENS,
+    )
+    from config.prompts.prompts_memory import render_recall_entry_tag
+    from utils.tokenize import (
+        count_tokens,
+        take_lines_within_token_budget,
+        truncate_to_tokens,
+    )
+
+    entries = [item for item in (results or []) if isinstance(item, _MappingABC)]
+    lines: list[str] = []
+    for item in entries:
+        # str() coerce: facts/reflections.json round-trips through JSON, so
+        # text SHOULD be a str — but manual edits, legacy formats and
+        # migration bugs all produce truthy non-strings, and a .strip() on
+        # one of those would take down the whole tool call.
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        text = truncate_to_tokens(text, RECALL_RENDER_ENTRY_MAX_TOKENS)
+        # tier / entity are internal enums (a scoped entry's entity is
+        # always its subject.kind); rendering them raw would push
+        # `[fact/group_chat]` into a Chinese prompt.
+        tag = render_recall_entry_tag(item.get("tier"), item.get("entity"), lang)
+        lines.append(
+            f"{len(lines) + 1}. {tag} {text}{_time_suffix(item, lang)}"
+        )
+    # 行级兜底与编号分开做：编号要按最终顺序连续，而截断只能在整行拼好之后
+    # 量。单条截断只管 text，tag 里的未知枚举是原样透出的，而整段预算的
+    # "至少留一条"规则会无条件留下第一行——畸形 entity 正是从这里进 prompt 的。
+    lines = [
+        truncate_to_tokens(
+            line, RECALL_RENDER_ENTRY_MAX_TOKENS + RECALL_RENDER_LINE_OVERHEAD_TOKENS,
+        )
+        for line in lines
+    ]
+
+    budget = RECALL_RENDER_TOTAL_MAX_TOKENS
+    if header_template is not None:
+        # 用 n=条目总数 估表头开销：最终 n 只会更小、位数只会更少，往大了
+        # 估是安全方向。
+        budget -= count_tokens(header_template.format(n=len(lines))) + count_tokens("\n")
+    kept, dropped = take_lines_within_token_budget(lines, max(0, budget))
+
+    block = list(kept)
+    if header_template is not None:
+        block.insert(0, header_template.format(n=len(kept)))
+    return RenderedRecallBlock(
+        text="\n".join(block), kept=len(kept), dropped=dropped,
+    )

--- a/plugin/plugins/qq_auto_reply/memory_bridge.py
+++ b/plugin/plugins/qq_auto_reply/memory_bridge.py
@@ -253,66 +253,38 @@ class QQMemoryBridge:
         *,
         kept_count_out: list[int] | None = None,
     ) -> str:
-        # tier / entity 是内部枚举（scoped 条目的 entity 恒等于 subject.kind），
-        # 裸拼会让 `[fact/group_chat]` 出现在中文 prompt 里。与本体侧
-        # main_logic/core/tool_calling.py 的召回渲染同一张标签表。
-        #
-        # 预算：这段此前只有"取前 5 条"，单条零上限——一条被合并出来的超长
-        # reflection 就能把召回段撑到几千 token。单条按 token 截断（不丢弃：
-        # 召回按相关度排，命中的那条留半段也比整条消失有用），整段按
-        # take_lines_within_token_budget 收口，与本体侧同一个 helper。
-        from config import (
-            RECALL_RENDER_ENTRY_MAX_TOKENS,
-            RECALL_RENDER_LINE_OVERHEAD_TOKENS,
-            RECALL_RENDER_TOTAL_MAX_TOKENS,
-        )
-        from config.prompts.prompts_memory import render_recall_entry_tag
-        from utils.language_utils import get_global_language_full
-        from utils.tokenize import take_lines_within_token_budget, truncate_to_tokens
+        """Render this group's recall hits through the shared entry point.
 
-        lang = get_global_language_full()
-        lines: list[str] = []
-        for index, item in enumerate(results, start=1):
-            text = str(item.get("text") or "").strip()
-            if not text:
-                continue
-            text = truncate_to_tokens(text, RECALL_RENDER_ENTRY_MAX_TOKENS)
-            tag = render_recall_entry_tag(
-                item.get("tier"), item.get("entity"), lang,
-            )
-            anchor = str(
-                item.get("event_end_at")
-                or item.get("event_start_at")
-                or item.get("created_at")
-                or ""
-            ).strip()
-            suffix = f" ({anchor[:10]})" if anchor else ""
-            # 整行再兜一次底。截断只管 text，而 tag 里的 tier / entity 是
-            # 未知枚举原样透出的（见 render_recall_entry_tag），手改过的
-            # facts.json 能塞进任意长的 entity——而整段预算的"至少留一条"
-            # 规则会无条件留下第一行。行上限用「单条 + 行装饰」的口径，
-            # 正常条目够不着，只有畸形数据会被它切。
-            lines.append(truncate_to_tokens(
-                f"{index}. {tag} {text}{suffix}",
-                RECALL_RENDER_ENTRY_MAX_TOKENS + RECALL_RENDER_LINE_OVERHEAD_TOKENS,
-            ))
-        kept, dropped = take_lines_within_token_budget(
-            lines, RECALL_RENDER_TOTAL_MAX_TOKENS,
-        )
+        No line building happens here. ``memory.recall_render`` is the one
+        place recall results become prompt text — it carries the token
+        budgets, and it carries them once so this side and the main app's
+        ``recall_memory`` tool cannot drift apart (issue #2588; the two
+        used to be hand-written twins). This method only supplies the
+        locale, reports the drop, and adapts the result to the caller's
+        out-param.
+
+        No header: the QQ side wraps the block in ``LONG_TERM_MEMORY_SECTION``
+        instead of an overview line.
+        """
+        from config import RECALL_RENDER_TOTAL_MAX_TOKENS
+        from memory.recall_render import render_recall_block
+        from utils.language_utils import get_global_language_full
+
+        block = render_recall_block(results, get_global_language_full())
         if kept_count_out is not None:
             # out-param 而非改返回签名（与 reply_context_node 的
             # used_member_subject_out 同模式）：既有直调方不受影响。
-            kept_count_out.append(len(kept))
+            kept_count_out.append(block.kept)
         logger = getattr(self.plugin, "logger", None)
-        if dropped and logger is not None:
+        if block.dropped and logger is not None:
             # 诊断行不该成为渲染的硬依赖：这个函数此前对 plugin 对象零依赖，
             # 抛 AttributeError 会被上游 _build_recalled_memory_text 的
             # except 吞掉，整段召回为了一条日志凭空消失。
             logger.info(
                 f"QQ 长期记忆召回段超出 {RECALL_RENDER_TOTAL_MAX_TOKENS} tok 预算，"
-                f"丢弃末尾 {dropped} 条"
+                f"丢弃末尾 {block.dropped} 条"
             )
-        return "\n".join(kept)
+        return block.text
 
     async def post_memory_history(self, endpoint: str, her_name: str, messages: list[dict[str, Any]], *, timeout: float = 5.0) -> dict[str, Any]:
         # QQ currently has no explicit per-conversation locale; do not turn

--- a/tests/unit/test_group_prompt_localization.py
+++ b/tests/unit/test_group_prompt_localization.py
@@ -464,7 +464,10 @@ def test_qq_recall_render_has_no_internal_enum_left():
     assert "[印象/群成员]" in rendered
     assert "fact" not in rendered and "group_chat" not in rendered
     assert "reflection" not in rendered and "group_participant" not in rendered
-    assert "(2026-05-01)" in rendered
+    # 日期后面还跟一个本地化的相对时间标签（"3 月前"）：QQ 侧此前自己用
+    # anchor[:10] 裁日期、没有这个标签，#2588 收口到 memory.recall_render
+    # 之后与本体侧同格式。断言写成前缀，免得跟"今天/几月前"的措辞绑死。
+    assert "(2026-05-01, " in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_recall_render_token_budget.py
+++ b/tests/unit/test_recall_render_token_budget.py
@@ -4,17 +4,35 @@
 bound was "take the first 5"; a single merged reflection could be
 arbitrarily long, so the block had no ceiling at all.
 
-Two twins render that block — the QQ plugin's ``render_relevant_memory``
-and the main program's ``recall_memory`` tool handler. Both cap each entry
-by tokens (truncate, never drop — recall is relevance-ranked, so half of
-the hit still beats none of it) and both stop the block at the total
-budget. The last test in this file discovers the renderers instead of
-listing them, so a third one cannot be added un-budgeted.
+There is now ONE renderer — ``memory.recall_render.render_recall_block``.
+The QQ plugin's ``render_relevant_memory`` and the main app's
+``recall_memory`` tool handler are thin shells over it. That collapse is
+what these tests rest on, and it is why they look different from the
+version this file shipped with:
+
+Until issue #2588 the two shells were hand-written twins, and the guard
+against a third un-budgeted renderer was structural — parse the repo, find
+functions that render recall lines, check they CALL the two budget
+functions. That inference was defeated five times running (substring match,
+module-wide AST walk, a dead helper nested inside the renderer, a budget
+call parked in a return annotation, one parked in ``if False:``), and an
+adversarial pass then measured 12 more ways through, up to 95x over budget.
+The root problem is not fixable by tightening: "will this call execute, and
+is its result used" is undecidable, and each tightening also produced false
+positives that invite someone to weaken the guard later.
+
+So the budget is no longer inferred from source shape. It is measured, on
+the single render path, by the behavioural tests below — oversized input in,
+``count_tokens`` on what comes out. Two much cruder structural checks
+remain, and neither has to reason about execution: nobody but the entry
+point may call the recall label table, and every module that talks to
+``/query_memory`` must import the entry point.
 """
 
 from __future__ import annotations
 
 import ast
+import re
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,6 +41,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from config import RECALL_RENDER_ENTRY_MAX_TOKENS, RECALL_RENDER_TOTAL_MAX_TOKENS
+from memory.recall_render import render_recall_block
 from utils.tokenize import count_tokens
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -111,6 +130,9 @@ def test_shared_helper_always_emits_the_top_ranked_line():
     assert dropped == 1
 
 
+# ── the constants have to add up ─────────────────────────────────────
+
+
 def test_entry_cap_cannot_exceed_the_block_cap():
     """The per-entry cap is what keeps the helper's always-emit-one rule
     from blowing the block budget. Raise it above the total and the first
@@ -150,7 +172,7 @@ def test_block_cap_funds_a_full_page_of_max_length_entries():
     ).parameters["limit"].default
     assert isinstance(limit, int) and limit > 0
 
-    # Both renderers cap each rendered line at ENTRY + OVERHEAD, so a line
+    # The renderer caps each rendered line at ENTRY + OVERHEAD, so a line
     # of exactly that size is the worst case the block has to fund.
     per_line = RECALL_RENDER_ENTRY_MAX_TOKENS + RECALL_RENDER_LINE_OVERHEAD_TOKENS
     unit = "群里聊过的一件事情，"
@@ -182,26 +204,288 @@ def test_line_overhead_allowance_covers_what_the_renderer_actually_adds():
     measurement lands on exactly the allowance being checked and shrinking
     the constant shrinks the measurement with it — the assertion holds for
     any value, which is no assertion at all.
+
+    The decoration is locale-dependent (the tag and the relative-time label
+    are both translated), so every shipped locale has to fit the one
+    allowance.
     """
     from config import RECALL_RENDER_LINE_OVERHEAD_TOKENS
+    from config.prompts.prompts_memory import RECALL_ENTRY_TIER_LABEL
 
     body = "群里聊过的一件事情"
-    with patch("utils.language_utils.get_global_language", return_value="zh"):
-        rendered = _bridge().render_relevant_memory([
-            {
+    for lang in sorted(RECALL_ENTRY_TIER_LABEL["reflection"]):
+        rendered = render_recall_block(
+            [{
                 "text": body,
                 "tier": "reflection",
                 "entity": "group_participant",
                 "created_at": "2026-05-01T10:00:00",
-            },
-        ])
+            }],
+            lang,
+        ).text
 
-    assert body in rendered, "夹具失效：短条目被截断了，量到的就不是纯装饰"
-    overhead = count_tokens(rendered) - count_tokens(body)
-    assert 0 < overhead <= RECALL_RENDER_LINE_OVERHEAD_TOKENS, (
-        f"实测行装饰 {overhead} tok 超出预留的 "
-        f"{RECALL_RENDER_LINE_OVERHEAD_TOKENS} tok"
+        assert body in rendered, f"[{lang}] 夹具失效：短条目被截断了，量到的就不是纯装饰"
+        overhead = count_tokens(rendered) - count_tokens(body)
+        assert 0 < overhead <= RECALL_RENDER_LINE_OVERHEAD_TOKENS, (
+            f"[{lang}] 实测行装饰 {overhead} tok 超出预留的 "
+            f"{RECALL_RENDER_LINE_OVERHEAD_TOKENS} tok：{rendered!r}"
+        )
+
+
+# ── the single entry point: measured, not inferred ───────────────────
+
+
+def test_entry_point_truncates_an_oversized_entry_instead_of_dropping_it():
+    """A merged reflection can be thousands of tokens. Cut it, don't lose
+    it — the entry is there because it ranked highest for this query.
+
+    The per-line cap would bound the total on its own, so size alone
+    cannot tell the two apart. What only the per-entry cap buys is room
+    for the decoration: it trims the TEXT, leaving the trailing time
+    anchor intact, where a line-level cut would take the date off the end.
+    """
+    long_text = "露营的细节" * 2000
+    assert count_tokens(long_text) > RECALL_RENDER_ENTRY_MAX_TOKENS
+
+    rendered = render_recall_block([{
+        "text": long_text,
+        "tier": "fact",
+        "entity": "group_chat",
+        "created_at": "2026-05-01T10:00:00",
+    }], "zh").text
+
+    assert "露营的细节" in rendered, "超长条目应被截断保留，而不是整条消失"
+    assert re.search(r"\(2026-05-01(, .+)?\)$", rendered.rstrip()), (
+        f"正文没先按单条上限截断，时间后缀被整行截断吃掉了：{rendered[-40:]!r}"
     )
+    assert count_tokens(rendered) <= RECALL_RENDER_ENTRY_MAX_TOKENS + 32, (
+        f"单条召回未按 {RECALL_RENDER_ENTRY_MAX_TOKENS} tok 截断"
+    )
+
+
+def test_entry_point_block_stops_at_the_total_budget():
+    """Ten near-max entries must not add up to a 4000-token prompt block."""
+    chunk = "群里聊过的一件事情" * 200
+    results = [_result(f"{i}{chunk}") for i in range(10)]
+
+    block = render_recall_block(results, "zh")
+
+    assert block.text
+    assert count_tokens(block.text) <= RECALL_RENDER_TOTAL_MAX_TOKENS, (
+        f"召回段整体 {count_tokens(block.text)} tok 超过 "
+        f"{RECALL_RENDER_TOTAL_MAX_TOKENS} tok 预算"
+    )
+    # The block is a prefix of the relevance ranking, not a length-sorted
+    # subset: the top hit is always in and the tail is what goes.
+    assert block.text.startswith("1. ")
+    assert "10. " not in block.text
+    assert block.kept + block.dropped == 10, (
+        f"kept={block.kept} + dropped={block.dropped} 对不上喂进去的 10 条，"
+        f"调用方的日志会按这个数报错"
+    )
+
+
+def test_entry_point_keeps_short_entries_verbatim():
+    """The budget must not touch the ordinary case."""
+    block = render_recall_block([
+        _result("群里在聊露营"),
+        _result("阿离喜欢辣条", tier="reflection", entity="group_participant"),
+    ], "zh")
+
+    assert "群里在聊露营" in block.text
+    assert "阿离喜欢辣条" in block.text
+    assert block.text.count("\n") == 1
+    assert (block.kept, block.dropped) == (2, 0)
+
+
+def test_entry_point_numbers_stay_contiguous_when_an_entry_has_no_text():
+    """A textless entry is skipped BEFORE numbering, not after.
+
+    Both former twins filtered inside an ``enumerate`` over the raw
+    results, so an empty hit burned its index and the model was handed
+    ``1. ... / 3. ...`` — a gap it can only read as "entry 2 was withheld
+    from me".
+    """
+    block = render_recall_block([
+        _result("第一条"),
+        _result("   "),
+        {"text": None, "tier": "fact", "entity": "group_chat"},
+        _result("最后一条"),
+    ], "zh")
+
+    numbers = [ln.split(".", 1)[0] for ln in block.text.split("\n")]
+    assert numbers == ["1", "2"], f"编号出现跳号：{block.text!r}"
+    assert block.kept == 2
+
+
+def test_entry_point_skips_non_mapping_entries():
+    """Upstream JSON is not a contract. A malformed ``results`` list with a
+    string or None in it must not take the whole tool call down with an
+    AttributeError."""
+    block = render_recall_block(
+        ["不是 dict", None, 42, _result("真正的一条")], "zh",
+    )
+
+    assert block.text.startswith("1. ")
+    assert "真正的一条" in block.text
+    assert block.kept == 1
+
+
+_LONG_TAG_RESULT = {
+    "text": "群里在聊露营",
+    "tier": "fact",
+    # `render_recall_entry_tag` echoes unknown enums verbatim, and a
+    # hand-edited facts.json can hold anything here. The per-entry cap
+    # only trims `text`, so without a line-level cap this rides straight
+    # into the prompt — and the block's always-keep-one rule guarantees
+    # it is never the entry that gets dropped.
+    "entity": "损坏的超长 entity 值" * 500,
+}
+
+
+def test_entry_point_bounds_a_line_whose_tag_is_corrupt():
+    rendered = render_recall_block([_LONG_TAG_RESULT], "zh").text
+
+    assert count_tokens(rendered) <= RECALL_RENDER_TOTAL_MAX_TOKENS, (
+        f"畸形 entity 让整段涨到 {count_tokens(rendered)} tok，越过了 "
+        f"{RECALL_RENDER_TOTAL_MAX_TOKENS} 的安全上限"
+    )
+
+
+@pytest.mark.parametrize(
+    "entry,expected",
+    [
+        (
+            {
+                "event_end_at": "2026-05-03T10:00:00",
+                "event_start_at": "2026-05-02T10:00:00",
+                "created_at": "2026-06-01T10:00:00",
+            },
+            "2026-05-03",
+        ),
+        (
+            {
+                "event_start_at": "2026-05-02T10:00:00",
+                "created_at": "2026-06-01T10:00:00",
+            },
+            "2026-05-02",
+        ),
+        ({"created_at": "2026-06-01T10:00:00"}, "2026-06-01"),
+        # Non-empty but unparseable high-priority fields must fall through
+        # rather than stop the search — a manual edit or a migration leaves
+        # exactly this shape, and picking by truthiness renders a garbage
+        # date while a usable anchor sits one field down.
+        (
+            {
+                "event_end_at": "去年夏天",
+                "event_start_at": 1234567890,
+                "created_at": "2026-06-01T10:00:00",
+            },
+            "2026-06-01",
+        ),
+    ],
+    ids=["event_end", "event_start", "created", "unparseable-falls-through"],
+)
+def test_entry_point_anchors_on_when_it_happened_not_when_it_was_written(
+    entry, expected,
+):
+    """``event_end_at`` → ``event_start_at`` → ``created_at``, same order as
+    the persona stale block and temporal ``_past_anchor``.
+
+    These fields had ZERO fixtures in this file before issue #2588, which
+    is how B7 ("append un-budgeted text keyed on a field nobody sets") got
+    past all 24 tests here.
+    """
+    rendered = render_recall_block(
+        [{"text": "露营", "tier": "fact", "entity": "user", **entry}], "zh",
+    ).text
+
+    assert expected in rendered, f"时间锚点选错了：{rendered!r}"
+
+
+def test_entry_point_stays_in_budget_with_every_time_field_populated():
+    """Budget measured on entries where EVERY renderable field is set.
+
+    The sparse fixtures elsewhere in this file leave the event-time fields
+    empty, so text appended after the budget on their account was free —
+    measured at 1.01x and climbing with the data (issue #2588, B7). Fill
+    them in and the same append is a red test.
+    """
+    chunk = "露营的细节" * 200
+    results = [
+        {
+            "text": f"{i}{chunk}",
+            "tier": "reflection",
+            "entity": "group_participant",
+            "event_start_at": "2026-05-01T09:00:00",
+            "event_end_at": "2026-05-03T18:30:00",
+            "created_at": "2026-06-01T10:00:00",
+        }
+        for i in range(10)
+    ]
+
+    block = render_recall_block(results, "zh")
+
+    assert count_tokens(block.text) <= RECALL_RENDER_TOTAL_MAX_TOKENS, (
+        f"条目字段填满后整段 {count_tokens(block.text)} tok 超过预算 "
+        f"{RECALL_RENDER_TOTAL_MAX_TOKENS}——有内容是在预算之后追加的"
+    )
+    assert block.dropped, "夹具失效：没触发丢弃，这条用例什么都没测到"
+
+
+@pytest.mark.parametrize("lang", ["zh", "en", "ja"])
+def test_entry_point_charges_the_header_to_the_same_budget(lang):
+    """The overview line lands in the same string, so it comes out of the
+    same allowance.
+
+    The gate is set right at "two entries plus the header", where leaving
+    the header unpaid buys exactly one entry too many. A roomier fixture
+    cannot show this: the greedy stop usually leaves more slack than a
+    header costs, so the block stays under budget either way and the
+    assertion passes for the wrong reason. Header width is locale-
+    dependent (``ja`` is over twice ``en``), hence the parametrize —
+    a reservation tuned against Chinese would pass zh and fail ja.
+    """
+    from config.prompts.prompts_memory import RECALL_MEMORY_TOOL_FOUND_HEADER
+
+    header_template = RECALL_MEMORY_TOOL_FOUND_HEADER[lang]
+    results = [_result(f"第{i}条召回到的记忆内容") for i in range(4)]
+    probe = render_recall_block(results[:1], lang, header_template=header_template)
+    line_cost = count_tokens(probe.text.split("\n")[1])
+    gate = 2 * line_cost + count_tokens(header_template.format(n=2))
+
+    with patch("config.RECALL_RENDER_TOTAL_MAX_TOKENS", gate):
+        block = render_recall_block(results, lang, header_template=header_template)
+
+    assert block.kept, "夹具失效：一条都没渲染出来"
+    assert count_tokens(block.text) <= gate, (
+        f"locale={lang}：整段 {count_tokens(block.text)} tok 超过闸门 {gate}"
+        f"——首行总览没有从预算里扣掉"
+    )
+
+
+def test_entry_point_header_counts_what_survived():
+    """Announcing "found 10" and then listing 3 makes the model believe it
+    lost seven results and call the tool again."""
+    from config.prompts.prompts_memory import RECALL_MEMORY_TOOL_FOUND_HEADER
+
+    chunk = "聊过的一件事情" * 200
+    template = RECALL_MEMORY_TOOL_FOUND_HEADER["zh"]
+    block = render_recall_block(
+        [_result(f"{i}{chunk}") for i in range(10)], "zh",
+        header_template=template,
+    )
+
+    lines = block.text.split("\n")
+    listed = [ln for ln in lines[1:] if ln.strip()]
+    assert listed, "夹具失效：一条都没渲染出来"
+    assert len(listed) < 10, "夹具失效：没触发丢弃，这条用例什么都没测到"
+    # 整行相等，不是子串包含：`str(4) in "找到 41 条相关记忆"` 会放过任何
+    # 以正确数字开头的错误计数。
+    assert lines[0] == template.format(n=len(listed)), (
+        f"首行总览与实际条数不符：{lines[0]!r} vs {len(listed)} 条"
+    )
+    assert block.kept == len(listed)
 
 
 def test_a_full_page_of_max_length_entries_all_survive():
@@ -218,8 +502,7 @@ def test_a_full_page_of_max_length_entries_all_survive():
         for i in range(5)
     ]
 
-    with patch("utils.language_utils.get_global_language", return_value="zh"):
-        rendered = _bridge().render_relevant_memory(results)
+    rendered = render_recall_block(results, "zh").text
 
     assert len(rendered.split("\n")) == 5, (
         f"5 条满额召回没能全部进 prompt：\n{rendered[:200]}"
@@ -227,7 +510,7 @@ def test_a_full_page_of_max_length_entries_all_survive():
     assert rendered.startswith("1. ") and "\n5. " in rendered
 
 
-# ── plugin side: memory_bridge.render_relevant_memory ────────────────
+# ── the two shells that call it ──────────────────────────────────────
 
 
 def _bridge():
@@ -236,68 +519,55 @@ def _bridge():
     return QQMemoryBridge(SimpleNamespace(logger=MagicMock()))
 
 
-def test_plugin_recall_truncates_an_oversized_entry_instead_of_dropping_it():
-    """A merged reflection can be thousands of tokens. Cut it, don't lose
-    it — the entry is there because it ranked highest for this query.
+def test_plugin_shell_renders_the_budgeted_block():
+    """The QQ side is a shell: same input, same string as the entry point.
 
-    The per-line cap would bound the total on its own, so size alone
-    cannot tell the two apart. What only the per-entry cap buys is room
-    for the decoration: it trims the TEXT, leaving the trailing date
-    intact, where a line-level cut would take the date off the end.
+    Compared against the entry point's own output rather than re-asserting
+    the budget, so this stays true if the format changes — what it pins is
+    that the shell adds no line building of its own. (It has: this side
+    used to cut its own date suffix with ``anchor[:10]``, losing the
+    relative-time label the main app showed.)
     """
-    long_text = "露营的细节" * 2000
-    assert count_tokens(long_text) > RECALL_RENDER_ENTRY_MAX_TOKENS
-
-    with patch("utils.language_utils.get_global_language", return_value="zh"):
-        rendered = _bridge().render_relevant_memory([{
-            "text": long_text,
-            "tier": "fact",
-            "entity": "group_chat",
+    results = [
+        _result("群里在聊露营"),
+        {
+            "text": "阿离喜欢辣条",
+            "tier": "reflection",
+            "entity": "group_participant",
             "created_at": "2026-05-01T10:00:00",
-        }])
+        },
+    ]
+    kept_out: list[int] = []
 
-    assert rendered, "超长条目应被截断保留，而不是整条消失"
-    assert "露营的细节" in rendered
-    assert rendered.rstrip().endswith("(2026-05-01)"), (
-        "正文没先按单条上限截断，日期后缀被整行截断吃掉了"
-    )
-    assert count_tokens(rendered) <= RECALL_RENDER_ENTRY_MAX_TOKENS + 32, (
-        f"单条召回未按 {RECALL_RENDER_ENTRY_MAX_TOKENS} tok 截断"
-    )
+    with patch(
+        "utils.language_utils.get_global_language_full", return_value="zh",
+    ):
+        rendered = _bridge().render_relevant_memory(results, kept_count_out=kept_out)
+
+    assert rendered == render_recall_block(results, "zh").text
+    assert kept_out == [2]
 
 
-def test_plugin_recall_block_stops_at_the_total_budget():
-    """Ten near-max entries must not add up to a 4000-token prompt block."""
+def test_plugin_shell_reports_the_drop_without_needing_a_logger():
+    """A missing logger must never cost the user their memory block.
+
+    ``render_relevant_memory`` had no plugin dependency at all until a
+    diagnostic line was added; an AttributeError there is swallowed by the
+    caller's ``except`` and the whole recall block silently disappears.
+    """
     chunk = "群里聊过的一件事情" * 200
-    results = [_result(f"{i}{chunk}") for i in range(10)]
+    bridge = _bridge()
+    bridge.plugin = SimpleNamespace()  # no .logger at all
 
-    with patch("utils.language_utils.get_global_language", return_value="zh"):
-        rendered = _bridge().render_relevant_memory(results)
+    with patch(
+        "utils.language_utils.get_global_language_full", return_value="zh",
+    ):
+        rendered = bridge.render_relevant_memory(
+            [_result(f"{i}{chunk}") for i in range(10)],
+        )
 
-    assert rendered
-    assert count_tokens(rendered) <= RECALL_RENDER_TOTAL_MAX_TOKENS, (
-        f"召回段整体超过 {RECALL_RENDER_TOTAL_MAX_TOKENS} tok 预算"
-    )
-    # The block is a prefix of the relevance ranking, not a length-sorted
-    # subset: the top hit is always in and the tail is what goes.
     assert rendered.startswith("1. ")
-    assert "10. " not in rendered
-
-
-def test_plugin_recall_keeps_short_entries_verbatim():
-    """The budget must not touch the ordinary case."""
-    with patch("utils.language_utils.get_global_language", return_value="zh"):
-        rendered = _bridge().render_relevant_memory([
-            _result("群里在聊露营"),
-            _result("阿离喜欢辣条", tier="reflection", entity="group_participant"),
-        ])
-
-    assert "群里在聊露营" in rendered
-    assert "阿离喜欢辣条" in rendered
-    assert rendered.count("\n") == 1
-
-
-# ── main-app twin: the recall_memory tool handler ────────────────────
+    assert count_tokens(rendered) <= RECALL_RENDER_TOTAL_MAX_TOKENS
 
 
 class _ToolHarness:
@@ -312,7 +582,9 @@ class _ToolHarness:
         self.memory_server_port = 12345
 
 
-async def _call_tool(results: list[dict]) -> str:
+async def _call_tool_in(lang: str, results: list[dict]) -> str:
+    harness = _ToolHarness()
+    harness.user_language = lang
     payload = {"results": results, "elapsed_ms": 3.0}
     response = SimpleNamespace(
         is_success=True, status_code=200, text="", json=lambda: payload,
@@ -322,35 +594,15 @@ async def _call_tool(results: list[dict]) -> str:
         "utils.internal_http_client.get_internal_http_client",
         return_value=client,
     ):
-        return await _ToolHarness()._handle_recall_memory_call({"query": "露营"})
+        return await harness._handle_recall_memory_call({"query": "露营"})
+
+
+async def _call_tool(results: list[dict]) -> str:
+    return await _call_tool_in("zh", results)
 
 
 @pytest.mark.asyncio
-async def test_tool_recall_truncates_an_oversized_entry_instead_of_dropping_it():
-    """Main-app twin of the plugin cap. This repo has shipped a group-side
-    fix without the private-side one before.
-
-    Same reasoning as the plugin twin: the time suffix surviving is what
-    distinguishes trimming the text from cutting the whole line.
-    """
-    long_text = "露营的细节" * 2000
-    rendered = await _call_tool([{
-        "text": long_text,
-        "tier": "fact",
-        "entity": "group_chat",
-        "created_at": "2026-05-01T10:00:00",
-    }])
-
-    assert "露营的细节" in rendered
-    assert rendered.rstrip().endswith(")"), (
-        "正文没先按单条上限截断，时间后缀被整行截断吃掉了"
-    )
-    assert "2026-05-01" in rendered
-    assert count_tokens(rendered) <= RECALL_RENDER_ENTRY_MAX_TOKENS + 64
-
-
-@pytest.mark.asyncio
-async def test_tool_recall_block_stops_at_the_total_budget():
+async def test_tool_shell_block_stops_at_the_total_budget():
     """hybrid_recall returns more than the plugin's five, so this side is
     where the total gate actually binds.
 
@@ -371,63 +623,25 @@ async def test_tool_recall_block_stops_at_the_total_budget():
     )
 
 
-async def _call_tool_in(lang: str, results: list[dict]) -> str:
-    harness = _ToolHarness()
-    harness.user_language = lang
-    payload = {"results": results, "elapsed_ms": 3.0}
-    response = SimpleNamespace(
-        is_success=True, status_code=200, text="", json=lambda: payload,
-    )
-    client = SimpleNamespace(post=AsyncMock(return_value=response))
-    with patch(
-        "utils.internal_http_client.get_internal_http_client",
-        return_value=client,
-    ):
-        return await harness._handle_recall_memory_call({"query": "露营"})
-
-
-@pytest.mark.parametrize("lang", ["zh", "en", "ja"])
 @pytest.mark.asyncio
-async def test_tool_recall_reserves_room_for_its_localized_header(lang):
-    """The overview line lands in the same string, so it comes out of the
-    same allowance.
-
-    The gate is set right at "two entries plus the header", where leaving
-    the header unpaid buys exactly one entry too many. A roomier fixture
-    cannot show this: the greedy stop usually leaves more slack than a
-    header costs, so the block stays under budget either way and the
-    assertion passes for the wrong reason. Header width is locale-
-    dependent (``ja`` is over twice ``en``), hence the parametrize —
-    a reservation tuned against Chinese would pass zh and fail ja.
-    """
+async def test_tool_shell_passes_its_localized_header_to_the_entry_point():
+    """The overview line is the tool side's own contribution, and it is
+    charged to the block budget only because the shell hands it over as
+    ``header_template`` — a shell that formatted it itself and prepended
+    the result would put it outside the budget again."""
     from config.prompts.prompts_memory import RECALL_MEMORY_TOOL_FOUND_HEADER
 
-    results = [_result(f"第{i}条召回到的记忆内容") for i in range(4)]
-    rendered_probe = await _call_tool_in(lang, results[:1])
-    header_probe = RECALL_MEMORY_TOOL_FOUND_HEADER[lang].format(n=2)
-    line_cost = count_tokens(rendered_probe.split("\n")[1])
-    header_cost = count_tokens(header_probe)
-    gate = 2 * line_cost + header_cost
+    results = [_result("露营那次带了帐篷"), _result("阿离没去")]
 
-    with patch(
-        # tool_calling 在函数体里 `from config import ...`，每次调用都重新
-        # 绑定，所以必须打在 config 上而不是模块属性上。
-        "config.RECALL_RENDER_TOTAL_MAX_TOKENS", gate,
-    ):
-        rendered = await _call_tool_in(lang, results)
+    rendered = await _call_tool(results)
 
-    listed = [ln for ln in rendered.split("\n")[1:] if ln.strip()]
-    assert listed, "夹具失效：一条都没渲染出来"
-    assert count_tokens(rendered) <= gate, (
-        f"locale={lang}：整段 {count_tokens(rendered)} tok 超过闸门 {gate}"
-        f"——首行总览没有从预算里扣掉"
-    )
+    assert rendered == render_recall_block(
+        results, "zh", header_template=RECALL_MEMORY_TOOL_FOUND_HEADER["zh"],
+    ).text
 
 
 @pytest.mark.asyncio
-async def test_tool_recall_header_count_matches_what_was_actually_rendered():
-    """Announcing "found 10" and then listing 3 makes the model believe it
-    lost seven results and call the tool again."""
+async def test_tool_shell_header_count_matches_what_was_actually_rendered():
     chunk = "聊过的一件事情" * 200
     rendered = await _call_tool([_result(f"{i}{chunk}") for i in range(10)])
 
@@ -437,44 +651,9 @@ async def test_tool_recall_header_count_matches_what_was_actually_rendered():
     listed = [ln for ln in lines[1:] if ln.strip()]
     assert listed, "夹具失效：一条都没渲染出来"
     assert len(listed) < 10, "夹具失效：没触发丢弃，这条用例什么都没测到"
-    # 整行相等，不是子串包含：`str(4) in "找到 41 条相关记忆"` 会放过任何
-    # 以正确数字开头的错误计数。
     assert lines[0] == RECALL_MEMORY_TOOL_FOUND_HEADER["zh"].format(
         n=len(listed)
     ), f"首行总览与实际条数不符：{lines[0]!r} vs {len(listed)} 条"
-
-
-# ── nothing on a rendered line is unbounded ──────────────────────────
-
-
-_LONG_TAG_RESULT = {
-    "text": "群里在聊露营",
-    "tier": "fact",
-    # `render_recall_entry_tag` echoes unknown enums verbatim, and a
-    # hand-edited facts.json can hold anything here. The per-entry cap
-    # only trims `text`, so without a line-level cap this rides straight
-    # into the prompt — and the block's always-keep-one rule guarantees
-    # it is never the entry that gets dropped.
-    "entity": "损坏的超长 entity 值" * 500,
-}
-
-
-def test_plugin_recall_bounds_a_line_whose_tag_is_corrupt():
-    with patch("utils.language_utils.get_global_language", return_value="zh"):
-        rendered = _bridge().render_relevant_memory([_LONG_TAG_RESULT])
-
-    assert count_tokens(rendered) <= RECALL_RENDER_TOTAL_MAX_TOKENS, (
-        f"畸形 entity 让整段涨到 {count_tokens(rendered)} tok，越过了 "
-        f"{RECALL_RENDER_TOTAL_MAX_TOKENS} 的安全上限"
-    )
-
-
-@pytest.mark.asyncio
-async def test_tool_recall_bounds_a_line_whose_tag_is_corrupt():
-    """Main-app twin of the same hole."""
-    rendered = await _call_tool([_LONG_TAG_RESULT])
-
-    assert count_tokens(rendered) <= RECALL_RENDER_TOTAL_MAX_TOKENS
 
 
 # ── recall tokenization stays off the event loop ─────────────────────
@@ -515,7 +694,7 @@ async def test_plugin_recall_render_runs_off_the_event_loop():
 
     with patch.object(bridge, "_client", return_value=client), \
             patch("utils.tokenize.truncate_to_tokens", recording), \
-            patch("utils.language_utils.get_global_language", return_value="zh"):
+            patch("utils.language_utils.get_global_language_full", return_value="zh"):
         await bridge.query_relevant_memory("Neko", "露营")
 
     assert threads, "夹具失效：渲染根本没调用 truncate_to_tokens"
@@ -563,596 +742,194 @@ def test_qq_section_wrapper_stays_fixed_size():
     )
 
 
-# ── discovery guard: no un-budgeted third renderer ───────────────────
+# ── structural guards: the entry point is the only way in ────────────
+#
+# Deliberately crude. Neither of these asks whether a budget call executes
+# or whether its result is used — that question is undecidable, five
+# rounds of trying is what issue #2588 documents, and the answer here is
+# that there is only one render path and it is measured above. What is
+# left is to keep it the ONLY one.
 
-# ONE literal, used by both the module scan and the function scan. They
-# each held their own copy until the two were noticed drifting apart in
-# review — and a docstring below claimed they were already unified.
-_RECALL_RENDER_MARKER = "render_recall_entry_tag"
+_ENTRY_POINT = "memory/recall_render.py"
+
+_SKIP_DIR_PARTS = {
+    ".venv", "venv", "node_modules", "__pycache__", ".git", "build",
+    "dist", ".claude", "tests", "docs",
+}
 
 
-def _discovered_recall_renderers() -> dict[str, str]:
-    """Every module that renders a recall block, found by scanning.
+def _repo_python_sources() -> dict[str, str]:
+    """``{relative posix path: source}`` for every non-test module.
 
-    A hand-kept list only covers the sites whoever wrote it knew about,
-    and this repo's recall block has already grown from one to two. The
-    marker is ``render_recall_entry_tag`` — the shared label table both
-    shipped recall renderers go through — so a third one written the same
-    way shows up here the moment it exists.
-
-    ⚠️ KNOWN BLIND SPOT — see issue #2588. The marker is a proxy for "renders
-    the localized tier/entity prefix", not for "renders recall results into
-    a prompt", and the two come apart for any surface that reasonably
-    chooses NOT to label its entries — a 1:1 chat, where every entity is
-    the same, is the obvious case. Such a renderer contains no marker, is
-    never parsed, and every guard below silently skips it. Nothing here
-    detects that; do not read a green run as "no un-budgeted renderer
-    exists".
+    An unreadable file FAILS rather than being skipped. The previous scan
+    swallowed ``OSError`` / ``UnicodeDecodeError`` with a ``continue``, so
+    a module in any other encoding was silently exempt from every guard
+    below — measured at 10x over budget (issue #2588, A3).
     """
-    marker = _RECALL_RENDER_MARKER
-    skip_parts = {
-        ".venv", "venv", "node_modules", "__pycache__", ".git", "build",
-        "dist", ".claude", "tests",
-    }
-    renderers: dict[str, str] = {}
+    sources: dict[str, str] = {}
+    unreadable: list[str] = []
     for path in _REPO_ROOT.rglob("*.py"):
         # Relative parts, not absolute: this checkout lives under a
         # `.claude/worktrees/...` path, so filtering on absolute parts
         # skips the entire repository and the scan silently finds nothing.
         rel = path.relative_to(_REPO_ROOT)
-        if skip_parts & set(rel.parts):
+        if _SKIP_DIR_PARTS & set(rel.parts):
             continue
         try:
-            source = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        if marker not in source:
-            continue
-        # The label table's own module defines the marker; it renders no block.
-        if rel.as_posix() == "config/prompts/prompts_memory.py":
-            continue
-        renderers[rel.as_posix()] = source
-    return renderers
+            sources[rel.as_posix()] = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            unreadable.append(f"{rel.as_posix()} ({type(exc).__name__})")
+    assert not unreadable, (
+        f"这些 .py 读不出来，下面的护栏对它们是空转的：{unreadable}。"
+        f"非 UTF-8 模块请转成 UTF-8，别让扫描静默跳过"
+    )
+    return sources
 
 
-_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+def _files_calling(sources: dict[str, str], func_name: str) -> set[str]:
+    """Files with a CALL to ``func_name`` — ``def`` and ``import`` don't count.
 
-
-def _called_function_names(node: ast.AST) -> set[str]:
-    """Function names called on `node`'s OWN execution path.
-
-    Two exclusions, both of them holes this guard has already been through:
-
-    Nested scopes. ``ast.walk`` descends into nested ``def`` / ``class`` /
-    ``lambda`` bodies, which attributes a nested helper's calls to the
-    function enclosing it: park a never-called ``def`` inside the real
-    renderer, move both budget calls into it, and the renderer looks
-    budgeted while its actual render path is not. A nested function that
-    renders a recall block of its own is picked up on its own by
-    ``_recall_render_functions`` — being nested does not exempt it, and
-    being an enclosing scope does not earn credit for it.
-
-    Signature and decorator fields. Seeding from ``iter_child_nodes(node)``
-    also sweeps ``decorator_list``, ``args`` (parameter defaults and
-    annotations) and ``returns``. Those run at def/import time, not on the
-    render path — and under ``from __future__ import annotations`` an
-    annotation is never evaluated at all — so a budget call parked in a
-    return annotation satisfies the guard while the body stays unbounded.
-    Seed from ``node.body``: the statements that actually execute when the
-    renderer is called.
-
-    Statically dead statements. ``if False:`` / ``if 0:`` /
-    ``if TYPE_CHECKING:`` bodies, ``while False:`` bodies, and anything
-    after an unconditional ``return`` / ``raise`` / ``break`` / ``continue``
-    never run, so a budget call parked in one of them is the nested-helper
-    trick again without the helper.
-
-    Comprehensions are NOT skipped: they carry their own scope at runtime
-    but a call inside one is genuinely on this function's execution path.
-
-    ⚠️ WHAT THIS DOES NOT DO, stated because this docstring has already
-    been wrong twice. It is constant folding, not reachability analysis:
-    a branch on a module-level or env flag, a call after ``sys.exit()``,
-    an ``except`` clause that cannot fire, a loop that never iterates —
-    all still count as "called". And even perfect reachability would not
-    settle the real question, because the guard checks that the budget
-    functions are CALLED, never that their results are USED: discard the
-    return value of ``take_lines_within_token_budget`` and join the
-    original list, or append un-budgeted text after the budget runs, and
-    every check here stays green while the prompt is unbounded. Both were
-    measured (45x and 1.01x-and-climbing over budget); issue #2588 has the
-    full list.
-
-    So: a green run here means "no recall renderer has an obviously
-    decorative budget call". It does not mean the budget runs, and it does
-    not mean the block is bounded. What actually bounds the two shipped
-    renderers is the behavioural tests in this file, which render
-    oversized input and measure the result. Adversarial fixtures for every
-    shape this function DOES catch live in
-    ``test_call_scan_ignores_names_that_never_run``, with the strict dual
-    in ``test_call_scan_still_sees_budget_calls_that_do_run``.
+    Call sites, not text: mentioning the name in a comment, importing it,
+    or defining it is not calling it. Attribute calls (``mod.f(...)``)
+    count on the attribute name, so re-exporting the table under another
+    module does not launder it.
     """
-    names: set[str] = set()
-    _collect_calls_in_block(getattr(node, 'body', []) or [], names)
-    return names
-
-
-_TERMINATORS = (ast.Return, ast.Raise, ast.Break, ast.Continue)
-
-# `match_case` only exists on 3.10+; the tuple stays valid either way.
-_MATCH_CASE = getattr(ast, "match_case", ())
-
-
-def _constant_truth(test: ast.AST) -> bool | None:
-    """`True`/`False` when `test` is decidable at parse time, else `None`.
-
-    ``TYPE_CHECKING`` counts as False: it is True only for type checkers,
-    and never when the renderer actually runs.
-    """
-    if isinstance(test, ast.Constant):
+    out: set[str] = set()
+    for rel, source in sources.items():
         try:
-            return bool(test.value)
-        except Exception:  # pragma: no cover — exotic __bool__ in a literal
-            return None
-    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
-        inner = _constant_truth(test.operand)
-        return None if inner is None else (not inner)
-    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
-        return False
-    if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
-        return False
-    return None
-
-
-def _collect_calls_in_block(body: list, names: set[str]) -> None:
-    """Walk a statement list, skipping branches that cannot execute."""
-    for stmt in body:
-        if isinstance(stmt, _NESTED_SCOPES):
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover — a broken file fails elsewhere
             continue
-        if isinstance(stmt, ast.If):
-            truth = _constant_truth(stmt.test)
-            if truth is True:
-                _collect_calls_in_block(stmt.body, names)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
                 continue
-            if truth is False:
-                _collect_calls_in_block(stmt.orelse, names)
-                continue
-        if isinstance(stmt, ast.While) and _constant_truth(stmt.test) is False:
-            _collect_calls_in_block(stmt.orelse, names)
-            continue
-        # Hand nested statement LISTS over whole, not one statement at a
-        # time. `iter_child_nodes` flattens them, and a one-element list
-        # makes the terminator rule below a no-op inside every compound
-        # statement — `for ...: return; truncate_to_tokens(...)` would
-        # still count. That made the docstring's "anything after an
-        # unconditional return" true only of the outermost block.
-        for field, value in ast.iter_fields(stmt):
-            if isinstance(value, list) and value and isinstance(value[0], ast.stmt):
-                _collect_calls_in_block(value, names)
-            elif isinstance(value, ast.stmt):
-                _collect_calls_in_block([value], names)
-            elif isinstance(value, ast.AST):
-                _collect_calls_in_expr(value, names)
-            elif isinstance(value, list):
-                for item in value:
-                    if isinstance(item, ast.AST):
-                        _collect_calls_in_expr(item, names)
-        if isinstance(stmt, _TERMINATORS):
-            return
-
-
-def _collect_calls_in_expr(node: ast.AST, names: set[str]) -> None:
-    """Collect call names from an expression subtree.
-
-    Recurses back into `_collect_calls_in_block` for any statement it meets
-    so the two halves cannot drift. ``except`` clauses and ``match`` cases
-    are neither statements nor expressions in the grammar (`excepthandler`
-    / `match_case`), so they get an explicit hand-off — otherwise their
-    bodies arrive here one statement at a time and the terminator rule
-    stops applying inside them.
-    """
-    stack = [node]
-    while stack:
-        child = stack.pop()
-        if isinstance(child, _NESTED_SCOPES):
-            continue
-        if isinstance(child, ast.stmt):
-            _collect_calls_in_block([child], names)
-            continue
-        if isinstance(child, (ast.ExceptHandler, _MATCH_CASE)):
-            for _field, value in ast.iter_fields(child):
-                if isinstance(value, list) and value and isinstance(value[0], ast.stmt):
-                    _collect_calls_in_block(value, names)
-                elif isinstance(value, ast.AST):
-                    _collect_calls_in_expr(value, names)
-            continue
-        if isinstance(child, ast.Call):
-            func = child.func
-            if isinstance(func, ast.Name):
-                names.add(func.id)
-            elif isinstance(func, ast.Attribute):
-                names.add(func.attr)
-        stack.extend(ast.iter_child_nodes(child))
-
-
-def _recall_render_functions(source: str) -> list[ast.AST]:
-    """The function(s) in `source` that actually render a recall block.
-
-    Scoping is the whole point. Collecting call names from the MODULE root
-    sweeps up every call in the file, so a function nobody ever calls can
-    satisfy the guards below on the renderer's behalf: rewrite the real
-    ``take_lines_within_token_budget(...)`` as a hand-rolled loop, park a
-    dead helper mentioning the old names at the bottom of the module, and
-    both guards stay green while unbounded memory text reaches the prompt.
-    Substring matching was the first hole in this wall (a comment could
-    satisfy it), AST-over-the-module was the second, and AST-over-the-
-    function-including-its-nested-defs was the third — same trick, one
-    indent level in.
-
-    A renderer is identified by `_RECALL_RENDER_MARKER`, the same literal
-    the module scan uses — one constant, so the two steps cannot come to
-    disagree about what a recall renderer is. (They held separate copies
-    of the string until review noticed, while this paragraph already
-    claimed they were unified.) Matching is on the function's own body, so
-    an enclosing scope is not credited with a nested renderer's marker
-    call either: whichever function directly renders the block is the one
-    that has to carry the budget.
-
-    Inherits the module scan's blind spot — see
-    `_discovered_recall_renderers`: a renderer that does not label its
-    entries never reaches this function at all.
-    """
-    tree = ast.parse(source)
-    return [
-        node for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and _RECALL_RENDER_MARKER in _called_function_names(node)
-    ]
-
-
-def _unbudgeted_recall_functions(source: str, required: set[str]) -> dict[str, list[str]]:
-    """`{function name: sorted missing calls}` for this module's renderers.
-
-    Checked per function, not against the union of all of them. The union
-    reopens the hole one level up: plant the marker in the dead helper too
-    and it is counted as a renderer, its budget calls join the pooled set,
-    and the real renderer is unbudgeted again with every guard green. Each
-    function that renders a recall block has to carry its own budget.
-    """
-    out: dict[str, list[str]] = {}
-    for node in _recall_render_functions(source):
-        missing = required - _called_function_names(node)
-        if missing:
-            out[node.name] = sorted(missing)
+            func = node.func
+            name = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name == func_name:
+                out.add(rel)
+                break
     return out
 
 
-def test_every_recall_renderer_is_token_budgeted():
-    """Discovered, not listed — and checked on calls, not on text.
+def _files_with_url_literal(sources: dict[str, str], needle: str) -> set[str]:
+    """Files with ``needle`` inside a real string literal.
 
-    Substring-matching the constant names would pass on an ``import`` that
-    is never used, or on a ``# TODO: hook up RECALL_RENDER_*`` comment. The
-    claim is that the budget RUNS, so both budget calls have to be present
-    as actual calls.
+    Not a substring scan over the source: the endpoint is named in
+    comments and docstrings all over the memory subsystem (the budget
+    constants explain what they bound, ``hybrid_recall`` says which route
+    calls it), and counting those would make the client set unpinnable.
+    Docstrings are excluded for the same reason; an f-string's literal
+    parts are included, since that is how both real call sites build the
+    URL.
     """
-    renderers = _discovered_recall_renderers()
-    assert len(renderers) >= 2, (
-        f"发现式扫描只找到 {sorted(renderers)}；标记词失效了，这条护栏已经形同虚设"
-    )
-    required = {"truncate_to_tokens", "take_lines_within_token_budget"}
-    unbudgeted = {}
-    for rel, source in sorted(renderers.items()):
-        assert _recall_render_functions(source), (
-            f"{rel} 因为出现标记词而被认成召回渲染点，却找不到任何真正调用它的"
-            f"函数——护栏在这个文件上是空转的（标记词只出现在注释/字符串里？）"
-        )
-        missing = _unbudgeted_recall_functions(source, required)
-        if missing:
-            unbudgeted[rel] = missing
-    assert unbudgeted == {}, (
-        f"这些召回渲染点没有真正调用 token 预算（只是提到了常量名不算），"
-        f"会把任意长度的记忆原文塞进 prompt：{unbudgeted}"
-    )
+    out: set[str] = set()
+    for rel, source in sources.items():
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover — a broken file fails elsewhere
+            continue
+        docstrings = set()
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                continue
+            body = getattr(node, "body", None) or []
+            if (
+                body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                docstrings.add(id(body[0].value))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and needle in node.value
+                and id(node) not in docstrings
+            ):
+                out.add(rel)
+                break
+    return out
 
 
-def test_every_recall_renderer_goes_through_the_shared_budget_helper():
-    """One helper for both, so the two budgets cannot drift apart.
+def test_repo_scan_reaches_the_files_it_claims_to_cover():
+    """A scan that finds nothing passes every guard below while proving
+    nothing. Pin that it actually reads this repo's modules."""
+    sources = _repo_python_sources()
 
-    The renderer set comes from the same discovery as above rather than a
-    second hardcoded list — otherwise a newly discovered third renderer
-    would be budget-checked but never helper-checked.
+    assert len(sources) > 200, f"仓库扫描只找到 {len(sources)} 个 .py，路径过滤把仓库滤没了"
+    for rel in (_ENTRY_POINT, "main_logic/core/tool_calling.py",
+                "plugin/plugins/qq_auto_reply/memory_bridge.py"):
+        assert rel in sources, f"扫描没覆盖到 {rel}，下面的护栏是空转的"
+
+
+def test_only_the_entry_point_labels_recall_entries():
+    """``render_recall_entry_tag`` is called from exactly one module.
+
+    This is the check that keeps the entry point single. A second renderer
+    that wants localized ``[tier/entity]`` prefixes has to call the table,
+    and calling it from anywhere else fails here.
+
+    Note what is NOT exempted: ``config/prompts/prompts_memory.py`` defines
+    the table, and the old scan skipped that file BY NAME — which made it
+    the one place a shared line-rendering helper could be parked to launder
+    a second renderer past every guard (issue #2588, A2, measured at 59x
+    over budget). Defining a function is not calling it, so no exemption is
+    needed and none is granted.
     """
-    renderers = _discovered_recall_renderers()
-    expected = {
-        "plugin/plugins/qq_auto_reply/memory_bridge.py",
-        "main_logic/core/tool_calling.py",
-    }
-    assert expected <= set(renderers), (
-        f"已知的两处渲染点没被发现式扫描找到：{expected - set(renderers)}"
-    )
-    hand_rolled = [
-        rel for rel, source in sorted(renderers.items())
-        if _unbudgeted_recall_functions(source, {"take_lines_within_token_budget"})
-    ]
-    assert hand_rolled == [], (
-        f"{hand_rolled} 没走共享预算 helper，会独自漂移"
+    callers = _files_calling(_repo_python_sources(), "render_recall_entry_tag")
+
+    assert callers == {_ENTRY_POINT}, (
+        f"召回条目标签表的调用点应当只有 {_ENTRY_POINT}，实测 {sorted(callers)}。\n"
+        f"召回渲染在 #2588 之后收口到单一入口：新的渲染面请调用 "
+        f"memory.recall_render.render_recall_block，别再手搓一份带预算的行渲染"
     )
 
 
-_KNOWN_RECALL_RENDERERS = {
-    "plugin/plugins/qq_auto_reply/memory_bridge.py",
+# Every module that talks to the structured recall endpoint. The memory
+# server's own route file defines it rather than calling it.
+_QUERY_MEMORY_ROUTE_DEFINITION = "app/memory_server/routes.py"
+_KNOWN_RECALL_CLIENTS = {
     "main_logic/core/tool_calling.py",
+    "plugin/plugins/qq_auto_reply/memory_bridge.py",
 }
 
 
-def test_the_known_recall_renderers_are_exactly_these_two():
-    """Pin the renderer set, so a new one is not waved through on an AST guess.
+def test_every_query_memory_client_renders_through_the_entry_point():
+    """Whoever fetches recall results has to render them through the entry point.
 
-    The two guards above infer "this is budgeted" from the SHAPE of the
-    source, and that inference has been defeated five times running —
-    substring match, module-wide AST walk, a dead helper nested in the
-    renderer, a budget call in a return annotation, a budget call in an
-    ``if False:`` branch. Each fix was correct and each was followed by a
-    new way in, because "does this call run, and is its result used"
-    is undecidable in general.
+    The complement of the label check: that one catches a renderer that
+    wants tags, this one catches a renderer that does NOT. Dropping the
+    ``[fact/user]`` prefix is a reasonable product choice in a 1:1 chat
+    where every entity is the same — and it was the biggest hole in the
+    old marker-based scan, since such a file contained no marker, was never
+    parsed, and every guard silently skipped it (issue #2588, A1, measured
+    at 95x over budget). It cannot skip this one: it still has to ask the
+    memory server for the results.
 
-    The two renderers this repo ships do not rest on that inference —
-    they have behavioural budget tests here that render oversized input
-    and measure the result. A renderer nobody has written yet has none, so
-    this makes its arrival a loud failure rather than a silent AST pass.
-
-    ⚠️ IT IS NOT A BACKSTOP FOR EVERYTHING (an earlier version of this
-    docstring said it was). It reuses `_discovered_recall_renderers`, so
-    it inherits that scan's blind spot exactly: a new renderer that never
-    calls the shared tag helper is not in `found`, `found` therefore still
-    equals the known set, and this passes. It catches a new renderer
-    written like the existing two — not one written differently. Issue
-    #2588 tracks that, with a measured case at 95x over budget.
+    Membership is asserted by equality, so a new client is a loud failure
+    that has to come here and say what it renders through.
     """
-    found = set(_discovered_recall_renderers())
-    assert found == _KNOWN_RECALL_RENDERERS, (
-        f"召回渲染点集合变了：新增 {sorted(found - _KNOWN_RECALL_RENDERERS)}，"
-        f"消失 {sorted(_KNOWN_RECALL_RENDERERS - found)}。\n"
-        f"新增渲染点请补**行为**预算测试（喂超长输入、量渲染结果的 token 数），"
-        f"再把它加进 _KNOWN_RECALL_RENDERERS——上面两条护栏只能从源码形状推断"
-        f"「调了预算」，那个推断已经被绕过五次，不足以单独担保一个新渲染点。"
+    sources = _repo_python_sources()
+    clients = _files_with_url_literal(
+        sources, "/query_memory",
+    ) - {_QUERY_MEMORY_ROUTE_DEFINITION}
+
+    assert clients == _KNOWN_RECALL_CLIENTS, (
+        f"/query_memory 的调用方集合变了：新增 {sorted(clients - _KNOWN_RECALL_CLIENTS)}，"
+        f"消失 {sorted(_KNOWN_RECALL_CLIENTS - clients)}。\n"
+        f"新调用方请把结果交给 memory.recall_render.render_recall_block 渲染，"
+        f"再加进 _KNOWN_RECALL_CLIENTS"
     )
-
-
-# ── the call scan's own adversarial fixtures ─────────────────────────
-#
-# Every shape below defeated this guard at some point. They are checked
-# against the helper directly, so the next round of hardening cannot
-# silently give one of them back.
-
-_BUDGET_CALLS = {"truncate_to_tokens", "take_lines_within_token_budget"}
-
-_DEAD_SHAPES = [
-    ("nested-def", '''
-def render(results):
-    def _unused():
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("return-annotation", '''
-def render(results) -> truncate_to_tokens(take_lines_within_token_budget([], 1), 1):
-    return "".join(results)
-'''),
-    ("param-default", '''
-def render(results, _x=truncate_to_tokens("", 1), *, _y=take_lines_within_token_budget([], 1)):
-    return "".join(results)
-'''),
-    ("decorator", '''
-@register(truncate_to_tokens("", 1), take_lines_within_token_budget([], 1))
-def render(results):
-    return "".join(results)
-'''),
-    ("if-False", '''
-def render(results):
-    if False:
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("if-zero", '''
-def render(results):
-    if 0:
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("if-TYPE_CHECKING", '''
-def render(results):
-    if TYPE_CHECKING:
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("else-of-if-True", '''
-def render(results):
-    if True:
-        pass
-    else:
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("while-False", '''
-def render(results):
-    while False:
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("after-return", '''
-def render(results):
-    return "".join(results)
-    truncate_to_tokens("", 1)
-    take_lines_within_token_budget([], 1)
-'''),
-    ("nested-if-False-inside-live-branch", '''
-def render(results, flag):
-    if flag:
-        if False:
-            truncate_to_tokens("", 1)
-            take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("class-body", '''
-def render(results):
-    class _Unused:
-        x = truncate_to_tokens("", 1)
-        y = take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    # The terminator rule used to apply only to the function's own
-    # statement list: every compound statement handed its children over one
-    # at a time, so a one-element list made the rule a no-op inside them.
-    ("after-return-inside-for", '''
-def render(results):
-    for r in results:
-        return r
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-    ("after-return-inside-live-if", '''
-def render(results, flag):
-    if flag:
-        return "".join(results)
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    return ""
-'''),
-    ("after-raise-inside-try", '''
-def render(results):
-    try:
-        raise ValueError("x")
-        truncate_to_tokens("", 1)
-        take_lines_within_token_budget([], 1)
-    except ValueError:
-        pass
-    return "".join(results)
-'''),
-    ("after-continue-inside-except", '''
-def render(results):
-    out = []
-    for r in results:
-        try:
-            out.append(r)
-        except ValueError:
-            continue
-            truncate_to_tokens("", 1)
-            take_lines_within_token_budget([], 1)
-    return "".join(out)
-'''),
-    ("if-False-inside-with", '''
-def render(results, lock):
-    with lock:
-        if False:
-            truncate_to_tokens("", 1)
-            take_lines_within_token_budget([], 1)
-    return "".join(results)
-'''),
-]
-
-_LIVE_SHAPES = [
-    ("straight-line", '''
-def render(results):
-    lines = [truncate_to_tokens(r, 400) for r in results]
-    kept, _ = take_lines_within_token_budget(lines, 2204)
-    return "\\n".join(kept)
-'''),
-    ("inside-a-real-branch", '''
-def render(results, flag):
-    if flag:
-        lines = [truncate_to_tokens(r, 400) for r in results]
-        kept, _ = take_lines_within_token_budget(lines, 2204)
-        return "\\n".join(kept)
-    return ""
-'''),
-    ("inside-try-except", '''
-def render(results):
-    try:
-        lines = [truncate_to_tokens(r, 400) for r in results]
-        kept, _ = take_lines_within_token_budget(lines, 2204)
-    except ValueError:
-        return ""
-    return "\\n".join(kept)
-'''),
-    ("else-of-if-False", '''
-def render(results):
-    if False:
-        pass
-    else:
-        lines = [truncate_to_tokens(r, 400) for r in results]
-        kept, _ = take_lines_within_token_budget(lines, 2204)
-    return "\\n".join(kept)
-'''),
-    ("inside-a-real-loop", '''
-def render(results):
-    out = []
-    for r in results:
-        out.append(truncate_to_tokens(r, 400))
-    kept, _ = take_lines_within_token_budget(out, 2204)
-    return "\\n".join(kept)
-'''),
-    ("inside-an-except-handler", '''
-def render(results):
-    try:
-        raise ValueError("x")
-    except ValueError:
-        lines = [truncate_to_tokens(r, 400) for r in results]
-        kept, _ = take_lines_within_token_budget(lines, 2204)
-        return "\\n".join(kept)
-    return ""
-'''),
-    ("inside-a-with-block", '''
-def render(results, lock):
-    with lock:
-        lines = [truncate_to_tokens(r, 400) for r in results]
-        kept, _ = take_lines_within_token_budget(lines, 2204)
-    return "\\n".join(kept)
-'''),
-    ("after-an-early-return-in-a-branch", '''
-def render(results, flag):
-    if not flag:
-        return ""
-    lines = [truncate_to_tokens(r, 400) for r in results]
-    kept, _ = take_lines_within_token_budget(lines, 2204)
-    return "\\n".join(kept)
-'''),
-]
-
-
-@pytest.mark.parametrize("name,source", _DEAD_SHAPES, ids=[s[0] for s in _DEAD_SHAPES])
-def test_call_scan_ignores_names_that_never_run(name, source):
-    """A budget call that cannot execute must not count as budgeting.
-
-    Each of these is a way the guard was defeated (or could be): the render
-    path is a bare join with no ceiling, while both budget names appear
-    somewhere the interpreter never reaches.
-    """
-    fn = ast.parse(source).body[0]
-    assert isinstance(fn, ast.FunctionDef), f"夹具失效：{name} 没解析出函数"
-    seen = _called_function_names(fn)
-    assert not (_BUDGET_CALLS & seen), (
-        f"[{name}] 永远不会执行的预算调用被算成了「调过预算」：{sorted(_BUDGET_CALLS & seen)}"
+    entry_module = _ENTRY_POINT[:-3].replace("/", ".")
+    not_rendering = sorted(
+        rel for rel in clients if entry_module not in sources[rel]
     )
-
-
-@pytest.mark.parametrize("name,source", _LIVE_SHAPES, ids=[s[0] for s in _LIVE_SHAPES])
-def test_call_scan_still_sees_budget_calls_that_do_run(name, source):
-    """The strict dual — and the half that keeps the tightening honest.
-
-    A scan that returned nothing would pass every test above while being
-    useless; each round of hardening has to keep real, reachable budget
-    calls visible or the guard degrades into a permanent red that someone
-    eventually deletes.
-    """
-    fn = ast.parse(source).body[0]
-    seen = _called_function_names(fn)
-    assert _BUDGET_CALLS <= seen, (
-        f"[{name}] 真实执行路径上的预算调用没被看见：缺 {sorted(_BUDGET_CALLS - seen)}"
+    assert not_rendering == [], (
+        f"{not_rendering} 拿了召回结果却没走 {entry_module}——召回段就没有 token 上限了"
     )

--- a/tests/unit/test_recall_render_token_budget.py
+++ b/tests/unit/test_recall_render_token_budget.py
@@ -891,6 +891,36 @@ def test_only_the_entry_point_labels_recall_entries():
     )
 
 
+def test_the_entry_point_has_no_runtime_switch():
+    """No env lookup inside the renderer.
+
+    This is the one shape the behavioural tests structurally cannot catch:
+    a budget that only runs when a flag says so passes every measurement
+    here (the tests take the default path) and is off in production —
+    measured at 6.4x over budget (issue #2588, B3). Tests cannot enumerate
+    the environments they were not run in, so the rule is that the render
+    path has no environments: same input, same output, budget always on.
+
+    Narrow on purpose, and NOT a general reachability check — that is the
+    inference this whole file stopped making. It pins one property of one
+    module: nothing here reads the environment. A flag threaded in from a
+    caller would still get through; what this stops is the cheap version.
+    """
+    tree = ast.parse((_REPO_ROOT / _ENTRY_POINT).read_text(encoding="utf-8"))
+    env_reads = sorted({
+        node.attr if isinstance(node, ast.Attribute) else node.id
+        for node in ast.walk(tree)
+        if (isinstance(node, ast.Attribute) and node.attr in {"environ", "getenv"})
+        or (isinstance(node, ast.Name) and node.id in {"environ", "getenv"})
+    })
+
+    assert env_reads == [], (
+        f"{_ENTRY_POINT} 读了环境变量 {env_reads}：召回渲染必须是同样输入同样"
+        f"输出、预算恒定生效的纯函数。挂在开关后面的预算，测试跑的是默认路径，"
+        f"量不出生产环境关掉之后的结果"
+    )
+
+
 # Every module that talks to the structured recall endpoint. The memory
 # server's own route file defines it rather than calling it.
 _QUERY_MEMORY_ROUTE_DEFINITION = "app/memory_server/routes.py"


### PR DESCRIPTION
Closes #2588。

## 原本啥样

`/query_memory` 的结果变成 prompt 文本有两条手搓路径：QQ 插件的 `render_relevant_memory` 和本体的 `recall_memory` 工具处理器。两边各自截断单条、各自收口整段，靠一条发现式护栏保证"不会冒出第三个没预算的渲染器"——那条护栏用 AST 从**源码形状**推断"预算调用有没有跑"。

这个推断在 #2578 的 review 里被连续绕过五次（子串匹配 → 模块级死函数背书 → 渲染器内部的死 helper → 返回注解里的预算调用 → `if False:` 分支）。#2588 随后的对抗排查又实测出 12 条可绕过路径，最高 95× 超预算。根因不可修：「这个调用会不会执行、返回值有没有被用」一般情况下不可判定，每次加固只是把边界挪一格，还引入了 false positive（把单条行渲染抽成独立函数这种正确重构会让护栏变红）。

## 这个 PR 做了什么

**收口**：新增 `memory/recall_render.py`，它是召回结果变成 prompt 文本的唯一地方。两处调用点退化成薄壳，只负责提供 locale、提供表头、打日志。预算不再靠推断，而是在这条唯一路径上用行为测试量出来（喂超长输入，`count_tokens` 量结果）。

**顺带统一了两侧此前不一致的地方**（都是往本体侧那个更完整的口径统一）：

- QQ 侧的日期后缀从 `anchor[:10]` 裸切改成同一套锚点解析（`event_end_at` → `event_start_at` → `created_at`，取第一个**能解析出来**的，不是第一个 truthy 的），并带上本地化相对时间标签
- 空 text 条目在**编号之前**过滤：两侧此前都在 `enumerate` 里 `continue`，一条空条目就让模型看到 `1.` / `3.` 的跳号，它只能理解成"第 2 条被藏起来了"
- `results` 里混进非 dict 元素不再能让整条 tool call 翻 `is_error`

**护栏换判据**（`tests/unit/test_recall_render_token_budget.py`）——两条都不需要推理执行：

1. 标签表 `render_recall_entry_tag` 的**调用点**必须只有入口一处。不再按文件名豁免 `config/prompts/prompts_memory.py`——那正是 A2 用来洗白第二个渲染器的地方（实测 59×）；定义不是调用，所以不需要豁免也不再给
2. 谁在源码里拼 `/query_memory` 的 URL，谁就必须走入口渲染。这条挡的是 A1：不打标签的渲染器不含 marker，旧扫描从不 parse 它（实测 95×），但它躲不掉"得先向 memory server 要结果"
3. 扫描读不出的文件从静默 `continue` 改成直接红（A3，实测 10×）
4. 入口里不许出现 `environ` / `getenv`（B3，实测 6.4×）：预算挂在开关后面是行为测试结构上抓不到的一类，测试跑的是默认路径，量不出生产环境关掉之后的结果
5. 补上 `event_start_at` / `event_end_at` 的夹具：这两个键此前全文件零覆盖，正是 B7「预算跑完之后再追加未计费文本」能同时骗过两条护栏和整个文件 24 条测试的原因

删掉的是 AST 可达性那一套（`_called_function_names` 及其 33 条对抗夹具）。收口之后没有第二处需要推断它。

## 回归报告

**改了什么、为什么必要**

- 新增 `memory/recall_render.py`（唯一召回渲染入口，带 `RenderedRecallBlock` 返回 text/kept/dropped）
- `plugin/plugins/qq_auto_reply/memory_bridge.py::render_relevant_memory`、`main_logic/core/tool_calling.py::_render_recall_block` 改为薄壳
- 护栏测试按上文换判据

必要性：召回段直接进 prompt，预算失守的后果是上下文被一条合并 reflection 吃掉（实测最高 95×）。而守住它的护栏此前是**不可靠**的——五次被绕过 + 12 条实测路径。收口把"必须靠 AST 推断"的面积从两个渲染器缩到一个函数，那个函数有真喂真量的行为测试。

**前后行为对比**

| | 之前 | 之后 |
|---|---|---|
| 本体 `recall_memory` 工具结果 | `1. [事实/关于用户] text  (2026-05-01, 3 月前)` | 不变 |
| QQ 群侧召回段 | `1. [事实/群聊] text (2026-05-01)` | `1. [事实/群聊] text  (2026-05-01, 3 月前)`（多了相对时间标签，与本体一致） |
| 空 text 条目 | 占掉编号，模型看到跳号 | 编号前过滤，编号连续 |
| `results` 里的非 dict 元素 | `.get` 抛 AttributeError → tool call 翻 is_error | 跳过 |
| 时间锚点（QQ 侧） | `anchor[:10]` 裸切字符串，脏值原样出 | 解析失败就落到下一个候选字段 |
| 预算数值 | 不变（`RECALL_RENDER_*` 三个常量原样） | 不变 |

**可能的回归**

1. **QQ 群侧行长变了**：多了相对时间标签，单行装饰变大。行上限（`ENTRY + OVERHEAD` = 440 tok）没变，`test_line_overhead_allowance_covers_what_the_renderer_actually_adds` 现在对**每个已上线 locale**都量了一遍实测装饰开销，都在 40 tok 预留内；整段预算仍能装下 5 条满额条目（`test_block_cap_funds_a_full_page_of_max_length_entries`）。
2. **本体侧空条目过滤是新行为**：此前空 text 会渲染成 `N. [tag]  (date)` 一行占位。现在不渲染，表头 `n=` 随之变小——表头本来就按实际渲染条数报，测试钉住了整行相等。
3. **`memory` 包被 QQ 插件 import 了**：`memory/recall_render.py` 只在函数体内 import `config` / `memory.temporal` / `utils.tokenize`，`memory/__init__.py` 是纯 docstring 无副作用，不引入启动期开销。
4. **护栏判据换了口径，可能有新的误报形态**：`/query_memory` 用的是 AST 字符串字面量（排除 docstring），所以注释里提到端点名不会误伤；新增真调用方会红，红的时候要做的事写在断言消息里。

**验证**

- 变异验证 12/12：A2 / A3 / B1 / B3 / B4 / B5 / B7、编号跳号、时间锚点按 truthy 选、表头不计预算、表头报错数、行级兜底删除——逐条造可运行变异，全部变红（B3 是补了第 4 条判据之后才红的，先漏网过一轮）
- 另起一个不打标签、自己 POST `/query_memory` 的渲染器文件（A1，issue 里实测 95× 的那条）：旧护栏静默放行，新护栏红
- `tests/unit/test_recall_render_token_budget.py` 35 passed
- 相关面全绿：`test_memory_recall` / `test_memory_render_token_budget` / `test_tool_calling` / `test_group_memory_recall_tool` / `test_group_memory_scopes` / `test_hybrid_recall` / `test_memory_temporal` / `test_memory_language_resolution` 690 passed 2 skipped；`test_group_memory_consent_and_locking` / `test_group_prompt_localization` / `test_memory_zh_tw` / `test_participant_memory_and_display_name` / `test_speaker_trust*` / `test_subject_identity` 805 passed
- `scripts/check_docstring_no_cjk.py --base origin/main` 通过

## 仍然没解决的

收口不等于封闭，issue #2588 的结论是别追求封闭：

- 从已经拿到结果的地方（比如 `QQMemoryQueryResult.raw_results`）再渲染一遍，两条结构护栏都看不见
- 开关从调用方 threading 进来，第 4 条判据只挡最直接的那种写法
- 第三方插件通过宿主 `query_memory` API 拿到 raw dict 自己拼 prompt，不在仓内护栏范围（那条走的是 deprecated 的 `/search_for_memory` GET）

这些都写进了对应护栏的 docstring，不再声称超出它能证明的范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
