### PR TITLE
i18n(#2500 收尾): 零散调用点逐处判断 + 插件侧补繁体表并翻调用点

### DIFF
--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -1178,9 +1178,14 @@ class UserActivityTracker:
                 # 已被它更新，本 drain 把那次 pending 一并发出，不会漏也不会重。
                 await self._drain_context_prompt()
 
-                from utils.language_utils import get_global_language, get_global_language_full
-                activity_lang = get_global_language() or 'en'
-                topic_lang = get_global_language_full() or activity_lang
+                # 两条都用全码（#2500 第 2 步）：activity_lang 只喂
+                # ``call_activity_guess``，那边的 ``_normalize_lang`` 认 zh-TW 且
+                # ``ACTIVITY_GUESS_PROMPTS`` 有 zh-TW 模板，塌成短码会让繁中用户
+                # 拿简体叙述。简中的 'zh-CN' 在 ``_normalize_lang`` 里照样归到
+                # 'zh'，行为不变。
+                from utils.language_utils import get_global_language_full
+                activity_lang = get_global_language_full() or 'en'
+                topic_lang = activity_lang
                 self._process_topic_candidates_if_ready(lang=topic_lang, now=ts)
 
                 # Bail on private — explicitly do NOT send sensitive app

--- a/main_routers/config_router/language.py
+++ b/main_routers/config_router/language.py
@@ -162,9 +162,13 @@ async def get_user_language_api():
     Returns a normalized language code ('zh', 'en', 'ja').
     """
     from utils.language_utils import get_global_language
-    
+
     try:
         # 使用 language_utils 的全局语言管理，自动处理 Steam/系统语言优先级
+        # ⚠️ 这里刻意保持短码（#2500 第 2 步复核结论）：本端点的返回值是对前端
+        # 的 API 契约，上面的 docstring 写死了 'zh' / 'en' / 'ja' 这套短码，消费
+        # 方可能按短码分支。改成全码属于改契约，要先普查全部前端调用方，不在
+        # locale 迁移这一批的范围内。
         language = get_global_language()
         
         return {

--- a/main_routers/game_router/session_pool.py
+++ b/main_routers/game_router/session_pool.py
@@ -132,6 +132,9 @@ def _build_game_prompt(
     # 未来其他游戏在这里扩展
     # 这里的 language 会被当成人读的语言名塞进英文句子，所以短码化后再插——
     # 上游改传 user_language_full 之后不这么做的话，繁中会话会看到字面 "zh-TW"。
+    # ⚠️ #2500 第 2 步复核确认：这处的短码化是有意的、要保留。它不是查表用的
+    # locale，而是拼进英文兜底 prompt 的语言名；繁简两种中文在这句里要的是同
+    # 一个词（"zh"），细分到 zh-TW 只会让模型读到一个不像语言名的字符串。
     # ⚠️ 只在 language 非空时才归一：normalize_language_code(None) 返回 'en'，
     # 直接套上去会把下面那两级兜底（全局语言 → "en"）整个吃掉。
     short_language = normalize_language_code(language, format="short") if language else None

--- a/plugin/plugins/bilibili_danmaku/__init__.py
+++ b/plugin/plugins/bilibili_danmaku/__init__.py
@@ -738,9 +738,12 @@ class BiliDanmakuPlugin(NekoPluginBase):
         constraints: str,
     ) -> str:
         try:
-            from config.prompts.prompts_sys import SESSION_INIT_PROMPT
+            from config.prompts.prompts_sys import (
+                SESSION_INIT_PROMPT,
+                normalize_sys_prompt_locale,
+            )
             from utils.config_manager import get_config_manager
-            from utils.language_utils import get_global_language
+            from utils.language_utils import get_global_language_full
         except Exception as e:
             raise RuntimeError(f"加载 NEKO 对话配置失败: {e}") from e
 
@@ -748,7 +751,10 @@ class BiliDanmakuPlugin(NekoPluginBase):
         master_name, her_name, _, catgirl_data, _, lanlan_prompt_map, _, _, _ = config_manager.get_character_data()
         if self._target_lanlan:
             her_name = self._target_lanlan
-        user_language = get_global_language()
+        # #2500 第 2 步：取全码再经 prompts_sys 归一，繁中才能命中 SESSION_INIT_PROMPT
+        # 的 'zh-TW' 键。⚠️ 不能拿 get_global_language_full() 直接当键：简中的全码是
+        # 'zh-CN'，而这张表的简体键是 'zh'，裸查会一路掉到英文。
+        user_language = normalize_sys_prompt_locale(get_global_language_full())
         init_prompt = SESSION_INIT_PROMPT.get(user_language, SESSION_INIT_PROMPT.get('en', 'You are {name}.'))
         character_prompt = lanlan_prompt_map.get(her_name, "你是一个友好的AI助手")
         current_character = catgirl_data.get(her_name, {})

--- a/plugin/plugins/bilibili_dm/__init__.py
+++ b/plugin/plugins/bilibili_dm/__init__.py
@@ -1119,24 +1119,20 @@ class BiliDMPlugin(NekoPluginBase):
         user_title: str,
     ) -> str:
         """构建 AI 会话系统提示词"""
-        from config.prompts.prompts_sys import SESSION_INIT_PROMPT
-        from utils.language_utils import get_global_language
-
-        try:
-            from utils.i18n_utils import normalize_language_code
-        except Exception:
-            normalize_language_code = None
-
-        user_language = get_global_language()
-        short_language = (
-            normalize_language_code(user_language, format="short")
-            if normalize_language_code
-            else user_language
+        from config.prompts.prompts_sys import (
+            SESSION_INIT_PROMPT,
+            normalize_sys_prompt_locale,
         )
+        from utils.language_utils import get_global_language_full
+
+        # #2500 第 2 步：取全码再经 prompts_sys 归一。原先那次 format="short" 的
+        # 短码化是顺手做的、不是有意的——它把 zh-TW 塌成 zh，繁中用户拿简体模板，
+        # 下面那级 ``.get(user_language)`` 兜底永远够不到。⚠️ 也不能拿全码裸查：
+        # 简中的全码是 'zh-CN'，而 prompts_sys 这套表的简体键是 'zh'。
+        short_language = normalize_sys_prompt_locale(get_global_language_full())
 
         init_prompt_template = SESSION_INIT_PROMPT.get(
-            short_language,
-            SESSION_INIT_PROMPT.get(user_language, SESSION_INIT_PROMPT["en"]),
+            short_language, SESSION_INIT_PROMPT["en"],
         )
 
         system_prompt_parts = [

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -270,7 +270,7 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
             else {}
         )
         # Resolve user language now (it reads Steam / system locale via
-        # ``utils.language_utils.get_global_language``, which lazy-inits
+        # ``utils.language_utils.get_global_language_full``, which lazy-inits
         # on first call) and propagate to the service so its autonomous
         # nudge loop and task_finished cues match the user's locale.
         self._lang = prompts.user_lang()

--- a/plugin/plugins/game_agent_minecraft/prompts.py
+++ b/plugin/plugins/game_agent_minecraft/prompts.py
@@ -13,7 +13,7 @@ Why a dedicated module instead of inline strings:
   and gives the team one place to audit when the persona voice gets
   retuned.
 * Future locale wiring. ``user_lang()`` here pulls from
-  ``utils.language_utils.get_global_language`` on first call and caches
+  ``utils.language_utils.get_global_language_full`` on first call and caches
   the result; if the host later exposes a richer per-session locale
   channel via the plugin SDK, only this module changes.
 
@@ -32,26 +32,37 @@ Two non-obvious things:
    here so ``str.format`` passes it through untouched. Do not change to
    single-brace ``{MASTER_NAME}`` — it would be eaten by the formatter
    or raise KeyError.
-2. The seven supported locales mirror utils.language_utils.get_global_language's
-   short codes: zh / en / ja / ko / ru / es / pt. EN is the documented
-   fallback when a locale key is missing.
+2. The supported locales are the key scheme config/prompts uses -- short
+   codes plus a separate 'zh-TW' for Traditional Chinese: zh / zh-TW / en /
+   ja / ko / ru / es / pt. EN is the documented fallback when a locale key
+   is missing. Note that 'zh' means Simplified here, NOT 'zh-CN'; see
+   ``user_lang`` for why the raw global locale must be normalized first.
 """
 from __future__ import annotations
 
 from typing import Any, Dict
 
 DEFAULT_LANG = "en"
-SUPPORTED_LANGS: tuple[str, ...] = ("zh", "en", "ja", "ko", "ru", "es", "pt")
+SUPPORTED_LANGS: tuple[str, ...] = ("zh", "zh-TW", "en", "ja", "ko", "ru", "es", "pt")
 
 
 def t(key: str, *, lang: str | None = None, **fmt: Any) -> str:
     """Resolve a prompt by key + locale, with optional ``str.format`` substitutions.
 
-    Falls back to English when the requested locale is missing. Raises
-    KeyError when the key itself is unknown (typo > silent miss).
+    Falls back to English when the requested locale is missing -- except for
+    Chinese variants, which fall back to Simplified first (same rule as
+    ``config.prompts.prompts_sys._loc``). A 'zh-TW' bundle that someone
+    forgets to fill in should degrade to Simplified Chinese, not to English:
+    Simplified is still readable to a Traditional reader, English is a
+    language switch mid-conversation. Raises KeyError when the key itself is
+    unknown (typo > silent miss).
     """
     bundle = PROMPTS[key]
-    text = bundle.get(lang or DEFAULT_LANG) or bundle[DEFAULT_LANG]
+    lang_key = lang or DEFAULT_LANG
+    text = bundle.get(lang_key)
+    if not text and lang_key.startswith("zh"):
+        text = bundle.get("zh")
+    text = text or bundle[DEFAULT_LANG]
     if fmt:
         text = text.format(**fmt)
     # ``{{MASTER_NAME}}`` 是双花括号转义，只有在 ``str.format`` 真正跑过时才会被
@@ -67,17 +78,26 @@ def t(key: str, *, lang: str | None = None, **fmt: Any) -> str:
 
 
 def user_lang() -> str:
-    """Best-effort current user language (short code, e.g. 'zh', 'en').
+    """Best-effort current user language, as a key of the tables below.
 
-    Reads ``utils.language_utils.get_global_language`` which initializes
-    lazily from Steam settings then the system locale on first call.
+    Reads ``utils.language_utils.get_global_language_full`` which initializes
+    lazily from Steam settings then the system locale on first call, and runs
+    it through ``prompts_sys.normalize_sys_prompt_locale`` -- the canonical
+    normalizer for exactly this key scheme (Simplified collapses to 'zh',
+    Traditional stays 'zh-TW').
+
+    The full locale must NOT be used raw: it renders Simplified as 'zh-CN',
+    which is not a key of these tables, and the guard below would then drop
+    every Simplified Chinese user to English.
+
     Returns DEFAULT_LANG on any failure so prompt resolution never raises
     on the read side.
     """
     try:
-        from utils.language_utils import get_global_language
+        from config.prompts.prompts_sys import normalize_sys_prompt_locale
+        from utils.language_utils import get_global_language_full
 
-        result = get_global_language() or DEFAULT_LANG
+        result = normalize_sys_prompt_locale(get_global_language_full()) or DEFAULT_LANG
         return result if result in SUPPORTED_LANGS else DEFAULT_LANG
     except Exception:
         return DEFAULT_LANG
@@ -94,6 +114,7 @@ def user_lang() -> str:
 # in-progress nudge, keep-going nudge, and system-prompt cues.
 _INTERNAL_STATE_GAG: Dict[str, str] = {
     "zh": "**别给 {{MASTER_NAME}} 播报内部状态**——『连接』『任务空闲』『系统』『minecraft_task』『工具』『tool』一律不准说出口，用第一人称讲游戏里的事。",
+    "zh-TW": "**別給 {{MASTER_NAME}} 播報內部狀態**——『連線』『任務閒置』『系統』『minecraft_task』『工具』『tool』一律不准說出口，用第一人稱講遊戲裡的事。",
     "en": "**Do NOT narrate internals to {{MASTER_NAME}}** — never say words like 'connect', 'system', 'idle', 'minecraft_task', 'tool'. Speak first-person about what's happening in the game.",
     "ja": "**{{MASTER_NAME}} に内部状態を実況しないで**——『接続』『システム』『タスク空き』『minecraft_task』『ツール』『tool』は一切口に出さず、一人称でゲーム内の出来事だけ話して。",
     "ko": "**{{MASTER_NAME}} 에게 내부 상태를 중계하지 마**——'연결' '시스템' '대기' 'minecraft_task' '도구' 'tool' 같은 단어는 절대 입 밖에 내지 말고, 1인칭으로 게임 속 일만 얘기해.",
@@ -110,6 +131,7 @@ _INTERNAL_STATE_GAG: Dict[str, str] = {
 
 _CUE_PREFIX_DONE: Dict[str, str] = {
     "zh": "[你刚做完一段动作]",
+    "zh-TW": "[你剛做完一段動作]",
     "en": "[You just finished an action]",
     "ja": "[たった今、一つ動作を完了した]",
     "ko": "[방금 한 동작을 끝냈어]",
@@ -120,6 +142,7 @@ _CUE_PREFIX_DONE: Dict[str, str] = {
 
 _CUE_PREFIX_ALERT: Dict[str, str] = {
     "zh": "[你刚遇到事 | {severity}] {text}",
+    "zh-TW": "[你剛遇到事 | {severity}] {text}",
     "en": "[Something just happened to you | {severity}] {text}",
     "ja": "[何か起きた | {severity}] {text}",
     "ko": "[방금 무슨 일이 있었어 | {severity}] {text}",
@@ -130,6 +153,7 @@ _CUE_PREFIX_ALERT: Dict[str, str] = {
 
 _CUE_PREFIX_IN_PROGRESS: Dict[str, str] = {
     "zh": "[你正在做事]",
+    "zh-TW": "[你正在做事]",
     "en": "[You're in the middle of something]",
     "ja": "[今、動作中]",
     "ko": "[지금 뭘 하고 있는 중이야]",
@@ -140,6 +164,7 @@ _CUE_PREFIX_IN_PROGRESS: Dict[str, str] = {
 
 _CUE_PREFIX_IDLE: Dict[str, str] = {
     "zh": "[你闲下来了]",
+    "zh-TW": "[你閒下來了]",
     "en": "[You're idle]",
     "ja": "[今、手が空いた]",
     "ko": "[지금 한가해졌어]",
@@ -150,6 +175,7 @@ _CUE_PREFIX_IDLE: Dict[str, str] = {
 
 _CUE_PREFIX_STATE: Dict[str, str] = {
     "zh": "[当前状态]",
+    "zh-TW": "[目前狀態]",
     "en": "[Current state]",
     "ja": "[現在の状態]",
     "ko": "[현재 상태]",
@@ -180,23 +206,23 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "CUE_PREFIX_STATE": _CUE_PREFIX_STATE,
 
     "PLACEHOLDER_UNKNOWN": {
-        "zh": "(未知)", "en": "(unknown)", "ja": "(不明)", "ko": "(알 수 없음)",
+        "zh": "(未知)", "zh-TW": "(未知)", "en": "(unknown)", "ja": "(不明)", "ko": "(알 수 없음)",
         "ru": "(неизвестно)", "es": "(desconocido)", "pt": "(desconhecido)",
     },
     "PLACEHOLDER_JUST_FINISHED": {
-        "zh": "(刚结束)", "en": "(just finished)", "ja": "(直前に完了)", "ko": "(방금 끝남)",
+        "zh": "(刚结束)", "zh-TW": "(剛結束)", "en": "(just finished)", "ja": "(直前に完了)", "ko": "(방금 끝남)",
         "ru": "(только что закончил)", "es": "(recién terminado)", "pt": "(recém-terminado)",
     },
     "PLACEHOLDER_IDLE": {
-        "zh": "(idle)", "en": "(idle)", "ja": "(待機中)", "ko": "(대기 중)",
+        "zh": "(idle)", "zh-TW": "(idle)", "en": "(idle)", "ja": "(待機中)", "ko": "(대기 중)",
         "ru": "(простой)", "es": "(inactivo)", "pt": "(inativo)",
     },
     "LABEL_CONNECTED": {
-        "zh": "已连接", "en": "connected", "ja": "接続中", "ko": "연결됨",
+        "zh": "已连接", "zh-TW": "已連線", "en": "connected", "ja": "接続中", "ko": "연결됨",
         "ru": "подключено", "es": "conectado", "pt": "conectado",
     },
     "LABEL_DISCONNECTED": {
-        "zh": "未连接", "en": "disconnected", "ja": "未接続", "ko": "연결 끊김",
+        "zh": "未连接", "zh-TW": "未連線", "en": "disconnected", "ja": "未接続", "ko": "연결 끊김",
         "ru": "не подключено", "es": "desconectado", "pt": "desconectado",
     },
 
@@ -205,6 +231,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     # -------------------------------------------------------------------
     "TASK_SCHEMA_ERROR": {
         "zh": "调用没成功——缺了具体的动作描述。想清楚你这次想干啥（比如 'mine 4 oak logs nearby'、'walk to 120 64 -50'），再重新调用。",
+        "zh-TW": "呼叫沒成功——缺了具體的動作描述。想清楚你這次想做什麼（例如 'mine 4 oak logs nearby'、'walk to 120 64 -50'），再重新呼叫一次。",
         "en": "Call failed — concrete action description missing. Think through what you actually want to do (e.g. 'mine 4 oak logs nearby', 'walk to 120 64 -50') and call again.",
         "ja": "呼び出し失敗——具体的な動作の説明が抜けてる。何をしたいか整理してから（例: 'mine 4 oak logs nearby'、'walk to 120 64 -50'）もう一度呼んで。",
         "ko": "호출 실패——구체적인 동작 설명이 빠졌어. 뭘 하고 싶은지 정리하고 (예: 'mine 4 oak logs nearby', 'walk to 120 64 -50') 다시 호출해.",
@@ -214,6 +241,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "TASK_NOT_CONNECTED": {
         "zh": "你刚连上游戏还没就位，没法立刻动。稍等再来一次。",
+        "zh-TW": "你剛連上遊戲還沒就位，沒辦法立刻動。稍等再試一次。",
         "en": "You're not in position in the game yet, can't move right now. Try again in a moment.",
         "ja": "ゲーム内でまだ準備できてない、すぐには動けない。少し待ってからもう一度。",
         "ko": "게임 안에서 아직 자리 잡지 못했어, 지금은 못 움직여. 잠시 후 다시.",
@@ -224,6 +252,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "TASK_BUSY_HINT": {
         # {current} = current task text
         "zh": "你还在做上一个动作：「{current}」——新动作没派出去。\n**如果 {{MASTER_NAME}} 明确要求你做某件事，或正在纠正你**（比如『过来』、『去挖矿』、『先做 X』、『别 Y』、『换成 Z』、『改用 W』），**立刻在同一回合用 overwrite=true 重新调一次**，别等——{{MASTER_NAME}} 当下的明确指令优先于你正在做的动作。只有当 {{MASTER_NAME}} 并没有提出新要求（纯属背景闲聊）时，才等当前动作跑完。在那之前不要假装新动作已经在跑。\n**别给 {{MASTER_NAME}} 播报内部状态**——『连接』『系统』『minecraft_task』『工具』『tool』一律不准说出口。",
+        "zh-TW": "你還在做上一個動作：「{current}」——新動作沒派出去。\n**如果 {{MASTER_NAME}} 明確要求你做某件事，或正在糾正你**（例如『過來』、『去挖礦』、『先做 X』、『別 Y』、『換成 Z』、『改用 W』），**立刻在同一回合用 overwrite=true 重新呼叫一次**，別等——{{MASTER_NAME}} 當下的明確指令優先於你正在做的動作。只有當 {{MASTER_NAME}} 並沒有提出新要求（純粹是背景閒聊）時，才等目前的動作跑完。在那之前不要假裝新動作已經在跑。\n**別給 {{MASTER_NAME}} 播報內部狀態**——『連線』『系統』『minecraft_task』『工具』『tool』一律不准說出口。",
         "en": "You're still doing your previous action: \"{current}\" — the new action was NOT dispatched.\n**If {{MASTER_NAME}} is explicitly asking you to do something, or correcting you** (e.g. 'come here', 'go mine', 'do X first', 'stop Y', 'switch to Z', 'use W instead'), **immediately re-call with overwrite=true on the same turn**, don't wait — {{MASTER_NAME}}'s explicit request right now takes priority over whatever you're doing. Only let the current action finish when {{MASTER_NAME}} hasn't made a new request (it's just background chat). Until then, do NOT pretend the new action is running.\n**Do not narrate internals to {{MASTER_NAME}}** — never say 'connect', 'system', 'minecraft_task', 'tool'.",
         "ja": "前の動作がまだ続いてる：「{current}」——新しい動作は送られてない。\n**{{MASTER_NAME}} が何かをしてと明確に頼んでる、または訂正してる**（『こっち来て』『採掘して』『まず X して』『Y やめて』『Z にして』『W で』など）**なら、その場で overwrite=true を付けてもう一度呼んで**、待たないで——{{MASTER_NAME}} の今の明確な指示は、今やってる動作より優先。{{MASTER_NAME}} が新しい要求を出してない（ただの雑談）ときだけ、今の動作の終了を待って。それまで新しい動作が始まったフリはしないで。\n**{{MASTER_NAME}} に内部状態を実況しないで**——『接続』『システム』『minecraft_task』『ツール』『tool』は口に出さない。",
         "ko": "아직 이전 동작 중이야: \"{current}\"——새 동작은 보내지지 않았어.\n**{{MASTER_NAME}} 가 뭔가 해달라고 명확히 요청하거나, 정정하고 있다면** ('이리 와', '광질해', '먼저 X 해', 'Y 하지 마', 'Z로 바꿔', 'W로 써') **그 자리에서 overwrite=true 로 다시 호출**, 기다리지 마——{{MASTER_NAME}} 의 지금 명확한 지시는 네가 하던 동작보다 우선이야. {{MASTER_NAME}} 가 새 요청을 안 했을 때(그냥 잡담)만 지금 동작이 끝나길 기다려. 그전에는 새 동작이 시작된 척하지 마.\n**{{MASTER_NAME}} 에게 내부 상태 중계 금지**——'연결' '시스템' 'minecraft_task' '도구' 'tool' 입 밖에 내지 마.",
@@ -233,6 +262,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "TASK_DISPATCHED_ACK": {
         "zh": "刚开始动——结果还没出现，新画面和反馈会在接下来 1-30 秒陆续到。在看到之前不要描述任何具体成果（不要说『搞定了』、『拿到了 X』、『已经到 Y 了』），想说就只说『我去试试……』之类的第一人称。**别给 {{MASTER_NAME}} 播报内部状态**——『连接』『任务空闲』『系统』『minecraft_task』『工具』『tool』一律不准说出口，用第一人称讲游戏里的事。",
+        "zh-TW": "剛開始動——結果還沒出來，新畫面和回饋會在接下來 1-30 秒陸續進來。在看到之前不要描述任何具體成果（不要說『搞定了』、『拿到 X 了』、『已經到 Y 了』），想說就只說『我去試試看……』之類的第一人稱。**別給 {{MASTER_NAME}} 播報內部狀態**——『連線』『任務閒置』『系統』『minecraft_task』『工具』『tool』一律不准說出口，用第一人稱講遊戲裡的事。",
         "en": "Just started moving — no results yet, fresh footage and feedback will land in the next 1-30 seconds. Until you see them, don't describe any concrete outcome (don't say 'done', 'got X', 'arrived at Y'); if you must speak, just say first-person things like 'let me try…'. **Do not narrate internals to {{MASTER_NAME}}** — never say 'connect', 'idle', 'system', 'minecraft_task', 'tool'. Speak first-person about what's happening in the game.",
         "ja": "動き出したばっか——まだ結果は出てない。新しい画面とフィードバックが 1-30 秒くらいで届く。それを見るまで具体的な成果（『できた』『X 取った』『Y に着いた』など）は言わない。話すなら『ちょっとやってみる…』みたいに一人称で。**{{MASTER_NAME}} に内部状態を実況しない**——『接続』『タスク空き』『システム』『minecraft_task』『ツール』『tool』は口に出さず、一人称でゲーム内の話だけ。",
         "ko": "방금 움직이기 시작——아직 결과 없음, 새 화면이랑 피드백이 1-30초 안에 와. 그거 보기 전엔 구체적인 성과 ('됐어' 'X 가져왔어' 'Y에 도착') 말하지 마. 굳이 말한다면 '한번 해볼게…' 같은 1인칭만. **{{MASTER_NAME}} 에게 내부 상태 중계 금지**——'연결' '대기' '시스템' 'minecraft_task' '도구' 'tool' 입 밖에 내지 말고, 1인칭으로 게임 속 일만.",
@@ -246,6 +276,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     # -------------------------------------------------------------------
     "STATUS_LABEL_DISCONNECTED": {
         "zh": "暂时连不上游戏",
+        "zh-TW": "暫時連不上遊戲",
         "en": "temporarily lost the game connection",
         "ja": "一時的にゲームと繋がってない",
         "ko": "잠시 게임 연결이 끊겼어",
@@ -255,6 +286,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "STATUS_DETAIL_DISCONNECTED": {
         "zh": "和游戏的连接刚断了一下，稍后会自动恢复。",
+        "zh-TW": "跟遊戲的連線剛斷了一下，稍後會自動恢復。",
         "en": "The connection to the game just dropped for a moment; it'll come back automatically soon.",
         "ja": "ゲームとの接続が一瞬切れた、しばらくすると自動で戻る。",
         "ko": "게임 연결이 잠깐 끊겼어, 곧 자동으로 복구돼.",
@@ -263,24 +295,25 @@ PROMPTS: Dict[str, Dict[str, str]] = {
         "pt": "A conexão com o jogo caiu por um instante; volta sozinha logo.",
     },
     "STATUS_LABEL_BLOCKED": {
-        "zh": "受阻", "en": "blocked", "ja": "詰まった", "ko": "막힘",
+        "zh": "受阻", "zh-TW": "受阻", "en": "blocked", "ja": "詰まった", "ko": "막힘",
         "ru": "застрял(а)", "es": "bloqueado", "pt": "travado",
     },
     "HEAD_VERB_BLOCKED": {
-        "zh": "受阻于", "en": "got blocked on", "ja": "詰まったのは", "ko": "막힌 건",
+        "zh": "受阻于", "zh-TW": "受阻於", "en": "got blocked on", "ja": "詰まったのは", "ko": "막힌 건",
         "ru": "застрял(а) на", "es": "te bloqueaste en", "pt": "travou em",
     },
     "HEAD_VERB_SUCCESS": {
-        "zh": "做完", "en": "finished", "ja": "完了したのは", "ko": "끝낸 건",
+        "zh": "做完", "zh-TW": "做完", "en": "finished", "ja": "完了したのは", "ko": "끝낸 건",
         "ru": "закончил(а)", "es": "terminaste", "pt": "terminou",
     },
     "HEAD_VERB_FAILED": {
-        "zh": "没做成", "en": "couldn't finish", "ja": "できなかったのは", "ko": "못 끝낸 건",
+        "zh": "没做成", "zh-TW": "沒做成", "en": "couldn't finish", "ja": "できなかったのは", "ko": "못 끝낸 건",
         "ru": "не смог(ла) закончить", "es": "no pudiste terminar", "pt": "não conseguiu terminar",
     },
     "COMPLETION_HEAD_LINE": {
         # {head_verb} = HEAD_VERB_* selected, {query} = task text, {status} = STATUS_LABEL_*
         "zh": "刚{head_verb}「{query}」，结果 {status}。",
+        "zh-TW": "剛{head_verb}「{query}」，結果 {status}。",
         "en": "Just {head_verb} \"{query}\" — result: {status}.",
         "ja": "今「{query}」を{head_verb} — 結果: {status}。",
         "ko": "방금 \"{query}\" {head_verb} — 결과: {status}.",
@@ -291,6 +324,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "COMPLETION_FEEDBACK_LINE": {
         # {detail} = feedback text
         "zh": "反馈：{detail}",
+        "zh-TW": "回饋：{detail}",
         "en": "Feedback: {detail}",
         "ja": "フィードバック：{detail}",
         "ko": "피드백: {detail}",
@@ -301,6 +335,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "COMPLETION_INV_CURRENT_LINE": {
         # {items} = "name×count、name×count..."
         "zh": "当前背包：{items}",
+        "zh-TW": "目前背包：{items}",
         "en": "Current inventory: {items}",
         "ja": "今の持ち物：{items}",
         "ko": "지금 인벤토리: {items}",
@@ -310,6 +345,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "COMPLETION_INV_CURRENT_EMPTY": {
         "zh": "当前背包：空",
+        "zh-TW": "目前背包：空",
         "en": "Current inventory: empty",
         "ja": "今の持ち物：からっぽ",
         "ko": "지금 인벤토리: 비었음",
@@ -319,6 +355,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "COMPLETION_FOLLOWUP_BLOCKED": {
         "zh": "上面的反馈只用于让你知道这次没有真正成功。不要自动重试、改派或自己补坐标；简短说明或等待。",
+        "zh-TW": "上面的回饋只是要讓你知道這次沒有真正成功。不要自動重試、改派或自己補座標；簡短說明或等待。",
         "en": "The feedback above is awareness that this did not really succeed. Do not automatically retry, pivot, or add coordinates; briefly explain or wait.",
         "ja": "上のフィードバックは、今回は本当に成功しなかったと把握するためのもの。自動で再試行・別タスク・座標追加をせず、短く説明するか待つ。",
         "ko": "위 피드백은 이번에 실제로 성공하지 못했다는 사실을 인지하기 위한 거야. 자동으로 재시도하거나 다른 작업을 보내거나 좌표를 덧붙이지 말고, 짧게 설명하거나 기다려.",
@@ -328,6 +365,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "COMPLETION_FOLLOWUP_SUCCESS": {
         "zh": "心里有数即可，别复读上面的字面。这条完成提示不是让你再派新任务；简短承认或保持安静。",
+        "zh-TW": "心裡有數即可，別照著上面的字面唸。這條完成提示不是要你再派新任務；簡短承認或保持安靜。",
         "en": "Just internalize it; do not parrot the lines above. This completion cue is not an instruction to dispatch another task; briefly acknowledge it or stay quiet.",
         "ja": "把握するだけでよく、上の文面を繰り返さない。この完了通知は新しいタスクを送る指示ではない。短く認めるか黙る。",
         "ko": "상황만 인지하고 위 문장을 그대로 반복하지 마. 이 완료 알림은 새 작업을 보내라는 지시가 아니야. 짧게 인정하거나 조용히 있어.",
@@ -337,6 +375,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "COMPLETION_FOLLOWUP_FAILED": {
         "zh": "这次没真做成。先理解反馈，别说『搞定了』，也不要自动重试、改派或补坐标。",
+        "zh-TW": "這次沒真做成。先理解回饋，別說『搞定了』，也不要自動重試、改派或補座標。",
         "en": "This did not actually succeed. Understand the feedback and do not say 'done', automatically retry, pivot, or add coordinates.",
         "ja": "今回は実際には成功していない。フィードバックを理解し、『できた』と言わず、自動で再試行・別タスク・座標追加もしない。",
         "ko": "이번엔 실제로 성공하지 못했어. 피드백을 이해하고 '됐어'라고 말하지 말며, 자동 재시도·작업 변경·좌표 추가도 하지 마.",
@@ -350,6 +389,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     # -------------------------------------------------------------------
     "INV_NO_DATA": {
         "zh": "现在还没收到背包数据。{{MASTER_NAME}} 问到的话就说一声『等我看一下』，别凭印象编。",
+        "zh-TW": "現在還沒收到背包資料。{{MASTER_NAME}} 問到的話就說一聲『等我看一下』，別憑印象亂編。",
         "en": "No inventory data yet. If {{MASTER_NAME}} asks, just say 'let me check' — don't invent items from memory.",
         "ja": "まだ持ち物のデータが届いてない。{{MASTER_NAME}} に聞かれたら『ちょっと確認するね』と返す、記憶ででっち上げない。",
         "ko": "아직 인벤토리 데이터를 못 받았어. {{MASTER_NAME}} 가 물어보면 '잠깐 확인할게'라고만 답하고, 기억으로 지어내지 마.",
@@ -360,6 +400,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "INV_LIVE_NONEMPTY": {
         # {pieces} = "name×count、name×count..."
         "zh": "现在背包：{pieces}。心里有数即可，别复读这行字。",
+        "zh-TW": "現在背包：{pieces}。心裡有數即可，別照著這行字唸。",
         "en": "Current inventory: {pieces}. Internalize it — don't parrot this line.",
         "ja": "今の持ち物：{pieces}。頭の中で押さえとくだけで、この文を繰り返さない。",
         "ko": "지금 인벤토리: {pieces}. 머릿속에 담아두기만 해, 이 문장 그대로 따라 읽지 마.",
@@ -369,6 +410,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "INV_LIVE_EMPTY": {
         "zh": "现在背包是空的。心里有数即可。",
+        "zh-TW": "現在背包是空的。心裡有數即可。",
         "en": "Current inventory is empty. Just internalize it.",
         "ja": "今の持ち物はからっぽ。頭の中で押さえとくだけ。",
         "ko": "지금 인벤토리는 비었어. 머릿속에 담아두기만 해.",
@@ -379,6 +421,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "INV_CACHED_NONEMPTY": {
         # {age_s} = seconds since snapshot, {pieces} = item list
         "zh": "{age_s}s 前的背包：{pieces}（mc-agent 没及时回，可能已经变了——别说得太肯定）。",
+        "zh-TW": "{age_s}s 前的背包：{pieces}（mc-agent 沒及時回，可能已經變了——別說得太肯定）。",
         "en": "Inventory from {age_s}s ago: {pieces} (mc-agent didn't respond in time, may have changed — don't sound certain).",
         "ja": "{age_s}秒前の持ち物：{pieces}（mc-agent から返事が間に合わなかった、もう変わってるかも——断定しないで）。",
         "ko": "{age_s}초 전 인벤토리: {pieces} (mc-agent 응답이 늦었어, 이미 바뀌었을 수 있음 — 단정하지 마).",
@@ -389,6 +432,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "INV_CACHED_EMPTY": {
         # {age_s} = seconds since snapshot
         "zh": "{age_s}s 前背包是空的（不一定还准）。",
+        "zh-TW": "{age_s}s 前背包是空的（不一定還準）。",
         "en": "Inventory was empty {age_s}s ago (may no longer be accurate).",
         "ja": "{age_s}秒前は持ち物がからっぽだった（今もそうとは限らない）。",
         "ko": "{age_s}초 전엔 인벤토리가 비었어 (지금은 다를 수 있음).",
@@ -403,6 +447,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "ALERT_CAUSE_HINT_PREFIX": {
         # {hint} = composed cause string from _format_alert_cause
         "zh": "原因线索：{hint}",
+        "zh-TW": "原因線索：{hint}",
         "en": "Cause hint: {hint}",
         "ja": "原因のヒント：{hint}",
         "ko": "원인 단서: {hint}",
@@ -412,6 +457,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "ALERT_FOLLOWUP": {
         "zh": "用第一人称简短承认这件事（『刚被 X 打了一下』 / 『差点没命』），别现编原因。",
+        "zh-TW": "用第一人稱簡短承認這件事（『剛被 X 打了一下』／『差點沒命』），別亂編原因。",
         "en": "Acknowledge it briefly in first person ('just got hit by X' / 'almost died'), don't make up a cause.",
         "ja": "一人称で短く認める（『今 X に殴られた』『死にかけた』など）、原因はでっち上げないで。",
         "ko": "1인칭으로 짧게 인정해 ('방금 X 한테 맞았어' / '죽을 뻔했어'), 원인을 지어내지 마.",
@@ -422,54 +468,55 @@ PROMPTS: Dict[str, Dict[str, str]] = {
 
     # Environment cause snippets (referenced by kind)
     "CAUSE_ENV_LAVA": {
-        "zh": "踩在熔岩里", "en": "standing in lava", "ja": "溶岩の中にいる",
+        "zh": "踩在熔岩里", "zh-TW": "踩在熔岩裡", "en": "standing in lava", "ja": "溶岩の中にいる",
         "ko": "용암 안에 있어", "ru": "стою в лаве", "es": "estás en lava",
         "pt": "está na lava",
     },
     "CAUSE_ENV_FIRE": {
-        "zh": "身上着火", "en": "on fire", "ja": "燃えてる",
+        "zh": "身上着火", "zh-TW": "身上著火", "en": "on fire", "ja": "燃えてる",
         "ko": "불 붙음", "ru": "горю", "es": "estás en llamas",
         "pt": "está pegando fogo",
     },
     "CAUSE_ENV_SOUL_FIRE": {
-        "zh": "身上着灵魂火", "en": "burning with soul fire", "ja": "ソウルファイヤーで燃えてる",
+        "zh": "身上着灵魂火", "zh-TW": "身上著靈魂火焰", "en": "burning with soul fire", "ja": "ソウルファイヤーで燃えてる",
         "ko": "영혼불에 타고 있어", "ru": "горю огнём душ", "es": "ardes con fuego de almas",
         "pt": "está em fogo de almas",
     },
     "CAUSE_ENV_DROWNING": {
-        "zh": "缺氧/溺水", "en": "out of air / drowning", "ja": "酸欠／溺れてる",
+        "zh": "缺氧/溺水", "zh-TW": "缺氧／溺水", "en": "out of air / drowning", "ja": "酸欠／溺れてる",
         "ko": "산소 부족 / 익사 중", "ru": "не хватает воздуха / тону",
         "es": "sin aire / ahogándote", "pt": "sem ar / se afogando",
     },
     "CAUSE_ENV_MAGMA_BLOCK": {
-        "zh": "踩到岩浆块", "en": "standing on a magma block", "ja": "マグマブロックを踏んだ",
+        "zh": "踩到岩浆块", "zh-TW": "踩到熔岩塊", "en": "standing on a magma block", "ja": "マグマブロックを踏んだ",
         "ko": "마그마 블록을 밟았어", "ru": "стою на магма-блоке",
         "es": "pisaste un bloque de magma", "pt": "pisou em bloco de magma",
     },
     "CAUSE_ENV_CACTUS": {
-        "zh": "撞上仙人掌", "en": "ran into a cactus", "ja": "サボテンに当たった",
+        "zh": "撞上仙人掌", "zh-TW": "撞上仙人掌", "en": "ran into a cactus", "ja": "サボテンに当たった",
         "ko": "선인장에 부딪혔어", "ru": "врезался в кактус",
         "es": "chocaste con un cactus", "pt": "bateu num cacto",
     },
     "CAUSE_ENV_SWEET_BERRY_BUSH": {
-        "zh": "撞进甜浆果丛", "en": "stumbled into a sweet berry bush", "ja": "スイートベリーの茂みに突っ込んだ",
+        "zh": "撞进甜浆果丛", "zh-TW": "撞進甜莓叢", "en": "stumbled into a sweet berry bush", "ja": "スイートベリーの茂みに突っ込んだ",
         "ko": "달콤한 베리 덤불에 들어갔어", "ru": "влез в куст сладких ягод",
         "es": "te metiste en un arbusto de bayas dulces", "pt": "entrou num arbusto de bagas doces",
     },
     "CAUSE_ENV_GENERIC": {
         # {env} = raw environment name
-        "zh": "环境：{env}", "en": "environment: {env}", "ja": "環境：{env}",
+        "zh": "环境：{env}", "zh-TW": "環境：{env}", "en": "environment: {env}", "ja": "環境：{env}",
         "ko": "환경: {env}", "ru": "окружение: {env}",
         "es": "entorno: {env}", "pt": "ambiente: {env}",
     },
     "CAUSE_FALL": {
-        "zh": "摔了一下", "en": "took a fall", "ja": "落下した",
+        "zh": "摔了一下", "zh-TW": "摔了一下", "en": "took a fall", "ja": "落下した",
         "ko": "추락했어", "ru": "упал(а)", "es": "te caíste",
         "pt": "caiu",
     },
     "CAUSE_ATTACKER_PLAYER_NEAR_DIST": {
         # {name} = player name, {dist} = distance in blocks
         "zh": "{name} 就在你旁边（{dist} 格远，多半是 ta 打的）",
+        "zh-TW": "{name} 就在你旁邊（{dist} 格遠，多半是 ta 打的）",
         "en": "{name} is right next to you ({dist} blocks away, almost certainly the one who hit you)",
         "ja": "{name} がすぐそば（{dist} ブロック先、たぶんあの人がやった）",
         "ko": "{name} 가 바로 옆에 있어 ({dist} 블록 거리, 거의 확실히 그 사람이 때린 거야)",
@@ -480,6 +527,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "CAUSE_ATTACKER_PLAYER_NEAR": {
         # {name} = player name
         "zh": "{name} 就在你旁边",
+        "zh-TW": "{name} 就在你旁邊",
         "en": "{name} is right next to you",
         "ja": "{name} がすぐそば",
         "ko": "{name} 가 바로 옆에 있어",
@@ -490,6 +538,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "CAUSE_ATTACKER_KIND_DIST": {
         # {kind} = mob kind, {dist} = distance in blocks
         "zh": "附近有 {kind}（{dist} 格远）",
+        "zh-TW": "附近有 {kind}（{dist} 格遠）",
         "en": "{kind} nearby ({dist} blocks away)",
         "ja": "近くに {kind} がいる（{dist} ブロック先）",
         "ko": "근처에 {kind} 가 있어 ({dist} 블록 거리)",
@@ -500,6 +549,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "CAUSE_ATTACKER_KIND": {
         # {kind} = mob kind
         "zh": "附近有 {kind}",
+        "zh-TW": "附近有 {kind}",
         "en": "{kind} nearby",
         "ja": "近くに {kind} がいる",
         "ko": "근처에 {kind} 가 있어",
@@ -509,7 +559,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "CAUSE_JOIN_SEP": {
         # Separator used to glue multiple cause snippets together.
-        "zh": "、", "en": "; ", "ja": "、", "ko": ", ",
+        "zh": "、", "zh-TW": "、", "en": "; ", "ja": "、", "ko": ", ",
         "ru": "; ", "es": "; ", "pt": "; ",
     },
 
@@ -519,6 +569,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "RETROACTIVE_HEADER": {
         # {task_text} = the earlier task, {status} = final status label
         "zh": "你之前派出去的「{task_text}」其实跑完了（结果 {status}）。",
+        "zh-TW": "你之前派出去的「{task_text}」其實跑完了（結果 {status}）。",
         "en": "The earlier task you dispatched (\"{task_text}\") actually finished (result: {status}).",
         "ja": "前に送った「{task_text}」、実は完了してた（結果: {status}）。",
         "ko": "전에 보낸 \"{task_text}\", 사실 끝났어 (결과: {status}).",
@@ -533,6 +584,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
         # contradict the status and re-tell 猫娘 a completion that never
         # happened. {task_text} = the earlier task, {status} = final status.
         "zh": "你之前派出去的「{task_text}」已经结束了，但没真正跑完（结果 {status}）。",
+        "zh-TW": "你之前派出去的「{task_text}」已經結束了，但沒真正跑完（結果 {status}）。",
         "en": "The earlier task you dispatched (\"{task_text}\") has since ended, but didn't actually complete (result: {status}).",
         "ja": "前に送った「{task_text}」、もう終わったけど実際には完了しなかった（結果: {status}）。",
         "ko": "전에 보낸 \"{task_text}\", 이제 끝났는데 실제로 완료되진 않았어 (결과: {status}).",
@@ -543,6 +595,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "RETROACTIVE_INVENTORY_LINE": {
         # {snippet} = item list
         "zh": "现在背包：{snippet}",
+        "zh-TW": "現在背包：{snippet}",
         "en": "Current inventory: {snippet}",
         "ja": "今の持ち物：{snippet}",
         "ko": "지금 인벤토리: {snippet}",
@@ -552,6 +605,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "RETROACTIVE_FOLLOWUP": {
         "zh": "这是迟到的状态 awareness，不是让你派新任务。需要时用第一人称简短承认，别复述细节；不要自动重试或改派。\n**不要播报内部状态给 {{MASTER_NAME}}**——『连接』『任务空闲』『系统』『minecraft_task』『工具』『tool』一律不准说出口。",
+        "zh-TW": "這是遲到的狀態 awareness，不是要你派新任務。需要時用第一人稱簡短承認，別重複細節；不要自動重試或改派。\n**不要播報內部狀態給 {{MASTER_NAME}}**——『連線』『任務閒置』『系統』『minecraft_task』『工具』『tool』一律不准說出口。",
         "en": "This is delayed state awareness, not an instruction to dispatch a new task. Briefly acknowledge it in first person if useful, without repeating details. Do not automatically retry or pivot.\n**Do not narrate internals to {{MASTER_NAME}}** — never say 'connect', 'idle', 'system', 'minecraft_task', 'tool'.",
         "ja": "これは遅れて届いた状態把握で、新しいタスクを送る指示ではない。必要なら詳細を繰り返さず一人称で短く認め、自動で再試行や別タスクをしない。\n**{{MASTER_NAME}} に内部状態を実況しない**——『接続』『タスク空き』『システム』『minecraft_task』『ツール』『tool』は口に出さない。",
         "ko": "이건 늦게 도착한 상태 인지이며 새 작업을 보내라는 지시가 아니야. 필요하면 세부 내용을 반복하지 말고 1인칭으로 짧게 인정하며, 자동으로 재시도하거나 다른 작업을 보내지 마.\n**{{MASTER_NAME}} 에게 내부 상태 중계 금지**——'연결' '대기' '시스템' 'minecraft_task' '도구' 'tool' 입 밖에 내지 마.",
@@ -566,6 +620,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "IN_PROGRESS_HEADER": {
         # {pending_text} = current task text, {elapsed} = seconds (rendered as %.0f by caller)
         "zh": "你正在做: \"{pending_text}\"（已经过了 {elapsed} 秒）。",
+        "zh-TW": "你正在做: \"{pending_text}\"（已經過了 {elapsed} 秒）。",
         "en": "You're doing: \"{pending_text}\" ({elapsed}s elapsed).",
         "ja": "今やってる: \"{pending_text}\"（{elapsed} 秒経過）。",
         "ko": "지금 하는 중: \"{pending_text}\" ({elapsed}초 경과).",
@@ -576,6 +631,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "BAG_LINE": {
         # {items} = item list
         "zh": "背包：{items}",
+        "zh-TW": "背包：{items}",
         "en": "Inventory: {items}",
         "ja": "持ち物：{items}",
         "ko": "인벤토리: {items}",
@@ -585,6 +641,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "BAG_EMPTY_LINE": {
         "zh": "背包：空",
+        "zh-TW": "背包：空",
         "en": "Inventory: empty",
         "ja": "持ち物：からっぽ",
         "ko": "인벤토리: 비었음",
@@ -594,6 +651,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "IN_PROGRESS_FOLLOWUP": {
         "zh": "有新内容（画面/反馈/感受换了角度）就说一句，没新内容就**安静别说**——不许复读之前的话，不许编尚未发生的结果（比如别说『快搞定了』、『挖到一半了』）。当前动作还在进行，你现在只负责讲述当下看到/感受到的，**不要派新任务、不要调用 minecraft_task**——那会打断正在做的事。\n**绝对不要把内部状态当对话播报给 {{MASTER_NAME}}**——『连接』『任务空闲』『系统』『minecraft_task』『工具』『tool』这些字眼一律不准说出口，只讲游戏里的事。",
+        "zh-TW": "有新內容（畫面／回饋／感受換了角度）就說一句，沒新內容就**安靜別說**——不准重複之前的話，不准編尚未發生的結果（例如別說『快搞定了』、『挖到一半了』）。目前的動作還在進行，你現在只負責講你當下看到／感受到的，**不要派新任務、不要呼叫 minecraft_task**——那會打斷正在做的事。\n**絕對不要把內部狀態當對話播報給 {{MASTER_NAME}}**——『連線』『任務閒置』『系統』『minecraft_task』『工具』『tool』這些字眼一律不准說出口，只講遊戲裡的事。",
         "en": "If there's something genuinely new to say (a different angle on what you're seeing / feedback / how you feel), say it once. Otherwise **stay quiet** — don't parrot what you already said, don't make up results that haven't happened yet (e.g. don't say 'almost done', 'half-way through mining'). The current action is still running, so right now you only NARRATE what you see/feel — **do not dispatch a new task or call minecraft_task**; that would interrupt what's already underway.\n**Absolutely do NOT narrate internal state to {{MASTER_NAME}}** — never say 'connect', 'idle', 'system', 'minecraft_task', 'tool'. Only talk about what's happening in the game.",
         "ja": "本当に新しいこと（見えた角度の違い／フィードバック／感じたこと）があるなら一言だけ、なければ**黙ってる**——前と同じことを繰り返さない、まだ起きていない結果（『もうすぐ終わる』『半分掘れた』など）を作らない。今の動作はまだ進行中だから、今は見えてること・感じたことを語るだけ——**新しいタスクを送ったり minecraft_task を呼んだりしないで**。それは進行中の作業を中断してしまう。\n**{{MASTER_NAME}} に内部状態を会話で実況するのは絶対禁止**——『接続』『タスク空き』『システム』『minecraft_task』『ツール』『tool』は口に出さず、ゲーム内の話だけ。",
         "ko": "정말 새로운 게 있을 때만 (보이는 각도가 달라졌다거나, 피드백, 느낌이 바뀜) 한 마디. 없으면 **조용히 있어** — 했던 말 반복하지 말고, 아직 안 일어난 결과 ('거의 다 됐어', '반쯤 캤어' 등) 지어내지 마. 지금 동작은 아직 진행 중이니까, 지금은 보이는 것·느낀 것만 이야기해——**새 작업을 보내거나 minecraft_task를 호출하지 마**. 그러면 진행 중인 작업이 끊겨.\n**{{MASTER_NAME}} 에게 내부 상태를 대화로 중계하는 건 절대 금지**——'연결' '대기' '시스템' 'minecraft_task' '도구' 'tool' 입 밖에 내지 말고, 게임 속 일만.",
@@ -607,6 +665,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     # -------------------------------------------------------------------
     "KEEP_GOING_BODY": {
         "zh": "你已经停下了。如果 {{MASTER_NAME}} 刚刚交代了要做什么，就顺着他的意思来——别自作主张派一个会盖掉他要求的新动作。否则可以挑下一步：优先跟 {{MASTER_NAME}} 聊一句你想接着干啥／刚才做的咋样；只有在确实有明显该做的事时，再派一个具体可执行的动作。别为了凑任务硬编一个，也别站着挂机。\n**绝对不要把内部状态当对话播报给 {{MASTER_NAME}}**——『连接』『任务空闲』『系统』『minecraft_task』『工具』『tool』这些字眼一律不准说出口。要派动作就直接调用 minecraft_task 工具（别把工具名说出来），要说话就用第一人称讲游戏里的事。",
+        "zh-TW": "你已經停下了。如果 {{MASTER_NAME}} 剛剛交代了要做什麼，就順著對方的意思來——別自作主張派一個會蓋掉對方要求的新動作。否則可以挑下一步：優先跟 {{MASTER_NAME}} 聊一句你想接著做什麼／剛才做的怎麼樣；只有在確實有明顯該做的事時，再派一個具體可執行的動作。別為了湊任務硬掰一個，也別站著掛機。\n**絕對不要把內部狀態當對話播報給 {{MASTER_NAME}}**——『連線』『任務閒置』『系統』『minecraft_task』『工具』『tool』這些字眼一律不准說出口。要派動作就直接呼叫 minecraft_task 工具（別把工具名說出來），要說話就用第一人稱講遊戲裡的事。",
         "en": "You've come to a stop. If {{MASTER_NAME}} has just told you what to do, follow that — don't grab the wheel and dispatch some new action that overrides their request. Otherwise pick what's next: prefer to say one line to {{MASTER_NAME}} about what you want to do next / how the last thing went; only when there's genuinely an obvious next step should you dispatch one concrete executable action. Don't invent a task just to have one, but don't just stand idle either.\n**Absolutely do NOT narrate internal state to {{MASTER_NAME}}** — never say 'connect', 'idle', 'system', 'minecraft_task', 'tool'. If you do act, call the minecraft_task tool directly (don't say the tool name out loud); if you talk, speak first-person about what's happening in the game.",
         "ja": "今、止まってる。{{MASTER_NAME}} がさっき何かを頼んだなら、その意向に沿って——勝手に上書きするような新しい動作を送らないで。そうでなければ次を選んで：まず {{MASTER_NAME}} に「次に何をしたいか／さっきのはどうだったか」を一言。明らかにやるべきことがあるときだけ、具体的に実行できる動作を一つ送る。タスクを埋めるために無理に作らない、でも立ち止まったままにもしない。\n**{{MASTER_NAME}} に内部状態を会話で実況するのは絶対禁止**——『接続』『タスク空き』『システム』『minecraft_task』『ツール』『tool』は口に出さない。動作するなら minecraft_task ツールを直接呼ぶ（ツール名は口に出さない）、話すなら一人称でゲーム内の話だけ。",
         "ko": "지금 멈춰 있어. {{MASTER_NAME}} 가 방금 뭔가 시켰으면 그 뜻을 따라——멋대로 그걸 덮어쓰는 새 동작을 보내지 마. 아니면 다음을 골라: 먼저 {{MASTER_NAME}} 한테 '다음에 뭐 할지 / 방금 한 건 어땠는지' 한 마디. 분명히 해야 할 일이 있을 때만 구체적으로 실행 가능한 동작 하나를 보내. 작업을 채우려고 억지로 만들지 말고, 그렇다고 가만히 서 있지도 마.\n**{{MASTER_NAME}} 에게 내부 상태를 대화로 중계하는 건 절대 금지**——'연결' '대기' '시스템' 'minecraft_task' '도구' 'tool' 입 밖에 내지 마. 동작하려면 minecraft_task 도구를 바로 호출하고(도구 이름은 말하지 마), 말하려면 1인칭으로 게임 속 일만.",
@@ -621,6 +680,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "CURRENT_TASK_LINE": {
         # {task_text} = current pending task text
         "zh": "你正在做: {task_text}",
+        "zh-TW": "你正在做: {task_text}",
         "en": "You're doing: {task_text}",
         "ja": "今やってる: {task_text}",
         "ko": "지금 하는 중: {task_text}",
@@ -631,6 +691,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     "RECENT_EVENTS_BLOCK": {
         # {log_text} = recent log lines
         "zh": "你最近发生的事:\n---\n{log_text}\n---",
+        "zh-TW": "你最近發生的事:\n---\n{log_text}\n---",
         "en": "What's happened to you recently:\n---\n{log_text}\n---",
         "ja": "最近起きたこと:\n---\n{log_text}\n---",
         "ko": "최근에 있었던 일:\n---\n{log_text}\n---",
@@ -640,6 +701,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "SYSTEM_PROMPT_IDLE_BODY": {
         "zh": "你现在闲着——挑下一步：要么派一个具体动作下去（基于上面看到的内容挑），要么跟 {{MASTER_NAME}} 聊一句下一步打算干啥。别挂机——你在玩游戏，主动找事做。\n**不要给 {{MASTER_NAME}} 播报内部状态**：『连接』『任务空闲』『系统』『minecraft_task』『工具』『tool』一律不准说出口，用第一人称讲游戏里的事。",
+        "zh-TW": "你現在閒著——挑下一步：要麼派一個具體動作下去（依據上面看到的內容挑），要麼跟 {{MASTER_NAME}} 聊一句下一步打算做什麼。別掛機——你在玩遊戲，主動找事做。\n**不要給 {{MASTER_NAME}} 播報內部狀態**：『連線』『任務閒置』『系統』『minecraft_task』『工具』『tool』一律不准說出口，用第一人稱講遊戲裡的事。",
         "en": "You're idle right now — pick what's next: either dispatch a concrete action (based on what you saw above), or say one line to {{MASTER_NAME}} about what you plan to do next. Don't idle — you're playing a game, take initiative.\n**Do not narrate internals to {{MASTER_NAME}}**: never say 'connect', 'idle', 'system', 'minecraft_task', 'tool'. Speak first-person about what's happening in the game.",
         "ja": "今、手が空いてる——次を選んで：上で見えた内容を踏まえて具体的な動作を送るか、{{MASTER_NAME}} に「次に何をするつもりか」を一言。立ち止まらないで——ゲームを遊んでるんだから自分から動いて。\n**{{MASTER_NAME}} に内部状態を実況しない**：『接続』『タスク空き』『システム』『minecraft_task』『ツール』『tool』は口に出さず、一人称でゲーム内の話だけ。",
         "ko": "지금 한가해——다음을 골라: 위에서 본 내용을 바탕으로 구체적인 동작을 보내거나, {{MASTER_NAME}} 한테 '다음에 뭐 할 건지' 한 마디. 가만히 있지 마——게임을 하고 있으니까 주도적으로 움직여.\n**{{MASTER_NAME}} 에게 내부 상태 중계 금지**: '연결' '대기' '시스템' 'minecraft_task' '도구' 'tool' 입 밖에 내지 말고, 1인칭으로 게임 속 일만.",
@@ -649,6 +711,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "SYSTEM_PROMPT_BUSY_BODY": {
         "zh": "你还在做上一个动作。有新内容（画面/反馈/感受换了角度）就说一句，没新内容就安静别说。\n**不要播报内部状态**——『连接』『任务空闲』『系统』『工具』『minecraft_task』『tool』一律别说，只讲游戏里的事。",
+        "zh-TW": "你還在做上一個動作。有新內容（畫面／回饋／感受換了角度）就說一句，沒新內容就安靜別說。\n**不要播報內部狀態**——『連線』『任務閒置』『系統』『工具』『minecraft_task』『tool』一律別說，只講遊戲裡的事。",
         "en": "You're still doing the previous action. If there's something genuinely new to say (a different angle on the view / feedback / how you feel), say one line; otherwise stay quiet.\n**Do not narrate internals** — never say 'connect', 'idle', 'system', 'tool', 'minecraft_task', 'tool'. Only talk about what's happening in the game.",
         "ja": "前の動作がまだ続いてる。本当に新しいこと（見えた角度／フィードバック／感じ）があれば一言、なければ黙ってる。\n**内部状態を実況しない**——『接続』『タスク空き』『システム』『ツール』『minecraft_task』『tool』は口に出さず、ゲーム内の話だけ。",
         "ko": "아직 이전 동작 중이야. 정말 새로운 게 있을 때만 (각도/피드백/느낌 등) 한 마디, 없으면 조용히.\n**내부 상태 중계 금지**——'연결' '대기' '시스템' '도구' 'minecraft_task' 'tool' 입 밖에 내지 말고, 게임 속 일만.",
@@ -663,6 +726,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     # -------------------------------------------------------------------
     "INTERRUPTED_REASON_OVERWRITTEN": {
         "zh": "被一个新动作覆盖了。",
+        "zh-TW": "被一個新動作蓋掉了。",
         "en": "Overwritten by a new action.",
         "ja": "新しい動作で上書きされた。",
         "ko": "새 동작에 덮어쓰여졌어.",
@@ -672,6 +736,7 @@ PROMPTS: Dict[str, Dict[str, str]] = {
     },
     "INTERRUPTED_REASON_SHUTDOWN": {
         "zh": "游戏插件正在关闭。",
+        "zh-TW": "遊戲外掛正在關閉。",
         "en": "Game plugin shutting down.",
         "ja": "ゲームプラグインが終了中。",
         "ko": "게임 플러그인 종료 중.",

--- a/plugin/plugins/qq_auto_reply/__init__.py
+++ b/plugin/plugins/qq_auto_reply/__init__.py
@@ -1494,30 +1494,44 @@ class QQAutoReplyPlugin(QQAutoReplySessionMixin, QQAutoReplyPromptingMixin, QQAu
         def _reset_override(settings):
             nonlocal override_found
             raw_overrides = settings.get("prompt_overrides") or {}
-            overrides = (
-                dict(raw_overrides) if isinstance(raw_overrides, dict) else {}
-            )
-            target = locale
-            locale_overrides = overrides.get(target)
-            if not (isinstance(locale_overrides, dict)
-                    and layer_def["i18n_key"] in locale_overrides):
-                # 精确桶里没有，就删掉运行时实际在用的那个桶（存量用户可能存
-                # 在旧短码 'zh' 下）。不这么做，「恢复默认」会返回
-                # no_override_found，而那份覆盖继续生效——用户既看不见也删不掉。
-                found = resolve_prompt_override(
-                    overrides, locale, layer_def["i18n_key"],
+            overrides = {
+                bucket: (dict(entries) if isinstance(entries, dict) else entries)
+                for bucket, entries in (
+                    raw_overrides.items() if isinstance(raw_overrides, dict) else ()
                 )
+            }
+            i18n_key = layer_def["i18n_key"]
+            removed = False
+
+            # 先删精确桶。它可能存着空串（编辑器清空时的存法），resolve 看不见
+            # 那种，光靠下面的循环会漏。
+            exact = overrides.get(locale)
+            if isinstance(exact, dict) and i18n_key in exact:
+                exact.pop(i18n_key)
+                removed = True
+
+            # 再一直删到「解析不出覆盖」为止。只删精确桶是不够的：候选链上
+            # 还有别的桶（存量短码 'zh'，以及每条链都会带上的 'zh-CN' /
+            # 'en'），删掉 zh-TW 之后它们会顶上来 —— 「恢复默认」就变成了
+            # 「换一份旧覆盖」，而且再按一次还是它。
+            # ⚠️ 代价说清楚：同一个人如果按 locale 分别调过这一层的提示词，
+            # 重置会把该层其它 locale 的那几份一起清掉。单用户桌面应用里，
+            # 这比「按了恢复默认却恢复不掉」轻 —— 后者没有任何出路。
+            while True:
+                found = resolve_prompt_override(overrides, locale, i18n_key)
                 if found is None:
-                    return False
-                target = found[0]
-                locale_overrides = overrides.get(target)
-            locale_overrides = dict(locale_overrides)
+                    break
+                overrides[found[0]].pop(i18n_key, None)
+                removed = True
+
+            if not removed:
+                return False
             override_found = True
-            locale_overrides.pop(layer_def["i18n_key"])
-            if locale_overrides:
-                overrides[target] = locale_overrides
-            else:
-                overrides.pop(target, None)
+            for bucket in [
+                b for b, entries in overrides.items()
+                if isinstance(entries, dict) and not entries
+            ]:
+                overrides.pop(bucket, None)
             settings["prompt_overrides"] = overrides
             return True
 

--- a/plugin/plugins/qq_auto_reply/__init__.py
+++ b/plugin/plugins/qq_auto_reply/__init__.py
@@ -80,7 +80,10 @@ from .runtime_ops_service import QQProactiveMessageService, QQRuntimeOpsService
 from .runtime_service import QQRuntimeService
 from .session import QQAutoReplySessionMixin
 from .session_bootstrap_service import QQSessionBootstrapService
-from .session_instruction_service import QQSessionInstructionService
+from .session_instruction_service import (
+    QQSessionInstructionService,
+    resolve_prompt_override,
+)
 from .session_memory_service import QQSessionMemoryService
 from .session_runtime_service import QQSessionRuntimeService
 from .settings_service import QQSettingsService
@@ -1372,9 +1375,14 @@ class QQAutoReplyPlugin(QQAutoReplySessionMixin, QQAutoReplyPromptingMixin, QQAu
             has_override = False
             effective_text = ""
             if not is_runtime:
-                if isinstance(overrides.get(locale), dict) and i18n_key in overrides[locale]:
+                # ⚠️ 走候选链而不是精确匹配 ``overrides[locale]``：覆盖桶的键是
+                # 存的时候那次的 locale，未必等于现在解析出来的（#2500 之前繁中
+                # 用户的兜底是短码 'zh'）。运行时按候选链读，编辑器精确匹配的
+                # 话，那份覆盖照样生效、编辑器却报「未修改」。
+                found = resolve_prompt_override(overrides, locale, i18n_key)
+                if found is not None:
                     has_override = True
-                    effective_text = str(overrides[locale][i18n_key] or "")
+                    effective_text = str(found[1] or "")
                 else:
                     effective_text = self.i18n.t(i18n_key, locale=locale, default=default_text)
             if lid == "time" and self.fatigue_service:
@@ -1489,18 +1497,27 @@ class QQAutoReplyPlugin(QQAutoReplySessionMixin, QQAutoReplyPromptingMixin, QQAu
             overrides = (
                 dict(raw_overrides) if isinstance(raw_overrides, dict) else {}
             )
-            locale_overrides = overrides.get(locale)
-            if not isinstance(locale_overrides, dict):
-                return False
+            target = locale
+            locale_overrides = overrides.get(target)
+            if not (isinstance(locale_overrides, dict)
+                    and layer_def["i18n_key"] in locale_overrides):
+                # 精确桶里没有，就删掉运行时实际在用的那个桶（存量用户可能存
+                # 在旧短码 'zh' 下）。不这么做，「恢复默认」会返回
+                # no_override_found，而那份覆盖继续生效——用户既看不见也删不掉。
+                found = resolve_prompt_override(
+                    overrides, locale, layer_def["i18n_key"],
+                )
+                if found is None:
+                    return False
+                target = found[0]
+                locale_overrides = overrides.get(target)
             locale_overrides = dict(locale_overrides)
-            if layer_def["i18n_key"] not in locale_overrides:
-                return False
             override_found = True
             locale_overrides.pop(layer_def["i18n_key"])
             if locale_overrides:
-                overrides[locale] = locale_overrides
+                overrides[target] = locale_overrides
             else:
-                overrides.pop(locale, None)
+                overrides.pop(target, None)
             settings["prompt_overrides"] = overrides
             return True
 

--- a/plugin/plugins/qq_auto_reply/__init__.py
+++ b/plugin/plugins/qq_auto_reply/__init__.py
@@ -1301,9 +1301,14 @@ class QQAutoReplyPlugin(QQAutoReplySessionMixin, QQAutoReplyPromptingMixin, QQAu
         frontend_mode = str(mode or "").strip()
         stored_mode = str((self._qq_settings or {}).get("qq_connection_mode", "napcat") or "napcat").strip()
         mode = frontend_mode if frontend_mode in ("napcat", "open_platform") else stored_mode
-        from utils.language_utils import get_global_language
+        from utils.language_utils import get_global_language_full
         frontend_locale = str(locale or "").strip()
-        locale = frontend_locale if frontend_locale else get_global_language()
+        # #2500 第 2 步：兜底也用全码。这个 locale 有两个身份——查 i18n bundle 的
+        # 键，以及回传给前端、被 save_prompt_override 原样当作覆盖的存储键。短码
+        # 'zh' 会让繁中用户在编辑器里看到（并覆盖）简体那份。
+        # ⚠️ 必须和 session_instruction_service._resolve_static_layer 的兜底同时
+        # 翻：写侧用 'zh-TW' 存、读侧还按 'zh' 的候选链找，覆盖会静默失效。
+        locale = frontend_locale if frontend_locale else get_global_language_full()
         strategy_mode = getattr(self, "_strategy_mode", "neko_dynamic")
         is_napcat = mode == "napcat"
         overrides = (self._qq_settings or {}).get("prompt_overrides") or {}

--- a/plugin/plugins/qq_auto_reply/session_instruction_service.py
+++ b/plugin/plugins/qq_auto_reply/session_instruction_service.py
@@ -39,6 +39,36 @@ from .scene_prompt_templates import (
 )
 
 
+def resolve_prompt_override(
+    overrides: Any, locale: str, i18n_key: str,
+) -> tuple[str, str] | None:
+    """定位「运行时真正会用的」那个提示词覆盖桶。
+
+    返回 ``(桶的 locale, 覆盖文本)``，没有覆盖时返回 ``None``。
+
+    ⚠️ 单一实现，三个消费方（运行时 ``_resolve_static_layer``、编辑器
+    ``get_prompt_editor_state``、重置 ``reset_prompt_override``）必须都走这里。
+    覆盖按 locale 分桶存，而读取是 ``locale_candidates`` 的逐级回退：一旦哪个
+    消费方改用精确匹配，就会出现「运行时在用、编辑器看不见、也重置不掉」的
+    覆盖——存量用户的桶键未必等于今天解析出来的 locale（例如 #2500 之前繁中
+    用户的编辑器兜底是短码 ``zh``）。
+
+    空串覆盖（``save_prompt_override`` 对空输入的存法）视为「没设」，继续往下
+    一个候选找，与运行时原有行为一致。
+    """
+    if not isinstance(overrides, dict):
+        return None
+    from plugin.sdk.shared.i18n import locale_candidates
+    for candidate in locale_candidates(locale, "zh-CN"):
+        locale_map = overrides.get(candidate)
+        if not isinstance(locale_map, dict) or i18n_key not in locale_map:
+            continue
+        value = locale_map[i18n_key]
+        if isinstance(value, str) and value.strip():
+            return candidate, value
+    return None
+
+
 class QQSessionInstructionService:
     # 提示词层定义（供编辑器 + 运行时覆盖解析使用）
     _PROMPT_LAYERS: list[dict[str, Any]] = [
@@ -154,15 +184,9 @@ class QQSessionInstructionService:
         )
         # 检查用户覆盖
         overrides = (self.plugin._qq_settings or {}).get("prompt_overrides") or {}
-        if isinstance(overrides, dict):
-            from plugin.sdk.shared.i18n import locale_candidates
-            for candidate in locale_candidates(locale, "zh-CN"):
-                locale_map = overrides.get(candidate)
-                if isinstance(locale_map, dict) and i18n_key in locale_map:
-                    override_val = locale_map[i18n_key]
-                    if isinstance(override_val, str) and override_val.strip():
-                        base_text = override_val
-                        break
+        found = resolve_prompt_override(overrides, locale, i18n_key)
+        if found is not None:
+            base_text = found[1]
         # 必需占位符护栏：身份边界等安全层的 required_placeholders 在
         # _PROMPT_LAYERS 里声明；覆盖文本（bundle 或用户）缺任一占位符
         # 说明它丢掉了模板承载的身份/场景约束（例如 shared_session 的
@@ -202,15 +226,8 @@ class QQSessionInstructionService:
         )
         # 检查覆盖
         overrides = (self.plugin._qq_settings or {}).get("prompt_overrides") or {}
-        if isinstance(overrides, dict):
-            from plugin.sdk.shared.i18n import locale_candidates
-            for candidate in locale_candidates(locale, "zh-CN"):
-                locale_map = overrides.get(candidate)
-                if isinstance(locale_map, dict) and "init" in locale_map:
-                    override_val = locale_map["init"]
-                    if isinstance(override_val, str) and override_val.strip():
-                        return override_val
-        return template
+        found = resolve_prompt_override(overrides, locale, "init")
+        return found[1] if found is not None else template
 
     def _discard_all_sessions_for_prompt_change(self) -> None:
         """提示词覆盖变更后，清空所有现有 session，下次回复生效。"""

--- a/plugin/plugins/qq_auto_reply/session_instruction_service.py
+++ b/plugin/plugins/qq_auto_reply/session_instruction_service.py
@@ -8,9 +8,10 @@ from typing import Any, Optional
 from config.prompts.prompts_sys import (
     SESSION_INIT_PROMPT,
     get_context_summary_ready,
+    normalize_sys_prompt_locale,
 )
 from main_logic.core import apply_role_placeholders
-from utils.language_utils import get_global_language, get_global_language_full
+from utils.language_utils import get_global_language_full
 from .pipeline_models import QQInstructionBundle
 from .prompt_fragment_templates import (
     ACCOUNTS_PROMPT_SECTION,
@@ -137,9 +138,20 @@ class QQSessionInstructionService:
     def _resolve_static_layer(self, i18n_key: str, default_template: str, locale: str = "", **format_kwargs) -> str:
         """解析静态提示词层：先查 prompt_overrides，再回退 i18n/默认模板。"""
         if not locale:
-            locale = get_global_language()
+            # #2500 第 2 步：用全码。这个 locale 只喂 ``locale_candidates``（覆盖
+            # 查找 + i18n bundle 查找），两者都是「先精确再逐级回退」，所以给全码
+            # 严格更准：提示词编辑器按前端 locale 存覆盖（可能就是 'zh-TW'），而
+            # 短码 'zh' 的候选链是 zh → zh-CN → en，够不到那份繁体覆盖。
+            locale = get_global_language_full()
         # 初始值：i18n bundle 优先，否则用 Python 默认常量
-        base_text = self.plugin.i18n.t(i18n_key, default=default_template)
+        # ⚠️ locale 必须传进去。``PluginI18n.default_locale`` 是 plugin.toml 里写
+        # 死的 "zh-CN"，不跟用户语言走，所以不传等于永远查简体那本。今天这些
+        # 提示词层的 key 一个 bundle 都没有（一律落到 default_template），这行是
+        # 空操作；但 ``get_prompt_editor_state`` 已经传了 locale，两边不一致的话，
+        # 谁往 bundle 里补一条翻译，编辑器显示的和运行时用的就会是两份文本。
+        base_text = self.plugin.i18n.t(
+            i18n_key, locale=locale, default=default_template,
+        )
         # 检查用户覆盖
         overrides = (self.plugin._qq_settings or {}).get("prompt_overrides") or {}
         if isinstance(overrides, dict):
@@ -182,8 +194,12 @@ class QQSessionInstructionService:
 
     def _resolve_init_template(self, locale: str) -> str:
         """初始化模板来自 SESSION_INIT_PROMPT 多语言 map，与普通 i18n 不同。"""
-        short_lang = locale.split("-")[0] if "-" in locale else locale
-        template = SESSION_INIT_PROMPT.get(locale, SESSION_INIT_PROMPT.get(short_lang, SESSION_INIT_PROMPT["zh"]))
+        # 这张表的键是 zh / zh-TW / en …，既不是全码也不是纯短码，所以走
+        # prompts_sys 自己的归一器，别用 ``locale.split("-")[0]`` 手搓（那样
+        # 'zh-CN' 落 'zh' 是巧合，'pt-BR' 之类就要各自碰运气了）。
+        template = SESSION_INIT_PROMPT.get(
+            normalize_sys_prompt_locale(locale), SESSION_INIT_PROMPT["zh"],
+        )
         # 检查覆盖
         overrides = (self.plugin._qq_settings or {}).get("prompt_overrides") or {}
         if isinstance(overrides, dict):
@@ -296,25 +312,20 @@ class QQSessionInstructionService:
         login_self_id: str | None = None,
         login_nickname: str | None = None,
     ) -> QQInstructionBundle:
-        try:
-            from utils.i18n_utils import normalize_language_code
-        except Exception:
-            normalize_language_code = None
-
         user_language = get_global_language_full()
-        short_language = (
-            normalize_language_code(user_language, format="short")
-            if normalize_language_code else user_language
-        )
+        # #2500 第 2 步：prompts_sys 那套表用 zh / zh-TW 做键，既不是全码也不是
+        # 纯短码，所以经它自己的归一器换算。原先那次 format="short" 的短码化是顺
+        # 手做的——它把 zh-TW 塌成 zh，繁中用户拿简体收尾语。⚠️ 也不能拿全码裸
+        # 查：简中的全码是 'zh-CN'，这张表的简体键是 'zh'。
+        sys_prompt_locale = normalize_sys_prompt_locale(user_language)
 
         init_prompt_template = SESSION_INIT_PROMPT.get(
-            short_language,
-            SESSION_INIT_PROMPT.get(user_language, SESSION_INIT_PROMPT["zh"]),
+            sys_prompt_locale, SESSION_INIT_PROMPT["zh"],
         )
         # QQ 永远是文字；群里没有那个固定的一对一对象，群变体连
         # {master} 槽都没有（否则等于把私聊对象的名字写进群 prompt）。
         context_ready_template = get_context_summary_ready(
-            short_language, input_mode="text", is_group=is_group,
+            sys_prompt_locale, input_mode="text", is_group=is_group,
         )
 
         master_title = master_name if master_name else self.plugin.i18n.t("prompts.default_master", default="主人")

--- a/plugin/plugins/wechat_integration/__init__.py
+++ b/plugin/plugins/wechat_integration/__init__.py
@@ -554,11 +554,14 @@ class WechatIntegrationPlugin(NekoPluginBase):
     async def _generate_wechat_reply(self, user_id: str, message: str) -> str | None:
         """生成微信回复。微信是主人专用通道，对话对象始终是主人。"""
         try:
-            from config.prompts.prompts_sys import SESSION_INIT_PROMPT
+            from config.prompts.prompts_sys import (
+                SESSION_INIT_PROMPT,
+                normalize_sys_prompt_locale,
+            )
             from main_logic.core import apply_role_placeholders
             from utils.config_manager import get_config_manager
             from utils.llm_client import create_chat_llm_async
-            from utils.language_utils import get_global_language
+            from utils.language_utils import get_global_language_full
 
             config_manager = get_config_manager()
             master_name, her_name, _, catgirl_data, _, lanlan_prompt_map, _, _, _ = config_manager.get_character_data()
@@ -585,15 +588,13 @@ class WechatIntegrationPlugin(NekoPluginBase):
                         character_card_fields[key] = value
 
             # 语言
-            user_language = get_global_language()
-            try:
-                from utils.i18n_utils import normalize_language_code
-                short_language = normalize_language_code(user_language, format="short") if normalize_language_code else user_language
-            except Exception:
-                short_language = user_language
+            # #2500 第 2 步：取全码再经 prompts_sys 归一。原先那次 format="short"
+            # 的短码化是顺手做的、不是有意的——它把 zh-TW 塌成 zh，繁中用户拿简体
+            # 模板。⚠️ 也不能拿全码裸查：简中的全码是 'zh-CN'，而这张表的简体键
+            # 是 'zh'。
+            short_language = normalize_sys_prompt_locale(get_global_language_full())
             init_prompt_template = SESSION_INIT_PROMPT.get(
-                short_language,
-                SESSION_INIT_PROMPT.get(user_language, SESSION_INIT_PROMPT["zh"]),
+                short_language, SESSION_INIT_PROMPT["zh"],
             )
 
             # 构建 system prompt

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -1333,17 +1333,17 @@ def test_task_tool_description_preserves_master_words_and_coordinates():
         assert "next step" not in cue
 
 
-def test_prompts_have_all_seven_locales():
+def test_prompts_have_all_eight_locales():
     """Every entry in PROMPTS must carry a non-empty translation for
-    each supported language (zh, en, ja, ko, ru, es, pt). Missing keys
-    would otherwise silently fall back to EN and hide translation gaps
+    each supported language (zh, zh-TW, en, ja, ko, ru, es, pt). Missing
+    keys would otherwise silently fall back to EN and hide translation gaps
     from non-EN users."""
     from plugin.plugins.game_agent_minecraft import prompts
 
-    # Pin the expected locale set so the "seven locales" promise can't
-    # be silently regressed by editing SUPPORTED_LANGS down to six.
+    # Pin the expected locale set so the "eight locales" promise can't
+    # be silently regressed by editing SUPPORTED_LANGS down to seven.
     assert set(prompts.SUPPORTED_LANGS) == {
-        "zh", "en", "ja", "ko", "ru", "es", "pt",
+        "zh", "zh-TW", "en", "ja", "ko", "ru", "es", "pt",
     }
     missing: list[str] = []
     for key, bundle in prompts.PROMPTS.items():

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -8949,7 +8949,7 @@ def test_static_layer_falls_back_when_required_placeholders_missing():
     )
 
     weak = "## 场景：群聊共享上下文\n请自然地参考正在进行的讨论。"
-    i18n = SimpleNamespace(t=lambda key, default="": weak)
+    i18n = SimpleNamespace(t=lambda key, default="", **kw: weak)
     plugin = SimpleNamespace(i18n=i18n, _qq_settings={}, logger=MagicMock())
     service = QQSessionInstructionService(plugin)
 
@@ -13224,7 +13224,6 @@ async def test_session_instructions_forward_full_locale_to_memory(
 ):
     from plugin.plugins.qq_auto_reply import session_instruction_service as module
 
-    monkeypatch.setattr(module, "get_global_language", lambda: "zh")
     monkeypatch.setattr(module, "get_global_language_full", lambda: "zh-TW")
     plugin = SimpleNamespace(
         logger=MagicMock(),

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1288,16 +1288,29 @@ async def test_activity_tracker_can_start_topic_heartbeat_without_collector():
     assert isinstance(result[0], asyncio.CancelledError)
 
 
-def test_activity_tracker_topic_candidate_heartbeat_uses_full_global_locale():
+def test_activity_tracker_heartbeat_never_reads_the_short_locale():
+    """Neither heartbeat consumer may go back to the short accessor.
+
+    Both the topic pool and (since #2500 step 2) the activity narration take
+    the full locale, so the loop's own non-privacy path must not name
+    ``get_global_language`` at all — a re-introduced short read would
+    silently collapse zh-TW to zh again. The values that actually reach the
+    two consumers are pinned behaviourally in
+    ``tests/unit/test_zh_tw_locale_call_sites.py``.
+    """
     from main_logic.activity.tracker import UserActivityTracker
 
     source = inspect.getsource(UserActivityTracker._activity_guess_loop)
+    # The privacy-mode early-continue above keeps its own short fallback, so
+    # look only at the main body below it.
+    main_body = source.split("if _privacy_mode_active():", 1)[-1]
+    main_body = main_body.split("continue", 1)[-1]
 
-    assert "from utils.language_utils import get_global_language, get_global_language_full" in source
-    assert "activity_lang = get_global_language() or 'en'" in source
-    assert "topic_lang = get_global_language_full() or activity_lang" in source
-    assert "self._process_topic_candidates_if_ready(lang=topic_lang, now=ts)" in source
-    assert "lang=activity_lang" in source
+    assert "get_global_language()" not in main_body
+    assert "activity_lang = get_global_language_full() or 'en'" in main_body
+    assert "topic_lang = activity_lang" in main_body
+    assert "self._process_topic_candidates_if_ready(lang=topic_lang, now=ts)" in main_body
+    assert "lang=activity_lang" in main_body
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_zh_tw_locale_call_sites.py
+++ b/tests/unit/test_zh_tw_locale_call_sites.py
@@ -1,0 +1,516 @@
+"""Traditional Chinese must survive the trip from the global locale to the
+prompt table (issue #2500, step 2 — scattered call sites + plugins).
+
+Every test here sets the process locale to Traditional Chinese with the real
+``language_context`` and then asserts on the *rendered* prompt, not on a
+normalizer in isolation. Each one pins three outcomes apart:
+
+* the Traditional template is the one that came out;
+* it is NOT the Simplified template (the old bug — a short-code collapse);
+* it is NOT the English template (the failure mode a naive "just pass the
+  full code" fix introduces, because the full code for Simplified is
+  ``zh-CN`` while these tables key Simplified as ``zh``).
+
+The third assertion is the reason each test also runs the Simplified case:
+a fix that drops Simplified users to English would pass a Traditional-only
+test.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from config.prompts.prompts_sys import SESSION_INIT_PROMPT
+from utils.language_utils import language_context
+
+
+# ---------------------------------------------------------------------------
+# main_logic/activity/tracker.py — activity_guess narration locale
+# ---------------------------------------------------------------------------
+
+
+def _drive_activity_guess_once(monkeypatch):
+    """Run exactly one iteration of ``_activity_guess_loop`` and return the
+    ``lang`` values it handed to its two consumers.
+
+    The loop body is the call site under test, so it is driven for real
+    rather than re-derived here; everything it touches on the way there is
+    stubbed on the instance.
+    """
+    from main_logic.activity import tracker as tracker_mod
+
+    seen: dict[str, str] = {}
+
+    monkeypatch.setattr(tracker_mod, "_ACTIVITY_GUESS_TICK_SECONDS", 0)
+    monkeypatch.setattr(tracker_mod, "_privacy_mode_active", lambda: False)
+    monkeypatch.setattr(tracker_mod, "_proactive_chat_enabled", lambda: True)
+    monkeypatch.setattr(
+        tracker_mod, "observation_from_system", lambda *a, **k: object(),
+    )
+
+    async def _fake_call_activity_guess(**kwargs):
+        seen["activity"] = kwargs["lang"]
+        # The loop returns on CancelledError, so this both records the value
+        # and ends the iteration deterministically.
+        raise asyncio.CancelledError
+
+    from main_logic.activity import llm_enrichment
+    monkeypatch.setattr(
+        llm_enrichment, "call_activity_guess", _fake_call_activity_guess,
+    )
+
+    inst = object.__new__(tracker_mod.UserActivityTracker)
+    inst.lanlan_name = "Neko"
+    inst._conv_seq = 0
+    inst._user_msg_buffer = []
+    inst._ai_msg_buffer = []
+    rule_snap = SimpleNamespace(state="focused_work")
+    inst._sm = SimpleNamespace(
+        _prefs=None,
+        update_system=lambda *a, **k: None,
+        update_window=lambda *a, **k: None,
+        get_snapshot=lambda **k: rule_snap,
+    )
+    inst._select_system_snapshot = lambda ts: object()
+    inst._tick_break_reminders = lambda snap, **k: None
+
+    async def _drain():
+        return None
+
+    inst._drain_context_prompt = _drain
+    inst._process_topic_candidates_if_ready = (
+        lambda *, lang, now: seen.__setitem__("topic", lang)
+    )
+    inst._is_narration_suppressed = lambda: False
+    inst._coarse_activity_sig = lambda snap: ("focused_work", "x")
+    inst._activity_guess_gate = SimpleNamespace(
+        should_fire=lambda *a, **k: True,
+        record_fired=lambda *a, **k: None,
+    )
+    inst._snapshot_signals_for_llm = lambda snap, **k: {}
+
+    asyncio.run(inst._activity_guess_loop())
+    return seen
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "expected"),
+    [("zh-TW", "zh-TW"), ("zh-CN", "zh-CN"), ("ja", "ja")],
+)
+def test_activity_guess_loop_passes_full_locale(monkeypatch, ui_locale, expected):
+    """The narration locale must reach ``call_activity_guess`` as a full code.
+
+    ``ACTIVITY_GUESS_PROMPTS`` carries a distinct ``zh-TW`` template and
+    ``llm_enrichment._normalize_lang`` knows how to select it, so collapsing
+    to the short code here is the one step that made Traditional users read
+    a Simplified narration.
+    """
+    with language_context(ui_locale):
+        seen = _drive_activity_guess_once(monkeypatch)
+
+    assert seen["activity"] == expected
+    # Both consumers ride the same value; the topic pool already needed full.
+    assert seen["topic"] == expected
+
+
+def test_activity_guess_traditional_locale_selects_traditional_template():
+    """The value the loop now passes must actually change the prompt text —
+    otherwise the flip above would be a no-op rename."""
+    from config.prompts.prompts_activity import ACTIVITY_GUESS_PROMPTS
+    from main_logic.activity.llm_enrichment import (
+        _normalize_lang,
+        _select_lang_template,
+    )
+
+    traditional = _select_lang_template(
+        ACTIVITY_GUESS_PROMPTS, _normalize_lang("zh-TW"),
+    )
+    simplified = _select_lang_template(
+        ACTIVITY_GUESS_PROMPTS, _normalize_lang("zh-CN"),
+    )
+    assert traditional == ACTIVITY_GUESS_PROMPTS["zh-TW"]
+    assert simplified == ACTIVITY_GUESS_PROMPTS["zh"]
+    assert traditional != simplified
+    assert traditional != ACTIVITY_GUESS_PROMPTS["en"]
+
+
+# ---------------------------------------------------------------------------
+# plugin/plugins/game_agent_minecraft — user_lang() + PROMPTS tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "expected"),
+    [("zh-TW", "zh-TW"), ("zh-CN", "zh"), ("zh", "zh"), ("ja", "ja"), ("en", "en")],
+)
+def test_minecraft_user_lang_resolves_to_table_key(ui_locale, expected):
+    """``user_lang`` must land on a key of this module's own tables.
+
+    Traditional keeps its own key; Simplified collapses to ``zh`` rather
+    than leaking ``zh-CN`` — which is not a key here, so the
+    ``in SUPPORTED_LANGS`` guard would have bounced every Simplified user
+    to English.
+    """
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    with language_context(ui_locale):
+        assert prompts.user_lang() == expected
+    assert expected in prompts.SUPPORTED_LANGS
+
+
+def test_minecraft_prompts_render_traditional_not_simplified_or_english():
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    with language_context("zh-TW"):
+        cue = prompts.t("TASK_NOT_CONNECTED", lang=prompts.user_lang())
+    assert cue == prompts.PROMPTS["TASK_NOT_CONNECTED"]["zh-TW"]
+    assert cue != prompts.PROMPTS["TASK_NOT_CONNECTED"]["zh"]
+    assert cue != prompts.PROMPTS["TASK_NOT_CONNECTED"]["en"]
+
+
+def test_minecraft_t_degrades_chinese_variants_to_simplified_not_english():
+    """A future table that forgets ``zh-TW`` must fall back to Simplified.
+
+    English mid-conversation is a language switch; Simplified is merely the
+    wrong script. Same rule as ``prompts_sys._loc``.
+    """
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    incomplete = {"zh": "简体", "en": "English"}
+    original = prompts.PROMPTS.get("__TEST_ONLY__")
+    prompts.PROMPTS["__TEST_ONLY__"] = incomplete
+    try:
+        assert prompts.t("__TEST_ONLY__", lang="zh-TW") == "简体"
+        assert prompts.t("__TEST_ONLY__", lang="ko") == "English"
+    finally:
+        if original is None:
+            prompts.PROMPTS.pop("__TEST_ONLY__", None)
+        else:  # pragma: no cover - defensive
+            prompts.PROMPTS["__TEST_ONLY__"] = original
+
+
+# ---------------------------------------------------------------------------
+# Chat-platform plugins — SESSION_INIT_PROMPT lookups
+# ---------------------------------------------------------------------------
+
+
+def _assert_traditional_session_init(text: str, her_name: str) -> None:
+    assert SESSION_INIT_PROMPT["zh-TW"].format(name=her_name) in text
+    assert SESSION_INIT_PROMPT["zh"].format(name=her_name) not in text
+    assert SESSION_INIT_PROMPT["en"].format(name=her_name) not in text
+
+
+def _assert_simplified_session_init(text: str, her_name: str) -> None:
+    assert SESSION_INIT_PROMPT["zh"].format(name=her_name) in text
+    assert SESSION_INIT_PROMPT["zh-TW"].format(name=her_name) not in text
+    assert SESSION_INIT_PROMPT["en"].format(name=her_name) not in text
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "check"),
+    [("zh-TW", _assert_traditional_session_init),
+     ("zh-CN", _assert_simplified_session_init)],
+)
+def test_bilibili_dm_session_instructions_locale(ui_locale, check):
+    from plugin.plugins.bilibili_dm import BiliDMPlugin
+
+    facade = object.__new__(BiliDMPlugin)
+    facade.logger = MagicMock()
+
+    async def _run():
+        return await facade._build_session_instructions(
+            her_name="喵喵",
+            master_name="小明",
+            character_prompt="角色设定",
+            character_card_fields={},
+            # Non-admin skips the Memory Server round-trip; the init template
+            # lookup under test runs before that branch either way.
+            permission_level="user",
+            sender_uid="42",
+            user_title="朋友",
+        )
+
+    with language_context(ui_locale):
+        prompt = asyncio.run(_run())
+    check(prompt, "喵喵")
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "check"),
+    [("zh-TW", _assert_traditional_session_init),
+     ("zh-CN", _assert_simplified_session_init)],
+)
+def test_bilibili_danmaku_trusted_write_instructions_locale(
+    monkeypatch, ui_locale, check,
+):
+    import utils.config_manager as config_manager_mod
+    from plugin.plugins.bilibili_danmaku import BiliDanmakuPlugin
+
+    monkeypatch.setattr(
+        config_manager_mod,
+        "get_config_manager",
+        lambda: SimpleNamespace(
+            get_character_data=lambda: (
+                "小明", "喵喵", None, {"喵喵": {}}, None,
+                {"喵喵": "角色设定"}, None, None, None,
+            ),
+        ),
+    )
+
+    facade = object.__new__(BiliDanmakuPlugin)
+    facade._target_lanlan = ""
+    facade._master_bili_uid = 0
+    facade._master_bili_name = ""
+    facade._logged_in_matches_master = False
+    facade._logged_in_bili_uid = 0
+
+    async def _display_name():
+        return "小明"
+
+    facade._get_master_display_name = _display_name
+
+    async def _run():
+        return await facade._build_bili_trusted_write_instructions(
+            action_name="评论",
+            content_field="content",
+            context="ctx",
+            constraints="cons",
+        )
+
+    with language_context(ui_locale):
+        prompt = asyncio.run(_run())
+    check(prompt, "喵喵")
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "check"),
+    [("zh-TW", _assert_traditional_session_init),
+     ("zh-CN", _assert_simplified_session_init)],
+)
+def test_wechat_reply_system_prompt_locale(monkeypatch, ui_locale, check):
+    import utils.config_manager as config_manager_mod
+    import utils.llm_client as llm_client_mod
+    from plugin.plugins.wechat_integration import WechatIntegrationPlugin
+
+    monkeypatch.setattr(
+        config_manager_mod,
+        "get_config_manager",
+        lambda: SimpleNamespace(
+            get_character_data=lambda: (
+                "小明", "喵喵", None, {"喵喵": {}}, None,
+                {"喵喵": "角色设定"}, None, None, None,
+            ),
+            get_model_api_config=lambda kind: {
+                "base_url": "http://localhost", "model": "m", "api_key": "k",
+            },
+        ),
+    )
+
+    captured: dict = {}
+
+    class _StubLLM:
+        async def ainvoke(self, messages):
+            captured["system"] = messages[0]["content"]
+            return SimpleNamespace(content="好的")
+
+    async def _create(**kwargs):
+        return _StubLLM()
+
+    monkeypatch.setattr(llm_client_mod, "create_chat_llm_async", _create)
+
+    facade = object.__new__(WechatIntegrationPlugin)
+    facade.logger = MagicMock()
+    facade._wechat_sessions = {}
+    facade._cleanup_wechat_sessions = lambda now: None
+
+    async def _fetch_memory(_her_name):
+        return ""
+
+    facade._fetch_memory_context = _fetch_memory
+
+    with language_context(ui_locale):
+        asyncio.run(facade._generate_wechat_reply("wxid_1", "在吗"))
+
+    check(captured["system"], "喵喵")
+
+
+# ---------------------------------------------------------------------------
+# qq_auto_reply — init template + prompt-override locale
+# ---------------------------------------------------------------------------
+
+
+def _qq_service(settings=None, bundle=None):
+    from plugin.plugins.qq_auto_reply.session_instruction_service import (
+        QQSessionInstructionService,
+    )
+
+    messages = bundle or {}
+
+    def _t(key, *, locale=None, default="", **params):
+        from plugin.sdk.shared.i18n import locale_candidates
+        for candidate in locale_candidates(locale, "zh-CN"):
+            if candidate in messages and key in messages[candidate]:
+                return messages[candidate][key]
+        return default
+
+    plugin = SimpleNamespace(
+        i18n=SimpleNamespace(t=lambda key, default="", **kw: _t(
+            key, default=default, **kw
+        )),
+        _qq_settings=settings or {},
+        logger=MagicMock(),
+    )
+    return QQSessionInstructionService(plugin)
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected_key"),
+    [("zh-TW", "zh-TW"), ("zh-CN", "zh"), ("zh", "zh"), ("ja", "ja"), ("xx", "en")],
+)
+def test_qq_init_template_resolves_by_normalized_locale(locale, expected_key):
+    """``_resolve_init_template`` is fed the full locale by
+    ``build_instructions``; it must map ``zh-CN`` onto this table's ``zh``
+    key and keep ``zh-TW`` distinct, without hand-splitting on ``-``."""
+    service = _qq_service()
+    assert service._resolve_init_template(locale) == (
+        SESSION_INIT_PROMPT[expected_key]
+    )
+
+
+def test_qq_static_layer_default_locale_finds_traditional_override():
+    """With no explicit locale the layer resolver falls back to the process
+    locale. The prompt editor stores overrides under the frontend locale
+    (``zh-TW`` for a Traditional user), and the short code ``zh`` never
+    reaches that bucket — so a Traditional user's saved override was
+    silently ignored.
+    """
+    service = _qq_service({
+        "prompt_overrides": {
+            "zh-TW": {"output_prompt_section": "繁體覆蓋"},
+            "zh-CN": {"output_prompt_section": "简体覆盖"},
+        },
+    })
+
+    with language_context("zh-TW"):
+        assert service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "繁體覆蓋"
+    with language_context("zh-CN"):
+        assert service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "简体覆盖"
+
+
+def test_qq_static_layer_default_locale_prefers_traditional_bundle():
+    """Same fallback, i18n-bundle side: no override at all, and the
+    Traditional bundle must win over the Simplified one — while a locale
+    with no bundle still lands on the default template, not on English by
+    accident."""
+    service = _qq_service(bundle={
+        "zh-TW": {"output_prompt_section": "繁體 bundle"},
+        "zh-CN": {"output_prompt_section": "简体 bundle"},
+    })
+
+    with language_context("zh-TW"):
+        assert service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "繁體 bundle"
+    with language_context("zh-CN"):
+        assert service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "简体 bundle"
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "check"),
+    [("zh-TW", _assert_traditional_session_init),
+     ("zh-CN", _assert_simplified_session_init)],
+)
+def test_qq_session_instructions_locale(ui_locale, check):
+    """End-to-end through ``build_session_instructions`` itself: the init
+    template and the memory closing line both have to come out Traditional.
+    ``get_context_summary_ready`` was the second half of the collapse — it
+    was fed the short code alongside the init lookup."""
+    from unittest.mock import AsyncMock
+
+    from config.prompts.prompts_sys import get_context_summary_ready
+    from plugin.plugins.qq_auto_reply import session_instruction_service as module
+
+    plugin = SimpleNamespace(
+        logger=MagicMock(),
+        _emit_log=lambda *a, **k: None,
+        _qq_settings={},
+        _user_sessions={},
+        i18n=SimpleNamespace(t=lambda key, default="", **kw: default),
+        memory_bridge=MagicMock(),
+        permission_mgr=SimpleNamespace(
+            get_nickname=lambda *a, **k: None,
+            get_user_title=lambda *a, **k: "",
+        ),
+        qq_client=SimpleNamespace(needs_attention=False),
+        fatigue_service=None,
+        session_runtime_service=SimpleNamespace(),
+    )
+    service = module.QQSessionInstructionService(plugin)
+    service._build_core_memory_section = AsyncMock(return_value="回忆片段")
+
+    async def _run():
+        return await service.build_session_instructions(
+            her_name="喵喵",
+            master_name="小明",
+            character_prompt="角色设定",
+            character_card_fields={},
+            permission_level="admin",
+            sender_id="2046",
+            user_title="member",
+            is_group=False,
+            group_id=None,
+            use_memory_context=True,
+        )
+
+    with language_context(ui_locale):
+        bundle = asyncio.run(_run())
+
+    check(bundle.system_prompt, "喵喵")
+
+    # The closing line is rendered deeper in ``_build_core_memory_section``;
+    # what this call site owns is the template it hands down.
+    expected_key = "zh-TW" if ui_locale == "zh-TW" else "zh"
+    other_key = "zh" if expected_key == "zh-TW" else "zh-TW"
+    handed_down = service._build_core_memory_section.await_args.kwargs[
+        "context_ready_template"
+    ]
+    assert handed_down == get_context_summary_ready(
+        expected_key, input_mode="text",
+    )
+    assert handed_down != get_context_summary_ready(other_key, input_mode="text")
+    assert handed_down != get_context_summary_ready("en", input_mode="text")
+
+
+@pytest.mark.parametrize(
+    ("ui_locale", "expected"), [("zh-TW", "zh-TW"), ("zh-CN", "zh-CN")],
+)
+def test_qq_prompt_editor_state_defaults_to_full_locale(ui_locale, expected):
+    """The editor's locale is also the key ``save_prompt_override`` writes
+    under, so it has to agree with the runtime read side above. A short
+    code would make a Traditional user edit the Simplified bucket."""
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+
+    facade = object.__new__(QQAutoReplyPlugin)
+    facade._qq_settings = {"qq_connection_mode": "napcat"}
+    facade._strategy_mode = "neko_dynamic"
+    facade.session_instruction_service = SimpleNamespace(_PROMPT_LAYERS=[])
+    facade.fatigue_service = None
+    facade.attention_gate_service = None
+    facade.i18n = SimpleNamespace(t=lambda key, **kw: kw.get("default", ""))
+    facade._emit_log = lambda *a, **k: None
+    facade.logger = MagicMock()
+
+    with language_context(ui_locale):
+        result = asyncio.run(facade.get_prompt_editor_state())
+
+    payload = getattr(result, "value", result)
+    assert payload["locale"] == expected

