### PR TITLE
feat(tutorial): require hold to skip with progress indicator

### DIFF
--- a/static/tutorial-skip-controller.test.cjs
+++ b/static/tutorial-skip-controller.test.cjs
@@ -159,13 +159,14 @@ test('tutorial skip does not absorb unrelated global release events', () => {
   assert.equal(heldRelease.immediateStopped, 1);
 });
 
-test('tutorial skip button renders a dedicated circular progress indicator', () => {
+test('tutorial skip source includes hold progress and preserves non-pointer activation', () => {
   assert.match(controllerSource, /DEFAULT_SKIP_HOLD_DURATION_MS = 1000/);
   assert.match(controllerSource, /class TutorialHoldProgressController/);
   assert.match(controllerSource, /neko-tutorial-skip-progress/);
   assert.match(controllerSource, /conic-gradient\(currentColor/);
   assert.match(controllerSource, /pointerleave', cancelHold/);
   assert.match(controllerSource, /touchcancel', cancelHold/);
-  assert.match(controllerSource, /addListener\(button, 'click', absorbClick\)/);
+  assert.match(controllerSource, /addListener\(button, 'click', handleClick\)/);
+  assert.match(controllerSource, /Number\(event\.detail\) !== 0/);
   assert.doesNotMatch(controllerSource, /addListener\(button, 'click', completeSkipRequest\)/);
 });

--- a/static/tutorial-skip-controller.test.cjs
+++ b/static/tutorial-skip-controller.test.cjs
@@ -1,0 +1,171 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const controllerSource = fs.readFileSync(
+  path.join(__dirname, 'tutorial/core/skip-controller.js'),
+  'utf8',
+);
+
+function createFakeClock() {
+  let now = 0;
+  let nextId = 1;
+  const scheduled = new Map();
+
+  function schedule(callback, delay, interval) {
+    const id = nextId++;
+    const normalizedDelay = Math.max(0, Number(delay) || 0);
+    scheduled.set(id, {
+      callback,
+      dueAt: now + normalizedDelay,
+      interval: interval ? normalizedDelay : 0,
+    });
+    return id;
+  }
+
+  function clear(id) {
+    scheduled.delete(id);
+  }
+
+  return {
+    window: {
+      setTimeout(callback, delay) {
+        return schedule(callback, delay, false);
+      },
+      clearTimeout: clear,
+      setInterval(callback, delay) {
+        return schedule(callback, delay, true);
+      },
+      clearInterval: clear,
+    },
+    now: () => now,
+    tick(durationMs) {
+      const target = now + durationMs;
+      while (true) {
+        const next = Array.from(scheduled.entries())
+          .filter(([, task]) => task.dueAt <= target)
+          .sort((left, right) => left[1].dueAt - right[1].dueAt || left[0] - right[0])[0];
+        if (!next) break;
+        const [id, task] = next;
+        now = task.dueAt;
+        if (task.interval > 0) {
+          task.dueAt += task.interval;
+        } else {
+          scheduled.delete(id);
+        }
+        task.callback();
+      }
+      now = target;
+    },
+  };
+}
+
+function loadControllerApi() {
+  const window = {};
+  vm.runInNewContext(controllerSource, { window, console, Date, Promise });
+  return window.TutorialSkipController;
+}
+
+function createPointerEvent(button = 0) {
+  return {
+    button,
+    prevented: 0,
+    stopped: 0,
+    immediateStopped: 0,
+    preventDefault() { this.prevented += 1; },
+    stopPropagation() { this.stopped += 1; },
+    stopImmediatePropagation() { this.immediateStopped += 1; },
+  };
+}
+
+test('tutorial skip requires one uninterrupted second and resets after early release', () => {
+  const api = loadControllerApi();
+  const clock = createFakeClock();
+  const progress = [];
+  let completed = 0;
+  const hold = api.createHoldController({
+    window: clock.window,
+    getNow: clock.now,
+    durationMs: 1000,
+    onProgress(value, active) {
+      progress.push({ value, active });
+    },
+    onComplete() {
+      completed += 1;
+    },
+  });
+
+  const firstPress = createPointerEvent();
+  assert.equal(hold.start(firstPress), true);
+  clock.tick(650);
+  assert.equal(completed, 0);
+  assert.ok(progress.at(-1).value >= 0.64 && progress.at(-1).value <= 0.66);
+  assert.equal(hold.cancel(createPointerEvent()), true);
+  assert.deepEqual(progress.at(-1), { value: 0, active: false });
+  clock.tick(1000);
+  assert.equal(completed, 0);
+
+  assert.equal(hold.start(createPointerEvent()), true);
+  clock.tick(999);
+  assert.equal(completed, 0);
+  clock.tick(1);
+  assert.equal(completed, 1);
+  assert.deepEqual(progress.at(-1), { value: 1, active: false });
+  assert.equal(hold.start(createPointerEvent()), false);
+});
+
+test('tutorial skip ignores non-primary mouse holds', () => {
+  const api = loadControllerApi();
+  const clock = createFakeClock();
+  let completed = 0;
+  const hold = api.createHoldController({
+    window: clock.window,
+    getNow: clock.now,
+    onComplete() {
+      completed += 1;
+    },
+  });
+  const secondaryPress = createPointerEvent(2);
+
+  assert.equal(hold.start(secondaryPress), false);
+  clock.tick(1500);
+  assert.equal(completed, 0);
+  assert.equal(secondaryPress.prevented, 1);
+});
+
+test('tutorial skip does not absorb unrelated global release events', () => {
+  const api = loadControllerApi();
+  const clock = createFakeClock();
+  const hold = api.createHoldController({
+    window: clock.window,
+    getNow: clock.now,
+  });
+  const unrelatedRelease = createPointerEvent();
+
+  assert.equal(hold.cancel(unrelatedRelease), false);
+  assert.equal(unrelatedRelease.prevented, 0);
+  assert.equal(unrelatedRelease.stopped, 0);
+  assert.equal(unrelatedRelease.immediateStopped, 0);
+
+  assert.equal(hold.start(createPointerEvent()), true);
+  const heldRelease = createPointerEvent();
+  assert.equal(hold.cancel(heldRelease), true);
+  assert.equal(heldRelease.prevented, 1);
+  assert.equal(heldRelease.stopped, 1);
+  assert.equal(heldRelease.immediateStopped, 1);
+});
+
+test('tutorial skip button renders a dedicated circular progress indicator', () => {
+  assert.match(controllerSource, /DEFAULT_SKIP_HOLD_DURATION_MS = 1000/);
+  assert.match(controllerSource, /class TutorialHoldProgressController/);
+  assert.match(controllerSource, /neko-tutorial-skip-progress/);
+  assert.match(controllerSource, /conic-gradient\(currentColor/);
+  assert.match(controllerSource, /pointerleave', cancelHold/);
+  assert.match(controllerSource, /touchcancel', cancelHold/);
+  assert.match(controllerSource, /addListener\(button, 'click', absorbClick\)/);
+  assert.doesNotMatch(controllerSource, /addListener\(button, 'click', completeSkipRequest\)/);
+});

--- a/static/tutorial-skip-controller.test.cjs
+++ b/static/tutorial-skip-controller.test.cjs
@@ -164,6 +164,8 @@ test('tutorial skip source includes hold progress and preserves non-pointer acti
   assert.match(controllerSource, /class TutorialHoldProgressController/);
   assert.match(controllerSource, /neko-tutorial-skip-progress/);
   assert.match(controllerSource, /conic-gradient\(currentColor/);
+  assert.match(controllerSource, /\.neko-tutorial-skip-progress \{[\s\S]*?opacity: 0;/);
+  assert.match(controllerSource, /\.is-holding \.neko-tutorial-skip-progress \{[\s\S]*?opacity: 1;/);
   assert.match(controllerSource, /pointerleave', cancelHold/);
   assert.match(controllerSource, /touchcancel', cancelHold/);
   assert.match(controllerSource, /addListener\(button, 'click', handleClick\)/);

--- a/static/tutorial/core/skip-controller.js
+++ b/static/tutorial/core/skip-controller.js
@@ -262,7 +262,6 @@ ${selector} {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
   background: rgba(255, 252, 248, 0.78) !important;
   color: rgba(48, 59, 74, 0.82);
   border: 1px solid rgba(47, 131, 255, 0.28);
@@ -287,19 +286,26 @@ ${selector} {
 ${selector} .neko-tutorial-skip-progress {
   --neko-tutorial-skip-progress-angle: 0deg;
   --neko-tutorial-skip-progress-track: rgba(48, 59, 74, 0.2);
-  width: 18px;
+  width: 0;
   height: 18px;
-  flex: 0 0 18px;
+  flex: 0 0 0;
+  margin-left: 0;
   border-radius: 50%;
   background: conic-gradient(currentColor var(--neko-tutorial-skip-progress-angle), var(--neko-tutorial-skip-progress-track) 0);
   -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
   mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
-  opacity: 0.72;
+  opacity: 0;
+  transform: scale(0.75);
+  transition: width 0.15s ease, flex-basis 0.15s ease, margin-left 0.15s ease, opacity 0.12s ease, transform 0.15s ease;
   pointer-events: none;
 }
 
 ${selector}.is-holding .neko-tutorial-skip-progress {
+  width: 18px;
+  flex-basis: 18px;
+  margin-left: 10px;
   opacity: 1;
+  transform: scale(1);
 }
 
 ${selector}:hover {

--- a/static/tutorial/core/skip-controller.js
+++ b/static/tutorial/core/skip-controller.js
@@ -700,6 +700,10 @@ html.dark ${selector}:hover {
                 }
                 return onSkip(event);
             };
+            const handleSkipError = (error) => {
+                console.warn('[TutorialSkipController] skip handler failed:', error);
+                resetSkipHandled();
+            };
 
             holdController = new TutorialHoldProgressController({
                 window: window,
@@ -713,10 +717,7 @@ html.dark ${selector}:hover {
                     button.classList.toggle('is-holding', active === true);
                 },
                 onComplete: completeSkipRequest,
-                onError: (error) => {
-                    console.warn('[TutorialSkipController] skip handler failed:', error);
-                    resetSkipHandled();
-                }
+                onError: handleSkipError
             });
 
             const common = window.YuiGuideCommon;
@@ -736,6 +737,17 @@ html.dark ${selector}:hover {
             const startHold = (event) => holdController.start(event);
             const cancelHold = (event) => holdController.cancel(event);
             const absorbClick = (event) => holdController.absorbEvent(event);
+            const handleClick = (event) => {
+                holdController.absorbEvent(event);
+                if (!event || Number(event.detail) !== 0) {
+                    return;
+                }
+                try {
+                    Promise.resolve(completeSkipRequest(event)).catch(handleSkipError);
+                } catch (error) {
+                    handleSkipError(error);
+                }
+            };
             const cancelHoldOnVisibilityLoss = () => {
                 if (this.document.hidden) {
                     holdController.cancel();
@@ -755,7 +767,7 @@ html.dark ${selector}:hover {
                 addListener(window, 'touchend', cancelHold, { capture: true, passive: false });
                 addListener(window, 'touchcancel', cancelHold, { capture: true, passive: false });
             }
-            addListener(button, 'click', absorbClick);
+            addListener(button, 'click', handleClick);
             addListener(button, 'contextmenu', absorbClick);
             addListener(button, 'dragstart', absorbClick);
             addListener(window, 'blur', cancelHold);

--- a/static/tutorial/core/skip-controller.js
+++ b/static/tutorial/core/skip-controller.js
@@ -1,6 +1,140 @@
 (function () {
     'use strict';
 
+    const DEFAULT_SKIP_HOLD_DURATION_MS = 1000;
+    const SKIP_HOLD_PROGRESS_INTERVAL_MS = 16;
+
+    class TutorialHoldProgressController {
+        constructor(options) {
+            const normalizedOptions = options || {};
+            this.window = normalizedOptions.window || window;
+            this.durationMs = Number.isFinite(normalizedOptions.durationMs)
+                ? Math.max(1, Math.round(normalizedOptions.durationMs))
+                : DEFAULT_SKIP_HOLD_DURATION_MS;
+            this.onProgress = typeof normalizedOptions.onProgress === 'function'
+                ? normalizedOptions.onProgress
+                : function () {};
+            this.onComplete = typeof normalizedOptions.onComplete === 'function'
+                ? normalizedOptions.onComplete
+                : function () {};
+            this.onError = typeof normalizedOptions.onError === 'function'
+                ? normalizedOptions.onError
+                : function () {};
+            this.getNow = typeof normalizedOptions.getNow === 'function'
+                ? normalizedOptions.getNow
+                : function () { return Date.now(); };
+            this.active = false;
+            this.completed = false;
+            this.startedAt = 0;
+            this.completionTimerId = null;
+            this.progressTimerId = null;
+        }
+
+        absorbEvent(event) {
+            if (event && typeof event.preventDefault === 'function') {
+                event.preventDefault();
+            }
+            if (event && typeof event.stopImmediatePropagation === 'function') {
+                event.stopImmediatePropagation();
+            }
+            if (event && typeof event.stopPropagation === 'function') {
+                event.stopPropagation();
+            }
+        }
+
+        clearTimers() {
+            if (this.completionTimerId !== null) {
+                this.window.clearTimeout(this.completionTimerId);
+                this.completionTimerId = null;
+            }
+            if (this.progressTimerId !== null) {
+                this.window.clearInterval(this.progressTimerId);
+                this.progressTimerId = null;
+            }
+        }
+
+        emitProgress(value) {
+            const progress = Math.max(0, Math.min(1, Number(value) || 0));
+            this.onProgress(progress, this.active);
+        }
+
+        updateProgress() {
+            if (!this.active) {
+                return;
+            }
+            const elapsedMs = Math.max(0, this.getNow() - this.startedAt);
+            this.emitProgress(elapsedMs / this.durationMs);
+        }
+
+        start(event) {
+            this.absorbEvent(event);
+            if (this.active || this.completed) {
+                return false;
+            }
+            if (event && Number.isFinite(Number(event.button)) && Number(event.button) !== 0) {
+                return false;
+            }
+
+            this.active = true;
+            this.startedAt = this.getNow();
+            this.emitProgress(0);
+            this.progressTimerId = this.window.setInterval(
+                () => this.updateProgress(),
+                SKIP_HOLD_PROGRESS_INTERVAL_MS
+            );
+            this.completionTimerId = this.window.setTimeout(
+                () => this.complete(event),
+                this.durationMs
+            );
+            return true;
+        }
+
+        cancel(event) {
+            if (!this.active) {
+                return false;
+            }
+            this.absorbEvent(event);
+            this.active = false;
+            this.clearTimers();
+            this.emitProgress(0);
+            return true;
+        }
+
+        complete(event) {
+            if (!this.active || this.completed) {
+                return false;
+            }
+            this.active = false;
+            this.completed = true;
+            this.clearTimers();
+            this.emitProgress(1);
+
+            try {
+                Promise.resolve(this.onComplete(event)).catch((error) => {
+                    this.completed = false;
+                    this.emitProgress(0);
+                    this.onError(error);
+                });
+            } catch (error) {
+                this.completed = false;
+                this.emitProgress(0);
+                this.onError(error);
+            }
+            return true;
+        }
+
+        reset() {
+            this.active = false;
+            this.completed = false;
+            this.clearTimers();
+            this.emitProgress(0);
+        }
+
+        destroy() {
+            this.reset();
+        }
+    }
+
     class TutorialSkipController {
         constructor(options) {
             const normalizedOptions = options || {};
@@ -12,6 +146,9 @@
             this.safeAreaCleanup = null;
             this.styleId = `${this.buttonId}-style`;
             this.portalId = normalizedOptions.portalId || 'neko-tutorial-fixed-ui-root';
+            this.holdDurationMs = Number.isFinite(normalizedOptions.holdDurationMs)
+                ? Math.max(1, Math.round(normalizedOptions.holdDurationMs))
+                : DEFAULT_SKIP_HOLD_DURATION_MS;
         }
 
         getElement() {
@@ -125,6 +262,7 @@ ${selector} {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 10px;
   background: rgba(255, 252, 248, 0.78) !important;
   color: rgba(48, 59, 74, 0.82);
   border: 1px solid rgba(47, 131, 255, 0.28);
@@ -144,6 +282,24 @@ ${selector} {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+}
+
+${selector} .neko-tutorial-skip-progress {
+  --neko-tutorial-skip-progress-angle: 0deg;
+  --neko-tutorial-skip-progress-track: rgba(48, 59, 74, 0.2);
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  border-radius: 50%;
+  background: conic-gradient(currentColor var(--neko-tutorial-skip-progress-angle), var(--neko-tutorial-skip-progress-track) 0);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
+  mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 0);
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+${selector}.is-holding .neko-tutorial-skip-progress {
+  opacity: 1;
 }
 
 ${selector}:hover {
@@ -170,6 +326,11 @@ html.dark ${selector} {
   color: rgba(236, 243, 252, 0.86);
   border-color: rgba(104, 183, 255, 0.34);
   box-shadow: 0 14px 34px rgba(0, 0, 0, 0.26), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+}
+
+html[data-theme='dark'] ${selector} .neko-tutorial-skip-progress,
+html.dark ${selector} .neko-tutorial-skip-progress {
+  --neko-tutorial-skip-progress-track: rgba(236, 243, 252, 0.22);
 }
 
 html[data-theme='dark'] ${selector}:hover,
@@ -498,19 +659,35 @@ html.dark ${selector}:hover {
 
             const button = this.document.createElement('button');
             button.id = this.buttonId;
-            button.textContent = label;
+            button.type = 'button';
+            button.setAttribute('aria-label', label);
+            button.setAttribute('data-hold-duration-ms', String(this.holdDurationMs));
             button.style.pointerEvents = 'auto';
             button.style.position = 'fixed';
             button.style.zIndex = '2147483647';
             button.style.touchAction = 'manipulation';
 
+            const labelElement = this.document.createElement('span');
+            labelElement.className = 'neko-tutorial-skip-label';
+            labelElement.textContent = label;
+            const progressElement = this.document.createElement('span');
+            progressElement.className = 'neko-tutorial-skip-progress';
+            progressElement.setAttribute('aria-hidden', 'true');
+            progressElement.style.setProperty('--neko-tutorial-skip-progress-angle', '0deg');
+            button.appendChild(labelElement);
+            button.appendChild(progressElement);
+
             let skipHandled = false;
+            let holdController = null;
             const resetSkipHandled = () => {
                 skipHandled = false;
                 button.disabled = false;
                 button.removeAttribute('aria-disabled');
+                if (holdController) {
+                    holdController.reset();
+                }
             };
-            const handleSkipRequest = (event) => {
+            const completeSkipRequest = (event) => {
                 if (skipHandled) {
                     return;
                 }
@@ -518,44 +695,71 @@ html.dark ${selector}:hover {
                 button.disabled = true;
                 button.setAttribute('aria-disabled', 'true');
 
-                if (event && typeof event.preventDefault === 'function') {
-                    event.preventDefault();
-                }
-                if (event && typeof event.stopImmediatePropagation === 'function') {
-                    event.stopImmediatePropagation();
-                }
-                if (event && typeof event.stopPropagation === 'function') {
-                    event.stopPropagation();
-                }
-
                 if (!onSkip) {
                     return;
                 }
+                return onSkip(event);
+            };
 
-                try {
-                    Promise.resolve(onSkip(event)).catch((error) => {
-                        console.warn('[TutorialSkipController] skip handler failed:', error);
-                        resetSkipHandled();
-                    });
-                } catch (error) {
-                    console.warn('[TutorialSkipController] skip handler threw:', error);
+            holdController = new TutorialHoldProgressController({
+                window: window,
+                durationMs: this.holdDurationMs,
+                onProgress: (progress, active) => {
+                    progressElement.style.setProperty(
+                        '--neko-tutorial-skip-progress-angle',
+                        `${Math.round(progress * 360)}deg`
+                    );
+                    progressElement.setAttribute('data-progress', progress.toFixed(3));
+                    button.classList.toggle('is-holding', active === true);
+                },
+                onComplete: completeSkipRequest,
+                onError: (error) => {
+                    console.warn('[TutorialSkipController] skip handler failed:', error);
                     resetSkipHandled();
                 }
-            };
+            });
 
             const common = window.YuiGuideCommon;
             const resources = common && typeof common.createScopedTutorialResources === 'function'
                 ? common.createScopedTutorialResources({ window: window })
                 : null;
             this.installSafeAreaRefreshHooks(resources);
-            const addListener = resources
-                ? (type, listenerOptions) => resources.addEventListener(button, type, handleSkipRequest, listenerOptions)
-                : (type, listenerOptions) => button.addEventListener(type, handleSkipRequest, listenerOptions);
+            const localListeners = [];
+            const addListener = (target, type, listener, listenerOptions) => {
+                if (resources) {
+                    resources.addEventListener(target, type, listener, listenerOptions);
+                    return;
+                }
+                target.addEventListener(type, listener, listenerOptions);
+                localListeners.push({ target, type, listener, listenerOptions });
+            };
+            const startHold = (event) => holdController.start(event);
+            const cancelHold = (event) => holdController.cancel(event);
+            const absorbClick = (event) => holdController.absorbEvent(event);
+            const cancelHoldOnVisibilityLoss = () => {
+                if (this.document.hidden) {
+                    holdController.cancel();
+                }
+            };
 
-            addListener('pointerdown');
-            addListener('mousedown');
-            addListener('touchstart', { passive: false });
-            addListener('click');
+            if (typeof window.PointerEvent === 'function') {
+                addListener(button, 'pointerdown', startHold);
+                addListener(button, 'pointerleave', cancelHold);
+                addListener(window, 'pointerup', cancelHold, true);
+                addListener(window, 'pointercancel', cancelHold, true);
+            } else {
+                addListener(button, 'mousedown', startHold);
+                addListener(button, 'mouseleave', cancelHold);
+                addListener(window, 'mouseup', cancelHold, true);
+                addListener(button, 'touchstart', startHold, { passive: false });
+                addListener(window, 'touchend', cancelHold, { capture: true, passive: false });
+                addListener(window, 'touchcancel', cancelHold, { capture: true, passive: false });
+            }
+            addListener(button, 'click', absorbClick);
+            addListener(button, 'contextmenu', absorbClick);
+            addListener(button, 'dragstart', absorbClick);
+            addListener(window, 'blur', cancelHold);
+            addListener(this.document, 'visibilitychange', cancelHoldOnVisibilityLoss);
             const host = this.getButtonHost();
             if (host && typeof host.appendChild === 'function') {
                 host.appendChild(button);
@@ -567,15 +771,15 @@ html.dark ${selector}:hover {
             this.applySafeAreaVariables();
             this.currentResources = resources;
             this.currentCleanup = () => {
+                holdController.destroy();
                 if (this.currentResources && typeof this.currentResources.destroy === 'function') {
                     this.currentResources.destroy();
                     this.currentResources = null;
                     return;
                 }
-                button.removeEventListener('pointerdown', handleSkipRequest);
-                button.removeEventListener('mousedown', handleSkipRequest);
-                button.removeEventListener('touchstart', handleSkipRequest, { passive: false });
-                button.removeEventListener('click', handleSkipRequest);
+                localListeners.forEach(({ target, type, listener, listenerOptions }) => {
+                    target.removeEventListener(type, listener, listenerOptions);
+                });
             };
         }
 
@@ -601,8 +805,12 @@ html.dark ${selector}:hover {
     }
 
     window.TutorialSkipController = {
+        DEFAULT_HOLD_DURATION_MS: DEFAULT_SKIP_HOLD_DURATION_MS,
         createController: function (options) {
             return new TutorialSkipController(options);
+        },
+        createHoldController: function (options) {
+            return new TutorialHoldProgressController(options);
         },
         applySafeAreaVariables: function (options) {
             const normalizedOptions = options || {};

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -3238,7 +3238,11 @@ test('skip controller uses scoped resources with a fallback cleanup path', () =>
 
     assert.match(source, /createScopedTutorialResources/);
     assert.match(source, /this\.currentResources\.destroy\(\)/);
-    assert.match(source, /button\.removeEventListener\('pointerdown', handleSkipRequest\)/);
+    assert.match(source, /holdController\.destroy\(\)/);
+    assert.match(
+        source,
+        /localListeners\.forEach\(\(\{ target, type, listener, listenerOptions \}\) => \{[\s\S]*target\.removeEventListener\(type, listener, listenerOptions\)/
+    );
     assert.match(source, /applySafeAreaVariables: function \(options\)/);
     assert.match(source, /portalId = normalizedOptions\.portalId \|\| 'neko-tutorial-fixed-ui-root'/);
     assert.match(source, /document\.documentElement\.appendChild\(portal\)/);


### PR DESCRIPTION
## Summary
- follow up on #2793 with a separate behavior-only change
- require one uninterrupted second of pointer/touch hold before the seven-day tutorial skip button activates
- show a circular progress indicator while holding and reset it on early release, pointer leave, blur, or visibility loss
- keep the existing Escape shortcut behavior unchanged
- avoid consuming unrelated global release events when no skip hold is active

## Tests
- `node --test static/tutorial-skip-controller.test.cjs` (4 passed)
- targeted skip-controller contracts in `static/yui-guide-common.test.cjs` (3 passed)

## Regression report
- runtime changes are limited to `static/tutorial/core/skip-controller.js`
- no locale, cache-version, tutorial-copy, or generic skip-label changes
- no changes to tutorial completion/teardown routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 跳过教程改为按住按钮触发，按住指定时长后完成跳过。
  - 新增环形进度指示器，实时展示按住进度。
  - 支持鼠标、触摸和指针操作，并在释放、失焦或页面隐藏时自动取消。
  - 忽略非主按键操作，提升交互可靠性。

- **改进**
  - 优化跳过控制器的清理和错误恢复，避免残留事件影响页面操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->