### PR TITLE
fix(tools): 工具调用历史保存并原样回传 extra_content / thought_signature

### DIFF
--- a/main_logic/omni_offline_client/_genai_support.py
+++ b/main_logic/omni_offline_client/_genai_support.py
@@ -116,8 +116,14 @@ def _thought_signature_from_extra_content(extra_content: Any) -> Optional[bytes]
     if not encoded or not isinstance(encoded, str):
         return None
     import base64 as _b64
+    # 只有我们自己写的那半边保证是标准字母表 + padding；另一半是 compat
+    # 端点原样存下来的串，字母表和 padding 由 Google 说了算。这里两种字母表
+    # 都收、缺 padding 也补，别让一个纯编码约定差异把签名静默丢掉——那等于
+    # 把本要修的 400 又放回来。真正的垃圾串仍被 validate=True 挡住。
+    normalized = encoded.replace("-", "+").replace("_", "/")
+    normalized += "=" * (-len(normalized) % 4)
     try:
-        return _b64.b64decode(encoded, validate=True)
+        return _b64.b64decode(normalized, validate=True)
     except (ValueError, TypeError) as e:
         logger.warning("genai: malformed thought_signature in history dropped: %s", e)
         return None

--- a/main_logic/omni_offline_client/_genai_support.py
+++ b/main_logic/omni_offline_client/_genai_support.py
@@ -74,6 +74,76 @@ class _GenaiToolsUnsupported(Exception):
     (SDK missing, model rejected, etc.) so the caller can fall back to
     the OpenAI-compat path with tools silently disabled."""
 
+
+# Gemini 的 thought_signature 在两条路径上形态不同：native SDK 给 ``Part
+# .thought_signature`` 的裸 bytes，OpenAI-compat 端点给
+# ``tool_calls[].extra_content.google.thought_signature`` 的 base64 字符串。
+# 统一工具调用历史（两条路径共用的 dict）一律按后者存：JSON 可序列化、能
+# 直接落盘、且换一条路线继续同一段历史时也能原样回传。
+_EXTRA_CONTENT_VENDOR_KEY = "google"
+_THOUGHT_SIGNATURE_KEY = "thought_signature"
+
+
+def _extra_content_from_thought_signature(signature: Any) -> Optional[dict]:
+    """Wrap a native ``Part.thought_signature`` into the shared history shape.
+
+    Returns ``None`` when the part carries no signature, so ordinary
+    non-thinking turns never grow an ``extra_content`` key."""
+    if not signature:
+        return None
+    if isinstance(signature, str):
+        encoded = signature  # 已是 base64（部分 SDK 版本直接给 str）
+    else:
+        import base64 as _b64
+        try:
+            encoded = _b64.b64encode(bytes(signature)).decode("ascii")
+        except (TypeError, ValueError) as e:
+            logger.debug("genai: unusable thought_signature dropped: %s", e)
+            return None
+    return {_EXTRA_CONTENT_VENDOR_KEY: {_THOUGHT_SIGNATURE_KEY: encoded}}
+
+
+def _thought_signature_from_extra_content(extra_content: Any) -> Optional[bytes]:
+    """Inverse of ``_extra_content_from_thought_signature``: pull the base64
+    signature out of a history entry and decode it back to the bytes the
+    native SDK wants. ``None`` when absent or unparseable."""
+    if not isinstance(extra_content, dict):
+        return None
+    vendor = extra_content.get(_EXTRA_CONTENT_VENDOR_KEY)
+    if not isinstance(vendor, dict):
+        return None
+    encoded = vendor.get(_THOUGHT_SIGNATURE_KEY)
+    if not encoded or not isinstance(encoded, str):
+        return None
+    import base64 as _b64
+    try:
+        return _b64.b64decode(encoded, validate=True)
+    except (ValueError, TypeError) as e:
+        logger.warning("genai: malformed thought_signature in history dropped: %s", e)
+        return None
+
+
+def _genai_function_call_part(types, *, call_id: str, name: str, args: dict, signature: Optional[bytes]):
+    """Build the ``Part(function_call=...)`` for a replayed tool call, carrying
+    ``thought_signature`` when history has one.
+
+    Gemini rejects a follow-up request whose function-call history lost the
+    signature (400 INVALID_ARGUMENT), so this is what makes multi-round tool
+    calling work at all on thinking models. Falls back to a signature-less
+    part if the installed SDK's ``Part`` doesn't accept the field — an old
+    SDK is better served by the pre-existing (broken-for-Gemini-3) behaviour
+    than by a hard crash."""
+    fc = types.FunctionCall(id=call_id, name=name, args=args)
+    if signature:
+        try:
+            return types.Part(function_call=fc, thought_signature=signature)
+        except Exception as e:  # pragma: no cover — old google-genai only
+            logger.warning(
+                "genai: Part rejected thought_signature (%s); replaying without it",
+                e,
+            )
+    return types.Part(function_call=fc)
+
 def _genai_messages_to_contents(
     messages: list,
 ) -> tuple[Optional[str], list]:
@@ -139,11 +209,17 @@ def _genai_messages_to_contents(
                             args = json.loads(fn.get("arguments") or "{}") if isinstance(fn.get("arguments"), str) else (fn.get("arguments") or {})
                         except json.JSONDecodeError:
                             args = {"_raw": fn.get("arguments") or ""}
-                        parts.append(types.Part(function_call=types.FunctionCall(
-                            id=tc.get("id") or "",
+                        parts.append(_genai_function_call_part(
+                            types,
+                            call_id=tc.get("id") or "",
                             name=fn.get("name") or "",
                             args=args,
-                        )))
+                            # thought_signature 必须跟着它那条 function_call
+                            # 一起回放，否则 Gemini 思考模型下一轮直接 400。
+                            signature=_thought_signature_from_extra_content(
+                                tc.get("extra_content")
+                            ),
+                        ))
                     contents.append(types.Content(role="model", parts=parts))
                 else:
                     parts = _genai_parts_from_content(msg.get("content", ""))
@@ -415,7 +491,8 @@ class _GenaiMixin:
                 raise
 
             # Per-iteration accumulators.
-            collected_tool_calls: list = []  # list of (id, name, args_dict, raw_args_str)
+            # list of (id, name, args_dict, raw_args_str, extra_content|None)
+            collected_tool_calls: list = []
             # 是否见过任何 function_call part（含名字为空、随后被 drop 的）：
             # "进入 tool 轮"的判据必须用它而不是 collected——全被 drop 时
             # collected 为空，但这轮确实不是普通文本轮。
@@ -486,11 +563,17 @@ class _GenaiMixin:
                                 raw_args = json.dumps(args, ensure_ascii=False)
                             except (TypeError, ValueError):
                                 raw_args = "{}"
+                            # thought_signature 挂在 Part 上（不在 FunctionCall
+                            # 里），必须在这里就抓走存进历史：下一轮回放这条
+                            # function_call 时 Gemini 思考模型要求原样带回。
                             collected_tool_calls.append((
                                 getattr(fn_call, "id", "") or "",
                                 tc_name,
                                 args,
                                 raw_args,
+                                _extra_content_from_thought_signature(
+                                    getattr(part, "thought_signature", None)
+                                ),
                             ))
                         elif text:
                             if tool_leak_filter is not None:
@@ -626,14 +709,16 @@ class _GenaiMixin:
             if collected_tool_calls and self.on_tool_call is not None:
                 # Execute tools, append a unified assistant + tool history (dict shape
                 # accepted by both paths), then continue tool-iteration loop.
-                tool_calls_dict = [
-                    {
+                tool_calls_dict = []
+                for i, (tc_id, tc_name, _args, tc_raw, tc_extra) in enumerate(collected_tool_calls):
+                    entry = {
                         "id": tc_id or f"call_{i}",
                         "type": "function",
                         "function": {"name": tc_name, "arguments": tc_raw},
                     }
-                    for i, (tc_id, tc_name, _args, tc_raw) in enumerate(collected_tool_calls)
-                ]
+                    if tc_extra:
+                        entry["extra_content"] = tc_extra
+                    tool_calls_dict.append(entry)
                 # 把本轮已经流给用户的 text 一起写进历史。Gemini 在同一 turn
                 # 里允许 text part 与 function_call part 并存；如果这里仍写
                 # ``content=""``，下一轮 LLM 看到的上下文会缺掉前半句，模型
@@ -647,7 +732,7 @@ class _GenaiMixin:
                     "tool_calls": tool_calls_dict,
                 })
                 executed_tool_calls += len(collected_tool_calls)
-                for i, (tc_id, tc_name, tc_args, tc_raw) in enumerate(collected_tool_calls):
+                for i, (tc_id, tc_name, tc_args, tc_raw, _tc_extra) in enumerate(collected_tool_calls):
                     tool_call = ToolCall(
                         name=tc_name,
                         arguments=tc_args,

--- a/main_logic/omni_offline_client/_streaming.py
+++ b/main_logic/omni_offline_client/_streaming.py
@@ -54,6 +54,42 @@ from ._genai_support import (
 )
 from ._lifecycle import _with_dialog_slop
 
+
+def _strip_route_bound_tool_call_extras(history) -> int:
+    """Drop ``tool_calls[].extra_content`` from a history that is about to be
+    replayed on a DIFFERENT endpoint. Returns how many were dropped.
+
+    ``extra_content`` is a vendor-private blob (today: Gemini's
+    ``thought_signature``) that only the endpoint which minted it understands.
+    It is stored so the same route can replay it — but the history outlives the
+    route: ``switch_model(vision_model, use_vision_config=True)`` re-points
+    ``self.llm`` at a separately configured provider for the rest of the session
+    and deliberately keeps the history. openai-python forwards unknown keys
+    inside ``messages[].tool_calls[]`` into the request body verbatim, so
+    without this the blob is POSTed to a provider that never issued it — and
+    endpoints that validate message objects strictly reject the request, which
+    would break every remaining turn of the session.
+
+    Dropping degrades that history to its pre-signature form (exactly what the
+    endpoint would have received before signatures were stored at all), so the
+    worst case is the old behaviour rather than a hard failure.
+
+    Scope note: the sibling ``reasoning_content`` field on the same assistant
+    turn has the same route-bound nature and predates this helper. It is left
+    alone deliberately — it has its own provider contract (thinking endpoints
+    require it echoed back) and its own failure mode, and changing it belongs
+    in its own change rather than riding along here.
+    """
+    stripped = 0
+    for msg in history or []:
+        if not isinstance(msg, dict):
+            continue
+        for tool_call in (msg.get("tool_calls") or []):
+            if isinstance(tool_call, dict) and tool_call.pop("extra_content", None) is not None:
+                stripped += 1
+    return stripped
+
+
 class _StreamingMixin:
     def update_max_response_length(self, max_length: int) -> None:
         """Update the response token cap (the user may change settings mid-conversation).