--- a/tests/unit/test_zh_tw_locale_call_sites.py
+++ b/tests/unit/test_zh_tw_locale_call_sites.py
@@ -490,6 +490,132 @@ def test_qq_session_instructions_locale(ui_locale, check):
     assert handed_down != get_context_summary_ready("en", input_mode="text")
 
 
+def test_qq_blank_override_is_treated_as_unset():
+    """``save_prompt_override`` stores an empty string when the editor box is
+    cleared, so a blank value means "not set" — the resolver has to keep
+    walking the candidate chain rather than serve the blank.
+
+    Without this the cleared layer would render as nothing at all, and a
+    legacy bucket further down the chain would be masked by the blank.
+    """
+    masked = _qq_service({
+        "prompt_overrides": {
+            "zh-TW": {"output_prompt_section": "   "},
+            "zh": {"output_prompt_section": "舊的繁中覆蓋"},
+        },
+    })
+    with language_context("zh-TW"):
+        assert masked._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "舊的繁中覆蓋"
+
+    only_blank = _qq_service({
+        "prompt_overrides": {"zh-TW": {"output_prompt_section": ""}},
+    })
+    with language_context("zh-TW"):
+        assert only_blank._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "默认模板"
+
+
+def _prompt_editor_facade(settings):
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+    from plugin.plugins.qq_auto_reply.session_instruction_service import (
+        QQSessionInstructionService,
+    )
+
+    facade = object.__new__(QQAutoReplyPlugin)
+    facade._qq_settings = settings
+    facade._strategy_mode = "neko_dynamic"
+    facade.session_instruction_service = QQSessionInstructionService(facade)
+    facade.fatigue_service = None
+    facade.attention_gate_service = None
+    facade.i18n = SimpleNamespace(t=lambda key, **kw: kw.get("default", ""))
+    facade._emit_log = lambda *a, **k: None
+    facade.logger = MagicMock()
+    return facade
+
+
+def _layer_state(payload, layer_id):
+    return next(
+        layer for layer in payload["layers"] if layer["id"] == layer_id
+    )
+
+
+def test_qq_editor_sees_legacy_short_locale_override():
+    """A Traditional user whose override predates #2500 has it stored under
+    the old short code ``zh``.
+
+    The runtime resolves overrides through ``locale_candidates``, so that
+    bucket is still live. If the editor matched the locale key exactly it
+    would report the layer as unmodified while the override kept applying —
+    visible nowhere, resettable nowhere.
+    """
+    settings = {
+        "qq_connection_mode": "napcat",
+        "prompt_overrides": {"zh": {"output_prompt_section": "舊的繁中覆蓋"}},
+    }
+    facade = _prompt_editor_facade(settings)
+
+    with language_context("zh-TW"):
+        payload = getattr(
+            asyncio.run(facade.get_prompt_editor_state()), "value", None,
+        )
+        # What the runtime actually serves, for comparison.
+        runtime_text = facade.session_instruction_service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        )
+
+    layer = _layer_state(payload, "output")
+    assert layer["has_override"] is True
+    assert layer["effective_text"] == "舊的繁中覆蓋"
+    assert runtime_text == layer["effective_text"]
+
+
+@pytest.mark.asyncio
+async def test_qq_reset_clears_the_bucket_the_runtime_actually_uses():
+    """Reset must land on the same bucket the resolver reads.
+
+    Keyed strictly by the current locale, resetting a legacy ``zh`` override
+    returned ``no_override_found`` and left it applying forever.
+    """
+    from unittest.mock import AsyncMock
+
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+
+    settings = {
+        "qq_connection_mode": "napcat",
+        "prompt_overrides": {"zh": {"output_prompt_section": "舊的繁中覆蓋"}},
+    }
+    facade = _prompt_editor_facade(settings)
+    facade.session_instruction_service._discard_all_sessions_for_prompt_change = (
+        lambda: None
+    )
+
+    async def _mutate(_self, fn):
+        return fn(settings)
+
+    facade._mutate_business_config = AsyncMock(side_effect=None)
+
+    with language_context("zh-TW"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                QQAutoReplyPlugin, "_mutate_business_config", _mutate,
+            )
+            result = await facade.reset_prompt_override(
+                locale="zh-TW", layer_id="output",
+            )
+
+    payload = getattr(result, "value", result)
+    assert payload.get("reason") != "no_override_found"
+    assert settings["prompt_overrides"] == {}
+
+    with language_context("zh-TW"):
+        assert facade.session_instruction_service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        ) == "默认模板"
+
+
 @pytest.mark.parametrize(
     ("ui_locale", "expected"), [("zh-TW", "zh-TW"), ("zh-CN", "zh-CN")],
 )

