### PR TITLE
优化“我的档案”为大弹窗，统一角色卡设定页表单样式，固定新增设定按钮，并修复新增字段弹窗闪烁问题

### DIFF
--- a/static/common_dialogs.js
+++ b/static/common_dialogs.js
@@ -1144,7 +1144,8 @@
                     }
                 }
                 document.removeEventListener('keydown', escHandler);
-                overlay.style.animation = 'fadeOut 0.2s ease-out';
+                // 动画与 DOM 清理均为 200ms；保持末帧，避免两者调度错开时闪回可见状态。
+                overlay.style.animation = 'fadeOut 0.2s ease-out forwards';
                 setTimeout(() => {
                     if (overlay.parentNode) {
                         overlay.parentNode.removeChild(overlay);

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -131,42 +131,6 @@ body .page-title-bar {
     justify-content: center;
 }
 
-.master-profile-arrow-bubble {
-    width: 20px;
-    height: 20px;
-    border-radius: 8px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex: 0 0 20px;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(218, 246, 255, 0.82));
-    border: 1px solid rgba(75, 212, 253, 0.48);
-    box-shadow: 0 4px 10px rgba(64, 197, 241, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.88);
-    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.master-profile-arrow-symbol {
-    width: 7px;
-    height: 7px;
-    border-right: 2px solid #40C5F1;
-    border-bottom: 2px solid #40C5F1;
-    transform: rotate(-45deg);
-    transition: transform 0.2s ease;
-}
-
-.master-profile-header:hover .master-profile-arrow-bubble {
-    background: linear-gradient(180deg, #ffffff, #cff4ff);
-    box-shadow: 0 6px 14px rgba(64, 197, 241, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.96);
-}
-
-.master-profile-header.open .master-profile-arrow-bubble {
-    transform: translateY(1px);
-}
-
-.master-profile-header.open .master-profile-arrow-symbol {
-    transform: rotate(45deg) translate(-1px, -1px);
-}
-
 .page-title-bar .close-btn img {
     width: 32px;
     height: 32px;
@@ -5977,14 +5941,14 @@ margin-top: 10px;
     background: linear-gradient(180deg, #ffffff 0%, #fbfeff 100%);
 }
 
-.catgirl-panel-right .panel-tab-settings {
+.settings-form-layout.panel-tab-settings {
     padding: 24px 28px 18px;
     --settings-label-col: clamp(116px, 12vw, 148px);
     --settings-action-col: clamp(148px, 10vw, 160px);
     --settings-column-gap: 14px;
 }
 
-.catgirl-panel-right .panel-tab-settings form {
+.settings-form-layout.panel-tab-settings form {
     display: flex;
     flex-direction: column;
     gap: 14px;
@@ -5992,7 +5956,140 @@ margin-top: 10px;
     padding-bottom: 28px;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper {
+/* 角色卡设定页与“我的档案”共用的表单控件基础。 */
+.settings-form-layout.panel-tab-settings .field-row {
+    display: flex;
+    align-items: center;
+    padding: 2px;
+    position: relative;
+    transition: border-color 0.2s, border-radius 0.3s ease;
+}
+
+.settings-form-layout.panel-tab-settings .field-row input,
+.settings-form-layout.panel-tab-settings .field-row select,
+.settings-form-layout.panel-tab-settings .field-row textarea {
+    flex: 1;
+    min-width: 0;
+    border: none !important;
+    border-radius: 48px;
+    resize: none !important;
+    line-height: 1.4;
+    font-family: 'Segoe UI', Arial, sans-serif;
+    box-sizing: border-box;
+    background: #fff;
+    color: #40C5F1;
+    outline: none !important;
+    outline-offset: 0 !important;
+    box-shadow: none !important;
+    appearance: none;
+}
+
+.settings-form-layout.panel-tab-settings .field-row input:focus,
+.settings-form-layout.panel-tab-settings .field-row select:focus,
+.settings-form-layout.panel-tab-settings .field-row textarea:focus,
+.settings-form-layout.panel-tab-settings .field-row input:hover,
+.settings-form-layout.panel-tab-settings .field-row select:hover,
+.settings-form-layout.panel-tab-settings .field-row textarea:hover {
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+}
+
+.settings-form-layout.panel-tab-settings .field-row input::placeholder,
+.settings-form-layout.panel-tab-settings .field-row textarea::placeholder {
+    color: #b3e5fc;
+}
+
+.settings-form-layout.panel-tab-settings .field-row:focus-within {
+    border-color: #40C5F1;
+}
+
+.settings-form-layout.panel-tab-settings .field-row textarea {
+    max-height: 80px;
+    overflow-y: auto;
+    transition: height 0.2s ease;
+}
+
+.settings-form-layout.panel-tab-settings .field-row textarea::-webkit-resizer {
+    display: none;
+}
+
+.settings-form-layout.panel-tab-settings .field-row textarea::-webkit-scrollbar {
+    width: 6px;
+}
+
+.settings-form-layout.panel-tab-settings .field-row textarea::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.settings-form-layout.panel-tab-settings .field-row textarea::-webkit-scrollbar-thumb {
+    background-color: rgba(64, 197, 241, 0.3);
+    border-radius: 3px;
+}
+
+.settings-form-layout.panel-tab-settings .field-row textarea::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(64, 197, 241, 0.5);
+}
+
+.settings-form-layout.panel-tab-settings .field-row.has-scrollbar {
+    overflow: hidden;
+}
+
+.settings-form-layout.panel-tab-settings .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 999px;
+    background: #40C5F1;
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: all 0.2s, transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.settings-form-layout.panel-tab-settings .btn:hover:not(:disabled) {
+    background: #3ab8e0;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(64, 197, 241, 0.3);
+}
+
+.settings-form-layout.panel-tab-settings .btn:active:not(:disabled) {
+    background: #2fa8d0;
+    transform: translateY(1px) scale(0.98);
+    box-shadow: 0 1px 3px rgba(64, 197, 241, 0.2);
+    opacity: 0.95;
+}
+
+.settings-form-layout.panel-tab-settings .btn.sm {
+    justify-content: center;
+    width: auto;
+    min-width: 80px;
+    height: 30px;
+    padding: 0 15px;
+    margin-right: 0;
+    font-size: 0.8rem;
+    line-height: 1;
+}
+
+.settings-form-layout.panel-tab-settings .btn.delete {
+    background: #ff5252;
+}
+
+.settings-form-layout.panel-tab-settings .btn.delete:hover:not(:disabled) {
+    background: #ff4444;
+    box-shadow: 0 2px 8px rgba(255, 82, 82, 0.3);
+}
+
+.settings-form-layout.panel-tab-settings .btn.delete:active:not(:disabled) {
+    background: #e53935;
+    box-shadow: 0 1px 3px rgba(255, 82, 82, 0.2);
+}
+
+.settings-form-layout.panel-tab-settings .field-row-wrapper {
     display: grid;
     grid-template-columns:
         var(--settings-label-col)
@@ -6006,7 +6103,7 @@ margin-top: 10px;
     padding: 0;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper label {
+.settings-form-layout.panel-tab-settings .field-row-wrapper label {
     min-width: 0;
     max-width: none;
     display: flex;
@@ -6018,11 +6115,11 @@ margin-top: 10px;
     line-height: 1.25;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper > label {
+.settings-form-layout.panel-tab-settings .field-row-wrapper > label {
     grid-column: 1;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper label::before {
+.settings-form-layout.panel-tab-settings .field-row-wrapper label::before {
     content: '';
     width: 22px;
     height: 22px;
@@ -6031,19 +6128,19 @@ margin-top: 10px;
     opacity: 0.78;
 }
 
-.catgirl-panel-right .panel-tab-settings .profile-row label::before {
+.settings-form-layout.panel-tab-settings .profile-row label::before {
     background-image: url('/static/icons/edit.png');
 }
 
-.catgirl-panel-right .panel-tab-settings .personality-row label::before {
+.settings-form-layout.panel-tab-settings .personality-row label::before {
     background-image: url('/static/icons/character_icon.png');
 }
 
-.catgirl-panel-right .panel-tab-settings .voice-row label::before {
+.settings-form-layout.panel-tab-settings .voice-row label::before {
     background-image: url('/static/icons/sound.png');
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row {
+.settings-form-layout.panel-tab-settings .field-row {
     grid-column: 2 / 4;
     min-height: 46px;
     min-width: 0;
@@ -6054,41 +6151,41 @@ margin-top: 10px;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
-.catgirl-panel-right .panel-tab-settings .profile-row:not(:has(> .btn.sm)) .field-row {
+.settings-form-layout.panel-tab-settings .profile-row:not(:has(> .btn.sm)) .field-row {
     grid-column: 2 / 5;
 }
 
-.catgirl-panel-right .panel-tab-settings .personality-row .field-row {
+.settings-form-layout.panel-tab-settings .personality-row .field-row {
     grid-column: 2;
 }
 
-.catgirl-panel-right .panel-tab-settings .custom-row .field-row,
-.catgirl-panel-right .panel-tab-settings .field-row.has-scrollbar {
+.settings-form-layout.panel-tab-settings .custom-row .field-row,
+.settings-form-layout.panel-tab-settings .field-row.has-scrollbar {
     border-radius: 18px;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row input,
-.catgirl-panel-right .panel-tab-settings .field-row select,
-.catgirl-panel-right .panel-tab-settings .field-row textarea,
-.catgirl-panel-right .panel-tab-settings .voice-select-header {
+.settings-form-layout.panel-tab-settings .field-row input,
+.settings-form-layout.panel-tab-settings .field-row select,
+.settings-form-layout.panel-tab-settings .field-row textarea,
+.settings-form-layout.panel-tab-settings .voice-select-header {
     min-height: 38px;
     padding: 7px 16px;
     font-size: 0.95rem;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row textarea {
+.settings-form-layout.panel-tab-settings .field-row textarea {
     border-radius: 16px;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row:has(select[name="voice_id"]) {
+.settings-form-layout.panel-tab-settings .field-row:has(select[name="voice_id"]) {
     flex: initial !important;
     width: 100% !important;
     min-width: 0 !important;
     max-width: none !important;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper > .btn.sm,
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper .btn.delete {
+.settings-form-layout.panel-tab-settings .field-row-wrapper > .btn.sm,
+.settings-form-layout.panel-tab-settings .field-row-wrapper .btn.delete {
     grid-column: 4;
     justify-self: stretch;
     justify-content: center;
@@ -6103,61 +6200,61 @@ margin-top: 10px;
     box-shadow: 0 8px 18px rgba(64, 197, 241, 0.18);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action {
     grid-column: 3;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
     grid-column: 4;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete {
     background: linear-gradient(135deg, #6bdcff, #5aa9ff);
     box-shadow: 0 8px 18px rgba(64, 197, 241, 0.2);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete:hover:not(:disabled) {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete:hover:not(:disabled) {
     background: linear-gradient(135deg, #7fe5ff, #68b6ff);
     box-shadow: 0 10px 22px rgba(64, 197, 241, 0.28);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete:active:not(:disabled) {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete:active:not(:disabled) {
     background: linear-gradient(135deg, #42c8f5, #4d9ef0);
     box-shadow: 0 3px 8px rgba(64, 197, 241, 0.2);
 }
 
-.catgirl-panel-right .panel-tab-settings .voice-register-action {
+.settings-form-layout.panel-tab-settings .voice-register-action {
     padding-inline: 12px;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper .btn.delete {
+.settings-form-layout.panel-tab-settings .field-row-wrapper .btn.delete {
     box-shadow: 0 8px 18px rgba(255, 82, 82, 0.16);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper > .btn.sm img,
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm img,
-.catgirl-panel-right .panel-tab-settings .settings-action-row .btn.sm img {
+.settings-form-layout.panel-tab-settings .field-row-wrapper > .btn.sm img,
+.settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm img,
+.settings-form-layout.panel-tab-settings .settings-action-row .btn.sm img {
     width: 18px !important;
     height: 18px !important;
     object-fit: contain;
     margin-right: 2px !important;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper > .btn.sm span,
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm span,
-.catgirl-panel-right .panel-tab-settings .settings-action-row .btn.sm span {
+.settings-form-layout.panel-tab-settings .field-row-wrapper > .btn.sm span,
+.settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm span,
+.settings-form-layout.panel-tab-settings .settings-action-row .btn.sm span {
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.catgirl-panel-right .panel-tab-settings .btn.sm .cancel-icon {
+.settings-form-layout.panel-tab-settings .btn.sm .cancel-icon {
     width: 16px !important;
     height: 16px !important;
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row,
-.catgirl-panel-right .panel-tab-settings .settings-action-row {
+.settings-form-layout.panel-tab-settings .settings-toolbar-row,
+.settings-form-layout.panel-tab-settings .settings-action-row {
     display: grid !important;
     grid-template-columns:
         var(--settings-label-col)
@@ -6170,13 +6267,13 @@ margin-top: 10px;
     margin: 2px 0 0 !important;
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row > div,
-.catgirl-panel-right .panel-tab-settings .settings-action-row > div {
+.settings-form-layout.panel-tab-settings .settings-toolbar-row > div,
+.settings-form-layout.panel-tab-settings .settings-action-row > div {
     display: none;
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm,
-.catgirl-panel-right .panel-tab-settings .settings-action-row .btn.sm {
+.settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm,
+.settings-form-layout.panel-tab-settings .settings-action-row .btn.sm {
     justify-self: stretch;
     justify-content: center;
     min-width: 0;
@@ -6189,7 +6286,7 @@ margin-top: 10px;
     box-shadow: 0 8px 18px rgba(64, 197, 241, 0.2);
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm {
+.settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm {
     grid-column: 4;
 }
 
@@ -6197,56 +6294,56 @@ margin-top: 10px;
    Add 按钮同一行 —— 同样的 pattern 用在 save-action / cancel-action 上。
    注意：必须放在上面 `.settings-toolbar-row .btn.sm { grid-column: 4 }`
    之后，靠 source order 覆盖（specificity 相同）。 */
-.catgirl-panel-right .panel-tab-settings .settings-toolbar-row .settings-secondary-action.btn.sm {
+.settings-form-layout.panel-tab-settings .settings-toolbar-row .settings-secondary-action.btn.sm {
     grid-column: 3;
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-action-row .settings-save-action {
+.settings-form-layout.panel-tab-settings .settings-action-row .settings-save-action {
     grid-column: 3;
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-action-row .settings-cancel-action {
+.settings-form-layout.panel-tab-settings .settings-action-row .settings-cancel-action {
     grid-column: 4;
 }
 
-.catgirl-panel-right .panel-tab-settings .settings-action-row {
+.settings-form-layout.panel-tab-settings .settings-action-row {
     padding-top: 2px;
 }
 
-.catgirl-panel-right .panel-tab-settings .voice-row {
+.settings-form-layout.panel-tab-settings .voice-row {
     z-index: 5;
 }
 
 @media (max-width: 1100px) {
-    .catgirl-panel-right .panel-tab-settings {
+    .settings-form-layout.panel-tab-settings {
         --settings-label-col: minmax(96px, 124px);
         --settings-action-col: 148px;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper {
         grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
     }
 
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row,
-    .catgirl-panel-right .panel-tab-settings .settings-action-row {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row,
+    .settings-form-layout.panel-tab-settings .settings-action-row {
         grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row,
-    .catgirl-panel-right .panel-tab-settings .profile-row:not(:has(> .btn.sm)) .field-row,
-    .catgirl-panel-right .panel-tab-settings .personality-row .field-row {
+    .settings-form-layout.panel-tab-settings .field-row,
+    .settings-form-layout.panel-tab-settings .profile-row:not(:has(> .btn.sm)) .field-row,
+    .settings-form-layout.panel-tab-settings .personality-row .field-row {
         grid-column: 2;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper > .btn.sm,
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper .btn.delete {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper > .btn.sm,
+    .settings-form-layout.panel-tab-settings .field-row-wrapper .btn.delete {
         grid-column: 2;
         justify-self: end;
         width: min(100%, var(--settings-action-col));
     }
 
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm,
-    .catgirl-panel-right .panel-tab-settings .settings-action-row .btn.sm {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm,
+    .settings-form-layout.panel-tab-settings .settings-action-row .btn.sm {
         grid-column: 2;
         justify-self: end;
         width: min(100%, var(--settings-action-col));
@@ -6257,7 +6354,7 @@ margin-top: 10px;
        通用 `.btn.sm { grid-column: 2 }` 规则被这两条更具体的选择器盖掉。
        窄于 768px 时 `@media (max-width: 768px)` 会把布局收回 1-col，让两个
        按钮叠成上下两行（screen 太窄时唯一合理的排版）。 */
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row {
         grid-template-columns:
             var(--settings-label-col)
             minmax(0, 1fr)
@@ -6265,70 +6362,70 @@ margin-top: 10px;
             var(--settings-action-col);
     }
 
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row .settings-secondary-action.btn.sm {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row .settings-secondary-action.btn.sm {
         grid-column: 3;
         justify-self: stretch;
         width: 100%;
     }
 
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm:not(.settings-secondary-action) {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm:not(.settings-secondary-action) {
         grid-column: 4;
         justify-self: stretch;
         width: 100%;
     }
 
-    .catgirl-panel-right .panel-tab-settings .personality-row {
+    .settings-form-layout.panel-tab-settings .personality-row {
         grid-template-columns: var(--settings-label-col) minmax(0, 1fr) minmax(0, 1fr);
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row .field-row {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row .field-row {
         grid-column: 2 / 4;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action,
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action,
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
         width: 100%;
         justify-self: stretch;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action {
         grid-column: 2;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
         grid-column: 3;
     }
 }
 
 @media (max-width: 768px) {
-    .catgirl-panel-right .panel-tab-settings {
+    .settings-form-layout.panel-tab-settings {
         padding: 18px 16px;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper {
         grid-template-columns: 1fr;
     }
 
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row,
-    .catgirl-panel-right .panel-tab-settings .settings-action-row {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row,
+    .settings-form-layout.panel-tab-settings .settings-action-row {
         grid-template-columns: 1fr;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row,
-    .catgirl-panel-right .panel-tab-settings .profile-row:not(:has(> .btn.sm)) .field-row,
-    .catgirl-panel-right .panel-tab-settings .personality-row .field-row {
+    .settings-form-layout.panel-tab-settings .field-row,
+    .settings-form-layout.panel-tab-settings .profile-row:not(:has(> .btn.sm)) .field-row,
+    .settings-form-layout.panel-tab-settings .personality-row .field-row {
         grid-column: 1;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper > .btn.sm,
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper .btn.delete {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper > .btn.sm,
+    .settings-form-layout.panel-tab-settings .field-row-wrapper .btn.delete {
         grid-column: 1;
         justify-self: stretch;
         width: 100%;
     }
 
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm,
-    .catgirl-panel-right .panel-tab-settings .settings-action-row .btn.sm {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm,
+    .settings-form-layout.panel-tab-settings .settings-action-row .btn.sm {
         grid-column: 1;
         justify-self: stretch;
         width: 100%;
@@ -6337,30 +6434,30 @@ margin-top: 10px;
     /* @media (max-width:1100px) 里把 AI 按钮固定在 col 3 / Add 在 col 4，
        phone breakpoint 1-col grid 时把它们也都收回 col 1，否则 grid-column:3/4
        会让 CSS Grid 隐式生成额外列，画面错位 */
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row .settings-secondary-action.btn.sm,
-    .catgirl-panel-right .panel-tab-settings .settings-toolbar-row .btn.sm:not(.settings-secondary-action) {
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row .settings-secondary-action.btn.sm,
+    .settings-form-layout.panel-tab-settings .settings-toolbar-row .btn.sm:not(.settings-secondary-action) {
         grid-column: 1;
     }
 
-    .catgirl-panel-right .panel-tab-settings .personality-row {
+    .settings-form-layout.panel-tab-settings .personality-row {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > label,
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row .field-row {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > label,
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row .field-row {
         grid-column: 1 / 3;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-select-action {
         grid-column: 1;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action {
         grid-column: 2;
     }
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row {
     grid-template-columns:
         var(--settings-label-col)
         minmax(260px, 1fr)
@@ -6368,11 +6465,11 @@ margin-top: 10px;
     column-gap: var(--settings-column-gap);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .field-row {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .field-row {
     grid-column: 2;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
     grid-column: 3;
     justify-self: end;
     align-self: center;
@@ -6386,64 +6483,68 @@ margin-top: 10px;
     box-shadow: 0 3px 8px rgba(64, 197, 241, 0.08);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:hover:not(:disabled) {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm::before {
+    content: '';
+    width: 17px;
+    height: 17px;
+    background: #2ca9d3;
+    -webkit-mask: url('/static/icons/delete.png') center / contain no-repeat;
+    mask: url('/static/icons/delete.png') center / contain no-repeat;
+}
+
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:hover:not(:disabled) {
     border-color: rgba(64, 197, 241, 0.5);
     background: rgba(232, 247, 255, 0.95);
     box-shadow: 0 6px 14px rgba(64, 197, 241, 0.16);
     transform: translateY(-1px);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:active:not(:disabled) {
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:active:not(:disabled) {
     background: rgba(211, 242, 255, 0.95);
     box-shadow: 0 2px 6px rgba(64, 197, 241, 0.14);
     transform: translateY(0);
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm .delete-icon {
-    width: 17px !important;
-    height: 17px !important;
-    margin: 0 !important;
-    opacity: 0.82;
-    filter: brightness(0) saturate(100%) invert(49%) sepia(72%) saturate(540%) hue-rotate(151deg) brightness(95%) contrast(89%);
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm .delete-icon {
+    display: none;
 }
 
-.catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:hover:not(:disabled) .delete-icon {
-    opacity: 1;
-    filter: brightness(0) saturate(100%) invert(44%) sepia(78%) saturate(716%) hue-rotate(153deg) brightness(97%) contrast(92%);
+.settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:hover:not(:disabled)::before {
+    background: #168fbd;
 }
 
 @media (max-width: 1100px) {
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row {
         grid-template-columns:
             var(--settings-label-col)
             minmax(0, 1fr)
             36px;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .field-row {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .field-row {
         grid-column: 2;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
         grid-column: 3;
         justify-self: start;
     }
 }
 
 @media (max-width: 768px) {
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row {
         grid-template-columns: minmax(0, 1fr) 36px;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > label {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > label {
         grid-column: 1 / 3;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .field-row {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .field-row {
         grid-column: 1;
     }
 
-    .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
+    .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
         grid-column: 2;
         justify-self: start;
     }
@@ -6954,26 +7055,45 @@ margin-top: 10px;
     box-shadow: 0 14px 28px rgba(0, 0, 0, 0.34);
 }
 
+[data-theme="dark"] .master-profile-section:has(.master-profile-header.open) {
+    background: linear-gradient(145deg, rgba(29, 43, 56, 0.98), rgba(20, 34, 46, 0.98));
+    border-color: rgba(125, 211, 252, 0.56);
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.38);
+}
+
+[data-theme="dark"] .master-profile-backdrop {
+    background: rgba(3, 12, 20, 0.54);
+}
+
+[data-theme="dark"] .master-profile-dialog-header {
+    color: #7dd3fc;
+    background: linear-gradient(135deg, rgba(36, 50, 65, 0.98), rgba(24, 39, 52, 0.98));
+    border-color: rgba(125, 211, 252, 0.24);
+}
+
+[data-theme="dark"] .master-profile-dialog-close {
+    color: #7dd3fc;
+    background: rgba(31, 42, 54, 0.92);
+    border-color: rgba(125, 211, 252, 0.34);
+}
+
+[data-theme="dark"] .master-profile-dialog-close:hover {
+    color: #0f2230;
+    background: #7dd3fc;
+}
+
+[data-theme="dark"] .master-profile-dialog-footer.settings-form-layout.panel-tab-settings {
+    background: rgba(24, 34, 44, 0.98);
+    border-top-color: rgba(125, 211, 252, 0.2);
+    box-shadow: 0 -8px 22px rgba(0, 0, 0, 0.18);
+}
+
 [data-theme="dark"] .master-profile-header,
-[data-theme="dark"] .master-profile-content .field-row-wrapper label,
 [data-theme="dark"] .hidden-catgirl-header-btn,
 [data-theme="dark"] .hidden-catgirl-arrow {
     color: #7dd3fc;
 }
 
-[data-theme="dark"] .master-profile-arrow-bubble {
-    background: linear-gradient(180deg, rgba(36, 58, 75, 0.96), rgba(24, 42, 56, 0.96));
-    border-color: rgba(125, 211, 252, 0.44);
-    box-shadow: 0 5px 12px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-[data-theme="dark"] .master-profile-arrow-symbol {
-    border-color: #7dd3fc;
-}
-
-[data-theme="dark"] .master-profile-content .field-row,
-[data-theme="dark"] .master-profile-content .field-row input,
-[data-theme="dark"] .master-profile-content .field-row textarea,
 [data-theme="dark"] .hidden-catgirl-item {
     background: #1f2a36;
     color: #e6edf3;
@@ -8350,44 +8470,67 @@ margin-top: 10px;
     background: linear-gradient(90deg, rgba(3, 7, 18, 0.34), rgba(31, 42, 54, 0));
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row {
     background: #18222c;
     border-color: rgba(125, 211, 252, 0.24);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row input,
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row select,
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row textarea {
+    background: #18222c;
+    color: #e6edf3;
+    border-color: rgba(125, 211, 252, 0.24);
+}
+
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row input:focus,
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row select:focus,
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row textarea:focus {
+    background: #223044;
+    color: #fff;
+}
+
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row input::placeholder,
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row textarea::placeholder {
+    color: #7a8da3;
+}
+
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper label {
+    color: #7dd3fc;
+}
+
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm {
     border-color: rgba(125, 211, 252, 0.22);
     background: rgba(24, 34, 44, 0.86);
     box-shadow: 0 3px 8px rgba(14, 116, 144, 0.12);
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:hover:not(:disabled) {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:hover:not(:disabled) {
     border-color: rgba(125, 211, 252, 0.42);
     background: rgba(32, 49, 62, 0.94);
     box-shadow: 0 6px 14px rgba(14, 116, 144, 0.22);
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:active:not(:disabled) {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm:active:not(:disabled) {
     background: rgba(18, 41, 54, 0.95);
     box-shadow: 0 2px 6px rgba(14, 116, 144, 0.18);
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm .delete-icon {
-    opacity: 0.86;
-    filter: brightness(0) saturate(100%) invert(77%) sepia(46%) saturate(810%) hue-rotate(162deg) brightness(96%) contrast(92%);
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper.setting-field-row > .setting-field-delete.btn.sm::before {
+    background: #7dd3fc;
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper label::before {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper label::before {
     filter: drop-shadow(0 0 4px rgba(125, 211, 252, 0.18));
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete {
     background: linear-gradient(135deg, #178fba, #2563eb);
     box-shadow: 0 8px 18px rgba(14, 116, 144, 0.28);
 }
 
-[data-theme="dark"] .catgirl-panel-right .panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete:hover:not(:disabled) {
+[data-theme="dark"] .settings-form-layout.panel-tab-settings .field-row-wrapper.personality-row > .personality-clear-action.btn.delete:hover:not(:disabled) {
     background: linear-gradient(135deg, #1da8d8, #2f72ff);
     box-shadow: 0 10px 22px rgba(14, 116, 144, 0.34);
 }

--- a/static/js/character_card_manager/card-list-and-panel.js
+++ b/static/js/character_card_manager/card-list-and-panel.js
@@ -820,7 +820,7 @@ function openCatgirlPanel(card, originEl) {
 
     // === 设定标签内容 ===
     const settingsContent = document.createElement('div');
-    settingsContent.className = 'panel-tab-content panel-tab-settings active';
+    settingsContent.className = 'panel-tab-content panel-tab-settings settings-form-layout active';
     buildCatgirlDetailForm(name, rawData, isNew, settingsContent);
     rightSection.appendChild(settingsContent);
 

--- a/static/js/character_card_manager/master-profile.js
+++ b/static/js/character_card_manager/master-profile.js
@@ -496,6 +496,40 @@ function toggleMasterSection() {
 
     if (isOpening) {
         content._masterProfilePreviousFocus = document.activeElement;
+        content._masterProfileFocusTrap = function (event) {
+            if (event.key !== 'Tab' || document.querySelector('.modal-overlay')) return;
+
+            const focusableElements = Array.from(content.querySelectorAll([
+                'a[href]',
+                'button:not([disabled])',
+                'input:not([disabled]):not([type="hidden"])',
+                'select:not([disabled])',
+                'textarea:not([disabled])',
+                '[contenteditable="true"]',
+                '[tabindex]:not([tabindex="-1"])'
+            ].join(','))).filter(element => (
+                !element.hidden
+                && element.getAttribute('aria-hidden') !== 'true'
+                && element.getClientRects().length > 0
+            ));
+            if (!focusableElements.length) {
+                event.preventDefault();
+                return;
+            }
+
+            const firstFocusable = focusableElements[0];
+            const lastFocusable = focusableElements[focusableElements.length - 1];
+            const activeElement = document.activeElement;
+            const activeElementIsFocusable = focusableElements.includes(activeElement);
+            if (event.shiftKey && (activeElement === firstFocusable || !activeElementIsFocusable)) {
+                event.preventDefault();
+                lastFocusable.focus({ preventScroll: true });
+            } else if (!event.shiftKey && (activeElement === lastFocusable || !activeElementIsFocusable)) {
+                event.preventDefault();
+                firstFocusable.focus({ preventScroll: true });
+            }
+        };
+        document.addEventListener('keydown', content._masterProfileFocusTrap);
         backdrop.style.display = 'block';
         content.style.display = 'flex';
         content.setAttribute('aria-hidden', 'false');
@@ -517,6 +551,10 @@ function toggleMasterSection() {
     backdrop.classList.remove('open');
     content.classList.remove('open');
     header.classList.remove('open');
+    if (content._masterProfileFocusTrap) {
+        document.removeEventListener('keydown', content._masterProfileFocusTrap);
+        content._masterProfileFocusTrap = null;
+    }
     const previousFocus = content._masterProfilePreviousFocus;
     if (previousFocus && typeof previousFocus.focus === 'function') {
         previousFocus.focus({ preventScroll: true });

--- a/static/js/character_card_manager/master-profile.js
+++ b/static/js/character_card_manager/master-profile.js
@@ -496,6 +496,7 @@ function toggleMasterSection() {
 
     if (isOpening) {
         content._masterProfilePreviousFocus = document.activeElement;
+        content.removeAttribute('inert');
         content._masterProfileFocusTrap = function (event) {
             if (event.key !== 'Tab' || document.querySelector('.modal-overlay')) return;
 
@@ -560,6 +561,7 @@ function toggleMasterSection() {
         previousFocus.focus({ preventScroll: true });
     }
     content.setAttribute('aria-hidden', 'true');
+    content.setAttribute('inert', '');
     backdrop.setAttribute('aria-hidden', 'true');
     document.body.classList.remove('master-profile-dialog-open');
 

--- a/static/js/character_card_manager/master-profile.js
+++ b/static/js/character_card_manager/master-profile.js
@@ -15,13 +15,15 @@ async function loadMasterProfile() {
 function renderMasterForm(master) {
     const form = document.getElementById('master-form');
     if (!form) return;
+    const fixedFooter = document.getElementById('master-profile-dialog-footer');
     form.innerHTML = '';
+    if (fixedFooter) fixedFooter.innerHTML = '';
     const masterProfileName = normalizeCharacterFieldName(master['档案名']);
     const hasMasterProfileName = !!masterProfileName;
 
     // 档案名
     const baseWrapper = document.createElement('div');
-    baseWrapper.className = 'field-row-wrapper';
+    baseWrapper.className = 'field-row-wrapper profile-row';
     const baseLabel = document.createElement('label');
     const profileNameText = window.t ? window.t('character.profileName') : '档案名';
     const requiredText = window.t ? window.t('character.required') : '*';
@@ -43,17 +45,18 @@ function renderMasterForm(master) {
             ? window.t('character.profileNameRenameOnlyHint')
             : '请通过“修改名称”按钮修改档案名';
     }
+    _panelAttachProfileNameLimiter(nameInput);
     fieldRow.appendChild(nameInput);
     baseWrapper.appendChild(fieldRow);
 
     // 重命名按钮
     const renameBtn = document.createElement('button');
     renameBtn.type = 'button';
-    renameBtn.className = 'btn sm';
-    renameBtn.style.minWidth = '70px';
+    renameBtn.className = 'btn sm row-action-btn rename-action';
     const renameText = window.t ? window.t('character.rename') : '修改名称';
     const renameTitle = window.t ? window.t('character.renameMasterTitle') : '重命名我的档案';
-    renameBtn.textContent = renameText;
+    renameBtn.innerHTML = '<img src="/static/icons/edit.png" alt="" class="edit-icon" aria-hidden="true">'
+        + ' <span data-i18n="character.rename">' + renameText + '</span>';
     renameBtn.title = renameTitle;
     renameBtn.setAttribute('aria-label', renameTitle);
     renameBtn.disabled = !hasMasterProfileName;
@@ -74,7 +77,7 @@ function renderMasterForm(master) {
         ) return;
         renderedCustomFields.add(normalizedKey);
         const wrapper = document.createElement('div');
-        wrapper.className = 'field-row-wrapper custom-row';
+        wrapper.className = 'field-row-wrapper custom-row setting-field-row';
 
         const label = document.createElement('label');
         _panelSetFieldLabel(label, normalizedKey);
@@ -85,15 +88,17 @@ function renderMasterForm(master) {
         const textarea = document.createElement('textarea');
         textarea.name = normalizedKey;
         textarea.rows = 1;
+        textarea.placeholder = window.t
+            ? window.t('character.detailDescriptionPlaceholder')
+            : '可输入详细描述';
         textarea.value = master[k];
         row.appendChild(textarea);
         wrapper.appendChild(row);
 
         const delBtn = document.createElement('button');
         delBtn.type = 'button';
-        delBtn.className = 'btn sm delete';
-        const deleteText = window.t ? window.t('character.deleteField') : '删除设定';
-        delBtn.textContent = deleteText;
+        delBtn.className = 'btn sm delete row-action-btn delete-action setting-field-delete';
+        _panelConfigureFieldDeleteButton(delBtn);
         delBtn.onclick = function () { deleteMasterField(this); };
         wrapper.appendChild(delBtn);
 
@@ -109,39 +114,60 @@ function renderMasterForm(master) {
         textarea.addEventListener('change', showMasterActionButtons);
     });
 
-    // 按钮区
-    const btnArea = document.createElement('div');
-    btnArea.className = 'btn-area';
-    btnArea.style.display = 'flex';
-    btnArea.style.justifyContent = 'flex-end';
-    btnArea.style.gap = '6px';
-    btnArea.style.marginTop = '8px';
+    // 新增设定工具栏：与角色卡设定页使用相同的布局槽位。
+    const addFieldArea = document.createElement('div');
+    addFieldArea.className = 'btn-area add-field-area settings-toolbar-row';
+    addFieldArea.id = 'master-profile-add-actions';
+
+    const addFieldLabelPlaceholder = document.createElement('div');
+    addFieldArea.appendChild(addFieldLabelPlaceholder);
+
+    const addFieldSpacer = document.createElement('div');
+    addFieldArea.appendChild(addFieldSpacer);
 
     const addBtn = document.createElement('button');
     addBtn.type = 'button';
-    addBtn.className = 'btn sm add';
+    addBtn.className = 'btn sm add settings-primary-action';
     const addText = window.t ? window.t('character.addMasterField') : '新增设定';
-    addBtn.textContent = addText;
+    addBtn.innerHTML = '<img src="/static/icons/add.png" alt="" class="add-icon" aria-hidden="true">'
+        + ' <span data-i18n="character.addMasterField">' + addText + '</span>';
     addBtn.onclick = addMasterField;
-    btnArea.appendChild(addBtn);
+    addFieldArea.appendChild(addBtn);
+    if (fixedFooter) {
+        fixedFooter.appendChild(addFieldArea);
+    } else {
+        form.appendChild(addFieldArea);
+    }
+
+    // 保存/取消操作区：与角色卡设定页保持同一排布和按钮机制。
+    const btnArea = document.createElement('div');
+    btnArea.className = 'btn-area settings-action-row';
+
+    const actionLabelPlaceholder = document.createElement('div');
+    btnArea.appendChild(actionLabelPlaceholder);
+
+    const actionSpacer = document.createElement('div');
+    btnArea.appendChild(actionSpacer);
 
     const saveBtn = document.createElement('button');
     saveBtn.type = 'button';
     saveBtn.id = 'save-master-btn';
-    saveBtn.className = 'btn sm';
+    saveBtn.className = 'btn sm settings-save-action';
     saveBtn.style.display = hasMasterProfileName ? 'none' : '';
     const saveText = window.t ? window.t('character.saveMaster') : '保存我的档案';
-    saveBtn.textContent = saveText;
+    saveBtn.innerHTML = '<img src="/static/icons/set_on.png" alt="" class="save-icon" aria-hidden="true">'
+        + ' <span data-i18n="character.saveMaster">' + saveText + '</span>';
     saveBtn.onclick = saveMasterForm;
     btnArea.appendChild(saveBtn);
 
     const cancelBtn = document.createElement('button');
     cancelBtn.type = 'button';
     cancelBtn.id = 'cancel-master-btn';
-    cancelBtn.className = 'btn sm';
+    cancelBtn.className = 'btn sm settings-cancel-action';
     cancelBtn.style.display = 'none';
     const cancelText = window.t ? window.t('character.cancel') : '取消';
-    cancelBtn.textContent = cancelText;
+    cancelBtn.innerHTML = '<img src="/static/icons/close_button.png" alt="" class="cancel-icon" aria-hidden="true">'
+        + ' <span data-i18n="character.cancel">' + cancelText + '</span>';
     cancelBtn.onclick = function () {
         loadMasterProfile();
     };
@@ -346,7 +372,7 @@ async function addMasterField() {
         return;
     }
     const wrapper = document.createElement('div');
-    wrapper.className = 'field-row-wrapper custom-row';
+    wrapper.className = 'field-row-wrapper custom-row setting-field-row';
     const label = document.createElement('label');
     _panelSetFieldLabel(label, key);
     wrapper.appendChild(label);
@@ -356,13 +382,16 @@ async function addMasterField() {
     const textarea = document.createElement('textarea');
     textarea.name = key;
     textarea.rows = 1;
+    textarea.placeholder = window.t
+        ? window.t('character.detailDescriptionPlaceholder')
+        : '可输入详细描述';
     row.appendChild(textarea);
     wrapper.appendChild(row);
 
     const delBtn = document.createElement('button');
     delBtn.type = 'button';
-    delBtn.className = 'btn sm delete';
-    delBtn.textContent = window.t ? window.t('character.deleteField') : '删除设定';
+    delBtn.className = 'btn sm delete row-action-btn delete-action setting-field-delete';
+    _panelConfigureFieldDeleteButton(delBtn);
     delBtn.onclick = function () { deleteMasterField(this); };
     wrapper.appendChild(delBtn);
 
@@ -452,7 +481,8 @@ async function renameMaster() {
 function toggleMasterSection() {
     const content = document.getElementById('master-profile-content');
     const header = document.getElementById('master-profile-header');
-    if (!content || !header) return;
+    const backdrop = document.getElementById('master-profile-backdrop');
+    if (!content || !header || !backdrop) return;
     const isOpening = !content.classList.contains('open');
 
     if (content._masterProfileHideTimer) {
@@ -465,24 +495,43 @@ function toggleMasterSection() {
     }
 
     if (isOpening) {
-        content.style.display = 'block';
-        content.style.setProperty('--master-profile-viewport-left', `${content.getBoundingClientRect().left}px`);
+        content._masterProfilePreviousFocus = document.activeElement;
+        backdrop.style.display = 'block';
+        content.style.display = 'flex';
+        content.setAttribute('aria-hidden', 'false');
+        backdrop.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('master-profile-dialog-open');
+        const body = content.querySelector('.master-profile-dialog-body');
+        if (body) body.scrollTop = 0;
+        backdrop.getBoundingClientRect();
         content.getBoundingClientRect();
+        backdrop.classList.add('open');
         content.classList.add('open');
         header.classList.add('open');
-        header.setAttribute('aria-expanded', 'true');
+        requestAnimationFrame(() => {
+            content.querySelector('.master-profile-dialog-close')?.focus({ preventScroll: true });
+        });
         return;
     }
 
+    backdrop.classList.remove('open');
     content.classList.remove('open');
     header.classList.remove('open');
-    header.setAttribute('aria-expanded', 'false');
+    const previousFocus = content._masterProfilePreviousFocus;
+    if (previousFocus && typeof previousFocus.focus === 'function') {
+        previousFocus.focus({ preventScroll: true });
+    }
+    content.setAttribute('aria-hidden', 'true');
+    backdrop.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('master-profile-dialog-open');
 
     const hideContent = function (event) {
         if (event && event.target !== content) return;
-        if (event && event.propertyName !== 'clip-path') return;
+        if (event && event.propertyName !== 'opacity') return;
         if (!content.classList.contains('open')) {
             content.style.display = 'none';
+            backdrop.style.display = 'none';
+            content._masterProfilePreviousFocus = null;
         }
         content.removeEventListener('transitionend', hideContent);
         if (content._masterProfileHideTimer) {
@@ -496,8 +545,19 @@ function toggleMasterSection() {
 
     content.addEventListener('transitionend', hideContent);
     content._masterProfileHideContent = hideContent;
-    content._masterProfileHideTimer = setTimeout(hideContent, 280);
+    content._masterProfileHideTimer = setTimeout(hideContent, 300);
 }
+
+document.addEventListener('keydown', function (event) {
+    const content = document.getElementById('master-profile-content');
+    if (
+        event.key === 'Escape'
+        && content?.classList.contains('open')
+        && !document.querySelector('.modal-overlay')
+    ) {
+        toggleMasterSection();
+    }
+});
 
 // ===================== 隐藏猫娘 =====================
 

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -107,11 +107,18 @@
         .master-profile-section {
             border: 2px solid #b3e5fc;
             border-radius: 16px;
-            background: #f0f8ff;
+            background: linear-gradient(145deg, rgba(249, 253, 255, 0.96), rgba(232, 247, 255, 0.94));
             padding: 10px 12px;
             margin-top: 8px;
             position: relative;
             z-index: 10;
+            box-shadow: 0 5px 16px rgba(64, 197, 241, 0.08);
+            transition: border-color 0.28s ease, box-shadow 0.28s ease, background 0.28s ease;
+        }
+        .master-profile-section:has(.master-profile-header.open) {
+            border-color: rgba(64, 197, 241, 0.72);
+            background: linear-gradient(145deg, rgba(252, 254, 255, 0.98), rgba(225, 246, 255, 0.96));
+            box-shadow: 0 12px 30px rgba(64, 197, 241, 0.18);
         }
         .master-profile-header {
             display: flex;
@@ -129,136 +136,125 @@
             -webkit-appearance: none;
             width: 100%;
             text-align: left;
+            min-height: 26px;
+        }
+        .master-profile-backdrop {
+            position: fixed;
+            inset: 0;
+            z-index: 998;
+            background: rgba(18, 72, 102, 0.2);
+            backdrop-filter: blur(3px);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.22s ease;
+        }
+        .master-profile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
         }
         .master-profile-content {
-            position: absolute;
-            left: 0;
-            right: auto;
-            top: 100%;
-            width: max(100%, 50vw);
-            max-width: calc(100vw - var(--master-profile-viewport-left, 0px) - 20px);
-            margin-top: 4px;
-            padding: 10px 12px;
-            background: #f0f8ff;
-            border: 2px solid #b3e5fc;
-            border-radius: 16px;
-            z-index: 20;
-            box-shadow: 0 8px 24px rgba(64, 197, 241, 0.15);
+            position: fixed;
+            left: 50%;
+            top: 50%;
+            z-index: 999;
+            display: flex;
+            flex-direction: column;
+            width: min(920px, calc(100vw - 48px));
+            height: min(720px, calc(100vh - 80px));
+            min-width: 0;
+            min-height: 0;
+            max-width: 920px;
+            max-height: 720px;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            background: linear-gradient(145deg, rgba(252, 254, 255, 0.99), rgba(230, 247, 255, 0.98));
+            border: 1px solid rgba(128, 213, 245, 0.86);
+            border-radius: 20px;
+            box-shadow: 0 30px 80px rgba(25, 106, 150, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.98);
             opacity: 0;
-            transform: translateY(-8px) scaleX(0.92);
-            transform-origin: top left;
-            clip-path: inset(0 100% 0 0 round 16px);
+            transform: translate(-50%, -48%) scale(0.975);
             pointer-events: none;
-            will-change: opacity, transform, clip-path;
+            will-change: opacity, transform;
             transition:
-                opacity 0.18s ease,
-                transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
-                clip-path 0.24s cubic-bezier(0.2, 0.8, 0.2, 1);
+                opacity 0.2s ease,
+                transform 0.26s cubic-bezier(0.2, 0.8, 0.2, 1);
         }
         .master-profile-content.open {
             opacity: 1;
-            transform: translateY(0) scaleX(1);
-            clip-path: inset(0 0 0 0 round 16px);
+            transform: translate(-50%, -50%) scale(1);
             pointer-events: auto;
         }
-        @media (max-width: 900px) {
-            .master-profile-content {
-                width: 100%;
-                max-width: 100%;
-            }
+        .master-profile-dialog-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex: 0 0 auto;
+            min-height: 58px;
+            padding: 12px 16px 12px 18px;
+            color: #2ab6e8;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(222, 246, 255, 0.9));
+            border-bottom: 1px solid rgba(128, 213, 245, 0.54);
+        }
+        .master-profile-dialog-title {
+            flex: 1;
+            min-width: 0;
+            font-size: 1rem;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+        }
+        .master-profile-dialog-close {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 34px;
+            height: 34px;
+            padding: 0;
+            color: #40C5F1;
+            background: rgba(255, 255, 255, 0.82);
+            border: 1px solid rgba(128, 213, 245, 0.66);
+            border-radius: 11px;
+            cursor: pointer;
+            font-size: 23px;
+            line-height: 1;
+            transition: color 0.18s ease, background 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+        }
+        .master-profile-dialog-close:hover {
+            color: #fff;
+            background: #40C5F1;
+            box-shadow: 0 5px 12px rgba(64, 197, 241, 0.24);
+            transform: translateY(-1px);
+        }
+        .master-profile-dialog-body {
+            flex: 1 1 auto;
+            min-width: 0;
+            min-height: 0;
+            overflow-x: hidden;
+            overflow-y: auto;
+            overscroll-behavior: contain;
+            scrollbar-gutter: stable;
+            scrollbar-width: thin;
+            scrollbar-color: rgba(64, 197, 241, 0.55) transparent;
+        }
+        .master-profile-dialog-footer.settings-form-layout.panel-tab-settings {
+            flex: 0 0 auto;
+            padding: 10px 28px 14px;
+            background: rgba(244, 252, 255, 0.96);
+            border-top: 1px solid rgba(128, 213, 245, 0.46);
+            box-shadow: 0 -8px 22px rgba(64, 197, 241, 0.07);
+        }
+        .master-profile-dialog-footer .settings-toolbar-row {
+            margin: 0 !important;
+        }
+        body.master-profile-dialog-open .layout-container {
+            overflow-y: hidden;
         }
         @media (prefers-reduced-motion: reduce) {
-            .master-profile-content {
+            .master-profile-backdrop,
+            .master-profile-content,
+            .master-profile-section {
                 transition: none;
             }
-        }
-        .master-profile-content .field-row-wrapper {
-            display: flex;
-            align-items: center;
-            margin-bottom: 8px;
-            gap: 6px;
-        }
-        .master-profile-content .field-row-wrapper label {
-            min-width: 60px;
-            max-width: 80px;
-            font-weight: 600;
-            color: #40C5F1;
-            font-size: 0.85rem;
-            flex-shrink: 0;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .master-profile-content .field-row {
-            display: flex;
-            align-items: center;
-            flex: 1;
-            padding: 2px;
-            border: 2px solid #b3e5fc;
-            border-radius: 50px;
-            background: #fff;
-            min-height: 28px;
-            transition: border-color 0.2s, border-radius 0.3s ease;
-            overflow: hidden;
-        }
-        .master-profile-content .field-row.has-scrollbar {
-            border-radius: 16px;
-        }
-        .master-profile-content .field-row.has-scrollbar textarea {
-            border-radius: 14px;
-        }
-        /* 自定义滚动条样式 */
-        .master-profile-content .field-row textarea::-webkit-scrollbar {
-            width: 6px;
-        }
-        .master-profile-content .field-row textarea::-webkit-scrollbar-track {
-            background: transparent;
-        }
-        .master-profile-content .field-row textarea::-webkit-scrollbar-thumb {
-            background-color: rgba(64, 197, 241, 0.3);
-            border-radius: 3px;
-        }
-        .master-profile-content .field-row textarea::-webkit-scrollbar-thumb:hover {
-            background-color: rgba(64, 197, 241, 0.5);
-        }
-        .master-profile-content .field-row input,
-        .master-profile-content .field-row textarea {
-            flex: 1;
-            padding: 4px 10px;
-            border: none;
-            border-radius: 48px;
-            font-size: 0.85rem;
-            background: #fff;
-            color: #40C5F1;
-            outline: none;
-            resize: none;
-            box-sizing: border-box;
-        }
-        .master-profile-content .field-row input:focus,
-        .master-profile-content .field-row textarea:focus {
-            outline: none !important;
-            box-shadow: none !important;
-        }
-        .master-profile-content .field-row:focus-within {
-            border-color: #40C5F1;
-        }
-        .master-profile-content .field-row textarea {
-            overflow-y: hidden;
-            min-height: 30px;
-            line-height: 1.4;
-            transition: height 0.2s ease;
-            box-sizing: border-box;
-        }
-        .master-profile-content .btn-area {
-            display: flex;
-            justify-content: flex-end;
-            align-items: center;
-            gap: 6px;
-            margin-top: 6px;
-        }
-        .master-profile-content .btn-area .btn#save-master-btn,
-        .master-profile-content .btn-area .btn#cancel-master-btn {
-            display: none;
         }
         /* 页面全局滚动条样式 */
         ::-webkit-scrollbar {
@@ -275,20 +271,17 @@
         ::-webkit-scrollbar-thumb:hover {
             background-color: rgba(64, 197, 241, 0.75);
         }
-        .master-profile-content .btn.sm {
-            padding: 0 10px;
-            border-radius: 999px;
-            min-width: 60px;
-            height: 26px;
-            font-size: 0.75rem;
-            background: #7fd6f4;
-            color: #fff;
-            border: none;
-            transition: background 0.2s, transform 0.15s;
-        }
-        .master-profile-content .btn.sm:hover {
-            background: #40C5F1;
-            transform: translateY(-1px);
+        @media (max-width: 620px) {
+            .master-profile-content {
+                width: calc(100vw - 20px);
+                height: calc(100vh - 20px);
+                max-width: none;
+                max-height: none;
+                border-radius: 16px;
+            }
+            .master-profile-dialog-footer.settings-form-layout.panel-tab-settings {
+                padding: 10px 16px 12px;
+            }
         }
         /* 已隐藏猫娘补充样式 */
         .hidden-catgirl-area {
@@ -492,17 +485,25 @@
 
 <!-- 我的档案区域 -->
 <div class="menu-section master-profile-section" id="master-profile-section">
-    <button type="button" class="master-profile-header" id="master-profile-header" onclick="toggleMasterSection()" aria-expanded="false">
-        <span class="master-profile-arrow-bubble" aria-hidden="true">
-            <span class="master-profile-arrow-symbol"></span>
-        </span>
+    <button type="button" class="master-profile-header" id="master-profile-header" onclick="toggleMasterSection()" aria-haspopup="dialog" aria-controls="master-profile-content">
         <span data-i18n="character.masterProfileTitle">我的档案</span>
     </button>
-    <div class="master-profile-content" id="master-profile-content" style="display:none;">
+</div>
+
+<div class="master-profile-backdrop" id="master-profile-backdrop" style="display:none;" aria-hidden="true" onclick="toggleMasterSection()"></div>
+<div class="master-profile-content" id="master-profile-content" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="master-profile-dialog-title" aria-hidden="true">
+    <div class="master-profile-dialog-header">
+        <span class="master-profile-dialog-title" id="master-profile-dialog-title" data-i18n="character.masterProfileTitle">我的档案</span>
+        <button type="button" class="master-profile-dialog-close" onclick="toggleMasterSection()" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
+            <span aria-hidden="true">×</span>
+        </button>
+    </div>
+    <div class="master-profile-dialog-body panel-tab-settings settings-form-layout">
         <form id="master-form" onsubmit="event.preventDefault();">
             <!-- 由 JS 动态渲染 -->
         </form>
     </div>
+    <div class="master-profile-dialog-footer panel-tab-settings settings-form-layout" id="master-profile-dialog-footer"></div>
 </div>
 
 <!-- 角色卡封面图展示区域 -->

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -491,7 +491,7 @@
 </div>
 
 <div class="master-profile-backdrop" id="master-profile-backdrop" style="display:none;" aria-hidden="true" onclick="toggleMasterSection()"></div>
-<div class="master-profile-content" id="master-profile-content" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="master-profile-dialog-title" aria-hidden="true">
+<div class="master-profile-content" id="master-profile-content" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="master-profile-dialog-title" aria-hidden="true" inert>
     <div class="master-profile-dialog-header">
         <span class="master-profile-dialog-title" id="master-profile-dialog-title" data-i18n="character.masterProfileTitle">我的档案</span>
         <button type="button" class="master-profile-dialog-close" onclick="toggleMasterSection()" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -908,11 +908,11 @@ def test_character_card_manager_localizes_master_profile_builtin_field_labels(
 
 @pytest.mark.frontend
 @pytest.mark.parametrize(
-    "viewport",
+    ("viewport", "expected_width", "expected_height"),
     [
-        {"width": 1440, "height": 900},
-        {"width": 700, "height": 900},
-        {"width": 560, "height": 900},
+        ({"width": 1440, "height": 900}, 920, 720),
+        ({"width": 700, "height": 900}, 652, 720),
+        ({"width": 560, "height": 900}, 540, 880),
     ],
     ids=["desktop-dialog", "single-column-dialog", "mobile-dialog"],
 )
@@ -920,6 +920,8 @@ def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
     mock_page: Page,
     running_server: str,
     viewport: dict[str, int],
+    expected_width: int,
+    expected_height: int,
 ):
     mock_page.set_viewport_size(viewport)
     _open_character_card_manager(mock_page, running_server)
@@ -1072,10 +1074,6 @@ def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
 
     assert state["position"] == "fixed"
     assert state["display"] == "flex"
-    expected_width = viewport["width"] - (20 if viewport["width"] <= 620 else 48)
-    expected_width = min(920, expected_width)
-    expected_height = viewport["height"] - (20 if viewport["width"] <= 620 else 80)
-    expected_height = min(720, expected_height) if viewport["width"] > 620 else expected_height
     assert state["contentWidth"] == pytest.approx(expected_width, abs=2)
     assert state["contentHeight"] == pytest.approx(expected_height, abs=2)
     assert state["usesDialogSemantics"] is True
@@ -1105,86 +1103,86 @@ def test_master_profile_dialog_traps_tab_focus_without_interfering_with_common_m
 ):
     _open_character_card_manager(mock_page, running_server)
 
-    state = mock_page.evaluate(
+    initial_state = mock_page.evaluate(
         """
-        async () => {
-            const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        () => {
             renderMasterForm({ '档案名': 'Master', '昵称': 'Yuki' });
 
             const trigger = document.getElementById('master-profile-header');
             const content = document.getElementById('master-profile-content');
-            trigger.click();
-            await wait(40);
-
-            const focusableElements = Array.from(content.querySelectorAll([
-                'a[href]',
-                'button:not([disabled])',
-                'input:not([disabled]):not([type="hidden"])',
-                'select:not([disabled])',
-                'textarea:not([disabled])',
-                '[contenteditable="true"]',
-                '[tabindex]:not([tabindex="-1"])'
-            ].join(','))).filter(element => (
-                !element.hidden
-                && element.getAttribute('aria-hidden') !== 'true'
-                && element.getClientRects().length > 0
-            ));
-            const firstFocusable = focusableElements[0];
-            const lastFocusable = focusableElements[focusableElements.length - 1];
-            const initiallyFocused = document.activeElement === firstFocusable;
-
-            lastFocusable.focus();
-            const forwardTab = new KeyboardEvent('keydown', {
-                key: 'Tab', bubbles: true, cancelable: true
-            });
-            lastFocusable.dispatchEvent(forwardTab);
-            const forwardTabWrapped = forwardTab.defaultPrevented
-                && document.activeElement === firstFocusable;
-
-            firstFocusable.focus();
-            const backwardTab = new KeyboardEvent('keydown', {
-                key: 'Tab', shiftKey: true, bubbles: true, cancelable: true
-            });
-            firstFocusable.dispatchEvent(backwardTab);
-            const backwardTabWrapped = backwardTab.defaultPrevented
-                && document.activeElement === lastFocusable;
-
-            const commonOverlay = document.createElement('div');
-            commonOverlay.className = 'modal-overlay';
-            document.body.appendChild(commonOverlay);
             trigger.focus();
-            const nestedModalTab = new KeyboardEvent('keydown', {
-                key: 'Tab', bubbles: true, cancelable: true
-            });
-            trigger.dispatchEvent(nestedModalTab);
-            const commonModalSkipped = !nestedModalTab.defaultPrevented
-                && document.activeElement === trigger;
-            commonOverlay.remove();
-
-            content.querySelector('.master-profile-dialog-close').click();
-            const closedDialogTab = new KeyboardEvent('keydown', {
-                key: 'Tab', bubbles: true, cancelable: true
-            });
-            trigger.dispatchEvent(closedDialogTab);
-
+            trigger.click();
+            window.__masterProfileTestFocusables = () => Array.from(content.querySelectorAll([
+                    'a[href]',
+                    'button:not([disabled])',
+                    'input:not([disabled]):not([type="hidden"])',
+                    'select:not([disabled])',
+                    'textarea:not([disabled])',
+                    '[contenteditable="true"]',
+                    '[tabindex]:not([tabindex="-1"])'
+                ].join(','))).filter(element => (
+                    !element.hidden
+                    && element.getAttribute('aria-hidden') !== 'true'
+                    && element.getClientRects().length > 0
+                ));
             return {
-                initiallyFocused,
-                forwardTabWrapped,
-                backwardTabWrapped,
-                commonModalSkipped,
-                focusTrapRemovedAfterClose: !closedDialogTab.defaultPrevented,
+                contentOpen: content.classList.contains('open'),
+                focusableCount: window.__masterProfileTestFocusables().length,
             };
         }
         """
     )
+    mock_page.wait_for_timeout(40)
 
-    assert state == {
-        "initiallyFocused": True,
-        "forwardTabWrapped": True,
-        "backwardTabWrapped": True,
-        "commonModalSkipped": True,
-        "focusTrapRemovedAfterClose": True,
-    }
+    assert initial_state["contentOpen"] is True
+    assert initial_state["focusableCount"] > 1
+    assert mock_page.evaluate(
+        "() => document.activeElement === window.__masterProfileTestFocusables()[0]"
+    )
+
+    mock_page.evaluate("() => window.__masterProfileTestFocusables().at(-1).focus()")
+    mock_page.keyboard.press("Tab")
+    assert mock_page.evaluate(
+        "() => document.activeElement === window.__masterProfileTestFocusables()[0]"
+    )
+
+    mock_page.keyboard.press("Shift+Tab")
+    assert mock_page.evaluate(
+        "() => document.activeElement === window.__masterProfileTestFocusables().at(-1)"
+    )
+
+    mock_page.locator("#master-profile-add-actions .btn.add").click()
+    common_overlay = mock_page.locator(".modal-overlay")
+    common_overlay.wait_for(state="visible")
+    mock_page.wait_for_timeout(120)
+    assert mock_page.evaluate(
+        "() => Boolean(document.activeElement?.closest('.modal-overlay'))"
+    )
+
+    mock_page.keyboard.press("Tab")
+    assert mock_page.evaluate(
+        """
+        () => Boolean(document.activeElement?.closest('.modal-overlay'))
+            && !document.activeElement?.closest('#master-profile-content')
+        """
+    )
+
+    common_overlay.locator(".modal-btn-secondary").click()
+    common_overlay.wait_for(state="detached")
+    mock_page.locator(".master-profile-dialog-close").click()
+    assert mock_page.evaluate(
+        "() => document.activeElement === document.getElementById('master-profile-header')"
+    )
+
+    mock_page.keyboard.press("Tab")
+    assert mock_page.evaluate(
+        """
+        () => document.activeElement !== document.getElementById('master-profile-header')
+            && !document.activeElement?.closest('#master-profile-content')
+        """
+    )
+
+    mock_page.evaluate("() => { delete window.__masterProfileTestFocusables; }")
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -911,9 +911,10 @@ def test_character_card_manager_localizes_master_profile_builtin_field_labels(
     "viewport",
     [
         {"width": 1440, "height": 900},
-        {"width": 800, "height": 900},
+        {"width": 700, "height": 900},
+        {"width": 560, "height": 900},
     ],
-    ids=["desktop-dialog", "narrow-dialog"],
+    ids=["desktop-dialog", "single-column-dialog", "mobile-dialog"],
 )
 def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
     mock_page: Page,
@@ -998,6 +999,7 @@ def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
                 position: getComputedStyle(content).position,
                 display: getComputedStyle(content).display,
                 contentWidth: contentRect.width,
+                contentHeight: contentRect.height,
                 usesDialogSemantics: trigger.getAttribute('aria-haspopup') === 'dialog'
                     && !trigger.hasAttribute('aria-expanded'),
                 hasNoDecorativeProfileIcon: !trigger.querySelector('svg')
@@ -1070,7 +1072,12 @@ def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
 
     assert state["position"] == "fixed"
     assert state["display"] == "flex"
-    assert state["contentWidth"] >= 700
+    expected_width = viewport["width"] - (20 if viewport["width"] <= 620 else 48)
+    expected_width = min(920, expected_width)
+    expected_height = viewport["height"] - (20 if viewport["width"] <= 620 else 80)
+    expected_height = min(720, expected_height) if viewport["width"] > 620 else expected_height
+    assert state["contentWidth"] == pytest.approx(expected_width, abs=2)
+    assert state["contentHeight"] == pytest.approx(expected_height, abs=2)
     assert state["usesDialogSemantics"] is True
     assert state["hasNoDecorativeProfileIcon"] is True
     assert state["usesSharedSettingsLayout"] is True
@@ -1089,6 +1096,95 @@ def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
     assert state["lastRowReachable"] is True
     assert state["hiddenAfterClose"] is True
     assert state["backdropHiddenAfterClose"] is True
+
+
+@pytest.mark.frontend
+def test_master_profile_dialog_traps_tab_focus_without_interfering_with_common_modal(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            renderMasterForm({ '档案名': 'Master', '昵称': 'Yuki' });
+
+            const trigger = document.getElementById('master-profile-header');
+            const content = document.getElementById('master-profile-content');
+            trigger.click();
+            await wait(40);
+
+            const focusableElements = Array.from(content.querySelectorAll([
+                'a[href]',
+                'button:not([disabled])',
+                'input:not([disabled]):not([type="hidden"])',
+                'select:not([disabled])',
+                'textarea:not([disabled])',
+                '[contenteditable="true"]',
+                '[tabindex]:not([tabindex="-1"])'
+            ].join(','))).filter(element => (
+                !element.hidden
+                && element.getAttribute('aria-hidden') !== 'true'
+                && element.getClientRects().length > 0
+            ));
+            const firstFocusable = focusableElements[0];
+            const lastFocusable = focusableElements[focusableElements.length - 1];
+            const initiallyFocused = document.activeElement === firstFocusable;
+
+            lastFocusable.focus();
+            const forwardTab = new KeyboardEvent('keydown', {
+                key: 'Tab', bubbles: true, cancelable: true
+            });
+            lastFocusable.dispatchEvent(forwardTab);
+            const forwardTabWrapped = forwardTab.defaultPrevented
+                && document.activeElement === firstFocusable;
+
+            firstFocusable.focus();
+            const backwardTab = new KeyboardEvent('keydown', {
+                key: 'Tab', shiftKey: true, bubbles: true, cancelable: true
+            });
+            firstFocusable.dispatchEvent(backwardTab);
+            const backwardTabWrapped = backwardTab.defaultPrevented
+                && document.activeElement === lastFocusable;
+
+            const commonOverlay = document.createElement('div');
+            commonOverlay.className = 'modal-overlay';
+            document.body.appendChild(commonOverlay);
+            trigger.focus();
+            const nestedModalTab = new KeyboardEvent('keydown', {
+                key: 'Tab', bubbles: true, cancelable: true
+            });
+            trigger.dispatchEvent(nestedModalTab);
+            const commonModalSkipped = !nestedModalTab.defaultPrevented
+                && document.activeElement === trigger;
+            commonOverlay.remove();
+
+            content.querySelector('.master-profile-dialog-close').click();
+            const closedDialogTab = new KeyboardEvent('keydown', {
+                key: 'Tab', bubbles: true, cancelable: true
+            });
+            trigger.dispatchEvent(closedDialogTab);
+
+            return {
+                initiallyFocused,
+                forwardTabWrapped,
+                backwardTabWrapped,
+                commonModalSkipped,
+                focusTrapRemovedAfterClose: !closedDialogTab.defaultPrevented,
+            };
+        }
+        """
+    )
+
+    assert state == {
+        "initiallyFocused": True,
+        "forwardTabWrapped": True,
+        "backwardTabWrapped": True,
+        "commonModalSkipped": True,
+        "focusTrapRemovedAfterClose": True,
+    }
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -907,6 +907,248 @@ def test_character_card_manager_localizes_master_profile_builtin_field_labels(
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize(
+    "viewport",
+    [
+        {"width": 1440, "height": 900},
+        {"width": 800, "height": 900},
+    ],
+    ids=["desktop-dialog", "narrow-dialog"],
+)
+def test_master_profile_opens_as_stable_dialog_without_reflowing_layout(
+    mock_page: Page,
+    running_server: str,
+    viewport: dict[str, int],
+):
+    mock_page.set_viewport_size(viewport)
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const master = { '档案名': 'Master Profile' };
+            for (let index = 1; index <= 14; index += 1) {
+                master['需要完整显示的设定名称 ' + index] = '第 ' + index + ' 项完整内容';
+            }
+            renderMasterForm(master);
+
+            const sidebar = document.getElementById('sidebar');
+            const main = document.querySelector('.main-content');
+            const cover = document.querySelector('.character-card-cover-section');
+            const snapshotRect = (element) => {
+                const rect = element.getBoundingClientRect();
+                return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+            };
+            const before = {
+                sidebar: snapshotRect(sidebar),
+                main: snapshotRect(main),
+                cover: snapshotRect(cover),
+            };
+
+            const trigger = document.getElementById('master-profile-header');
+            trigger.click();
+            const afterClick = {
+                sidebar: snapshotRect(sidebar),
+                main: snapshotRect(main),
+                cover: snapshotRect(cover),
+            };
+            await wait(100);
+            const duringAnimation = {
+                sidebar: snapshotRect(sidebar),
+                main: snapshotRect(main),
+                cover: snapshotRect(cover),
+            };
+            await wait(200);
+
+            const content = document.getElementById('master-profile-content');
+            const backdrop = document.getElementById('master-profile-backdrop');
+            const dialogBody = content.querySelector('.master-profile-dialog-body');
+            const dialogFooter = content.querySelector('.master-profile-dialog-footer');
+            const addButton = dialogFooter.querySelector('.settings-primary-action');
+            const addButtonBeforeScroll = snapshotRect(addButton);
+            const rows = Array.from(content.querySelectorAll('.field-row-wrapper'));
+            const customRows = Array.from(content.querySelectorAll('.field-row-wrapper.custom-row'));
+            const labels = Array.from(content.querySelectorAll('.field-row-wrapper label'));
+            const contentRect = content.getBoundingClientRect();
+            const bodyRect = dialogBody.getBoundingClientRect();
+            const after = {
+                sidebar: snapshotRect(sidebar),
+                main: snapshotRect(main),
+                cover: snapshotRect(cover),
+            };
+            const rectStable = (first, second) => (
+                Math.abs(first.left - second.left) < 1
+                && Math.abs(first.top - second.top) < 1
+                && Math.abs(first.width - second.width) < 1
+                && Math.abs(first.height - second.height) < 1
+            );
+
+            const hasInternalScroll = dialogBody.scrollHeight > dialogBody.clientHeight + 1;
+            dialogBody.scrollTop = dialogBody.scrollHeight;
+            await wait(0);
+            const lastRowRect = rows.at(-1).getBoundingClientRect();
+            const addButtonAfterScroll = snapshotRect(addButton);
+            const transitionProperties = getComputedStyle(content).transitionProperty
+                .split(',')
+                .map(value => value.trim())
+                .sort();
+
+            const openState = {
+                position: getComputedStyle(content).position,
+                display: getComputedStyle(content).display,
+                contentWidth: contentRect.width,
+                usesDialogSemantics: trigger.getAttribute('aria-haspopup') === 'dialog'
+                    && !trigger.hasAttribute('aria-expanded'),
+                hasNoDecorativeProfileIcon: !trigger.querySelector('svg')
+                    && !content.querySelector('.master-profile-dialog-header svg'),
+                usesSharedSettingsLayout: dialogBody.classList.contains('settings-form-layout')
+                    && dialogBody.classList.contains('panel-tab-settings')
+                    && dialogFooter.classList.contains('settings-form-layout')
+                    && dialogFooter.classList.contains('panel-tab-settings'),
+                addActionAlwaysVisible: dialogFooter.contains(addButton)
+                    && !dialogBody.contains(addButton)
+                    && rectStable(addButtonBeforeScroll, addButtonAfterScroll)
+                    && addButtonAfterScroll.top >= contentRect.top
+                    && addButtonAfterScroll.top + addButtonAfterScroll.height <= contentRect.bottom,
+                usesCharacterSettingRows: customRows.length === 14 && customRows.every(row => {
+                    const textarea = row.querySelector('textarea');
+                    const deleteButton = row.querySelector('.setting-field-delete');
+                    const deleteStyle = deleteButton && getComputedStyle(deleteButton);
+                    const deleteGlyph = deleteButton && getComputedStyle(deleteButton, '::before');
+                    return row.classList.contains('setting-field-row')
+                        && textarea?.dataset.autoResizeAttached === 'true'
+                        && deleteButton?.getAttribute('aria-label')
+                        && Math.abs(Number.parseFloat(deleteStyle.width) - 36) < 1
+                        && deleteGlyph.content !== 'none';
+                }),
+                usesCharacterSettingActions: Boolean(
+                    content.querySelector('.profile-row .rename-action .edit-icon')
+                    && content.querySelector('.settings-toolbar-row .settings-primary-action .add-icon')
+                    && content.querySelector('.settings-action-row .settings-save-action .save-icon')
+                    && content.querySelector('.settings-action-row .settings-cancel-action .cancel-icon')
+                ),
+                backdropVisible: getComputedStyle(backdrop).display === 'block'
+                    && Number.parseFloat(getComputedStyle(backdrop).opacity) > 0.99,
+                dialogInsideViewport: contentRect.left >= 0
+                    && contentRect.top >= 0
+                    && contentRect.right <= window.innerWidth
+                    && contentRect.bottom <= window.innerHeight,
+                sidebarStable: rectStable(before.sidebar, after.sidebar),
+                mainStable: rectStable(before.main, after.main),
+                decorationStable: rectStable(before.cover, after.cover),
+                stableThroughoutAnimation: [afterClick, duringAnimation, after].every(snapshot => (
+                    rectStable(before.sidebar, snapshot.sidebar)
+                    && rectStable(before.main, snapshot.main)
+                    && rectStable(before.cover, snapshot.cover)
+                )),
+                transformOnlyAnimation: transitionProperties.length === 2
+                    && transitionProperties.includes('opacity')
+                    && transitionProperties.includes('transform'),
+                labelsUnclipped: labels.every(label => {
+                    const style = getComputedStyle(label);
+                    return style.whiteSpace === 'normal'
+                        && style.overflow !== 'hidden'
+                        && label.scrollWidth <= label.clientWidth + 1;
+                }),
+                hasInternalScroll,
+                lastRowReachable: lastRowRect.top >= bodyRect.top - 1
+                    && lastRowRect.bottom <= bodyRect.bottom + 1,
+            };
+
+            content.querySelector('.master-profile-dialog-close').click();
+            await wait(340);
+
+            return {
+                ...openState,
+                hiddenAfterClose: getComputedStyle(content).display === 'none',
+                backdropHiddenAfterClose: getComputedStyle(backdrop).display === 'none',
+            };
+        }
+        """
+    )
+
+    assert state["position"] == "fixed"
+    assert state["display"] == "flex"
+    assert state["contentWidth"] >= 700
+    assert state["usesDialogSemantics"] is True
+    assert state["hasNoDecorativeProfileIcon"] is True
+    assert state["usesSharedSettingsLayout"] is True
+    assert state["addActionAlwaysVisible"] is True
+    assert state["usesCharacterSettingRows"] is True
+    assert state["usesCharacterSettingActions"] is True
+    assert state["backdropVisible"] is True
+    assert state["dialogInsideViewport"] is True
+    assert state["sidebarStable"] is True
+    assert state["mainStable"] is True
+    assert state["decorationStable"] is True
+    assert state["stableThroughoutAnimation"] is True
+    assert state["transformOnlyAnimation"] is True
+    assert state["labelsUnclipped"] is True
+    assert state["hasInternalScroll"] is True
+    assert state["lastRowReachable"] is True
+    assert state["hiddenAfterClose"] is True
+    assert state["backdropHiddenAfterClose"] is True
+
+
+@pytest.mark.frontend
+def test_master_add_field_prompt_keeps_fade_out_final_frame_until_removal(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const originalSetTimeout = window.setTimeout;
+            const nativeSetTimeout = originalSetTimeout.bind(window);
+            const wait = (ms) => new Promise(resolve => nativeSetTimeout(resolve, ms));
+
+            renderMasterForm({ '档案名': 'Master' });
+            document.querySelector('#master-profile-add-actions .btn.add').click();
+            const overlay = document.querySelector('.modal-overlay');
+            overlay.querySelector('.modal-input').value = 'Stable Field';
+
+            let delayedRemoval = false;
+            window.setTimeout = (callback, delay, ...args) => {
+                if (!delayedRemoval && delay === 200) {
+                    delayedRemoval = true;
+                    return nativeSetTimeout(callback, 350, ...args);
+                }
+                return nativeSetTimeout(callback, delay, ...args);
+            };
+
+            overlay.querySelector('.modal-btn-primary').click();
+            await wait(230);
+            const opacityAfterFadeOut = getComputedStyle(overlay).opacity;
+            const connectedAfterFadeOut = overlay.isConnected;
+            const closingFillMode = getComputedStyle(overlay).animationFillMode;
+
+            window.setTimeout = originalSetTimeout;
+            await wait(150);
+
+            return {
+                opacityAfterFadeOut,
+                connectedAfterFadeOut,
+                closingFillMode,
+                removedAfterCleanup: !overlay.isConnected,
+                fieldCount: document.querySelectorAll('#master-form textarea[name="Stable Field"]').length,
+            };
+        }
+        """
+    )
+
+    assert state == {
+        "opacityAfterFadeOut": "0",
+        "connectedAfterFadeOut": True,
+        "closingFillMode": "forwards",
+        "removedAfterCleanup": True,
+        "fieldCount": 1,
+    }
+
+
+@pytest.mark.frontend
 def test_character_card_manager_saved_new_field_survives_immediate_reopen_with_stale_reload(
     mock_page: Page,
     running_server: str,


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化“我的档案”为大弹窗，统一角色卡设定页表单样式，固定新增设定按钮，并修复新增字段弹窗闪烁问题

## 测试 / Testing

手动查看UI可用

## 对比

之前：
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/9ccb7f5d-8412-4dd4-8e4f-ab093e69805e" />

之后：
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/57413a65-83b4-4ccb-b59b-2d05833acf05" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * “我的档案”现以全屏居中对话框打开，支持滚动内容区、固定底部操作栏及小屏设备适配。
  * 统一新增字段、编辑和删除操作的控件、图标与提示样式。
  * 深色模式下的档案设置界面显示更加协调。
* **问题修复**
  * 优化对话框打开与关闭体验，减少页面布局跳动。
  * 修复关闭动画期间遮罩闪烁及淡出不完整的问题。
  * 支持使用 Escape 键关闭对话框，并改善焦点管理与页面滚动控制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->