@@ -144,6 +180,11 @@ class _StreamingMixin:
                 timeout=DIALOG_LLM_STREAM_TIMEOUT_SECONDS,  # hang-guard; generous so normal/long replies aren't truncated
                 provider_type=provider_type,
             )
+            # 端点是否真的换了 —— 换 endpoint（或换账号）才需要清掉历史里
+            # 那些只有铸造方看得懂的 vendor 私有字段。同一个 endpoint 只换
+            # 模型（conversation → vision 都在同一家）不能清：那正是签名要
+            # 起作用的场景，清了等于把本要修的 400 又放回来。
+            route_changed = (base_url != self.base_url) or (api_key != self.api_key)
             old_llm = self.llm
             self.llm = new_llm
             self.model = new_model
@@ -152,6 +193,18 @@ class _StreamingMixin:
             # 把 vision 走的 Gemini endpoint 错误路由到 OpenAI-compat（反之亦然）。
             self.base_url = base_url
             self.api_key = api_key
+            if route_changed:
+                # getattr 防御与本文件其余处一致：__new__ 绕过 __init__ 的测试桩
+                # 没有这个字段，helper 对 None 也是 no-op。
+                dropped = _strip_route_bound_tool_call_extras(
+                    getattr(self, "_conversation_history", None)
+                )
+                if dropped:
+                    logger.info(
+                        "switch_model: dropped %d route-bound tool_call extra_content "
+                        "entry/entries before replaying history on %s",
+                        dropped, base_url or "(default endpoint)",
+                    )
             # 路由旗标随之刷新；旧 _genai_client 抛弃（若 api_key 变了它已失效）。
             # genai.Client 内部持有 httpx 连接池——直接 = None 靠 GC 回收虽不
             # 是 leak，但提早 close() 能马上释放底层连接（SDK 没暴露 aclose，

--- a/main_logic/omni_offline_client/_streaming.py
+++ b/main_logic/omni_offline_client/_streaming.py
@@ -184,7 +184,16 @@ class _StreamingMixin:
             # 那些只有铸造方看得懂的 vendor 私有字段。同一个 endpoint 只换
             # 模型（conversation → vision 都在同一家）不能清：那正是签名要
             # 起作用的场景，清了等于把本要修的 400 又放回来。
-            route_changed = (base_url != self.base_url) or (api_key != self.api_key)
+            #
+            # 比较前把空串归一成 None：上面 vision 分支已经做过这一步而
+            # conversation 分支没有，两边留着不同的"空"表示会让同一个端点被
+            # 判成换了路由——误判方向是"多清"，正好打在本改动的目标场景上。
+            def _same(a, b) -> bool:
+                return (a or None) == (b or None)
+
+            route_changed = not (
+                _same(base_url, self.base_url) and _same(api_key, self.api_key)
+            )
             old_llm = self.llm
             self.llm = new_llm
             self.model = new_model

--- a/main_logic/omni_offline_client/_tools.py
+++ b/main_logic/omni_offline_client/_tools.py
@@ -131,20 +131,29 @@ class _ToolingMixin:
         calls = [c for c in calls if (getattr(c, "name", "") or "").strip()]
         if not calls:
             return 0
+        tool_calls_dict = []
+        for i, c in enumerate(calls):
+            entry = {
+                "id": c.id or f"call_{i}",
+                "type": "function",
+                "function": {
+                    "name": c.name,
+                    "arguments": c.arguments or "{}",
+                },
+            }
+            # Provider-owned blob that came down with this call (Gemini's
+            # OpenAI-compat ``thought_signature``). Round-tripped verbatim:
+            # Gemini rejects the follow-up request when a function call in
+            # history lost its signature. Only attached when the provider
+            # actually sent one, so ordinary endpoints keep a clean history.
+            extra_content = getattr(c, "extra_content", None)
+            if extra_content:
+                entry["extra_content"] = extra_content
+            tool_calls_dict.append(entry)
         assistant_turn = {
             "role": "assistant",
             "content": assistant_text or "",
-            "tool_calls": [
-                {
-                    "id": c.id or f"call_{i}",
-                    "type": "function",
-                    "function": {
-                        "name": c.name,
-                        "arguments": c.arguments or "{}",
-                    },
-                }
-                for i, c in enumerate(calls)
-            ],
+            "tool_calls": tool_calls_dict,
         }
         if assistant_reasoning:
             assistant_turn["reasoning_content"] = assistant_reasoning

--- a/tests/unit/test_tool_call_thought_signature.py
+++ b/tests/unit/test_tool_call_thought_signature.py
@@ -488,11 +488,7 @@ def test_thought_signature_decodes_both_base64_alphabets(encoded, expected):
     pydantic serializer emits the URL-safe alphabet. An alphabet or padding
     difference must not silently drop the signature — that would put the very
     400 this change fixes right back."""
-    from main_logic.omni_offline_client._genai_support import (
-        _thought_signature_from_extra_content,
-    )
-
-    decoded = _thought_signature_from_extra_content(
+    decoded = _ofc_genai._thought_signature_from_extra_content(
         {"google": {"thought_signature": encoded}}
     )
     assert decoded == expected
@@ -504,12 +500,8 @@ def test_thought_signature_rejects_garbage_instead_of_decoding_it():
     corrupted string decodes to plausible-but-wrong bytes and we hand Gemini a
     signature that was never issued. Returning None (replay without a signature)
     is the honest failure."""
-    from main_logic.omni_offline_client._genai_support import (
-        _thought_signature_from_extra_content,
-    )
-
     # Lenient base64 would drop the '!' characters and happily return b'ABCD\x00B'.
