### PR TITLE
chore(config): 刷新各 provider 默认模型档位并补齐 extra_body 映射

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -28,7 +28,7 @@
       "name": "GPT-Realtime（OpenAI）",
       "description": "智能水平最高，但国内无法使用且价格昂贵",
       "core_url": "wss://api.openai.com/v1/realtime",
-      "core_model": "gpt-realtime-2"
+      "core_model": "gpt-realtime-2.1"
     },
     "step": {
       "key": "step",
@@ -82,7 +82,7 @@
       "conversation_model": "qwen3.7-plus",
       "summary_model": "qwen3.7-plus",
       "correction_model": "qwen3.7-plus-2026-05-26",
-      "emotion_model": "qwen3.6-flash",
+      "emotion_model": "qwen3.7-flash-2026-07-15",
       "vision_model": "qwen3.7-plus",
       "agent_model": "qwen3.7-plus-2026-05-26"
     },
@@ -95,12 +95,12 @@
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         "https://dashscope-us.aliyuncs.com/compatible-mode/v1"
       ],
-      "conversation_model": "qwen3.6-plus",
-      "summary_model": "qwen3.6-plus",
-      "correction_model": "qwen3.6-plus",
-      "emotion_model": "qwen3.6-flash-2026-04-16",
-      "vision_model": "qwen3.6-plus",
-      "agent_model": "qwen3.6-plus"
+      "conversation_model": "qwen3.7-plus",
+      "summary_model": "qwen3.7-plus",
+      "correction_model": "qwen3.7-plus",
+      "emotion_model": "qwen3.7-flash",
+      "vision_model": "qwen3.7-plus",
+      "agent_model": "qwen3.7-plus"
     },
     "openai": {
       "key": "openai",
@@ -108,11 +108,11 @@
       "description": "记忆管理能力强，价格很贵",
       "openrouter_url": "https://api.openai.com/v1",
       "conversation_model": "gpt-5-chat-latest",
-      "summary_model": "gpt-5-chat-latest",
-      "correction_model": "gpt-5-chat-latest",
-      "emotion_model": "gpt-4.1-nano",
+      "summary_model": "gpt-5.6-luna",
+      "correction_model": "gpt-5.6-luna",
+      "emotion_model": "gpt-5-nano",
       "vision_model": "gpt-5-chat-latest",
-      "agent_model": "glm-5v-turbo"
+      "agent_model": "gpt-5.6-terra"
     },
     "glm": {
       "key": "glm",
@@ -124,7 +124,7 @@
       "correction_model": "glm-4.7-flash",
       "emotion_model": "glm-4.7-flash",
       "vision_model": "glm-4.6v-flash",
-      "agent_model": "glm-4.6v"
+      "agent_model": "glm-5v-turbo"
     },
     "step": {
       "key": "step",
@@ -210,7 +210,7 @@
       "correction_model": "doubao-seed-character-260628",
       "emotion_model": "doubao-seed-2-0-mini-260428",
       "vision_model": "doubao-seed-character-260628",
-      "agent_model": "doubao-seed-2-0-pro-260215"
+      "agent_model": "doubao-seed-2-0-lite-260428"
     },
     "minimax": {
       "key": "minimax",
@@ -229,12 +229,12 @@
       "name": "MiniMax（国际服）",
       "description": "支持语音克隆（TTS），国际服版本",
       "openrouter_url": "https://api.minimax.io/v1",
-      "conversation_model": "MiniMax-M2.5",
-      "summary_model": "MiniMax-M2.5",
-      "correction_model": "MiniMax-M2.5",
-      "emotion_model": "MiniMax-M2.5",
-      "vision_model": "",
-      "agent_model": "MiniMax-M2.7"
+      "conversation_model": "MiniMax-M3",
+      "summary_model": "MiniMax-M3",
+      "correction_model": "MiniMax-M3",
+      "emotion_model": "MiniMax-M3",
+      "vision_model": "MiniMax-M3",
+      "agent_model": "MiniMax-M3"
     },
     "mimo": {
       "key": "mimo",
@@ -260,24 +260,24 @@
       "description": "Anthropic的强力模型，国内无法使用",
       "openrouter_url": "https://api.anthropic.com/v1",
       "provider_type": "anthropic",
-      "conversation_model": "claude-sonnet-4-6",
-      "summary_model": "claude-sonnet-4-6",
-      "correction_model": "claude-sonnet-4-6",
+      "conversation_model": "claude-sonnet-5",
+      "summary_model": "claude-sonnet-5",
+      "correction_model": "claude-sonnet-5",
       "emotion_model": "claude-haiku-4-5-20251001",
-      "vision_model": "claude-sonnet-4-6",
-      "agent_model": "claude-opus-4-6"
+      "vision_model": "claude-sonnet-5",
+      "agent_model": "claude-sonnet-5"
     },
     "grok": {
       "key": "grok",
       "name": "Grok（xAI）",
       "description": "xAI的强力模型，国内版不支持",
       "openrouter_url": "https://api.x.ai/v1",
-      "conversation_model": "grok-4-1-fast-non-reasoning",
-      "summary_model": "grok-4-1-fast-non-reasoning",
-      "correction_model": "grok-4-1-fast-non-reasoning",
-      "emotion_model": "grok-3-mini-fast",
-      "vision_model": "grok-4-1-fast-non-reasoning",
-      "agent_model": "grok-4-1-fast-non-reasoning"
+      "conversation_model": "grok-4.20-0309-non-reasoning",
+      "summary_model": "grok-4.20-0309-non-reasoning",
+      "correction_model": "grok-4.20-0309-non-reasoning",
+      "emotion_model": "grok-4.20-0309-non-reasoning",
+      "vision_model": "grok-4.20-0309-non-reasoning",
+      "agent_model": "grok-4.3"
     },
     "openrouter": {
       "key": "openrouter",
@@ -321,16 +321,16 @@
     }
   },
   "default_models": {
-    "router_model": "openai/gpt-4.1",
+    "router_model": "qwen-plus",
     "summary_model": "qwen-plus",
     "setting_proposer_model": "qwen-max",
     "setting_verifier_model": "qwen-max",
     "semantic_model": "text-embedding-v4",
     "reranker_model": "qwen-plus",
     "correction_model": "qwen-max",
-    "emotion_model": "qwen-turbo",
-    "vision_model": "qwen3-vl-plus-2025-09-23",
-    "core_model": "qwen3-omni-flash-realtime",
+    "emotion_model": "qwen-flash",
+    "vision_model": "qwen-plus",
+    "core_model": "qwen3.5-omni-flash-realtime",
     "core_url": "wss://dashscope.aliyuncs.com/api-ws/v1/realtime",
     "openrouter_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
     "cosyvoice_clone_model": "cosyvoice-v3.5-plus",

--- a/config/providers.py
+++ b/config/providers.py
@@ -77,10 +77,13 @@ AGENT_USE_EXTRA_BODY = True
 
 # 模型到 extra_body 的映射
 MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
-    # OpenAI 系列
-    "gpt-5.6-luna": EXTRA_BODY_OPENAI,
-    "gpt-5.6-terra": EXTRA_BODY_OPENAI,
-    "gpt-5-nano": EXTRA_BODY_OPENAI,
+    # OpenAI 原生（api.openai.com）故意不在本表里 —— EXTRA_BODY_OPENAI 那个名字指的是
+    # 「OpenAI-compatible 形状」的 enable_thinking，是 DashScope/Silicon 等国产兼容网关的
+    # 方言，不是 OpenAI 自己的参数：发给 api.openai.com 会被判 Unrecognized request
+    # argument 直接 400。OpenAI 侧对应的旋钮是顶层 reasoning_effort（档位随模型而异，
+    # none 要 gpt-5.1+），需要单开一组常量并逐模型确认可用档位，留 follow-up。在那之前
+    # 这里保持空缺 —— get_extra_body 回落成空 dict、不下发任何 extra_body，与既有的
+    # gpt-5-chat-latest / 旧 gpt-4.1-nano 一致。
     # Qwen 系列
     "qwen-flash": EXTRA_BODY_OPENAI,
     "qwen3.6-flash": EXTRA_BODY_OPENAI,

--- a/config/providers.py
+++ b/config/providers.py
@@ -77,13 +77,13 @@ AGENT_USE_EXTRA_BODY = True
 
 # 模型到 extra_body 的映射
 MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
-    # OpenAI 原生（api.openai.com）故意不在本表里 —— EXTRA_BODY_OPENAI 那个名字指的是
-    # 「OpenAI-compatible 形状」的 enable_thinking，是 DashScope/Silicon 等国产兼容网关的
-    # 方言，不是 OpenAI 自己的参数：发给 api.openai.com 会被判 Unrecognized request
-    # argument 直接 400。OpenAI 侧对应的旋钮是顶层 reasoning_effort（档位随模型而异，
-    # none 要 gpt-5.1+），需要单开一组常量并逐模型确认可用档位，留 follow-up。在那之前
-    # 这里保持空缺 —— get_extra_body 回落成空 dict、不下发任何 extra_body，与既有的
-    # gpt-5-chat-latest / 旧 gpt-4.1-nano 一致。
+    # OpenAI 系列 —— 用 reasoning.effort 而不是 EXTRA_BODY_OPENAI。后者名字里的
+    # 「OPENAI」指的是「OpenAI-compatible 形状」的 enable_thinking，那是 DashScope /
+    # Silicon 这类兼容网关的方言，OpenAI 自己不认，发过去会被判 Unrecognized request
+    # argument。effort 档位跟 OpenRouter 同形，凝神侧也因此自动有 none→low 的对偶。
+    "gpt-5.6-luna": EXTRA_BODY_OPENROUTER,
+    "gpt-5.6-terra": EXTRA_BODY_OPENROUTER,
+    "gpt-5-nano": EXTRA_BODY_OPENROUTER,
     # Qwen 系列
     "qwen-flash": EXTRA_BODY_OPENAI,
     "qwen3.6-flash": EXTRA_BODY_OPENAI,
@@ -112,6 +112,7 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "kimi-k2-0905-preview": EXTRA_BODY_CLAUDE,
     "kimi-k2.5": EXTRA_BODY_CLAUDE,
     "kimi-k2.6": EXTRA_BODY_CLAUDE,
+    "kimi-k3": EXTRA_BODY_CLAUDE,
     # MiniMax系列
     "MiniMax-M2.5": EXTRA_BODY_MINIMAX,
     "MiniMax-M2.7": EXTRA_BODY_MINIMAX,

--- a/config/providers.py
+++ b/config/providers.py
@@ -77,6 +77,10 @@ AGENT_USE_EXTRA_BODY = True
 
 # 模型到 extra_body 的映射
 MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
+    # OpenAI 系列
+    "gpt-5.6-luna": EXTRA_BODY_OPENAI,
+    "gpt-5.6-terra": EXTRA_BODY_OPENAI,
+    "gpt-5-nano": EXTRA_BODY_OPENAI,
     # Qwen 系列
     "qwen-flash": EXTRA_BODY_OPENAI,
     "qwen3.6-flash": EXTRA_BODY_OPENAI,
@@ -91,6 +95,8 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "qwen3.7-plus-2026-05-26": EXTRA_BODY_OPENAI,
     "qwen3.7-plus": EXTRA_BODY_OPENAI,
     "qwen3.7-max": EXTRA_BODY_OPENAI,
+    "qwen3.7-flash": EXTRA_BODY_OPENAI,
+    "qwen3.7-flash-2026-07-15": EXTRA_BODY_OPENAI,
     # GLM 系列
     "glm-4.5-air": EXTRA_BODY_CLAUDE,
     "glm-4.6v-flash": EXTRA_BODY_CLAUDE,
@@ -119,6 +125,7 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     # 平时下发 disabled、凝神由 focus_extra_body flip 成 enabled。
     "free-model": EXTRA_BODY_CLAUDE,
     # Claude 系列（Anthropic 原生：enable 须用 adaptive，本 PR 暂不翻，见 EXTRA_BODY_ANTHROPIC）
+    "claude-sonnet-5": EXTRA_BODY_ANTHROPIC,
     "claude-sonnet-4-6": EXTRA_BODY_ANTHROPIC,
     "claude-haiku-4-5-20251001": EXTRA_BODY_ANTHROPIC,
     "claude-opus-4-7": EXTRA_BODY_ANTHROPIC,

--- a/config/providers.py
+++ b/config/providers.py
@@ -40,6 +40,21 @@ from typing import Any
 EXTRA_BODY_OPENAI = {"enable_thinking": False}
 EXTRA_BODY_OPENAI_THINKING = {"enable_thinking": True}
 
+# ⚠️ 上面那个 OPENAI 指的是「OpenAI-compatible 形状」—— enable_thinking 是 DashScope /
+# Silicon 这类兼容网关的方言，OpenAI 自己不认。下面这两组才是 api.openai.com 原生的。
+# 实测（2026-08-07，Chat Completions）：
+#   - 嵌套 {"reasoning": {"effort": ...}} 是 OpenRouter / Responses API 的形状，Chat
+#     Completions 直接 400 Unknown parameter: 'reasoning'；原生只收顶层 reasoning_effort。
+#   - 档位按模型分裂，没有一个全家通用的「最低档」：
+#       gpt-5.6-luna / gpt-5.6-terra → none / low / medium / high / xhigh（无 minimal）
+#       gpt-5-nano                   → minimal / low / medium / high（无 none）
+#     所以关思考要分两组常量，凝神侧都收敛到 low（两家都支持）。
+EXTRA_BODY_OPENAI_NATIVE = {"reasoning_effort": "none"}
+EXTRA_BODY_OPENAI_NATIVE_THINKING = {"reasoning_effort": "low"}
+
+EXTRA_BODY_OPENAI_NATIVE_MINIMAL = {"reasoning_effort": "minimal"}
+EXTRA_BODY_OPENAI_NATIVE_MINIMAL_THINKING = {"reasoning_effort": "low"}
+
 EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
 EXTRA_BODY_CLAUDE_THINKING = {"thinking": {"type": "enabled"}}
 
@@ -77,13 +92,11 @@ AGENT_USE_EXTRA_BODY = True
 
 # 模型到 extra_body 的映射
 MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
-    # OpenAI 系列 —— 用 reasoning.effort 而不是 EXTRA_BODY_OPENAI。后者名字里的
-    # 「OPENAI」指的是「OpenAI-compatible 形状」的 enable_thinking，那是 DashScope /
-    # Silicon 这类兼容网关的方言，OpenAI 自己不认，发过去会被判 Unrecognized request
-    # argument。effort 档位跟 OpenRouter 同形，凝神侧也因此自动有 none→low 的对偶。
-    "gpt-5.6-luna": EXTRA_BODY_OPENROUTER,
-    "gpt-5.6-terra": EXTRA_BODY_OPENROUTER,
-    "gpt-5-nano": EXTRA_BODY_OPENROUTER,
+    # OpenAI 原生系列 —— 走顶层 reasoning_effort，别拿 EXTRA_BODY_OPENAI /
+    # EXTRA_BODY_OPENROUTER 来填，那两个形状都会被 400（见常量处的实测记录）。
+    "gpt-5.6-luna": EXTRA_BODY_OPENAI_NATIVE,
+    "gpt-5.6-terra": EXTRA_BODY_OPENAI_NATIVE,
+    "gpt-5-nano": EXTRA_BODY_OPENAI_NATIVE_MINIMAL,
     # Qwen 系列
     "qwen-flash": EXTRA_BODY_OPENAI,
     "qwen3.6-flash": EXTRA_BODY_OPENAI,
@@ -182,6 +195,8 @@ def get_agent_extra_body(model: str) -> dict | None:
 # MODELS_FOCUS_EXTRA_BODY_MAP 里回退为原值、原样保留。
 _THINKING_ENABLE_FORM: dict[int, dict] = {
     id(EXTRA_BODY_OPENAI): EXTRA_BODY_OPENAI_THINKING,
+    id(EXTRA_BODY_OPENAI_NATIVE): EXTRA_BODY_OPENAI_NATIVE_THINKING,
+    id(EXTRA_BODY_OPENAI_NATIVE_MINIMAL): EXTRA_BODY_OPENAI_NATIVE_MINIMAL_THINKING,
     id(EXTRA_BODY_CLAUDE): EXTRA_BODY_CLAUDE_THINKING,
     id(EXTRA_BODY_GEMINI): EXTRA_BODY_GEMINI_THINKING,
     id(EXTRA_BODY_GEMINI_3): EXTRA_BODY_GEMINI_3_THINKING,
@@ -210,6 +225,8 @@ def focus_extra_body(model: str) -> dict | None:
       - thinking_budget: 0 -> 800 (low fixed budget)    (Gemini 2.5)
       - thinking_level low (kept minimal), include_thoughts->True (Gemini 3)
       - reasoning.effort: none -> low                   (OpenRouter)
+      - reasoning_effort: none|minimal -> low           (OpenAI native; the
+        floor differs per model, low is the one both generations accept)
 
     Provider extras that are NOT thinking knobs (e.g. ``step-2-mini``'s built-in
     ``web_search`` tools, or MiniMax's reasoning_split) are preserved unchanged.


### PR DESCRIPTION
## 改了什么

把 `config/api_providers.json` 里各家 provider 的默认模型统一升到当前在售档位，并把新引入的模型名补进 `config/providers.py` 的 extra_body 注册表。

**模型档位（api_providers.json）**

| provider | 变化 |
| --- | --- |
| core / gpt-realtime | `gpt-realtime-2` → `gpt-realtime-2.1` |
| qwen | emotion `qwen3.6-flash` → `qwen3.7-flash-2026-07-15` |
| qwen_intl | 整组 3.6 → 3.7（plus / flash） |
| openai | summary/correction → `gpt-5.6-luna`，agent → `gpt-5.6-terra`，emotion `gpt-4.1-nano` → `gpt-5-nano` |
| glm | agent `glm-4.6v` → `glm-5v-turbo` |
| doubao | agent pro → `doubao-seed-2-0-lite-260428` |
| minimax_intl | 整组 M2.5/M2.7 → `MiniMax-M3`，顺带补上原本为空的 `vision_model` |
| claude | sonnet-4-6 → `claude-sonnet-5`；agent 也从 opus-4-6 收到 sonnet-5 |
| grok | → `grok-4.20-0309-non-reasoning`，agent → `grok-4.3` |
| default_models | router 从 `openai/gpt-4.1` 改回 `qwen-plus`；emotion `qwen-turbo` → `qwen-flash`；vision → `qwen-plus`；core → `qwen3.5-omni-flash-realtime` |

其中 openai 的 `agent_model` 原本误填成 `glm-5v-turbo`（串行到别家了），一并纠正。

**extra_body 注册（providers.py）**

新模型名不进 `MODELS_EXTRA_BODY_MAP` 的话，`get_extra_body` 会回落成空 dict，等于这些模型的思考开关根本不下发。本 PR 按各自方言补齐：

- `gpt-5.6-luna` / `gpt-5.6-terra` → `EXTRA_BODY_OPENAI_NATIVE`（`reasoning_effort="none"`，新增）
- `gpt-5-nano` → `EXTRA_BODY_OPENAI_NATIVE_MINIMAL`（`reasoning_effort="minimal"`，新增）
- `qwen3.7-flash` / `qwen3.7-flash-2026-07-15` → `EXTRA_BODY_OPENAI`（同 `qwen3.6-flash`）
- `claude-sonnet-5` → `EXTRA_BODY_ANTHROPIC`（同 `claude-sonnet-4-6`）
- `kimi-k3` → `EXTRA_BODY_CLAUDE`（同 `kimi-k2.6`）

### OpenAI 原生为什么要单开两组常量

`EXTRA_BODY_OPENAI` 那个名字里的「OPENAI」指的是「OpenAI-**compatible** 形状」的 `enable_thinking`，是 DashScope / Silicon 这类兼容网关的方言，OpenAI 自己不认。对着 `api.openai.com` 实测（Chat Completions）：

| 形状 | gpt-5.6-luna | gpt-5.6-terra | gpt-5-nano |
|---|---|---|---|
| `{"reasoning":{"effort":"none"}}`（OpenRouter / Responses 形状） | 400 unknown_parameter | 400 | 400 |
| `{"enable_thinking": false}` | 400 unknown_parameter | 400 | 400 |
| `reasoning_effort="none"` | 200 | 200 | 400 unsupported_value |
| `reasoning_effort="minimal"` | 400 unsupported_value | 400 | 200 |
| `reasoning_effort="low"` | 200 | 200 | 200 |

两个结论：原生只收**顶层** `reasoning_effort`；**档位按模型分裂，没有全家通用的最低档** —— `gpt-5.6-*` 有 `none` 没 `minimal`，`gpt-5-nano` 反过来。所以关思考分两组常量，凝神侧都收敛到 `low`（两代都支持），照旧进 `_THINKING_ENABLE_FORM` 拿对偶。实测记录写进了常量处的注释。

（过程中这三条一度写成 `enable_thinking` 又改成嵌套 `reasoning.effort`，都会 400，`ea42fa250` 修正。）

`MODELS_FOCUS_EXTRA_BODY_MAP` 与该表同源派生，凝神侧自动跟随。`leaks_thinking_in_content` 按 `qwen3.7` 前缀匹配，新增的 flash 也已覆盖。旧档位条目保留在表里 —— 用户手填旧模型名时仍需生效。

## 验证

单测：

```
uv run pytest tests/unit/test_providers.py tests/unit/test_focus_mode.py tests/unit/test_thinking_stream_stripper.py tests/unit/test_api_config_manager.py tests/unit/test_connectivity_endpoint.py
269 passed
```

端到端：走仓库自己的 `create_chat_llm` + `get_extra_body` / `focus_extra_body`（不是手拼 body），对 `api.openai.com` 打真实请求，三个模型 × 常规轮/凝神轮共 6 次全部 200，`reasoning_tokens=0` 确认关思考真生效。

## 已知遗留（本 PR 未动）

**`config/model_defaults.py` 与 json 的 core 模型漂移** —— `DEFAULT_CORE_MODEL` / `DEFAULT_REALTIME_MODEL` / `DEFAULT_TTS_MODEL` 仍是 `qwen3-omni-flash-realtime`，注释写着"与 api_providers.json 对齐"，本次 json 改成了 `qwen3.5-omni-flash-realtime`。要不要跟着改取决于这三个常量的实际生效路径，留作单独 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
