### PR TITLE
修复 Windows CI 上说话人影子后端「活着却超时」的假红，并放宽两条擦边的墙钟时限

### DIFF
--- a/main_logic/asr_client/speaker_shadow/runtime.py
+++ b/main_logic/asr_client/speaker_shadow/runtime.py
@@ -138,6 +138,9 @@ class _BackendProcessHost:
         )
         self._connection: Connection | None = parent_connection
         self._child_connection: Connection | None = child_connection
+        # Abandoned host reads keep a strong reference here until the thread
+        # they are blocked in unwinds, so the event loop cannot drop them.
+        self._pending_responses: set[asyncio.Future[Any]] = set()
         self._pcm_buffer = pcm_buffer
         self._process: BaseProcess | None = process
         self._terminate_timeout_seconds = terminate_timeout_seconds
@@ -264,32 +267,52 @@ class _BackendProcessHost:
             await self.terminate()
             raise _BackendHostError("backend host command failed") from exc
 
-        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        # One blocking read off the event loop, not a ``poll(0)`` spin. Each
+        # zero-timeout poll starts an overlapped pipe read and cancels it in
+        # the same breath, and on Windows that cancellation races the very
+        # response it asked about: the child answers and stays alive, the
+        # answer is swallowed, and the parent spins to a false timeout that no
+        # later poll can recover. A plain ``recv`` issues one read and never
+        # cancels it. Nothing else waits on this connection, so the read is
+        # released either by the response or by the host dying — including the
+        # ``terminate`` below, which closes the pipe on timeout and on
+        # cancellation.
+        response = asyncio.ensure_future(asyncio.to_thread(connection.recv))
+        self._pending_responses.add(response)
+        response.add_done_callback(self._consume_response_result)
         try:
-            while True:
-                if connection.poll(0.0):
-                    try:
-                        succeeded, value = connection.recv()
-                    except (BrokenPipeError, EOFError, OSError) as exc:
-                        await self.terminate()
-                        raise _BackendHostError(
-                            "backend host response failed"
-                        ) from exc
-                    if succeeded:
-                        return value
-                    raise _BackendHostError(f"backend operation failed: {value}")
-                if not process.is_alive():
-                    await asyncio.to_thread(self._dispose_handles)
-                    raise _BackendHostError("backend host exited without a response")
-                remaining = deadline - asyncio.get_running_loop().time()
-                if remaining <= 0:
-                    self.timed_out = True
-                    await self.terminate()
-                    raise _BackendHostTimeout(f"backend {operation} timed out")
-                await asyncio.sleep(min(_HOST_POLL_INTERVAL_SECONDS, remaining))
+            done, _ = await asyncio.wait({response}, timeout=timeout_seconds)
         except asyncio.CancelledError:
             await self.terminate()
             raise
+        if not done:
+            self.timed_out = True
+            # Terminating kills the child first, which breaks the pipe and
+            # releases the blocked read before the handles are disposed.
+            await self.terminate()
+            await asyncio.wait({response}, timeout=self._terminate_timeout_seconds)
+            raise _BackendHostTimeout(f"backend {operation} timed out")
+        try:
+            succeeded, value = response.result()
+        except (BrokenPipeError, EOFError, OSError) as exc:
+            if not process.is_alive():
+                await asyncio.to_thread(self._dispose_handles)
+                raise _BackendHostError(
+                    "backend host exited without a response"
+                ) from exc
+            await self.terminate()
+            raise _BackendHostError("backend host response failed") from exc
+        if succeeded:
+            return value
+        raise _BackendHostError(f"backend operation failed: {value}")
+
+    def _consume_response_result(self, response: asyncio.Future[Any]) -> None:
+        """Retire an abandoned host read once its blocked thread unwinds."""
+
+        self._pending_responses.discard(response)
+        if response.cancelled():
+            return
+        response.exception()
 
     async def _wait_for_exit(self, timeout_seconds: float) -> bool:
         process = self._process

