### PR TITLE
docs(mc): 教程改为在控制面板 UI 里填密钥，并清掉面板上的开发向说明

### DIFF
--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -36,9 +36,12 @@ agent 端启动方式由你自己决定：绿色包用户在解压出来的包�
 ## 启用步骤
 
 1. 启动 Minecraft agent server（绿色包双击 `启动.bat` 即可，端口默认
-   `48909` 不用管；改端口用 `NEKO_PLUGIN_WS_PORT`）。密钥、模型、MC 端口
-   都在 mc-agent 自己的控制面板 `http://localhost:8765` 里填，不需要手动
-   编辑它的任何配置文件
+   `48909` 不用管）。密钥、模型、MC 端口都在 mc-agent 自己的控制面板
+   `http://localhost:8765` 里填，不需要手动编辑它的任何配置文件。
+
+   > 改桥接端口要**改两处**：agent 侧的 `NEKO_PLUGIN_WS_PORT` 只挪动它自己
+   > 的监听端口，插件侧读的是下面 `[game_agent]` 里独立的 `ws_url`（默认
+   > `ws://localhost:48909`）。只改一处两边就连不上了。
 2. 在 N.E.K.O 插件管理界面启用 `game_agent_minecraft` 插件
 3. 如需修改配置，编辑 `plugin.toml` 的 `[game_agent]` 节后调
    `game_agent_reload_config` entry 应用：

--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -29,12 +29,16 @@ agent server 与本插件通过单一 WebSocket 连接通信，JSON 帧格式：
 也兼容**——插件会回退到按完成顺序匹配（见下方"已知限制"）。建议有内部并发
 的 agent 实现一定带上 `task_id` 以避免 out-of-order 完成被错误归属。
 
-agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.js --port 48909`
-或类似命令），插件只负责连进去。
+agent 端启动方式由你自己决定：绿色包用户在解压出来的包根双击 `启动.bat`，
+开发态直接 `node main.js`。桥接端口不是命令行参数，而是环境变量
+`NEKO_PLUGIN_WS_PORT`（默认 `48909`）。插件只负责连进去。
 
 ## 启用步骤
 
-1. 启动 Minecraft agent server，记下监听端口（默认 `48909`）
+1. 启动 Minecraft agent server（绿色包双击 `启动.bat` 即可，端口默认
+   `48909` 不用管；改端口用 `NEKO_PLUGIN_WS_PORT`）。密钥、模型、MC 端口
+   都在 mc-agent 自己的控制面板 `http://localhost:8765` 里填，不需要手动
+   编辑它的任何配置文件
 2. 在 N.E.K.O 插件管理界面启用 `game_agent_minecraft` 插件
 3. 如需修改配置，编辑 `plugin.toml` 的 `[game_agent]` 节后调
    `game_agent_reload_config` entry 应用：
@@ -61,6 +65,13 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 | `stream_screenshots_to_llm` | `true` | 收到 agent 截图就 push 到模型视觉上下文（`ai_behavior="read"`），按下面的最小间隔节流 |
 | `screenshot_stream_min_interval_seconds` | `6.0` | 内联截图流 push 的最小间隔（节流，防止按 agent ~1Hz 速率灌爆模型视觉上下文）；窗口内的帧折叠为最新一张 |
 | `screenshot_cache_size` | `3` | 内存里保留的最近 N 张截图，nudge 时一并发出 |
+
+> 截图节流阀从 mc-agent v0.2.0 起才真的开始工作：更早的发行包里 bot 视角截图
+> 默认是关的（一帧都不发），v0.2.0 把它默认打开成 ~1Hz。插件侧不用改代码——
+> `screenshot_stream_min_interval_seconds` 本来就是按这个速率设计的——但视觉
+> 上下文的实际 token 消耗会从零变成有，嫌多就调大这个值或直接把
+> `stream_screenshots_to_llm` 关掉，也可以在 mc-agent 面板的「高级 → 视觉」里
+> 关掉或降频。
 
 ## LLM 工具：`minecraft_task`
 

