### PR TITLE
修复猫猫辅助生成因为缓存模型导致生成后模型意外替换的问题

### DIFF
--- a/main_routers/characters_router/live2d_models.py
+++ b/main_routers/characters_router/live2d_models.py
@@ -121,6 +121,75 @@ def _derive_model_asset_binding(model_path: str, *, item_id: str = "") -> tuple[
     return "", ""
 
 
+def _normalize_live2d_idle_animation(value):
+    """Validate a Live2D idle motion without touching the model binding."""
+    if value is None:
+        return None, None
+    if not isinstance(value, str):
+        return None, 'live2d_idle_animation 必须是字符串或 null'
+
+    idle_animation = value.strip()
+    if not idle_animation:
+        return None, None
+    if '://' in idle_animation or idle_animation.startswith('data:'):
+        return None, 'Live2D待机动作路径不能包含URL方案'
+    if '..' in idle_animation:
+        return None, 'Live2D待机动作路径不能包含路径遍历（..）'
+    if idle_animation.startswith(('/', '\\')) or re.match(r'^[A-Za-z]:', idle_animation):
+        return None, 'Live2D待机动作路径必须是相对路径，不能是绝对路径'
+    if not idle_animation.lower().endswith('.motion3.json'):
+        return None, 'Live2D待机动作必须是 .motion3.json 文件'
+    return idle_animation, None
+
+
+def _get_persisted_avatar_model_type(catgirl: dict) -> str:
+    """Resolve the active persisted model type for partial avatar updates."""
+    model_type = str(
+        get_reserved(
+            catgirl,
+            'avatar',
+            'model_type',
+            default='',
+            legacy_keys=('model_type',),
+        )
+        or ''
+    ).strip().lower()
+    if model_type == 'vrm':
+        return 'live3d'
+    if model_type in {'live2d', 'live3d', 'pngtuber'}:
+        return model_type
+
+    pngtuber_idle = get_reserved(
+        catgirl,
+        'avatar',
+        'pngtuber',
+        'idle_image',
+        default='',
+        legacy_keys=('pngtuber_idle_image',),
+    )
+    if pngtuber_idle:
+        return 'pngtuber'
+    vrm_path = get_reserved(
+        catgirl,
+        'avatar',
+        'vrm',
+        'model_path',
+        default='',
+        legacy_keys=('vrm',),
+    )
+    mmd_path = get_reserved(
+        catgirl,
+        'avatar',
+        'mmd',
+        'model_path',
+        default='',
+        legacy_keys=('mmd',),
+    )
+    if vrm_path or mmd_path:
+        return 'live3d'
+    return 'live2d'
+
+
 def _find_live2d_model_catalog_entry(
     all_models: list[dict],
     *,
@@ -511,6 +580,63 @@ async def update_catgirl_l2d(name: str, request: Request):
         query_params = getattr(request, 'query_params', {})
         if 'apply_runtime' in query_params:
             apply_runtime = _config_value_is_enabled(query_params.get('apply_runtime'))
+
+        # The profile panel only owns the Live2D idle motion. It may have been
+        # opened before the model manager changed the active model, so an
+        # idle-only request must never rewrite a cached model binding.
+        idle_only_keys = {'live2d_idle_animation', 'apply_runtime'}
+        is_idle_only_update = (
+            'live2d_idle_animation' in data
+            and set(data).issubset(idle_only_keys)
+        )
+        if is_idle_only_update:
+            live2d_idle_animation, validation_error = _normalize_live2d_idle_animation(
+                data.get('live2d_idle_animation')
+            )
+            if validation_error:
+                return JSONResponse(
+                    content={'success': False, 'error': validation_error},
+                    status_code=400,
+                )
+
+            _config_manager = get_config_manager()
+            characters = await _config_manager.aload_characters()
+            catgirls = characters.get('猫娘')
+            if not isinstance(catgirls, dict) or name not in catgirls:
+                return JSONResponse(
+                    content={'success': False, 'error': '猫娘不存在'},
+                    status_code=404,
+                )
+
+            catgirl = catgirls[name]
+            current_model_type = _get_persisted_avatar_model_type(catgirl)
+            if current_model_type != 'live2d':
+                return JSONResponse(content={
+                    'success': True,
+                    'idle_animation_updated': False,
+                    'skipped': 'current_model_is_not_live2d',
+                    'applied_runtime': False,
+                })
+
+            set_reserved(
+                catgirl,
+                'avatar',
+                'live2d',
+                'idle_animation',
+                live2d_idle_animation,
+            )
+            await _config_manager.asave_characters(characters)
+
+            if apply_runtime:
+                init_one_catgirl = get_init_one_catgirl()
+                await init_one_catgirl(name, is_new=False)
+
+            return JSONResponse(content={
+                'success': True,
+                'idle_animation_updated': True,
+                'applied_runtime': apply_runtime,
+            })
+
         live2d_model = data.get('live2d')
         vrm_model = data.get('vrm')
         mmd_model = data.get('mmd')
@@ -842,30 +968,21 @@ async def update_catgirl_l2d(name: str, request: Request):
             set_reserved(characters['猫娘'][name], 'avatar', 'model_type', 'live2d')
 
             if 'live2d_idle_animation' in data:
-                live2d_idle_animation = data.get('live2d_idle_animation')
-                logger.info(f"[Live2D Save] 收到 live2d_idle_animation 请求: {live2d_idle_animation}")
-
-                if live2d_idle_animation is None:
-                    set_reserved(characters['猫娘'][name], 'avatar', 'live2d', 'idle_animation', None)
-                    logger.info(f"[Live2D Save] 已清空 idle_animation")
-                elif isinstance(live2d_idle_animation, str):
-                    live2d_idle_str = live2d_idle_animation.strip()
-                    if not live2d_idle_str:
-                        set_reserved(characters['猫娘'][name], 'avatar', 'live2d', 'idle_animation', None)
-                        logger.info(f"[Live2D Save] 已清空 idle_animation")
-                    else:
-                        if '://' in live2d_idle_str or live2d_idle_str.startswith('data:'):
-                            return JSONResponse(content={'success': False, 'error': 'Live2D待机动作路径不能包含URL方案'}, status_code=400)
-                        if '..' in live2d_idle_str:
-                            return JSONResponse(content={'success': False, 'error': 'Live2D待机动作路径不能包含路径遍历（..）'}, status_code=400)
-                        if live2d_idle_str.startswith('/') or live2d_idle_str.startswith('\\') or re.match(r'^[A-Za-z]:', live2d_idle_str):
-                            return JSONResponse(content={'success': False, 'error': 'Live2D待机动作路径必须是相对路径，不能是绝对路径'}, status_code=400)
-                        if not live2d_idle_str.lower().endswith('.motion3.json'):
-                            return JSONResponse(content={'success': False, 'error': 'Live2D待机动作必须是 .motion3.json 文件'}, status_code=400)
-                        set_reserved(characters['猫娘'][name], 'avatar', 'live2d', 'idle_animation', live2d_idle_str)
-                        logger.info(f"[Live2D Save] 已保存 idle_animation: {live2d_idle_str}")
-                else:
-                    return JSONResponse(content={'success': False, 'error': 'live2d_idle_animation 必须是字符串或 null'}, status_code=400)
+                live2d_idle_animation, validation_error = _normalize_live2d_idle_animation(
+                    data.get('live2d_idle_animation')
+                )
+                if validation_error:
+                    return JSONResponse(
+                        content={'success': False, 'error': validation_error},
+                        status_code=400,
+                    )
+                set_reserved(
+                    characters['猫娘'][name],
+                    'avatar',
+                    'live2d',
+                    'idle_animation',
+                    live2d_idle_animation,
+                )
             else:
                 logger.info(f"[Live2D Save] 请求中未包含 live2d_idle_animation 字段, data keys: {list(data.keys())}")
 

--- a/main_routers/characters_router/live2d_models.py
+++ b/main_routers/characters_router/live2d_models.py
@@ -25,7 +25,7 @@ from .voice_providers import _config_value_is_enabled
 import re
 import os
 import math
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from ..shared_state import (
@@ -131,11 +131,27 @@ def _normalize_live2d_idle_animation(value):
     idle_animation = value.strip()
     if not idle_animation:
         return None, None
-    if '://' in idle_animation or idle_animation.startswith('data:'):
+
+    # Canonicalize URL encoding before validation so encoded separators and
+    # traversal segments cannot bypass the checks. Decode repeatedly to cover
+    # values that would otherwise be decoded by more than one URL layer.
+    try:
+        for _ in range(3):
+            decoded_idle_animation = unquote(idle_animation, errors='strict')
+            if decoded_idle_animation == idle_animation:
+                break
+            idle_animation = decoded_idle_animation
+    except UnicodeDecodeError:
+        return None, 'Live2D待机动作路径包含无效URL编码'
+    if re.search(r'%[0-9A-Fa-f]{2}', idle_animation):
+        return None, 'Live2D待机动作路径包含过多层URL编码'
+
+    idle_animation = idle_animation.replace('\\', '/')
+    if re.match(r'^[A-Za-z][A-Za-z0-9+.-]*:', idle_animation):
         return None, 'Live2D待机动作路径不能包含URL方案'
-    if '..' in idle_animation:
+    if any(part == '..' for part in idle_animation.split('/')):
         return None, 'Live2D待机动作路径不能包含路径遍历（..）'
-    if idle_animation.startswith(('/', '\\')) or re.match(r'^[A-Za-z]:', idle_animation):
+    if idle_animation.startswith('/'):
         return None, 'Live2D待机动作路径必须是相对路径，不能是绝对路径'
     if not idle_animation.lower().endswith('.motion3.json'):
         return None, 'Live2D待机动作必须是 .motion3.json 文件'

--- a/static/js/character_card_manager/card-form-and-actions.js
+++ b/static/js/character_card_manager/card-form-and-actions.js
@@ -1531,7 +1531,8 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             }
         }
 
-        // 保存 Live2D 待机动作（如果当前是 Live2D 模型且动作选择器有值）
+        // 只保存 Live2D 待机动作。角色资料保存不负责模型绑定；这里的表单快照可能已经过期，
+        // 不能把 form._live2dModel 一并写回，否则辅助生成自动保存会恢复旧模型。
         if (!isNew && form._modelType === 'live2d' && form._live2dModel) {
             const motionSelect = document.getElementById('preview-motion-select');
             const idleAnimation = motionSelect ? (motionSelect.value || '') : '';
@@ -1540,8 +1541,6 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        model_type: 'live2d',
-                        live2d: form._live2dModel,
                         live2d_idle_animation: idleAnimation
                     })
                 });

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -51,6 +51,20 @@ def read_character_card_manager_source() -> str:
     )
 
 
