### PR TITLE
style: Polish jukebox controls and cache handling

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -511,7 +511,10 @@ async def get_jukebox_page(request: Request):
 async def get_jukebox_manager_page(request: Request):
     """Standalone jukebox manager window page (opened from the jukebox)."""
     templates = get_templates()
-    return templates.TemplateResponse("templates/jukebox_manager.html", {"request": request})
+    return templates.TemplateResponse("templates/jukebox_manager.html", {
+        "request": request,
+        **_static_assets_ctx(),
+    })
 
 
 @router.get("/toast", response_class=HTMLResponse)

--- a/static/jukebox/jukebox/manager.js
+++ b/static/jukebox/jukebox/manager.js
@@ -558,13 +558,21 @@ Object.assign(window.Jukebox, {
                 const idJs = Jukebox.escapeJsAttr(id);
                 return `
                 <div class="sam-item ${song.visible === false ? 'sam-item-hidden' : ''} ${this.selectedSongs?.has(id) ? 'sam-item-selected' : ''}" data-id="${idAttr}" draggable="true">
-                  <div class="sam-item-header">
-                    <label class="sam-checkbox sam-item-checkbox">
-                      <input type="checkbox" class="sam-song-select" data-id="${idAttr}" ${this.selectedSongs?.has(id) ? 'checked' : ''} onchange="Jukebox.SongActionManager.toggleSongSelect('${idJs}', this.checked)">
-                    </label>
-                    <span class="sam-item-name" contenteditable="true" data-neko-marquee data-tooltip="${Jukebox.escapeAttr(song.name)}"
-                          onblur="Jukebox.SongActionManager.updateSongName('${idJs}', this.innerText)"
-                          onkeydown="if(event.key==='Enter'){this.blur();event.preventDefault();}">${Jukebox.escapeHtml(song.name)}</span>
+                  <div class="sam-item-main">
+                    <div class="sam-item-info">
+                      <div class="sam-item-header">
+                        <label class="sam-checkbox sam-item-checkbox">
+                          <input type="checkbox" class="sam-song-select" data-id="${idAttr}" ${this.selectedSongs?.has(id) ? 'checked' : ''} onchange="Jukebox.SongActionManager.toggleSongSelect('${idJs}', this.checked)">
+                        </label>
+                        <span class="sam-item-name" contenteditable="true" data-neko-marquee data-tooltip="${Jukebox.escapeAttr(song.name)}"
+                              onblur="Jukebox.SongActionManager.updateSongName('${idJs}', this.innerText)"
+                              onkeydown="if(event.key==='Enter'){this.blur();event.preventDefault();}">${Jukebox.escapeHtml(song.name)}</span>
+                      </div>
+                      <div class="sam-item-artist" contenteditable="true" data-neko-marquee data-tooltip="${Jukebox.escapeAttr(song.artist || window.t('Jukebox.unknown', '未知'))}"
+                           onblur="Jukebox.SongActionManager.updateSongArtist('${idJs}', this.innerText)"
+                           onkeydown="if(event.key==='Enter'){this.blur();event.preventDefault();}">${Jukebox.escapeHtml(song.artist || window.t('Jukebox.unknown', '未知'))}
+                      </div>
+                    </div>
                     <div class="sam-item-actions">
                       <button class="sam-visibility-btn ${song.visible === false ? 'hidden' : ''}"
                               onclick="Jukebox.SongActionManager.toggleSongVisibility('${idJs}')"
@@ -574,12 +582,8 @@ Object.assign(window.Jukebox, {
                           ? '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/><line x1="3" y1="3" x2="21" y2="21" stroke="currentColor" stroke-width="2"/></svg>'
                           : '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>'}
                       </button>
-                      <button class="sam-delete-btn" onclick="Jukebox.SongActionManager.confirmDeleteSong('${idJs}')" data-tooltip="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}" aria-label="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}">🗑</button>
+                      <button class="sam-delete-btn" onclick="Jukebox.SongActionManager.confirmDeleteSong('${idJs}')" data-tooltip="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}" aria-label="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}"><svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M4 7h16M10 11v6M14 11v6M9 7V4h6v3m-9 0 1 13h10l1-13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
                     </div>
-                  </div>
-                  <div class="sam-item-artist" contenteditable="true" data-neko-marquee data-tooltip="${Jukebox.escapeAttr(song.artist || window.t('Jukebox.unknown', '未知'))}"
-                       onblur="Jukebox.SongActionManager.updateSongArtist('${idJs}', this.innerText)"
-                       onkeydown="if(event.key==='Enter'){this.blur();event.preventDefault();}">${Jukebox.escapeHtml(song.artist || window.t('Jukebox.unknown', '未知'))}
                   </div>
                   <div class="sam-item-bindings">
                     ${this.getSongBindings(id).filter(actionId => this.shouldShowAction(this.data.actions[actionId])).map(actionId => {
@@ -637,14 +641,18 @@ Object.assign(window.Jukebox, {
                 const formatColor = this.getFormatColor(format);
                 return `
                 <div class="sam-item ${action.visible === false ? 'sam-item-hidden' : ''} ${this.selectedActions?.has(id) ? 'sam-item-selected' : ''}" data-id="${idAttr}" draggable="true">
-                  <div class="sam-item-header">
-                    <label class="sam-checkbox sam-item-checkbox">
-                      <input type="checkbox" class="sam-action-select" data-id="${idAttr}" ${this.selectedActions?.has(id) ? 'checked' : ''} onchange="Jukebox.SongActionManager.toggleActionSelect('${idJs}', this.checked)">
-                    </label>
-                    <span class="sam-format-dot" style="background-color: ${formatColor};"></span>
-                    <span class="sam-item-name" contenteditable="true" data-neko-marquee data-tooltip="${Jukebox.escapeAttr(action.name)}"
-                          onblur="Jukebox.SongActionManager.updateActionName('${idJs}', this.innerText)"
-                          onkeydown="if(event.key==='Enter'){this.blur();event.preventDefault();}">${Jukebox.escapeHtml(action.name)}</span>
+                  <div class="sam-item-main">
+                    <div class="sam-item-info">
+                      <div class="sam-item-header">
+                        <label class="sam-checkbox sam-item-checkbox">
+                          <input type="checkbox" class="sam-action-select" data-id="${idAttr}" ${this.selectedActions?.has(id) ? 'checked' : ''} onchange="Jukebox.SongActionManager.toggleActionSelect('${idJs}', this.checked)">
+                        </label>
+                        <span class="sam-format-dot" style="background-color: ${formatColor};"></span>
+                        <span class="sam-item-name" contenteditable="true" data-neko-marquee data-tooltip="${Jukebox.escapeAttr(action.name)}"
+                              onblur="Jukebox.SongActionManager.updateActionName('${idJs}', this.innerText)"
+                              onkeydown="if(event.key==='Enter'){this.blur();event.preventDefault();}">${Jukebox.escapeHtml(action.name)}</span>
+                      </div>
+                    </div>
                     <div class="sam-item-actions">
                       ${action.missing ? `<span class="sam-missing-badge">${window.t('Jukebox.missing', '缺失')}</span>` : ''}
                       <button class="sam-visibility-btn ${action.visible === false ? 'hidden' : ''}"
@@ -655,7 +663,7 @@ Object.assign(window.Jukebox, {
                           ? '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/><line x1="3" y1="3" x2="21" y2="21" stroke="currentColor" stroke-width="2"/></svg>'
                           : '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>'}
                       </button>
-                      <button class="sam-delete-btn" onclick="Jukebox.SongActionManager.confirmDeleteAction('${idJs}')" data-tooltip="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}" aria-label="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}">🗑</button>
+                      <button class="sam-delete-btn" onclick="Jukebox.SongActionManager.confirmDeleteAction('${idJs}')" data-tooltip="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}" aria-label="${Jukebox.escapeAttr(window.t('Jukebox.delete', '删除'))}"><svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M4 7h16M10 11v6M14 11v6M9 7V4h6v3m-9 0 1 13h10l1-13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
                     </div>
                   </div>
                   <div class="sam-item-bindings">
@@ -3230,6 +3238,10 @@ Object.assign(window.Jukebox, {
           border: ${C.item.border};
           border-radius: 10px;
           box-shadow: ${C.item.shadow};
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) auto;
+          column-gap: 12px;
+          align-items: stretch;
           cursor: default;
           transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
         }
@@ -3270,6 +3282,8 @@ Object.assign(window.Jukebox, {
         }
 
         .sam-item-bindings {
+          grid-column: 1;
+          margin-top: 8px;
           display: flex;
           flex-wrap: wrap;
           gap: 4px;
@@ -3973,9 +3987,22 @@ Object.assign(window.Jukebox, {
         .sam-item-header {
           display: flex;
           align-items: center;
-          justify-content: space-between;
+          justify-content: flex-start;
           gap: 8px;
           min-width: 0;
+        }
+
+        .sam-item-main {
+          display: contents;
+        }
+
+        .sam-item-info {
+          grid-column: 1;
+          flex: 1 1 auto;
+          min-width: 0;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
         }
 
         .sam-item-name {
@@ -4025,15 +4052,23 @@ Object.assign(window.Jukebox, {
         }
 
         .sam-item-actions {
+          grid-column: 2;
+          grid-row: 1 / span 2;
+          align-self: stretch;
           display: flex;
           align-items: center;
-          gap: 4px;
+          flex-direction: column;
+          justify-content: center;
+          gap: 6px;
           flex-shrink: 0;
+          padding-left: 10px;
+          border-left: 1px solid ${C.borders.divider};
         }
 
         .sam-visibility-btn {
-          width: 24px;
-          height: 24px;
+          width: 30px;
+          height: 30px;
+          padding: 0;
           border: 1px solid rgba(99, 199, 232, 0.28);
           background: linear-gradient(160deg, rgba(255,255,255,0.88), rgba(232,247,255,0.72));
           cursor: pointer;
@@ -4044,6 +4079,13 @@ Object.assign(window.Jukebox, {
           align-items: center;
           justify-content: center;
           color: ${C.buttons.visibility.color};
+        }
+
+        .sam-visibility-btn svg,
+        .sam-delete-btn svg {
+          display: block;
+          width: 18px;
+          height: 18px;
         }
 
         .sam-visibility-btn:hover {
@@ -4059,15 +4101,21 @@ Object.assign(window.Jukebox, {
         }
 
         .sam-delete-btn {
-          width: 24px;
-          height: 24px;
+          width: 30px;
+          height: 30px;
+          padding: 0;
           border: 1px solid rgba(217,75,97,0.24);
           background: linear-gradient(160deg, rgba(255,255,255,0.88), rgba(255,239,244,0.72));
           cursor: pointer;
           font-size: 14px;
           border-radius: 999px;
+          box-sizing: border-box;
           transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
           color: ${C.buttons.delete.color};
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          line-height: 1;
         }
 
         .sam-delete-btn:hover {

--- a/static/jukebox/jukebox/manager.js
+++ b/static/jukebox/jukebox/manager.js
@@ -6,7 +6,7 @@ Object.assign(window.Jukebox, {
     Config: {
       // 面板
       panel: {
-        background: 'linear-gradient(160deg, rgba(255,255,255,.92), rgba(232,247,255,.86))',
+        background: 'rgba(248, 250, 252, 0.96)',
         color: 'rgba(28, 48, 68, 0.94)',
         border: '1px solid rgba(120, 203, 232, 0.45)',
         shadow: '0 18px 48px rgba(78, 153, 190, 0.28), 0 4px 18px rgba(255, 159, 189, 0.16)'
@@ -16,8 +16,8 @@ Object.assign(window.Jukebox, {
         borderBottom: 'rgba(116, 190, 224, 0.28)',
         tabColor: 'rgba(54, 92, 118, 0.76)',
         tabHoverBg: 'rgba(99, 199, 232, 0.14)',
-        tabActiveBg: 'linear-gradient(135deg, rgba(99,199,232,.92), rgba(255,159,189,.82))',
-        tabActiveShadow: '0 6px 16px rgba(99, 199, 232, 0.25)'
+        tabActiveBg: '#238bb5',
+        tabActiveShadow: '0 4px 10px rgba(35, 139, 181, 0.2)'
       },
       // 列表项
       item: {
@@ -3602,7 +3602,7 @@ Object.assign(window.Jukebox, {
         .sam-add-binding-btn:hover {
           border-color: rgba(255, 159, 189, 0.5);
           color: rgba(28, 48, 68, 0.94);
-          background: linear-gradient(135deg, rgba(99,199,232,0.24), rgba(255,159,189,0.2));
+          background: rgba(99, 199, 232, 0.2);
           transform: translateY(-1px);
           box-shadow: 0 5px 12px rgba(99, 199, 232, 0.18);
         }

--- a/static/jukebox/jukebox/shell.js
+++ b/static/jukebox/jukebox/shell.js
@@ -1393,7 +1393,7 @@ Object.assign(window.Jukebox, {
       }
 
       .jukebox-pin.is-pinned {
-        background: linear-gradient(145deg, rgba(99,199,232,0.34), rgba(255,255,255,0.58));
+        background: rgba(99, 199, 232, 0.28);
         border-color: rgba(73,181,220,0.38);
         color: rgba(28, 48, 68, 0.96);
         box-shadow:
@@ -1409,7 +1409,7 @@ Object.assign(window.Jukebox, {
       }
 
       .jukebox-pin.is-pinned:hover {
-        background: linear-gradient(145deg, rgba(99,199,232,0.44), rgba(255,255,255,0.68));
+        background: rgba(99, 199, 232, 0.38);
         border-color: rgba(73,181,220,0.48);
         box-shadow:
           inset 0 0 0 1px rgba(255,255,255,0.62),
@@ -1545,7 +1545,7 @@ Object.assign(window.Jukebox, {
       .jukebox-sort-lock-btn:hover,
       .jukebox-sort-lock-btn.unlocked {
         color: rgba(28, 48, 68, 0.94);
-        background: linear-gradient(135deg, rgba(99,199,232,0.24), rgba(255,159,189,0.2));
+        background: rgba(99, 199, 232, 0.2);
         box-shadow: 0 5px 12px rgba(99, 199, 232, 0.18);
         transform: translateY(-1px);
       }
@@ -1711,19 +1711,19 @@ Object.assign(window.Jukebox, {
       }
 
       .play-btn.jukebox-mode-btn:hover {
-        background: linear-gradient(135deg, rgba(99,199,232,0.24), rgba(255,159,189,0.2));
+        background: rgba(99, 199, 232, 0.2);
         color: rgba(28,48,68,0.94);
       }
 
       .play-btn.jukebox-mode-btn.active {
-        background: linear-gradient(135deg, rgba(99,199,232,0.92), rgba(255,159,189,0.82));
+        background: #238bb5;
         border-color: rgba(99,199,232,0.42);
         color: white;
         box-shadow: 0 6px 14px rgba(99,199,232,0.22);
       }
 
       .play-btn.jukebox-mode-btn.active:hover {
-        background: linear-gradient(135deg, rgba(83,188,222,0.98), rgba(255,143,180,0.88));
+        background: #38a6d2;
       }
 
       .jukebox-controls-row {
@@ -1789,9 +1789,9 @@ Object.assign(window.Jukebox, {
         min-width: 0;
         -webkit-appearance: none;
         appearance: none;
-        height: 6px;
+        height: 3px;
         background: ${Jukebox.Config.progress.trackBg};
-        border-radius: 3px;
+        border-radius: 999px;
         outline: none;
         cursor: default;
         pointer-events: none;
@@ -1805,8 +1805,8 @@ Object.assign(window.Jukebox, {
       #jukebox-progress-slider::-webkit-slider-thumb {
         -webkit-appearance: none;
         appearance: none;
-        width: 14px;
-        height: 14px;
+        width: 8px;
+        height: 8px;
         background: ${Jukebox.Config.progress.sliderBg};
         border-radius: 50%;
         transition: background 0.3s;
@@ -1818,8 +1818,8 @@ Object.assign(window.Jukebox, {
       }
 
       #jukebox-progress-slider::-moz-range-thumb {
-        width: 14px;
-        height: 14px;
+        width: 8px;
+        height: 8px;
         background: ${Jukebox.Config.progress.sliderBg};
         border-radius: 50%;
         border: none;
@@ -2050,7 +2050,7 @@ Object.assign(window.Jukebox, {
       }
 
       [data-theme="dark"] .jukebox-container {
-        background: linear-gradient(160deg, rgba(18, 25, 36, 0.96), rgba(26, 38, 52, 0.94));
+        background: #151d29;
         color: #e6edf3;
         border-color: rgba(124, 218, 244, 0.24);
         box-shadow: 0 20px 54px rgba(2, 8, 23, 0.54), 0 4px 18px rgba(0, 0, 0, 0.28);
@@ -2082,7 +2082,7 @@ Object.assign(window.Jukebox, {
       [data-theme="dark"] .jukebox-speaker-btn,
       [data-theme="dark"] .play-btn.jukebox-mode-btn {
         color: #b7e8f8;
-        background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.82));
+        background: rgba(30, 41, 59, 0.9);
         border-color: rgba(124, 218, 244, 0.22);
         box-shadow: 0 4px 12px rgba(2, 8, 23, 0.26);
       }
@@ -2095,14 +2095,14 @@ Object.assign(window.Jukebox, {
       [data-theme="dark"] .jukebox-speaker-btn:hover,
       [data-theme="dark"] .play-btn.jukebox-mode-btn:hover {
         color: #f8fafc;
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.28), rgba(244, 114, 182, 0.18));
+        background: rgba(14, 165, 233, 0.2);
         border-color: rgba(124, 218, 244, 0.36);
         box-shadow: 0 6px 16px rgba(14, 165, 233, 0.16);
       }
 
       [data-theme="dark"] .jukebox-pin.is-pinned {
         color: #f8fafc;
-        background: linear-gradient(145deg, rgba(14,165,233,0.42), rgba(244,114,182,0.2));
+        background: rgba(14, 165, 233, 0.32);
         border-color: rgba(124,218,244,0.48);
         box-shadow:
           inset 0 0 0 1px rgba(186,230,253,0.16),
@@ -2110,7 +2110,7 @@ Object.assign(window.Jukebox, {
       }
 
       [data-theme="dark"] .jukebox-pin.is-pinned:hover {
-        background: linear-gradient(145deg, rgba(14,165,233,0.52), rgba(244,114,182,0.26));
+        background: rgba(14, 165, 233, 0.42);
         border-color: rgba(186,230,253,0.58);
       }
 
@@ -2132,13 +2132,13 @@ Object.assign(window.Jukebox, {
 
       [data-theme="dark"] .play-btn.jukebox-mode-btn.active {
         color: #ffffff;
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.88), rgba(244, 114, 182, 0.62));
+        background: #238bb5;
         border-color: rgba(125, 211, 252, 0.48);
         box-shadow: 0 8px 20px rgba(14, 165, 233, 0.24);
       }
 
       [data-theme="dark"] .play-btn.jukebox-mode-btn.active:hover {
-        background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(251, 113, 133, 0.68));
+        background: #38a6d2;
       }
 
       [data-theme="dark"] .speaker-icon,
@@ -2153,7 +2153,7 @@ Object.assign(window.Jukebox, {
       }
 
       [data-theme="dark"] .jukebox-table thead {
-        background: rgba(30, 41, 59, 0.66);
+        background: #202c3e;
       }
 
       [data-theme="dark"] .jukebox-table th {
@@ -2320,7 +2320,7 @@ Object.assign(window.Jukebox, {
       /* Keep this SongActionManager dark palette in sync with templates/jukebox_manager.html. */
       [data-theme="dark"] .jukebox-sam-panel {
         color: #e6edf3;
-        background: linear-gradient(160deg, rgba(18, 25, 36, 0.97), rgba(26, 38, 52, 0.94));
+        background: #151d29;
         border-color: rgba(124, 218, 244, 0.24);
         box-shadow: 0 20px 54px rgba(2, 8, 23, 0.54), 0 4px 18px rgba(0, 0, 0, 0.28);
       }
@@ -2343,7 +2343,7 @@ Object.assign(window.Jukebox, {
       [data-theme="dark"] .sam-add-binding-btn,
       [data-theme="dark"] .sam-visibility-btn {
         color: #b7e8f8;
-        background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.82));
+        background: rgba(30, 41, 59, 0.9);
         border-color: rgba(124, 218, 244, 0.22);
       }
 
@@ -2353,13 +2353,13 @@ Object.assign(window.Jukebox, {
       [data-theme="dark"] .sam-add-binding-btn:hover,
       [data-theme="dark"] .sam-visibility-btn:hover {
         color: #f8fafc;
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.28), rgba(244, 114, 182, 0.18));
+        background: rgba(14, 165, 233, 0.2);
         border-color: rgba(124, 218, 244, 0.36);
       }
 
       [data-theme="dark"] .sam-tab.active {
         color: #ffffff;
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.88), rgba(244, 114, 182, 0.62));
+        background: #238bb5;
         box-shadow: 0 8px 20px rgba(14, 165, 233, 0.22);
       }
 

--- a/static/jukebox/jukebox/shell.js
+++ b/static/jukebox/jukebox/shell.js
@@ -1703,10 +1703,16 @@ Object.assign(window.Jukebox, {
       }
 
       .play-btn.jukebox-mode-btn {
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+        min-height: 32px;
         background: linear-gradient(160deg, rgba(255,255,255,0.86), rgba(232,247,255,0.72));
         border: 1px solid rgba(99,199,232,0.24);
         color: rgba(38,118,148,0.88);
-        padding: 6px 7px;
+        padding: 5px;
+        box-sizing: border-box;
+        border-radius: 999px;
         box-shadow: 0 3px 8px rgba(78,153,190,0.12);
       }
 
@@ -1724,6 +1730,11 @@ Object.assign(window.Jukebox, {
 
       .play-btn.jukebox-mode-btn.active:hover {
         background: #38a6d2;
+      }
+
+      .play-btn.jukebox-mode-btn svg {
+        display: block;
+        fill: currentColor;
       }
 
       .jukebox-controls-row {
@@ -1775,13 +1786,29 @@ Object.assign(window.Jukebox, {
 
       .jukebox-transport-btn,
       .jukebox-play-pause-btn {
+        width: 32px;
+        height: 32px;
         min-width: 32px;
-        min-height: 30px;
-        box-shadow: 0 4px 10px rgba(53,169,201,0.18);
+        min-height: 32px;
+        padding: 5px;
+        box-sizing: border-box;
+        border: 1px solid rgba(99,199,232,0.24);
+        border-radius: 999px;
+        background: linear-gradient(160deg, rgba(255,255,255,0.86), rgba(232,247,255,0.72));
+        color: ${Jukebox.Config.volume.iconColor};
+        box-shadow: 0 3px 8px rgba(78,153,190,0.12);
       }
 
-      .jukebox-play-pause-btn {
-        min-width: 36px;
+      .play-btn.jukebox-transport-btn:hover {
+        background: ${Jukebox.Config.volume.iconHoverBg};
+        color: ${Jukebox.Config.volume.iconHoverColor};
+        transform: translateY(-1px);
+        box-shadow: 0 5px 12px rgba(99,199,232,0.18);
+      }
+
+      .play-btn.jukebox-transport-btn svg {
+        display: block;
+        fill: currentColor;
       }
 
       #jukebox-progress-slider {
@@ -1789,9 +1816,9 @@ Object.assign(window.Jukebox, {
         min-width: 0;
         -webkit-appearance: none;
         appearance: none;
-        height: 3px;
-        background: ${Jukebox.Config.progress.trackBg};
-        border-radius: 999px;
+        height: 14px;
+        margin: 0;
+        background: transparent;
         outline: none;
         cursor: default;
         pointer-events: none;
@@ -1809,7 +1836,14 @@ Object.assign(window.Jukebox, {
         height: 8px;
         background: ${Jukebox.Config.progress.sliderBg};
         border-radius: 50%;
+        margin-top: -2.5px;
         transition: background 0.3s;
+      }
+
+      #jukebox-progress-slider::-webkit-slider-runnable-track {
+        height: 3px;
+        background: ${Jukebox.Config.progress.trackBg};
+        border-radius: 999px;
       }
 
       #jukebox-progress-slider.seekable::-webkit-slider-thumb {
@@ -1823,6 +1857,12 @@ Object.assign(window.Jukebox, {
         background: ${Jukebox.Config.progress.sliderBg};
         border-radius: 50%;
         border: none;
+      }
+
+      #jukebox-progress-slider::-moz-range-track {
+        height: 3px;
+        background: ${Jukebox.Config.progress.trackBg};
+        border-radius: 999px;
       }
 
       #jukebox-progress-slider.seekable::-moz-range-thumb {
@@ -2224,7 +2264,26 @@ Object.assign(window.Jukebox, {
       }
 
       [data-theme="dark"] #jukebox-progress-slider {
+        background: transparent;
+      }
+
+      [data-theme="dark"] #jukebox-progress-slider::-webkit-slider-runnable-track,
+      [data-theme="dark"] #jukebox-progress-slider::-moz-range-track {
         background: rgba(148, 163, 184, 0.22);
+      }
+
+      [data-theme="dark"] .play-btn.jukebox-transport-btn {
+        color: #b7e8f8;
+        background: rgba(30, 41, 59, 0.9);
+        border-color: rgba(124, 218, 244, 0.22);
+        box-shadow: 0 4px 12px rgba(2, 8, 23, 0.26);
+      }
+
+      [data-theme="dark"] .play-btn.jukebox-transport-btn:hover {
+        color: #f8fafc;
+        background: rgba(14, 165, 233, 0.2);
+        border-color: rgba(124, 218, 244, 0.36);
+        box-shadow: 0 6px 16px rgba(14, 165, 233, 0.16);
       }
 
       [data-theme="dark"] #jukebox-progress-slider::-webkit-slider-thumb,

--- a/static/jukebox/jukebox/shell.js
+++ b/static/jukebox/jukebox/shell.js
@@ -2181,6 +2181,40 @@ Object.assign(window.Jukebox, {
         background: #38a6d2;
       }
 
+      /* 复用聊天轮盘按钮的激活蓝色，保持跨界面操作色一致。 */
+      [data-theme="dark"] .jukebox-table td.song-action .play-btn {
+        color: #d9f3ff;
+        background: radial-gradient(circle at 30% 25%, rgba(92, 196, 255, 0.3) 0%, rgba(36, 68, 96, 0.96) 44%, rgba(17, 34, 51, 0.98) 100%);
+        border: 1px solid rgba(92, 196, 255, 0.42);
+        box-shadow:
+          0 0 0 1px rgba(92, 196, 255, 0.22),
+          0 4px 12px rgba(14, 83, 128, 0.28),
+          inset 0 1px 0 rgba(255, 255, 255, 0.14),
+          inset 0 -8px 14px rgba(6, 19, 32, 0.2);
+      }
+
+      [data-theme="dark"] .jukebox-table td.song-action .play-btn:hover {
+        color: #ffffff;
+        background: radial-gradient(circle at 30% 25%, rgba(126, 211, 255, 0.38) 0%, rgba(42, 78, 109, 0.98) 44%, rgba(17, 34, 51, 1) 100%);
+        border-color: rgba(126, 211, 255, 0.58);
+        box-shadow:
+          0 0 0 2px rgba(92, 196, 255, 0.3),
+          0 7px 16px rgba(14, 83, 128, 0.34),
+          inset 0 1px 0 rgba(255, 255, 255, 0.18);
+      }
+
+      [data-theme="dark"] .jukebox-table td.song-action .play-btn.playing,
+      [data-theme="dark"] .jukebox-table td.song-action .play-btn.playing:hover {
+        color: #fff4f5;
+        background: radial-gradient(circle at 30% 25%, rgba(255, 170, 180, 0.3) 0%, rgba(122, 49, 65, 0.98) 44%, rgba(66, 24, 36, 1) 100%);
+        border-color: rgba(255, 151, 165, 0.5);
+        box-shadow:
+          0 0 0 1px rgba(255, 151, 165, 0.22),
+          0 5px 14px rgba(132, 35, 57, 0.3),
+          inset 0 1px 0 rgba(255, 255, 255, 0.16),
+          inset 0 -8px 14px rgba(54, 12, 24, 0.22);
+      }
+
       [data-theme="dark"] .speaker-icon,
       [data-theme="dark"] .speaker-muted-icon {
         filter: none;
@@ -2418,8 +2452,13 @@ Object.assign(window.Jukebox, {
 
       [data-theme="dark"] .sam-tab.active {
         color: #ffffff;
-        background: #238bb5;
-        box-shadow: 0 8px 20px rgba(14, 165, 233, 0.22);
+        background: radial-gradient(circle at 30% 25%, rgba(92, 196, 255, 0.3) 0%, rgba(36, 68, 96, 0.96) 44%, rgba(17, 34, 51, 0.98) 100%);
+        border-color: rgba(92, 196, 255, 0.42);
+        box-shadow:
+          0 0 0 1px rgba(92, 196, 255, 0.22),
+          0 8px 20px rgba(14, 83, 128, 0.28),
+          inset 0 1px 0 rgba(255, 255, 255, 0.14),
+          inset 0 -8px 14px rgba(6, 19, 32, 0.2);
       }
 
       [data-theme="dark"] .sam-file-drop-zone,

--- a/templates/jukebox.html
+++ b/templates/jukebox.html
@@ -236,13 +236,13 @@
         };
         window.__NEKO_ENSURE_JUKEBOX_MINIMUM_BOUNDS__();
     </script>
-    <script src="/static/jukebox/jukebox/bootstrap.js"></script>
-    <script src="/static/jukebox/jukebox/core.js"></script>
-    <script src="/static/jukebox/jukebox/manager.js"></script>
-    <script src="/static/jukebox/jukebox/shell.js"></script>
-    <script src="/static/jukebox/jukebox/transport.js"></script>
-    <script src="/static/jukebox/jukebox/wiring.js"></script>
-    <script src="/static/jukebox/jukebox-standalone.js"></script>
+    <script src="/static/jukebox/jukebox/bootstrap.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/core.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/manager.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/shell.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/transport.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/wiring.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox-standalone.js?v={{ static_asset_version }}"></script>
     <script>
         async function _fetchModelType() {
             try {

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -373,12 +373,12 @@
         window.__NEKO_JUKEBOX_MANAGER_STANDALONE__ = true;
     </script>
     <!-- jukebox/*.js 包含 SongActionManager 定义 -->
-    <script src="/static/jukebox/jukebox/bootstrap.js"></script>
-    <script src="/static/jukebox/jukebox/core.js"></script>
-    <script src="/static/jukebox/jukebox/manager.js"></script>
-    <script src="/static/jukebox/jukebox/shell.js"></script>
-    <script src="/static/jukebox/jukebox/transport.js"></script>
-    <script src="/static/jukebox/jukebox/wiring.js"></script>
+    <script src="/static/jukebox/jukebox/bootstrap.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/core.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/manager.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/shell.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/transport.js?v={{ static_asset_version }}"></script>
+    <script src="/static/jukebox/jukebox/wiring.js?v={{ static_asset_version }}"></script>
     <script>
         // 管理器独立窗口初始化
         // 拖动走 CSS `-webkit-app-region: drag`（OS 原生），不再用 JS mousedown 模拟。


### PR DESCRIPTION
## 改动概述 / Summary

- 优化点歌台深色界面的播放控制、进度条和管理器条目布局。
- 为点歌台独立窗口脚本增加版本查询参数，避免静态资源缓存导致样式更新不生效。
- 管理器标签页及播放按钮复用轮盘蓝色状态；播放中的停止按钮维持红色系。

## 回归报告 / Regression Report

不适用（未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件）。

## 不拆分理由 / Why Not Split

不适用（本 PR 仅修改 5 个文件）。

## 测试 / Testing

- `node --check static/jukebox/jukebox/shell.js`
- `node --check static/jukebox/jukebox/manager.js`
- `.venv\\Scripts\\python.exe -m py_compile main_routers\\pages_router.py`
- `git diff --check`

## 屏幕截图 / Screenshots

改动前：
<img width="830" height="522" alt="music-old" src="https://github.com/user-attachments/assets/830c35c5-9f24-4ae0-85db-81bc81c23236" />

改动后：
<img width="778" height="515" alt="music-new" src="https://github.com/user-attachments/assets/6c13264b-3e5d-42d7-ac66-03060effa057" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化点歌台与管理器界面布局，提升歌曲、动画列表及操作按钮的可读性和易用性。
  * 改进浅色与深色主题下的按钮、播放控制、进度条及面板视觉效果。

* **改进**
  * 静态资源加载增加版本标识，确保更新后的脚本能够及时生效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->