### PR TITLE
将独立 ASR 默认设置为关闭，并同步前后端缺省逻辑及相关测试

### DIFF
--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -712,7 +712,7 @@ class AsrRuntimeMixin:
             # settings POST failed or was still in flight at session start.
             enabled = handshake_enabled
         else:
-            enabled = bool(settings.get("independentAsrEnabled", True))
+            enabled = bool(settings.get("independentAsrEnabled", False))
         optimization_handshake = resource_optimization_override
         if resource_optimization_override is ...:
             optimization_handshake = getattr(

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -578,7 +578,7 @@
             focusModeEnabled: false,
             focusCognitionEnabled: true,
             noiseReductionEnabled: true,
-            independentAsrEnabled: true,
+            independentAsrEnabled: false,
             voiceInputResourceOptimizationEnabled: true,
             avatarReactionBubbleEnabled: true,
             slopFilterEnabled: true,
@@ -1896,7 +1896,7 @@
                 S.mergeMessagesEnabled = settings.mergeMessagesEnabled ?? false;
                 S.focusModeEnabled = settings.focusModeEnabled ?? false;
                 S.focusCognitionEnabled = settings.focusCognitionEnabled ?? true;
-                S.independentAsrEnabled = settings.independentAsrEnabled ?? true;
+                S.independentAsrEnabled = settings.independentAsrEnabled ?? false;
                 S.voiceInputResourceOptimizationEnabled =
                     settings.voiceInputResourceOptimizationEnabled ?? true;
                 S.avatarReactionBubbleEnabled = settings.avatarReactionBubbleEnabled ?? true;

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -88,7 +88,7 @@
         selectedMicrophoneId: null,
         microphoneGainDb: 0,
         noiseReductionEnabled: true,
-        independentAsrEnabled: true,
+        independentAsrEnabled: false,
         // Current Core capability loaded from /api/config/core_api. Keep this
         // tri-state: only an explicit false may disable the effective UI;
         // null means unknown and leaves the user's persisted preference alone.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1670,11 +1670,11 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           const resetPriorDecision = {
             writeId: Date.now() + 1000,
             writerId: 'server-before-reset',
-            value: false,
+            value: true,
           };
           assert(
-            resetPriorDecision.value !== true,
-            'the pre-reset ASR decision must differ from the enabled reset default'
+            resetPriorDecision.value !== false,
+            'the pre-reset ASR decision must differ from the disabled reset default'
           );
           const reset = makeContext(false, {
             success: true,
@@ -1690,7 +1690,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             reset.S.slopFilterEnabled === true
               && reset.S.proactiveVisionEnabled === resetVisionDefault
-              && reset.S.independentAsrEnabled === true
+              && reset.S.independentAsrEnabled === false
               && reset.S.voiceInputResourceOptimizationEnabled === true,
             'an empty authoritative restore must reset stale local values to defaults: '
               + JSON.stringify({
@@ -1708,7 +1708,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             ]
           );
           assert(
-            resetWritebackDecision.value === true
+            resetWritebackDecision.value === false
               && resetWritebackDecision.writeId
                 > resetPriorDecision.writeId,
             'a reset writeback must rebase the stale tuple onto the reset default'
@@ -1721,7 +1721,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             resetBody.slopFilterEnabled === true
               && resetBody.proactiveVisionEnabled === resetVisionDefault
-              && resetBody.independentAsrEnabled === true
+              && resetBody.independentAsrEnabled === false
               && resetBody.voiceInputResourceOptimizationEnabled === true,
             'the reset writeback must not repopulate the server with stale localStorage'
           );
@@ -1744,7 +1744,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             reset.store.get('project_neko_settings')
           );
           assert(
-            resetPersisted._sharedWriteMeta.asrDecision.value === true
+            resetPersisted._sharedWriteMeta.asrDecision.value === false
               && resetPersisted._sharedWriteMeta.serverRevision === 11,
             'a full-write success must adopt and rebroadcast the generated server ASR tuple'
           );
@@ -1768,7 +1768,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               'X-Conversation-Settings-ASR-Decision'
             ]
           );
