### PR TITLE
fix: 统一媒体凭证窗口控制样式

### DIFF
--- a/static/css/window_controls.css
+++ b/static/css/window_controls.css
@@ -1,10 +1,32 @@
-/* 自绘窗口控制按钮：最小化、最大化/恢复 */
-.neko-window-actions,
-.neko-window-controls {
+/* 统一窗口控制按钮：置顶、最小化、最大化/恢复、关闭 */
+.neko-window-actions {
     display: flex;
     align-items: center;
     gap: 8px;
     margin-left: auto;
+    flex-shrink: 0;
+    -webkit-app-region: no-drag;
+}
+
+.neko-window-controls {
+    --neko-window-control-color: #fff;
+    --neko-window-control-group-background: rgba(255, 255, 255, 0.1);
+    --neko-window-control-group-border: rgba(255, 255, 255, 0.16);
+    --neko-window-control-hover-background: rgba(255, 255, 255, 0.2);
+    --neko-window-control-active-background: rgba(255, 255, 255, 0.3);
+    --neko-window-control-close-color: #fff5f5;
+    --neko-window-control-close-hover-background: rgba(248, 113, 113, 0.28);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    margin-left: auto;
+    padding: 3px;
+    border: 1px solid var(--neko-window-control-group-border);
+    border-radius: 12px;
+    background: var(--neko-window-control-group-background);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 4px 16px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     flex-shrink: 0;
     -webkit-app-region: no-drag;
 }
@@ -19,67 +41,86 @@
     margin: 0;
 }
 
+.neko-window-controls .neko-window-control-btn,
+.neko-window-controls .minimize-btn,
+.neko-window-controls .maximize-btn,
 .neko-window-controls .close-btn,
-.neko-window-controls .close-page-btn {
-    position: static;
-    right: auto;
+.neko-window-controls .close-page-btn,
+.neko-window-controls .voice-close {
+    position: relative;
     top: auto;
-    transform: none;
-    margin: 0;
-    flex-shrink: 0;
-    -webkit-app-region: no-drag;
-}
-
-.neko-window-controls .close-btn:hover,
-.neko-window-controls .close-page-btn:hover {
-    transform: translateY(-1px);
-}
-
-.neko-window-controls .close-btn:active,
-.neko-window-controls .close-page-btn:active {
-    transform: translateY(1px) scale(0.95);
-}
-
-.neko-window-control-btn {
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    border: none;
-    border-radius: 4px;
-    background: transparent;
-    color: #fff;
-    cursor: pointer;
-    line-height: 1;
+    right: auto;
+    bottom: auto;
+    left: auto;
     display: flex;
+    width: 32px;
+    height: 30px;
     align-items: center;
     justify-content: center;
-    transition:
-        background 0.2s ease,
-        color 0.2s ease,
-        transform 0.1s ease,
-        opacity 0.2s ease,
-        box-shadow 0.2s ease;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--neko-window-control-color);
+    cursor: pointer;
+    line-height: 1;
+    transform: none;
+    opacity: 1;
+    z-index: auto;
+    transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
     flex-shrink: 0;
     -webkit-app-region: no-drag;
 }
 
-.neko-window-control-btn[hidden] {
+.neko-window-controls .neko-window-control-btn[hidden] {
     display: none;
 }
 
-.neko-window-control-btn.is-pinned {
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.18));
-    color: #fff;
-    box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.32),
-        0 3px 10px rgba(15, 79, 120, 0.16);
+.neko-window-controls .neko-window-control-btn:hover,
+.neko-window-controls .minimize-btn:hover,
+.neko-window-controls .maximize-btn:hover,
+.neko-window-controls .close-btn:hover,
+.neko-window-controls .close-page-btn:hover,
+.neko-window-controls .voice-close:hover {
+    background: var(--neko-window-control-hover-background);
+    transform: translateY(-1px);
+    box-shadow: 0 3px 8px rgba(15, 23, 42, 0.12);
 }
 
