### PR TITLE
完善音乐搭话候选交错与跨源兜底，补充播放失败原因上报，并修复窄聊天框下音乐卡片溢出

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -7257,6 +7257,27 @@ describe('App', () => {
     );
   });
 
+  it('keeps link and music cards inside narrow message bubbles', () => {
+    expect(compactChatStyles).toMatch(
+      /\.message-stack\s*\{[\s\S]*?max-width: min\(86%, 320px\);[\s\S]*?min-width: 0;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.message-bubble\s*\{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.message-block\s*\{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.message-block-link\s*\{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);[\s\S]*?width: 100%;[\s\S]*?min-width: min\(220px, 100%\);[\s\S]*?max-width: 100%;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.message-link-thumb\s*\{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.message-link-copy\s*\{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;/,
+    );
+  });
+
   it('keeps compact composer text legible over both light and dark backdrops', () => {
     expect(compactChatStyles).toMatch(
       /\.compact-chat-surface-frame\[data-compact-chat-state="input"\] \.composer-input\s*\{[\s\S]*?color: #2f526b;[\s\S]*?caret-color: #167fbd;[\s\S]*?0 1px 1px rgba\(255, 255, 255, 0\.94\),[\s\S]*?0 0 4px rgba\(255, 255, 255, 0\.72\);/,

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1104,6 +1104,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 
 .message-stack {
   max-width: min(86%, 320px);
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -1123,6 +1124,8 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 }
 
 .message-bubble {
+  min-width: 0;
+  max-width: 100%;
   padding: 9px 11px;
   border-radius: 8px 16px 16px 16px;
   box-shadow: 0 5px 14px rgba(53, 72, 104, 0.05);
@@ -1156,6 +1159,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 
 .message-block {
   min-width: 0;
+  max-width: 100%;
 }
 
 /* 流式文字分块渐现 — 每批新文本整体淡入，参考 ChatGPT / Claude.ai */
@@ -1382,9 +1386,11 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 
 .message-block-link {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: 10px;
-  min-width: 220px;
+  width: 100%;
+  min-width: min(220px, 100%);
+  max-width: 100%;
   padding: 10px;
   border-radius: 12px;
   color: inherit;
@@ -1394,6 +1400,8 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 }
 
 .message-link-thumb {
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   border-radius: 10px;
   background: rgba(220, 228, 240, 0.9);
@@ -1409,6 +1417,8 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 .message-link-copy {
   display: grid;
   gap: 4px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .message-link-title {

--- a/main_logic/music_playback.py
+++ b/main_logic/music_playback.py
@@ -37,6 +37,15 @@ logger = get_module_logger(__name__, "Main")
 
 _session_manager_getter: Callable[[str], Any | None] | None = None
 _PLAYBACK_STATES = frozenset({"playing", "paused", "ended", "error"})
+_PLAYBACK_FAILURE_REASONS = frozenset(
+    {
+        "load_timeout",
+        "media_error",
+        "missing_audio",
+        "player_error",
+        "track_too_long",
+    }
+)
 _REPLY_START_GRACE_SECONDS = 1.0
 _REPLY_WAIT_TIMEOUT_SECONDS = 5.0
 _REPLY_WAIT_POLL_SECONDS = 0.05
@@ -250,6 +259,11 @@ def handle_music_playback_state(manager: Any, event: dict[str, Any]) -> bool:
     )
     request_id = _clean_playback_text(event.get("request_id"), 64)
     source = _clean_playback_text(event.get("source"), 16).lower()
+    failure_reason = _clean_playback_text(event.get("reason"), 32).lower()
+    if state != "error":
+        failure_reason = ""
+    elif failure_reason not in _PLAYBACK_FAILURE_REASONS:
+        failure_reason = "unknown"
     if not playback_id or not playback_window_id or playback_started_at is None:
         return False
 
@@ -283,6 +297,13 @@ def handle_music_playback_state(manager: Any, event: dict[str, Any]) -> bool:
     if getattr(manager, "_music_playback_event_key", None) == event_key:
         return False
     manager._music_playback_event_key = event_key
+
+    if state == "error":
+        logger.warning(
+            "[%s] 音乐播放器报告失败: reason=%s",
+            getattr(manager, "lanlan_name", "") or "unknown",
+            failure_reason,
+        )
 
     title = f"《{name}》" if name else "所选歌曲"
     by_artist = f"（{artist}）" if artist else ""
@@ -325,6 +346,7 @@ def handle_music_playback_state(manager: Any, event: dict[str, Any]) -> bool:
             "playback_window_id": playback_window_id,
             "playback_started_at": playback_started_at,
             "request_id": request_id,
+            "failure_reason": failure_reason,
         },
         "context_type": "music_playback",
     }

--- a/main_logic/proactive_chat/delivery.py
+++ b/main_logic/proactive_chat/delivery.py
@@ -396,6 +396,13 @@ async def _record_committed_delivery(
     active_logger = log or logger
     primary_channel = delivery.primary_channel
     source_links = delivery.source_links
+    effective_source_mode = primary_channel.lower()
+    if (
+        effective_source_mode not in {"music", "both"}
+        and delivery.is_music_used
+        and delivery.delivered_music_link
+    ):
+        effective_source_mode = "music"
     state_storage_kwargs = (
         {"memory_dir": memory_dir} if memory_dir is not None else {}
     )
@@ -500,7 +507,7 @@ async def _record_committed_delivery(
             PROACTIVE_REASON_CHAT_DELIVERED,
             message="主动搭话已发送",
             lanlan_name=lanlan_name,
-            source_mode=primary_channel.lower(),
+            source_mode=effective_source_mode,
             source_tag=source_tag or "unknown",
             active_channels=active_channels,
             source_links=source_links,

--- a/static/jukebox/music_ui.js
+++ b/static/jukebox/music_ui.js
@@ -174,7 +174,7 @@
         };
     }
 
-    function reportMusicPlaybackState(state, track, playbackContext) {
+    function reportMusicPlaybackState(state, track, playbackContext, failureReason) {
         try {
             const appState = window.appState;
             const socket = appState && appState.socket;
@@ -195,6 +195,9 @@
                 playback_started_at: context.lifecycleStartedAt,
                 request_id: context.requestId,
                 source: context.source,
+                reason: state === 'error'
+                    ? String(failureReason || 'unknown').slice(0, 32)
+                    : '',
                 track: {
                     name: String(currentTrack.name || '').slice(0, 120),
                     artist: String(currentTrack.artist || '').slice(0, 120)
@@ -2601,7 +2604,7 @@
                         showErrorToast('music.playError', errorDetail);
                         updatePlayBtnState(false);
                         setMusicBarVisualState(musicBar, 'error');
-                        reportMusicPlaybackState('error', null, reportContext);
+                        reportMusicPlaybackState('error', null, reportContext, 'media_error');
 
                         if (autoDestroyTimer) clearTimeout(autoDestroyTimer);
                         autoDestroyTimer = setTimeout(() => {
@@ -2922,7 +2925,12 @@
                     showErrorToast('music.loadTimeout', 'Music loading timed out');
                 }
                 setMusicBarVisualState(musicBar, 'error');
-                reportMusicPlaybackState('error', null, playbackReportContext);
+                reportMusicPlaybackState(
+                    'error',
+                    null,
+                    playbackReportContext,
+                    mediaResult.reason
+                );
                 updateMusicCard('error', currentPlayingTrack);
                 emitBarState();
                 return musicPlayResult(
@@ -2940,7 +2948,12 @@
         } catch (err) {
             if (currentToken !== latestMusicRequestToken) return musicPlayResult(false, 'superseded');
             console.error('[Music UI] 播放器处理异常:', err);
-            reportMusicPlaybackState('error', null, playbackReportContext);
+            reportMusicPlaybackState(
+                'error',
+                null,
+                playbackReportContext,
+                'player_error'
+            );
             updateMusicCard('error', currentPlayingTrack);
             destroyMusicPlayer(true, false, true);
             showErrorToast('music.playError', 'Music playback failed to load');

--- a/tests/unit/test_music_crawlers.py
+++ b/tests/unit/test_music_crawlers.py
@@ -13,7 +13,8 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"
 from utils.music_crawlers import (
     NeteaseCrawler, iTunesCrawler, SoundCloudCrawler, 
     MusopenCrawler, FMACrawler, BandcampCrawler, MusicCache, fetch_music_content,
-    music_cache, close_all_crawlers, _select_requested_song
+    music_cache, close_all_crawlers, _select_requested_song,
+    _sample_distinct_background_sources,
 )
 
 # ==========================================
@@ -1602,6 +1603,93 @@ async def test_fetch_music_content_orchestration():
             response = await fetch_music_content("keyword", limit=1)
             assert response['success'] is True
             assert any(r['name'] == "Mock Netease" for r in response['data'])
+
+
+@pytest.mark.unit
+def test_background_music_samples_distinct_providers():
+    style_options = [
+        ('netease', '华语'),
+        ('netease', '流行'),
+        ('musopen', None),
+        ('fma', 'lofi'),
+    ]
+
+    with (
+        patch(
+            'utils.music_crawlers.random.sample',
+            side_effect=lambda population, count: population[:count],
+        ),
+        patch(
+            'utils.music_crawlers.random.choice',
+            side_effect=lambda choices: choices[0],
+        ),
+    ):
+        selected = _sample_distinct_background_sources(style_options)
+
+    assert selected == [
+        ('netease', '华语'),
+        ('musopen', None),
+        ('fma', 'lofi'),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_background_music_interleaves_distinct_provider_fallbacks():
+    """The first playback candidates must not all fail with one provider."""
+    mock_musopen = MagicMock()
+    mock_musopen.search = AsyncMock(return_value=[
+        {'name': 'Musopen 1', 'url': 'https://dl.musopen.org/m1.mp3', 'artist': 'M'},
+        {'name': 'Musopen 2', 'url': 'https://dl.musopen.org/m2.mp3', 'artist': 'M'},
+        {'name': 'Musopen 3', 'url': 'https://dl.musopen.org/m3.mp3', 'artist': 'M'},
+    ])
+    mock_netease = MagicMock()
+    mock_netease._cookie_invalid = False
+    mock_netease.search = AsyncMock(return_value=[
+        {'name': 'Netease 1', 'url': '/api/music/play/netease/n1', 'artist': 'N1'},
+        {'name': 'Netease 2', 'url': '/api/music/play/netease/n2', 'artist': 'N2'},
+        {'name': 'Netease 3', 'url': '/api/music/play/netease/n3', 'artist': 'N3'},
+    ])
+    mock_fma = MagicMock()
+    mock_fma.search = AsyncMock(return_value=[
+        {'name': 'FMA 1', 'url': 'https://freemusicarchive.org/f1.mp3', 'artist': 'F1'},
+        {'name': 'FMA 2', 'url': 'https://freemusicarchive.org/f2.mp3', 'artist': 'F2'},
+        {'name': 'FMA 3', 'url': 'https://freemusicarchive.org/f3.mp3', 'artist': 'F3'},
+    ])
+
+    with (
+        patch(
+            'utils.music_crawlers.get_music_crawlers',
+            return_value={
+                'musopen': mock_musopen,
+                'netease': mock_netease,
+                'fma': mock_fma,
+            },
+        ),
+        patch('utils.music_crawlers.is_china_region', return_value=True),
+        patch(
+            'utils.music_crawlers._sample_distinct_background_sources',
+            return_value=[
+                ('musopen', None),
+                ('netease', '流行'),
+                ('fma', 'chill'),
+            ],
+        ),
+    ):
+        response = await fetch_music_content(
+            '',
+            limit=5,
+            bypass_recommendation_dedupe=True,
+        )
+
+    assert response['success'] is True
+    assert [item['name'] for item in response['data']] == [
+        'Musopen 1',
+        'Netease 1',
+        'FMA 1',
+        'Musopen 2',
+        'Netease 2',
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_music_playback_static.py
+++ b/tests/unit/test_music_playback_static.py
@@ -248,13 +248,18 @@ def test_music_player_reports_confirmed_state_to_backend():
     player_source = MUSIC_UI_PATH.read_text(encoding="utf-8")
     router_source = WEBSOCKET_ROUTER_PATH.read_text(encoding="utf-8")
 
-    assert "function reportMusicPlaybackState(state, track, playbackContext)" in player_source
+    assert (
+        "function reportMusicPlaybackState(state, track, playbackContext, failureReason)"
+        in player_source
+    )
     assert "function createMusicPlaybackReportContext(playbackId, options, track, token)" in player_source
     assert "function getOwnedMusicPlaybackReportContext(player, state)" in player_source
     assert "function normalizeMusicEventTimestamp(event)" in player_source
     assert "action: 'music_playback_state'" in player_source
     assert "playback_window_id: MUSIC_COORD_SENDER_ID" in player_source
     assert "playback_started_at: context.lifecycleStartedAt" in player_source
+    assert "reason: state === 'error'" in player_source
+    assert "String(failureReason || 'unknown').slice(0, 32)" in player_source
     assert "localPlayer._musicPlaybackReportContext = playbackReportContext" in player_source
     ownership_source = player_source.split(
         "function getOwnedMusicPlaybackReportContext(player, state)", 1
@@ -269,7 +274,12 @@ def test_music_player_reports_confirmed_state_to_backend():
     assert ") !== reportContext" in player_source
     assert "reportMusicPlaybackState('playing', null, reportContext)" in player_source
     assert "reportMusicPlaybackState('ended', null, reportContext)" in player_source
-    assert "reportMusicPlaybackState('error', null, reportContext)" in player_source
+    assert (
+        "reportMusicPlaybackState('error', null, reportContext, 'media_error')"
+        in player_source
+    )
+    assert "mediaResult.reason" in player_source
+    assert "'player_error'" in player_source
     assert "localPlayer === boundPlayer && boundPlayer._latestToken === tokenAtEvent" in player_source
     assert 'elif action == "music_playback_state":' in router_source
     assert "handle_music_playback_state(" in router_source

--- a/tests/unit/test_proactive_action_note.py
+++ b/tests/unit/test_proactive_action_note.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import sys
 from queue import Queue
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -21,6 +22,11 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"
 
 from config.prompts.prompts_proactive import build_proactive_action_note
 from main_logic.core import LLMSessionManager
+from main_logic.proactive_chat import delivery as proactive_delivery
+from main_logic.proactive_chat.delivery import (
+    CommittedDelivery,
+    _record_committed_delivery,
+)
 from main_logic.session_state import SessionStateMachine
 from main_routers.system_router.proactive_parsing import _extract_links_from_raw
 
@@ -77,6 +83,76 @@ def test_action_note_chat_channel_with_music_fallback_uses_music_note():
     assert '稻香' in note
     assert '周杰伦' in note
     assert MASTER in note
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('primary_channel', 'expected_source_mode'),
+    [('chat', 'music'), ('music', 'music'), ('both', 'both')],
+)
+async def test_music_delivery_reports_effective_source_mode(
+    monkeypatch,
+    primary_channel,
+    expected_source_mode,
+):
+    """Promote a CHAT fallback while preserving native player modes."""
+    music_link = {
+        'title': '稻香',
+        'artist': '周杰伦',
+        'url': 'https://example.com/track.mp3',
+        'source': '音乐推荐',
+        'type': 'music',
+    }
+    delivery = CommittedDelivery(
+        primary_channel=primary_channel,
+        source_links=[music_link],
+        delivered_tag='MUSIC',
+        delivered_music_link=music_link,
+        is_music_used=True,
+        action_note='[已分享音乐]',
+        vision_screenshot_b64=None,
+    )
+
+    monkeypatch.setattr(proactive_delivery, '_record_proactive_chat', MagicMock())
+    monkeypatch.setattr(proactive_delivery, '_record_proactive_material', MagicMock())
+    monkeypatch.setattr(
+        proactive_delivery,
+        '_mini_game_invite_count_post_response_chat',
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        proactive_delivery,
+        '_increment_proactive_chat_total',
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        proactive_delivery,
+        '_get_internal_http_client',
+        MagicMock(return_value=MagicMock()),
+    )
+
+    result = await _record_committed_delivery(
+        mgr=SimpleNamespace(current_speech_id='turn-1'),
+        delivery=delivery,
+        lanlan_name='Neko',
+        response_text='这首歌分享给你。',
+        source_tag='CHAT',
+        active_channels=['music'],
+        has_unfinished_thread=False,
+        surfaced_reflection_ids=[],
+        selected_web_link=None,
+        selected_web_topic_key=None,
+        web_parsed=None,
+        selected_music_link=music_link,
+        selected_music_topic_key=None,
+        selected_meme_link=None,
+        selected_meme_topic_key=None,
+        meme_content=None,
+    )
+
+    assert result.body['source_mode'] == expected_source_mode
+    assert result.body['source_tag'] == 'CHAT'
+    assert result.body['source_links'] == [music_link]
 
 
 def test_action_note_unknown_channel_falls_back_to_source_links():

--- a/tests/unit/test_proactive_service_boundary.py
+++ b/tests/unit/test_proactive_service_boundary.py
@@ -883,6 +883,47 @@ def test_non_user_music_state_is_passive_and_coalesced() -> None:
     manager.submit_proactive_callback.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("reported_reason", "expected_reason"),
+    (("load_timeout", "load_timeout"), ("secret conversation", "unknown")),
+)
+def test_music_playback_error_logs_only_sanitized_reason(
+    monkeypatch,
+    reported_reason: str,
+    expected_reason: str,
+) -> None:
+    warning = MagicMock()
+    monkeypatch.setattr(music_playback.logger, "warning", warning)
+    manager = SimpleNamespace(
+        lanlan_name="YUI",
+        submit_proactive_callback=MagicMock(),
+        enqueue_agent_callback=MagicMock(),
+    )
+
+    assert music_playback.handle_music_playback_state(
+        manager,
+        {
+            "state": "error",
+            "reason": reported_reason,
+            "playback_id": "player:error",
+            "playback_window_id": "window:error",
+            "playback_started_at": 250,
+            "source": "proactive",
+            "track": {"name": "Track", "artist": "Artist"},
+        },
+    ) is True
+
+    callback = manager.enqueue_agent_callback.call_args.args[0]
+    assert callback["metadata"]["failure_reason"] == expected_reason
+    warning.assert_called_once_with(
+        "[%s] 音乐播放器报告失败: reason=%s",
+        "YUI",
+        expected_reason,
+    )
+    if expected_reason == "unknown":
+        assert reported_reason not in repr(warning.call_args)
+
+
 def test_music_playback_keeps_current_owner_during_replacement_search() -> None:
     manager = SimpleNamespace(
         lanlan_name="YUI",
@@ -989,6 +1030,66 @@ def test_music_dedupe_is_recorded_only_after_delivery_commit() -> None:
     assert "mark_music_as_played(track)" not in inspect.getsource(
         music_recommendation._select_music_recommendation
     )
+
+
+def test_music_selection_trims_skipped_tracks_before_delivery_fallback() -> None:
+    tracks = [
+        {
+            "name": "easy hiphop",
+            "artist": "VibeDepot",
+            "url": "https://freemusicarchive.org/track/easy-hiphop/stream/",
+        },
+        {
+            "name": "Nocturne in B flat minor",
+            "artist": "Pianist A",
+            "url": "https://dl.musopen.org/nocturne-flat.mp3",
+        },
+        {
+            "name": "Left Track",
+            "artist": "Singer",
+            "url": "/api/music/play/netease/123",
+        },
+        {
+            "name": "calm hiphop",
+            "artist": "VibeDepot",
+            "url": "https://freemusicarchive.org/track/calm-hiphop/stream/",
+        },
+        {
+            "name": "Nocturne in B minor",
+            "artist": "Pianist B",
+            "url": "https://dl.musopen.org/nocturne-minor.mp3",
+        },
+    ]
+    skipped_urls = {track["url"] for track in tracks[:3]}
+    music_content = {
+        "formatted_content": "music candidates",
+        "raw_data": {"success": True, "data": tracks},
+    }
+
+    selection = music_recommendation._select_music_recommendation(
+        music_content,
+        lang="en",
+        source_hash=lambda url, _title: url,
+        should_skip_source=lambda key: key in skipped_urls,
+        lanlan_name="YUI",
+    )
+
+    assert selection.link["title"] == "calm hiphop"
+    assert [
+        track["name"] for track in selection.content["raw_data"]["data"]
+    ] == ["calm hiphop", "Nocturne in B minor"]
+
+    source_links = [selection.link]
+    appended = music_recommendation._append_music_recommendations(
+        source_links,
+        selection.content,
+    )
+
+    assert appended == 1
+    assert [link["title"] for link in source_links] == [
+        "calm hiphop",
+        "Nocturne in B minor",
+    ]
 
 
 def test_proactive_command_parses_music_occupied() -> None:

--- a/utils/music_crawlers.py
+++ b/utils/music_crawlers.py
@@ -2212,6 +2212,40 @@ async def close_all_crawlers():
 # 4. 主调度函数
 # =======================================================
 
+def _sample_distinct_background_sources(
+    style_options: List[tuple[str, str | None]],
+    limit: int = 3,
+) -> List[tuple[str, str | None]]:
+    """Pick at most one randomized style from each selected provider."""
+    styles_by_source: Dict[str, List[str | None]] = {}
+    for source, keyword in style_options:
+        styles_by_source.setdefault(source, []).append(keyword)
+
+    selected_sources = random.sample(
+        list(styles_by_source),
+        min(limit, len(styles_by_source)),
+    )
+    return [
+        (source, random.choice(styles_by_source[source]))
+        for source in selected_sources
+    ]
+
+
+def _interleave_music_result_groups(
+    result_groups: List[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Round-robin provider results so early playback fallbacks stay independent."""
+    if not result_groups:
+        return []
+
+    interleaved: List[Dict[str, Any]] = []
+    for index in range(max(len(group) for group in result_groups)):
+        for group in result_groups:
+            if index < len(group):
+                interleaved.append(group[index])
+    return interleaved
+
+
 async def fetch_music_content(
     keyword: str,
     limit: int = 1,
@@ -2412,14 +2446,14 @@ async def fetch_music_content(
                 ('netease', '说唱'), ('musopen', None), ('fma', 'lofi'), 
                 ('fma', 'chill'), ('fma', 'electronic'), ('fma', 'hiphop')
             ]
-            selected_styles = random.sample(china_styles, min(3, len(china_styles)))
+            selected_styles = _sample_distinct_background_sources(china_styles)
         else:
             global_styles = [
                 ('itunes', 'lofi'), ('itunes', 'chill'), ('fma', 'ambient'), 
                 ('fma', 'electronic'), ('musopen', None), ('bandcamp', 'indie'), 
                 ('bandcamp', 'vgm'), ('bandcamp', 'lofi')
             ]
-            selected_styles = random.sample(global_styles, min(3, len(global_styles)))
+            selected_styles = _sample_distinct_background_sources(global_styles)
         
         for source, kw in selected_styles:
             if source == 'musopen':
@@ -2431,9 +2465,12 @@ async def fetch_music_content(
                 tasks.append(all_crawlers[source].search(kw, limit))
                 
         crawler_results = await asyncio.gather(*tasks, return_exceptions=True)
-        for res in crawler_results:
-            if isinstance(res, list) and res:
-                all_results.extend(res)
+        result_groups = [
+            res
+            for res in crawler_results
+            if isinstance(res, list) and res
+        ]
+        all_results.extend(_interleave_music_result_groups(result_groups))
 
     # 最终防线：即使未来某个 crawler 忘记在源头过滤，只要它带回标准化时长，
     # 超长内容也不会进入主动推荐和播放器。


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

<!-- 这个 PR 做了什么。若有对应 Issue 可关联（如 Closes #123），非必须。 -->
优化音乐搜索候选的多来源交错顺序，使现有重试流程能够跨网易云、FMA、Musopen 兜底。
修正普通聊天回退到音乐搭话时的来源标记，确保音乐通道历史与权重正确记录。
增加播放器失败原因上报与后端日志，覆盖加载超时、媒体错误等场景。
修复窄聊天框及紧凑历史记录中音乐卡片溢出消息气泡的问题。
## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
改动内容及必要性
main_logic/proactive_chat/delivery.py
按实际投递结果确定来源类型。
避免模型选择普通聊天、实际回退到音乐后仍被错误记为 chat。

main_logic/music_playback.py
接收并清洗播放器上报的失败原因。
播放失败时记录明确原因，无法识别的值统一降级为 unknown。

改动前后对比
改动前：
音乐候选可能集中来自同一来源，连续失败时跨源兜底效果较弱。
聊天回退产生的音乐可能被记入普通聊天通道。
播放失败只显示通用错误，日志无法判断具体原因。
音乐封面固有宽度会在窄聊天框中撑出气泡。

改动后：
候选按来源交错，后续选择和加载重试能更快切换来源。
实际投递音乐时统一按音乐通道记录。
日志可区分 load_timeout、media_error、missing_audio、player_error 等失败原因。
音乐卡片会随气泡宽度收缩，适配普通聊天、紧凑历史和导出预览。

潜在回归点与验证
音乐候选排序、去重及来源轮转。
主动搭话来源历史和通道权重。
播放状态 WebSocket 协议及旧前端兼容性。
普通链接卡片与音乐卡片的响应式布局。
以上链路均通过对应单元测试、完整前端测试、类型检查和生产构建验证；重启后日志中连续三次音乐投递均未出现新的播放失败或代理请求错误。

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->
后端测试：1098 passed, 1 skipped
前端完整测试：447 passed
TypeScript 类型检查通过
前端生产构建通过
Ruff 检查通过
music_ui.js Node.js 语法检查通过
git diff --check 通过
检查重启后的运行日志：音乐多来源候选交错生效，未发现新的播放失败、403 或 5xx。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **体验优化**
  - 优化窄屏聊天布局，链接卡片、音乐卡片及消息内容可自适应收缩，减少横向溢出。
  - 改进背景音乐推荐，增加不同来源的多样性与交错展示。
  - 主动聊天中的音乐内容将准确标识实际来源模式。

- **问题修复**
  - 改进音乐播放错误反馈，提供规范化的失败原因，便于识别播放问题。
  - 优化音乐推荐候选筛选，避免重复推荐已跳过的曲目。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->