-          resetRace.S.independentAsrEnabled = false;
+          resetRace.S.independentAsrEnabled = true;
           resetRace.mod.saveSettings({
             skipServerSync: true,
             explicitSharedKeys: ['independentAsrEnabled'],
@@ -1785,7 +1785,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             resetRace.store.get('project_neko_settings')
           )._sharedWriteMeta.asrDecision;
           assert(
-            resetToggleDecision.value === false
+            resetToggleDecision.value === true
               && resetToggleDecision.writeId
                 > resetRaceBaselineDecision.writeId,
             'a toggle during reset must mint above the rebased reset decision'
@@ -1797,7 +1797,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             {
               success: true,
               settings: {
-                independentAsrEnabled: true,
+                independentAsrEnabled: false,
                 slopFilterEnabled: true,
               },
               revision: 11,
@@ -1810,7 +1810,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
           await tick();
           assert(
-            resetRace.S.independentAsrEnabled === false
+            resetRace.S.independentAsrEnabled === true
               && resetRace.postCalls.length === 2,
             'the older reset response must not overwrite the queued toggle'
           );
@@ -1821,7 +1821,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             ]
           );
           assert(
-            resetToggleBody.independentAsrEnabled === false
+            resetToggleBody.independentAsrEnabled === true
               && JSON.stringify(resetToggleHeader)
                 === JSON.stringify(resetToggleDecision),
             'the queued sync must persist the newer toggle tuple'
@@ -2816,13 +2816,14 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             ctx.S.focusModeEnabled === true
               && ctx.S.slopFilterEnabled === true
-              && ctx.S.independentAsrEnabled === true,
+              && ctx.S.independentAsrEnabled === false,
             'a partial reset response must materialize defaults without losing the edit'
           );
           const restoredLocal = JSON.parse(ctx.store.get('project_neko_settings'));
           assert(
             restoredLocal.focusModeEnabled === true
-              && restoredLocal.slopFilterEnabled === true,
+              && restoredLocal.slopFilterEnabled === true
+              && restoredLocal.independentAsrEnabled === false,
             'the partial reset response must replace stale localStorage values'
           );
         }

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -5585,7 +5585,7 @@ async def test_start_session_handshake_missing_falls_back_to_persisted(
     start_mock.assert_awaited_once()
 
 
-async def test_missing_independent_asr_setting_defaults_enabled(monkeypatch) -> None:
+async def test_missing_independent_asr_setting_defaults_disabled(monkeypatch) -> None:
     runtime = _Runtime()
     runtime.core_api_type = "gemini"
     monkeypatch.setattr(
@@ -5603,9 +5603,8 @@ async def test_missing_independent_asr_setting_defaults_enabled(monkeypatch) -> 
 
     await runtime._start_independent_asr_if_enabled("audio")
 
-    start_mock.assert_awaited_once()
-    assert start_mock.await_args.kwargs["resource_optimization_enabled"] is True
-    assert runtime._asr_route_mode != "native"
+    start_mock.assert_not_awaited()
+    assert runtime._asr_route_mode == "native"
 
 
 @pytest.mark.parametrize("malformed", ["true", 1, 0, [True], {"enabled": True}])

--- a/tests/unit/test_voice_recognition_settings_static.py
+++ b/tests/unit/test_voice_recognition_settings_static.py
@@ -7,14 +7,15 @@ ROOT = Path(__file__).resolve().parents[2]
 APP_STATE = ROOT / "static" / "app" / "app-state.js"
 APP_SETTINGS = ROOT / "static" / "app" / "app-settings.js"
 APP_AUDIO_CAPTURE = ROOT / "static" / "app" / "app-audio-capture.js"
+ASR_RUNTIME = ROOT / "main_logic" / "core" / "asr_runtime.py"
 LOCALE_DIR = ROOT / "static" / "locales"
 LOCALES = ("en", "es", "ja", "ko", "pt", "ru", "zh-CN", "zh-TW")
 
 
-def test_new_profile_voice_settings_default_enabled_without_becoming_authoritative() -> None:
+def test_new_profile_independent_asr_defaults_off_without_becoming_authoritative() -> None:
     state = APP_STATE.read_text(encoding="utf-8")
 
-    assert "independentAsrEnabled: true" in state
+    assert "independentAsrEnabled: false" in state
     assert "coreApiSupportsIndependentAsr: null" in state
     assert "voiceInputResourceOptimizationEnabled: true" in state
     assert "settingsHydrated: false" in state
@@ -25,7 +26,7 @@ def test_new_profile_voice_settings_default_enabled_without_becoming_authoritati
 def test_voice_settings_preserve_explicit_false_during_boot_merge() -> None:
     settings = APP_SETTINGS.read_text(encoding="utf-8")
 
-    assert "settings.independentAsrEnabled ?? true" in settings
+    assert "settings.independentAsrEnabled ?? false" in settings
     assert "settings.voiceInputResourceOptimizationEnabled ?? true" in settings
     assert "settings.independentAsrEnabled || true" not in settings
     assert "settings.voiceInputResourceOptimizationEnabled || true" not in settings
@@ -38,8 +39,14 @@ def test_reset_defaults_match_new_profile_voice_defaults() -> None:
         maxsplit=1,
     )[1].split("function _serverSettingsForMerge", maxsplit=1)[0]
 
-    assert "independentAsrEnabled: true" in reset_defaults
+    assert "independentAsrEnabled: false" in reset_defaults
     assert "voiceInputResourceOptimizationEnabled: true" in reset_defaults
+
+
+def test_backend_defaults_missing_independent_asr_preference_off() -> None:
+    runtime = ASR_RUNTIME.read_text(encoding="utf-8")
+
+    assert 'settings.get("independentAsrEnabled", False)' in runtime
 
 
 def test_resource_optimization_uses_only_the_canonical_shared_setting_key() -> None:


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

将“语音识别 / 独立 ASR”开关的默认状态改为关闭，并统一前端初始状态、本地配置回退、恢复默认设置及后端缺省路由逻辑。用户已保存的显式设置保持不变。

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
改动内容：调整 main_logic/core/asr_runtime.py 中独立 ASR 配置缺失时的默认值。
理由：独立 ASR 应由用户主动开启，不能在新用户或配置字段缺失时自动启用。
改动前：未保存相关配置时，前后端默认启用独立 ASR。
改动后：未保存相关配置时默认使用原生语音识别路由；显式开启后仍正常启用独立 ASR。
潜在回归点：语音路由选择、设置恢复、跨窗口设置同步及显式开关持久化。
验证方式：覆盖配置缺失、显式开启/关闭、恢复默认及设置同步竞态场景，相关回归测试均已通过。

## 测试 / Testing

uv run pytest tests/unit/test_voice_recognition_settings_static.py tests/unit/test_app_websocket_static.py -q：91 项通过。
uv run pytest tests/unit/test_core_independent_asr.py -q：285 项通过。
uv run ruff check main_logic/core/asr_runtime.py tests/unit/test_core_independent_asr.py tests/unit/test_voice_recognition_settings_static.py tests/unit/test_app_websocket_static.py：通过。
git diff --check：通过。
手动清理数据确认默认为关闭


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 独立 ASR 在未提供有效配置时，默认改为关闭。
  - 首次启动、设置重置、本地加载及应用状态中的独立 ASR 默认值统一为关闭。
  - 未显式启用时，将继续使用原生语音识别路由。

- **测试**
  - 更新相关设置、重置及配置缺失场景的验证，确保默认关闭行为一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->