+def test_character_profile_idle_save_does_not_rewrite_cached_model_binding():
+    script = (CHARACTER_CARD_MANAGER_JS_DIR / "card-form-and-actions.js").read_text(encoding="utf-8")
+    idle_save_start = script.index("// 只保存 Live2D 待机动作")
+    idle_save_end = script.index("let selectedAfterSave", idle_save_start)
+    idle_save_block = script[idle_save_start:idle_save_end]
+    payload_start = idle_save_block.index("body: JSON.stringify({")
+    payload_end = idle_save_block.index("})", payload_start)
+    payload = idle_save_block[payload_start:payload_end]
+
+    assert "live2d_idle_animation: idleAnimation" in payload
+    assert "model_type:" not in payload
+    assert "live2d: form._live2dModel" not in payload
+
+
 def test_character_card_manager_parts_load_in_dependency_order():
     discovered_names = {path.name for path in CHARACTER_CARD_MANAGER_JS_DIR.glob("*.js")}
     assert discovered_names == set(CHARACTER_CARD_MANAGER_PART_NAMES)

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -56,13 +56,23 @@ def test_character_profile_idle_save_does_not_rewrite_cached_model_binding():
     idle_save_start = script.index("// 只保存 Live2D 待机动作")
     idle_save_end = script.index("let selectedAfterSave", idle_save_start)
     idle_save_block = script[idle_save_start:idle_save_end]
