### PR TITLE
修复猫娘回来后立即开启语言控制失败，以及屏幕分享按钮残留的问题

### DIFF
--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -106,6 +106,9 @@
         window.addEventListener('neko:cat-return-complete', () => {
             catReturnInProgress = false;
         });
+        window.addEventListener('neko:cat-return-abort', () => {
+            catReturnInProgress = false;
+        });
 
         function waitForCatReturnComplete(timeoutMs) {
             if (!catReturnInProgress) {
@@ -119,10 +122,13 @@
                     settled = true;
                     if (timeoutId) clearTimeout(timeoutId);
                     window.removeEventListener('neko:cat-return-complete', handleComplete);
+                    window.removeEventListener('neko:cat-return-abort', handleAbort);
                     resolve(completed);
                 };
                 const handleComplete = () => finish(true);
+                const handleAbort = () => finish(false);
                 window.addEventListener('neko:cat-return-complete', handleComplete);
+                window.addEventListener('neko:cat-return-abort', handleAbort);
                 timeoutId = setTimeout(() => finish(false), timeoutMs);
             });
         }
@@ -1295,6 +1301,8 @@
                     timestamp: Date.now()
                 }
             }));
+            let returnTerminalPublished = false;
+            try {
             const isReturningToPngtuber = (window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber';
             if (I.multiWindowReturnBallDragState) {
                 I.multiWindowReturnBallDragState.dragSessionToken += 1;
@@ -1765,8 +1773,20 @@
                     timestamp: Date.now()
                 }
             }));
+            returnTerminalPublished = true;
 
             console.log('[App] 请她回来完成，未自动开始会话，等待用户主动发起对话');
+            } finally {
+                if (!returnTerminalPublished) {
+                    window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
+                        detail: {
+                            source: event && event.type ? event.type : 'return-click',
+                            reason: 'return-incomplete',
+                            timestamp: Date.now()
+                        }
+                    }));
+                }
+            }
         };
 
         // 统一监听各模型类型的回来事件

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -94,8 +94,60 @@
             });
         }
 