--- a/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
+++ b/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
@@ -109,7 +109,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   "zh-CN": {
     title: "Minecraft 游戏插件 快速开始",
     subtitle: "让猫娘陪你玩 MC——她会有一个自己的游戏角色，和你在同一个世界里一起行动。",
-    notice: "mc-agent 还在持续更新中：安装流程和控制面板的界面会随版本变化，网盘里的包也会不定期替换。如果你看到的界面和这里写的对不上，多半是新版还没发布或你手上还是旧包，请耐心等待更新。",
+    notice: "mc-agent 还在持续更新中：安装流程和控制面板的界面会随版本变化，网盘里的包也会不定期替换。如果你看到的界面和这里写的对不上，先回上面的下载卡片重新下一份最新的包；重下之后还是对不上，那就是新版还没发布，请耐心等待更新。",
     cards: [
       { title: "先装 Minecraft", badge: "Install", body: "Java 版 v1.21.1 推荐，其他 1.21.x 也可。自己买正版或离线启动。" },
       { title: "再开 mc-agent", badge: "Setup", body: "下面下个 mc-agent 解压、双击「启动.bat」启动它。它和 N.E.K.O 是两个各自独立的程序，都开着就会自动连上。首次启动会自动打开控制面板网页，密钥、模型、游戏端口全在网页里填，不用碰任何文件。猫娘默认用离线模式进游戏，不需要另外给她买正版账号（代价是进不了开了正版验证的联机服务器，你自己开的局域网世界不受影响）。" },
@@ -139,7 +139,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupSteps: [
       { title: "1. 装 Minecraft Java Edition", body: "推荐 v1.21.1（1.21.x 系列都行）。自己选择正版 / 离线启动器。" },
       { title: "2. 装 mc-agent（如果上面状态显示「未连接」）", body: "用上面的下载卡片，三个网盘挑一个下 mc-agent 压缩包，解压到一个路径短一点的目录（比如 C:\\mc-agent 或桌面）。然后双击里面的「启动.bat」（会开一个命令行黑窗口，别关）。它第一次启动会提示「还没有选择 AI 供应商，bot 暂不启动」，同时自动打开控制面板网页——接下来全部配置都在那个网页里做，不需要复制或编辑任何文件。" },
-      { title: "3. 在控制面板「AI 配置」页填密钥", body: "供应商分「国内直连 / 境外服务 / 本机运行」三组，国内那组不需要梯子、注册即用（DeepSeek、通义千问、智谱 GLM、Kimi、豆包、硅基流动等）。点一家 → 粘贴密钥（每张卡片上都有「去申请密钥」的外链）→ 点「测试连接」→ 测通后模型下拉会自动拉到该供应商的真实模型列表，挑一个保存。密钥只存在你自己电脑上，网页里永远显示成掩码。" },
+      { title: "3. 在控制面板「AI 配置」页填密钥", body: "供应商分「国内直连 / 境外服务 / 本机运行」三组，国内那组不需要梯子、注册即用（DeepSeek、通义千问、智谱 GLM、Kimi、豆包、硅基流动等）。点一家 → 粘贴密钥（每张卡片上都有「去申请密钥」的外链）→ 点「测试连接」→ 测通后模型下拉会自动拉到该供应商的真实模型列表，挑一个保存。密钥保存在你自己电脑上、网页里只显示掩码；调用模型时它会发给你选的那家供应商——用别人家的 API 本来就得带密钥认证。" },
       { title: "4. 开 MC 世界并「对局域网开放」", body: "进入单人世界 → ESC → 对局域网开放 → 选游戏模式 → 创建局域网世界。MC 会在聊天框显示「Local game hosted on port XXXXX」，记下这个端口号。" },
       { title: "5. 在控制面板「游戏连接」页填端口，再点「启动 Bot」", body: "点上面「打开管理面板」按钮 → 「游戏连接」页 → 把上一步抄下来的端口填进去 → 保存 → 点「启动 Bot」。包里自带的端口是占位值 25565，必须换成你自己那局的。" },
       { title: "6. 验证 bot 进游戏了", body: "MC 聊天框会看到「Neko joined the game」。看不到就刷新本页状态，或者看「启动.bat」那个黑窗口最后几行报什么错。" },
@@ -147,7 +147,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     ],
     portsTitle: "端口说明",
     ports: [
-      { key: "mc", label: "MC 游戏端口（默认 55916）", value: "你「对局域网开放」时显示的那个数字。bot 通过它连进游戏世界。" },
+      { key: "mc", label: "MC 游戏端口", value: "你「对局域网开放」时显示的那个数字，bot 通过它连进游戏世界。包里自带的是占位值 25565，一定要换成你自己那局的。" },
       { key: "admin", label: "管理面板（localhost:8765）", value: "上面那个「打开管理面板」按钮跳的就是这个。密钥、模型、猫娘的名字和人设、皮肤、游戏连接、行为开关全在这里改。" },
     ],
     tipsTitle: "排错",
@@ -164,7 +164,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   en: {
     title: "Minecraft Game Plugin — Quickstart",
     subtitle: "Let neko-chan play MC with you — she gets her own in-game character and moves around the same world you do.",
-    notice: "mc-agent is still under active development: the install flow and the control panel UI change between versions, and the netdisk archives get replaced from time to time. If what you see doesn't match this page, you're most likely on an older build or the new one isn't out yet — please be patient and wait for the update.",
+    notice: "mc-agent is still under active development: the install flow and the control panel UI change between versions, and the netdisk archives get replaced from time to time. If what you see doesn't match this page, first re-download the latest archive from the download card above. If it still doesn't match after that, the new build simply isn't out yet — please be patient and wait for the update.",
     cards: [
       { title: "Install Minecraft", badge: "Install", body: "Java Edition v1.21.1 recommended; other 1.21.x versions also work. Use any launcher you like." },
       { title: "Run mc-agent", badge: "Setup", body: "Download mc-agent below, unzip, double-click 启动.bat. It's a separate program from N.E.K.O.; run both and they connect on their own. On first launch it opens a control panel in your browser — API key, model and game port all go in there, you never edit a file. Neko-chan joins in offline mode by default, so she doesn't need her own paid Minecraft account (the trade-off: she can't join online-mode servers; your own LAN world is unaffected)." },
@@ -194,7 +194,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupSteps: [
       { title: "1. Install Minecraft Java Edition", body: "v1.21.1 recommended (any 1.21.x is fine). Pick any launcher (official, MultiMC, Prism, etc.)." },
       { title: "2. Install mc-agent (if status above is \"Disconnected\")", body: "Use the download card above — pick any of the three drives, grab the mc-agent archive, extract it into a short path (e.g. C:\\mc-agent or your Desktop). Then double-click 启动.bat inside (it opens a black console window — don't close it). On first launch it prints \"no AI provider selected yet, bot not started\" and opens the control panel in your browser — everything from here on is done in that web page, you never copy or edit a file." },
-      { title: "3. Set your API key on the panel's \"AI config\" page", body: "Providers are grouped into China-direct / overseas / local. Pick one → paste your key (each card links straight to that vendor's console to get one) → click \"Test connection\" → once it passes, the model dropdown auto-fills with that provider's real model list; pick one and save. The key never leaves your machine and is always shown masked in the UI." },
+      { title: "3. Set your API key on the panel's \"AI config\" page", body: "Providers are grouped into China-direct / overseas / local. Pick one → paste your key (each card links straight to that vendor's console to get one) → click \"Test connection\" → once it passes, the model dropdown auto-fills with that provider's real model list; pick one and save. Your key is stored on your own machine and always shown masked in the UI; it does get sent to the provider you picked whenever a request is made — that is how authenticating against their API works." },
       { title: "4. Open a world to LAN", body: "Single player → ESC → Open to LAN → pick game mode → Start. MC will print \"Local game hosted on port XXXXX\" in chat. Note the port number." },
       { title: "5. Enter the port on the \"Game connection\" page, then Start Bot", body: "Click \"Open admin panel\" above → Game connection page → type in the port you wrote down → save → click \"Start Bot\". The shipped value 25565 is only a placeholder; it must be replaced with your own session's port." },
       { title: "6. Confirm the bot joined", body: "You should see \"Neko joined the game\" in MC chat. If not, refresh status here or check the last few lines of the 启动.bat console window." },
@@ -202,7 +202,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     ],
     portsTitle: "Ports",
     ports: [
-      { key: "mc", label: "MC game port (default 55916)", value: "The number MC shows when you Open to LAN. The bot uses this to join your world." },
+      { key: "mc", label: "MC game port", value: "The number MC shows when you Open to LAN — the bot uses it to join your world. The shipped value 25565 is only a placeholder and must be replaced with your own session's port." },
       { key: "admin", label: "Admin panel (localhost:8765)", value: "Where the \"Open admin panel\" button goes. API key, model, neko-chan's name and persona, skin, game connection and behavior toggles all live here." },
     ],
     tipsTitle: "Troubleshooting",
@@ -219,7 +219,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ja: {
     title: "Minecraft ゲームプラグイン クイックスタート",
     subtitle: "猫娘ちゃんと MC を遊ぼう。彼女は自分のキャラクターを持って、同じ世界であなたと一緒に動きます。",
-    notice: "mc-agent は現在も更新中です：導入手順やコントロールパネルの画面はバージョンごとに変わり、ネットディスク上のパッケージも随時差し替えられます。ここの説明と実際の画面が食い違う場合は、新版が未公開か手元が旧版のことがほとんどなので、アップデートをお待ちください。",
+    notice: "mc-agent は現在も更新中です：導入手順やコントロールパネルの画面はバージョンごとに変わり、ネットディスク上のパッケージも随時差し替えられます。ここの説明と実際の画面が食い違う場合は、まず上のダウンロードカードから最新のパッケージを取り直してください。それでも合わない場合は新版がまだ公開されていないので、アップデートをお待ちください。",
     cards: [
       { title: "Minecraft を入れる", badge: "Install", body: "Java 版 v1.21.1 推奨。他の 1.21.x でも可。お好きなランチャーで。" },
       { title: "mc-agent を起動", badge: "Setup", body: "下のカードから mc-agent を入手・解凍し「启动.bat」をダブルクリック。N.E.K.O とは別のプログラムで、両方を起動しておけば自動でつながります。初回起動時にブラウザでコントロールパネルが自動的に開き、API キー・モデル・ゲームのポートはすべてそこで入力します（ファイルを編集する必要はありません）。猫娘ちゃんは既定でオフラインモードで参加するので、専用の正規アカウントは不要です（その代わり正規認証のマルチサーバーには入れません。自分で開いた LAN ワールドは問題なし）。" },
@@ -249,7 +249,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupSteps: [
       { title: "1. Minecraft Java 版をインストール", body: "v1.21.1 推奨（1.21.x なら何でも）。公式 / MultiMC / Prism いずれでも。" },
       { title: "2. mc-agent をインストール（上が「未接続」なら）", body: "上のダウンロードカードから mc-agent の配布パッケージを取得し、パスの短いフォルダ（例：C:\\mc-agent やデスクトップ）に解凍。中の「启动.bat」をダブルクリックで起動（黒いコンソール窓が開く、閉じないこと）。初回は「AI プロバイダーが未選択のためボットは起動しません」と表示され、ブラウザでコントロールパネルが自動的に開く。以降の設定はすべてその画面で行い、ファイルのコピーや編集は一切不要。" },
-      { title: "3. コントロールパネルの「AI 設定」ページで API キーを入力", body: "プロバイダーは「中国国内直結 / 海外サービス / ローカル実行」の 3 グループ。1 つ選ぶ → キーを貼り付け（各カードに発行ページへの外部リンクあり）→「接続テスト」→ 成功するとモデル一覧がそのプロバイダーの実データで埋まるので、1 つ選んで保存。キーは自分の PC 内にのみ保存され、画面上は常にマスク表示。" },
+      { title: "3. コントロールパネルの「AI 設定」ページで API キーを入力", body: "プロバイダーは「中国国内直結 / 海外サービス / ローカル実行」の 3 グループ。1 つ選ぶ → キーを貼り付け（各カードに発行ページへの外部リンクあり）→「接続テスト」→ 成功するとモデル一覧がそのプロバイダーの実データで埋まるので、1 つ選んで保存。キーは自分の PC に保存され、画面上は常にマスク表示。ただしリクエストのたびに選んだプロバイダーへ送信されます（相手の API を使う以上、キーによる認証は避けられません）。" },
       { title: "4. ワールドを LANに公開", body: "シングルプレイ → ESC → LANに公開 → モード選択 → 開始。チャットに「Local game hosted on port XXXXX」と出るのでポート番号を控える。" },
       { title: "5. 「ゲーム接続」ページにポートを入れて「ボット起動」", body: "上の「管理パネルを開く」→「ゲーム接続」ページ → 控えた番号を入力 → 保存 →「ボット起動」。同梱の 25565 は仮の値なので、必ず自分のセッションのポートに変更すること。" },
       { title: "6. ボットの参加を確認", body: "MC のチャットに「Neko joined the game」と出れば成功。出なければ本ページの状態を更新、または「启动.bat」の黒い窓の最終行のエラーを確認。" },
@@ -257,7 +257,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     ],
     portsTitle: "ポート一覧",
     ports: [
-      { key: "mc", label: "MC ゲームポート（既定 55916）", value: "「LANに公開」時に MC が表示する番号。ボットがこれでワールドに参加。" },
+      { key: "mc", label: "MC ゲームポート", value: "「LANに公開」時に MC が表示する番号。ボットがこれでワールドに参加。同梱の 25565 は仮の値なので、必ず自分のセッションのポートに変更すること。" },
       { key: "admin", label: "管理パネル（localhost:8765）", value: "「管理パネルを開く」が飛ぶ先。API キー、モデル、猫娘ちゃんの名前と人格、スキン、ゲーム接続、動作スイッチはすべてここ。" },
     ],
     tipsTitle: "トラブルシューティング",
@@ -274,7 +274,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ko: {
     title: "Minecraft 게임 플러그인 빠른 시작",
     subtitle: "고양이와 함께 MC를 즐기세요. 고양이는 자기 캐릭터로 같은 월드에 들어와 너와 함께 움직여요.",
-    notice: "mc-agent는 아직 계속 업데이트 중입니다: 설치 흐름과 제어판 화면이 버전마다 달라지고, 네트워크 드라이브의 압축 파일도 수시로 교체돼요. 여기 설명과 실제 화면이 다르면 대개 새 버전이 아직 안 나왔거나 예전 빌드를 쓰고 있는 것이니, 업데이트를 조금만 기다려 주세요.",
+    notice: "mc-agent는 아직 계속 업데이트 중입니다: 설치 흐름과 제어판 화면이 버전마다 달라지고, 네트워크 드라이브의 압축 파일도 수시로 교체돼요. 여기 설명과 실제 화면이 다르면 먼저 위 다운로드 카드에서 최신 패키지를 다시 받아 보세요. 다시 받아도 그대로면 새 버전이 아직 안 나온 것이니 업데이트를 조금만 기다려 주세요.",
     cards: [
       { title: "Minecraft 설치", badge: "Install", body: "Java 에디션 v1.21.1 권장. 다른 1.21.x도 가능. 원하는 런처 사용." },
       { title: "mc-agent 실행", badge: "Setup", body: "아래에서 mc-agent 다운로드 → 압축 해제 → 「启动.bat」 더블클릭. N.E.K.O와는 별개 프로그램이라 둘 다 켜 두면 알아서 연결돼요. 처음 실행하면 브라우저에 제어판이 자동으로 열리고, API 키·모델·게임 포트를 전부 그 웹 화면에서 입력해요(파일을 건드릴 일 없음). 고양이는 기본적으로 오프라인 모드로 접속하니 정품 계정을 따로 살 필요는 없어요(대신 정품 인증을 켠 멀티 서버에는 못 들어가요. 직접 연 LAN 월드는 문제없음)." },
@@ -304,7 +304,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupSteps: [
       { title: "1. Minecraft Java 에디션 설치", body: "v1.21.1 권장 (1.21.x 모두 가능). 공식 / MultiMC / Prism 등 원하는 런처." },
       { title: "2. mc-agent 설치 (위 상태가 「연결 안 됨」이면)", body: "위 다운로드 카드에서 mc-agent 압축 파일을 받아 경로가 짧은 폴더(예: C:\\mc-agent 또는 바탕화면)에 압축 해제. 그다음 안의 「启动.bat」을 더블클릭해 실행 (검은 콘솔 창이 열림, 닫지 말 것). 처음 실행하면 「AI 제공자를 아직 고르지 않아 봇을 시작하지 않습니다」라고 뜨면서 브라우저에 제어판이 자동으로 열려요. 이후 설정은 전부 그 웹 화면에서 하며, 파일을 복사하거나 편집할 일은 없어요." },
-      { title: "3. 제어판 「AI 설정」 페이지에서 API 키 입력", body: "제공자는 「중국 직결 / 해외 서비스 / 로컬 실행」 세 그룹. 하나 선택 → 키 붙여넣기(카드마다 발급 페이지 외부 링크 있음) → 「연결 테스트」 → 통과하면 모델 드롭다운이 그 제공자의 실제 모델 목록으로 채워지니 하나 골라 저장. 키는 내 PC에만 저장되고 화면에는 항상 마스킹되어 보여요." },
+      { title: "3. 제어판 「AI 설정」 페이지에서 API 키 입력", body: "제공자는 「중국 직결 / 해외 서비스 / 로컬 실행」 세 그룹. 하나 선택 → 키 붙여넣기(카드마다 발급 페이지 외부 링크 있음) → 「연결 테스트」 → 통과하면 모델 드롭다운이 그 제공자의 실제 모델 목록으로 채워지니 하나 골라 저장. 키는 내 PC에 저장되고 화면에는 항상 마스킹되어 보여요. 다만 요청할 때마다 고른 제공자에게 전송돼요 — 남의 API를 쓰려면 키 인증이 필요하니까요." },
       { title: "4. 월드를 LAN에 공개", body: "싱글 플레이 → ESC → LAN에 공개 → 게임 모드 선택 → 시작. 채팅창에 「Local game hosted on port XXXXX」가 표시되니 포트 번호 기록." },
       { title: "5. 「게임 연결」 페이지에 포트를 넣고 「봇 시작」", body: "위「관리 패널 열기」클릭 → 「게임 연결」 페이지 → 기록한 번호 입력 → 저장 → 「봇 시작」. 기본값 25565는 자리표시자일 뿐이니 반드시 본인 세션의 포트로 바꿔야 해요." },
       { title: "6. 봇 참가 확인", body: "MC 채팅에「Neko joined the game」이 보이면 성공. 안 보이면 본 페이지 상태를 새로고침하거나 「启动.bat」 콘솔 창의 마지막 줄 에러 확인." },
@@ -312,7 +312,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     ],
     portsTitle: "포트 안내",
     ports: [
-      { key: "mc", label: "MC 게임 포트 (기본 55916)", value: "「LAN에 공개」 시 MC가 보여주는 숫자. 봇이 이를 통해 월드 참가." },
+      { key: "mc", label: "MC 게임 포트", value: "「LAN에 공개」 시 MC가 보여주는 숫자. 봇이 이를 통해 월드에 참가해요. 기본값 25565는 자리표시자일 뿐이니 반드시 본인 세션의 포트로 바꿔야 해요." },
       { key: "admin", label: "관리 패널 (localhost:8765)", value: "「관리 패널 열기」가 가는 곳. API 키, 모델, 고양이 이름과 성격, 스킨, 게임 연결, 동작 스위치가 전부 여기에 있어요." },
     ],
     tipsTitle: "문제 해결",
@@ -329,7 +329,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ru: {
     title: "Игровой плагин Minecraft — Быстрый старт",
     subtitle: "Играй в MC вместе с нэко-тян — у неё будет свой персонаж, и она будет ходить по тому же миру, что и ты.",
-    notice: "mc-agent всё ещё активно обновляется: процесс установки и интерфейс панели управления меняются от версии к версии, архивы на дисках время от времени заменяются. Если увиденное не совпадает с этой страницей — скорее всего, новая версия ещё не вышла или у тебя старая сборка. Пожалуйста, дождись обновления.",
+    notice: "mc-agent всё ещё активно обновляется: процесс установки и интерфейс панели управления меняются от версии к версии, архивы на дисках время от времени заменяются. Если увиденное не совпадает с этой страницей, сначала перекачай свежий архив по карточке «Скачать» выше. Если и после этого не совпадает — новая версия просто ещё не вышла, дождись обновления.",
     cards: [
       { title: "Установи Minecraft", badge: "Install", body: "Java Edition v1.21.1 рекомендуется; другие 1.21.x тоже подойдут. Любой лаунчер." },
       { title: "Запусти mc-agent", badge: "Setup", body: "Скачай mc-agent ниже, распакуй, дважды кликни 启动.bat. Это отдельная программа от N.E.K.O. — запусти обе, и они соединятся сами. При первом запуске в браузере сама откроется панель управления — ключ API, модель и игровой порт вводятся только там, никакие файлы править не нужно. Нэко-тян по умолчанию заходит в офлайн-режиме, так что отдельный лицензионный аккаунт покупать не надо (расплата: на серверы с проверкой лицензии она не попадёт; твой собственный LAN-мир это не затрагивает)." },
@@ -359,7 +359,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupSteps: [
       { title: "1. Установи Minecraft Java Edition", body: "v1.21.1 рекомендуется (любой 1.21.x подойдёт). Любой лаунчер: официальный, MultiMC, Prism." },
       { title: "2. Установи mc-agent (если статус выше «Нет связи»)", body: "Через карточку «Скачать» выше скачай архив mc-agent и распакуй его в папку с коротким путём (например C:\\mc-agent или на Рабочий стол). Затем дважды кликни 启动.bat внутри (откроется чёрное окно консоли — не закрывай). При первом запуске он напишет «AI-провайдер ещё не выбран, бот не стартует» и сам откроет панель управления в браузере — вся дальнейшая настройка делается на этой веб-странице, копировать или править файлы не нужно." },
-      { title: "3. Впиши ключ API на странице «Настройка AI»", body: "Провайдеры разбиты на три группы: китайские напрямую / зарубежные сервисы / локальный запуск. Выбери одного → вставь ключ (на каждой карточке есть ссылка на консоль этого провайдера) → нажми «Проверить соединение» → после успеха выпадающий список моделей заполнится реальным перечнем этого провайдера, выбери одну и сохрани. Ключ хранится только на твоём компьютере, в интерфейсе он всегда показан маской." },
+      { title: "3. Впиши ключ API на странице «Настройка AI»", body: "Провайдеры разбиты на три группы: китайские напрямую / зарубежные сервисы / локальный запуск. Выбери одного → вставь ключ (на каждой карточке есть ссылка на консоль этого провайдера) → нажми «Проверить соединение» → после успеха выпадающий список моделей заполнится реальным перечнем этого провайдера, выбери одну и сохрани. Ключ хранится на твоём компьютере и в интерфейсе всегда показан маской, но при каждом запросе он отправляется выбранному провайдеру — иначе его API тебя не аутентифицирует." },
       { title: "4. Открой мир для сети", body: "Одиночная игра → ESC → Открыть для сети → выбери режим → Старт. MC напишет в чате «Local game hosted on port XXXXX». Запомни порт." },
       { title: "5. Впиши порт на странице «Подключение к игре» и нажми «Запустить бота»", body: "Жми «Открыть админ-панель» сверху → страница «Подключение к игре» → впиши записанный номер → сохрани → «Запустить бота». Идущее в комплекте значение 25565 — просто заглушка, его обязательно надо заменить на порт своей сессии." },
       { title: "6. Подтверди вход бота", body: "В чате MC появится «Neko joined the game». Если нет — обнови статус здесь или посмотри последние строки в чёрном окне 启动.bat." },
@@ -367,7 +367,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     ],
     portsTitle: "Порты",
     ports: [
-      { key: "mc", label: "Игровой порт MC (по умолч. 55916)", value: "Число, которое показывает MC при открытии для сети. Бот использует его для входа в мир." },
+      { key: "mc", label: "Игровой порт MC", value: "Число, которое показывает MC при открытии для сети — по нему бот заходит в мир. Идущее в комплекте значение 25565 это лишь заглушка, его обязательно надо заменить на порт своей сессии." },
       { key: "admin", label: "Админ-панель (localhost:8765)", value: "Куда ведёт кнопка «Открыть админ-панель». Здесь ключ API, модель, имя и характер нэко-тян, скин, подключение к игре и переключатели поведения." },
     ],
     tipsTitle: "Решение проблем",

--- a/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
+++ b/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
@@ -109,7 +109,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   "zh-CN": {
     title: "Minecraft 游戏插件 快速开始",
     subtitle: "让猫娘陪你玩 MC——她会有一个自己的游戏角色，和你在同一个世界里一起行动。",
-    notice: "mc-agent 还在持续更新中：安装流程和控制面板的界面会随版本变化，网盘里的包也会不定期替换。如果你看到的界面和这里写的对不上，先回上面的下载卡片重新下一份最新的包；重下之后还是对不上，那就是新版还没发布，请耐心等待更新。",
+    notice: "mc-agent 还在持续更新中：安装流程和控制面板的界面会随版本变化，网盘里的包也会不定期替换。如果你看到的界面和这里写的对不上，先用本页的「下载 mc-agent」卡片重新下一份最新的包；重下之后还是对不上，那就是新版还没发布，请耐心等待更新。",
     cards: [
       { title: "先装 Minecraft", badge: "Install", body: "Java 版 v1.21.1 推荐，其他 1.21.x 也可。自己买正版或离线启动。" },
       { title: "再开 mc-agent", badge: "Setup", body: "下面下个 mc-agent 解压、双击「启动.bat」启动它。它和 N.E.K.O 是两个各自独立的程序，都开着就会自动连上。首次启动会自动打开控制面板网页，密钥、模型、游戏端口全在网页里填，不用碰任何文件。猫娘默认用离线模式进游戏，不需要另外给她买正版账号（代价是进不了开了正版验证的联机服务器，你自己开的局域网世界不受影响）。" },
@@ -130,7 +130,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     },
     download: {
       title: "下载 mc-agent",
-      hint: "三个网盘任选其一，下载完解压到一个短路径的目录（整条路径最好别超过 90 个字符），双击里面的「启动.bat」即可。启动后回这里点刷新看状态。",
+      hint: "三个网盘任选其一，下载完解压到一个短路径的目录（整条路径最好别超过 90 个字符），双击里面的「启动.bat」即可。启动后回这里点刷新看状态。已经装好了也可以从这里下新版覆盖更新。",
       quark: "夸克网盘",
       gdrive: "Google Drive",
       baidu: "百度网盘（提取码 kuro）",
@@ -164,7 +164,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   en: {
     title: "Minecraft Game Plugin — Quickstart",
     subtitle: "Let neko-chan play MC with you — she gets her own in-game character and moves around the same world you do.",
-    notice: "mc-agent is still under active development: the install flow and the control panel UI change between versions, and the netdisk archives get replaced from time to time. If what you see doesn't match this page, first re-download the latest archive from the download card above. If it still doesn't match after that, the new build simply isn't out yet — please be patient and wait for the update.",
+    notice: "mc-agent is still under active development: the install flow and the control panel UI change between versions, and the netdisk archives get replaced from time to time. If what you see doesn't match this page, first re-download the latest archive from the \"Download mc-agent\" card on this page. If it still doesn't match after that, the new build simply isn't out yet — please be patient and wait for the update.",
     cards: [
       { title: "Install Minecraft", badge: "Install", body: "Java Edition v1.21.1 recommended; other 1.21.x versions also work. Use any launcher you like." },
       { title: "Run mc-agent", badge: "Setup", body: "Download mc-agent below, unzip, double-click 启动.bat. It's a separate program from N.E.K.O.; run both and they connect on their own. On first launch it opens a control panel in your browser — API key, model and game port all go in there, you never edit a file. Neko-chan joins in offline mode by default, so she doesn't need her own paid Minecraft account (the trade-off: she can't join online-mode servers; your own LAN world is unaffected)." },
@@ -185,7 +185,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     },
     download: {
       title: "Download mc-agent",
-      hint: "Pick whichever drive is fastest. Unzip into a folder with a short path (keep the whole path under ~90 characters), double-click 启动.bat inside to launch, then hit Refresh here.",
+      hint: "Pick whichever drive is fastest. Unzip into a folder with a short path (keep the whole path under ~90 characters), double-click 启动.bat inside to launch, then hit Refresh here. Already set up? These are also the links to grab a newer build and update over it.",
       quark: "Quark Drive (CN)",
       gdrive: "Google Drive",
       baidu: "Baidu Pan (code: kuro)",
@@ -219,7 +219,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ja: {
     title: "Minecraft ゲームプラグイン クイックスタート",
     subtitle: "猫娘ちゃんと MC を遊ぼう。彼女は自分のキャラクターを持って、同じ世界であなたと一緒に動きます。",
-    notice: "mc-agent は現在も更新中です：導入手順やコントロールパネルの画面はバージョンごとに変わり、ネットディスク上のパッケージも随時差し替えられます。ここの説明と実際の画面が食い違う場合は、まず上のダウンロードカードから最新のパッケージを取り直してください。それでも合わない場合は新版がまだ公開されていないので、アップデートをお待ちください。",
+    notice: "mc-agent は現在も更新中です：導入手順やコントロールパネルの画面はバージョンごとに変わり、ネットディスク上のパッケージも随時差し替えられます。ここの説明と実際の画面が食い違う場合は、まずは本ページの「mc-agent をダウンロード」カードから最新のパッケージを取り直してください。それでも合わない場合は新版がまだ公開されていないので、アップデートをお待ちください。",
     cards: [
       { title: "Minecraft を入れる", badge: "Install", body: "Java 版 v1.21.1 推奨。他の 1.21.x でも可。お好きなランチャーで。" },
       { title: "mc-agent を起動", badge: "Setup", body: "下のカードから mc-agent を入手・解凍し「启动.bat」をダブルクリック。N.E.K.O とは別のプログラムで、両方を起動しておけば自動でつながります。初回起動時にブラウザでコントロールパネルが自動的に開き、API キー・モデル・ゲームのポートはすべてそこで入力します（ファイルを編集する必要はありません）。猫娘ちゃんは既定でオフラインモードで参加するので、専用の正規アカウントは不要です（その代わり正規認証のマルチサーバーには入れません。自分で開いた LAN ワールドは問題なし）。" },
@@ -240,7 +240,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     },
     download: {
       title: "mc-agent をダウンロード",
-      hint: "回線に合うものを選んで DL し、パスの短いフォルダに解凍（全体で 90 文字以内が目安）→ 中の「启动.bat」をダブルクリックで起動 → こちらで更新ボタンを押す。",
+      hint: "回線に合うものを選んで DL し、パスの短いフォルダに解凍（全体で 90 文字以内が目安）→ 中の「启动.bat」をダブルクリックで起動 → こちらで更新ボタンを押す。導入済みでも、新版を取り直して上書き更新する入口はここです。",
       quark: "Quark Drive（中国）",
       gdrive: "Google Drive",
       baidu: "百度网盘（パスワード kuro）",
@@ -274,7 +274,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ko: {
     title: "Minecraft 게임 플러그인 빠른 시작",
     subtitle: "고양이와 함께 MC를 즐기세요. 고양이는 자기 캐릭터로 같은 월드에 들어와 너와 함께 움직여요.",
-    notice: "mc-agent는 아직 계속 업데이트 중입니다: 설치 흐름과 제어판 화면이 버전마다 달라지고, 네트워크 드라이브의 압축 파일도 수시로 교체돼요. 여기 설명과 실제 화면이 다르면 먼저 위 다운로드 카드에서 최신 패키지를 다시 받아 보세요. 다시 받아도 그대로면 새 버전이 아직 안 나온 것이니 업데이트를 조금만 기다려 주세요.",
+    notice: "mc-agent는 아직 계속 업데이트 중입니다: 설치 흐름과 제어판 화면이 버전마다 달라지고, 네트워크 드라이브의 압축 파일도 수시로 교체돼요. 여기 설명과 실제 화면이 다르면 먼저 이 페이지의 「mc-agent 다운로드」 카드에서 최신 패키지를 다시 받아 보세요. 다시 받아도 그대로면 새 버전이 아직 안 나온 것이니 업데이트를 조금만 기다려 주세요.",
     cards: [
       { title: "Minecraft 설치", badge: "Install", body: "Java 에디션 v1.21.1 권장. 다른 1.21.x도 가능. 원하는 런처 사용." },
       { title: "mc-agent 실행", badge: "Setup", body: "아래에서 mc-agent 다운로드 → 압축 해제 → 「启动.bat」 더블클릭. N.E.K.O와는 별개 프로그램이라 둘 다 켜 두면 알아서 연결돼요. 처음 실행하면 브라우저에 제어판이 자동으로 열리고, API 키·모델·게임 포트를 전부 그 웹 화면에서 입력해요(파일을 건드릴 일 없음). 고양이는 기본적으로 오프라인 모드로 접속하니 정품 계정을 따로 살 필요는 없어요(대신 정품 인증을 켠 멀티 서버에는 못 들어가요. 직접 연 LAN 월드는 문제없음)." },
@@ -295,7 +295,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     },
     download: {
       title: "mc-agent 다운로드",
-      hint: "네트워크에 맞는 드라이브를 골라 다운로드 후 경로가 짧은 폴더에 압축 해제(전체 경로 90자 이내 권장) → 안의 「启动.bat」 더블클릭으로 실행 → 여기서 새로고침.",
+      hint: "네트워크에 맞는 드라이브를 골라 다운로드 후 경로가 짧은 폴더에 압축 해제(전체 경로 90자 이내 권장) → 안의 「启动.bat」 더블클릭으로 실행 → 여기서 새로고침. 이미 설치했더라도 새 버전을 받아 덮어쓰는 입구도 여기예요.",
       quark: "Quark Drive (중국)",
       gdrive: "Google Drive",
       baidu: "百度网盘 (비밀번호 kuro)",
@@ -329,7 +329,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ru: {
     title: "Игровой плагин Minecraft — Быстрый старт",
     subtitle: "Играй в MC вместе с нэко-тян — у неё будет свой персонаж, и она будет ходить по тому же миру, что и ты.",
-    notice: "mc-agent всё ещё активно обновляется: процесс установки и интерфейс панели управления меняются от версии к версии, архивы на дисках время от времени заменяются. Если увиденное не совпадает с этой страницей, сначала перекачай свежий архив по карточке «Скачать» выше. Если и после этого не совпадает — новая версия просто ещё не вышла, дождись обновления.",
+    notice: "mc-agent всё ещё активно обновляется: процесс установки и интерфейс панели управления меняются от версии к версии, архивы на дисках время от времени заменяются. Если увиденное не совпадает с этой страницей, сначала перекачай свежий архив по карточке «Скачать mc-agent» на этой странице. Если и после этого не совпадает — новая версия просто ещё не вышла, дождись обновления.",
     cards: [
       { title: "Установи Minecraft", badge: "Install", body: "Java Edition v1.21.1 рекомендуется; другие 1.21.x тоже подойдут. Любой лаунчер." },
       { title: "Запусти mc-agent", badge: "Setup", body: "Скачай mc-agent ниже, распакуй, дважды кликни 启动.bat. Это отдельная программа от N.E.K.O. — запусти обе, и они соединятся сами. При первом запуске в браузере сама откроется панель управления — ключ API, модель и игровой порт вводятся только там, никакие файлы править не нужно. Нэко-тян по умолчанию заходит в офлайн-режиме, так что отдельный лицензионный аккаунт покупать не надо (расплата: на серверы с проверкой лицензии она не попадёт; твой собственный LAN-мир это не затрагивает)." },
@@ -350,7 +350,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     },
     download: {
       title: "Скачать mc-agent",
-      hint: "Выбери диск побыстрее, распакуй в папку с коротким путём (весь путь лучше держать короче ~90 символов), дважды кликни 启动.bat внутри для запуска, затем жми «Обновить» здесь.",
+      hint: "Выбери диск побыстрее, распакуй в папку с коротким путём (весь путь лучше держать короче ~90 символов), дважды кликни 启动.bat внутри для запуска, затем жми «Обновить» здесь. Уже всё настроено? Отсюда же качается свежая сборка для обновления поверх.",
       quark: "Quark Drive (Китай)",
       gdrive: "Google Drive",
       baidu: "Baidu Pan (код kuro)",
@@ -534,27 +534,29 @@ export default function GameAgentMinecraftQuickstart(props: PluginSurfaceProps) 
         </Stack>
       </Card>
 
-      {state.connected !== true ? (
-        <Card title={copy.download.title}>
-          <Stack>
-            <Text>{copy.download.hint}</Text>
-            <ButtonGroup>
-              <Button
-                tone="primary"
-                onClick={() => openExternalUrl(DOWNLOAD_LINKS.quark)}
-              >
-                {copy.download.quark}
-              </Button>
-              <Button onClick={() => openExternalUrl(DOWNLOAD_LINKS.gdrive)}>
-                {copy.download.gdrive}
-              </Button>
-              <Button onClick={() => openExternalUrl(DOWNLOAD_LINKS.baidu)}>
-                {copy.download.baidu}
-              </Button>
-            </ButtonGroup>
-          </Stack>
-        </Card>
-      ) : null}
+      {/* Always rendered, including when already connected. An outdated
+          mc-agent still speaks the bridge protocol and so reports as
+          connected — those are exactly the users the notice above sends
+          here to re-download, and hiding the card would strand them. */}
+      <Card title={copy.download.title}>
+        <Stack>
+          <Text>{copy.download.hint}</Text>
+          <ButtonGroup>
+            <Button
+              tone="primary"
+              onClick={() => openExternalUrl(DOWNLOAD_LINKS.quark)}
+            >
+              {copy.download.quark}
+            </Button>
+            <Button onClick={() => openExternalUrl(DOWNLOAD_LINKS.gdrive)}>
+              {copy.download.gdrive}
+            </Button>
+            <Button onClick={() => openExternalUrl(DOWNLOAD_LINKS.baidu)}>
+              {copy.download.baidu}
+            </Button>
+          </ButtonGroup>
+        </Stack>
+      </Card>
 
       <Grid cols={3}>
         {copy.cards.map((card) => (

--- a/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
+++ b/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
@@ -71,7 +71,6 @@ type StatusCopy = {
   disconnected: string
   checking: string
   unknown: string
-  wsLabel: string
   taskLabel: string
   taskIdle: string
   adminHint: string
@@ -109,11 +108,11 @@ type GuideCopy = {
 const COPY: Record<LocaleKey, GuideCopy> = {
   "zh-CN": {
     title: "Minecraft 游戏插件 快速开始",
-    subtitle: "让猫娘陪你玩 MC——通过 mc-agent 桥接 mineflayer bot 控制游戏内化身。",
+    subtitle: "让猫娘陪你玩 MC——她会有一个自己的游戏角色，和你在同一个世界里一起行动。",
     notice: "mc-agent 还在持续更新中：安装流程和控制面板的界面会随版本变化，网盘里的包也会不定期替换。如果你看到的界面和这里写的对不上，多半是新版还没发布或你手上还是旧包，请耐心等待更新。",
     cards: [
       { title: "先装 Minecraft", badge: "Install", body: "Java 版 v1.21.1 推荐，其他 1.21.x 也可。自己买正版或离线启动。" },
-      { title: "再开 mc-agent", badge: "Bridge", body: "下面下个 mc-agent 解压、双击「启动.bat」启动它。它和 N.E.K.O 是两个独立程序，靠 WebSocket 联通。首次启动会自动打开控制面板网页，密钥、模型、游戏端口全在网页里填，不用碰任何文件。猫娘默认用离线模式进游戏，不需要另外给她买正版账号（代价是进不了开了正版验证的联机服务器，你自己开的局域网世界不受影响）。" },
+      { title: "再开 mc-agent", badge: "Setup", body: "下面下个 mc-agent 解压、双击「启动.bat」启动它。它和 N.E.K.O 是两个各自独立的程序，都开着就会自动连上。首次启动会自动打开控制面板网页，密钥、模型、游戏端口全在网页里填，不用碰任何文件。猫娘默认用离线模式进游戏，不需要另外给她买正版账号（代价是进不了开了正版验证的联机服务器，你自己开的局域网世界不受影响）。" },
       { title: "最后和猫娘一起玩吧", badge: "Play", body: "先在 MC 里把单人世界「对局域网开放」，猫娘才连得进来。然后和她正常聊天，她会一边陪你说话、一边和你在游戏里一起玩，就像身边真多了个玩家。（部分 AI 供应商暂时没法同时语音对话和操作游戏。）" },
     ],
     status: {
@@ -124,10 +123,9 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       disconnected: "未连接",
       checking: "检查中…",
       unknown: "未知",
-      wsLabel: "WebSocket",
       taskLabel: "当前任务",
       taskIdle: "（空闲）",
-      adminHint: "密钥、模型、MC 端口、bot 名字和皮肤全在管理面板（mindserver UI）里改，这是唯一的配置入口。",
+      adminHint: "密钥、模型、MC 端口、猫娘的名字和皮肤全在管理面板里改，这是唯一的配置入口。",
       errorPrefix: "查询失败：",
     },
     download: {
@@ -150,8 +148,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     portsTitle: "端口说明",
     ports: [
       { key: "mc", label: "MC 游戏端口（默认 55916）", value: "你「对局域网开放」时显示的那个数字。bot 通过它连进游戏世界。" },
-      { key: "mindserver", label: "mindserver 管理端口（默认 8765）", value: "上面那个「打开管理面板」按钮跳的就是这个。密钥、模型、bot 名字和人设、皮肤、游戏连接、行为开关全在这里改。" },
-      { key: "plugin", label: "plugin 桥接端口（默认 48909）", value: "插件和 mc-agent 之间的内部通信。一般不用动；想动改 NEKO_PLUGIN_WS_PORT 环境变量。" },
+      { key: "admin", label: "管理面板（localhost:8765）", value: "上面那个「打开管理面板」按钮跳的就是这个。密钥、模型、猫娘的名字和人设、皮肤、游戏连接、行为开关全在这里改。" },
     ],
     tipsTitle: "排错",
     tips: [
@@ -162,15 +159,15 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       "在面板里换了皮肤但游戏里没变：皮肤要真显示出来，Minecraft 服务端得装 FabricTailor 模组；没装的话面板里能看到、游戏里还是默认皮肤，其他功能不受影响。",
       "想关掉 mc-agent：在管理面板的 bot 列表里点 Stop，或者直接关 N.E.K.O。",
     ],
-    warning: "本插件只控制 bot；它在 MC 世界里的行为受你的指令和当前 LLM 模型能力影响，复杂任务可能会失败或绕路。",
+    warning: "猫娘在 MC 世界里的行为受你的指令和当前 AI 模型能力影响，复杂任务可能会失败或绕路。",
   },
   en: {
     title: "Minecraft Game Plugin — Quickstart",
-    subtitle: "Let neko-chan play MC with you. mc-agent bridges a mineflayer bot to control an in-game avatar.",
+    subtitle: "Let neko-chan play MC with you — she gets her own in-game character and moves around the same world you do.",
     notice: "mc-agent is still under active development: the install flow and the control panel UI change between versions, and the netdisk archives get replaced from time to time. If what you see doesn't match this page, you're most likely on an older build or the new one isn't out yet — please be patient and wait for the update.",
     cards: [
       { title: "Install Minecraft", badge: "Install", body: "Java Edition v1.21.1 recommended; other 1.21.x versions also work. Use any launcher you like." },
-      { title: "Run mc-agent", badge: "Bridge", body: "Download mc-agent below, unzip, double-click 启动.bat. It's a separate program from N.E.K.O., they talk over WebSocket. On first launch it opens a control panel in your browser — API key, model and game port all go in there, you never edit a file. Neko-chan joins in offline mode by default, so she doesn't need her own paid Minecraft account (the trade-off: she can't join online-mode servers; your own LAN world is unaffected)." },
+      { title: "Run mc-agent", badge: "Setup", body: "Download mc-agent below, unzip, double-click 启动.bat. It's a separate program from N.E.K.O.; run both and they connect on their own. On first launch it opens a control panel in your browser — API key, model and game port all go in there, you never edit a file. Neko-chan joins in offline mode by default, so she doesn't need her own paid Minecraft account (the trade-off: she can't join online-mode servers; your own LAN world is unaffected)." },
       { title: "Play together", badge: "Play", body: "First, open your single-player world to LAN so neko-chan can connect. Then just chat with neko-chan — she'll keep talking with you while playing alongside you in the world, like a real second player. (Some AI providers can't yet voice-chat and operate the game at the same time.)" },
     ],
     status: {
@@ -181,10 +178,9 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       disconnected: "Disconnected",
       checking: "Checking…",
       unknown: "Unknown",
-      wsLabel: "WebSocket",
       taskLabel: "Current task",
       taskIdle: "(idle)",
-      adminHint: "API key, model, MC port, bot name and skin are all changed in the admin panel (mindserver UI) — it's the only place you configure anything.",
+      adminHint: "API key, model, MC port, neko-chan's name and skin are all changed in the admin panel — it's the only place you configure anything.",
       errorPrefix: "Query failed: ",
     },
     download: {
@@ -207,8 +203,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     portsTitle: "Ports",
     ports: [
       { key: "mc", label: "MC game port (default 55916)", value: "The number MC shows when you Open to LAN. The bot uses this to join your world." },
-      { key: "mindserver", label: "mindserver admin port (default 8765)", value: "Where the \"Open admin panel\" button goes. API key, model, bot name and persona, skin, game connection and behavior toggles all live here." },
-      { key: "plugin", label: "plugin bridge port (default 48909)", value: "Internal channel between this plugin and mc-agent. Don't touch unless port is in use — override with NEKO_PLUGIN_WS_PORT env var." },
+      { key: "admin", label: "Admin panel (localhost:8765)", value: "Where the \"Open admin panel\" button goes. API key, model, neko-chan's name and persona, skin, game connection and behavior toggles all live here." },
     ],
     tipsTitle: "Troubleshooting",
     tips: [
@@ -219,15 +214,15 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       "Changed the skin in the panel but the game looks the same: skins only render if the Minecraft server has the FabricTailor mod installed. Without it the panel shows your skin but the game keeps the default one; nothing else is affected.",
       "To stop mc-agent: click Stop in the admin panel's bot list, or just close N.E.K.O.",
     ],
-    warning: "This plugin only controls the bot. In-world behavior depends on your prompts and the current LLM's capability; complex tasks may stall or detour.",
+    warning: "What neko-chan does in the world depends on your instructions and the capability of the AI model in use; complex tasks may stall or detour.",
   },
   ja: {
     title: "Minecraft ゲームプラグイン クイックスタート",
-    subtitle: "猫娘ちゃんと MC を遊ぼう。mc-agent が mineflayer ボットを橋渡しして、ゲーム内アバターを操作します。",
+    subtitle: "猫娘ちゃんと MC を遊ぼう。彼女は自分のキャラクターを持って、同じ世界であなたと一緒に動きます。",
     notice: "mc-agent は現在も更新中です：導入手順やコントロールパネルの画面はバージョンごとに変わり、ネットディスク上のパッケージも随時差し替えられます。ここの説明と実際の画面が食い違う場合は、新版が未公開か手元が旧版のことがほとんどなので、アップデートをお待ちください。",
     cards: [
       { title: "Minecraft を入れる", badge: "Install", body: "Java 版 v1.21.1 推奨。他の 1.21.x でも可。お好きなランチャーで。" },
-      { title: "mc-agent を起動", badge: "Bridge", body: "下のカードから mc-agent を入手・解凍し「启动.bat」をダブルクリック。N.E.K.O とは別プログラムで WebSocket 経由で連携。初回起動時にブラウザでコントロールパネルが自動的に開き、API キー・モデル・ゲームのポートはすべてそこで入力します（ファイルを編集する必要はありません）。猫娘ちゃんは既定でオフラインモードで参加するので、専用の正規アカウントは不要です（その代わり正規認証のマルチサーバーには入れません。自分で開いた LAN ワールドは問題なし）。" },
+      { title: "mc-agent を起動", badge: "Setup", body: "下のカードから mc-agent を入手・解凍し「启动.bat」をダブルクリック。N.E.K.O とは別のプログラムで、両方を起動しておけば自動でつながります。初回起動時にブラウザでコントロールパネルが自動的に開き、API キー・モデル・ゲームのポートはすべてそこで入力します（ファイルを編集する必要はありません）。猫娘ちゃんは既定でオフラインモードで参加するので、専用の正規アカウントは不要です（その代わり正規認証のマルチサーバーには入れません。自分で開いた LAN ワールドは問題なし）。" },
       { title: "一緒に遊ぼう", badge: "Play", body: "まず自分のシングルプレイ世界を「LANに公開」すると猫娘ちゃんが入れます。あとは普通におしゃべりするだけ。猫娘ちゃんは会話を続けながら、本物のもう一人のプレイヤーのように一緒に遊んでくれる。（一部の AI プロバイダーでは、音声会話とゲーム操作の同時進行がまだできない場合があります。）" },
     ],
     status: {
@@ -238,10 +233,9 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       disconnected: "未接続",
       checking: "確認中…",
       unknown: "不明",
-      wsLabel: "WebSocket",
       taskLabel: "現在のタスク",
       taskIdle: "（待機）",
-      adminHint: "API キー、モデル、MC ポート、ボット名、スキンはすべて管理パネル（mindserver UI）で変更します。設定の入口はここだけです。",
+      adminHint: "API キー、モデル、MC ポート、猫娘ちゃんの名前、スキンはすべて管理パネルで変更します。設定の入口はここだけです。",
       errorPrefix: "問い合わせ失敗: ",
     },
     download: {
@@ -264,8 +258,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     portsTitle: "ポート一覧",
     ports: [
       { key: "mc", label: "MC ゲームポート（既定 55916）", value: "「LANに公開」時に MC が表示する番号。ボットがこれでワールドに参加。" },
-      { key: "mindserver", label: "mindserver 管理ポート（既定 8765）", value: "「管理パネルを開く」が飛ぶ先。API キー、モデル、ボット名と人格、スキン、ゲーム接続、動作スイッチはすべてここ。" },
-      { key: "plugin", label: "plugin ブリッジポート（既定 48909）", value: "プラグインと mc-agent の内部通信。基本いじらない。変えるなら NEKO_PLUGIN_WS_PORT 環境変数で。" },
+      { key: "admin", label: "管理パネル（localhost:8765）", value: "「管理パネルを開く」が飛ぶ先。API キー、モデル、猫娘ちゃんの名前と人格、スキン、ゲーム接続、動作スイッチはすべてここ。" },
     ],
     tipsTitle: "トラブルシューティング",
     tips: [
@@ -276,15 +269,15 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       "パネルでスキンを変えてもゲーム内が変わらない: スキンの反映には Minecraft サーバー側に FabricTailor モッドが必要。未導入だとパネルには表示されてもゲーム内は既定スキンのまま（他の機能に影響なし）。",
       "mc-agent を止める: 管理パネルのボット一覧から Stop、または N.E.K.O ごと終了。",
     ],
-    warning: "本プラグインはボット操作のみ。世界内での挙動は指示内容と現在の LLM 性能に依存し、複雑なタスクは失敗 / 迂回することがあります。",
+    warning: "世界内での猫娘ちゃんの挙動は、指示内容と使用中の AI モデルの性能に左右されます。複雑なタスクは失敗 / 迂回することがあります。",
   },
   ko: {
     title: "Minecraft 게임 플러그인 빠른 시작",
-    subtitle: "고양이 캐릭터와 함께 MC를 즐기세요. mc-agent가 mineflayer 봇을 게임 내 아바타로 다리 놓아 줍니다.",
+    subtitle: "고양이와 함께 MC를 즐기세요. 고양이는 자기 캐릭터로 같은 월드에 들어와 너와 함께 움직여요.",
     notice: "mc-agent는 아직 계속 업데이트 중입니다: 설치 흐름과 제어판 화면이 버전마다 달라지고, 네트워크 드라이브의 압축 파일도 수시로 교체돼요. 여기 설명과 실제 화면이 다르면 대개 새 버전이 아직 안 나왔거나 예전 빌드를 쓰고 있는 것이니, 업데이트를 조금만 기다려 주세요.",
     cards: [
       { title: "Minecraft 설치", badge: "Install", body: "Java 에디션 v1.21.1 권장. 다른 1.21.x도 가능. 원하는 런처 사용." },
-      { title: "mc-agent 실행", badge: "Bridge", body: "아래에서 mc-agent 다운로드 → 압축 해제 → 「启动.bat」 더블클릭. N.E.K.O와는 별개 프로그램으로 WebSocket으로 연동. 처음 실행하면 브라우저에 제어판이 자동으로 열리고, API 키·모델·게임 포트를 전부 그 웹 화면에서 입력해요(파일을 건드릴 일 없음). 고양이는 기본적으로 오프라인 모드로 접속하니 정품 계정을 따로 살 필요는 없어요(대신 정품 인증을 켠 멀티 서버에는 못 들어가요. 직접 연 LAN 월드는 문제없음)." },
+      { title: "mc-agent 실행", badge: "Setup", body: "아래에서 mc-agent 다운로드 → 압축 해제 → 「启动.bat」 더블클릭. N.E.K.O와는 별개 프로그램이라 둘 다 켜 두면 알아서 연결돼요. 처음 실행하면 브라우저에 제어판이 자동으로 열리고, API 키·모델·게임 포트를 전부 그 웹 화면에서 입력해요(파일을 건드릴 일 없음). 고양이는 기본적으로 오프라인 모드로 접속하니 정품 계정을 따로 살 필요는 없어요(대신 정품 인증을 켠 멀티 서버에는 못 들어가요. 직접 연 LAN 월드는 문제없음)." },
       { title: "함께 놀기", badge: "Play", body: "먼저 본인 싱글플레이 월드를 「LAN에 공개」해야 고양이가 들어올 수 있어요. 그다음 그냥 평범하게 대화하세요. 고양이는 너와 이야기를 나누면서 진짜 또 한 명의 플레이어처럼 함께 놀아 줍니다. (일부 AI 제공자는 아직 음성 대화와 게임 조작을 동시에 못 할 수 있어요.)" },
     ],
     status: {
@@ -295,10 +288,9 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       disconnected: "연결 안 됨",
       checking: "확인 중…",
       unknown: "알 수 없음",
-      wsLabel: "WebSocket",
       taskLabel: "현재 작업",
       taskIdle: "(대기)",
-      adminHint: "API 키, 모델, MC 포트, 봇 이름, 스킨 모두 관리 패널(mindserver UI)에서 변경합니다. 설정 입구는 여기 하나뿐이에요.",
+      adminHint: "API 키, 모델, MC 포트, 고양이 이름, 스킨 모두 관리 패널에서 변경합니다. 설정 입구는 여기 하나뿐이에요.",
       errorPrefix: "조회 실패: ",
     },
     download: {
@@ -321,8 +313,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     portsTitle: "포트 안내",
     ports: [
       { key: "mc", label: "MC 게임 포트 (기본 55916)", value: "「LAN에 공개」 시 MC가 보여주는 숫자. 봇이 이를 통해 월드 참가." },
-      { key: "mindserver", label: "mindserver 관리 포트 (기본 8765)", value: "「관리 패널 열기」가 가는 곳. API 키, 모델, 봇 이름과 성격, 스킨, 게임 연결, 동작 스위치가 전부 여기에 있어요." },
-      { key: "plugin", label: "plugin 브릿지 포트 (기본 48909)", value: "플러그인과 mc-agent 사이 내부 통신. 보통 손대지 않음. 바꾸려면 NEKO_PLUGIN_WS_PORT 환경변수." },
+      { key: "admin", label: "관리 패널 (localhost:8765)", value: "「관리 패널 열기」가 가는 곳. API 키, 모델, 고양이 이름과 성격, 스킨, 게임 연결, 동작 스위치가 전부 여기에 있어요." },
     ],
     tipsTitle: "문제 해결",
     tips: [
@@ -333,15 +324,15 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       "패널에서 스킨을 바꿨는데 게임에서 그대로: 스킨이 실제로 보이려면 Minecraft 서버에 FabricTailor 모드가 설치돼 있어야 해요. 없으면 패널에만 보이고 게임에서는 기본 스킨 (다른 기능에는 영향 없음).",
       "mc-agent 종료: 관리 패널의 봇 목록에서 Stop, 또는 N.E.K.O 전체 종료.",
     ],
-    warning: "본 플러그인은 봇 제어만 담당. 월드 내 행동은 지시 내용과 현재 LLM 능력에 따라 달라지며 복잡한 작업은 실패 / 우회할 수 있음.",
+    warning: "월드 안에서 고양이가 하는 행동은 네 지시와 지금 쓰는 AI 모델의 능력에 따라 달라져요. 복잡한 작업은 실패하거나 돌아갈 수 있어요.",
   },
   ru: {
     title: "Игровой плагин Minecraft — Быстрый старт",
-    subtitle: "Играй в MC вместе с нэко-тян. mc-agent связывает mineflayer-бота с аватаром в игре.",
+    subtitle: "Играй в MC вместе с нэко-тян — у неё будет свой персонаж, и она будет ходить по тому же миру, что и ты.",
     notice: "mc-agent всё ещё активно обновляется: процесс установки и интерфейс панели управления меняются от версии к версии, архивы на дисках время от времени заменяются. Если увиденное не совпадает с этой страницей — скорее всего, новая версия ещё не вышла или у тебя старая сборка. Пожалуйста, дождись обновления.",
     cards: [
       { title: "Установи Minecraft", badge: "Install", body: "Java Edition v1.21.1 рекомендуется; другие 1.21.x тоже подойдут. Любой лаунчер." },
-      { title: "Запусти mc-agent", badge: "Bridge", body: "Скачай mc-agent ниже, распакуй, дважды кликни 启动.bat. Это отдельная программа от N.E.K.O., связь по WebSocket. При первом запуске в браузере сама откроется панель управления — ключ API, модель и игровой порт вводятся только там, никакие файлы править не нужно. Нэко-тян по умолчанию заходит в офлайн-режиме, так что отдельный лицензионный аккаунт покупать не надо (расплата: на серверы с проверкой лицензии она не попадёт; твой собственный LAN-мир это не затрагивает)." },
+      { title: "Запусти mc-agent", badge: "Setup", body: "Скачай mc-agent ниже, распакуй, дважды кликни 启动.bat. Это отдельная программа от N.E.K.O. — запусти обе, и они соединятся сами. При первом запуске в браузере сама откроется панель управления — ключ API, модель и игровой порт вводятся только там, никакие файлы править не нужно. Нэко-тян по умолчанию заходит в офлайн-режиме, так что отдельный лицензионный аккаунт покупать не надо (расплата: на серверы с проверкой лицензии она не попадёт; твой собственный LAN-мир это не затрагивает)." },
       { title: "Играйте вместе", badge: "Play", body: "Сначала открой свой одиночный мир для сети (кнопка «Открыть для сети»), чтобы нэко-тян смогла подключиться. Затем просто болтай с нэко-тян — она будет общаться с тобой и одновременно играть рядом, как настоящий второй игрок. (У части AI-провайдеров пока не получается одновременно вести голосовой диалог и управлять игрой.)" },
     ],
     status: {
@@ -352,10 +343,9 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       disconnected: "Нет связи",
       checking: "Проверка…",
       unknown: "Неизвестно",
-      wsLabel: "WebSocket",
       taskLabel: "Текущая задача",
       taskIdle: "(простой)",
-      adminHint: "Ключ API, модель, MC-порт, имя бота и скин меняются в админ-панели (mindserver UI) — это единственная точка настройки.",
+      adminHint: "Ключ API, модель, MC-порт, имя нэко-тян и скин меняются в админ-панели — это единственная точка настройки.",
       errorPrefix: "Ошибка запроса: ",
     },
     download: {
@@ -378,8 +368,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     portsTitle: "Порты",
     ports: [
       { key: "mc", label: "Игровой порт MC (по умолч. 55916)", value: "Число, которое показывает MC при открытии для сети. Бот использует его для входа в мир." },
-      { key: "mindserver", label: "Админ-порт mindserver (по умолч. 8765)", value: "Куда ведёт кнопка «Открыть админ-панель». Здесь ключ API, модель, имя и характер бота, скин, подключение к игре и переключатели поведения." },
-      { key: "plugin", label: "Мост-порт plugin (по умолч. 48909)", value: "Внутренняя связь между плагином и mc-agent. Обычно не трогай. Меняй переменной окружения NEKO_PLUGIN_WS_PORT." },
+      { key: "admin", label: "Админ-панель (localhost:8765)", value: "Куда ведёт кнопка «Открыть админ-панель». Здесь ключ API, модель, имя и характер нэко-тян, скин, подключение к игре и переключатели поведения." },
     ],
     tipsTitle: "Решение проблем",
     tips: [
@@ -390,7 +379,7 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       "Поменял скин в панели, а в игре без изменений: чтобы скин реально отображался, на сервере Minecraft должен стоять мод FabricTailor. Без него скин виден только в панели, а в игре остаётся стандартный (на остальное не влияет).",
       "Остановить mc-agent: нажми Stop в списке ботов админ-панели, или просто закрой N.E.K.O.",
     ],
-    warning: "Плагин управляет только ботом. Поведение в мире зависит от твоих инструкций и текущей модели LLM; сложные задачи могут провалиться или пойти в обход.",
+    warning: "Что нэко-тян делает в мире, зависит от твоих инструкций и возможностей используемой AI-модели; сложные задачи могут провалиться или пойти в обход.",
   },
 }
 
@@ -406,7 +395,6 @@ function resolveLocale(locale: string | undefined): LocaleKey {
 type StatusState = {
   loading: boolean
   connected: boolean | null  // null = never queried yet
-  wsUrl: string
   pendingTask: string
   error: string
 }
@@ -431,7 +419,6 @@ export default function GameAgentMinecraftQuickstart(props: PluginSurfaceProps) 
   const [state, setState] = useState<StatusState>({
     loading: false,
     connected: null,
-    wsUrl: "",
     pendingTask: "",
     error: "",
   })
@@ -459,7 +446,6 @@ export default function GameAgentMinecraftQuickstart(props: PluginSurfaceProps) 
       setState({
         loading: false,
         connected: Boolean(data.connected),
-        wsUrl: String(data.ws_url || ""),
         pendingTask: String(data.pending_task || ""),
         error: "",
       })
@@ -509,8 +495,10 @@ export default function GameAgentMinecraftQuickstart(props: PluginSurfaceProps) 
         ? status.connected
         : status.disconnected
 
+  // Only the player-facing bits go on this card. The bridge URL the status
+  // entry also returns (ws://localhost:48909) is plumbing — it belongs in the
+  // plugin README, not on a panel end users read.
   const statusItems = [
-    { key: "ws", label: status.wsLabel, value: state.wsUrl || "—" },
     {
       key: "task",
       label: status.taskLabel,

--- a/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
+++ b/plugin/plugins/game_agent_minecraft/surfaces/quickstart.tsx
@@ -29,7 +29,7 @@ const STATUS_REFRESH_INTERVAL_MS = 5000
 
 // mc-agent is distributed as a zip on three netdisks (China-friendly +
 // global). End users pick whichever one is fastest, download, unzip
-// anywhere on disk, and double-click the bundled 启动mc-agent.bat to
+// anywhere on disk, and double-click the bundled 启动.bat to
 // run it — it's a separate program from N.E.K.O., the two communicate
 // over WebSocket (ws://localhost:48909 by default). We deliberately do
 // NOT bundle / auto-spawn mc-agent from N.E.K.O.: non-MC users would
@@ -89,6 +89,7 @@ type DownloadCopy = {
 type GuideCopy = {
   title: string
   subtitle: string
+  notice: string
   cards: Array<{ title: string; badge: string; body: string }>
   status: StatusCopy
   download: DownloadCopy
@@ -109,9 +110,10 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   "zh-CN": {
     title: "Minecraft 游戏插件 快速开始",
     subtitle: "让猫娘陪你玩 MC——通过 mc-agent 桥接 mineflayer bot 控制游戏内化身。",
+    notice: "mc-agent 还在持续更新中：安装流程和控制面板的界面会随版本变化，网盘里的包也会不定期替换。如果你看到的界面和这里写的对不上，多半是新版还没发布或你手上还是旧包，请耐心等待更新。",
     cards: [
       { title: "先装 Minecraft", badge: "Install", body: "Java 版 v1.21.1 推荐，其他 1.21.x 也可。自己买正版或离线启动。" },
-      { title: "再开 mc-agent", badge: "Bridge", body: "下面下个 mc-agent 解压、双击「启动mc-agent.bat」启动它。它和 N.E.K.O 是两个独立程序，靠 WebSocket 联通。还要给猫娘准备一个正版 Minecraft（微软）账号、在 mc-agent 里登录，她才进得了游戏。" },
+      { title: "再开 mc-agent", badge: "Bridge", body: "下面下个 mc-agent 解压、双击「启动.bat」启动它。它和 N.E.K.O 是两个独立程序，靠 WebSocket 联通。首次启动会自动打开控制面板网页，密钥、模型、游戏端口全在网页里填，不用碰任何文件。猫娘默认用离线模式进游戏，不需要另外给她买正版账号（代价是进不了开了正版验证的联机服务器，你自己开的局域网世界不受影响）。" },
       { title: "最后和猫娘一起玩吧", badge: "Play", body: "先在 MC 里把单人世界「对局域网开放」，猫娘才连得进来。然后和她正常聊天，她会一边陪你说话、一边和你在游戏里一起玩，就像身边真多了个玩家。（部分 AI 供应商暂时没法同时语音对话和操作游戏。）" },
     ],
     status: {
@@ -125,12 +127,12 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       wsLabel: "WebSocket",
       taskLabel: "当前任务",
       taskIdle: "（空闲）",
-      adminHint: "改 MC 端口、bot 名字、profile 都去管理面板（mindserver UI）。",
+      adminHint: "密钥、模型、MC 端口、bot 名字和皮肤全在管理面板（mindserver UI）里改，这是唯一的配置入口。",
       errorPrefix: "查询失败：",
     },
     download: {
       title: "下载 mc-agent",
-      hint: "三个网盘任选其一，下载完解压到任意目录，双击里面的「启动mc-agent.bat」即可。启动后回这里点刷新看状态。",
+      hint: "三个网盘任选其一，下载完解压到一个短路径的目录（整条路径最好别超过 90 个字符），双击里面的「启动.bat」即可。启动后回这里点刷新看状态。",
       quark: "夸克网盘",
       gdrive: "Google Drive",
       baidu: "百度网盘（提取码 kuro）",
@@ -138,23 +140,26 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupTitle: "完整流程",
     setupSteps: [
       { title: "1. 装 Minecraft Java Edition", body: "推荐 v1.21.1（1.21.x 系列都行）。自己选择正版 / 离线启动器。" },
-      { title: "2. 装 mc-agent（如果上面状态显示「未连接」）", body: "用上面的下载卡片，三个网盘挑一个下 mc-agent.zip，解压到任意目录。首次启动前：在解压出来的根目录（和「启动mc-agent.bat」同一层）把 keys.example.json 复制成 keys.json，填上你的 OPENAI_API_KEY（或其他 LLM 提供商的 key）。如果用的不是 OpenAI 而是别家的 key，记得同步把 neko.json 里的模型名改成该提供商支持的模型。然后双击「启动mc-agent.bat」启动它（会开一个命令行黑窗口，别关）。N.E.K.O 这边会自动连上。" },
-      { title: "3. 开 MC 世界并「对局域网开放」", body: "进入单人世界 → ESC → 对局域网开放 → 选游戏模式 → 创建局域网世界。MC 会在聊天框显示「Local game hosted on port XXXXX」，记下这个端口号。" },
-      { title: "4. 在管理面板里把 MC 端口改成你抄下的那个", body: "点上面「打开管理面板」按钮 → 找到 bot 配置 → 修改 port 字段 → 保存。bot 会自动重启用新端口连进 MC 世界。" },
-      { title: "5. 验证 bot 进游戏了", body: "MC 聊天框会看到「Neko joined the game」。看不到就刷新本页状态，或者看「启动mc-agent.bat」那个黑窗口报什么错。" },
-      { title: "6. 跟猫娘说话", body: "你可以和猫娘一边聊天一边玩耍，她会根据你的要求和她自己的想法行动。" },
+      { title: "2. 装 mc-agent（如果上面状态显示「未连接」）", body: "用上面的下载卡片，三个网盘挑一个下 mc-agent 压缩包，解压到一个路径短一点的目录（比如 C:\\mc-agent 或桌面）。然后双击里面的「启动.bat」（会开一个命令行黑窗口，别关）。它第一次启动会提示「还没有选择 AI 供应商，bot 暂不启动」，同时自动打开控制面板网页——接下来全部配置都在那个网页里做，不需要复制或编辑任何文件。" },
+      { title: "3. 在控制面板「AI 配置」页填密钥", body: "供应商分「国内直连 / 境外服务 / 本机运行」三组，国内那组不需要梯子、注册即用（DeepSeek、通义千问、智谱 GLM、Kimi、豆包、硅基流动等）。点一家 → 粘贴密钥（每张卡片上都有「去申请密钥」的外链）→ 点「测试连接」→ 测通后模型下拉会自动拉到该供应商的真实模型列表，挑一个保存。密钥只存在你自己电脑上，网页里永远显示成掩码。" },
+      { title: "4. 开 MC 世界并「对局域网开放」", body: "进入单人世界 → ESC → 对局域网开放 → 选游戏模式 → 创建局域网世界。MC 会在聊天框显示「Local game hosted on port XXXXX」，记下这个端口号。" },
+      { title: "5. 在控制面板「游戏连接」页填端口，再点「启动 Bot」", body: "点上面「打开管理面板」按钮 → 「游戏连接」页 → 把上一步抄下来的端口填进去 → 保存 → 点「启动 Bot」。包里自带的端口是占位值 25565，必须换成你自己那局的。" },
+      { title: "6. 验证 bot 进游戏了", body: "MC 聊天框会看到「Neko joined the game」。看不到就刷新本页状态，或者看「启动.bat」那个黑窗口最后几行报什么错。" },
+      { title: "7. 跟猫娘说话", body: "你可以和猫娘一边聊天一边玩耍，她会根据你的要求和她自己的想法行动。" },
     ],
     portsTitle: "端口说明",
     ports: [
       { key: "mc", label: "MC 游戏端口（默认 55916）", value: "你「对局域网开放」时显示的那个数字。bot 通过它连进游戏世界。" },
-      { key: "mindserver", label: "mindserver 管理端口（默认 8765）", value: "上面那个「打开管理面板」按钮跳的就是这个。改 bot 配置都在这里。" },
+      { key: "mindserver", label: "mindserver 管理端口（默认 8765）", value: "上面那个「打开管理面板」按钮跳的就是这个。密钥、模型、bot 名字和人设、皮肤、游戏连接、行为开关全在这里改。" },
       { key: "plugin", label: "plugin 桥接端口（默认 48909）", value: "插件和 mc-agent 之间的内部通信。一般不用动；想动改 NEKO_PLUGIN_WS_PORT 环境变量。" },
     ],
     tipsTitle: "排错",
     tips: [
-      "状态一直「未连接」：没启动「启动mc-agent.bat」，或者 bat 启动后报错就退了；看那个黑窗口最后几行报什么错。",
-      "bot 进不了 MC 世界：99% 端口对不上；MC 那边随机端口，每次重开都不一样，要在管理面板里改。",
+      "状态一直「未连接」：没启动「启动.bat」，或者启动后报错就退了；看那个黑窗口最后几行报什么错。",
+      "解压时报「找不到路径的一部分」：不是压缩包坏了，是解压目录路径太长（Windows 上限 260 字符）。换个短路径重解压，比如 C:\\mc-agent。",
+      "bot 进不了 MC 世界：99% 端口对不上；MC 那边随机端口，每次重新「对局域网开放」都不一样，要回控制面板「游戏连接」页改。",
       "bot 进了但啥也不干：可能是 N.E.K.O. 没有正确识别连接；回本页点刷新看状态，并在 N.E.K.O 设置页确认本插件是「已启用」。",
+      "在面板里换了皮肤但游戏里没变：皮肤要真显示出来，Minecraft 服务端得装 FabricTailor 模组；没装的话面板里能看到、游戏里还是默认皮肤，其他功能不受影响。",
       "想关掉 mc-agent：在管理面板的 bot 列表里点 Stop，或者直接关 N.E.K.O。",
     ],
     warning: "本插件只控制 bot；它在 MC 世界里的行为受你的指令和当前 LLM 模型能力影响，复杂任务可能会失败或绕路。",
@@ -162,9 +167,10 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   en: {
     title: "Minecraft Game Plugin — Quickstart",
     subtitle: "Let neko-chan play MC with you. mc-agent bridges a mineflayer bot to control an in-game avatar.",
+    notice: "mc-agent is still under active development: the install flow and the control panel UI change between versions, and the netdisk archives get replaced from time to time. If what you see doesn't match this page, you're most likely on an older build or the new one isn't out yet — please be patient and wait for the update.",
     cards: [
       { title: "Install Minecraft", badge: "Install", body: "Java Edition v1.21.1 recommended; other 1.21.x versions also work. Use any launcher you like." },
-      { title: "Run mc-agent", badge: "Bridge", body: "Download mc-agent below, unzip, double-click 启动mc-agent.bat. It's a separate program from N.E.K.O., they talk over WebSocket. You also need to give neko-chan her own genuine Minecraft (Microsoft) account and log it in inside mc-agent — otherwise she can't join the game." },
+      { title: "Run mc-agent", badge: "Bridge", body: "Download mc-agent below, unzip, double-click 启动.bat. It's a separate program from N.E.K.O., they talk over WebSocket. On first launch it opens a control panel in your browser — API key, model and game port all go in there, you never edit a file. Neko-chan joins in offline mode by default, so she doesn't need her own paid Minecraft account (the trade-off: she can't join online-mode servers; your own LAN world is unaffected)." },
       { title: "Play together", badge: "Play", body: "First, open your single-player world to LAN so neko-chan can connect. Then just chat with neko-chan — she'll keep talking with you while playing alongside you in the world, like a real second player. (Some AI providers can't yet voice-chat and operate the game at the same time.)" },
     ],
     status: {
@@ -178,12 +184,12 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       wsLabel: "WebSocket",
       taskLabel: "Current task",
       taskIdle: "(idle)",
-      adminHint: "Change MC port, bot name, or profile via the admin panel (mindserver UI).",
+      adminHint: "API key, model, MC port, bot name and skin are all changed in the admin panel (mindserver UI) — it's the only place you configure anything.",
       errorPrefix: "Query failed: ",
     },
     download: {
       title: "Download mc-agent",
-      hint: "Pick whichever drive is fastest. Unzip anywhere, double-click 启动mc-agent.bat inside to launch, then hit Refresh here.",
+      hint: "Pick whichever drive is fastest. Unzip into a folder with a short path (keep the whole path under ~90 characters), double-click 启动.bat inside to launch, then hit Refresh here.",
       quark: "Quark Drive (CN)",
       gdrive: "Google Drive",
       baidu: "Baidu Pan (code: kuro)",
@@ -191,23 +197,26 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupTitle: "Full setup flow",
     setupSteps: [
       { title: "1. Install Minecraft Java Edition", body: "v1.21.1 recommended (any 1.21.x is fine). Pick any launcher (official, MultiMC, Prism, etc.)." },
-      { title: "2. Install mc-agent (if status above is \"Disconnected\")", body: "Use the download card above — pick any of the three drives, grab mc-agent.zip, extract anywhere. First-time setup: in the extracted root folder (same level as 启动mc-agent.bat), copy keys.example.json to keys.json, and fill in your OPENAI_API_KEY (or another LLM provider's key). If you use a non-OpenAI provider, also change the model name in neko.json to one that provider supports. Then double-click 启动mc-agent.bat (it opens a black console window — don't close it). N.E.K.O. will auto-connect." },
-      { title: "3. Open a world to LAN", body: "Single player → ESC → Open to LAN → pick game mode → Start. MC will print \"Local game hosted on port XXXXX\" in chat. Note the port number." },
-      { title: "4. Change MC port via admin panel", body: "Click \"Open admin panel\" above → find your bot config → change the port field to the number you wrote down → save. The bot will restart and join your world." },
-      { title: "5. Confirm the bot joined", body: "You should see \"Neko joined the game\" in MC chat. If not, refresh status here or check the 启动mc-agent.bat console window for errors." },
-      { title: "6. Talk to neko-chan", body: "Chat and play with neko-chan — she'll act on what you ask and on her own ideas." },
+      { title: "2. Install mc-agent (if status above is \"Disconnected\")", body: "Use the download card above — pick any of the three drives, grab the mc-agent archive, extract it into a short path (e.g. C:\\mc-agent or your Desktop). Then double-click 启动.bat inside (it opens a black console window — don't close it). On first launch it prints \"no AI provider selected yet, bot not started\" and opens the control panel in your browser — everything from here on is done in that web page, you never copy or edit a file." },
+      { title: "3. Set your API key on the panel's \"AI config\" page", body: "Providers are grouped into China-direct / overseas / local. Pick one → paste your key (each card links straight to that vendor's console to get one) → click \"Test connection\" → once it passes, the model dropdown auto-fills with that provider's real model list; pick one and save. The key never leaves your machine and is always shown masked in the UI." },
+      { title: "4. Open a world to LAN", body: "Single player → ESC → Open to LAN → pick game mode → Start. MC will print \"Local game hosted on port XXXXX\" in chat. Note the port number." },
+      { title: "5. Enter the port on the \"Game connection\" page, then Start Bot", body: "Click \"Open admin panel\" above → Game connection page → type in the port you wrote down → save → click \"Start Bot\". The shipped value 25565 is only a placeholder; it must be replaced with your own session's port." },
+      { title: "6. Confirm the bot joined", body: "You should see \"Neko joined the game\" in MC chat. If not, refresh status here or check the last few lines of the 启动.bat console window." },
+      { title: "7. Talk to neko-chan", body: "Chat and play with neko-chan — she'll act on what you ask and on her own ideas." },
     ],
     portsTitle: "Ports",
     ports: [
       { key: "mc", label: "MC game port (default 55916)", value: "The number MC shows when you Open to LAN. The bot uses this to join your world." },
-      { key: "mindserver", label: "mindserver admin port (default 8765)", value: "Where the \"Open admin panel\" button goes. Change bot config here." },
+      { key: "mindserver", label: "mindserver admin port (default 8765)", value: "Where the \"Open admin panel\" button goes. API key, model, bot name and persona, skin, game connection and behavior toggles all live here." },
       { key: "plugin", label: "plugin bridge port (default 48909)", value: "Internal channel between this plugin and mc-agent. Don't touch unless port is in use — override with NEKO_PLUGIN_WS_PORT env var." },
     ],
     tipsTitle: "Troubleshooting",
     tips: [
-      "Status stays \"Disconnected\": 启动mc-agent.bat isn't running, or it crashed at startup — check the last few lines in that black console window.",
-      "Bot can't join the world: 99% wrong port. MC picks a random LAN port each time; update it in the admin panel.",
+      "Status stays \"Disconnected\": 启动.bat isn't running, or it crashed at startup — check the last few lines in that black console window.",
+      "Extraction fails with \"Could not find a part of the path\": the archive isn't broken — your target folder path is too long (Windows caps at 260 chars). Re-extract somewhere short like C:\\mc-agent.",
+      "Bot can't join the world: 99% wrong port. MC picks a random LAN port every time you re-open to LAN; update it on the panel's Game connection page.",
       "Bot joins but does nothing: N.E.K.O. may not have registered the connection correctly. Hit Refresh here to recheck the status, and confirm this plugin is enabled in N.E.K.O. settings.",
+      "Changed the skin in the panel but the game looks the same: skins only render if the Minecraft server has the FabricTailor mod installed. Without it the panel shows your skin but the game keeps the default one; nothing else is affected.",
       "To stop mc-agent: click Stop in the admin panel's bot list, or just close N.E.K.O.",
     ],
     warning: "This plugin only controls the bot. In-world behavior depends on your prompts and the current LLM's capability; complex tasks may stall or detour.",
@@ -215,9 +224,10 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ja: {
     title: "Minecraft ゲームプラグイン クイックスタート",
     subtitle: "猫娘ちゃんと MC を遊ぼう。mc-agent が mineflayer ボットを橋渡しして、ゲーム内アバターを操作します。",
+    notice: "mc-agent は現在も更新中です：導入手順やコントロールパネルの画面はバージョンごとに変わり、ネットディスク上のパッケージも随時差し替えられます。ここの説明と実際の画面が食い違う場合は、新版が未公開か手元が旧版のことがほとんどなので、アップデートをお待ちください。",
     cards: [
       { title: "Minecraft を入れる", badge: "Install", body: "Java 版 v1.21.1 推奨。他の 1.21.x でも可。お好きなランチャーで。" },
-      { title: "mc-agent を起動", badge: "Bridge", body: "下のカードから mc-agent を入手・解凍し「启动mc-agent.bat」をダブルクリック。N.E.K.O とは別プログラムで WebSocket 経由で連携。さらに猫娘ちゃん用の正規 Minecraft（Microsoft）アカウントを用意し、mc-agent でログインしないとゲームに入れません。" },
+      { title: "mc-agent を起動", badge: "Bridge", body: "下のカードから mc-agent を入手・解凍し「启动.bat」をダブルクリック。N.E.K.O とは別プログラムで WebSocket 経由で連携。初回起動時にブラウザでコントロールパネルが自動的に開き、API キー・モデル・ゲームのポートはすべてそこで入力します（ファイルを編集する必要はありません）。猫娘ちゃんは既定でオフラインモードで参加するので、専用の正規アカウントは不要です（その代わり正規認証のマルチサーバーには入れません。自分で開いた LAN ワールドは問題なし）。" },
       { title: "一緒に遊ぼう", badge: "Play", body: "まず自分のシングルプレイ世界を「LANに公開」すると猫娘ちゃんが入れます。あとは普通におしゃべりするだけ。猫娘ちゃんは会話を続けながら、本物のもう一人のプレイヤーのように一緒に遊んでくれる。（一部の AI プロバイダーでは、音声会話とゲーム操作の同時進行がまだできない場合があります。）" },
     ],
     status: {
@@ -231,12 +241,12 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       wsLabel: "WebSocket",
       taskLabel: "現在のタスク",
       taskIdle: "（待機）",
-      adminHint: "MC ポート、ボット名、プロファイルは管理パネル（mindserver UI）で変更。",
+      adminHint: "API キー、モデル、MC ポート、ボット名、スキンはすべて管理パネル（mindserver UI）で変更します。設定の入口はここだけです。",
       errorPrefix: "問い合わせ失敗: ",
     },
     download: {
       title: "mc-agent をダウンロード",
-      hint: "回線に合うものを選んで DL し、任意の場所に解凍 → 中の「启动mc-agent.bat」をダブルクリックで起動 → こちらで更新ボタンを押す。",
+      hint: "回線に合うものを選んで DL し、パスの短いフォルダに解凍（全体で 90 文字以内が目安）→ 中の「启动.bat」をダブルクリックで起動 → こちらで更新ボタンを押す。",
       quark: "Quark Drive（中国）",
       gdrive: "Google Drive",
       baidu: "百度网盘（パスワード kuro）",
@@ -244,23 +254,26 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupTitle: "セットアップ全体",
     setupSteps: [
       { title: "1. Minecraft Java 版をインストール", body: "v1.21.1 推奨（1.21.x なら何でも）。公式 / MultiMC / Prism いずれでも。" },
-      { title: "2. mc-agent をインストール（上が「未接続」なら）", body: "上のダウンロードカードから mc-agent.zip を取得し、任意の場所に解凍。初回起動の前に：解凍したルートフォルダ（「启动mc-agent.bat」と同じ階層）で keys.example.json を keys.json にコピーして OPENAI_API_KEY（または他の LLM プロバイダの key）を書き込む。OpenAI 以外のプロバイダの key を使う場合は、neko.json のモデル名もそのプロバイダが対応するモデルに変更して。そのあと「启动mc-agent.bat」をダブルクリックして起動（黒いコンソール窓が開く、閉じないこと）。N.E.K.O が自動で接続。" },
-      { title: "3. ワールドを LANに公開", body: "シングルプレイ → ESC → LANに公開 → モード選択 → 開始。チャットに「Local game hosted on port XXXXX」と出るのでポート番号を控える。" },
-      { title: "4. 管理パネルで MC ポートを書き換え", body: "上の「管理パネルを開く」→ ボット設定 → port を控えた番号に変更 → 保存。ボットが再起動して新ポートでワールドに参加。" },
-      { title: "5. ボットの参加を確認", body: "MC のチャットに「Neko joined the game」と出れば成功。出なければ本ページの状態を更新、または「启动mc-agent.bat」の黒い窓のエラーを確認。" },
-      { title: "6. 猫娘に話しかける", body: "猫娘とおしゃべりしながら一緒に遊べる。リクエストと猫娘自身の判断で動く。" },
+      { title: "2. mc-agent をインストール（上が「未接続」なら）", body: "上のダウンロードカードから mc-agent の配布パッケージを取得し、パスの短いフォルダ（例：C:\\mc-agent やデスクトップ）に解凍。中の「启动.bat」をダブルクリックで起動（黒いコンソール窓が開く、閉じないこと）。初回は「AI プロバイダーが未選択のためボットは起動しません」と表示され、ブラウザでコントロールパネルが自動的に開く。以降の設定はすべてその画面で行い、ファイルのコピーや編集は一切不要。" },
+      { title: "3. コントロールパネルの「AI 設定」ページで API キーを入力", body: "プロバイダーは「中国国内直結 / 海外サービス / ローカル実行」の 3 グループ。1 つ選ぶ → キーを貼り付け（各カードに発行ページへの外部リンクあり）→「接続テスト」→ 成功するとモデル一覧がそのプロバイダーの実データで埋まるので、1 つ選んで保存。キーは自分の PC 内にのみ保存され、画面上は常にマスク表示。" },
+      { title: "4. ワールドを LANに公開", body: "シングルプレイ → ESC → LANに公開 → モード選択 → 開始。チャットに「Local game hosted on port XXXXX」と出るのでポート番号を控える。" },
+      { title: "5. 「ゲーム接続」ページにポートを入れて「ボット起動」", body: "上の「管理パネルを開く」→「ゲーム接続」ページ → 控えた番号を入力 → 保存 →「ボット起動」。同梱の 25565 は仮の値なので、必ず自分のセッションのポートに変更すること。" },
+      { title: "6. ボットの参加を確認", body: "MC のチャットに「Neko joined the game」と出れば成功。出なければ本ページの状態を更新、または「启动.bat」の黒い窓の最終行のエラーを確認。" },
+      { title: "7. 猫娘に話しかける", body: "猫娘とおしゃべりしながら一緒に遊べる。リクエストと猫娘自身の判断で動く。" },
     ],
     portsTitle: "ポート一覧",
     ports: [
       { key: "mc", label: "MC ゲームポート（既定 55916）", value: "「LANに公開」時に MC が表示する番号。ボットがこれでワールドに参加。" },
-      { key: "mindserver", label: "mindserver 管理ポート（既定 8765）", value: "「管理パネルを開く」が飛ぶ先。ボット設定はここで変更。" },
+      { key: "mindserver", label: "mindserver 管理ポート（既定 8765）", value: "「管理パネルを開く」が飛ぶ先。API キー、モデル、ボット名と人格、スキン、ゲーム接続、動作スイッチはすべてここ。" },
       { key: "plugin", label: "plugin ブリッジポート（既定 48909）", value: "プラグインと mc-agent の内部通信。基本いじらない。変えるなら NEKO_PLUGIN_WS_PORT 環境変数で。" },
     ],
     tipsTitle: "トラブルシューティング",
     tips: [
-      "ステータスがずっと「未接続」: 「启动mc-agent.bat」が起動していない、または起動直後にクラッシュ。黒いコンソール窓の最終行のエラーを確認。",
-      "ボットがワールドに入れない: 99% ポート不一致。MC は毎回ランダムポート、管理パネルで更新。",
+      "ステータスがずっと「未接続」: 「启动.bat」が起動していない、または起動直後にクラッシュ。黒いコンソール窓の最終行のエラーを確認。",
+      "解凍時に「パスの一部が見つかりません」: パッケージの破損ではなく、解凍先のパスが長すぎる（Windows の上限は 260 文字）。C:\\mc-agent など短いパスに解凍し直す。",
+      "ボットがワールドに入れない: 99% ポート不一致。MC は「LANに公開」のたびにランダムなポートを選ぶので、パネルの「ゲーム接続」ページで更新。",
       "入ったが何もしない: N.E.K.O が接続を正しく認識できていない可能性。本ページで更新して状態を確認し、N.E.K.O 設定で本プラグインが「有効」か確認。",
+      "パネルでスキンを変えてもゲーム内が変わらない: スキンの反映には Minecraft サーバー側に FabricTailor モッドが必要。未導入だとパネルには表示されてもゲーム内は既定スキンのまま（他の機能に影響なし）。",
       "mc-agent を止める: 管理パネルのボット一覧から Stop、または N.E.K.O ごと終了。",
     ],
     warning: "本プラグインはボット操作のみ。世界内での挙動は指示内容と現在の LLM 性能に依存し、複雑なタスクは失敗 / 迂回することがあります。",
@@ -268,9 +281,10 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ko: {
     title: "Minecraft 게임 플러그인 빠른 시작",
     subtitle: "고양이 캐릭터와 함께 MC를 즐기세요. mc-agent가 mineflayer 봇을 게임 내 아바타로 다리 놓아 줍니다.",
+    notice: "mc-agent는 아직 계속 업데이트 중입니다: 설치 흐름과 제어판 화면이 버전마다 달라지고, 네트워크 드라이브의 압축 파일도 수시로 교체돼요. 여기 설명과 실제 화면이 다르면 대개 새 버전이 아직 안 나왔거나 예전 빌드를 쓰고 있는 것이니, 업데이트를 조금만 기다려 주세요.",
     cards: [
       { title: "Minecraft 설치", badge: "Install", body: "Java 에디션 v1.21.1 권장. 다른 1.21.x도 가능. 원하는 런처 사용." },
-      { title: "mc-agent 실행", badge: "Bridge", body: "아래에서 mc-agent 다운로드 → 압축 해제 → 「启动mc-agent.bat」 더블클릭. N.E.K.O와는 별개 프로그램으로 WebSocket으로 연동. 또한 고양이용 정품 Minecraft(Microsoft) 계정을 준비해 mc-agent에서 로그인해야 게임에 들어올 수 있어요." },
+      { title: "mc-agent 실행", badge: "Bridge", body: "아래에서 mc-agent 다운로드 → 압축 해제 → 「启动.bat」 더블클릭. N.E.K.O와는 별개 프로그램으로 WebSocket으로 연동. 처음 실행하면 브라우저에 제어판이 자동으로 열리고, API 키·모델·게임 포트를 전부 그 웹 화면에서 입력해요(파일을 건드릴 일 없음). 고양이는 기본적으로 오프라인 모드로 접속하니 정품 계정을 따로 살 필요는 없어요(대신 정품 인증을 켠 멀티 서버에는 못 들어가요. 직접 연 LAN 월드는 문제없음)." },
       { title: "함께 놀기", badge: "Play", body: "먼저 본인 싱글플레이 월드를 「LAN에 공개」해야 고양이가 들어올 수 있어요. 그다음 그냥 평범하게 대화하세요. 고양이는 너와 이야기를 나누면서 진짜 또 한 명의 플레이어처럼 함께 놀아 줍니다. (일부 AI 제공자는 아직 음성 대화와 게임 조작을 동시에 못 할 수 있어요.)" },
     ],
     status: {
@@ -284,12 +298,12 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       wsLabel: "WebSocket",
       taskLabel: "현재 작업",
       taskIdle: "(대기)",
-      adminHint: "MC 포트, 봇 이름, 프로필은 관리 패널(mindserver UI)에서 변경.",
+      adminHint: "API 키, 모델, MC 포트, 봇 이름, 스킨 모두 관리 패널(mindserver UI)에서 변경합니다. 설정 입구는 여기 하나뿐이에요.",
       errorPrefix: "조회 실패: ",
     },
     download: {
       title: "mc-agent 다운로드",
-      hint: "네트워크에 맞는 드라이브를 골라 다운로드 후 임의 폴더에 압축 해제 → 안의 「启动mc-agent.bat」 더블클릭으로 실행 → 여기서 새로고침.",
+      hint: "네트워크에 맞는 드라이브를 골라 다운로드 후 경로가 짧은 폴더에 압축 해제(전체 경로 90자 이내 권장) → 안의 「启动.bat」 더블클릭으로 실행 → 여기서 새로고침.",
       quark: "Quark Drive (중국)",
       gdrive: "Google Drive",
       baidu: "百度网盘 (비밀번호 kuro)",
@@ -297,23 +311,26 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupTitle: "전체 설정 흐름",
     setupSteps: [
       { title: "1. Minecraft Java 에디션 설치", body: "v1.21.1 권장 (1.21.x 모두 가능). 공식 / MultiMC / Prism 등 원하는 런처." },
-      { title: "2. mc-agent 설치 (위 상태가 「연결 안 됨」이면)", body: "위 다운로드 카드에서 mc-agent.zip을 받아 임의 폴더에 압축 해제. 첫 실행 전: 압축 푼 루트 폴더에서 (「启动mc-agent.bat」와 같은 위치) keys.example.json을 keys.json으로 복사하고 OPENAI_API_KEY (또는 다른 LLM 제공자의 key)를 채워 넣어. OpenAI가 아닌 다른 제공자의 key를 쓰면 neko.json의 모델명도 그 제공자가 지원하는 모델로 같이 바꿔. 그다음 「启动mc-agent.bat」을 더블클릭해 실행 (검은 콘솔 창이 열림, 닫지 말 것). N.E.K.O가 자동 연결." },
-      { title: "3. 월드를 LAN에 공개", body: "싱글 플레이 → ESC → LAN에 공개 → 게임 모드 선택 → 시작. 채팅창에 「Local game hosted on port XXXXX」가 표시되니 포트 번호 기록." },
-      { title: "4. 관리 패널에서 MC 포트 변경", body: "위「관리 패널 열기」클릭 → 봇 설정 → port 필드를 기록한 번호로 변경 → 저장. 봇이 재시작되어 새 포트로 월드에 참가." },
-      { title: "5. 봇 참가 확인", body: "MC 채팅에「Neko joined the game」이 보이면 성공. 안 보이면 본 페이지 상태를 새로고침하거나 「启动mc-agent.bat」 콘솔 창의 에러 확인." },
-      { title: "6. 고양이에게 말 걸기", body: "고양이와 대화하면서 함께 놀 수 있어. 네 요청과 고양이 본인의 생각에 따라 움직여." },
+      { title: "2. mc-agent 설치 (위 상태가 「연결 안 됨」이면)", body: "위 다운로드 카드에서 mc-agent 압축 파일을 받아 경로가 짧은 폴더(예: C:\\mc-agent 또는 바탕화면)에 압축 해제. 그다음 안의 「启动.bat」을 더블클릭해 실행 (검은 콘솔 창이 열림, 닫지 말 것). 처음 실행하면 「AI 제공자를 아직 고르지 않아 봇을 시작하지 않습니다」라고 뜨면서 브라우저에 제어판이 자동으로 열려요. 이후 설정은 전부 그 웹 화면에서 하며, 파일을 복사하거나 편집할 일은 없어요." },
+      { title: "3. 제어판 「AI 설정」 페이지에서 API 키 입력", body: "제공자는 「중국 직결 / 해외 서비스 / 로컬 실행」 세 그룹. 하나 선택 → 키 붙여넣기(카드마다 발급 페이지 외부 링크 있음) → 「연결 테스트」 → 통과하면 모델 드롭다운이 그 제공자의 실제 모델 목록으로 채워지니 하나 골라 저장. 키는 내 PC에만 저장되고 화면에는 항상 마스킹되어 보여요." },
+      { title: "4. 월드를 LAN에 공개", body: "싱글 플레이 → ESC → LAN에 공개 → 게임 모드 선택 → 시작. 채팅창에 「Local game hosted on port XXXXX」가 표시되니 포트 번호 기록." },
+      { title: "5. 「게임 연결」 페이지에 포트를 넣고 「봇 시작」", body: "위「관리 패널 열기」클릭 → 「게임 연결」 페이지 → 기록한 번호 입력 → 저장 → 「봇 시작」. 기본값 25565는 자리표시자일 뿐이니 반드시 본인 세션의 포트로 바꿔야 해요." },
+      { title: "6. 봇 참가 확인", body: "MC 채팅에「Neko joined the game」이 보이면 성공. 안 보이면 본 페이지 상태를 새로고침하거나 「启动.bat」 콘솔 창의 마지막 줄 에러 확인." },
+      { title: "7. 고양이에게 말 걸기", body: "고양이와 대화하면서 함께 놀 수 있어. 네 요청과 고양이 본인의 생각에 따라 움직여." },
     ],
     portsTitle: "포트 안내",
     ports: [
       { key: "mc", label: "MC 게임 포트 (기본 55916)", value: "「LAN에 공개」 시 MC가 보여주는 숫자. 봇이 이를 통해 월드 참가." },
-      { key: "mindserver", label: "mindserver 관리 포트 (기본 8765)", value: "「관리 패널 열기」가 가는 곳. 봇 설정 변경." },
+      { key: "mindserver", label: "mindserver 관리 포트 (기본 8765)", value: "「관리 패널 열기」가 가는 곳. API 키, 모델, 봇 이름과 성격, 스킨, 게임 연결, 동작 스위치가 전부 여기에 있어요." },
       { key: "plugin", label: "plugin 브릿지 포트 (기본 48909)", value: "플러그인과 mc-agent 사이 내부 통신. 보통 손대지 않음. 바꾸려면 NEKO_PLUGIN_WS_PORT 환경변수." },
     ],
     tipsTitle: "문제 해결",
     tips: [
-      "상태가 계속 「연결 안 됨」: 「启动mc-agent.bat」이 실행되지 않았거나 실행 직후 죽음. 검은 콘솔 창의 마지막 줄 에러 확인.",
-      "봇이 월드에 못 들어감: 99% 포트 불일치. MC는 매번 랜덤 포트이므로 관리 패널에서 갱신.",
+      "상태가 계속 「연결 안 됨」: 「启动.bat」이 실행되지 않았거나 실행 직후 죽음. 검은 콘솔 창의 마지막 줄 에러 확인.",
+      "압축 해제 중 「경로의 일부를 찾을 수 없습니다」: 파일이 손상된 게 아니라 대상 폴더 경로가 너무 김 (Windows 상한 260자). C:\\mc-agent 같은 짧은 경로에 다시 풀기.",
+      "봇이 월드에 못 들어감: 99% 포트 불일치. MC는 「LAN에 공개」할 때마다 랜덤 포트를 고르니 제어판 「게임 연결」 페이지에서 갱신.",
       "들어갔지만 아무것도 안 함: N.E.K.O가 연결을 제대로 인식하지 못했을 수 있어요. 본 페이지에서 새로고침해 상태를 확인하고, N.E.K.O 설정에서 본 플러그인이 「활성화」인지 확인.",
+      "패널에서 스킨을 바꿨는데 게임에서 그대로: 스킨이 실제로 보이려면 Minecraft 서버에 FabricTailor 모드가 설치돼 있어야 해요. 없으면 패널에만 보이고 게임에서는 기본 스킨 (다른 기능에는 영향 없음).",
       "mc-agent 종료: 관리 패널의 봇 목록에서 Stop, 또는 N.E.K.O 전체 종료.",
     ],
     warning: "본 플러그인은 봇 제어만 담당. 월드 내 행동은 지시 내용과 현재 LLM 능력에 따라 달라지며 복잡한 작업은 실패 / 우회할 수 있음.",
@@ -321,9 +338,10 @@ const COPY: Record<LocaleKey, GuideCopy> = {
   ru: {
     title: "Игровой плагин Minecraft — Быстрый старт",
     subtitle: "Играй в MC вместе с нэко-тян. mc-agent связывает mineflayer-бота с аватаром в игре.",
+    notice: "mc-agent всё ещё активно обновляется: процесс установки и интерфейс панели управления меняются от версии к версии, архивы на дисках время от времени заменяются. Если увиденное не совпадает с этой страницей — скорее всего, новая версия ещё не вышла или у тебя старая сборка. Пожалуйста, дождись обновления.",
     cards: [
       { title: "Установи Minecraft", badge: "Install", body: "Java Edition v1.21.1 рекомендуется; другие 1.21.x тоже подойдут. Любой лаунчер." },
-      { title: "Запусти mc-agent", badge: "Bridge", body: "Скачай mc-agent ниже, распакуй, дважды кликни 启动mc-agent.bat. Это отдельная программа от N.E.K.O., связь по WebSocket. Ещё нужно завести для нэко-тян отдельный лицензионный аккаунт Minecraft (Microsoft) и войти под ним в mc-agent — иначе она не сможет зайти в игру." },
+      { title: "Запусти mc-agent", badge: "Bridge", body: "Скачай mc-agent ниже, распакуй, дважды кликни 启动.bat. Это отдельная программа от N.E.K.O., связь по WebSocket. При первом запуске в браузере сама откроется панель управления — ключ API, модель и игровой порт вводятся только там, никакие файлы править не нужно. Нэко-тян по умолчанию заходит в офлайн-режиме, так что отдельный лицензионный аккаунт покупать не надо (расплата: на серверы с проверкой лицензии она не попадёт; твой собственный LAN-мир это не затрагивает)." },
       { title: "Играйте вместе", badge: "Play", body: "Сначала открой свой одиночный мир для сети (кнопка «Открыть для сети»), чтобы нэко-тян смогла подключиться. Затем просто болтай с нэко-тян — она будет общаться с тобой и одновременно играть рядом, как настоящий второй игрок. (У части AI-провайдеров пока не получается одновременно вести голосовой диалог и управлять игрой.)" },
     ],
     status: {
@@ -337,12 +355,12 @@ const COPY: Record<LocaleKey, GuideCopy> = {
       wsLabel: "WebSocket",
       taskLabel: "Текущая задача",
       taskIdle: "(простой)",
-      adminHint: "Меняй MC-порт, имя бота, профиль через админ-панель (mindserver UI).",
+      adminHint: "Ключ API, модель, MC-порт, имя бота и скин меняются в админ-панели (mindserver UI) — это единственная точка настройки.",
       errorPrefix: "Ошибка запроса: ",
     },
     download: {
       title: "Скачать mc-agent",
-      hint: "Выбери диск побыстрее, распакуй в любую папку, дважды кликни 启动mc-agent.bat внутри для запуска, затем жми «Обновить» здесь.",
+      hint: "Выбери диск побыстрее, распакуй в папку с коротким путём (весь путь лучше держать короче ~90 символов), дважды кликни 启动.bat внутри для запуска, затем жми «Обновить» здесь.",
       quark: "Quark Drive (Китай)",
       gdrive: "Google Drive",
       baidu: "Baidu Pan (код kuro)",
@@ -350,23 +368,26 @@ const COPY: Record<LocaleKey, GuideCopy> = {
     setupTitle: "Полный путь настройки",
     setupSteps: [
       { title: "1. Установи Minecraft Java Edition", body: "v1.21.1 рекомендуется (любой 1.21.x подойдёт). Любой лаунчер: официальный, MultiMC, Prism." },
-      { title: "2. Установи mc-agent (если статус выше «Нет связи»)", body: "Через карточку «Скачать» выше скачай mc-agent.zip, распакуй в любую папку. Перед первым запуском: в распакованной корневой папке (там же, где 启动mc-agent.bat) скопируй keys.example.json как keys.json и впиши свой OPENAI_API_KEY (или ключ другого LLM-провайдера). Если используешь не-OpenAI провайдера, поменяй и название модели в neko.json на ту, что этот провайдер поддерживает. Затем дважды кликни 启动mc-agent.bat (откроется чёрное окно консоли — не закрывай). N.E.K.O автоматически подключится." },
-      { title: "3. Открой мир для сети", body: "Одиночная игра → ESC → Открыть для сети → выбери режим → Старт. MC напишет в чате «Local game hosted on port XXXXX». Запомни порт." },
-      { title: "4. Поменяй MC-порт в админ-панели", body: "Жми «Открыть админ-панель» сверху → найди конфиг бота → измени port на записанный номер → сохрани. Бот перезапустится и зайдёт в твой мир." },
-      { title: "5. Подтверди вход бота", body: "В чате MC появится «Neko joined the game». Если нет — обнови статус здесь или посмотри ошибки в чёрном окне 启动mc-agent.bat." },
-      { title: "6. Поговори с нэко-тян", body: "Болтай с нэко-тян и играй вместе — она будет действовать по твоим просьбам и по собственным идеям." },
+      { title: "2. Установи mc-agent (если статус выше «Нет связи»)", body: "Через карточку «Скачать» выше скачай архив mc-agent и распакуй его в папку с коротким путём (например C:\\mc-agent или на Рабочий стол). Затем дважды кликни 启动.bat внутри (откроется чёрное окно консоли — не закрывай). При первом запуске он напишет «AI-провайдер ещё не выбран, бот не стартует» и сам откроет панель управления в браузере — вся дальнейшая настройка делается на этой веб-странице, копировать или править файлы не нужно." },
+      { title: "3. Впиши ключ API на странице «Настройка AI»", body: "Провайдеры разбиты на три группы: китайские напрямую / зарубежные сервисы / локальный запуск. Выбери одного → вставь ключ (на каждой карточке есть ссылка на консоль этого провайдера) → нажми «Проверить соединение» → после успеха выпадающий список моделей заполнится реальным перечнем этого провайдера, выбери одну и сохрани. Ключ хранится только на твоём компьютере, в интерфейсе он всегда показан маской." },
+      { title: "4. Открой мир для сети", body: "Одиночная игра → ESC → Открыть для сети → выбери режим → Старт. MC напишет в чате «Local game hosted on port XXXXX». Запомни порт." },
+      { title: "5. Впиши порт на странице «Подключение к игре» и нажми «Запустить бота»", body: "Жми «Открыть админ-панель» сверху → страница «Подключение к игре» → впиши записанный номер → сохрани → «Запустить бота». Идущее в комплекте значение 25565 — просто заглушка, его обязательно надо заменить на порт своей сессии." },
+      { title: "6. Подтверди вход бота", body: "В чате MC появится «Neko joined the game». Если нет — обнови статус здесь или посмотри последние строки в чёрном окне 启动.bat." },
+      { title: "7. Поговори с нэко-тян", body: "Болтай с нэко-тян и играй вместе — она будет действовать по твоим просьбам и по собственным идеям." },
     ],
     portsTitle: "Порты",
     ports: [
       { key: "mc", label: "Игровой порт MC (по умолч. 55916)", value: "Число, которое показывает MC при открытии для сети. Бот использует его для входа в мир." },
-      { key: "mindserver", label: "Админ-порт mindserver (по умолч. 8765)", value: "Куда ведёт кнопка «Открыть админ-панель». Меняй настройки бота здесь." },
+      { key: "mindserver", label: "Админ-порт mindserver (по умолч. 8765)", value: "Куда ведёт кнопка «Открыть админ-панель». Здесь ключ API, модель, имя и характер бота, скин, подключение к игре и переключатели поведения." },
       { key: "plugin", label: "Мост-порт plugin (по умолч. 48909)", value: "Внутренняя связь между плагином и mc-agent. Обычно не трогай. Меняй переменной окружения NEKO_PLUGIN_WS_PORT." },
     ],
     tipsTitle: "Решение проблем",
     tips: [
-      "Статус всё время «Нет связи»: 启动mc-agent.bat не запущен, или упал на старте — смотри последние строки в том чёрном окне консоли.",
-      "Бот не заходит в мир: 99% — порт не совпадает. MC выбирает случайный LAN-порт каждый раз; обнови в админ-панели.",
+      "Статус всё время «Нет связи»: 启动.bat не запущен, или упал на старте — смотри последние строки в том чёрном окне консоли.",
+      "При распаковке ошибка «Could not find a part of the path»: архив не битый — слишком длинный путь до папки назначения (предел Windows 260 символов). Распакуй заново в короткий путь, например C:\\mc-agent.",
+      "Бот не заходит в мир: 99% — порт не совпадает. MC выбирает случайный LAN-порт при каждом открытии для сети; обнови его на странице «Подключение к игре».",
       "Бот зашёл, но ничего не делает: возможно, N.E.K.O. не распознал подключение правильно. Нажми «Обновить» здесь, чтобы перепроверить статус, и убедись в настройках N.E.K.O., что плагин «включен».",
+      "Поменял скин в панели, а в игре без изменений: чтобы скин реально отображался, на сервере Minecraft должен стоять мод FabricTailor. Без него скин виден только в панели, а в игре остаётся стандартный (на остальное не влияет).",
       "Остановить mc-agent: нажми Stop в списке ботов админ-панели, или просто закрой N.E.K.O.",
     ],
     warning: "Плагин управляет только ботом. Поведение в мире зависит от твоих инструкций и текущей модели LLM; сложные задачи могут провалиться или пойти в обход.",
@@ -499,6 +520,10 @@ export default function GameAgentMinecraftQuickstart(props: PluginSurfaceProps) 
 
   return (
     <Page title={copy.title} subtitle={copy.subtitle}>
+      {/* mc-agent 是独立演进的外部程序，安装流程和面板 UI 会随版本变化；
+          先把这句摆在最上面，免得用户拿旧包对着新教程一步步试。 */}
+      <Alert tone="info">{copy.notice}</Alert>
+
       <Card title={status.title}>
         <Stack>
           <StatusBadge tone={tone}>{badgeText}</StatusBadge>


### PR DESCRIPTION
## 背景

mc-agent v0.2.0 起，**面向最终用户的安装流程整个变了**（依据：上游交接文档 `docs/HANDOFF-neko-mc-agent-v0.2.0.md`）：

| | 旧 | 新 |
|---|---|---|
| 启动器 | `启动mc-agent.bat` | `启动.bat` |
| 填密钥 | 手动把 `keys.example.json` 复制成 `keys.json` 再用记事本填 | **在控制面板网页里填**，`keys.example.json` 已删除 |
| 换模型 | 手改 `neko.json` 里的模型名 | 面板「AI 配置」页下拉选，自动写回 |
| 供应商 | 实际只有 OpenAI 路径顺畅 | 国内 13 家直连 + 境外 5 家 + 本机 2 家 |

也就是说快速开始面板里「复制 keys.example.json → 填 OPENAI_API_KEY → 改 neko.json 模型名」这一整段现在是**错的**。

WebSocket 桥接协议、端口、帧格式一个字没改，插件代码不用动，本 PR 只改文档与面板文案。

## 改了什么

### 1. 快速开始面板改为引导用户在 UI 里填密钥

`surfaces/quickstart.tsx` 的内联 COPY（不走 `t()`，zh-CN / en / ja / ko / ru 五份各改一遍）：

- 安装步骤 6 步 → 7 步，新流程是：解压 → 双击 `启动.bat` → 浏览器自动开控制面板 → **「AI 配置」页选供应商、填密钥、点「测试连接」、选模型** → 对局域网开放抄端口 → **「游戏连接」页填端口、点「启动 Bot」** → 验证进游戏 → 聊天。**全程不再出现任何文件名，也不再让用户手动编辑任何东西。**
- 顶部加一条提示：**mc-agent 仍在持续更新中**，安装流程和面板界面会随版本变化，看到的和本页对不上多半是版本还没跟上，请耐心等待更新。
- 删掉「要给猫娘准备一个正版 Minecraft（微软）账号」——上游 `settings.js` 里 `auth` 默认是 `"offline"`，随包的使用说明也是按离线模式写的，两处说法本来就矛盾。改成说明默认离线模式及其代价（进不了开了正版验证的联机服务器，自己开的局域网世界不受影响）。
- 新增两条排错：解压报「找不到路径的一部分」其实是路径太长（Windows MAX_PATH 260，包里最长相对路径 168 字符）；面板里换了皮肤游戏里不变是因为服务端要装 FabricTailor 模组。
- 管理面板的定位从「可选的管理界面」升级为唯一配置入口（旧面板改设置只写内存，重启就丢；现在有 settings.json 覆盖层 + REST API，真正持久化）。

### 2. 面板上清掉面向开发的说明

这个 surface 是玩家看的，第二个 commit 把只有开发才用得上的东西清干净（同样五个语言一起）：

- 状态卡片删掉 WebSocket 地址那一行（值是 `ws://localhost:48909`），连带 `wsLabel` / `wsUrl` 字段一起去掉——玩家看「已连接 / 未连接」徽章和当前任务就够了
- 端口卡片删掉「plugin 桥接端口 48909 / `NEKO_PLUGIN_WS_PORT` 环境变量」整项
- `mindserver`、`mineflayer`、`LLM`、`WebSocket` 这些内部词换成玩家说得出口的说法
- 卡片徽章 `Bridge` → `Setup`；「本插件只控制 bot」等以插件视角写的句子改回猫娘视角

源码注释里的实现说明保留原样——那才是这些内容该待的地方。

### 3. README 同步

- 启动方式：绿色包双击 `启动.bat`，开发态 `node main.js`；端口不是 CLI 参数而是 `NEKO_PLUGIN_WS_PORT` 环境变量（原文写的 `node minecraft-agent/index.js --port 48909` 路径和参数都已失效）
- 补一条截图节流阀的说明：v0.2.0 起 bot 视角截图**默认开启**（~1Hz），而更早的发行包里默认是关的（一帧都不发）。插件侧不用改代码——`screenshot_stream_min_interval_seconds = 6.0` 本来就是按这个速率设计的——但视觉上下文的 token 消耗会从零变成有，嫌多可以调大它、关掉 `stream_screenshots_to_llm`，或在 mc-agent 面板的「高级 → 视觉」里降频

## 验证

`frontend/plugin-manager` 下 `node scripts/check-hosted-tsx.mjs` 跑过，本插件无报错。输出里 `mcp_adapter` / `study_companion` 那两条错误在 `main` 上同样存在，与本 PR 无关。

## 待办（不在本 PR 范围）

- **网盘里的 zip 要换成 v0.2.0**，否则用户下到旧包会对着新教程一步步试不通。三个网盘链接本身不用改。
- 离线模式这段文案是按上游当前默认值写的；如果决定默认走微软账号，要改的是上游 `settings.js` 而不是这里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增版本更新提示，并优化 Minecraft 快速开始流程。
  - 支持通过管理面板配置 API 密钥、模型、游戏端口、名称和皮肤。
  - 新增 AI 配置、游戏连接、端口设置及 FabricTailor 皮肤说明。
  - 支持调整或关闭约每秒 1 次的截图推送。

- **文档**
  - 更新启动方式、安装解压说明及常见路径错误排查指引。
  - 覆盖中文、英文、日文、韩文和俄文界面文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->