### PR TITLE
修复 Day1 新手教程顶部探头动画时序

### DIFF
--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -3080,6 +3080,7 @@
             this.reducedMotion = !!normalizedOptions.reducedMotion;
             this.hideMs = normalizeDuration(normalizedOptions.hideMs, PLUGIN_DASHBOARD_CORNER_HIDE_MS);
             this.appearMs = normalizeDuration(normalizedOptions.appearMs, PLUGIN_DASHBOARD_CORNER_APPEAR_MS);
+            this.holdMs = normalizeDuration(normalizedOptions.holdMs, 0);
             this.totalDurationMs = this.reducedMotion ? 0 : this.hideMs + this.appearMs;
             this.targetPosition = normalizeAvatarCornerPeekPosition(
                 normalizedOptions.position
@@ -3120,6 +3121,8 @@
             this.phase = 'idle';
             this.tickerAttached = false;
             this.interruptSuspendedAt = 0;
+            this.holdStartedAt = 0;
+            this.holdTimer = 0;
             this.tick = this.tick.bind(this);
         }
 
@@ -3165,6 +3168,16 @@
             this.applyFrame(this.reducedMotion ? this.cornerFrame : this.initialModelFrame, this.reducedMotion ? 1 : this.initialAlpha);
             if (this.reducedMotion) {
                 this.elevateContainerZIndex();
+                if (this.holdMs > 0) {
+                    this.phase = 'hold';
+                    this.holdStartedAt = performance.now();
+                    this.holdTimer = window.setTimeout(() => {
+                        this.holdTimer = 0;
+                        if (this.active && !this.finished) {
+                            this.requestStop('hold_complete', true);
+                        }
+                    }, this.holdMs);
+                }
                 return true;
             }
             if (this.ticker && typeof this.ticker.add === 'function') {
@@ -3208,6 +3221,10 @@
             this.active = false;
             this.finished = true;
             this.phase = 'finished';
+            if (this.holdTimer) {
+                window.clearTimeout(this.holdTimer);
+                this.holdTimer = 0;
+            }
             this.result = reason || this.result || 'stopped';
             this.detachTicker();
             if (this.frameId) {
@@ -3766,9 +3783,18 @@
                     lerp(0, 1, progress)
                 );
             } else {
-                this.phase = 'hold';
+                if (this.phase !== 'hold') {
+                    this.phase = 'hold';
+                    this.holdStartedAt = performance.now();
+                }
                 this.applyFrame(this.cornerFrame, 1);
                 this.elevateContainerZIndex();
+                if (
+                    this.holdMs > 0
+                    && performance.now() - this.holdStartedAt >= this.holdMs
+                ) {
+                    this.requestStop('hold_complete', true);
+                }
             }
         }
 
@@ -5914,6 +5940,7 @@
             isCancelled: normalizedOptions.isCancelled,
             hideMs: normalizedOptions.hideMs,
             appearMs: normalizedOptions.appearMs,
+            holdMs: normalizedOptions.holdMs,
             position: normalizedOptions.position,
             targetPosition: normalizedOptions.targetPosition,
             targetPreset: normalizedOptions.targetPreset,

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -892,7 +892,14 @@
         const currentNow = Number.isFinite(Number(now)) ? Number(now) : performance.now();
         if (!isInterruptResistOverrideActive(session) && !isAngryExitOverrideActive(session)) {
             if (Number.isFinite(Number(session.interruptSuspendedAt)) && session.interruptSuspendedAt > 0) {
-                session.startedAt += Math.max(0, currentNow - session.interruptSuspendedAt);
+                const suspendedDuration = Math.max(0, currentNow - session.interruptSuspendedAt);
+                session.startedAt += suspendedDuration;
+                if (
+                    session.phase === 'hold'
+                    && Number.isFinite(Number(session.holdStartedAt))
+                ) {
+                    session.holdStartedAt += suspendedDuration;
+                }
                 session.interruptSuspendedAt = 0;
             }
             return false;
@@ -3174,6 +3181,10 @@
                     this.holdTimer = window.setTimeout(() => {
                         this.holdTimer = 0;
                         if (this.active && !this.finished) {
+                            if (this.isCancelled()) {
+                                this.requestStop('cancelled', false);
+                                return;
+                            }
                             this.requestStop('hold_complete', true);
                         }
                     }, this.holdMs);

--- a/static/tutorial/yui-guide/director/page-flows.js
+++ b/static/tutorial/yui-guide/director/page-flows.js
@@ -1634,6 +1634,23 @@
                 return false;
             }
 