-    payload_start = idle_save_block.index("body: JSON.stringify({")
-    payload_end = idle_save_block.index("})", payload_start)
-    payload = idle_save_block[payload_start:payload_end]
+    payload_match = re.search(
+        r"body:\s*JSON\.stringify\(\{(?P<body>.*?)\}\)",
+        idle_save_block,
+        re.DOTALL,
+    )
+    assert payload_match is not None
+    payload_body = payload_match.group("body")
+    payload_fields = re.findall(
+        r"""^\s*(?:['\"]([^'\"]+)['\"]|([A-Za-z_$][\w$]*))\s*:""",
+        payload_body,
+        re.MULTILINE,
+    )
+    fields = [quoted or bare for quoted, bare in payload_fields]
 
-    assert "live2d_idle_animation: idleAnimation" in payload
-    assert "model_type:" not in payload
-    assert "live2d: form._live2dModel" not in payload
+    assert fields == ["live2d_idle_animation"]
+    assert "live2d_idle_animation: idleAnimation" in payload_body
+    assert "..." not in payload_body
 
 
 def test_character_card_manager_parts_load_in_dependency_order():

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -145,6 +145,66 @@ async def _call_update(monkeypatch, payload, characters=None, init_calls=None):
 
 
 @pytest.mark.asyncio
