### PR TITLE
fix(tests): 修 main 当前的红——图钉静态契约用过时的 class token 定位最小化按钮

### DIFF
--- a/tests/unit/test_window_pin_static_contracts.py
+++ b/tests/unit/test_window_pin_static_contracts.py
@@ -93,7 +93,12 @@ def test_only_requested_top_level_templates_define_pin_controls():
     assert_pin_precedes_minimize(
         character_manager,
         "templates/character_card_manager.html",
-        'class="minimize-btn"',
+        # Anchor on the id, not on ``class="minimize-btn"``: #2750 unified the
+        # window-control styling by prepending ``neko-window-control-btn`` to the
+        # class list, so a token that assumed minimize-btn was the FIRST class
+        # stopped matching and ``str.index`` raised instead of asserting. The id
+        # survives restyling (same reason the openclaw_guide case below uses one).
+        'id="minimizeBtn"',
     )
 
     openclaw_guide = read_text("templates/openclaw_guide.html")


### PR DESCRIPTION
## 现象

main 当前的 `Unit pytest (Windows)` 是红的：

```
FAILED tests/unit/test_window_pin_static_contracts.py::test_only_requested_top_level_templates_define_pin_controls
  - ValueError: substring not found
```

在干净的 `origin/main`（`718d295bc`）上可稳定复现，与任何在途 PR 无关。因为 PR 的 CI 测的是 merge commit，这条红会传染给所有开着的 PR。

## 根因

`assert_pin_precedes_minimize` 用 `str.index` 定位两个按钮。`character_card_manager.html` 这一处传的 minimize token 是字面量 `class="minimize-btn"`：

```python
assert_pin_precedes_minimize(
    character_manager,
    "templates/character_card_manager.html",
    'class="minimize-btn"',
)
```

#2750（统一媒体凭证窗口控制样式）把该按钮的 class 列表改成了 `class="neko-window-control-btn minimize-btn"`。token 隐含假设 `minimize-btn` 是**第一个** class，于是不再匹配，`str.index` 抛 `ValueError` 而不是走到断言。

## 改了什么

模板本身是对的——#2750 的统一是有意的改动。过时的是测试锚点。改成锚 `id="minimizeBtn"`：它不随重新配色 / 加 class 而变，而且同一个函数里 `openclaw_guide` 那条本来就是用 id 锚的（`id="minimizeGuideBtn"`），这样两处口径也一致了。

只动测试，不动模板。

## 验证

- `origin/main` 上先复现红：`1 failed, 21 passed`
- 改后：`22 passed`
- 变异验证（确认断言没被改弱）：把 pin 按钮整块挪到 minimize 之后，该用例仍然转红

🤖 Generated with [Claude Code](https://claude.com/claude-code)