+        // The floating controls become visible before the return flow has
+        // finished resetting the hidden session buttons. Preserve a mic click
+        // made in that window and replay it after the return is complete.
+        let catReturnInProgress = false;
+        let floatingMicToggleGeneration = 0;
+
+        window.addEventListener('neko:cat-return-commit', () => {
+            catReturnInProgress = true;
+        });
+        window.addEventListener('neko:cat-return-complete', () => {
+            catReturnInProgress = false;
+        });
+
+        function waitForCatReturnComplete(timeoutMs) {
+            if (!catReturnInProgress) {
+                return Promise.resolve(true);
+            }
+            return new Promise((resolve) => {
+                let settled = false;
+                let timeoutId = null;
+                const finish = (completed) => {
+                    if (settled) return;
+                    settled = true;
+                    if (timeoutId) clearTimeout(timeoutId);
+                    window.removeEventListener('neko:cat-return-complete', handleComplete);
+                    resolve(completed);
+                };
+                const handleComplete = () => finish(true);
+                window.addEventListener('neko:cat-return-complete', handleComplete);
+                timeoutId = setTimeout(() => finish(false), timeoutMs);
+            });
+        }
+
+        function reconcileFloatingMicButtonState() {
+            const active = !!(I.S.isRecording || I.S.voiceStartPending || window.isMicStarting);
+            if (typeof window.syncFloatingMicButtonState === 'function') {
+                window.syncFloatingMicButtonState(active);
+            }
+            return active;
+        }
+
         window.addEventListener('live2d-mic-toggle', async (e) => {
+            const toggleGeneration = ++floatingMicToggleGeneration;
             if (e.detail.active) {
+                if (catReturnInProgress) {
+                    const returnCompleted = await waitForCatReturnComplete(15000);
+                    if (toggleGeneration !== floatingMicToggleGeneration) {
+                        return;
+                    }
+                    if (!returnCompleted) {
+                        reconcileFloatingMicButtonState();
+                        return;
+                    }
+                }
                 if (I.S.isRecording) {
                     // 已在录音：仅按需联动自动共享屏幕
                     if (voiceAutoScreenEnabled()) {
@@ -117,6 +169,13 @@
                     micButton.click();
                     await waitForVoiceRecordingReady(5000);
                 }
+                if (toggleGeneration !== floatingMicToggleGeneration) {
+                    return;
+                }
+                // Disabled native buttons silently reject click(). Reconcile
+                // the optimistic floating state so its screen-share shortcut
+                // cannot remain visible after a rejected or failed start.
+                reconcileFloatingMicButtonState();
                 // 仅当用户显式开启「语音时自动共享屏幕」才联动起屏；默认关 = 开麦只开麦。
                 if (I.S.isRecording && voiceAutoScreenEnabled()) {
                     await startScreenSharingFromVoiceButton();

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -1068,9 +1068,20 @@ def test_cat_return_commit_always_publishes_complete_or_abort_terminal_event():
     failed_model_return = handler.index("if (modelDisplayReady === false) {", try_index)
     finally_index = handler.index("} finally {", failed_model_return)
     abort_index = handler.index("new CustomEvent('neko:cat-return-abort'", finally_index)
+    complete_index = handler.index(
+        "new CustomEvent('neko:cat-return-complete'",
+        try_index,
+    )
+    published_index = handler.index(
+        "returnTerminalPublished = true;",
+        complete_index,
+    )
+    finally_brace = handler.index("{", finally_index)
+    finally_end = _balanced_js_block_end(handler, finally_brace)
 
     assert commit_index < guard_index < try_index < failed_model_return < finally_index < abort_index
-    assert "returnTerminalPublished = true;" in handler[try_index:finally_index]
+    assert try_index < complete_index < published_index < finally_index
+    assert finally_brace < abort_index <= finally_end
 
 
 def test_voice_auto_screen_stops_owned_share_even_after_setting_is_disabled():

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -202,9 +202,12 @@ class FakeButton {{
     this.classList = new FakeClassList();
     this.disabled = false;
     this.clickCount = 0;
+    this.onClick = null;
   }}
   click() {{
+    if (this.disabled) return;
     this.clickCount += 1;
+    if (typeof this.onClick === 'function') this.onClick();
   }}
 }}
 
@@ -241,6 +244,16 @@ global.window = {{
     const handlers = this._listeners.get(type) || [];
     handlers.push(handler);
     this._listeners.set(type, handlers);
+  }},
+  removeEventListener(type, handler) {{
+    const handlers = this._listeners.get(type) || [];
+    this._listeners.set(type, handlers.filter((candidate) => candidate !== handler));
+  }},
+  async dispatchNamed(type, detail = {{}}) {{
+    const handlers = [...(this._listeners.get(type) || [])];
+    for (const handler of handlers) {{
+      await handler({{ type, detail }});
+    }}
   }},
   async dispatchMicToggle(active) {{
     const handlers = this._listeners.get('live2d-mic-toggle') || [];
@@ -989,6 +1002,31 @@ def test_floating_mic_toggle_actual_state_matrix(name, script_body, expected):
     assert result["mic"]["disabled"] is expected["disabled"], name
     assert result["mic"]["classes"] == expected["classes"], name
     assert result["stopCalls"] == expected["stopCalls"], name
+
+
+def test_floating_mic_click_during_cat_return_replays_after_return_completion():
+    result = _run_floating_mic_toggle_scenario(
+        """
+    await window.dispatchNamed('neko:cat-return-commit');
+    micButton.disabled = true;
+    const togglePromise = window.dispatchMicToggle(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const clicksBeforeReturnComplete = micButton.clickCount;
+
+    micButton.disabled = false;
+    micButton.onClick = function () {
+      S.isRecording = true;
+      micButton.classList.add('active', 'recording');
+    };
+    await window.dispatchNamed('neko:cat-return-complete');
+    await togglePromise;
+    return { clicksBeforeReturnComplete };
+        """
+    )
+
+    assert result["result"]["clicksBeforeReturnComplete"] == 0
+    assert result["mic"]["clicks"] == 1
+    assert result["mic"]["classes"] == ["active", "recording"]
 
 
 def test_voice_auto_screen_stops_owned_share_even_after_setting_is_disabled():

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -1029,6 +1029,50 @@ def test_floating_mic_click_during_cat_return_replays_after_return_completion():
     assert result["mic"]["classes"] == ["active", "recording"]
 
 
+def test_floating_mic_click_during_aborted_cat_return_is_released_immediately():
+    result = _run_floating_mic_toggle_scenario(
+        """
+    await window.dispatchNamed('neko:cat-return-commit');
+    micButton.disabled = true;
+    const abortedTogglePromise = window.dispatchMicToggle(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await window.dispatchNamed('neko:cat-return-abort');
+    await abortedTogglePromise;
+    const clicksAfterAbort = micButton.clickCount;
+
+    micButton.disabled = false;
+    micButton.onClick = function () {
+      S.isRecording = true;
+      micButton.classList.add('active', 'recording');
+    };
+    await window.dispatchMicToggle(true);
+    return { clicksAfterAbort };
+        """
+    )
+
+    assert result["result"]["clicksAfterAbort"] == 0
+    assert result["mic"]["clicks"] == 1
+    assert result["mic"]["classes"] == ["active", "recording"]
+
+
+def test_cat_return_commit_always_publishes_complete_or_abort_terminal_event():
+    source = _read(APP_UI_PATH)
+    marker = "const handleReturnClick = async (event) => {"
+    start = source.index(marker)
+    brace = source.index("{", start)
+    handler = source[start : _balanced_js_block_end(source, brace) + 1]
+
+    commit_index = handler.index("new CustomEvent('neko:cat-return-commit'")
+    guard_index = handler.index("let returnTerminalPublished = false;", commit_index)
+    try_index = handler.index("try {", guard_index)
+    failed_model_return = handler.index("if (modelDisplayReady === false) {", try_index)
+    finally_index = handler.index("} finally {", failed_model_return)
+    abort_index = handler.index("new CustomEvent('neko:cat-return-abort'", finally_index)
+
+    assert commit_index < guard_index < try_index < failed_model_return < finally_index < abort_index
+    assert "returnTerminalPublished = true;" in handler[try_index:finally_index]
+
+
 def test_voice_auto_screen_stops_owned_share_even_after_setting_is_disabled():
     result = _run_floating_mic_toggle_scenario(
         """


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复猫娘回来后立即开启语言控制失败，以及屏幕分享按钮残留的问题

## 测试 / Testing

手动进行复现操作确保问题以及修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化浮动麦克风按钮与录音状态的同步，减少状态显示错误。
  - 麦克风启动失败、按钮被禁用或等待超时时，按钮会自动恢复正确状态。
  - 返回操作完成前点击麦克风会暂存操作，完成后自动处理；若返回中止则立即释放。
  - 忽略过期的切换请求，避免快速操作导致按钮状态异常。
  - 确保返回流程始终正确结束，避免麦克风操作持续等待。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->