+async def test_live2d_idle_only_update_preserves_current_builtin_model_binding(monkeypatch):
+    characters = _build_characters_fixture()
+    catgirl = characters['猫娘']['测试角色']
+    set_reserved(catgirl, 'avatar', 'model_type', 'live2d')
+    set_reserved(
+        catgirl,
+        'avatar',
+        'live2d',
+        'model_path',
+        '/static/another_builtin/another_builtin.model3.json',
+    )
+    set_reserved(catgirl, 'avatar', 'asset_source', 'builtin')
+    set_reserved(catgirl, 'avatar', 'asset_source_id', '')
+
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {
+            'live2d_idle_animation': 'motions/wait.motion3.json',
+            'apply_runtime': False,
+        },
+        characters=characters,
+    )
+
+    assert response.status_code == 200
+    assert body['success'] is True
+    assert body['idle_animation_updated'] is True
+    saved_catgirl = saved['猫娘']['测试角色']
+    assert get_reserved(saved_catgirl, 'avatar', 'model_type') == 'live2d'
+    assert get_reserved(saved_catgirl, 'avatar', 'live2d', 'model_path') == (
+        '/static/another_builtin/another_builtin.model3.json'
+    )
+    assert get_reserved(saved_catgirl, 'avatar', 'asset_source') == 'builtin'
+    assert get_reserved(saved_catgirl, 'avatar', 'asset_source_id') == ''
+    assert get_reserved(saved_catgirl, 'avatar', 'live2d', 'idle_animation') == (
+        'motions/wait.motion3.json'
+    )
+
+
+@pytest.mark.asyncio
+async def test_live2d_idle_only_update_skips_current_live3d_model(monkeypatch):
+    init_calls = []
+
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {'live2d_idle_animation': 'motions/wait.motion3.json'},
+        init_calls=init_calls,
+    )
+
+    assert response.status_code == 200
+    assert body == {
+        'success': True,
+        'idle_animation_updated': False,
+        'skipped': 'current_model_is_not_live2d',
+        'applied_runtime': False,
+    }
+    assert saved is None
+    assert init_calls == []
+
+
+@pytest.mark.asyncio
 async def test_pngtuber_save_preserves_and_bounds_mobile_layout_fields(monkeypatch):
     response, body, saved = await _call_update(
         monkeypatch,

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -147,6 +147,7 @@ async def _call_update(monkeypatch, payload, characters=None, init_calls=None):
 @pytest.mark.asyncio
 async def test_live2d_idle_only_update_preserves_current_builtin_model_binding(monkeypatch):
     characters = _build_characters_fixture()
+    init_calls = []
     catgirl = characters['猫娘']['测试角色']
     set_reserved(catgirl, 'avatar', 'model_type', 'live2d')
     set_reserved(
@@ -166,6 +167,7 @@ async def test_live2d_idle_only_update_preserves_current_builtin_model_binding(m
             'apply_runtime': False,
         },
         characters=characters,
+        init_calls=init_calls,
     )
 
     assert response.status_code == 200
@@ -180,6 +182,55 @@ async def test_live2d_idle_only_update_preserves_current_builtin_model_binding(m
     assert get_reserved(saved_catgirl, 'avatar', 'asset_source_id') == ''
     assert get_reserved(saved_catgirl, 'avatar', 'live2d', 'idle_animation') == (
         'motions/wait.motion3.json'
+    )
+    assert init_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'idle_animation',
+    [
+        'https:host/motion.motion3.json',
+        'file:motion.motion3.json',
+        'motions/%2e%2e/other.motion3.json',
+        'motions/%252e%252e/other.motion3.json',
+        '..\\other.motion3.json',
+    ],
+)
+async def test_live2d_idle_only_update_rejects_uri_and_encoded_traversal(
+    monkeypatch,
+    idle_animation,
+):
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {'live2d_idle_animation': idle_animation},
+    )
+
+    assert response.status_code == 400
+    assert body['success'] is False
+    assert saved is None
+
+
+@pytest.mark.asyncio
+async def test_live2d_idle_only_update_canonicalizes_safe_url_encoding(monkeypatch):
+    characters = _build_characters_fixture()
+    catgirl = characters['猫娘']['测试角色']
+    set_reserved(catgirl, 'avatar', 'model_type', 'live2d')
+
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {
+            'live2d_idle_animation': 'motions/wait%20pose.motion3.json',
+            'apply_runtime': False,
+        },
+        characters=characters,
+    )
+
+    assert response.status_code == 200
+    assert body['success'] is True
+    saved_catgirl = saved['猫娘']['测试角色']
+    assert get_reserved(saved_catgirl, 'avatar', 'live2d', 'idle_animation') == (
+        'motions/wait pose.motion3.json'
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary

修复角色编辑面板使用打开时缓存的旧模型配置，导致辅助生成自动保存后覆盖当前模型的问题。

- 角色资料保存仅提交 Live2D 待机动作，不再回写缓存的模型类型和路径。
- 后端以当前持久化模型类型处理待机动作局部更新，非 Live2D 模型会安全跳过。
- 加强待机动作路径规范化与校验，阻止 URI 方案及编码后的路径遍历。
- 补充模型绑定保护、请求字段契约和运行时刷新行为的回归测试。

## 回归报告 / Regression Report

- **改动内容**：在 `main_routers/characters_router/live2d_models.py` 增加 Live2D 待机动作局部更新路径，将待机动作校验抽为独立逻辑，并根据角色当前持久化的模型类型决定更新或跳过。
- **理由 / 必要性**：角色编辑面板会保留打开时的模型快照。辅助生成触发自动保存时，旧逻辑会把该快照与待机动作一起写回，从而覆盖用户之后选择的内置 Live2D、VRM、MMD 或 PNGTuber 模型。
- **改动前后对比**：改动前，普通资料保存或辅助生成自动保存可能把旧模型（包括 YUI）重新设为当前模型；改动后，资料保存不再修改模型绑定，只会在当前模型仍为 Live2D 时更新待机动作，其他模型类型保持不变。
- **潜在回归点与验证**：重点检查 Live2D 待机动作保存、完整模型设置接口、非 Live2D 跳过逻辑、`apply_runtime` 开关以及 URI/路径遍历校验。相关单元和静态契约测试 60 项通过，辅助生成与角色卡浏览器回归测试 63 项通过，Ruff 检查通过。

## 不拆分理由 / Why Not Split

不适用。本 PR 仅修改 4 个文件，未超过拆分阈值。

## 测试 / Testing

```text
uv run pytest tests/unit/test_characters_router_model_settings.py tests/unit/test_card_maker_static_contracts.py -q
```

结果：60 passed。

```text
uv run pytest tests/unit/test_card_assist_action_recovery.py tests/unit/test_card_assist_csrf.py tests/unit/test_zh_tw_request_locale_routing.py tests/frontend/test_character_card_manager_regressions.py -q
```

结果：63 passed。

```text
uv run ruff check main_routers/characters_router/live2d_models.py tests/unit/test_card_maker_static_contracts.py tests/unit/test_characters_router_model_settings.py
```

结果：All checks passed。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持单独保存 Live2D 角色的待机动作设置，并可选择立即应用到运行状态。
  - 更新设置时保留现有模型绑定，避免过期信息覆盖当前配置。
  - 非 Live2D 角色不会应用待机动作更新。

- **问题修复**
  - 完善待机动作文件校验，拒绝无效类型、非法路径及不符合格式的文件。

- **测试**
  - 新增保存流程及不同模型类型下的行为验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->