### PR TITLE
fix(memory): 修复 Windows 中文环境 review 打印 emoji 崩溃（GBK 编码）

### DIFF
--- a/memory/recent.py
+++ b/memory/recent.py
@@ -48,6 +48,24 @@ from config import (
 from datetime import datetime
 
 
+def _safe_print(*args, **kwargs):
+    """Print without crashing on GBK consoles (emoji cannot be encoded).
+
+    On Windows Chinese (GBK) consoles, printing emoji like ✅/⚠️ raises
+    ``UnicodeEncodeError`` and aborts the memory pipeline mid-flight. Keep the
+    plain ``print`` (privacy rule: raw dialog only via print, never logger) but
+    degrade un-encodable characters to ``?`` instead of crashing.
+    """
+    try:
+        print(*args, **kwargs)
+    except UnicodeEncodeError:
+        text = " ".join(str(a) for a in args)
+        safe = text.encode("ascii", "replace").decode("ascii")
+        kwargs.pop("file", None)
+        kwargs.pop("flush", None)
+        print(safe, **kwargs)
+
+
 def _detect_recent_prompt_language(text: str) -> str:
     return detect_prompt_language_with_ascii_fallback(
         text,
@@ -987,23 +1005,23 @@ class CompressedRecentHistoryManager:
                         raw_summary if isinstance(raw_summary, str)
                         else json.dumps(raw_summary, ensure_ascii=False)
                     )
-                    print(f"💗摘要结果：{summary}")
+                    _safe_print(f"💗摘要结果：{summary}")
                     return summary
                 else:
-                    print('💥 摘要failed: ', response_content)
+                    _safe_print('💥 摘要failed: ', response_content)
                     retries += 1
             except openai_retry_error_types() as e:
                 logger.info(f"ℹ️ 捕获到 {type(e).__name__} 错误")
                 retries += 1
                 if retries >= max_retries:
-                    print(f'❌ 摘要模型失败，已达到最大重试次数: {e}')
+                    _safe_print(f'❌ 摘要模型失败，已达到最大重试次数: {e}')
                     break
                 # 指数退避: 1, 2, 4 秒
                 wait_time = 2 ** (retries - 1)
-                print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
+                _safe_print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
                 await asyncio.sleep(wait_time)
             except Exception as e:
-                print(f'❌ 摘要模型失败：{e}')
+                _safe_print(f'❌ 摘要模型失败：{e}')
                 # 如果解析失败，重试
                 retries += 1
         return None
@@ -1394,23 +1412,23 @@ class CompressedRecentHistoryManager:
                     sane = truncate_to_last_sentence_end(summary_text)
                     if not sane:
                         sane = summary_text
-                    print(f"💗第二轮摘要结果：{sane}")
+                    _safe_print(f"💗第二轮摘要结果：{sane}")
                     return sane
                 else:
-                    print('💥 第二轮摘要failed: ', response_content)
+                    _safe_print('💥 第二轮摘要failed: ', response_content)
                     retries += 1
             except openai_retry_error_types() as e:
                 logger.info(f"ℹ️ 捕获到 {type(e).__name__} 错误")
                 retries += 1
                 if retries >= max_retries:
-                    print(f'❌ 第二轮摘要模型失败，已达到最大重试次数: {e}')
+                    _safe_print(f'❌ 第二轮摘要模型失败，已达到最大重试次数: {e}')
                     return None
                 # 指数退避: 1, 2, 4 秒
                 wait_time = 2 ** (retries - 1)
-                print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
+                _safe_print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
                 await asyncio.sleep(wait_time)
             except Exception as e:
-                print(f'❌ 第二轮摘要模型失败：{e}')
+                _safe_print(f'❌ 第二轮摘要模型失败：{e}')
                 retries += 1
         return None
 
@@ -1582,7 +1600,7 @@ class CompressedRecentHistoryManager:
 
         # 检查是否被取消
         if cancel_event and cancel_event.is_set():
-            print(f"⚠️ {lanlan_name} 的记忆整理被取消（启动前）")
+            _safe_print(f"⚠️ {lanlan_name} 的记忆整理被取消（启动前）")
             return ('failed', None)
 
         # snapshot 由 caller 提供（spawn 时拍下）；为兼容老调用兜底从磁盘读
@@ -1618,7 +1636,7 @@ class CompressedRecentHistoryManager:
 
         # 检查是否被取消
         if cancel_event and cancel_event.is_set():
-            print(f"⚠️ {lanlan_name} 的记忆整理被取消（准备调用LLM前）")
+            _safe_print(f"⚠️ {lanlan_name} 的记忆整理被取消（准备调用LLM前）")
             return ('failed', None)
 
         retries = 0
@@ -1654,11 +1672,11 @@ class CompressedRecentHistoryManager:
 
                 # 检查是否被取消（LLM调用后）
                 if cancel_event and cancel_event.is_set():
-                    print(f"⚠️ {lanlan_name} 的记忆整理被取消（LLM调用后，保存前）")
+                    _safe_print(f"⚠️ {lanlan_name} 的记忆整理被取消（LLM调用后，保存前）")
                     return ('failed', None)
 
                 if _review_response_hit_output_limit(response):
-                    print(f"⚠️ {lanlan_name} 的历史审阅输出达到 token 上限，本轮暂停解析")
+                    _safe_print(f"⚠️ {lanlan_name} 的历史审阅输出达到 token 上限，本轮暂停解析")
                     return ('output_exhausted', None)
 
                 # 确保response_content是字符串
@@ -1677,7 +1695,7 @@ class CompressedRecentHistoryManager:
                     and 'explanation' in review_result
                     and isinstance(review_result.get('corrected_dialogue'), list)
                 ):