-    assert _thought_signature_from_extra_content(
+    assert _ofc_genai._thought_signature_from_extra_content(
         {"google": {"thought_signature": "Q!U!J!D!RABC"}}
     ) is None
 

--- a/tests/unit/test_tool_call_thought_signature.py
+++ b/tests/unit/test_tool_call_thought_signature.py
@@ -42,13 +42,23 @@ _SIGNATURE_BYTES = b"\xfb\xef\xbe\x03\xff\xe0sig"
 _SIGNATURE_B64 = "++++A//gc2ln"  # standard alphabet; URL-safe would be "----A__gc2ln"
 _SIGNATURE_EXTRA = {"google": {"thought_signature": _SIGNATURE_B64}}
 
+# 9 bytes divides by 3, so _SIGNATURE_B64 needs no padding at all — it cannot
+# exercise the "re-pad a stripped string" branch. This 10-byte twin encodes to a
+# "==" tail, and still differs between the two alphabets.
+_PADDED_BYTES = _SIGNATURE_BYTES + b"\xff"
+_PADDED_B64 = "++++A//gc2ln/w=="
+
 
 def test_signature_fixture_discriminates_base64_alphabets():
-    """Guard on the guard: if the fixture ever loses its alphabet-specific
-    characters, every other test in this file silently stops being able to
-    catch an encoder/decoder alphabet swap."""
+    """Guard on the guard: if the fixtures ever lose their alphabet-specific
+    characters — or the padded twin stops needing padding — every other test in
+    this file silently stops being able to catch an encoder/decoder alphabet or
+    padding change."""
     assert base64.b64encode(_SIGNATURE_BYTES).decode() == _SIGNATURE_B64
     assert base64.urlsafe_b64encode(_SIGNATURE_BYTES).decode() != _SIGNATURE_B64
+    assert base64.b64encode(_PADDED_BYTES).decode() == _PADDED_B64
+    assert base64.urlsafe_b64encode(_PADDED_BYTES).decode() != _PADDED_B64
+    assert _PADDED_B64.endswith("==") and "=" not in _SIGNATURE_B64
 
 
 class _FakeAsyncStream:
@@ -459,12 +469,20 @@ def test_genai_messages_to_contents_survives_malformed_signature():
     assert not part.thought_signature
 
 
-@pytest.mark.parametrize("encoded", [
-    _SIGNATURE_B64,                                    # standard, padded
-    _SIGNATURE_B64.replace("+", "-").replace("/", "_"),  # URL-safe alphabet
-    _SIGNATURE_B64.rstrip("="),                        # standard, padding stripped
+@pytest.mark.parametrize("encoded,expected", [
+    # standard alphabet, length needs no padding
+    (_SIGNATURE_B64, _SIGNATURE_BYTES),
+    (_SIGNATURE_B64.replace("+", "-").replace("/", "_"), _SIGNATURE_BYTES),
+    # standard alphabet, padded — and the same string with its padding stripped,
+    # which is the only case that reaches the re-padding branch
+    (_PADDED_B64, _PADDED_BYTES),
+    (_PADDED_B64.rstrip("="), _PADDED_BYTES),
+    # URL-safe, padded and unpadded — the exact forms google-genai's own pydantic
+    # serializer produces and accepts
+    (_PADDED_B64.replace("+", "-").replace("/", "_"), _PADDED_BYTES),
+    (_PADDED_B64.replace("+", "-").replace("/", "_").rstrip("="), _PADDED_BYTES),
 ])
-def test_thought_signature_decodes_both_base64_alphabets(encoded):
+def test_thought_signature_decodes_both_base64_alphabets(encoded, expected):
     """Only the half we write ourselves is guaranteed standard+padded; the other
     half is whatever the compat endpoint sent down, and google-genai's own
     pydantic serializer emits the URL-safe alphabet. An alphabet or padding
@@ -477,7 +495,7 @@ def test_thought_signature_decodes_both_base64_alphabets(encoded):
     decoded = _thought_signature_from_extra_content(
         {"google": {"thought_signature": encoded}}
     )
-    assert decoded == _SIGNATURE_BYTES
+    assert decoded == expected
 
 
 def test_thought_signature_rejects_garbage_instead_of_decoding_it():
@@ -572,10 +590,12 @@ async def test_offline_openai_history_keeps_signature_on_its_own_call():
 
 
 @pytest.mark.asyncio
-async def test_offline_genai_signature_stays_on_its_own_part():
+async def test_offline_genai_signature_stays_on_its_own_part(monkeypatch):
     """genai twin: two function_call parts in one chunk, only the second Part
     carries a thought_signature."""
     from main_logic.tool_calling import ToolCall, ToolResult
+
+    monkeypatch.setattr(_ofc_genai, "_GENAI_AVAILABLE", True)
 
     async def _round1():
         yield _Chunk([
@@ -772,6 +792,46 @@ async def test_switch_model_keeps_signature_on_same_endpoint(monkeypatch):
     client.vision_model = "gemini-3-pro-vision"
     client.vision_base_url = "https://www.lanlan.app/v1"
     client.vision_api_key = "free-key"
+    client.max_response_length = 300
+    client._genai_client = None
+    client._use_genai_sdk = False
+    client.llm = type("F", (), {"aclose": staticmethod(_aclose)})()
+    client._conversation_history = [
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "c1", "type": "function",
+            "function": {"name": "recall_memory", "arguments": "{}"},
+            "extra_content": _SIGNATURE_EXTRA,
+        }]},
+    ]
+
+    async def _fake_create(*_a, **_kw):
+        return type("F", (), {"aclose": staticmethod(_aclose)})()
+
+    monkeypatch.setattr(_streaming, "create_chat_llm_async", _fake_create)
+
+    await client.switch_model("gemini-3-pro-vision", use_vision_config=True)
+
+    assert client._conversation_history[0]["tool_calls"][0]["extra_content"] == _SIGNATURE_EXTRA
+
+
+@pytest.mark.asyncio
+async def test_switch_model_treats_empty_and_none_credentials_as_same_route(monkeypatch):
+    """Empty string and None are the same "no explicit endpoint / key", and the
+    two branches that pick them normalize differently. Comparing the raw values
+    would call one endpoint two routes and strip a signature that is still
+    valid — the misfire lands exactly on the case this change exists to fix."""
+    import main_logic.omni_offline_client._streaming as _streaming
+
+    async def _aclose():
+        return None
+
+    client = _bare_offline_client()
+    client.model = "gemini-3-pro"
+    client.base_url = ""        # 空串
+    client.api_key = ""
+    client.vision_model = "gemini-3-pro-vision"
+    client.vision_base_url = None   # 同一个"默认端点"，另一种写法
+    client.vision_api_key = None
     client.max_response_length = 300
     client._genai_client = None
     client._use_genai_sdk = False

--- a/tests/unit/test_tool_call_thought_signature.py
+++ b/tests/unit/test_tool_call_thought_signature.py
@@ -32,8 +32,23 @@ if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
 
-# base64 of b"sig-123" — the shape the Gemini compat endpoint sends down.
-_SIGNATURE_EXTRA = {"google": {"thought_signature": "c2lnLTEyMw=="}}
+# The signature bytes deliberately encode to a string containing BOTH '+' and
+# '/', so the standard and URL-safe base64 alphabets disagree on it. A neutral
+# fixture (e.g. b"sig-123" -> "c2lnLTEyMw==", identical under both alphabets)
+# would leave the encode/decode pair free to drift to another alphabet with
+# every test still green — and the alphabet is the one thing that decides
+# whether a real signature survives the round trip.
+_SIGNATURE_BYTES = b"\xfb\xef\xbe\x03\xff\xe0sig"
+_SIGNATURE_B64 = "++++A//gc2ln"  # standard alphabet; URL-safe would be "----A__gc2ln"
+_SIGNATURE_EXTRA = {"google": {"thought_signature": _SIGNATURE_B64}}
+
+
+def test_signature_fixture_discriminates_base64_alphabets():
+    """Guard on the guard: if the fixture ever loses its alphabet-specific
+    characters, every other test in this file silently stops being able to
+    catch an encoder/decoder alphabet swap."""
+    assert base64.b64encode(_SIGNATURE_BYTES).decode() == _SIGNATURE_B64
+    assert base64.urlsafe_b64encode(_SIGNATURE_BYTES).decode() != _SIGNATURE_B64
 
 
 class _FakeAsyncStream:
@@ -337,7 +352,7 @@ async def test_offline_genai_persists_thought_signature_into_history(monkeypatch
     async def _round1():
         yield _Chunk([_Part(
             function_call=_FunctionCall("recall_memory", {"q": "x"}, id_="c1"),
-            thought_signature=b"sig-123",
+            thought_signature=_SIGNATURE_BYTES,
         )])
 
     async def _round2():
@@ -361,7 +376,11 @@ async def test_offline_genai_persists_thought_signature_into_history(monkeypatch
     )
     stored = assistant_turn["tool_calls"][0].get("extra_content")
     assert stored is not None, "genai 路径必须把 Part.thought_signature 存进历史"
-    assert base64.b64decode(stored["google"]["thought_signature"]) == b"sig-123"
+    encoded = stored["google"]["thought_signature"]
+    assert base64.b64decode(encoded) == _SIGNATURE_BYTES
+    # Pin the alphabet, not just round-trippability: the compat endpoint's own
+    # strings are what this history is replayed as.
+    assert encoded == _SIGNATURE_B64
 
 
 @pytest.mark.asyncio
@@ -419,7 +438,7 @@ def test_genai_messages_to_contents_replays_thought_signature():
     model_turn = next(c for c in contents if c.role == "model")
     fc_parts = [p for p in model_turn.parts if getattr(p, "function_call", None)]
     assert len(fc_parts) == 2
-    assert fc_parts[0].thought_signature == b"sig-123"
+    assert fc_parts[0].thought_signature == _SIGNATURE_BYTES
     # A call with no signature must not be given a fabricated one.
     assert not fc_parts[1].thought_signature
 
@@ -438,3 +457,338 @@ def test_genai_messages_to_contents_survives_malformed_signature():
     _, contents = _genai_messages_to_contents(messages)
     part = next(p for p in contents[0].parts if getattr(p, "function_call", None))
     assert not part.thought_signature
+
+
+@pytest.mark.parametrize("encoded", [
+    _SIGNATURE_B64,                                    # standard, padded
+    _SIGNATURE_B64.replace("+", "-").replace("/", "_"),  # URL-safe alphabet
+    _SIGNATURE_B64.rstrip("="),                        # standard, padding stripped
+])
+def test_thought_signature_decodes_both_base64_alphabets(encoded):
+    """Only the half we write ourselves is guaranteed standard+padded; the other
+    half is whatever the compat endpoint sent down, and google-genai's own
+    pydantic serializer emits the URL-safe alphabet. An alphabet or padding
+    difference must not silently drop the signature — that would put the very
+    400 this change fixes right back."""
+    from main_logic.omni_offline_client._genai_support import (
+        _thought_signature_from_extra_content,
+    )
+
+    decoded = _thought_signature_from_extra_content(
+        {"google": {"thought_signature": encoded}}
+    )
+    assert decoded == _SIGNATURE_BYTES
+
+
+def test_thought_signature_rejects_garbage_instead_of_decoding_it():
+    """Accepting two alphabets must not slide into accepting anything: without
+    strict validation, base64 silently DISCARDS non-alphabet characters, so a
+    corrupted string decodes to plausible-but-wrong bytes and we hand Gemini a
+    signature that was never issued. Returning None (replay without a signature)
+    is the honest failure."""
+    from main_logic.omni_offline_client._genai_support import (
+        _thought_signature_from_extra_content,
+    )
+
+    # Lenient base64 would drop the '!' characters and happily return b'ABCD\x00B'.
+    assert _thought_signature_from_extra_content(
+        {"google": {"thought_signature": "Q!U!J!D!RABC"}}
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Signature belongs to the call it arrived on, not to a position
+# ---------------------------------------------------------------------------
+
+
+def test_collect_tool_calls_signature_stays_on_non_zero_index():
+    """Mirror of the index-0 case: a signature that arrives on index 1 must land
+    on index 1. Testing only "index 0 has it, index 1 doesn't" cannot tell a
+    correct implementation apart from one that always attaches to the first
+    call."""
+    from utils.llm_client import ChatOpenAI
+
+    deltas_per_chunk = [[
+        {"index": 0, "id": "c0", "type": "function",
+         "function": {"name": "first_tool", "arguments": "{}"}},
+        {"index": 1, "id": "c1", "type": "function",
+         "function": {"name": "recall_memory", "arguments": "{}"},
+         "extra_content": _SIGNATURE_EXTRA},
+    ]]
+    out = ChatOpenAI.collect_tool_calls(deltas_per_chunk)
+    assert [c.name for c in out] == ["first_tool", "recall_memory"]
+    assert out[0].extra_content is None
+    assert out[1].extra_content == _SIGNATURE_EXTRA
+
+
+@pytest.mark.asyncio
+async def test_offline_openai_history_keeps_signature_on_its_own_call():
+    """Same invariant one layer up: with two parallel calls where only the
+    second carries a signature, the history entry that gets it must be the
+    second one."""
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+    from utils.llm_client import LLMStreamChunk
+
+    tools = [
+        ToolDefinition(name="first_tool", description="a",
+                       parameters={"type": "object", "properties": {}}),
+        ToolDefinition(name="recall_memory", description="b",
+                       parameters={"type": "object", "properties": {}}),
+    ]
+    chunks_call_1 = [
+        LLMStreamChunk(content="", tool_call_deltas=[
+            {"index": 0, "id": "c0", "type": "function",
+             "function": {"name": "first_tool", "arguments": "{}"}},
+            {"index": 1, "id": "c1", "type": "function",
+             "function": {"name": "recall_memory", "arguments": "{}"},
+             "extra_content": _SIGNATURE_EXTRA},
+        ]),
+        LLMStreamChunk(content="", finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [LLMStreamChunk(content="done", finish_reason="stop")]
+
+    client = _bare_offline_client()
+    client.llm = _FakeLLM([chunks_call_1, chunks_call_2])
+    client._tool_definitions = tools
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "x"}]
+    async for _ in client._astream_with_tools(messages):
+        pass
+
+    calls = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )["tool_calls"]
+    assert [c["function"]["name"] for c in calls] == ["first_tool", "recall_memory"]
+    assert "extra_content" not in calls[0]
+    assert calls[1]["extra_content"] == _SIGNATURE_EXTRA
+
+
+@pytest.mark.asyncio
+async def test_offline_genai_signature_stays_on_its_own_part():
+    """genai twin: two function_call parts in one chunk, only the second Part
+    carries a thought_signature."""
+    from main_logic.tool_calling import ToolCall, ToolResult
+
+    async def _round1():
+        yield _Chunk([
+            _Part(function_call=_FunctionCall("first_tool", {}, id_="c0")),
+            _Part(function_call=_FunctionCall("recall_memory", {}, id_="c1"),
+                  thought_signature=_SIGNATURE_BYTES),
+        ])
+
+    async def _round2():
+        yield _Chunk([_Part(text="done")])
+
+    client = _bare_offline_client()
+    _genai_client_state(client, _genai_client_for(_round1, _round2))
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "x"}]
+    async for _ in client._astream_genai_with_tools(messages):
+        pass
+
+    calls = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )["tool_calls"]
+    assert [c["function"]["name"] for c in calls] == ["first_tool", "recall_memory"]
+    assert "extra_content" not in calls[0]
+    assert calls[1]["extra_content"] == _SIGNATURE_EXTRA
+
+
+# ---------------------------------------------------------------------------
+# 5. The real SDK boundary — fakes above cannot prove either of these
+# ---------------------------------------------------------------------------
+
+
+def test_extra_content_survives_openai_sdk_into_request_body():
+    """The whole change is worthless unless the key survives openai-python's
+    request transform into the actual HTTP body. Every other test in this file
+    stops at "the key is in the messages list", which a TypedDict-filtering SDK
+    would happily strip afterwards."""
+    import json
+
+    import httpx
+    import openai
+
+    captured = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={
+            "id": "x", "object": "chat.completion", "created": 0, "model": "m",
+            "choices": [{"index": 0, "finish_reason": "stop",
+                         "message": {"role": "assistant", "content": "ok"}}],
+        })
+
+    sdk = openai.OpenAI(
+        api_key="sk-test", base_url="https://api.example.com/v1",
+        http_client=httpx.Client(transport=httpx.MockTransport(_handler)),
+    )
+    sdk.chat.completions.create(model="m", messages=[
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "c1", "type": "function",
+            "function": {"name": "recall_memory", "arguments": "{}"},
+            "extra_content": _SIGNATURE_EXTRA,
+        }]},
+        {"role": "tool", "tool_call_id": "c1", "name": "recall_memory", "content": "{}"},
+    ])
+
+    wire_call = captured["body"]["messages"][1]["tool_calls"][0]
+    assert wire_call["extra_content"] == _SIGNATURE_EXTRA, (
+        "openai-python 把 tool_calls 里的未知字段剥掉了——本改动的整条链就断了"
+    )
+
+
+def test_extra_content_readable_off_real_sdk_delta_object():
+    """The streaming tests fake the SDK's delta with SimpleNamespace, which can
+    expose an attribute the real model class would have dropped. Pin the read
+    against the type openai-python actually constructs from a raw chunk."""
+    from openai._models import construct_type
+    from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
+
+    from utils.llm_client.openai_client import _plain_dict
+
+    tool_call = construct_type(
+        value={
+            "index": 0, "id": "c1", "type": "function",
+            "function": {"name": "recall_memory", "arguments": "{}"},
+            "extra_content": _SIGNATURE_EXTRA,
+        },
+        type_=ChoiceDeltaToolCall,
+    )
+    assert _plain_dict(getattr(tool_call, "extra_content", None)) == _SIGNATURE_EXTRA
+
+
+def test_plain_dict_handles_model_objects_and_scalars():
+    """``_plain_dict``'s non-dict fallbacks are the reason a future SDK that
+    materializes unknown fields as models still works. Untested, they are just
+    a claim in a comment."""
+    from utils.llm_client.openai_client import _plain_dict
+
+    class _Dumpable:
+        def model_dump(self):
+            return dict(_SIGNATURE_EXTRA)
+
+    class _ToDict:
+        def to_dict(self):
+            return dict(_SIGNATURE_EXTRA)
+
+    class _Exploding:
+        def model_dump(self):
+            raise RuntimeError("boom")
+
+    assert _plain_dict(_Dumpable()) == _SIGNATURE_EXTRA
+    assert _plain_dict(_ToDict()) == _SIGNATURE_EXTRA
+    assert _plain_dict(None) is None
+    assert _plain_dict("not-a-dict") is None
+    # A dumper that raises must degrade to "no extra_content", never propagate.
+    assert _plain_dict(_Exploding()) is None
+
+
+# ---------------------------------------------------------------------------
+# 6. The signature is bound to the route that minted it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_switch_model_strips_signature_when_endpoint_changes(monkeypatch):
+    """``switch_model(vision_model, use_vision_config=True)`` re-points the
+    session at a separately configured provider and deliberately keeps the
+    history. A Google-private blob must not ride along to that endpoint —
+    openai-python forwards unknown tool_call keys verbatim, and a strict
+    endpoint rejects the request, breaking every remaining turn."""
+    import main_logic.omni_offline_client._streaming as _streaming
+
+    client = _bare_offline_client()
+    client.model = "gemini-3-pro"
+    client.base_url = "https://www.lanlan.app/v1"
+    client.api_key = "free-key"
+    client.vision_model = "gpt-4o"
+    client.vision_base_url = "https://api.openai.com/v1"
+    client.vision_api_key = "sk-vision"
+    client.max_response_length = 300
+    client._genai_client = None
+    client._use_genai_sdk = False
+
+    async def _aclose():
+        return None
+
+    client.llm = type("F", (), {"aclose": staticmethod(_aclose)})()
+    client._conversation_history = [
+        {"role": "user", "content": "还记得吗"},
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "c1", "type": "function",
+            "function": {"name": "recall_memory", "arguments": "{}"},
+            "extra_content": _SIGNATURE_EXTRA,
+        }]},
+        {"role": "tool", "tool_call_id": "c1", "name": "recall_memory", "content": "{}"},
+    ]
+
+    async def _fake_create(*_a, **_kw):
+        return type("F", (), {"aclose": staticmethod(_aclose)})()
+
+    monkeypatch.setattr(_streaming, "create_chat_llm_async", _fake_create)
+
+    await client.switch_model("gpt-4o", use_vision_config=True)
+
+    assistant_turn = client._conversation_history[1]
+    assert "extra_content" not in assistant_turn["tool_calls"][0], (
+        "切到另一个 endpoint 后，Gemini 的 thought_signature 不能跟着历史发过去"
+    )
+    # The rest of the tool round must survive — dropping the whole turn would
+    # orphan the tool result and cost the model its own context.
+    assert assistant_turn["tool_calls"][0]["function"]["name"] == "recall_memory"
+    assert client._conversation_history[2]["role"] == "tool"
+
+
+@pytest.mark.asyncio
+async def test_switch_model_keeps_signature_on_same_endpoint(monkeypatch):
+    """Dual, and the more important half: swapping models WITHIN one endpoint
+    (both slots pointed at the same Gemini route) must keep the signature —
+    stripping there would hand back the exact 400 this change fixes."""
+    import main_logic.omni_offline_client._streaming as _streaming
+
+    async def _aclose():
+        return None
+
+    client = _bare_offline_client()
+    client.model = "gemini-3-pro"
+    client.base_url = "https://www.lanlan.app/v1"
+    client.api_key = "free-key"
+    client.vision_model = "gemini-3-pro-vision"
+    client.vision_base_url = "https://www.lanlan.app/v1"
+    client.vision_api_key = "free-key"
+    client.max_response_length = 300
+    client._genai_client = None
+    client._use_genai_sdk = False
+    client.llm = type("F", (), {"aclose": staticmethod(_aclose)})()
+    client._conversation_history = [
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "c1", "type": "function",
+            "function": {"name": "recall_memory", "arguments": "{}"},
+            "extra_content": _SIGNATURE_EXTRA,
+        }]},
+    ]
+
+    async def _fake_create(*_a, **_kw):
+        return type("F", (), {"aclose": staticmethod(_aclose)})()
+
+    monkeypatch.setattr(_streaming, "create_chat_llm_async", _fake_create)
+
+    await client.switch_model("gemini-3-pro-vision", use_vision_config=True)
+
+    assert client._conversation_history[0]["tool_calls"][0]["extra_content"] == _SIGNATURE_EXTRA

--- a/tests/unit/test_tool_call_thought_signature.py
+++ b/tests/unit/test_tool_call_thought_signature.py
@@ -1,0 +1,440 @@
+# -*- coding: utf-8 -*-
+"""Verbatim round-trip of ``extra_content`` / ``thought_signature`` through
+the shared tool-call history.
+
+Gemini thinking models require the signature that came down with a function
+call to be handed back with that same call on every later request. A history
+that keeps only id/name/args gets a stable 400 INVALID_ARGUMENT from the
+second round onwards (observed on the international free route's
+``recall_memory`` recall).
+
+The two links carry it in different shapes:
+  - OpenAI-compat (Google's compat endpoint / the lanlan.app free route):
+    ``tool_calls[].extra_content.google.thought_signature``, a base64 string
+  - native google-genai: ``Part.thought_signature``, raw bytes
+
+The shared history always stores the former: JSON-serializable, and the two
+paths can replay each other's history.
+"""
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import main_logic.omni_offline_client._genai_support as _ofc_genai
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# base64 of b"sig-123" — the shape the Gemini compat endpoint sends down.
+_SIGNATURE_EXTRA = {"google": {"thought_signature": "c2lnLTEyMw=="}}
+
+
+class _FakeAsyncStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for c in self._chunks:
+            yield c
+
+
+class _FakeLLM:
+    """Drop-in for ``self.llm``: pops one scripted chunk batch per astream."""
+
+    def __init__(self, scripted_chunks_per_call, max_completion_tokens=100):
+        self._scripted = list(scripted_chunks_per_call)
+        self.calls = []
+        self.max_completion_tokens = max_completion_tokens
+
+    def astream(self, messages, **overrides):
+        self.calls.append((messages, overrides))
+        if not self._scripted:
+            raise RuntimeError("FakeLLM ran out of scripted responses")
+        return _FakeAsyncStream(self._scripted.pop(0))
+
+    async def aclose(self):
+        pass
+
+
+def _bare_offline_client():
+    """``__new__``-built client with only the baseline attributes the tool
+    loop reads (mirrors ``_init_bare`` in test_tool_calling.py)."""
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client._proactive_image_to_inject = None
+    client._proactive_image_staged_at = 0.0
+    client._proactive_image_history_len = 0
+    client.vision_provider_type = None
+    client._genai_tools_unsupported = False
+    return client
+
+
+# ---------------------------------------------------------------------------
+# 1. Wire ingest: SDK object -> tool_call_deltas -> aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_collect_tool_calls_preserves_extra_content():
+    """extra_content must aggregate onto the call it arrived with."""
+    from utils.llm_client import ChatOpenAI
+
+    deltas_per_chunk = [
+        [
+            {"index": 0, "id": "c1", "type": "function",
+             "function": {"name": "recall_memory", "arguments": '{"q":'},
+             "extra_content": _SIGNATURE_EXTRA},
+            {"index": 1, "id": "c2", "type": "function",
+             "function": {"name": "other_tool", "arguments": "{}"}},
+        ],
+        [{"index": 0, "function": {"name": "", "arguments": '"x"}'}}],
+    ]
+    out = ChatOpenAI.collect_tool_calls(deltas_per_chunk)
+    assert [c.name for c in out] == ["recall_memory", "other_tool"]
+    assert out[0].extra_content == _SIGNATURE_EXTRA
+    # A call without extra_content stays None so ordinary providers keep a
+    # clean history.
+    assert out[1].extra_content is None
+
+
+def test_collect_tool_calls_merges_split_extra_content():
+    """One call's extra_content split across chunks merges per vendor
+    namespace; whole-blob overwrite would silently drop the earlier
+    signature."""
+    from utils.llm_client import ChatOpenAI
+
+    deltas_per_chunk = [
+        [{"index": 0, "id": "c1", "function": {"name": "t", "arguments": "{}"},
+          "extra_content": {"google": {"thought_signature": "AAA="}}}],
+        [{"index": 0, "function": {"name": "", "arguments": ""},
+          "extra_content": {"google": {"other_hint": 1}, "vendor2": {"k": "v"}}}],
+    ]
+    out = ChatOpenAI.collect_tool_calls(deltas_per_chunk)
+    assert out[0].extra_content == {
+        "google": {"thought_signature": "AAA=", "other_hint": 1},
+        "vendor2": {"k": "v"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_astream_forwards_tool_call_extra_content():
+    """The non-standard ``extra_content`` field on the SDK's tool_call object
+    must reach tool_call_deltas — nothing downstream can recover it."""
+    from utils.llm_client import ChatOpenAI
+
+    raw_tool_call = SimpleNamespace(
+        index=0, id="c1", type="function",
+        function=SimpleNamespace(name="recall_memory", arguments="{}"),
+        extra_content=_SIGNATURE_EXTRA,
+    )
+
+    class _Stream:
+        def __aiter__(self):
+            return self._iter()
+
+        async def _iter(self):
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(
+                    delta=SimpleNamespace(content="", tool_calls=[raw_tool_call]),
+                    finish_reason="tool_calls",
+                )],
+                usage=None,
+            )
+
+    async def _create(**_kw):
+        return _Stream()
+
+    client = ChatOpenAI.__new__(ChatOpenAI)
+    client._params = lambda messages, **kw: {"model": "gemini-3-pro"}
+    client._aclient = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+
+    chunks = [c async for c in client.astream([{"role": "user", "content": "hi"}])]
+    deltas = [d for c in chunks if c.tool_call_deltas for d in c.tool_call_deltas]
+    assert len(deltas) == 1
+    assert deltas[0]["extra_content"] == _SIGNATURE_EXTRA
+
+
+# ---------------------------------------------------------------------------
+# 2. OpenAI-compat tool loop writing history back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_offline_openai_tool_loop_echoes_extra_content_to_history():
+    """The assistant.tool_calls entry the loop appends must carry
+    extra_content verbatim — that history IS the next request body."""
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+    from utils.llm_client import LLMStreamChunk
+
+    tool_def = ToolDefinition(
+        name="recall_memory", description="recall",
+        parameters={"type": "object", "properties": {}},
+    )
+    chunks_call_1 = [
+        LLMStreamChunk(content="", tool_call_deltas=[{
+            "index": 0, "id": "c1", "type": "function",
+            "function": {"name": "recall_memory", "arguments": "{}"},
+            "extra_content": _SIGNATURE_EXTRA,
+        }]),
+        LLMStreamChunk(content="", finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [LLMStreamChunk(content="想起来了喵。", finish_reason="stop")]
+
+    client = _bare_offline_client()
+    client.llm = _FakeLLM([chunks_call_1, chunks_call_2])
+    client._tool_definitions = [tool_def]
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "还记得吗"}]
+    async for _ in client._astream_with_tools(messages):
+        pass
+
+    assistant_turn = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert assistant_turn["tool_calls"][0]["extra_content"] == _SIGNATURE_EXTRA, (
+        "工具调用历史必须原样保存 extra_content（thought_signature），"
+        "否则 Gemini 第二轮起稳定报 400 INVALID_ARGUMENT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_offline_openai_tool_loop_omits_extra_content_when_absent():
+    """Dual: no provider blob means no such key in history — an unknown
+    field can get a plain OpenAI endpoint to reject the request."""
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+    from utils.llm_client import LLMStreamChunk
+
+    tool_def = ToolDefinition(
+        name="t", description="t", parameters={"type": "object", "properties": {}},
+    )
+    chunks_call_1 = [
+        LLMStreamChunk(content="", tool_call_deltas=[{
+            "index": 0, "id": "c1", "type": "function",
+            "function": {"name": "t", "arguments": "{}"},
+        }]),
+        LLMStreamChunk(content="", finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [LLMStreamChunk(content="done", finish_reason="stop")]
+
+    client = _bare_offline_client()
+    client.llm = _FakeLLM([chunks_call_1, chunks_call_2])
+    client._tool_definitions = [tool_def]
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "x"}]
+    async for _ in client._astream_with_tools(messages):
+        pass
+
+    assistant_turn = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert "extra_content" not in assistant_turn["tool_calls"][0]
+
+
+# ---------------------------------------------------------------------------
+# 3. native genai: Part.thought_signature <-> history
+# ---------------------------------------------------------------------------
+
+
+class _Part:
+    def __init__(self, *, text=None, function_call=None, thought_signature=None):
+        self.text = text
+        self.function_call = function_call
+        self.thought_signature = thought_signature
+
+
+class _FunctionCall:
+    def __init__(self, name, args, id_=""):
+        self.name = name
+        self.args = args
+        self.id = id_
+
+
+class _Chunk:
+    def __init__(self, parts):
+        content = type("K", (), {"parts": parts})()
+        self.candidates = [type("C", (), {"content": content})()]
+        self.usage_metadata = None
+
+
+class _StreamWrapper:
+    def __init__(self, gen):
+        self._gen = gen
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._gen.__anext__()
+
+
+def _genai_client_for(round1, round2):
+    """Fake genai client: first generate_content_stream call yields the tool
+    round, the second the follow-up text."""
+    call_count = [0]
+
+    class _FakeClient:
+        class aio:
+            class models:
+                @staticmethod
+                async def generate_content_stream(**_kw):
+                    call_count[0] += 1
+                    gen = round1() if call_count[0] == 1 else round2()
+                    return _StreamWrapper(gen)
+
+        def close(self):
+            pass
+
+    return _FakeClient()
+
+
+def _genai_client_state(client, fake_client):
+    client.model = "gemini-3-pro"
+    client.api_key = "fake"
+    client._tool_definitions = []
+    client.has_tools = lambda: False
+    client.max_tool_iterations = 3
+    client._genai_client = fake_client
+    client.llm = type("F", (), {"max_completion_tokens": 100})()
+
+
+@pytest.mark.asyncio
+async def test_offline_genai_persists_thought_signature_into_history(monkeypatch):
+    """Native genai path: thought_signature hangs off the Part (not the
+    FunctionCall), so it must be captured while streaming and stored in the
+    shared history in the extra_content shape."""
+    from main_logic.tool_calling import ToolCall, ToolResult
+
+    monkeypatch.setattr(_ofc_genai, "_GENAI_AVAILABLE", True)
+
+    async def _round1():
+        yield _Chunk([_Part(
+            function_call=_FunctionCall("recall_memory", {"q": "x"}, id_="c1"),
+            thought_signature=b"sig-123",
+        )])
+
+    async def _round2():
+        yield _Chunk([_Part(text="想起来了喵。")])
+
+    client = _bare_offline_client()
+    _genai_client_state(client, _genai_client_for(_round1, _round2))
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "还记得吗"}]
+    async for _ in client._astream_genai_with_tools(messages):
+        pass
+
+    assistant_turn = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    stored = assistant_turn["tool_calls"][0].get("extra_content")
+    assert stored is not None, "genai 路径必须把 Part.thought_signature 存进历史"
+    assert base64.b64decode(stored["google"]["thought_signature"]) == b"sig-123"
+
+
+@pytest.mark.asyncio
+async def test_offline_genai_no_signature_keeps_history_clean(monkeypatch):
+    """Dual: a model that sends no signature leaves history without the key."""
+    from main_logic.tool_calling import ToolCall, ToolResult
+
+    monkeypatch.setattr(_ofc_genai, "_GENAI_AVAILABLE", True)
+
+    async def _round1():
+        yield _Chunk([_Part(function_call=_FunctionCall("t", {}, id_="c1"))])
+
+    async def _round2():
+        yield _Chunk([_Part(text="done")])
+
+    client = _bare_offline_client()
+    _genai_client_state(client, _genai_client_for(_round1, _round2))
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "x"}]
+    async for _ in client._astream_genai_with_tools(messages):
+        pass
+
+    assistant_turn = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert "extra_content" not in assistant_turn["tool_calls"][0]
+
+
+def test_genai_messages_to_contents_replays_thought_signature():
+    """The base64 signature in history must decode back to bytes on the
+    rebuilt function_call Part — that is the only thing making Gemini accept
+    the replayed history."""
+    pytest.importorskip("google.genai")
+    from main_logic.omni_offline_client import _genai_messages_to_contents
+
+    messages = [
+        {"role": "user", "content": "还记得吗"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "recall_memory", "arguments": "{}"},
+             "extra_content": _SIGNATURE_EXTRA},
+            {"id": "c2", "type": "function",
+             "function": {"name": "other_tool", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "name": "recall_memory",
+         "content": '{"ok": true}'},
+    ]
+    _, contents = _genai_messages_to_contents(messages)
+    model_turn = next(c for c in contents if c.role == "model")
+    fc_parts = [p for p in model_turn.parts if getattr(p, "function_call", None)]
+    assert len(fc_parts) == 2
+    assert fc_parts[0].thought_signature == b"sig-123"
+    # A call with no signature must not be given a fabricated one.
+    assert not fc_parts[1].thought_signature
+
+
+def test_genai_messages_to_contents_survives_malformed_signature():
+    """A history polluted with invalid base64 degrades to "no signature"
+    instead of blowing up the whole conversation."""
+    pytest.importorskip("google.genai")
+    from main_logic.omni_offline_client import _genai_messages_to_contents
+
+    messages = [{"role": "assistant", "content": "", "tool_calls": [{
+        "id": "c1", "type": "function",
+        "function": {"name": "t", "arguments": "{}"},
+        "extra_content": {"google": {"thought_signature": "not!base64!"}},
+    }]}]
+    _, contents = _genai_messages_to_contents(messages)
+    part = next(p for p in contents[0].parts if getattr(p, "function_call", None))
+    assert not part.thought_signature

--- a/utils/llm_client/messages.py
+++ b/utils/llm_client/messages.py
@@ -130,6 +130,10 @@ class LLMStreamChunk:
     #     "function": {"name": "...", "arguments": "<json fragment>"}}]``
     # Multiple chunks may carry the same ``index`` — callers must
     # accumulate ``function.arguments`` strings before JSON-parsing.
+    # A fragment may additionally carry ``extra_content`` — the
+    # non-standard, provider-owned blob (Gemini's OpenAI-compat surface
+    # puts ``thought_signature`` there) that must be echoed back verbatim
+    # on the assistant turn; see ``ToolCallAggregate.extra_content``.
     tool_call_deltas: list[dict] | None = None
     # Reason the model finished this stream segment: ``"stop"`` / ``"length"`` /
     # ``"tool_calls"`` / ``"content_filter"`` / None. ``"tool_calls"`` signals
@@ -162,6 +166,13 @@ class ToolCallAggregate:
     id: str
     name: str
     arguments: str  # JSON string; caller decides whether to ``json.loads``
+    # Provider-owned passthrough blob attached to THIS call, e.g.
+    # ``{"google": {"thought_signature": "<base64>"}}`` from Gemini's
+    # OpenAI-compat endpoint. Opaque to us: the tool loop writes it back
+    # onto the assistant ``tool_calls`` entry unchanged, because Gemini
+    # rejects a follow-up request whose function call lost its signature
+    # (400 INVALID_ARGUMENT). ``None`` on providers that don't send one.
+    extra_content: dict | None = None
 
 def _normalize_messages(messages: Any) -> list[dict]:
     """Convert various message formats to openai-compatible dicts.

--- a/utils/llm_client/openai_client.py
+++ b/utils/llm_client/openai_client.py
@@ -29,6 +29,46 @@ from .lifecycle import (
 from .messages import LLMResponse, LLMStreamChunk, ToolCallAggregate, _normalize_messages
 from .thinking import strip_thinking_segments
 
+
+def _plain_dict(value: Any) -> dict | None:
+    """Best-effort "SDK object → plain JSON-ish dict" for passthrough fields.
+
+    Unknown response fields land on the openai-python model as raw dicts
+    (``extra="allow"``), but a future SDK version may materialize them as
+    models; ``model_dump`` / ``to_dict`` cover that. Anything else (a
+    scalar, ``None``) yields ``None`` so callers can just skip it."""
+    if isinstance(value, dict):
+        return dict(value)
+    for attr in ("model_dump", "to_dict", "dict"):
+        fn = getattr(value, attr, None)
+        if callable(fn):
+            try:
+                dumped = fn()
+            except Exception:
+                continue
+            if isinstance(dumped, dict):
+                return dumped
+    return None
+
+
+def _merge_extra_content(old: dict | None, new: dict) -> dict:
+    """Merge a streamed ``extra_content`` fragment into the accumulated one.
+
+    Providers send it whole today, but a split across chunks must not make
+    one vendor namespace clobber another — so dict values merge recursively
+    and only leaf conflicts take the newer value."""
+    if not old:
+        return dict(new)
+    merged = dict(old)
+    for k, v in new.items():
+        prev = merged.get(k)
+        if isinstance(prev, dict) and isinstance(v, dict):
+            merged[k] = _merge_extra_content(prev, v)
+        else:
+            merged[k] = v
+    return merged
+
+
 class ChatOpenAI:
     """OpenAI-compatible chat client with streaming, invoke, and resource management."""
 
@@ -316,7 +356,7 @@ class ChatOpenAI:
                         # SDK objects → plain dicts. ``index`` ties fragments
                         # of the same call together across chunks.
                         fn = getattr(tc, "function", None)
-                        tool_call_deltas.append({
+                        frag = {
                             "index": getattr(tc, "index", 0),
                             "id": getattr(tc, "id", "") or "",
                             "type": getattr(tc, "type", "function") or "function",
@@ -324,7 +364,16 @@ class ChatOpenAI:
                                 "name": getattr(fn, "name", "") if fn else "",
                                 "arguments": getattr(fn, "arguments", "") if fn else "",
                             },
-                        })
+                        }
+                        # 非标准字段 ``extra_content``：Gemini 的 OpenAI-compat
+                        # 端点（含 lanlan.app 海外免费线路）把 thought_signature
+                        # 挂在这里，且要求下一轮把它原样带回该 tool call；丢了
+                        # 就稳定报 400 INVALID_ARGUMENT。这里只做透传，不解析
+                        # 内容——别的 provider 往里塞什么都照样带回去。
+                        extra_content = _plain_dict(getattr(tc, "extra_content", None))
+                        if extra_content:
+                            frag["extra_content"] = extra_content
+                        tool_call_deltas.append(frag)
             # Thinking 模型把推理链放在非标准的 ``delta.reasoning_content``
             # 字段（openai-python 的 BaseModel extra=allow，未知字段照样可
             # getattr）。普通端点没有这个字段，getattr 返回 None。
@@ -371,7 +420,9 @@ class ChatOpenAI:
                 continue
             for frag in fragments:
                 idx = int(frag.get("index", 0))
-                slot = merged.setdefault(idx, {"id": "", "name": "", "arguments": ""})
+                slot = merged.setdefault(
+                    idx, {"id": "", "name": "", "arguments": "", "extra_content": None}
+                )
                 if frag.get("id"):
                     slot["id"] = frag["id"]
                 fn = frag.get("function") or {}
@@ -379,6 +430,11 @@ class ChatOpenAI:
                     slot["name"] = fn["name"]
                 if fn.get("arguments"):
                     slot["arguments"] += fn["arguments"]
+                extra_content = frag.get("extra_content")
+                if isinstance(extra_content, dict) and extra_content:
+                    slot["extra_content"] = _merge_extra_content(
+                        slot.get("extra_content"), extra_content
+                    )
         out: list[ToolCallAggregate] = []
         for idx in sorted(merged.keys()):
             slot = merged[idx]
@@ -394,6 +450,7 @@ class ChatOpenAI:
                 id=slot["id"],
                 name=slot["name"],
                 arguments=slot["arguments"],
+                extra_content=slot.get("extra_content"),
             ))
         return out
 


### PR DESCRIPTION
## 背景

Gemini 思考模型要求：模型发起 function call 时下发的 `thought_signature`，必须在后续请求里**跟着那条 function call 原样带回**。

客户端此前的统一工具调用历史只保留 `id / name / args`，签名在写历史那一步就丢了。表现是：普通文字回复正常，一旦进入需要连续工具调用的场景（记忆召回），第二轮起稳定收到 `400 INVALID_ARGUMENT`。国际免费双子座线路上必现。

这与 #2602 的 `response.created` 过渡事件过滤是两件独立的事。

官方约束（[Thought Signatures](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures)）：每个 step 的**第一个** `functionCall` part 必须带签名，否则 400；并行调用时签名只挂在第一条上。

## 改了什么

签名在两条链路上载体形状不同，历史统一按 OpenAI-compat 的形状存（JSON 可序列化，两条路径能互相回放对方写的历史）：

```
tool_calls[].extra_content.google.thought_signature   // base64 字符串
```

**OpenAI-compat 路径**（Google 官方 compat 端点 / www.lanlan.app 海外免费线路）

- `ChatOpenAI.astream`：把 SDK tool_call 对象上那个非标准的 `extra_content` 字段透传进 `tool_call_deltas`。只做透传不解析内容——别的 provider 往里塞什么都照样带回去。
- `collect_tool_calls`：按 `index` 汇聚到 `ToolCallAggregate.extra_content`。万一被拆到多个 chunk，按 vendor 命名空间递归合并，避免整块互顶把先到的签名顶掉。
- 工具循环写回 `assistant.tool_calls` 条目时原样带上——这条历史就是下一轮发出去的请求体。

**native google-genai 路径**

- `thought_signature` 挂在 `Part` 上而不是 `FunctionCall` 里，所以在收流处就抓走，base64 后存进同一个 `extra_content` 字段。
- 重建历史时解回 bytes 挂到 `Part(function_call=...)` 上。老版本 SDK 的 `Part` 是 `extra='forbid'`，不吃这个字段时降级成无签名重放并打 warning，不硬崩。
- 解码端两种 base64 字母表都收、缺 padding 也补：compat 端点实测下发标准 base64，而 google-genai 自己的 pydantic 序列化器产 URL-safe（`-_`）。仍保留 `validate=True`——宽松模式会静默丢弃非字母表字符，让损坏的串解出"看起来合理但错误"的字节。

**签名绑定它的路由**

`extra_content` 是只有铸造方看得懂的 vendor 私有字段，但历史比路由活得久：`switch_model(vision_model, use_vision_config=True)` 会把整个会话永久切到另一套 provider 配置且刻意保留历史。所以只在 endpoint / 账号真的变了时把这个字段从历史里清掉；同一端点换模型不清——那正是签名要起作用的场景。

provider 没下发签名时历史里不会多出 `extra_content` 这个键，普通 OpenAI 端点的请求体一个字节都没变。

## 没做什么

只覆盖 function call 上的签名。Gemini 也会把签名挂在 text part 上，但官方文档明确区分两者：text part 的签名是 *recommended*，"The API does not strictly enforce validation. You won't receive a blocking error if you omit them, though performance may degrade."——只有 function call 那条是 400 的硬约束。客户端历史里的文本是整轮拼接后的单个字符串，没有 per-part 锚点可以挂回去，所以这里是明确的质量取舍，不是协议缺口。

## 回归报告

**改动内容**：见上。落点是 `utils/llm_client`（收流 + 汇聚）和 `main_logic/omni_offline_client`（写历史 + 重建 genai contents + 路由切换时清签名）。

**必要性**：不带回签名 = 国际免费线路上工具调用场景（记忆召回）完全不可用，稳定 400。这是发布阻塞项。

**改动前后行为**

| | 改动前 | 改动后 |
|---|---|---|
| Gemini + 工具调用（compat 线路） | 第二轮起 400 INVALID_ARGUMENT | 签名随 call 原样回传，正常多轮 |
| Gemini + 工具调用（native genai） | `Part(function_call=...)` 无签名重放 | 签名解回 bytes 挂回 Part |
| Gemini 工具轮后切 vision（异端点） | 无此字段 | 切换时清掉，请求体与改动前一致 |
| Gemini 工具轮后切 vision（同端点） | 无此字段 | 保留签名，多轮继续可用 |
| 其它 provider（不下发 extra_content） | 无此字段 | 无此字段（请求体不变） |
| 单轮文字回复 | 正常 | 正常（不经过这条路径） |

**潜在回归**

1. **请求体多出未知字段**：只在 provider 自己下发过 `extra_content` 时才写回，没下发就不写；且切到另一个 endpoint 时主动清掉。已加对偶用例钉死"不许凭空多出这个键"与"同端点不许误清"。
2. **签名串到别的 call 上**：汇聚严格按 `index`（OpenAI）/ 按 part（genai）。已加"签名挂在非 0 index 上"的对偶用例——只测 index 0 区分不出"总是挂到第一条"的错误实现。
3. **base64 字母表漂移**：签名 fixture 特意选了标准与 URL-safe 编码不同的字节串，编解码任一端换字母表都会红。
4. **老版本 google-genai 崩溃**：`Part` 是 `extra='forbid'`，不接受该字段时 catch 住降级重放，退回改动前的（对 Gemini 3 而言本来就坏的）行为，不比现在更差。
5. **历史落盘**：现有落盘格式只存 `content`，工具轮的 dict 行不入盘，不引入持久化格式变更。

**已知边界（不在本次范围）**

- 流里第一条 tool_call 分片若因空 name 被丢弃，而签名恰好只挂在它上面，这个 step 的签名会随之消失。把签名转嫁给下一条存活的 call 是无法离线验证的猜测（签名与具体 call 绑定），所以维持现状。这是既有的分片丢弃路径，本改动没有让它变差。
- 同一条 assistant turn 上的 `reasoning_content` 有同样的路由绑定性质，且早于本改动。它有自己的 provider 契约（thinking 端点要求原样回传）和失败形态，按各自契约单独处理，不在此顺带改。

**测试**：`tests/unit/test_tool_call_thought_signature.py`，22 条。包含两条打到真实 SDK 边界的用例——`httpx.MockTransport` 断言字段确实进了出站 HTTP body（openai-python 的 TypedDict transform 不剥未知 key），以及用 SDK 真实构造的 `ChoiceDeltaToolCall` 断言收流侧读得到（此前只有 `SimpleNamespace` 伪造对象）。16 个变异体逐个验证全部转红，无盲区。相关既有套件（`test_tool_calling` / `test_group_memory_recall_tool` / `test_llm_client_response_safety` / `test_tool_call_leak_filter` / `test_focus_mode`）288 条全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持 Gemini 工具调用签名的保存、恢复与跨请求传递，提升多轮对话及工具调用连续性。
  - 流式工具调用可保留提供商专属信息，兼容 OpenAI 及原生 SDK 调用流程。
- **问题修复**
  - 模型或服务端点切换时，自动处理不适用的调用信息，减少历史数据干扰。
  - 无效或异常签名将被安全忽略，不影响请求执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->