### PR TITLE
复用喵宇宙老玩家识别机制，让铸造券同步解锁状态并跳过三天等待，同时保持教程重置后不重新锁定

### DIFF
--- a/static/avatar/avatar-ui-buttons/methods-buttons.js
+++ b/static/avatar/avatar-ui-buttons/methods-buttons.js
@@ -7,6 +7,7 @@
     let tutorialReadyRefreshBound = false;
     let tutorialLoadListenerBound = false;
     let fallbackFirstSeenDate = null;
+    let lastPublishedUnlockStatus = '';
 
     function getLocalDateKey(date = new Date()) {
         const year = date.getFullYear();
@@ -76,6 +77,24 @@
         return getLocalDateKey(unlockedDate);
     }
 
+    function publishUnlockStatus(status) {
+        if (!status || typeof window.dispatchEvent !== 'function'
+            || typeof window.CustomEvent !== 'function') return;
+        const detail = {
+            firstSeenDate: status.firstSeenDate,
+            unlocked: status.unlocked === true,
+            existingUser: status.existingUser === true
+        };
+        const signature = `${detail.firstSeenDate}|${detail.unlocked ? 1 : 0}|${detail.existingUser ? 1 : 0}`;
+        if (signature === lastPublishedUnlockStatus) return;
+        try {
+            window.dispatchEvent(new window.CustomEvent('neko-social-unlock-status', { detail }));
+            lastPublishedUnlockStatus = signature;
+        } catch (_) {
+            // Electron preload 同步只是共享门控的镜像；失败不能影响喵宇宙入口本身。
+        }
+    }
+
     function readUnlockEvidence(todayDate) {
         const today = getLocalDateKey(todayDate);
         const tutorialState = readTutorialState();
@@ -115,12 +134,14 @@
         const firstSeenDate = evidence.firstSeenDate;
         const today = getLocalDateKey(todayDate);
         const dayDelta = getCalendarDayDelta(firstSeenDate, today);
-        return {
+        const status = {
             firstSeenDate,
             dayDelta,
             remainingDays: Math.max(0, LOCK_DAYS - dayDelta),
             unlocked: evidence.existingUser || dayDelta >= LOCK_DAYS
         };
+        publishUnlockStatus({ ...status, existingUser: evidence.existingUser });
+        return status;
     }
 
     function getTitle(status) {

--- a/tests/frontend/social_unlock_state.test.cjs
+++ b/tests/frontend/social_unlock_state.test.cjs
@@ -64,7 +64,14 @@ function loadSocialUnlock(options = {}) {
         window
     });
     vm.runInContext(METHODS_SOURCE, context, { filename: 'methods-buttons.js' });
-    return { api: window.nekoSocialUnlock, storage, listeners, registeredButtons, dispatchedEvents };
+    return {
+        api: window.nekoSocialUnlock,
+        storage,
+        listeners,
+        registeredButtons,
+        dispatchedEvents,
+        setTutorialState(nextState) { tutorialState = nextState; }
+    };
 }
 
 test('natural-day countdown persists first-seen date and unlocks on day four', () => {
@@ -93,7 +100,7 @@ test('clock moving backward does not unlock the social entry early', () => {
 });
 
 test('existing users migrated by the seven-day tutorial skip charging immediately', () => {
-    const { api, storage, dispatchedEvents } = loadSocialUnlock({
+    const { api, storage, dispatchedEvents, setTutorialState } = loadSocialUnlock({
         withTutorialState: true,
         tutorialState: {
             firstSeenDate: '2026-01-01',
@@ -111,6 +118,25 @@ test('existing users migrated by the seven-day tutorial skip charging immediatel
     assert.equal(event.detail.firstSeenDate, '2025-12-29');
     assert.equal(event.detail.unlocked, true);
     assert.equal(event.detail.existingUser, true);
+
+    api.getStatus(new Date(2026, 0, 1, 12));
+    assert.equal(
+        dispatchedEvents.filter(item => item.type === 'neko-social-unlock-status').length,
+        1
+    );
+
+    setTutorialState({
+        firstSeenDate: '2026-01-01',
+        completedRounds: [],
+        skippedRounds: []
+    });
+    const afterReset = api.getStatus(new Date(2026, 0, 1, 12));
+    assert.equal(afterReset.unlocked, true);
+    const unlockEvents = dispatchedEvents.filter(item => item.type === 'neko-social-unlock-status');
+    assert.equal(unlockEvents.length, 2);
+    assert.equal(unlockEvents[1].detail.firstSeenDate, '2025-12-29');
+    assert.equal(unlockEvents[1].detail.unlocked, true);
+    assert.equal(unlockEvents[1].detail.existingUser, false);
 });
 
 test('users whose tutorial first-seen date is three days old skip charging', () => {

--- a/tests/frontend/social_unlock_state.test.cjs
+++ b/tests/frontend/social_unlock_state.test.cjs
@@ -14,13 +14,27 @@ function loadSocialUnlock(options = {}) {
     const storage = new Map();
     const listeners = new Map();
     const registeredButtons = [];
+    const dispatchedEvents = [];
     let tutorialState = options.tutorialState || null;
+    class CustomEvent {
+        constructor(type, init = {}) {
+            this.type = type;
+            this.detail = init.detail;
+        }
+    }
     const window = {
+        CustomEvent,
         localStorage: {
             getItem(key) { return storage.has(key) ? storage.get(key) : null; },
             setItem(key, value) { storage.set(key, String(value)); }
         },
         addEventListener(type, listener) { listeners.set(type, listener); },
+        dispatchEvent(event) {
+            dispatchedEvents.push(event);
+            const listener = listeners.get(event && event.type);
+            if (listener) listener(event);
+            return true;
+        },
         t(key, params = {}) { return `${key}:${params.days ?? ''}`; }
     };
     if (options.withTutorialState) {
@@ -50,7 +64,7 @@ function loadSocialUnlock(options = {}) {
         window
     });
     vm.runInContext(METHODS_SOURCE, context, { filename: 'methods-buttons.js' });
-    return { api: window.nekoSocialUnlock, storage, listeners, registeredButtons };
+    return { api: window.nekoSocialUnlock, storage, listeners, registeredButtons, dispatchedEvents };
 }
 
 test('natural-day countdown persists first-seen date and unlocks on day four', () => {
@@ -79,7 +93,7 @@ test('clock moving backward does not unlock the social entry early', () => {
 });
 
 test('existing users migrated by the seven-day tutorial skip charging immediately', () => {
-    const { api, storage } = loadSocialUnlock({
+    const { api, storage, dispatchedEvents } = loadSocialUnlock({
         withTutorialState: true,
         tutorialState: {
             firstSeenDate: '2026-01-01',
@@ -92,6 +106,11 @@ test('existing users migrated by the seven-day tutorial skip charging immediatel
     assert.equal(status.unlocked, true);
     assert.equal(status.remainingDays, 0);
     assert.equal(storage.get('neko.social.unlock.v1'), '2025-12-29');
+    const event = dispatchedEvents.find(item => item.type === 'neko-social-unlock-status');
+    assert.ok(event);
+    assert.equal(event.detail.firstSeenDate, '2025-12-29');
+    assert.equal(event.detail.unlocked, true);
+    assert.equal(event.detail.existingUser, true);
 });
 
 test('users whose tutorial first-seen date is three days old skip charging', () => {

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -2804,10 +2804,10 @@ async def test_unreadable_settings_do_not_kill_the_mic_when_asr_is_disabled():
     assert "ASR_INDEPENDENT_DISABLED" in codes
 
 
-async def test_absent_settings_still_default_without_failing_closed():
+async def test_absent_settings_use_disabled_default_without_failing_closed():
     # The other half of the strict read: an ABSENT file is not a failure. A
-    # first run has no settings yet and must use the enabled default rather
-    # than blocking the route.
+    # first run has no settings yet and must use the disabled default rather
+    # than blocking the microphone route.
     mgr = _make_routable_audio_manager(True)
     mgr._begin_voice_input_connection("socket-a")
     _authorize_core_lease(mgr)
@@ -2816,14 +2816,7 @@ async def test_absent_settings_still_default_without_failing_closed():
     mgr.send_status = AsyncMock()
     mgr._asr_runtime.abort = AsyncMock()
 
-    async def _ready_start(**_kwargs):
-        return AsrStartResult(
-            AsrStartStatus.READY,
-            provider="qwen",
-            session_epoch=mgr._capture_ingress_token().session_epoch,
-        )
-
-    mgr._asr_runtime.start = AsyncMock(side_effect=_ready_start)
+    mgr._asr_runtime.start = AsyncMock()
 
     async def _empty(**_kwargs):
         return {}
@@ -2835,7 +2828,8 @@ async def test_absent_settings_still_default_without_failing_closed():
     ):
         await LLMSessionManager._start_independent_asr_if_enabled(mgr, "audio")
 
-    assert mgr._asr_route_mode == "independent"
+    assert mgr._asr_route_mode == "native"
+    mgr._asr_runtime.start.assert_not_awaited()
 
 
 async def test_fail_closed_chokepoint_honours_the_callers_own_predicate():

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -2829,7 +2829,7 @@ async def test_absent_settings_use_disabled_default_without_failing_closed():
         await LLMSessionManager._start_independent_asr_if_enabled(mgr, "audio")
 
     assert mgr._asr_route_mode == "native"
-    mgr._asr_runtime.start.assert_not_awaited()
+    mgr._asr_runtime.start.assert_not_called()
 
 
 async def test_fail_closed_chokepoint_honours_the_callers_own_predicate():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

复用喵宇宙老玩家识别机制，让铸造券同步解锁状态并跳过三天等待，同时保持教程重置后不重新锁定

## 测试 / Testing

手动测试修改前无法掉卡，修复后可以


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增社交解锁状态通知，包含首次访问日期、解锁状态及老用户标记。
  * 状态未变化时不重复通知；状态重置后会重新发送更新通知。

* **错误修复**
  * 通知异常不会影响社交解锁入口正常使用。
  * 未配置音频设置时，默认使用原生路由，不再启动独立语音识别服务。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->