-                    print(f"❌ 审阅响应格式错误：{response_content}")
+                    _safe_print(f"❌ 审阅响应格式错误：{response_content}")
                     return ('failed', None)
 
                 print(f"记忆整理结果：{review_result['explanation']}")
@@ -1779,33 +1797,33 @@ class CompressedRecentHistoryManager:
                 except recent_file.RecentFileDeletedError:
                     return ('failed', None)
                 if commit_status == 'white':
-                    print(f"⚠️ {lanlan_name} {detail}（白 review，丢弃）")
+                    _safe_print(f"⚠️ {lanlan_name} {detail}（白 review，丢弃）")
                     return ('white', None)
                 if commit_status != 'patched':
-                    print(f"❌ {lanlan_name} review 提交失败：{detail}")
+                    _safe_print(f"❌ {lanlan_name} review 提交失败：{detail}")
                     return ('failed', None)
 
-                print(f"✅ {lanlan_name} 的记忆已修正：{detail}")
+                _safe_print(f"✅ {lanlan_name} 的记忆已修正：{detail}")
                 return ('patched', new_fingerprint)
 
             except openai_retry_error_types() as e:
                 logger.info(f"ℹ️ 捕获到 {type(e).__name__} 错误")
                 retries += 1
                 if retries >= max_retries:
-                    print(f'❌ 记忆整理失败，已达到最大重试次数: {e}')
+                    _safe_print(f'❌ 记忆整理失败，已达到最大重试次数: {e}')
                     return ('failed', None)
                 # 指数退避: 1, 2, 4 秒
                 wait_time = 2 ** (retries - 1)
-                print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
+                _safe_print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
                 await asyncio.sleep(wait_time)
                 # 检查是否被取消
                 if cancel_event and cancel_event.is_set():
-                    print(f"⚠️ {lanlan_name} 的记忆整理在重试等待期间被取消")
+                    _safe_print(f"⚠️ {lanlan_name} 的记忆整理在重试等待期间被取消")
                     return ('failed', None)
             except Exception as e:
                 logger.error(f"❌ 历史记录审阅失败：{e}")
                 return ('failed', None)
 
         # 如果所有重试都失败
