### PR TITLE
ci(checker): dist 闸只要求 int8 embedding 权重

### DIFF
--- a/scripts/check_nuitka_dist.py
+++ b/scripts/check_nuitka_dist.py
@@ -85,9 +85,11 @@ _REQUIRED_ASSETS: tuple[tuple[str, str | None], ...] = (
     # 漏打则本地端点检测/说话人识别/向量记忆静默降级。CI 另有逐文件深检（Verify bundled
     # offline assets），此处兜住"目录/权重缺失"这类静默漂移。embedding 须查到具体文件：
     # 下载中断会留下只有空 profile 子目录的 data/embedding_models，目录非空判据挡不住。
+    # 只查 int8：CI 备的是 --variant both，本地 Steam 包只装 int8（fp32 权重 810MB，
+    # 压缩后仍给成品加 ~370MB，为极少数 CPU 才走的 fallback 不划算）。这里是两边
+    # 共用的闸，所以只能要求两边都保证的那一份；CI 侧的 fp32 由 build-desktop.yml
+    # 的 "Verify bundled offline assets" 步骤单独硬校验。
     ("data/embedding_models/local-text-retrieval-v1", "tokenizer.json"),
-    ("data/embedding_models/local-text-retrieval-v1/onnx", "model.onnx"),
-    ("data/embedding_models/local-text-retrieval-v1/onnx", "model.onnx_data"),
     ("data/embedding_models/local-text-retrieval-v1/onnx", "model_quantized.onnx"),
     ("data/embedding_models/local-text-retrieval-v1/onnx", "model_quantized.onnx_data"),
     ("main_logic/asr_client/endpointing/models", "silero_vad.onnx"),


### PR DESCRIPTION
## 背景

PR #2767 给 `check_nuitka_dist.py` 加了 embedding profile 的逐文件必查项，其中包含 fp32 的 `model.onnx` / `model.onnx_data`。

实测这两个文件是 **810 MB**（int8 是 236 MB），打进 Steam 包后压缩仍让成品从 865 MB 涨到 1233 MB（+368 MB）。而 fp32 只服务于一条 fallback：`memory/embeddings.py` 在非 VNNI CPU 上会打日志建议用户设 `VECTORS_QUANTIZATION=fp32`。为极少数机器才走到的路径让所有用户多下近 400 MB 不划算，因此本地打包脚本改为只打 int8。

## 改动

`check_nuitka_dist.py` 是本地 `build_nuitka.bat` 与 CI `build-desktop.yml` **共用**的闸，只能要求两边都保证的那一份，故去掉 fp32 两条必查项，保留 `tokenizer.json` 与 int8 两个文件。

CI 侧不降覆盖：`build-desktop.yml` 仍 `--variant both`，其 fp32 由该 workflow 的 `Verify bundled offline assets` 内联步骤逐文件硬校验（`onnx/model.onnx`、`onnx/model.onnx_data` 非空即 fail）。

## 验证

- `py_compile` 通过
- `tests/unit/test_prepare_nuitka_plugins.py` 7 passed（该文件是 checker 的唯一单测消费方，只 import `_check_plugin_stage` / `_check_plugin_tomls`）
- 本地 int8-only 的 `dist/Xiao8` 跑 checker 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)