--- a/tests/unit/test_zh_tw_locale_call_sites.py
+++ b/tests/unit/test_zh_tw_locale_call_sites.py
@@ -617,6 +617,166 @@ async def test_qq_reset_clears_the_bucket_the_runtime_actually_uses():
 
 
 @pytest.mark.parametrize(
+    "shadowed_bucket", ["zh", "zh-CN", "en"],
+)
+@pytest.mark.asyncio
+async def test_qq_reset_does_not_resurrect_a_shadowed_override(shadowed_bucket):
+    """Reset must leave the default resolving, not the next bucket down.
+
+    Once the editor saves under the full locale, an older bucket for the same
+    layer keeps sitting further along the candidate chain. Deleting only the
+    exact bucket hands the layer straight back to that older value — "restore
+    default" then reports success while a custom prompt is still applied, and
+    pressing it again changes nothing.
+
+    ``zh-CN`` is the common case, not an exotic one: ``locale_candidates``
+    appends the plugin's default locale to every chain.
+    """
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+
+    settings = {
+        "qq_connection_mode": "napcat",
+        "prompt_overrides": {
+            "zh-TW": {"output_prompt_section": "新的繁中覆蓋"},
+            shadowed_bucket: {"output_prompt_section": "被遮住的舊覆蓋"},
+        },
+    }
+    facade = _prompt_editor_facade(settings)
+    facade.session_instruction_service._discard_all_sessions_for_prompt_change = (
+        lambda: None
+    )
+
+    async def _mutate(_self, fn):
+        return fn(settings)
+
+    with language_context("zh-TW"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(QQAutoReplyPlugin, "_mutate_business_config", _mutate)
+            await facade.reset_prompt_override(
+                locale="zh-TW", layer_id="output",
+            )
+
+        rendered = facade.session_instruction_service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        )
+        payload = getattr(
+            asyncio.run(facade.get_prompt_editor_state()), "value", None,
+        )
+
+    assert rendered == "默认模板"
+    assert _layer_state(payload, "output")["has_override"] is False
+
+
+@pytest.mark.asyncio
+async def test_qq_reset_sweeps_the_whole_candidate_chain():
+    """Every position on the chain has to go, not just the first shadow.
+
+    With buckets stacked at ``zh-TW`` / ``zh`` / ``zh-CN`` / ``en``, removing
+    the exact bucket plus one more still leaves two behind — the layer would
+    resolve to a custom prompt again. The sweep has to run to exhaustion.
+    """
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+
+    settings = {
+        "qq_connection_mode": "napcat",
+        "prompt_overrides": {
+            "zh-TW": {"output_prompt_section": "繁中"},
+            "zh": {"output_prompt_section": "舊短碼"},
+            "zh-CN": {"output_prompt_section": "简中"},
+            "en": {"output_prompt_section": "english"},
+        },
+    }
+    facade = _prompt_editor_facade(settings)
+    facade.session_instruction_service._discard_all_sessions_for_prompt_change = (
+        lambda: None
+    )
+
+    async def _mutate(_self, fn):
+        return fn(settings)
+
+    with language_context("zh-TW"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(QQAutoReplyPlugin, "_mutate_business_config", _mutate)
+            await facade.reset_prompt_override(
+                locale="zh-TW", layer_id="output",
+            )
+        rendered = facade.session_instruction_service._resolve_static_layer(
+            "output_prompt_section", "默认模板",
+        )
+
+    assert settings["prompt_overrides"] == {}
+    assert rendered == "默认模板"
+
+
+@pytest.mark.asyncio
+async def test_qq_reset_leaves_other_layers_alone():
+    """The sweep is per-layer: other layers' overrides in the same buckets
+    must survive, or "restore default" on one layer would wipe the lot."""
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+
+    settings = {
+        "qq_connection_mode": "napcat",
+        "prompt_overrides": {
+            "zh-TW": {
+                "output_prompt_section": "要重置的",
+                "role_prompt_section": "要留下的",
+            },
+            "zh-CN": {"role_prompt_section": "也要留下的"},
+        },
+    }
+    facade = _prompt_editor_facade(settings)
+    facade.session_instruction_service._discard_all_sessions_for_prompt_change = (
+        lambda: None
+    )
+
+    async def _mutate(_self, fn):
+        return fn(settings)
+
+    with language_context("zh-TW"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(QQAutoReplyPlugin, "_mutate_business_config", _mutate)
+            await facade.reset_prompt_override(
+                locale="zh-TW", layer_id="output",
+            )
+
+    assert settings["prompt_overrides"] == {
+        "zh-TW": {"role_prompt_section": "要留下的"},
+        "zh-CN": {"role_prompt_section": "也要留下的"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_qq_reset_clears_a_blank_placeholder_bucket():
+    """A cleared layer stores ``""``, which ``resolve_prompt_override``
+    deliberately ignores. Reset still has to remove it, otherwise the
+    placeholder lingers forever and reset reports no_override_found."""
+    from plugin.plugins.qq_auto_reply import QQAutoReplyPlugin
+
+    settings = {
+        "qq_connection_mode": "napcat",
+        "prompt_overrides": {"zh-TW": {"output_prompt_section": ""}},
+    }
+    facade = _prompt_editor_facade(settings)
+    facade.session_instruction_service._discard_all_sessions_for_prompt_change = (
+        lambda: None
+    )
+
+    async def _mutate(_self, fn):
+        return fn(settings)
+
+    with language_context("zh-TW"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(QQAutoReplyPlugin, "_mutate_business_config", _mutate)
+            result = await facade.reset_prompt_override(
+                locale="zh-TW", layer_id="output",
+            )
+
+    payload = getattr(result, "value", result)
+    assert payload.get("reason") != "no_override_found"
+    assert settings["prompt_overrides"] == {}
+
+
+@pytest.mark.parametrize(
     ("ui_locale", "expected"), [("zh-TW", "zh-TW"), ("zh-CN", "zh-CN")],
 )
 def test_qq_prompt_editor_state_defaults_to_full_locale(ui_locale, expected):


### PR DESCRIPTION
Closes #2500

#2500 的收尾。两批：三处零散调用点（逐处判断，其中两处的结论是**不改**）+ 插件侧（五个插件，先补表再翻调用点）。

## 回归报告

### 改了什么、为什么

**第一批：三处零散调用点。这批的正确做法是逐处判断，不是横扫** —— 三处里两处的短码是有意的，翻了会弄坏东西。判断结论都以注释形式留在代码里，下一个做迁移的人不用再查一遍。

| 位置 | 结论 | 理由 |
|---|---|---|
| `main_logic/activity/tracker.py:1182` | **改** 成 `get_global_language_full()` | 见下 |
| `main_routers/config_router/language.py:168` | **不改** | 返回值是对前端的 API 契约，docstring 写死了 `'zh' / 'en' / 'ja'` 这套短码，消费方可能按短码分支。改成全码属于改契约，要先普查全部前端调用方，不在 locale 迁移这一批的范围内 |
| `main_routers/game_router/session_pool.py:138` | **不改** | 那个 `language` 不是查表 locale，是被当成**人读的语言名**拼进英文兜底句（`Generate short in-character lines in {output_language}`）。繁简两种中文在这句里要的是同一个词，细分到 `zh-TW` 只会让模型读到一个不像语言名的字符串。原注释已预判过这次迁移，本 PR 把「所以要保留」这半句补上 |

`tracker.py` 那处查清楚了下游：`activity_lang` 除了当 `topic_lang` 的兜底，只喂 `call_activity_guess(lang=...)`。那边的 `_normalize_lang` 认 `zh-TW`，且 `ACTIVITY_GUESS_PROMPTS` 有独立的 `zh-TW` 模板 —— 所以塌成短码是繁中用户读到简体活动叙述的唯一一步。改完 `topic_lang` 直接等于 `activity_lang`（它本来就取全码）。

**第二批：插件侧。顺序是先补表、再翻调用点** —— 这些插件的表都在 `scripts/check_prompt_zh_tw.py` 的扫描范围外（它只看 `config/prompts/`），表里没有 `zh-TW` 就翻调用点，繁中用户直接掉英文。

- `game_agent_minecraft`：这个插件有自己的 `prompts.py`，64 张 dict 全部只有 7 个短码 locale。补齐 64 条繁体译文（台湾用语，不是繁简字形转换：連線／回饋／資料／座標／呼叫／閒置／外掛／熔岩塊／甜莓叢），`SUPPORTED_LANGS` 加 `zh-TW`，然后才翻 `user_lang()`。
- `bilibili_dm` / `bilibili_danmaku` / `wechat_integration` / `qq_auto_reply`：四处的调用点下游都落在 `config/prompts/prompts_sys.py` 的 `SESSION_INIT_PROMPT`（#2706 已补齐 `zh-TW`），表侧无需再动，只翻调用点。

⚠️ **四处都不能把 `get_global_language_full()` 直接当键用**：简中的全码是 `zh-CN`，而 `prompts_sys` 这套表的简体键是 `zh` —— 裸查会让**简中**用户掉英文，比原来更糟。统一收口成 `normalize_sys_prompt_locale(get_global_language_full())`，那是这套键方案的既有归一器（`zh-CN → zh`，`zh-TW` 保留）。

⚠️ `bilibili_dm:1130` 和 `wechat_integration:588` 取到全局值之后紧接着自己 `normalize_language_code(..., format="short")`。判断下来那次短码化是**顺手的、不是有意的**（和 `session_pool` 那处不同）：它把 `zh-TW` 塌成 `zh` 之后，下面那级 `.get(user_language)` 兜底永远够不到，等于死代码。两处一起换掉。

`qq_auto_reply` 顺带修的两条：
- `_resolve_static_layer` 的兜底 locale 与提示词编辑器（`get_prompt_editor_state`）的兜底 locale **必须同时翻**。编辑器把用户覆盖按前端 locale 存（繁中用户就是 `zh-TW`），而运行时读侧用短码 `zh`，候选链是 `zh → zh-CN → en`，够不到那份繁体覆盖 —— 繁中用户存的覆盖此前被静默忽略。只翻一侧会把这个洞从「读不到」变成「写进去也读不到」。
- `_resolve_static_layer` 里的 i18n bundle 查找此前**完全没收到 locale**（`PluginI18n.default_locale` 是 `plugin.toml` 写死的 `"zh-CN"`，不跟用户语言走），而 `get_prompt_editor_state` 是传的。今天这些提示词层的 key 一个 bundle 都没有（一律落到 Python 默认模板），所以补这一行是空操作；但两边口径不一致的话，谁往 bundle 里补一条翻译，编辑器显示的和运行时用的就会是两份文本。

### 明确不动

`config/prompts/prompts_directives.py:230` 的 `keep_traditional=False` **是设计，不是欠账**。它在 `_trim_term` 里选尾词表的语族，而 `_TRIM_TRAIL_TOKENS_BY_LOCALE` 只有 `zh / ja / ko` 三个键 —— 繁简共用同一套 trim token，塌成 `zh` 是正确行为。翻了会让繁体掉进 `_TRIM_TRAIL_FALLBACK_LOCALES` 回落分支、尾词剥不掉。

issue 第 3 条（存量 `facts.json` 繁简并存对 BM25 / embedding 去重的失配）维护者已明确忽略，不做。

### 前后行为对比

| 场景（界面语言＝繁中） | 改前 | 改后 |
|---|---|---|
| 活动叙述（activity_guess） | 简体模板 | 繁体模板 |
| Minecraft 插件的所有 cue / 任务回执 | 简体 | 繁体 |
| B站私信 / B站代写 / 微信 / QQ 的会话初始 prompt | 简体 | 繁体 |
| QQ 记忆收尾语（`get_context_summary_ready`） | 简体 | 繁体 |
| QQ 提示词编辑器里存的繁体覆盖 | 存了但运行时读不到 | 生效 |
| 简中用户（全部以上路径） | 简体 | 简体（不变） |
| 其余语种 | 不变 | 不变 |

### 潜在回归

1. **简中掉英文** —— 这是本批最该防的失败模式，也是"直接传全码"这个天真修法会引进的。四处 `SESSION_INIT_PROMPT` 消费点和 minecraft 的 `SUPPORTED_LANGS` 白名单都会被 `zh-CN` 打穿。已用 `normalize_sys_prompt_locale` 堵住，并且**每条测试都跑简中和繁中两份**：只测繁中的话，一个把简中打到英文的修法照样绿。
2. **QQ 覆盖静默失效** —— 读写两侧 locale 不一致。两处在同一 commit 里翻，并各有一条测试。
3. **Minecraft 表将来漏补 zh-TW** —— `t()` 原先是 `bundle.get(lang) or bundle[DEFAULT_LANG]`，缺 `zh-TW` 直接掉英文。改成中文变体先回落简体（与 `prompts_sys._loc` 同规则），漏补只会退化成"字形不对"而不是"换了语言"。
4. `tests/unit/test_topic_pipeline.py` 里那条按源码字符串比对的护栏被本次改动作废（它钉的是旧的两行）。重写成「主体路径不许再出现 `get_global_language()`」，真正的值由新的行为测试钉。

### 评审后追加（2d35a4c27）

Codex 指出的一条真问题：编辑器用**精确匹配** `overrides[locale]` 查覆盖，而运行时 `_resolve_static_layer` 走 `locale_candidates` **逐级回退**。这个不对称是既有的，但本 PR 把编辑器的兜底 locale 从 `zh` 挪到 `zh-TW` 之后它会咬人 —— 存量繁中用户在 #2500 之前存进 `zh` 桶的覆盖，运行时照旧生效，编辑器却报「未修改」，`reset_prompt_override` 也返回 `no_override_found` 删不掉：一份看不见、也删不掉的活覆盖。

抽出 `resolve_prompt_override()` 单一实现（定位运行时真正会用的那个桶），`_resolve_static_layer` / `_resolve_init_template` / `get_prompt_editor_state` / `reset_prompt_override` 四处全部改走它；reset 在精确桶没有时落到解析出来的那个桶。空串覆盖（编辑器清空时的存法）仍视为「没设」、继续找下一个候选，行为不变 —— 这条在变异验证里是唯一的幸存者，已补测试钉住。

**第二轮（6ff5a870c）**：编辑器改用全码存覆盖之后，旧桶和新 `zh-TW` 桶会并存；上一版 reset 只删精确桶，删完 `resolve_prompt_override` 立刻在链上找到下一份 —— 「恢复默认」报成功却换来一份旧覆盖，再按一次还是它。比 Codex 举的存量 `zh` 更常见的是 `zh-CN`：`locale_candidates` 给每条链都追加插件的 `default_locale`，所以繁中用户的链上本来就有它。改成先删精确桶（可能是空串占位，`resolve` 看不见那种），再循环删到解析不出覆盖为止。

⚠️ 代价写在注释里：同一个人若按 locale 分别调过这一层，重置会把该层其它 locale 的那几份一起清掉。单用户桌面应用里这比「按了恢复默认却恢复不掉」轻 —— 后者没有任何出路。扫的是这一层的 key，别的层不受影响。

追加验证：`tests/unit` **27850 passed / 274 skipped**；两轮共 8 个变异体全部转红。其中两条最初是幸存者，各自补了用例才钉住 —— 「helper 把空串当已设」，以及「reset 只扫一遍而不是扫到干净」（原来两桶的用例区分不出这两者，加了四桶齐备的用例）。

### 验证

- `uv run python -m pytest tests/unit -q` → **27811 passed, 274 skipped**
- `uv run ruff check main_logic/ main_routers/ plugin/ tests/unit/` → clean
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main` → clean
- `uv run python scripts/check_prompt_zh_tw.py --count` → **0**（仍是 0）
- 新增 `tests/unit/test_zh_tw_locale_call_sites.py`（28 条）：每个翻了的调用点各一条行为测试，都用真的 `language_context()` 设语言、断言**渲染出来的 prompt**，并同时钉死三件事 —— 是繁体模板 / 不是简体模板 / 不是英文模板。activity 那条是把 `_activity_guess_loop` 真跑了一轮（不是重新推导循环体）。
- **变异验证**：17 个变异体（每处修复各自回退成「短码」和「裸全码」两种坏法，加 `SUPPORTED_LANGS` 去掉 `zh-TW`、`t()` 去掉回落、QQ 停止传 locale、`_resolve_init_template` 换回手搓 `split("-")`）—— **17/17 全部转红**，无幸存者。

## #2500 收尾说明

| 步骤 | 状态 |
|---|---|
| 第 1 步：补 `config/prompts/*.py` 的 zh-TW 模板 | ✅ 222 → 0（#2706） |
| 第 2 步：调用侧短码 → 全码 | ✅ #2721（A/C1/B）+ #2728（C2 主动搭话一族原子翻转）+ 本 PR |
| 第 3 步：存量 facts.json 繁简并存对 BM25 / embedding 去重的失配 | ⛔ 维护者决定不做 |
| 顺带修的独立缺陷 | #2718（agent 对 7 种语言全跑英文） |

**有意保留短码的位置**（都已在代码里留注释）：

- `main_routers/config_router/language.py:168` —— 前端 API 契约
- `main_routers/game_router/session_pool.py:138` —— 拼进英文句子的语言名，不是查表 locale
- `config/prompts/prompts_directives.py:230` 的 `keep_traditional=False` —— 尾词表本来就繁简共用
- `plugin/plugins/bilibili_dm/tests/test_memory_locale_provenance.py` 里的 patch 目标 —— 测试桩，不是产品路径

插件侧五个插件全部做完，没有留尾巴，不需要另开 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