--- a/tests/unit/asr_client/speaker_shadow/test_runtime.py
+++ b/tests/unit/asr_client/speaker_shadow/test_runtime.py
@@ -20,6 +20,7 @@ from main_logic.asr_client.speaker_shadow.contracts import (
 from main_logic.asr_client.speaker_shadow.runtime import (
     SpeakerShadowRuntime,
     _AudioFrame,
+    _BackendProcessHost,
     _CandidateFinished,
     _CandidateToken,
     _backend_host_main,
@@ -167,6 +168,79 @@ class _InspectingHostConnection:
 
     def close(self) -> None:
         self.closed = True
+
+
+class _PollBlindProcess:
+    """A live child whose only job is to keep the request path going."""
+
+    pid = -1
+    exitcode = None
+
+    def is_alive(self) -> bool:
+        return True
+
+    # Reaping hooks, so a host that gives up on the response fails with the
+    # timeout it actually hit instead of an AttributeError that hides it.
+    def terminate(self) -> None:
+        return None
+
+    def kill(self) -> None:
+        return None
+
+    def join(self, timeout: float | None = None) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class _PollBlindConnection:
+    """A pipe end that answers a read but never admits readiness to ``poll``."""
+
+    def __init__(self, response: tuple[object, ...]) -> None:
+        self._response = response
+        self.sent: list[tuple[object, ...]] = []
+        self.polls = 0
+
+    def poll(self, timeout: float = 0.0) -> bool:
+        self.polls += 1
+        return False
+
+    def send(self, message: tuple[object, ...]) -> None:
+        self.sent.append(message)
+
+    def recv(self) -> tuple[object, ...]:
+        return self._response
+
+    def close(self) -> None:
+        return None
+
+
+async def test_host_response_survives_a_pipe_that_never_polls_ready() -> None:
+    # Windows loses a response when the host waits on ``poll(0)``: each poll
+    # starts an overlapped pipe read and cancels it in the same breath, and
+    # that cancellation can swallow the very answer it asked about. The child
+    # stays alive, the answer never comes back, and the request spins to a
+    # false timeout — a live backend reported as "failed" roughly half the
+    # time on a loaded runner. So the request path must not gate the read on
+    # a readiness poll at all: a connection that answers ``recv`` but always
+    # reports "not ready" has to complete the request anyway.
+    host = _BackendProcessHost(
+        factory=_BackendFactory(),
+        terminate_timeout_seconds=0.1,
+    )
+    parent_connection = host._connection
+    child_connection = host._child_connection
+    assert parent_connection is not None and child_connection is not None
+    parent_connection.close()
+    child_connection.close()
+    connection = _PollBlindConnection((True, True))
+    host._connection = connection  # type: ignore[assignment]
+    host._child_connection = None
+    host._process = _PollBlindProcess()  # type: ignore[assignment]
+
+    assert await host.load(timeout_seconds=1.0) is True
+    assert connection.sent == [("load",)]
 
 
 def test_backend_host_wipes_score_pcm_before_waiting_for_next_command() -> None:

--- a/tests/unit/test_ban_topic_regex_zh_tw.py
+++ b/tests/unit/test_ban_topic_regex_zh_tw.py
@@ -1410,12 +1410,16 @@ def test_filler_dedup_stays_linear_on_many_directives():
     # ⚠️ 光筛 suspects 不够：话题本身就以填充词结尾时（`成就别提了。` 重复几千遍）
     # 每条都是 suspect，逐条再扫全表又变回 O(n²)——4000 条曾要 1.25 秒。按起点分桶
     # 之后只看邻桶（命中区间长度有上界），这里用时限钉住那个量级差（codex P2）。
+    #
+    # ⚠️ 时限是 4 秒不是 1 秒：桶索引版本本机 0.14 秒，Windows CI 上量到过 1.01 秒
+    # （比本机慢 7 倍），1 秒的线就在那台机器上擦边误红。要钉的是**量级差**——
+    # 退回逐条扫全表本机就要 1.25 秒，同样慢 7 倍就是 9 秒左右，4 秒的线照样拦得住。
     import time
 
     started = time.perf_counter()
     extract_directives("成就别提了。" * 4000)
     elapsed = time.perf_counter() - started
-    assert elapsed < 1.0, f"4000 条以填充词结尾的话题跑了 {elapsed:.2f}s，桶索引失效了"
+    assert elapsed < 4.0, f"4000 条以填充词结尾的话题跑了 {elapsed:.2f}s，桶索引失效了"
 
     hits = [("zh", "ban_topic", f"话题{i}") for i in range(50)]
     spans = [(i * 10, i * 10 + 5) for i in range(50)]
@@ -1641,14 +1645,21 @@ def test_bracket_bodies_are_bounded(pair):
 
 @pytest.mark.parametrize("pair", D._ZH_BRACKET_PAIRS)
 def test_no_bracket_pair_scans_to_the_end(pair):
-    """行为面：每一对括号单独喂 8000 个未配对开括号都必须是线性的。"""  # noqa: DOCSTRING_CJK
+    """行为面：每一对括号单独喂 8000 个未配对开括号都必须是线性的。
+
+    ⚠️ 时限是 10 秒不是 1 秒。有界版本本机 0.14 秒，Windows CI 上量到过 7.37 秒
+    （跑 runner 卡顿时能慢到本机的五十倍），1 秒的线在那种时候纯误红。要拦的是
+    上面那条 docstring 记的量级差——单把一对放成无界，本机就从 0.04 涨到 2.5 秒
+    （六十倍），同样的 CI 上是分钟级，10 秒的线照样拦得住。逐对的**精确**判据在
+    ``test_bracket_bodies_are_bounded``（结构面、全称），这条只是它的行为面兜底。
+    """  # noqa: DOCSTRING_CJK
     import time
 
     lo, _hi = pair
     started = time.perf_counter()
     extract_directives(lo * 8000)
     elapsed = time.perf_counter() - started
-    assert elapsed < 1.0, f"{lo!r} * 8000 跑了 {elapsed:.2f}s"
+    assert elapsed < 10.0, f"{lo!r} * 8000 跑了 {elapsed:.2f}s"
 
 
 def test_unmatched_openers_stay_linear():
@@ -1661,8 +1672,11 @@ def test_unmatched_openers_stay_linear():
         extract_directives(text)
         timings[n] = time.perf_counter() - start
     # 二次方的话 4 倍输入是 16 倍时间；给足余量只要求**远小于**二次方。
+    # ⚠️ 比值那条才是判据，它自带机器归一化。下面的绝对值只是兜底，线放到 10 秒
+    # ——同一段 ``"《" * 8000`` 在 Windows CI 上被 runner 卡顿量到过 7.37 秒
+    #（见 test_no_bracket_pair_scans_to_the_end），1 秒的线在那种时候纯误红。
     assert timings[8000] < timings[2000] * 8 + 0.2, timings
-    assert timings[8000] < 1.0, timings
+    assert timings[8000] < 10.0, timings
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 这个 PR 干了啥

修 Windows 上 `Unit Tests` 从 8 月 4 日起断续红的主因，外加两条擦边的墙钟时限。

### 1. 说话人影子后端「活着却超时」（主因）

`tests/unit/asr_client/speaker_shadow/test_runtime.py::test_candidate_pcm_is_capped_at_four_seconds_across_frames`
在 main 上反复红，断言 `scored_candidate_count == 0`。

后端宿主（`_BackendProcessHost._request`）原来用 `connection.poll(0)` + `asyncio.sleep(5ms)`
轮询子进程回包。Windows 上每次零超时 poll 都会起一个 overlapped 管道读、紧接着又把它取消，
这个取消会和它正要问的那条回包抢跑：**回包被吞掉，子进程还活着，父进程一路空转到超时，
之后再怎么 poll 也捞不回来**。

定位时量到的直接证据（本机 6 路并发复现）：

- 子进程打印「load 回包已发送」；
- 父进程轮询 195 次全部 not-ready，超时后再补一次**阻塞** `poll(2.0)` 仍然拿不到，
  `PeekNamedPipe` 也是 `(0, 0)`——回包确实不在父进程管道里；
- 让子进程隔 0.4 秒**补发**一条，父进程立刻收到——通道没坏，丢的就是那一条。

改法：回包读改成在线程里一次阻塞 `recv()`，只发一次读、永不取消。超时/取消路径先
`terminate()` 子进程，管道随之断开，阻塞中的读自己解开；被放弃的读用一个 set 持住引用，
线程解开后由 done-callback 回收。

新增 `test_host_response_survives_a_pipe_that_never_polls_ready`：喂一个「`recv` 能答、
`poll` 永远说没数据」的管道端，钉住请求路径不再拿就绪轮询当门。撤掉本 PR 的实现改动后
这条会以 `_BackendHostTimeout` 变红（已验证）。

### 2. 两条擦边的墙钟时限（`test_ban_topic_regex_zh_tw.py`）

判据仍是**量级差**，只是把绝对值的线抬到不会被 runner 抖动擦到的位置：

| 用例 | 本机 | CI 实测（好实现） | 退化实现 | 原线 → 新线 |
|---|---|---|---|---|
| 填充词去重 4000 条 | 0.14s | **1.01s**（擦线红） | 本机 1.25s → CI 约 9s | 1.0s → 4.0s |
| 未配对开括号 8000 个 | 0.14s | **7.37s**（卡顿红） | 本机 2.5s（60×）→ CI 分钟级 | 1.0s → 10.0s |

括号那条逐对的**精确**判据本来就在结构面的 `test_bracket_bodies_are_bounded`（全称断言，
未动），这条只是它的行为面兜底。同一段 `"《" * 8000` 在
`test_unmatched_openers_stay_linear` 里的绝对值兜底一并抬到 10s，那条真正的判据是它自带的
比值断言（机器归一化），未动。

## 回归报告

**改了什么 / 为什么必要**
`main_logic/asr_client/speaker_shadow/runtime.py` 的 `_BackendProcessHost._request`：
把「零超时 poll 自旋 + 5ms sleep」换成「线程里一次阻塞 `recv`」。必要性见上——这不只是
测试抖动：产线上同样会把一个**活着且已应答**的后端判成超时，进而 terminate 掉宿主、
该次候选按 failed 收尾。影子打分是 observation-only，所以不会伤到 ASR 主路，但白白丢分
且每次请求都在以 200 次/秒的频率空转 CPU。

**改动前后行为**
- 前：请求期间事件循环每 5ms 醒一次做一次 `poll(0)`；回包可能被 poll 的取消吞掉 →
  假超时 → 宿主被 terminate、候选记 failed。
- 后：请求期间不占事件循环，回包由线程里的阻塞读拿到；超时/取消先杀子进程再回收读。
  对外错误面不变：仍然是 `_BackendHostTimeout` / `_BackendHostError`
  （`backend host exited without a response` 这条也保留，改由 `recv` 抛 EOF 且进程已死时给出）。

**潜在回归**
- 每次请求多占一个默认 executor 线程（串行，同时最多一个；超时被放弃的那个在子进程被杀后
  立即解开）。默认 executor 至少 32 线程，本 runtime 只用到个位数。
- `terminate()` 里 `_dispose_handles` 关句柄时读已经在 OS 层完成（先杀进程再关句柄），
  没有「关一个正有 I/O 在跑的句柄」的常态路径。
- 已跑：`tests/unit/asr_client` + `test_asr_detector_runtime` + `test_check_core_contracts`
  + `test_core_independent_asr` 全绿（788 passed）；speaker_shadow 模块 8 路并发 × 24 次全绿
  （改动前同等压力 6/12 红）；`tests/unit` 全量。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进后端通信响应处理，确保异步请求在超时、取消或连接未及时就绪时能够安全完成或终止。
  * 提升语音相关请求的稳定性，避免通信读取阻塞导致进程无法正常释放。

* **Tests**
  * 新增后端响应接收场景测试，验证无需轮询即可成功完成请求。
  * 调整跨平台性能测试的耗时阈值，减少运行环境差异造成的误报。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->