-.neko-window-control-btn.is-pinned:hover {
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.24));
+.neko-window-controls .neko-window-control-btn:active,
+.neko-window-controls .minimize-btn:active,
+.neko-window-controls .maximize-btn:active,
+.neko-window-controls .close-btn:active,
+.neko-window-controls .close-page-btn:active,
+.neko-window-controls .voice-close:active {
+    background: var(--neko-window-control-active-background);
+    transform: translateY(0) scale(0.94);
+    box-shadow: none;
+}
+
+.neko-window-controls .neko-window-control-btn:focus-visible,
+.neko-window-controls .minimize-btn:focus-visible,
+.neko-window-controls .maximize-btn:focus-visible,
+.neko-window-controls .close-btn:focus-visible,
+.neko-window-controls .close-page-btn:focus-visible,
+.neko-window-controls .voice-close:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--neko-window-control-color) 78%, transparent);
+    outline-offset: 2px;
+}
+
+.neko-window-controls .neko-window-control-btn.is-pinned {
+    background: var(--neko-window-control-hover-background);
     box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.4),
-        0 4px 12px rgba(15, 79, 120, 0.2);
+        inset 0 0 0 1px color-mix(in srgb, var(--neko-window-control-color) 24%, transparent),
+        0 3px 8px rgba(15, 23, 42, 0.12);
+}
+
+.neko-window-controls .neko-window-control-btn.is-pinned:hover {
+    background: var(--neko-window-control-active-background);
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--neko-window-control-color) 32%, transparent),
+        0 4px 10px rgba(15, 23, 42, 0.16);
 }
 
 .neko-window-pin-icon {
@@ -117,25 +158,12 @@
     animation: neko-window-pin-lock 0.28s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-[data-neko-window-control="pin"]:focus-visible {
-    outline: 2px solid rgba(255, 255, 255, 0.92);
-    outline-offset: 2px;
-}
-
-.neko-window-control-btn:hover {
-    background: rgba(255, 255, 255, 0.2);
-    transform: translateY(-1px);
-}
-
-.neko-window-control-btn:active {
-    background: rgba(255, 255, 255, 0.3);
-    transform: translateY(1px) scale(0.95);
-    opacity: 0.9;
-}
-
-.neko-window-control-btn:disabled,
+.neko-window-controls .neko-window-control-btn:disabled,
+.neko-window-controls .minimize-btn:disabled,
+.neko-window-controls .maximize-btn:disabled,
 .neko-window-controls .close-btn:disabled,
-.neko-window-controls .close-page-btn:disabled {
+.neko-window-controls .close-page-btn:disabled,
+.neko-window-controls .voice-close:disabled {
     cursor: not-allowed;
     opacity: 0.45;
     transform: none;
@@ -154,39 +182,94 @@
 
 .neko-window-minimize-icon {
     display: block;
-    width: 16px;
-    height: 2px;
+    width: 14px;
+    height: 1.5px;
     background: currentColor;
-    border-radius: 2px;
+    border-radius: 999px;
     transform: translateY(5px);
 }
 
 .neko-window-maximize-icon {
     display: block;
-    width: 14px;
-    height: 14px;
-    border: 2px solid currentColor;
-    border-radius: 2px;
+    width: 13px;
+    height: 13px;
+    border: 1.6px solid currentColor;
+    border-radius: 3px;
     box-sizing: border-box;
-    transition: all 0.2s ease;
+    transition: transform 0.18s ease;
 }
 
 .neko-window-maximize-icon.restored {
     position: relative;
-    background: #40c5f1;
+    transform: translate(2px, 2px);
 }
 
 .neko-window-maximize-icon.restored::after {
     content: '';
     position: absolute;
-    top: -3px;
-    left: 3px;
-    width: 14px;
-    height: 14px;
-    border: 2px solid currentColor;
-    border-radius: 2px;
-    background: #40c5f1;
+    top: -5px;
+    left: -5px;
+    width: 11px;
+    height: 11px;
+    border: 1.6px solid currentColor;
+    border-radius: 3px;
     box-sizing: border-box;
+}
+
+.neko-window-controls [data-neko-window-control="close"],
+.neko-window-controls .close-btn,
+.neko-window-controls .close-page-btn,
+.neko-window-controls .voice-close {
+    color: var(--neko-window-control-close-color);
+}
+
+.neko-window-controls [data-neko-window-control="close"]::before,
+.neko-window-controls [data-neko-window-control="close"]::after,
+.neko-window-controls .close-btn::before,
+.neko-window-controls .close-btn::after,
+.neko-window-controls .close-page-btn::before,
+.neko-window-controls .close-page-btn::after,
+.neko-window-controls .voice-close::before,
+.neko-window-controls .voice-close::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 15px;
+    height: 1.7px;
+    margin: -0.85px 0 0 -7.5px;
+    border-radius: 999px;
+    background: currentColor;
+    box-shadow: 0 1px 1px rgba(15, 23, 42, 0.14);
+}
+
+.neko-window-controls [data-neko-window-control="close"]::before,
+.neko-window-controls .close-btn::before,
+.neko-window-controls .close-page-btn::before,
+.neko-window-controls .voice-close::before {
+    transform: rotate(45deg);
+}
+
+.neko-window-controls [data-neko-window-control="close"]::after,
+.neko-window-controls .close-btn::after,
+.neko-window-controls .close-page-btn::after,
+.neko-window-controls .voice-close::after {
+    transform: rotate(-45deg);
+}
+
+.neko-window-controls [data-neko-window-control="close"] img,
+.neko-window-controls .close-btn img,
+.neko-window-controls .close-page-btn img,
+.neko-window-controls .voice-close img {
+    display: none !important;
+}
+
+.neko-window-controls [data-neko-window-control="close"]:hover,
+.neko-window-controls .close-btn:hover,
+.neko-window-controls .close-page-btn:hover,
+.neko-window-controls .voice-close:hover {
+    background: var(--neko-window-control-close-hover-background);
+    color: #fff;
 }
 
 html:has(body > .container > .container-header),

--- a/static/css/window_controls.css
+++ b/static/css/window_controls.css
@@ -14,8 +14,7 @@
     --neko-window-control-group-border: rgba(255, 255, 255, 0.16);
     --neko-window-control-hover-background: rgba(255, 255, 255, 0.2);
     --neko-window-control-active-background: rgba(255, 255, 255, 0.3);
-    --neko-window-control-close-color: #fff5f5;
-    --neko-window-control-close-hover-background: rgba(248, 113, 113, 0.28);
+    --neko-window-control-close-color: var(--neko-window-control-color);
     display: flex;
     align-items: center;
     gap: 2px;
@@ -261,14 +260,6 @@
 .neko-window-controls .close-page-btn img,
 .neko-window-controls .voice-close img {
     display: none !important;
-}
-
-.neko-window-controls [data-neko-window-control="close"]:hover,
-.neko-window-controls .close-btn:hover,
-.neko-window-controls .close-page-btn:hover,
-.neko-window-controls .voice-close:hover {
-    background: var(--neko-window-control-close-hover-background);
-    color: #fff;
 }
 
 html:has(body > .container > .container-header),

--- a/static/css/window_controls.css
+++ b/static/css/window_controls.css
@@ -186,7 +186,6 @@
     height: 1.5px;
     background: currentColor;
     border-radius: 999px;
-    transform: translateY(5px);
 }
 
 .neko-window-maximize-icon {

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -21,86 +21,9 @@
         /* 标题栏按钮容器 */
         .title-bar-buttons {
             display: flex;
-            gap: 8px;
+            gap: 2px;
             align-items: center;
             -webkit-app-region: no-drag;
-        }
-
-        /* 最小化、最大化/恢复按钮 - 样式与关闭按钮统一 */
-        .minimize-btn,
-        .maximize-btn {
-            background: transparent;
-            border: none;
-            color: #fff;
-            cursor: pointer;
-            padding: 0;
-            line-height: 1;
-            border-radius: 4px;
-            transition: background 0.2s, transform 0.1s ease;
-            width: 32px;
-            height: 32px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            -webkit-app-region: no-drag;
-        }
-
-        .minimize-btn:hover,
-        .maximize-btn:hover {
-            background: rgba(255, 255, 255, 0.2);
-            transform: translateY(-1px);
-        }
-
-        .minimize-btn:active,
-        .maximize-btn:active {
-            background: rgba(255, 255, 255, 0.3);
-            transform: translateY(1px) scale(0.95);
-            opacity: 0.9;
-        }
-
-        /* 最小化图标：横线 */
-        .minimize-icon {
-            display: block;
-            width: 16px;
-            height: 2px;
-            background: #fff;
-            border-radius: 2px;
-            transform: translateY(5px);
-        }
-
-        /* 最大化图标：实心方框 */
-        .maximize-icon {
-            display: block;
-            width: 14px;
-            height: 14px;
-            border: 2px solid #fff;
-            border-radius: 2px;
-            box-sizing: border-box;
-            transition: all 0.2s ease;
-        }
-
-        /* 恢复图标：重叠方框（模拟窗口层叠） */
-        .maximize-icon.restored {
-            width: 14px;
-            height: 14px;
-            border: 2px solid #fff;
-            border-radius: 2px;
-            position: relative;
-            background: #4BD4FD;
-            box-sizing: border-box;
-        }
-
-        .maximize-icon.restored::after {
-            content: '';
-            position: absolute;
-            top: -3px;
-            left: 3px;
-            width: 14px;
-            height: 14px;
-            border: 2px solid #fff;
-            border-radius: 2px;
-            background: #4BD4FD;
-            box-sizing: border-box;
         }
 
         /* 我的档案补充样式 */
@@ -425,12 +348,7 @@
             }
             .title-bar-buttons {
                 flex: 0 0 auto;
-                gap: clamp(4px, 1.5vw, 8px);
-            }
-            .minimize-btn,
-            .maximize-btn {
-                width: clamp(28px, 10vw, 32px);
-                height: clamp(28px, 10vw, 32px);
+                gap: 2px;
             }
         }
     </style>
