### PR TITLE
修复喵宇宙充能误判老用户的问题，复用七日教程状态，在老用户或使用满 3 个自然日时自动解锁，并补充回归测试

### DIFF
--- a/static/avatar/avatar-ui-buttons/methods-buttons.js
+++ b/static/avatar/avatar-ui-buttons/methods-buttons.js
@@ -4,6 +4,8 @@
     const DAY_MS = 24 * 60 * 60 * 1000;
     let midnightTimer = null;
     let localeListenerBound = false;
+    let tutorialReadyRefreshBound = false;
+    let tutorialLoadListenerBound = false;
     let fallbackFirstSeenDate = null;
 
     function getLocalDateKey(date = new Date()) {
@@ -34,29 +36,90 @@
         return Math.max(0, Math.floor((todayUtc - firstUtc) / DAY_MS));
     }
 
-    function readFirstSeenDate(todayDate) {
+    function getEarlierDateKey(left, right) {
+        const parsedLeft = parseDateKey(left);
+        const parsedRight = parseDateKey(right);
+        if (!parsedLeft) return parsedRight ? right : null;
+        if (!parsedRight) return left;
+        const leftUtc = Date.UTC(parsedLeft.year, parsedLeft.month - 1, parsedLeft.day);
+        const rightUtc = Date.UTC(parsedRight.year, parsedRight.month - 1, parsedRight.day);
+        return leftUtc <= rightUtc ? left : right;
+    }
+
+    function readTutorialState() {
+        const tutorialApi = window.NekoSevenDayTutorialState;
+        if (!tutorialApi || typeof tutorialApi.loadState !== 'function') return null;
+        try {
+            const state = tutorialApi.loadState({ persistMigration: false });
+            return state && typeof state === 'object' ? state : null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function isExistingTutorialUser(state) {
+        if (!state) return false;
+        const settledRounds = new Set([
+            ...(Array.isArray(state.completedRounds) ? state.completedRounds : []),
+            ...(Array.isArray(state.skippedRounds) ? state.skippedRounds : [])
+        ].map(Number));
+        const roundCount = Number(window.NekoSevenDayTutorialState?.ROUND_COUNT) || 7;
+        for (let round = 1; round <= roundCount; round += 1) {
+            if (!settledRounds.has(round)) return false;
+        }
+        return true;
+    }
+
+    function getUnlockedDateKey(todayDate) {
+        const unlockedDate = new Date(todayDate);
+        unlockedDate.setDate(unlockedDate.getDate() - LOCK_DAYS);
+        return getLocalDateKey(unlockedDate);
+    }
+
+    function readUnlockEvidence(todayDate) {
         const today = getLocalDateKey(todayDate);
+        const tutorialState = readTutorialState();
+        const tutorialFirstSeenDate = tutorialState && parseDateKey(tutorialState.firstSeenDate)
+            ? tutorialState.firstSeenDate
+            : null;
+        const existingUser = isExistingTutorialUser(tutorialState);
+        let storedFirstSeenDate = null;
         try {
             const stored = window.localStorage && window.localStorage.getItem(STORAGE_KEY);
-            if (parseDateKey(stored)) return stored;
-            if (!fallbackFirstSeenDate) fallbackFirstSeenDate = today;
-            if (window.localStorage) window.localStorage.setItem(STORAGE_KEY, fallbackFirstSeenDate);
+            if (parseDateKey(stored)) storedFirstSeenDate = stored;
         } catch (_) {
             // localStorage may be unavailable in private or restricted contexts.
         }
-        if (!fallbackFirstSeenDate) fallbackFirstSeenDate = today;
-        return fallbackFirstSeenDate;
+
+        let firstSeenDate = getEarlierDateKey(storedFirstSeenDate, tutorialFirstSeenDate);
+        if (!firstSeenDate) firstSeenDate = fallbackFirstSeenDate || today;
+        if (existingUser && getCalendarDayDelta(firstSeenDate, today) < LOCK_DAYS) {
+            // 七日教程会把升级用户迁移为“全部轮次已结算”。将这个结论固化到
+            // 社交入口自己的状态里，避免教程被重置后老用户又重新充能。
+            firstSeenDate = getUnlockedDateKey(todayDate);
+        }
+        fallbackFirstSeenDate = firstSeenDate;
+
+        if (storedFirstSeenDate !== firstSeenDate) {
+            try {
+                if (window.localStorage) window.localStorage.setItem(STORAGE_KEY, firstSeenDate);
+            } catch (_) {
+                // localStorage may be unavailable in private or restricted contexts.
+            }
+        }
+        return { firstSeenDate, existingUser };
     }
 
     function getStatus(todayDate = new Date()) {
-        const firstSeenDate = readFirstSeenDate(todayDate);
+        const evidence = readUnlockEvidence(todayDate);
+        const firstSeenDate = evidence.firstSeenDate;
         const today = getLocalDateKey(todayDate);
         const dayDelta = getCalendarDayDelta(firstSeenDate, today);
         return {
             firstSeenDate,
             dayDelta,
             remainingDays: Math.max(0, LOCK_DAYS - dayDelta),
-            unlocked: dayDelta >= LOCK_DAYS
+            unlocked: evidence.existingUser || dayDelta >= LOCK_DAYS
         };
     }
 
@@ -128,6 +191,15 @@
         }, Math.max(1000, nextMidnight.getTime() - Date.now()));
     }
 