-        print(f"❌ {lanlan_name} 的记忆整理失败，已达到最大重试次数")
+        _safe_print(f"❌ {lanlan_name} 的记忆整理失败，已达到最大重试次数")
         return ('failed', None)

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -1622,7 +1622,7 @@ class CompressedRecentHistoryManager:
                 return ('failed', None)
 
         if not snapshot:
-            print(f"{lanlan_name} 的历史记录为空，无需审阅")
+            _safe_print(f"{lanlan_name} 的历史记录为空，无需审阅")
             return ('failed', None)
 
         # 将 snapshot 转为可读文本格式（喂 LLM）
@@ -1704,7 +1704,7 @@ class CompressedRecentHistoryManager:
                     _safe_print(f"❌ 审阅响应格式错误：{response_content}")
                     return ('failed', None)
 
-                print(f"记忆整理结果：{review_result['explanation']}")
+                _safe_print(f"记忆整理结果：{review_result['explanation']}")
 
                 # 将修正后的对话转换回消息格式。SystemMessage 类型由 compress
                 # 产生（summary 备忘录），review 不应该输出，丢弃以保护压缩边界。

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -21,6 +21,8 @@ import os
 import asyncio
 import hashlib
 import logging
+import locale
+import sys
 from contextlib import suppress
 
 from config.prompts.prompts_memory import (
@@ -54,13 +56,17 @@ def _safe_print(*args, **kwargs):
     On Windows Chinese (GBK) consoles, printing emoji like ✅/⚠️ raises
     ``UnicodeEncodeError`` and aborts the memory pipeline mid-flight. Keep the
     plain ``print`` (privacy rule: raw dialog only via print, never logger) but
-    degrade un-encodable characters to ``?`` instead of crashing.
+    degrade only the un-encodable emoji to ``?`` (keep CJK text readable by
+    encoding with the target stream's encoding).
     """
     try:
         print(*args, **kwargs)
     except UnicodeEncodeError:
-        text = " ".join(str(a) for a in args)
-        safe = text.encode("ascii", "replace").decode("ascii")
+        output = kwargs.get("file") or sys.stdout
+        encoding = getattr(output, "encoding", None) or locale.getpreferredencoding(False)
+        sep = kwargs.get("sep", " ")
+        joined = str(sep).join(str(a) for a in args)
+        safe = joined.encode(encoding, "replace").decode(encoding)
         kwargs.pop("file", None)
         kwargs.pop("flush", None)
         print(safe, **kwargs)


### PR DESCRIPTION
## 改动概述 / Summary

**修复 Windows 中文环境下记忆 review 流程因 emoji 打印崩溃的问题**

`memory/recent.py` 中有 22 处 `print(...)` 使用了 emoji（`✅` `⚠️` `❌` `💥` 等）。在 Windows 中文系统（GBK 控制台编码）上，打印这些 emoji 会抛出 `UnicodeEncodeError`，导致记忆整理（review）流程在**每次 LLM 调用成功后、提交落盘完成后**崩溃：

```
UnicodeEncodeError: 'gbk' codec can't encode character '\u2705' in position 0: illegal multibyte sequence
File ".../memory/recent.py", line 1788, in review_history
    print(f"✅ {lanlan_name} 的记忆已修正：{detail}")
```

崩溃使 review 被上层误判为失败（`review.py:1027` 的 `except Exception` → `('failed', None)`），进而触发不必要的重试与重复 LLM 调用（因用户持续聊天、输入 fingerprint 一直变化，Gate 6 dead-letter 不生效，`MEMORY_LIVENESS_MAX_ATTEMPTS=5` 每轮都被重置）。修复后 review 可正常完成，消除重复 LLM 调用与 error 日志刷屏。

**修复方式**：新增 `_safe_print()` 安全打印包装，在 `UnicodeEncodeError` 时把无法编码的字符降级为 `?`（`errors='replace'`）而不崩溃；22 处含 emoji 的 `print(` 全部替换为 `_safe_print(`。

**为何用包装而非删 emoji / 换 logger**：
- 项目规范（`.agent/rules/neko-guide.md`）要求涉及用户隐私的原始对话只能用 `print`、禁止 `logger`，故不能简单替换为 logger；
- emoji 是日志的视觉层级提示（成功/失败/警告），删除会丢失信息；
- `_safe_print` 保留 `print` 语义，在 UTF-8 环境（Linux/macOS/官方 CI）行为不变，仅在 GBK 控制台降级。

## 回归报告 / Regression Report

**改动了什么**
- `memory/recent.py`：
  - 新增 `_safe_print(*args, **kwargs)` 函数（约 16 行），捕获 `UnicodeEncodeError`，将无法编码的字符以 `?` 替换后输出；
  - 将 22 处含 emoji 的 `print(...)` 替换为 `_safe_print(...)`。

**理由 / 必要性**
- 当前代码在 Windows 中文（GBK）环境运行时会崩溃，导致记忆 review（Phase C 记忆修正）流程无法完成；
- 崩溃使 review 被误判为失败，触发重复重试与重复 LLM 调用，浪费 token（本项目默认含免费额度通道，重复调用同样受限流影响）；
- 这是一个跨平台编码缺陷：开发/CI 在 UTF-8 环境正常，Windows 中文用户必现。

**改动前后的表现对比**
| 项 | 修复前（Windows 中文） | 修复后 |
|---|---|---|
| error 日志 | 每次 review 都刷 `UnicodeEncodeError` | 无此类错误 |
| review 流程 | 在 `print` 处崩溃，被误判 `failed` | 正常走完（提取→蒸馏→入库→修正完成） |
| LLM 调用 | 崩溃→误判失败→重试，重复调用 | 每轮 review 一次调用，无额外重试 |
| 记忆落盘 | 基础 recent 正常，但 review 修正从未成功完成 | 全部正常 |

**潜在回归点与验证**
- **回归点**：`print` → `_safe_print` 是否会改变输出内容或丢失信息？—— 不会：UTF-8 环境下 `_safe_print` 与 `print` 行为完全一致；GBK 环境下仅 emoji 降级为 `?`，中英文正文不受影响。
- **回归点**：`_safe_print` 是否影响并发/异步？—— 不会：它是纯函数，仅做打印，无 I/O 状态、无锁，与原有 `print` 语义等价。
- **验证方式**：
  1. 语法检查：`py_compile.compile()` 通过；
  2. GBK 环境模拟测试：普通 `print` 复现崩溃，`_safe_print` 不崩溃（emoji 降级为 `?`，中文保留）；
  3. 实机验证：重启 memory_server，正常对话触发 review，流程完整走通，error 日志零新增，记忆文件正常落盘；
  4. `recent.py` 中剩余 2 处裸 `print`（L1619/L1701）经验证不含 emoji，无需改动。

## 不拆分理由 / Why Not Split

不适用（改动计入上限的文件数：1，远小于 20）。

## 测试 / Testing

- **单元级**：`py_compile` 语法通过；`_safe_print` 在 GBK 编码 stdout 下的行为测试通过（见上「潜在回归点与验证」）。
- **集成级**：重启 `memory_server` 后与猫娘对话，触发 review：
  - 修复前：error 日志持续刷 `UnicodeEncodeError`，失败退避计数 1→5 循环；
  - 修复后：`cache → review → 事实提取 → Stage-2 → evidence 入库 → 修正完成` 全链路日志正常，error 日志零新增。
- **数据验证**：`recent.json` / `facts.json` / `persona.json` 在对话后正常更新，内容完整无损坏。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复控制台不支持 Unicode 字符时可能导致记忆处理流程中断的问题。
  * 相关提示信息现在会自动替换为兼容字符，确保成功、失败、重试、取消及结果输出等流程稳定完成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->