@@ -442,17 +360,17 @@
     <!-- 页面标题栏 - 支持拖动窗口 -->
     <div class="page-title-bar">
         <h2 data-i18n="steam.workshopManager" data-text="Character Card Manager - Project N.E.K.O.">Character Card Manager - Project N.E.K.O.</h2>
-        <div class="title-bar-buttons">
+        <div class="title-bar-buttons neko-window-controls">
             <button type="button" class="neko-window-control-btn" data-neko-window-control="pin" hidden data-i18n-title="common.pinWindow" data-i18n-aria="common.pinWindow" title="置顶窗口" aria-label="置顶窗口" aria-pressed="false">
                 <span class="neko-window-pin-icon" aria-hidden="true"></span>
             </button>
-            <button class="minimize-btn" id="minimizeBtn" onclick="minimizeWindow()" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
-                <span class="minimize-icon"></span>
+            <button class="neko-window-control-btn minimize-btn" id="minimizeBtn" onclick="minimizeWindow()" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
+                <span class="neko-window-minimize-icon minimize-icon"></span>
             </button>
-            <button class="maximize-btn" id="maximizeBtn" onclick="toggleMaximize()" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
-                <span class="maximize-icon"></span>
+            <button class="neko-window-control-btn maximize-btn" id="maximizeBtn" onclick="toggleMaximize()" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
+                <span class="neko-window-maximize-icon maximize-icon"></span>
             </button>