+            const avatarStageApi = window.YuiGuideAvatarStage;
+            if (avatarStageApi && typeof avatarStageApi.startPluginDashboardCornerPeek === 'function') {
+                try {
+                    this.takeoverTopPeekHandle = await avatarStageApi.startPluginDashboardCornerPeek({
+                        targetPreset: 'top_flipped',
+                        hideMs: 1500,
+                        appearMs: 2000,
+                        holdMs: 2500,
+                        reducedMotion: this.shouldReduceTutorialMotion(),
+                        isCancelled: () => runId !== this.sceneRunId || this.isStopping()
+                    });
+                } catch (error) {
+                    console.warn('[YuiGuide] 插件面板角落动作启动失败:', error);
+                    this.takeoverTopPeekHandle = null;
+                }
+            }
+
             const keyboardToggle = await this.waitForElement(() => {
                 const toggleItem = this.getAgentToggleElement('agent-keyboard');
                 return this.getElementRect(toggleItem) ? toggleItem : null;
@@ -1740,19 +1757,6 @@
             await this.stopPersistentGhostCursorLookAtPerformance('takeover_top_peek');
             if (guardFailed()) {
                 return false;
-            }
-            const avatarStageApi = window.YuiGuideAvatarStage;
-            if (avatarStageApi && typeof avatarStageApi.startPluginDashboardCornerPeek === 'function') {
-                try {
-                    this.takeoverTopPeekHandle = await avatarStageApi.startPluginDashboardCornerPeek({
-                        targetPreset: 'top_flipped',
-                        reducedMotion: this.shouldReduceTutorialMotion(),
-                        isCancelled: () => runId !== this.sceneRunId || this.isStopping()
-                    });
-                } catch (error) {
-                    console.warn('[YuiGuide] 插件面板角落动作启动失败:', error);
-                    this.takeoverTopPeekHandle = null;
-                }
             }
             if (guardFailed()) {
                 return false;

--- a/static/tutorial/yui-guide/director/page-flows.js
+++ b/static/tutorial/yui-guide/director/page-flows.js
@@ -1559,10 +1559,11 @@
         async runTakeoverKeyboardControlSequence(step, performance, runId) {
             const scaleSceneMs = this.createSceneScaler(performance && performance.voiceKey);
             const guardFailed = () => this.isGuardFailed(runId);
+            let localTakeoverTopPeekHandle = null;
             const stopTakeoverTopPeek = async (reason) => {
-                const handle = this.takeoverTopPeekHandle;
+                const handle = localTakeoverTopPeekHandle;
+                localTakeoverTopPeekHandle = null;
                 if (!handle || typeof handle.stop !== 'function') {
-                    this.takeoverTopPeekHandle = null;
                     return;
                 }
                 try {
@@ -1656,7 +1657,7 @@
             const avatarStageApi = window.YuiGuideAvatarStage;
             if (avatarStageApi && typeof avatarStageApi.startPluginDashboardCornerPeek === 'function') {
                 try {
-                    this.takeoverTopPeekHandle = await avatarStageApi.startPluginDashboardCornerPeek({
+                    localTakeoverTopPeekHandle = await avatarStageApi.startPluginDashboardCornerPeek({
                         targetPreset: 'top_flipped',
                         hideMs: 1500,
                         appearMs: 2000,
@@ -1664,9 +1665,16 @@
                         reducedMotion: this.shouldReduceTutorialMotion(),
                         isCancelled: () => runId !== this.sceneRunId || this.isStopping()
                     });
+                    if (localTakeoverTopPeekHandle && guardFailed()) {
+                        await stopTakeoverTopPeek('takeover_keyboard_control_aborted');
+                        return false;
+                    }
+                    if (localTakeoverTopPeekHandle) {
+                        this.takeoverTopPeekHandle = localTakeoverTopPeekHandle;
+                    }
                 } catch (error) {
                     console.warn('[YuiGuide] 插件面板角落动作启动失败:', error);
-                    this.takeoverTopPeekHandle = null;
+                    localTakeoverTopPeekHandle = null;
                 }
             }
 

--- a/static/tutorial/yui-guide/director/page-flows.js
+++ b/static/tutorial/yui-guide/director/page-flows.js
@@ -1559,6 +1559,25 @@
         async runTakeoverKeyboardControlSequence(step, performance, runId) {
             const scaleSceneMs = this.createSceneScaler(performance && performance.voiceKey);
             const guardFailed = () => this.isGuardFailed(runId);
+            const stopTakeoverTopPeek = async (reason) => {
+                const handle = this.takeoverTopPeekHandle;
+                if (!handle || typeof handle.stop !== 'function') {
+                    this.takeoverTopPeekHandle = null;
+                    return;
+                }
+                try {
+                    await handle.stop(reason || 'takeover_scene_failed', { animateReturn: false });
+                } catch (_) {
+                } finally {
+                    if (this.takeoverTopPeekHandle === handle) {
+                        this.takeoverTopPeekHandle = null;
+                    }
+                }
+            };
+            const failAfterTakeoverTopPeek = async (reason) => {
+                await stopTakeoverTopPeek(reason);
+                return false;
+            };
             const createToggleSpotlightTarget = (key, element) => {
                 const rect = this.getElementRect(element);
                 if (!rect) {
@@ -1656,7 +1675,7 @@
                 return this.getElementRect(toggleItem) ? toggleItem : null;
             }, 2400);
             if (!keyboardToggle || guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
             let keyboardToggleSpotlight = null;
             const isKeyboardToggleSpotlight = (candidate) => {
@@ -1685,7 +1704,7 @@
             await this.waitForStableElementRect(keyboardToggle, scaleSceneMs(320, 160, 760));
             keyboardToggleSpotlight = refreshKeyboardToggleSpotlight({ activate: true });
             if (!keyboardToggleSpotlight || guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
             this.removeRetainedExtraSpotlight(agentMasterSpotlight);
 
@@ -1701,12 +1720,12 @@
                 }
             );
             if (!movedToKeyboardToggle || guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
 
             keyboardToggleSpotlight = refreshKeyboardToggleSpotlight();
             if (!keyboardToggleSpotlight || guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
             if (!this.isCursorAlignedWithElement(keyboardToggle, 5)) {
                 const realignedToKeyboardToggle = await this.moveCursorToTrackedElement(
@@ -1718,11 +1737,11 @@
                     }
                 );
                 if (!realignedToKeyboardToggle || guardFailed()) {
-                    return false;
+                    return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
                 }
                 keyboardToggleSpotlight = refreshKeyboardToggleSpotlight();
                 if (!keyboardToggleSpotlight || guardFailed()) {
-                    return false;
+                    return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
                 }
             }
 
@@ -1737,13 +1756,13 @@
                 }
             );
             if (!enabledKeyboardControl || guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
 
             await this.waitForStableElementRect(keyboardToggle, scaleSceneMs(320, 160, 760));
             keyboardToggleSpotlight = refreshKeyboardToggleSpotlight();
             if (!keyboardToggleSpotlight || guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
             this.rememberAvatarFloatingSceneCursorAnchor('day1_takeover_capture_cursor', keyboardToggleSpotlight);
 
@@ -1756,10 +1775,10 @@
                 );
             await this.stopPersistentGhostCursorLookAtPerformance('takeover_top_peek');
             if (guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
             if (guardFailed()) {
-                return false;
+                return await failAfterTakeoverTopPeek('takeover_keyboard_control_aborted');
             }
 
             if (this.emotionBridge && typeof this.emotionBridge.applyExpressionFile === 'function') {
@@ -1767,7 +1786,11 @@
             }
 
             await this.waitForSceneDelay(scaleSceneMs(180, 80, 420));
-            return !guardFailed();
+            const completed = !guardFailed();
+            if (!completed) {
+                await stopTakeoverTopPeek('takeover_keyboard_control_aborted');
+            }
+            return completed;
         },
 
         async runPluginDashboardLaunchSequence(step, performance, runId) {


### PR DESCRIPTION
## 改动概述 / Summary

修复 PC 端 Day1 新手教程中顶部探头动画的时序。动画现在在开启 Agent 总开关后、移动到键盘开关前启动，并按淡出、探头、保持、反向退出的完整流程播放。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/、main_routers/ 或 memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 仅修改 2 个直接相关的前端动画文件，改动属于同一条 Day1 演出链路。

## 测试 / Testing

- `git diff --check`
- `node --check static/tutorial/avatar/yui-stage.js`
- `node --check static/tutorial/yui-guide/director/page-flows.js`
- `node --test tests/unit/live2d_peek_behavior.test.js`（50 项通过）
- `.venv/bin/python -m pytest tests/test_agent_rewrite_regression.py -q -k plugin_dashboard_corner_peek`（1 项通过）
- `.venv/bin/python -m pytest tests/unit/test_avatar_floating_day1_round_contracts.py -q -k day1_takeover_restores_original_agent_switches or day1_return_control_declares_externalized_cursor_preservation or peek_intro_avatar_motions_keep_floating_buttons_attached_only_for_intro`（3 项通过）

未进行真实桌面端交互回归。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 角落预览动画新增可配置的停留时长，结束后会自动退出。
  * 键盘接管流程支持插件面板角落预览，并可配置隐藏、出现及停留时长。
  * 减弱动作模式支持停留与退出控制，提升无障碍体验。
* **体验优化**
  * 动画完成、取消、失败或退出时会及时停止预览并清理计时状态，减少流程异常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->