### PR TITLE
优化角色外形自定义页的背景拖动交互

### DIFF
--- a/static/css/model_manager.css
+++ b/static/css/model_manager.css
@@ -110,6 +110,14 @@ body {
     cursor: grabbing;
 }
 
+body.model-manager-page.model-manager-background-dragging #live2d-canvas,
+body.model-manager-page.model-manager-background-dragging #vrm-canvas,
+body.model-manager-page.model-manager-background-dragging #mmd-canvas,
+body.model-manager-page.model-manager-background-dragging #pngtuber-container {
+    cursor: grabbing !important;
+    user-select: none;
+}
+
 #model-manager-toast {
     position: fixed;
     left: 50%;

--- a/static/js/model_manager/background-model-drag.js
+++ b/static/js/model_manager/background-model-drag.js
@@ -1,0 +1,320 @@
+(function installModelManagerBackgroundDrag() {
+    'use strict';
+
+    const DRAG_THRESHOLD_PX = 4;
+    let dragSession = null;
+
+    function isModelManagerPage() {
+        return !!(
+            document.body && document.body.classList.contains('model-manager-page')
+        );
+    }
+
+    function isGuideBlockingDrag() {
+        const body = document.body;
+        return !!(body && (
+            body.classList.contains('yui-guide-home-ui-suppressed') ||
+            body.classList.contains('yui-taking-over')
+        ));
+    }
+
+    function isVisible(element) {
+        if (!element || element.classList.contains('hidden')) return false;
+        if (element.style.display === 'none' || element.style.visibility === 'hidden') return false;
+        try {
+            const style = window.getComputedStyle(element);
+            return style.display !== 'none' && style.visibility !== 'hidden';
+        } catch (_) {
+            return true;
+        }
+    }
+
+    function getLive3DSubType() {
+        const declared = window._modelManagerCurrentLive3dSubType;
+        if (declared === 'vrm' || declared === 'mmd') return declared;
+        if (isVisible(document.getElementById('mmd-container'))) return 'mmd';
+        return 'vrm';
+    }
+
+    function getActiveModelType() {
+        const type = window._modelManagerCurrentAvatarType;
+        if (type === 'pngtuber' || type === 'live3d' || type === 'live2d') return type;
+        if (isVisible(document.getElementById('pngtuber-container'))) return 'pngtuber';
+        if (isVisible(document.getElementById('mmd-container')) ||
+            isVisible(document.getElementById('vrm-container'))) {
+            return 'live3d';
+        }
+        return 'live2d';
+    }
+
+    function getLive2DCanvasPoint(manager, clientX, clientY) {
+        const canvas = manager && manager.pixi_app && manager.pixi_app.view;
+        const rendererScreen = manager && manager.pixi_app && manager.pixi_app.renderer
+            ? manager.pixi_app.renderer.screen
+            : null;
+        if (!canvas || typeof canvas.getBoundingClientRect !== 'function') return null;
+        const rect = canvas.getBoundingClientRect();
+        if (!(rect.width > 0) || !(rect.height > 0)) return null;
+        const rendererWidth = Number(rendererScreen && rendererScreen.width) || rect.width;
+        const rendererHeight = Number(rendererScreen && rendererScreen.height) || rect.height;
+        return {
+            canvas,
+            x: (clientX - rect.left) * (rendererWidth / rect.width),
+            y: (clientY - rect.top) * (rendererHeight / rect.height),
+            scaleX: rendererWidth / rect.width,
+            scaleY: rendererHeight / rect.height
+        };
+    }
+
+    function isPointOnLive2DModel(manager, clientX, clientY) {
+        const model = manager && manager.currentModel;
+        const point = getLive2DCanvasPoint(manager, clientX, clientY);
+        if (!model || !point || typeof model.getBounds !== 'function') return false;
+
+        try {
+            const bounds = model.getBounds();
+            const left = Number.isFinite(bounds.left) ? bounds.left : bounds.x;
+            const top = Number.isFinite(bounds.top) ? bounds.top : bounds.y;
+            const right = Number.isFinite(bounds.right) ? bounds.right : left + bounds.width;
+            const bottom = Number.isFinite(bounds.bottom) ? bounds.bottom : top + bounds.height;
+            return Number.isFinite(left) && Number.isFinite(top) &&
+                Number.isFinite(right) && Number.isFinite(bottom) &&
+                point.x >= left && point.x <= right &&
+                point.y >= top && point.y <= bottom;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function createLive2DAdapter(event) {
+        const manager = window.live2dManager;
+        const model = manager && manager.currentModel;
+        const point = getLive2DCanvasPoint(manager, event.clientX, event.clientY);
+        if (!manager || !model || !point || event.target !== point.canvas) return null;
+        if (!manager._isModelReadyForInteraction || manager.isLocked) return null;
+        if (isPointOnLive2DModel(manager, event.clientX, event.clientY)) return null;
+
+        return {
+            type: 'live2d',
+            surface: point.canvas,
+            move(deltaX, deltaY) {
+                if (manager.currentModel !== model || model.destroyed) return false;
+                model.x += deltaX * point.scaleX;
+                model.y += deltaY * point.scaleY;
+                manager.isFocusing = false;
+                if (typeof manager.boostLinuxX11InteractiveFPS === 'function') {
+                    manager.boostLinuxX11InteractiveFPS(1400);
+                }
+                return true;
+            },
+            async finish(moved) {
+                if (!moved || manager.currentModel !== model || model.destroyed) return;
+                let snapped = false;
+                if (typeof manager._checkAndPerformSnap === 'function') {
+                    snapped = await manager._checkAndPerformSnap(model);
+                }
+                if (!snapped && typeof manager._savePositionAfterInteraction === 'function') {
+                    await manager._savePositionAfterInteraction();
+                }
+            }
+        };
+    }
+
+    function createThreeDAdapter(event, type) {
+        const manager = type === 'mmd' ? window.mmdManager : window.vrmManager;
+        const interaction = manager && manager.interaction;
+        const canvas = manager && manager.renderer && manager.renderer.domElement;
+        if (!manager || !interaction || !canvas || event.target !== canvas) return null;
+        if (!manager._isModelReadyForInteraction ||
+            (typeof interaction.checkLocked === 'function' && interaction.checkLocked())) {
+            return null;
+        }
+        if (typeof interaction._hitTestModel === 'function' &&
+            interaction._hitTestModel(event.clientX, event.clientY)) {
+            return null;
+        }
+
+        return {
+            type,
+            surface: canvas,
+            move(deltaX, deltaY) {
+                const center = typeof interaction._getProjectedModelCenterInWindow === 'function'
+                    ? interaction._getProjectedModelCenterInWindow()
+                    : null;
+                if (!center || typeof interaction._moveModelCenterToWindowPoint !== 'function') {
+                    return false;
+                }
+                if (type === 'mmd' && manager.core &&
+                    typeof manager.core._boostInteractiveFPS === 'function') {
+                    manager.core._boostInteractiveFPS();
+                } else if (type === 'vrm' && typeof manager._boostInteractiveFPS === 'function') {
+                    manager._boostInteractiveFPS();
+                }
+                return interaction._moveModelCenterToWindowPoint(
+                    center.x + deltaX,
+                    center.y + deltaY
+                );
+            },
+            async finish(moved) {
+                if (!moved) return;
+                let snapped = false;
+                if (typeof interaction._snapModelIntoScreen === 'function') {
+                    snapped = await interaction._snapModelIntoScreen({ animate: true });
+                }
+                // VRM 的回弹只负责改位置，MMD 的回弹内部已经保存；保持两者原有语义。
+                if ((type === 'vrm' || !snapped) &&
+                    typeof interaction._savePositionAfterInteraction === 'function') {
+                    await interaction._savePositionAfterInteraction();
+                }
+            }
+        };
+    }
+
+    function createPNGTuberAdapter(event) {
+        const manager = window.pngtuberManager;
+        const container = manager && manager.container;
+        if (!manager || !container || event.target !== container || manager.isLocked) return null;
+        if (!manager.image || !isVisible(container)) return null;
+
+        return {
+            type: 'pngtuber',
+            surface: container,
+            move(deltaX, deltaY) {
+                const placement = manager.getActivePlacement();
+                manager.setActiveOffsets(
+                    placement.offsetX + deltaX,
+                    placement.offsetY + deltaY
+                );
+                manager.applyTransform();
+                if (manager.isLayeredActive()) manager.drawLayeredState();
+                manager.syncGlobalConfig();
+                if (typeof manager.updateFloatingButtonsPosition === 'function') {
+                    manager.updateFloatingButtonsPosition();
+                }
+                if (typeof manager.updateLockIconPosition === 'function') {
+                    manager.updateLockIconPosition();
+                }
+                return true;
+            },
+            async finish(moved) {
+                if (!moved) return;
+                if (typeof manager.restartLayeredAnimationLoop === 'function') {
+                    manager.restartLayeredAnimationLoop();
+                }
+                if (typeof manager.saveCurrentConfig === 'function') {
+                    await manager.saveCurrentConfig();
+                }
+            }
+        };
+    }
+
+    function createBackgroundAdapter(event) {
+        const modelType = getActiveModelType();
+        if (modelType === 'pngtuber') return createPNGTuberAdapter(event);
+        if (modelType === 'live3d') {
+            return createThreeDAdapter(event, getLive3DSubType());
+        }
+        return createLive2DAdapter(event);
+    }
+
+    function setDraggingUi(active) {
+        if (!document.body) return;
+        document.body.classList.toggle('model-manager-background-dragging', active);
+        if (window.DragHelpers) {
+            const method = active ? 'disableButtonPointerEvents' : 'restoreButtonPointerEvents';
+            if (typeof window.DragHelpers[method] === 'function') {
+                window.DragHelpers[method]();
+            }
+        }
+    }
+
+    function onPointerDown(event) {
+        if (!isModelManagerPage() || dragSession || isGuideBlockingDrag()) return;
+        if (event.button !== 0 || event.isPrimary === false) return;
+
+        const adapter = createBackgroundAdapter(event);
+        if (!adapter) return;
+
+        dragSession = {
+            adapter,
+            pointerId: event.pointerId,
+            startX: event.clientX,
+            startY: event.clientY,
+            lastX: event.clientX,
+            lastY: event.clientY,
+            moved: false
+        };
+
+        if (adapter.surface && typeof adapter.surface.setPointerCapture === 'function') {
+            try { adapter.surface.setPointerCapture(event.pointerId); } catch (_) {}
+        }
+        setDraggingUi(true);
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    function onPointerMove(event) {
+        const session = dragSession;
+        if (!session || (session.pointerId !== undefined && event.pointerId !== session.pointerId)) {
+            return;
+        }
+
+        const totalX = event.clientX - session.startX;
+        const totalY = event.clientY - session.startY;
+        if (!session.moved && Math.hypot(totalX, totalY) < DRAG_THRESHOLD_PX) {
+            event.preventDefault();
+            return;
+        }
+
+        const deltaX = event.clientX - session.lastX;
+        const deltaY = event.clientY - session.lastY;
+        session.lastX = event.clientX;
+        session.lastY = event.clientY;
+        session.moved = session.adapter.move(deltaX, deltaY) || session.moved;
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    function finishDrag(event) {
+        const session = dragSession;
+        if (!session) return;
+        if (event && session.pointerId !== undefined && event.pointerId !== session.pointerId) return;
+        dragSession = null;
+
+        if (session.adapter.surface &&
+            typeof session.adapter.surface.releasePointerCapture === 'function' &&
+            session.pointerId !== undefined) {
+            try { session.adapter.surface.releasePointerCapture(session.pointerId); } catch (_) {}
+        }
+        setDraggingUi(false);
+        Promise.resolve(session.adapter.finish(session.moved)).catch((error) => {
+            console.warn('[ModelManager] 背景拖动结束处理失败:', error);
+        });
+    }
+
+    function install() {
+        if (!isModelManagerPage() || window.__modelManagerBackgroundDragInstalled) return;
+        window.__modelManagerBackgroundDragInstalled = true;
+        document.addEventListener('pointerdown', onPointerDown, true);
+        window.addEventListener('pointermove', onPointerMove, true);
+        window.addEventListener('pointerup', finishDrag, true);
+        window.addEventListener('pointercancel', finishDrag, true);
+        window.addEventListener('blur', () => finishDrag(null));
+    }
+
+    window.ModelManagerBackgroundDragController = {
+        createBackgroundAdapter,
+        finishDrag,
+        getActiveModelType,
+        install,
+        isPointOnLive2DModel,
+        onPointerDown,
+        onPointerMove
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', install, { once: true });
+    } else {
+        install();
+    }
+})();

--- a/static/js/model_manager/background-model-drag.js
+++ b/static/js/model_manager/background-model-drag.js
@@ -180,6 +180,9 @@
             type: 'pngtuber',
             surface: container,
             move(deltaX, deltaY) {
+                if (typeof manager.beginModelManagerPositionEditing === 'function') {
+                    manager.beginModelManagerPositionEditing();
+                }
                 const placement = manager.getActivePlacement();
                 manager.setActiveOffsets(
                     placement.offsetX + deltaX,
@@ -201,8 +204,8 @@
                 if (typeof manager.restartLayeredAnimationLoop === 'function') {
                     manager.restartLayeredAnimationLoop();
                 }
-                if (typeof manager.saveCurrentConfig === 'function') {
-                    await manager.saveCurrentConfig();
+                if (typeof window.stageModelManagerPNGTuberPlacement === 'function') {
+                    window.stageModelManagerPNGTuberPlacement(manager.config);
                 }
             }
         };

--- a/static/js/model_manager/page-controller.js
+++ b/static/js/model_manager/page-controller.js
@@ -2031,6 +2031,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else if (type !== 'live3d') {
             currentLive3dSubType = '';
         }
+        window._modelManagerCurrentLive3dSubType = currentLive3dSubType;
         localStorage.setItem('modelType', type);
 
         // 无论后续初始化是否成功，都保证派发教程事件

--- a/static/js/model_manager/page-controller.js
+++ b/static/js/model_manager/page-controller.js
@@ -1655,6 +1655,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         );
     }
 
+    function stageModelManagerPNGTuberPlacement(runtimeConfig) {
+        if (currentModelType !== 'pngtuber' || !runtimeConfig || !currentModelInfo) {
+            return false;
+        }
+        currentModelInfo.pngtuber = mergePNGTuberConfigForSave(
+            null,
+            currentModelInfo.pngtuber,
+            runtimeConfig
+        );
+        window.hasUnsavedChanges = true;
+        if (savePositionBtn) savePositionBtn.disabled = false;
+        markModelChangedForCardFacePrompt();
+        return true;
+    }
+
+    window.stageModelManagerPNGTuberPlacement = stageModelManagerPNGTuberPlacement;
+
     async function saveModelToCharacter(modelName, itemId = null, vrmAnimation = null) {
         let effectiveLive3dSubType = currentLive3dSubType || '';
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2532,7 +2532,7 @@
             const modelManagerPage = isModelManagerPage();
             const pointerEvents = this.isLocked ? 'none' : 'auto';
             if (this.container) {
-                this.container.style.pointerEvents = 'none';
+                this.container.style.pointerEvents = modelManagerPage ? 'auto' : 'none';
             }
             const centerAnchored = modelManagerPage || this.config.position_anchor === 'center';
             if (centerAnchored) {
@@ -3632,7 +3632,7 @@
             this.container.classList.remove('hidden');
             this.container.style.display = 'block';
             this.container.style.visibility = 'visible';
-            this.container.style.pointerEvents = 'none';
+            this.container.style.pointerEvents = isModelManagerPage() ? 'auto' : 'none';
             if (this.image) {
                 this.image.style.visibility = 'visible';
                 this.image.style.pointerEvents = this.isLocked ? 'none' : 'auto';

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2590,13 +2590,25 @@
         }
 
         getRenderPlacement(placement) {
-            if (isModelManagerPage() && !this.config.preserve_model_manager_position) {
+            if (isModelManagerPage()
+                && !this.config.preserve_model_manager_position
+                && !this._modelManagerUseCurrentPlacement) {
                 return Object.assign({}, placement, {
                     offsetX: 0,
                     offsetY: 0
                 });
             }
             return placement;
+        }
+
+        beginModelManagerPositionEditing() {
+            if (!isModelManagerPage()) return false;
+            if (!this._modelManagerUseCurrentPlacement) {
+                const renderPlacement = this.getRenderPlacement(this.getActivePlacement());
+                this.setActiveOffsets(renderPlacement.offsetX, renderPlacement.offsetY);
+            }
+            this._modelManagerUseCurrentPlacement = true;
+            return true;
         }
 
         setActiveScale(nextScale) {
@@ -3053,6 +3065,7 @@
         async load(config) {
             this.detachDragListeners();
             this.clearEmotion({ render: false });
+            this._modelManagerUseCurrentPlacement = false;
             this.config = normalizeConfig(config || {});
             await this.setupLayeredAdapter();
             this.ensureContainer();

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -687,6 +687,7 @@
     <script src="/static/js/model_manager/card-face.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/js/model_manager/path-request-fullscreen.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/js/model_manager/page-controller.js?v={{ static_asset_version | default('0') }}"></script>
+    <script src="/static/js/model_manager/background-model-drag.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/js/model_manager/window-lifecycle.js?v={{ static_asset_version | default('0') }}"></script>
 
     <!-- 性能分析器 -->

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -33,6 +33,7 @@ MODEL_MANAGER_PART_NAMES = (
     "card-face.js",
     "path-request-fullscreen.js",
     "page-controller.js",
+    "background-model-drag.js",
     "window-lifecycle.js",
 )
 

--- a/tests/unit/test_model_manager_background_drag.py
+++ b/tests/unit/test_model_manager_background_drag.py
@@ -1,0 +1,136 @@
+import json
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
+
+
+def read_source(relative_path: str) -> str:
+    return Path(relative_path).read_text(encoding="utf-8")
+
+
+def test_existing_model_drag_hit_areas_are_not_expanded():
+    live2d = read_source("static/live2d/live2d-interaction.js")
+    live2d_drag = live2d.split(
+        "Live2DManager.prototype.setupDragAndDrop = function (model)", 1
+    )[1].split("Live2DManager.prototype.setupWheelZoom", 1)[0]
+    assert not re.search(r"^\s*stage\.hitArea\s*=", live2d_drag, re.MULTILINE)
+    assert "modelManagerBackgroundDragEnabled" not in live2d_drag
+
+    vrm = read_source("static/vrm/vrm-interaction.js")
+    mmd = read_source("static/mmd/mmd-interaction.js")
+    assert "if (!this._hitTestModel(e.clientX, e.clientY))" in vrm
+    assert "if (!this._hitTestModel(e.clientX, e.clientY)) return;" in mmd
+    assert "_isModelManagerBackgroundPanEnabled" not in vrm
+    assert "_isModelManagerBackgroundPanEnabled" not in mmd
+
+
+def test_background_drag_is_a_separate_model_manager_controller():
+    source = read_source("static/js/model_manager/background-model-drag.js")
+    template = read_source("templates/model_manager.html")
+
+    assert "/static/js/model_manager/background-model-drag.js" in template
+    assert "document.addEventListener('pointerdown', onPointerDown, true);" in source
+    assert "const adapter = createBackgroundAdapter(event);" in source
+    assert "if (!adapter) return;" in source
+    assert "isPointOnLive2DModel(manager" in source
+    assert "interaction._hitTestModel(event.clientX, event.clientY)" in source
+    assert "event.target !== container" in source
+    assert "model.x += deltaX * point.scaleX;" in source
+    assert "interaction._moveModelCenterToWindowPoint(" in source
+    assert "manager.setActiveOffsets(" in source
+
+
+def test_pngtuber_background_surface_does_not_reuse_image_drag_handler():
+    source = read_source("static/pngtuber-core.js")
+
+    assert "modelManagerPage ? 'auto' : 'none'" in source
+    assert "isModelManagerPage() ? 'auto' : 'none'" in source
+    assert "_boundBackgroundDragStart" not in source
+    assert "captureTarget" not in source
+
+
+def test_live2d_background_drag_moves_by_page_delta_without_stealing_model_hit():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for model-manager background drag tests")
+
+    source = read_source("static/js/model_manager/background-model-drag.js")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const documentListeners = new Map();
+const windowListeners = new Map();
+const bodyClasses = new Set(['model-manager-page']);
+const canvas = {{
+  getBoundingClientRect() {{ return {{ left: 0, top: 0, width: 1000, height: 800 }}; }},
+  setPointerCapture() {{}},
+  releasePointerCapture() {{}},
+}};
+const model = {{
+  destroyed: false,
+  x: 100,
+  y: 100,
+  getBounds() {{
+    return {{ left: this.x - 50, right: this.x + 50, top: this.y - 50, bottom: this.y + 50 }};
+  }},
+}};
+let saves = 0;
+const manager = {{
+  currentModel: model,
+  _isModelReadyForInteraction: true,
+  isLocked: false,
+  isFocusing: true,
+  pixi_app: {{ view: canvas, renderer: {{ screen: {{ width: 1000, height: 800 }} }} }},
+  _checkAndPerformSnap: async () => false,
+  _savePositionAfterInteraction: async () => {{ saves += 1; }},
+}};
+const document = {{
+  readyState: 'complete',
+  body: {{
+    classList: {{
+      contains(name) {{ return bodyClasses.has(name); }},
+      toggle(name, active) {{ if (active) bodyClasses.add(name); else bodyClasses.delete(name); }},
+    }},
+  }},
+  addEventListener(name, handler) {{ documentListeners.set(name, handler); }},
+  getElementById() {{ return null; }},
+}};
+const window = {{
+  _modelManagerCurrentAvatarType: 'live2d',
+  live2dManager: manager,
+  addEventListener(name, handler) {{ windowListeners.set(name, handler); }},
+  getComputedStyle() {{ return {{ display: 'block', visibility: 'visible' }}; }},
+}};
+const context = {{ console, document, window, Promise, Math }};
+vm.runInNewContext({json.dumps(source)}, context);
+
+function pointer(target, x, y) {{
+  return {{
+    target, clientX: x, clientY: y, pointerId: 7, button: 0, isPrimary: true,
+    preventDefault() {{}}, stopPropagation() {{}},
+  }};
+}}
+
+(async () => {{
+  documentListeners.get('pointerdown')(pointer(canvas, 500, 500));
+  windowListeners.get('pointermove')(pointer(canvas, 530, 520));
+  assert.equal(model.x, 130);
+  assert.equal(model.y, 120);
+  windowListeners.get('pointerup')(pointer(canvas, 530, 520));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(saves, 1);
+
+  const modelX = model.x;
+  const modelY = model.y;
+  documentListeners.get('pointerdown')(pointer(canvas, model.x, model.y));
+  windowListeners.get('pointermove')(pointer(canvas, model.x + 40, model.y + 40));
+  assert.equal(model.x, modelX);
+  assert.equal(model.y, modelY);
+}})().catch(error => {{ console.error(error); process.exit(1); }});
+"""
+    run_node_script(node, script, check=True, cwd=Path.cwd())

--- a/tests/unit/test_model_manager_background_drag.py
+++ b/tests/unit/test_model_manager_background_drag.py
@@ -42,6 +42,8 @@ def test_background_drag_is_a_separate_model_manager_controller():
     assert "model.x += deltaX * point.scaleX;" in source
     assert "interaction._moveModelCenterToWindowPoint(" in source
     assert "manager.setActiveOffsets(" in source
+    assert "manager.beginModelManagerPositionEditing();" in source
+    assert "window.stageModelManagerPNGTuberPlacement(manager.config);" in source
 
 
 def test_pngtuber_background_surface_does_not_reuse_image_drag_handler():
@@ -134,3 +136,111 @@ function pointer(target, x, y) {{
 }})().catch(error => {{ console.error(error); process.exit(1); }});
 """
     run_node_script(node, script, check=True, cwd=Path.cwd())
+
+
+def test_pngtuber_background_drag_renders_offsets_and_stages_manager_save():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for model-manager background drag tests")
+
+    source = read_source("static/js/model_manager/background-model-drag.js")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const documentListeners = new Map();
+const windowListeners = new Map();
+const bodyClasses = new Set(['model-manager-page']);
+const container = {{
+  classList: {{ contains() {{ return false; }} }},
+  style: {{ display: 'block', visibility: 'visible' }},
+  setPointerCapture() {{}},
+  releasePointerCapture() {{}},
+}};
+let renderedPlacement = null;
+let stagedConfig = null;
+const manager = {{
+  container,
+  image: {{}},
+  isLocked: false,
+  config: {{ offset_x: 100, offset_y: 50 }},
+  editing: false,
+  beginModelManagerPositionEditing() {{
+    if (!this.editing) this.setActiveOffsets(0, 0);
+    this.editing = true;
+  }},
+  getActivePlacement() {{
+    return {{ offsetX: this.config.offset_x, offsetY: this.config.offset_y }};
+  }},
+  setActiveOffsets(x, y) {{ this.config.offset_x = x; this.config.offset_y = y; }},
+  applyTransform() {{
+    renderedPlacement = this.editing
+      ? {{ x: this.config.offset_x, y: this.config.offset_y }}
+      : {{ x: 0, y: 0 }};
+  }},
+  isLayeredActive() {{ return false; }},
+  syncGlobalConfig() {{}},
+  saveCurrentConfig() {{ throw new Error('model-manager drag must not use runtime auto-save'); }},
+}};
+const document = {{
+  readyState: 'complete',
+  body: {{
+    classList: {{
+      contains(name) {{ return bodyClasses.has(name); }},
+      toggle(name, active) {{ if (active) bodyClasses.add(name); else bodyClasses.delete(name); }},
+    }},
+  }},
+  addEventListener(name, handler) {{ documentListeners.set(name, handler); }},
+  getElementById() {{ return null; }},
+}};
+const window = {{
+  _modelManagerCurrentAvatarType: 'pngtuber',
+  pngtuberManager: manager,
+  stageModelManagerPNGTuberPlacement(config) {{ stagedConfig = {{ ...config }}; }},
+  addEventListener(name, handler) {{ windowListeners.set(name, handler); }},
+  getComputedStyle(element) {{ return element.style; }},
+}};
+const context = {{ console, document, window, Promise, Math }};
+vm.runInNewContext({json.dumps(source)}, context);
+
+function pointer(x, y) {{
+  return {{
+    target: container, clientX: x, clientY: y, pointerId: 11,
+    button: 0, isPrimary: true,
+    preventDefault() {{}}, stopPropagation() {{}},
+  }};
+}}
+
+(async () => {{
+  documentListeners.get('pointerdown')(pointer(400, 300));
+  windowListeners.get('pointermove')(pointer(430, 320));
+  assert.deepEqual(renderedPlacement, {{ x: 30, y: 20 }});
+  windowListeners.get('pointerup')(pointer(430, 320));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(stagedConfig.offset_x, 30);
+  assert.equal(stagedConfig.offset_y, 20);
+}})().catch(error => {{ console.error(error); process.exit(1); }});
+"""
+    run_node_script(node, script, check=True, cwd=Path.cwd())
+
+
+def test_pngtuber_manager_page_stages_dragged_config_for_explicit_save():
+    core = read_source("static/pngtuber-core.js")
+    controller = read_source("static/js/model_manager/page-controller.js")
+
+    render_block = core.split("getRenderPlacement(placement) {", 1)[1].split(
+        "setActiveScale(nextScale)", 1
+    )[0]
+    stage_block = controller.split(
+        "function stageModelManagerPNGTuberPlacement(runtimeConfig) {", 1
+    )[1].split("async function saveModelToCharacter", 1)[0]
+
+    assert "!this._modelManagerUseCurrentPlacement" in render_block
+    assert "beginModelManagerPositionEditing()" in core
+    assert "const renderPlacement = this.getRenderPlacement(this.getActivePlacement());" in core
+    assert "this.setActiveOffsets(renderPlacement.offsetX, renderPlacement.offsetY);" in core
+    assert "this._modelManagerUseCurrentPlacement = false;" in core
+    assert "currentModelInfo.pngtuber = mergePNGTuberConfigForSave(" in stage_block
+    assert "window.hasUnsavedChanges = true;" in stage_block
+    assert "savePositionBtn.disabled = false;" in stage_block
+    assert "window.stageModelManagerPNGTuberPlacement" in stage_block

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -23,6 +23,7 @@ MODEL_MANAGER_PART_NAMES = (
     "card-face.js",
     "path-request-fullscreen.js",
     "page-controller.js",
+    "background-model-drag.js",
     "window-lifecycle.js",
 )
 

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -112,7 +112,7 @@ def test_pngtuber_model_manager_preview_centering_does_not_mutate_saved_offsets(
     assert "this.config.mobile_offset_y = 0" not in source
 
 
-def test_pngtuber_container_pointer_events_stay_passthrough_on_restore_paths():
+def test_pngtuber_container_pointer_events_stay_passthrough_outside_model_manager():
     core_source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     interpage_source = read_js_parts(APP_INTERPAGE_PATH)
     app_ui_source = read_js_parts(APP_UI_PATH)
@@ -128,7 +128,8 @@ def test_pngtuber_container_pointer_events_stay_passthrough_on_restore_paths():
     ]
     assert "pointer-events: none;" in css_container_block
     assert "pointer-events: auto;" in css_image_block
-    assert "this.container.style.pointerEvents = 'none';" in core_source
+    assert "this.container.style.pointerEvents = modelManagerPage ? 'auto' : 'none';" in core_source
+    assert "this.container.style.pointerEvents = isModelManagerPage() ? 'auto' : 'none';" in core_source
 
     assert "restoredPngtuberContainer.style.pointerEvents = 'auto';" not in interpage_source
     assert "pngtuberContainer.style.pointerEvents = 'auto';" not in interpage_source


### PR DESCRIPTION
## 改动概述 / Summary

- 本 PR 定义为交互优化（UX enhancement），不是缺陷修复。
- 在“角色设置 → 角色外形”的自定义界面中，允许从当前模型未命中的背景区域按住左键拖动模型。
- 保留模型本体原有的拖动命中范围，不通过扩大模型接触面积来模拟背景拖动。
- 对 Live2D、VRM、MMD 与 PNGTuber 使用各自现有的位置更新、回弹与保存链路。
- PNGTuber 在管理页拖动时从当前居中预览位置平滑开始，并进入现有“保存设置”持久化流程。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 代码。

## 不拆分理由 / Why Not Split

不适用：改动集中于同一个模型管理页交互能力。

## 测试 / Testing

- `uv run --no-sync python -m pytest --noconftest -c NUL -p no:cacheprovider tests/unit/test_model_manager_background_drag.py tests/unit/test_model_manager_window_features.py tests/unit/test_card_maker_static_contracts.py tests/unit/test_pngtuber_static_contracts.py -q`（75 passed）
- `node --check static/js/model_manager/background-model-drag.js`
- `node --check static/js/model_manager/page-controller.js`
- `node --check static/pngtuber-core.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 模型管理页面支持拖动 Live2D、VRM、MMD 和 PNGTuber 背景调整模型位置。
  - 拖动结束后支持位置吸附；PNGTuber 会暂存调整结果，并可通过保存按钮确认。
  - 拖动过程中显示抓取光标并暂时禁用文本选择。

- **问题修复**
  - 优化背景拖动与模型自身交互区域的区分，避免误触发模型拖动。
  - 修复模型位置编辑后被意外重置的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->