-            <button class="close-btn" onclick="window.close(); window.history.back();" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
+            <button class="neko-window-control-btn close-btn" onclick="window.close(); window.history.back();" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
                 <img src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false">
             </button>
         </div>

--- a/templates/cookies_guide.html
+++ b/templates/cookies_guide.html
@@ -81,30 +81,18 @@
         .header-brand { display: flex; align-items: center; gap: 10px; font-weight: 700; }
         .header-brand img { width: 30px; height: 30px; border-radius: 50%; border: 2px solid var(--accent); }
         .header-right {
+            --neko-window-control-color: var(--fg);
+            --neko-window-control-group-background: color-mix(in oklch, var(--surface) 92%, transparent);
+            --neko-window-control-group-border: color-mix(in oklch, var(--border) 82%, transparent);
+            --neko-window-control-hover-background: var(--accent-soft);
+            --neko-window-control-active-background: color-mix(in oklch, var(--accent-soft) 78%, var(--accent));
+            --neko-window-control-close-color: var(--fg);
+            --neko-window-control-close-hover-background: oklch(0.62 0.18 25 / 0.76);
             display: flex;
             align-items: center;
-            gap: 8px;
+            gap: 2px;
             padding-right: 0;
             -webkit-app-region: no-drag;
-        }
-        .header-right .neko-window-control-btn {
-            color: var(--fg);
-        }
-        .header-right .neko-window-control-btn:hover {
-            background: var(--accent-soft);
-        }
-        .header-right .close-page-btn {
-            width: 32px;
-            height: 32px;
-            padding: 0;
-            border: none;
-            background: transparent;
-            cursor: pointer;
-        }
-        .header-right .close-page-btn img {
-            display: block;
-            width: 32px;
-            height: 32px;
         }
         .guide-shell {
             position: relative;

--- a/templates/cookies_guide.html
+++ b/templates/cookies_guide.html
@@ -83,109 +83,29 @@
         .header-right {
             display: flex;
             align-items: center;
-            gap: 4px;
+            gap: 8px;
             padding-right: 0;
             -webkit-app-region: no-drag;
         }
-        .header-right .window-dot {
-            position: relative;
+        .header-right .neko-window-control-btn {
+            color: var(--fg);
+        }
+        .header-right .neko-window-control-btn:hover {
+            background: var(--accent-soft);
+        }
+        .header-right .close-page-btn {
             width: 32px;
             height: 32px;
-            background: transparent;
-            border: none;
-            cursor: pointer;
             padding: 0;
-            margin: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 50%;
-            -webkit-app-region: no-drag;
+            border: none;
+            background: transparent;
+            cursor: pointer;
         }
-        .header-right .window-dot::before {
-            content: '';
-            width: 18px;
-            height: 18px;
-            border-radius: 50%;
+        .header-right .close-page-btn img {
             display: block;
-            box-shadow: inset 0 0 0 0.75px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(24, 48, 58, 0.16);
-            transition: filter 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+            width: 32px;
+            height: 32px;
         }
-        .header-right .dot-close::before { background: #ff5f57; }
-        .header-right .dot-min::before { background: #febc2e; }
-        .header-right .dot-max::before { background: #28c840; }
-        .header-right .dot-close { color: #7a211d; }
-        .header-right .dot-min { color: #765313; }
-        .header-right .dot-max { color: #176126; }
-        .header-right .window-dot-icon {
-            position: absolute;
-            z-index: 1;
-            display: block;
-            width: 10px;
-            height: 10px;
-            pointer-events: none;
-            opacity: 0.94;
-            transition: opacity 0.15s ease;
-        }
-        .header-right .window-dot:hover .window-dot-icon { opacity: 1; }
-        .header-right .dot-close-icon::before,
-        .header-right .dot-close-icon::after {
-            content: '';
-            position: absolute;
-            top: 4px;
-            left: 0;
-            width: 10px;
-            height: 2px;
-            border-radius: 1px;
-            background: currentColor;
-        }
-        .header-right .dot-close-icon::before { transform: rotate(45deg); }
-        .header-right .dot-close-icon::after { transform: rotate(-45deg); }
-        .header-right .dot-min-icon {
-            width: 10px;
-            height: 2px;
-            border-radius: 1px;
-            background: currentColor;
-        }
-        .header-right .neko-window-maximize-icon {
-            width: 10px;
-            height: 10px;
-            border: 2px solid currentColor;
-            border-radius: 1.5px;
-            background: transparent;
-            box-sizing: border-box;
-            transition: opacity 0.15s ease;
-        }
-        .header-right .neko-window-maximize-icon.restored {
-            position: absolute;
-            background: transparent;
-            transform: translate(1px, 1px);
-        }
-        .header-right .neko-window-maximize-icon.restored::after {
-            content: '';
-            position: absolute;
-            top: -4px;
-            left: -4px;
-            width: 9px;
-            height: 9px;
-            border: 2px solid currentColor;
-            border-radius: 1.5px;
-            background: transparent;
-            box-sizing: border-box;
-        }
-        .header-right .window-dot:hover::before {
-            filter: saturate(1.08) brightness(1.04);
-            transform: scale(1.06);
-            box-shadow: inset 0 0 0 0.75px rgba(0, 0, 0, 0.16), 0 2px 5px rgba(24, 48, 58, 0.2);
-        }
-        .header-right .window-dot:active::before {
-            filter: saturate(0.96) brightness(0.95);
-            transform: scale(0.92);
-            box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
-        }
-        .header-right .window-dot:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 1px; }
-        .header-right .header-pin { width: 28px; height: 28px; border-radius: 50%; }
-        .header-right .header-pin .neko-window-pin-icon { width: 14px; height: 14px; }
         .guide-shell {
             position: relative;
             z-index: 1;
@@ -369,14 +289,14 @@
             <button type="button" class="neko-window-control-btn header-pin" data-neko-window-control="pin" hidden data-i18n-title="common.pinWindow" data-i18n-aria="common.pinWindow" title="置顶窗口" aria-label="置顶窗口" aria-pressed="false">
                 <span class="neko-window-pin-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="window-dot dot-min" data-neko-window-control="minimize" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
-                <span class="window-dot-icon dot-min-icon" aria-hidden="true"></span>
+            <button type="button" class="neko-window-control-btn" data-neko-window-control="minimize" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
+                <span class="neko-window-minimize-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="window-dot dot-max" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
-                <span class="window-dot-icon neko-window-maximize-icon" aria-hidden="true"></span>
+            <button type="button" class="neko-window-control-btn" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
+                <span class="neko-window-maximize-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="window-dot dot-close" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
-                <span class="window-dot-icon dot-close-icon" aria-hidden="true"></span>
+            <button type="button" class="close-page-btn" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
+                <img src="/static/icons/close_button.png" data-i18n-alt="common.close" alt="关闭" draggable="false">
             </button>
         </div>
     </header>

--- a/templates/cookies_guide.html
+++ b/templates/cookies_guide.html
@@ -86,8 +86,6 @@
             --neko-window-control-group-border: color-mix(in oklch, var(--border) 82%, transparent);
             --neko-window-control-hover-background: var(--accent-soft);
             --neko-window-control-active-background: color-mix(in oklch, var(--accent-soft) 78%, var(--accent));
-            --neko-window-control-close-color: var(--fg);
-            --neko-window-control-close-hover-background: oklch(0.62 0.18 25 / 0.76);
             display: flex;
             align-items: center;
             gap: 2px;

--- a/templates/cookies_guide.html
+++ b/templates/cookies_guide.html
@@ -295,7 +295,7 @@
             <button type="button" class="neko-window-control-btn" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
                 <span class="neko-window-maximize-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="close-page-btn" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
+            <button type="button" class="neko-window-control-btn close-page-btn" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
                 <img src="/static/icons/close_button.png" data-i18n-alt="common.close" alt="关闭" draggable="false">
             </button>
         </div>

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -1279,7 +1279,7 @@
             <button type="button" class="neko-window-control-btn" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
                 <span class="neko-window-maximize-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="close-page-btn" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
+            <button type="button" class="neko-window-control-btn close-page-btn" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
                 <img src="/static/icons/close_button.png" data-i18n-alt="common.close" alt="关闭" draggable="false">
             </button>
         </div>

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -164,109 +164,29 @@
         .header-right {
             display: flex;
             align-items: center;
-            gap: 4px;
+            gap: 8px;
             padding-right: 0;
             -webkit-app-region: no-drag;
         }
-        .header-right .window-dot {
-            position: relative;
+        .header-right .neko-window-control-btn {
+            color: var(--fg);
+        }
+        .header-right .neko-window-control-btn:hover {
+            background: var(--accent-soft);
+        }
+        .header-right .close-page-btn {
             width: 32px;
             height: 32px;
-            background: transparent;
-            border: none;
-            cursor: pointer;
             padding: 0;
-            margin: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 50%;
-            -webkit-app-region: no-drag;
+            border: none;
+            background: transparent;
+            cursor: pointer;
         }
-        .header-right .window-dot::before {
-            content: '';
-            width: 18px;
-            height: 18px;
-            border-radius: 50%;
+        .header-right .close-page-btn img {
             display: block;
-            box-shadow: inset 0 0 0 0.75px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(24, 48, 58, 0.16);
-            transition: filter 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+            width: 32px;
+            height: 32px;
         }
-        .header-right .dot-close::before { background: #ff5f57; }
-        .header-right .dot-min::before { background: #febc2e; }
-        .header-right .dot-max::before { background: #28c840; }
-        .header-right .dot-close { color: #7a211d; }
-        .header-right .dot-min { color: #765313; }
-        .header-right .dot-max { color: #176126; }
-        .header-right .window-dot-icon {
-            position: absolute;
-            z-index: 1;
-            display: block;
-            width: 10px;
-            height: 10px;
-            pointer-events: none;
-            opacity: 0.94;
-            transition: opacity 0.15s ease;
-        }
-        .header-right .window-dot:hover .window-dot-icon { opacity: 1; }
-        .header-right .dot-close-icon::before,
-        .header-right .dot-close-icon::after {
-            content: '';
-            position: absolute;
-            top: 4px;
-            left: 0;
-            width: 10px;
-            height: 2px;
-            border-radius: 1px;
-            background: currentColor;
-        }
-        .header-right .dot-close-icon::before { transform: rotate(45deg); }
-        .header-right .dot-close-icon::after { transform: rotate(-45deg); }
-        .header-right .dot-min-icon {
-            width: 10px;
-            height: 2px;
-            border-radius: 1px;
-            background: currentColor;
-        }
-        .header-right .neko-window-maximize-icon {
-            width: 10px;
-            height: 10px;
-            border: 2px solid currentColor;
-            border-radius: 1.5px;
-            background: transparent;
-            box-sizing: border-box;
-            transition: opacity 0.15s ease;
-        }
-        .header-right .neko-window-maximize-icon.restored {
-            position: absolute;
-            background: transparent;
-            transform: translate(1px, 1px);
-        }
-        .header-right .neko-window-maximize-icon.restored::after {
-            content: '';
-            position: absolute;
-            top: -4px;
-            left: -4px;
-            width: 9px;
-            height: 9px;
-            border: 2px solid currentColor;
-            border-radius: 1.5px;
-            background: transparent;
-            box-sizing: border-box;
-        }
-        .header-right .window-dot:hover::before {
-            filter: saturate(1.08) brightness(1.04);
-            transform: scale(1.06);
-            box-shadow: inset 0 0 0 0.75px rgba(0, 0, 0, 0.16), 0 2px 5px rgba(24, 48, 58, 0.2);
-        }
-        .header-right .window-dot:active::before {
-            filter: saturate(0.96) brightness(0.95);
-            transform: scale(0.92);
-            box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
-        }
-        .header-right .window-dot:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 1px; }
-        .header-right .header-pin { width: 28px; height: 28px; border-radius: 50%; }
-        .header-right .header-pin .neko-window-pin-icon { width: 14px; height: 14px; }
 
         /* ==============================
            SCROLLABLE CONTENT AREA
@@ -1326,9 +1246,6 @@
         [data-theme="dark"] .content-card { border-color: var(--border); }
         [data-theme="dark"] .alert.error { background: oklch(0.28 0.06 30); border-color: oklch(0.4 0.12 30); color: oklch(0.8 0.08 30); }
         [data-theme="dark"] .alert.success { background: oklch(0.24 0.06 150); border-color: oklch(0.35 0.12 150); color: oklch(0.78 0.08 150); }
-        [data-theme="dark"] .header-right .dot-close::before { background: #ff5f57; }
-        [data-theme="dark"] .header-right .dot-min::before { background: #febc2e; }
-        [data-theme="dark"] .header-right .dot-max::before { background: #28c840; }
         [data-theme="dark"] ::-webkit-scrollbar { width: 8px; height: 8px; }
         [data-theme="dark"] ::-webkit-scrollbar-track { background: rgba(0,0,0,0.3); border-radius: 4px; }
         [data-theme="dark"] ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
@@ -1356,14 +1273,14 @@
             <button type="button" class="neko-window-control-btn header-pin" data-neko-window-control="pin" hidden data-i18n-title="common.pinWindow" data-i18n-aria="common.pinWindow" title="置顶窗口" aria-label="置顶窗口" aria-pressed="false">
                 <span class="neko-window-pin-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="window-dot dot-min" data-neko-window-control="minimize" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
-                <span class="window-dot-icon dot-min-icon" aria-hidden="true"></span>
+            <button type="button" class="neko-window-control-btn" data-neko-window-control="minimize" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
+                <span class="neko-window-minimize-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="window-dot dot-max" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
-                <span class="window-dot-icon neko-window-maximize-icon" aria-hidden="true"></span>
+            <button type="button" class="neko-window-control-btn" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
+                <span class="neko-window-maximize-icon" aria-hidden="true"></span>
             </button>
-            <button type="button" class="window-dot dot-close" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
-                <span class="window-dot-icon dot-close-icon" aria-hidden="true"></span>
+            <button type="button" class="close-page-btn" data-neko-window-control="close" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
+                <img src="/static/icons/close_button.png" data-i18n-alt="common.close" alt="关闭" draggable="false">
             </button>
         </div>
     </header>

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -167,8 +167,6 @@
             --neko-window-control-group-border: color-mix(in oklch, var(--border) 82%, transparent);
             --neko-window-control-hover-background: var(--accent-soft);
             --neko-window-control-active-background: color-mix(in oklch, var(--accent-soft) 78%, var(--accent));
-            --neko-window-control-close-color: var(--fg);
-            --neko-window-control-close-hover-background: oklch(0.62 0.18 25 / 0.76);
             display: flex;
             align-items: center;
             gap: 2px;

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -162,30 +162,18 @@
             display: block;
         }
         .header-right {
+            --neko-window-control-color: var(--fg);
+            --neko-window-control-group-background: color-mix(in oklch, var(--surface) 92%, transparent);
+            --neko-window-control-group-border: color-mix(in oklch, var(--border) 82%, transparent);
+            --neko-window-control-hover-background: var(--accent-soft);
+            --neko-window-control-active-background: color-mix(in oklch, var(--accent-soft) 78%, var(--accent));
+            --neko-window-control-close-color: var(--fg);
+            --neko-window-control-close-hover-background: oklch(0.62 0.18 25 / 0.76);
             display: flex;
             align-items: center;
-            gap: 8px;
+            gap: 2px;
             padding-right: 0;
             -webkit-app-region: no-drag;
-        }
-        .header-right .neko-window-control-btn {
-            color: var(--fg);
-        }
-        .header-right .neko-window-control-btn:hover {
-            background: var(--accent-soft);
-        }
-        .header-right .close-page-btn {
-            width: 32px;
-            height: 32px;
-            padding: 0;
-            border: none;
-            background: transparent;
-            cursor: pointer;
-        }
-        .header-right .close-page-btn img {
-            display: block;
-            width: 32px;
-            height: 32px;
         }
 
         /* ==============================


### PR DESCRIPTION
## 改动概述 / Summary

- 统一媒体凭证管理页右上角最小化、最大化与关闭按钮的视觉和交互样式。
- 同步更新凭证获取教程子页，避免页面跳转后窗口控件样式不一致。

## 回归报告 / Regression Report

不适用：未改动 pp/、main_logic/ 或 memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：改动文件数不超过 20 个。

## 测试 / Testing

- git diff --check
- 静态检查两个页面均仅保留一组最小化、最大化、关闭控件，并复用全局窗口控制类。

## 效果图 / Screenshot

<img width="1531" height="265" alt="clipboard_2026-08-07_13-52" src="https://github.com/user-attachments/assets/761be9e8-f2e9-4fcf-8763-99cbf87d499d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式**
  * 统一登录页、指南页及角色卡片管理器的窗口控制按钮样式。
  * 更新最小化、最大化、关闭及置顶按钮的视觉效果、间距和交互状态。
  * 优化按钮焦点提示、禁用状态及移动端显示效果。
  * 关闭按钮改用统一图标，移除旧版彩色圆点设计。
  * 保留窗口控制功能及无障碍标签。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->