+    function bindTutorialReadyRefresh() {
+        if (tutorialReadyRefreshBound) return true;
+        const tutorialApi = window.NekoSevenDayTutorialState;
+        if (!tutorialApi || typeof tutorialApi.ready !== 'function') return false;
+        tutorialReadyRefreshBound = true;
+        Promise.resolve(tutorialApi.ready()).then(refreshButtons, refreshButtons);
+        return true;
+    }
+
     window.nekoSocialUnlock = window.nekoSocialUnlock || {
         getStatus,
         isUnlocked: (todayDate) => getStatus(todayDate).unlocked,
@@ -139,6 +211,13 @@
             if (!localeListenerBound) {
                 window.addEventListener('localechange', refreshButtons);
                 localeListenerBound = true;
+            }
+            if (!bindTutorialReadyRefresh() && !tutorialLoadListenerBound) {
+                window.addEventListener('load', () => {
+                    bindTutorialReadyRefresh();
+                    refreshButtons();
+                }, { once: true });
+                tutorialLoadListenerBound = true;
             }
             if (!status.unlocked && !midnightTimer) scheduleNextMidnight();
             return status;

--- a/tests/frontend/social_unlock_state.test.cjs
+++ b/tests/frontend/social_unlock_state.test.cjs
@@ -10,10 +10,11 @@ const METHODS_SOURCE = fs.readFileSync(
     'utf8'
 );
 
-function loadSocialUnlock() {
+function loadSocialUnlock(options = {}) {
     const storage = new Map();
     const listeners = new Map();
     const registeredButtons = [];
+    let tutorialState = options.tutorialState || null;
     const window = {
         localStorage: {
             getItem(key) { return storage.has(key) ? storage.get(key) : null; },
@@ -22,6 +23,18 @@ function loadSocialUnlock() {
         addEventListener(type, listener) { listeners.set(type, listener); },
         t(key, params = {}) { return `${key}:${params.days ?? ''}`; }
     };
+    if (options.withTutorialState) {
+        window.NekoSevenDayTutorialState = {
+            ROUND_COUNT: 7,
+            loadState() { return tutorialState; },
+            ready() {
+                if (options.authoritativeTutorialState) {
+                    tutorialState = options.authoritativeTutorialState;
+                }
+                return Promise.resolve(tutorialState);
+            }
+        };
+    }
     const document = {
         querySelectorAll(selector) {
             assert.equal(selector, '[data-social-button="true"]');
@@ -63,6 +76,90 @@ test('clock moving backward does not unlock the social entry early', () => {
     assert.equal(earlier.dayDelta, 0);
     assert.equal(earlier.remainingDays, 3);
     assert.equal(earlier.unlocked, false);
+});
+
+test('existing users migrated by the seven-day tutorial skip charging immediately', () => {
+    const { api, storage } = loadSocialUnlock({
+        withTutorialState: true,
+        tutorialState: {
+            firstSeenDate: '2026-01-01',
+            completedRounds: [],
+            skippedRounds: [1, 2, 3, 4, 5, 6, 7]
+        }
+    });
+
+    const status = api.getStatus(new Date(2026, 0, 1, 12));
+    assert.equal(status.unlocked, true);
+    assert.equal(status.remainingDays, 0);
+    assert.equal(storage.get('neko.social.unlock.v1'), '2025-12-29');
+});
+
+test('users whose tutorial first-seen date is three days old skip charging', () => {
+    const { api, storage } = loadSocialUnlock({
+        withTutorialState: true,
+        tutorialState: {
+            firstSeenDate: '2026-01-01',
+            completedRounds: [1],
+            skippedRounds: []
+        }
+    });
+
+    const status = api.getStatus(new Date(2026, 0, 4, 12));
+    assert.equal(status.unlocked, true);
+    assert.equal(status.remainingDays, 0);
+    assert.equal(storage.get('neko.social.unlock.v1'), '2026-01-01');
+});
+
+test('genuinely new users still charge from the shared first-seen date', () => {
+    const { api } = loadSocialUnlock({
+        withTutorialState: true,
+        tutorialState: {
+            firstSeenDate: '2026-01-01',
+            completedRounds: [],
+            skippedRounds: []
+        }
+    });
+
+    const status = api.getStatus(new Date(2026, 0, 1, 12));
+    assert.equal(status.unlocked, false);
+    assert.equal(status.remainingDays, 3);
+});
+
+test('authoritative tutorial migration refreshes an already-rendered social button', async () => {
+    const now = new Date();
+    const today = [
+        now.getFullYear(),
+        String(now.getMonth() + 1).padStart(2, '0'),
+        String(now.getDate()).padStart(2, '0')
+    ].join('-');
+    const { api, registeredButtons } = loadSocialUnlock({
+        withTutorialState: true,
+        tutorialState: {
+            firstSeenDate: today,
+            completedRounds: [],
+            skippedRounds: []
+        },
+        authoritativeTutorialState: {
+            firstSeenDate: today,
+            completedRounds: [],
+            skippedRounds: [1, 2, 3, 4, 5, 6, 7]
+        }
+    });
+    const button = {
+        dataset: {},
+        style: {},
+        setAttribute(name, value) { this[name] = value; },
+        removeAttribute(name) { delete this[name]; },
+        querySelectorAll() { return []; }
+    };
+
+    api.registerButton(button);
+    registeredButtons.push(button);
+    assert.equal(button.dataset.socialLocked, 'true');
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(button.dataset.socialLocked, 'false');
+    assert.equal(button['aria-disabled'], 'false');
 });
 
 test('all social opening paths contain the shared unlock guard', () => {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复喵宇宙充能误判老用户的问题，复用七日教程状态，在老用户或使用满 3 个自然日时自动解锁，并补充回归测试

## 测试 / Testing

使用老玩家备份和新玩家测试能否判断成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 社交解锁状态现支持读取教程进度，已完成或跳过全部教程的用户可直接解锁。
  * 教程状态准备完成后，社交按钮会自动刷新并同步最新解锁状态。
* **改进**
  * 教程首次访问达到条件的用户可跳过等待。
  * 新用户仍按照共享首次访问日期正常计算解锁时间。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->