### PR TITLE
QQ 召回收口到 recall_memory 工具，删掉路由门控与每轮无条件同步召回

### DIFF
--- a/main_logic/omni_offline_client/__init__.py
+++ b/main_logic/omni_offline_client/__init__.py
@@ -86,7 +86,6 @@ from ._genai_support import (  # noqa: F401 - preserve the legacy module namespa
     _genai_parts_from_content,
     _genai_types,
     _should_use_genai_sdk,
-    route_supports_tool_calls,
 )
 from ._lifecycle import (  # noqa: F401 - preserve the legacy module namespace
     _slop_reduced_for_genai,

--- a/main_logic/omni_offline_client/_genai_support.py
+++ b/main_logic/omni_offline_client/_genai_support.py
@@ -325,8 +325,7 @@ def _genai_parts_from_content(content: Any) -> list:
 
 def _should_use_genai_sdk(model: str, base_url: str | None) -> bool:
     """Decide whether to route this Gemini-flavoured offline call through
-    the native google-genai SDK (which supports tool calling) instead of
-    the OpenAI-compat endpoint (which silently drops ``tools``).
+    the native google-genai SDK instead of the OpenAI-compat endpoint.
 
     Returns True only when:
       1. ``google-genai`` is importable in the running env, AND
@@ -334,10 +333,11 @@ def _should_use_genai_sdk(model: str, base_url: str | None) -> bool:
          the model name contains "gemini" AND base_url is empty/None
          (i.e. caller wants direct genai with no proxy).
 
-    Explicitly excluded: lanlan.app's international free proxy uses
-    Gemini under the hood but exposes only the OpenAI-compat surface, so
-    its base_url ('lanlan.app') stays on the OpenAI path. Tools won't
-    work there until the proxy is upgraded — see TODO in core.py.
+    This is a transport choice, not a capability one: both paths carry
+    ``tools`` to the model, so callers never have to ask which one they
+    landed on before handing over a tool definition. lanlan's free proxy
+    exposes only the OpenAI-compat surface and therefore stays on the
+    OpenAI path — it forwards tools like any other compat endpoint.
     """
     # 先做便宜的字符串判断：只有路由确实指向 native Gemini 时才去 import SDK。
     # 这样常规 OpenAI-compat 端点（含 greeting）构造 client 时不会触发 genai
@@ -355,59 +355,6 @@ def _should_use_genai_sdk(model: str, base_url: str | None) -> bool:
     if _GENAI_AVAILABLE is None:
         return _ensure_genai()
     return bool(_GENAI_AVAILABLE)
-
-
-# 免费路由的两个特征：base_url 落在 lanlan 免费域（lanlan.tech 国内 /
-# lanlan.app 海外，含 www. 等子域），或模型名是免费路由固定的 free-model。
-# 两个信号各自独立成立（区域改写只动 URL，模型名由配置层固定），任一命中
-# 即视为免费路由。
-_FREE_ROUTE_BASE_URL_HINTS = ("lanlan.app", "lanlan.tech")
-_FREE_ROUTE_MODEL_NAME = "free-model"
-
-
-def _is_free_route_host(base_url: str | None) -> bool:
-    """Whether ``base_url``'s HOST is a lanlan free-proxy domain.
-
-    Host-parsed on purpose (same discipline as the voice registry's
-    free-route check): a custom endpoint whose path or query merely
-    mentions ``lanlan.app`` must not be misread as the free proxy."""
-    from urllib.parse import urlparse
-
-    bl = (base_url or "").strip()
-    if not bl:
-        return False
-    parsed = urlparse(bl if "//" in bl else "//" + bl)
-    host = (parsed.hostname or "").lower()
-    if not host:
-        return False
-    return any(
-        host == hint or host.endswith("." + hint)
-        for hint in _FREE_ROUTE_BASE_URL_HINTS
-    )
-
-
-def route_supports_tool_calls(model: str, base_url: str | None) -> bool:
-    """Whether tool definitions handed to ``OmniOfflineClient`` on this
-    route actually reach the model.
-
-    The native google-genai path supports tools. Standard OpenAI-compat
-    endpoints honour the ``tools`` param. The known exception is the free
-    proxy (lanlan.app international / lanlan.tech domestic, fixed model
-    name ``free-model``): it exposes only the OpenAI-compat surface and
-    silently DROPS ``tools`` (see ``_should_use_genai_sdk``'s exclusion
-    note). Callers that depend on a tool being callable (e.g. the QQ
-    plugin's ``recall_memory``) must check this and fall back to a
-    host-driven path, otherwise those users lose the feature silently.
-    The domestic free proxy's tool support is undocumented, so it is
-    treated as unsupported too — the fallback keeps working either way.
-    """
-    if _should_use_genai_sdk(model, base_url):
-        return True
-    if _is_free_route_host(base_url):
-        return False
-    if (model or "").strip().lower() == _FREE_ROUTE_MODEL_NAME:
-        return False
-    return True
 
 
 class _GenaiMixin:

--- a/main_logic/omni_offline_client/_tools.py
+++ b/main_logic/omni_offline_client/_tools.py
@@ -271,8 +271,7 @@ class _ToolingMixin:
         - Native Gemini (``_use_genai_sdk``): dispatches to
           ``_astream_genai_with_tools`` and on tools-related failures sets
           ``_genai_tools_unsupported`` so subsequent calls degrade to the
-          OpenAI-compat path (where tools won't work — that's the
-          documented lanlan.app/free trade-off).
+          OpenAI-compat path, which carries ``tools`` too.
         - Otherwise: ``_astream_openai_with_tools``.
         """
         tool_leak_filter = overrides.pop("_tool_leak_filter", None)

--- a/plugin/plugins/qq_auto_reply/memory_bridge.py
+++ b/plugin/plugins/qq_auto_reply/memory_bridge.py
@@ -278,8 +278,8 @@ class QQMemoryBridge:
         logger = getattr(self.plugin, "logger", None)
         if block.dropped and logger is not None:
             # 诊断行不该成为渲染的硬依赖：这个函数此前对 plugin 对象零依赖，
-            # 抛 AttributeError 会被上游 _build_recalled_memory_text 的
-            # except 吞掉，整段召回为了一条日志凭空消失。
+            # 抛 AttributeError 会被上游 execute_recall 的 except 吞掉，
+            # 整段召回为了一条日志凭空消失。
             logger.info(
                 f"QQ 长期记忆召回段超出 {RECALL_RENDER_TOTAL_MAX_TOKENS} tok 预算，"
                 f"丢弃末尾 {block.dropped} 条"

--- a/plugin/plugins/qq_auto_reply/memory_tool_service.py
+++ b/plugin/plugins/qq_auto_reply/memory_tool_service.py
@@ -27,10 +27,9 @@ async def resolve_group_recall_subjects(
 ) -> tuple[list[dict[str, str]], bool]:
     """One place for the group read path's subject list.
 
-    Shared by the per-turn fallback recall, the recall_memory tool
-    handler AND the scoped bootstrap context: the three paths must
-    authorize exactly the same scopes, or a provider switch would
-    silently change what a group turn can read.
+    Shared by the recall_memory tool handler AND the scoped bootstrap
+    context: both paths must authorize exactly the same scopes, or what
+    a group turn may read would depend on which one ran.
     Returns ``(subjects, used_member_subject)``.
 
     形状：[群] + [当前发言人] + [本轮上下文里最近说过话的另外
@@ -71,8 +70,8 @@ def resolve_participant_recall_subjects(
 ) -> list[dict[str, str]]:
     """One place for the private participant read path's subject list.
 
-    与 resolve_group_recall_subjects 同一角色：tool handler、回落召回、
-    bootstrap 核心记忆段三条读路径必须授权完全一致的域。返回 ``[]`` 表示
+    与 resolve_group_recall_subjects 同一角色：tool handler 与 bootstrap
+    核心记忆段两条读路径必须授权完全一致的域。返回 ``[]`` 表示
     fail-closed（sender 缺失 / 开关已关）——bridge 对空列表直接空结果，
     **绝不**允许调用方把它换成 None（None = legacy 私聊主人语料）。
     同步函数：不需要像群版那样读 backlog 扩容。"""
@@ -304,7 +303,7 @@ class QQMemoryToolService:
             if not subjects:
                 return no_result, {}
         # 私聊 admin（use_memory_context 已按政策解析）：subjects=None 走
-        # legacy 私聊主人语料，与回落路径一致。
+        # legacy 私聊主人语料。
 
         try:
             result = await self.plugin.memory_bridge.query_relevant_memory(

--- a/plugin/plugins/qq_auto_reply/pipeline_models.py
+++ b/plugin/plugins/qq_auto_reply/pipeline_models.py
@@ -196,10 +196,6 @@ class QQReplyContext:
     # core memory 段是否含 participant 域：member 授权在生成前被撤销时
     # 该段（及混合域召回）要一并撤除。
     used_member_subject: bool = False
-    # 本轮召回通道：True=挂 recall_memory 工具、模型自主决定何时查（此时
-    # 构建期不做同步召回，recalled_memory_text 恒空）；False=线路不支持
-    # tool call（免费代理会静默丢 tools），回落到宿主生成前同步召回。
-    recall_via_tool: bool = False
     # 本轮上下文的唯一标识：投递钩子的幂等键。绝不能用 id(context)——
     # CPython 会把刚释放的同尺寸对象原样发回，下一轮的 context 常常拿到
     # 同一地址，幂等扫描会把新一轮的行误判成"已经补过了"。

--- a/plugin/plugins/qq_auto_reply/reply_context_node.py
+++ b/plugin/plugins/qq_auto_reply/reply_context_node.py
@@ -2,123 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from main_logic.omni_offline_client import route_supports_tool_calls
 from utils.config_manager import get_config_manager
 
-from .memory_tool_service import (
-    resolve_group_recall_subjects,
-    resolve_participant_recall_subjects,
-)
 from .pipeline_models import is_synthetic_source, QQInstructionBundle, QQPipelineStageTrace, QQReplyContext
-from .prompt_fragment_templates import LONG_TERM_MEMORY_SECTION
 
 
 class QQReplyContextNode:
     def __init__(self, plugin: Any):
         self.plugin = plugin
-
-    async def _build_recalled_memory_text(
-        self,
-        *,
-        used_member_subject_out: list | None = None,
-        her_name: str,
-        message: str,
-        should_use_memory_context: bool,
-        attachments: list[dict[str, Any]] | None,
-        is_group: bool = False,
-        group_id: str | None = None,
-        sender_id: str = "",
-        participant_memory: bool = False,
-    ) -> str:
-        if not should_use_memory_context:
-            return ""
-        if is_group and not bool(
-            (getattr(self.plugin, "_qq_settings", {}) or {}).get(
-                "group_memory_enabled", False,
-            )
-        ):
-            # 读点前复检实时策略：请求构造时捕获的 use=True 在上下文构建的
-            # await 窗口里可能已被 opt-out 反超——persist 侧有 prime 门控，
-            # 读侧也不得在 OFF 之后把 scoped 召回注入群回复。
-            return ""
-        if self.plugin._should_skip_direct_llm_fallback_for_images(message=message, attachments=attachments):
-            return ""
-        normalized_message = str(message or "").strip()
-        if not normalized_message:
-            return ""
-        group_id = str(group_id or "").strip()
-        if is_group and not group_id:
-            # 先标准化再判：空白串不得越界生成 subject_id="qq:" 无效 subject。
-            # Fail-closed（与 session_instruction_service._build_core_memory_
-            # section 对齐）：畸形群事件缺 group_id 时不能让 subjects 退化成
-            # None——bridge 侧 None 的语义是「legacy 私聊调用方」，会把主人的
-            # 私聊记忆召回进群回复。
-            return ""
-        try:
-            subjects = None
-            used_member_subject = False
-            if is_group and group_id:
-                # subject 组装与 recall_memory 工具 handler 共用一处（含
-                # member 开关的读点实时复检、sender 规范化）：两条召回通道
-                # 授权的域必须一致，线路切换不得悄悄改变群轮能读什么。
-                subjects, used_member_subject = await resolve_group_recall_subjects(
-                    self.plugin, group_id=group_id, memory_sender_id=sender_id,
-                )
-            elif participant_memory:
-                # 私聊 participant 轮：subject 组装与 tool handler / 核心
-                # 记忆段共用 resolver（含开关实时复检、sender 规范化）。
-                # resolver fail-closed 返回 []——bridge 对 [] 直接空结果，
-                # **绝不**让 subjects 保持 None 落进 legacy 主人语料。
-                subjects = resolve_participant_recall_subjects(
-                    self.plugin, memory_sender_id=sender_id,
-                )
-            if used_member_subject and used_member_subject_out is not None:
-                # 回传给调用方：召回是否真的带上了 participant 域。绑定
-                # bootstrap 段是否非空是错的——bootstrap 为空、召回命中
-                # participant 的组合下，member 撤销时不会撤这段召回。
-                used_member_subject_out.append(True)
-            recall_result = await self.plugin.memory_bridge.query_relevant_memory(
-                her_name,
-                normalized_message,
-                subjects=subjects,
-            )
-            if used_member_subject and not bool(
-                (getattr(self.plugin, "_qq_settings", {}) or {}).get(
-                    "group_member_memory_enabled", False,
-                )
-            ):
-                # member 侧读后复检：召回结果混合群域与 participant 域、
-                # 事后无法拆分，opt-out 落在这次调用飞行期间时整体丢弃。
-                return ""
-            if is_group and not bool(
-                (getattr(self.plugin, "_qq_settings", {}) or {}).get(
-                    "group_memory_enabled", False,
-                )
-            ):
-                # 读后复检：opt-out 可能落在上面这次网络调用飞行期间——
-                # 数据已读回也要丢弃，不注入 opt-out 之后的群回复。此处是
-                # 读侧最后的收敛点：该轮的 persist 已由转变盖章+prime 门控
-                # 挡住。
-                return ""
-            if participant_memory and not bool(
-                (getattr(self.plugin, "_qq_settings", {}) or {}).get(
-                    "private_participant_memory_enabled", False,
-                )
-            ):
-                # participant 侧读后复检（对偶上面两处）：opt-out 落在召回
-                # 飞行期间时，已读回的 participant 域内容整体丢弃。
-                return ""
-            if not recall_result.text:
-                return ""
-            self.plugin.logger.info(
-                "QQ 长期记忆召回完成: hits=%s elapsed=%.0fms",
-                recall_result.hit_count,
-                recall_result.elapsed_ms,
-            )
-            return LONG_TERM_MEMORY_SECTION.format(memory_context=recall_result.text)
-        except Exception as e:
-            self.plugin.logger.warning(f"QQ 长期记忆召回失败: {e}")
-            return ""
 
     def _strip_section_if_member_revoked(
         self, system_prompt: str, section_text: str, used_member_subject: bool,
@@ -474,49 +365,21 @@ class QQReplyContextNode:
         system_prompt = instruction_bundle.system_prompt
         core_memory_text = instruction_bundle.core_memory_text
         memory_context_used = instruction_bundle.memory_context_used
-        recall_used_member: list = []
-        recall_via_tool = False
-        if should_use_memory_context:
-            # 召回通道决策：线路支持 tool call 就把召回交给模型自主决定
-            # （reply_generation_service 按轮挂载 recall_memory 工具，构建
-            # 期不再同步召回）；免费代理只暴露 OpenAI-compat 且会静默丢
-            # tools，那批用户回落到构建期同步召回，否则群记忆会静默归零。
-            # 判定出错按回落处理——回落路径至少确定生效。
-            try:
-                conversation_config = config_manager.get_model_api_config(
-                    "conversation",
-                )
-                recall_via_tool = route_supports_tool_calls(
-                    str(conversation_config.get("model") or ""),
-                    str(conversation_config.get("base_url") or ""),
-                )
-            except Exception:
-                recall_via_tool = False
-        recalled_memory_text = ""
-        if not recall_via_tool:
-            recalled_memory_text = await self._build_recalled_memory_text(
-                used_member_subject_out=recall_used_member,
-                her_name=her_name,
-                message=message,
-                should_use_memory_context=should_use_memory_context,
-                attachments=attachments,
-                is_group=is_group,
-                group_id=group_id,
-                sender_id=memory_sender_id,
-                participant_memory=participant_memory_snapshot,
-            )
-        recalled_memory_used = bool(recalled_memory_text)
+        # 召回只有 recall_memory 工具这一条通道：generation service 按轮挂
+        # 工具，由模型自己决定这轮要不要查。构建期一次检索都不发——上下文
+        # 构建拿不到"这轮到底需不需要记忆"的信息，在这里查就是每轮无条件付
+        # 一次检索（HTTP + prompt token），无论结果用不用得上。
+        # recalled_memory_text / used 留空由 execute_recall 在真的读到内容
+        # 时回填（主会话空回复时的 direct fallback 读它）。
         traces.append(
             QQPipelineStageTrace(
                 stage="context_memory_recall",
                 status=(
-                    "tool_deferred" if recall_via_tool
-                    else ("used" if recalled_memory_used else "skipped")
+                    "tool_deferred" if should_use_memory_context else "skipped"
                 ),
                 metadata={
-                    "recalled_memory_used": recalled_memory_used,
-                    "recalled_memory_length": len(recalled_memory_text),
-                    "recall_via_tool": recall_via_tool,
+                    "recalled_memory_used": False,
+                    "recalled_memory_length": 0,
                 },
             )
         )
@@ -613,8 +476,8 @@ class QQReplyContextNode:
             system_prompt=system_prompt,
             memory_context_used=memory_context_used,
             core_memory_text=core_memory_text,
-            recalled_memory_text=recalled_memory_text,
-            recalled_memory_used=recalled_memory_used,
+            recalled_memory_text="",
+            recalled_memory_used=False,
             login_status=login_status,
             login_self_id=login_self_id,
             login_nickname=login_nickname,
@@ -631,7 +494,6 @@ class QQReplyContextNode:
             private_permission_level_at_receipt=(
                 private_permission_level_at_receipt
             ),
-            recall_via_tool=recall_via_tool,
             cross_group_section=(
                 getattr(instruction_bundle, "cross_group_section", "")
                 if cross_group_alive else ""
@@ -640,12 +502,11 @@ class QQReplyContextNode:
                 getattr(instruction_bundle, "cross_session_section", "")
                 if cross_session_alive else ""
             ),
+            # 只剩 bootstrap 段这一个构建期来源：召回侧的 participant 域是
+            # 生成中途才可能读到的，由 execute_recall 命中 member 域时置位。
             used_member_subject=bool(
-                (
-                    core_memory_alive
-                    and getattr(instruction_bundle, "used_member_subject", False)
-                )
-                or (recall_used_member and recalled_memory_text)
+                core_memory_alive
+                and getattr(instruction_bundle, "used_member_subject", False)
             ),
             traces=traces,
         )

--- a/plugin/plugins/qq_auto_reply/reply_generation_service.py
+++ b/plugin/plugins/qq_auto_reply/reply_generation_service.py
@@ -4,7 +4,6 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Optional
 
-from main_logic.omni_offline_client import route_supports_tool_calls
 from main_logic.tool_calling import ToolResult
 from utils.llm_client import AIMessage, SystemMessage, create_chat_llm_async
 from utils.token_tracker import set_call_type
@@ -451,14 +450,12 @@ class QQReplyGenerationService:
     ) -> bool:
         """Install this turn's recall_memory tool + handler on the client.
 
-        Returns whether the tool is actually armed. The capability check
-        runs against the SESSION CLIENT's frozen route, not the current
-        config: a cached session can outlive a provider switch, and a
-        route that silently drops ``tools`` must not count as armed (the
-        turn would think it has a recall channel it does not have).
+        Returns whether the tool is actually armed. This is the ONLY
+        recall channel: when arming fails the turn simply has no recall.
+        There is deliberately no build-time fallback recall to catch it —
+        that path fired a retrieval round-trip on every single turn, even
+        the ones whose reply never needed memory.
         """
-        if not getattr(context, "recall_via_tool", False):
-            return False
         if not getattr(context, "use_memory_context", False):
             return False
         set_tools = getattr(user_session, "set_tools", None)
@@ -467,14 +464,6 @@ class QQReplyGenerationService:
             user_session, "set_tool_round_start_callback", None,
         )
         if not callable(set_tools) or not callable(set_handler):
-            return False
-        if not route_supports_tool_calls(
-            str(getattr(user_session, "model", "") or ""),
-            str(getattr(user_session, "base_url", "") or ""),
-        ):
-            self.plugin.logger.warning(
-                "缓存会话的线路不支持 tool call，本轮无召回（会话重建后恢复）"
-            )
             return False
         try:
             set_tools([

--- a/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
+++ b/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
@@ -234,7 +234,7 @@ class QQSessionBootstrapService:
                 model=model,
                 on_text_delta=on_text_delta,
                 on_response_discarded=on_response_discarded,
-                # 一轮只允许一次召回：与旧的每轮同步召回同预算，也压住
+                # 一轮只允许一次召回：给这轮的检索定死一次的预算，也压住
                 # 工具轮的最坏超时（每多一次迭代就多一整段 LLM 流，而这里
                 # 超时的代价是丢弃整个共享群会话）。封顶后 forced-finalize
                 # 会摘掉 tools 逼出最终文本，召回结果不会白拿。

--- a/plugin/plugins/qq_auto_reply/session_instruction_service.py
+++ b/plugin/plugins/qq_auto_reply/session_instruction_service.py
@@ -774,8 +774,8 @@ class QQSessionInstructionService:
                 "group_memory_enabled", False,
             )
         ):
-            # 读点前复检实时策略（对偶 _build_recalled_memory_text）：构建
-            # 期间 opt-out 的群，不得再拉 scoped bootstrap 上下文。
+            # 读点前复检实时策略（对偶 execute_recall 的 handler 入口闸）：
+            # 构建期间 opt-out 的群，不得再拉 scoped bootstrap 上下文。
             return ""
         group_id = str(group_id or "").strip()
         if is_group and not group_id:
@@ -783,9 +783,9 @@ class QQSessionInstructionService:
         try:
             if is_group:
                 # subject 组装收口进 resolve_group_recall_subjects：本段此前
-                # 是一份内联副本（群 + 当前发言人），三条读路径（tool
-                # handler / 回落召回 / 本段 bootstrap）必须授权完全一致的
-                # 域，扩容（+最近发言人）也只在一处生效。
+                # 是一份内联副本（群 + 当前发言人），两条读路径（tool
+                # handler / 本段 bootstrap）必须授权完全一致的域，扩容
+                # （+最近发言人）也只在一处生效。
                 from .memory_tool_service import resolve_group_recall_subjects
 
                 subjects, used_member = await resolve_group_recall_subjects(
@@ -813,13 +813,13 @@ class QQSessionInstructionService:
                         "group_memory_enabled", False,
                     )
                 ):
-                    # 读后复检（对偶 _build_recalled_memory_text）：opt-out
+                    # 读后复检（对偶 execute_recall 的读后闸）：opt-out
                     # 落在 fetch 飞行期间时丢弃已读回的数据。
                     return ""
             elif participant_memory:
-                # 私聊 participant 轮：subject 组装与 tool handler / 回落
-                # 召回共用 resolver（开关实时复检 + sender 规范化收口在它
-                # 那一处）。resolver fail-closed 返回 []，bridge 对空列表
+                # 私聊 participant 轮：subject 组装与 tool handler 共用
+                # resolver（开关实时复检 + sender 规范化收口在它那一处）。
+                # resolver fail-closed 返回 []，bridge 对空列表
                 # 直接返回空串——**绝不**落到下面的 legacy 分支：那是
                 # 主人的私聊 persona，交给非 admin 好友就是隐私泄漏。
                 from .memory_tool_service import (

--- a/plugin/tests/unit/plugins/test_qq_pre_tool_text_contract.py
+++ b/plugin/tests/unit/plugins/test_qq_pre_tool_text_contract.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from plugin.plugins.qq_auto_reply import reply_generation_service as reply_module
 from plugin.plugins.qq_auto_reply.pipeline_models import QQMessageBlock
 from plugin.plugins.qq_auto_reply.pipeline_models import QQModelResult
 from plugin.plugins.qq_auto_reply.reply_buffer_service import (
@@ -20,7 +19,7 @@ from plugin.plugins.qq_auto_reply.reply_postprocess_node import (
 from plugin.plugins.qq_auto_reply.prompting import QQAutoReplyPromptingMixin
 
 
-def test_qq_recall_tool_does_not_install_a_pre_tool_discard_hook(monkeypatch):
+def test_qq_recall_tool_does_not_install_a_pre_tool_discard_hook():
     """QQ must not receive ownership of the model's outbound text buffer."""
 
     class _ToolService:
@@ -45,7 +44,6 @@ def test_qq_recall_tool_does_not_install_a_pre_tool_discard_hook(monkeypatch):
         def set_tool_round_start_callback(self, callback):
             self.round_start_callbacks.append(callback)
 
-    monkeypatch.setattr(reply_module, "route_supports_tool_calls", lambda *_: True)
     service = QQReplyGenerationService.__new__(QQReplyGenerationService)
     service.plugin = SimpleNamespace(
         memory_tool_service=_ToolService(),
@@ -54,7 +52,7 @@ def test_qq_recall_tool_does_not_install_a_pre_tool_discard_hook(monkeypatch):
     client = _Client()
 
     armed = service._arm_recall_tool(
-        context=SimpleNamespace(recall_via_tool=True, use_memory_context=True),
+        context=SimpleNamespace(use_memory_context=True),
         user_session=client,
         consent_before={},
     )

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -90,7 +90,6 @@ def _group_context(sender_id="2046", **overrides):
         cross_session_section="",
         used_member_subject=False,
         use_memory_context=True,
-        recall_via_tool=True,
         member_memory_enabled=True,
         source_kind="",
         permission_level="user",
@@ -475,7 +474,6 @@ async def test_private_participant_turn_refreshes_empty_memory_prompt():
         core_memory_text="",
         cross_session_section="",
         cross_group_section="",
-        recall_via_tool=False,
         participant_memory_enabled=True,
         private_memory_mode="participant",
         used_member_subject=False,
@@ -571,10 +569,13 @@ async def test_final_disarm_clears_handler_when_tool_cleanup_fails():
 
 
 @pytest.mark.asyncio
-async def test_arm_respects_the_session_clients_frozen_route():
-    """Arming binds to the CLIENT's route, not the current config: a
-    cached session can outlive a provider switch, and a route that
-    silently drops ``tools`` must not count as armed."""
+async def test_arm_installs_the_tool_whatever_the_route():
+    """Arming does not inspect the client's route at all.
+
+    The free proxy used to be classified as tool-less, which pushed those
+    turns onto a build-time recall. That fallback is gone — every turn's
+    only recall channel is this tool — so a route-shaped check returning
+    False here would leave the turn with no memory whatsoever."""
     plugin = _tool_plugin()
     service = _generation_service(plugin)
 
@@ -586,13 +587,13 @@ async def test_arm_respects_the_session_clients_frozen_route():
         context=_group_context(),
         user_session=free_client,
         consent_before={},
-    ) is False
-    assert free_client.armed_tool_names == []
+    ) is True
+    assert free_client.armed_tool_names[-1] == ["recall_memory"]
 
-    # recall_via_tool=False（构建期决定走回落）：连 set_tools 都不碰。
+    # 记忆政策关着：本轮压根不该读记忆，是唯一还会拦住挂载的业务条件。
     capable_client = _RecallToolClient(AsyncMock())
     assert service._arm_recall_tool(
-        context=_group_context(recall_via_tool=False),
+        context=_group_context(use_memory_context=False),
         user_session=capable_client,
         consent_before={},
     ) is False
@@ -1498,7 +1499,7 @@ async def test_tool_turn_timeout_covers_the_whole_tool_loop(monkeypatch):
 
     captured.clear()
     await service._run_session_generation(
-        context=_group_context(recall_via_tool=False),
+        context=_group_context(use_memory_context=False),
         session_key="group:7788",
         user_data={"lock": asyncio.Lock()},
         user_session=_RecallToolClient(_quiet),
@@ -1508,10 +1509,9 @@ async def test_tool_turn_timeout_covers_the_whole_tool_loop(monkeypatch):
 
 
 def test_plugin_session_clients_cap_tool_iterations_to_one():
-    """One recall per turn: same budget as the old per-turn synchronous
-    recall, and it bounds the armed-turn worst case the timeout above is
-    sized for. The forced-finalize after the cap still feeds the recall
-    result back, so the read is never wasted.
+    """One recall per turn: that cap bounds the armed-turn worst case the
+    timeout above is sized for. The forced-finalize after the cap still
+    feeds the recall result back, so the read is never wasted.
 
     AST 而非源码字面量计数：旧写法比较两个字符串的出现次数，任何后续
     PR 在注释/docstring 里写下 "OmniOfflineClient(" 或
@@ -1548,33 +1548,25 @@ def test_plugin_session_clients_cap_tool_iterations_to_one():
 
 
 # ---------------------------------------------------------------------------
-# Route capability fallback (连带 #8)
+# Retired: the route capability gate (free proxy forwards tools now)
 # ---------------------------------------------------------------------------
 
 
-def test_route_capability_predicate_knows_the_free_proxy():
-    from main_logic.omni_offline_client import route_supports_tool_calls
+def test_offline_client_grows_no_route_capability_gate():
+    """No "does this route support tools" predicate may come back.
 
-    assert route_supports_tool_calls(
-        "free-model", "https://www.lanlan.app/text/v1",
-    ) is False
-    assert route_supports_tool_calls(
-        "free-model", "https://www.lanlan.tech/text/v1",
-    ) is False
-    # 区域改写只动 URL：模型名单独命中也算免费路由。
-    assert route_supports_tool_calls("free-model", "https://example.com/v1") is False
-    assert route_supports_tool_calls(
-        TOOL_CAPABLE_MODEL, TOOL_CAPABLE_BASE_URL,
-    ) is True
-    assert route_supports_tool_calls("", "") is True
-    # 免费域按 host 判，不是子串：路径/查询串里提到 lanlan.* 的自配端点
-    # 不是免费代理（与 voice registry 的免费路由判法同口径）。
-    assert route_supports_tool_calls(
-        TOOL_CAPABLE_MODEL, "https://custom.example/v1/lanlan.tech",
-    ) is True
-    assert route_supports_tool_calls(
-        TOOL_CAPABLE_MODEL, "https://api.lanlan.app/v1",
-    ) is False
+    One existed while lanlan's free proxy silently dropped ``tools``: QQ
+    consulted it and pushed those turns onto a build-time recall. The
+    proxy forwards tools now and that fallback is deleted, so a predicate
+    answering False would no longer mean "use the other channel" — it
+    would mean the turn gets no memory at all, silently.
+    """
+    import main_logic.omni_offline_client as ooc
+
+    assert [
+        name for name in dir(ooc)
+        if "supports_tool" in name or "free_route" in name
+    ] == []
 
 
 @pytest.mark.asyncio
@@ -1665,97 +1657,54 @@ def _build_config_manager(model, base_url):
     )
 
 
-@pytest.mark.asyncio
-async def test_free_route_falls_back_to_synchronous_recall(monkeypatch):
-    """Providers that silently drop ``tools`` (the free proxy) must keep
-    the pre-generation synchronous recall — flipping them to tool-call
-    mode would zero group memory for those users with no error anywhere."""
-    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
-
-    bridge = _mock_bridge()
-    plugin = _build_stub_plugin(bridge)
-    monkeypatch.setattr(
-        rcn, "get_config_manager",
-        lambda: _build_config_manager(
-            "free-model", "https://www.lanlan.app/text/v1",
-        ),
-    )
-    node = rcn.QQReplyContextNode.__new__(rcn.QQReplyContextNode)
-    node.plugin = plugin
-
-    context = await node.build(
-        message="群规是什么？",
-        permission_level="user",
-        sender_id="2046",
-        is_group=True,
-        group_id="7788",
-        use_memory_context=True,
-    )
-    assert context.recall_via_tool is False
-    bridge.query_relevant_memory.assert_awaited_once()
-    assert "群规是不剧透" in context.recalled_memory_text
-
-    # 回落路径的 consent 复检依旧生效：构建期间已 opt-out 的群不发起召回。
-    bridge.query_relevant_memory.reset_mock()
-    plugin._qq_settings["group_memory_enabled"] = False
-    context = await node.build(
-        message="群规是什么？",
-        permission_level="user",
-        sender_id="2046",
-        is_group=True,
-        group_id="7788",
-        use_memory_context=True,
-    )
-    bridge.query_relevant_memory.assert_not_awaited()
-    assert context.recalled_memory_text == ""
-
-
-@pytest.mark.asyncio
-async def test_tool_capable_route_defers_recall_to_the_model(monkeypatch):
-    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
-
-    bridge = _mock_bridge()
-    plugin = _build_stub_plugin(bridge)
-    monkeypatch.setattr(
-        rcn, "get_config_manager",
-        lambda: _build_config_manager(TOOL_CAPABLE_MODEL, TOOL_CAPABLE_BASE_URL),
-    )
-    node = rcn.QQReplyContextNode.__new__(rcn.QQReplyContextNode)
-    node.plugin = plugin
-
-    context = await node.build(
-        message="群规是什么？",
-        permission_level="user",
-        sender_id="2046",
-        is_group=True,
-        group_id="7788",
-        use_memory_context=True,
-    )
-    assert context.recall_via_tool is True
-    bridge.query_relevant_memory.assert_not_awaited()
-    assert context.recalled_memory_text == ""
-    assert context.recalled_memory_used is False
-
-
-@pytest.mark.asyncio
-async def test_capability_probe_failure_degrades_to_fallback(monkeypatch):
-    """When the route cannot be determined, choose the channel that is
-    KNOWN to work — the synchronous recall."""
-    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
-
-    bridge = _mock_bridge()
-    plugin = _build_stub_plugin(bridge)
-
+def _unreadable_config_manager():
     def _boom(kind):
         raise RuntimeError("config store busy")
 
-    config_manager = SimpleNamespace(
+    return SimpleNamespace(
         get_character_data=lambda: (
             "Master", "Neko", None, {}, None, {}, None, None, None,
         ),
         get_model_api_config=_boom,
     )
-    monkeypatch.setattr(rcn, "get_config_manager", lambda: config_manager)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "make_config_manager",
+    [
+        pytest.param(
+            lambda: _build_config_manager(
+                "free-model", "https://www.lanlan.app/text/v1",
+            ),
+            id="free-proxy",
+        ),
+        pytest.param(
+            lambda: _build_config_manager(
+                TOOL_CAPABLE_MODEL, TOOL_CAPABLE_BASE_URL,
+            ),
+            id="tool-capable",
+        ),
+        pytest.param(_unreadable_config_manager, id="config-unreadable"),
+    ],
+)
+async def test_context_build_never_spends_a_retrieval(
+    monkeypatch, make_config_manager,
+):
+    """Building a turn's context must never cost a recall round-trip.
+
+    Recall belongs to the model, mid-generation, through the tool. Doing
+    it here would spend a retrieval (HTTP + prompt tokens) on EVERY turn
+    — the build cannot know whether this reply needs memory at all. The
+    route the turn happens to run on is not a reason to reintroduce one,
+    and neither is a config store that refuses to answer: the answer to
+    "I can't tell what the route is" is still to leave it to the tool.
+    """
+    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
+
+    bridge = _mock_bridge()
+    plugin = _build_stub_plugin(bridge)
+    monkeypatch.setattr(rcn, "get_config_manager", make_config_manager)
     node = rcn.QQReplyContextNode.__new__(rcn.QQReplyContextNode)
     node.plugin = plugin
 
@@ -1767,8 +1716,10 @@ async def test_capability_probe_failure_degrades_to_fallback(monkeypatch):
         group_id="7788",
         use_memory_context=True,
     )
-    assert context.recall_via_tool is False
-    bridge.query_relevant_memory.assert_awaited_once()
+
+    bridge.query_relevant_memory.assert_not_awaited()
+    assert context.recalled_memory_text == ""
+    assert context.recalled_memory_used is False
 
 
 # ---------------------------------------------------------------------------
@@ -2035,11 +1986,11 @@ async def test_bridge_forwards_time_spec_and_allows_time_only():
 
 
 @pytest.mark.asyncio
-async def test_fallback_recall_shares_the_subject_resolver():
-    """The fallback recall, the tool handler AND the scoped bootstrap
-    context must authorize identical scopes — enforced by all three
-    calling resolve_group_recall_subjects. A re-inlined copy in any path
-    is where the scopes would drift (the bootstrap path WAS such a copy
+async def test_group_read_paths_share_the_subject_resolver():
+    """The tool handler AND the scoped bootstrap context must authorize
+    identical scopes — enforced by both calling
+    resolve_group_recall_subjects. A re-inlined copy in either path is
+    where the scopes would drift (the bootstrap path WAS such a copy
     until the recent-speaker expansion collapsed it).
 
     AST 而非源码字符串：函数体内的 import 语句 / 注释同样含这个名字，
@@ -2050,7 +2001,6 @@ async def test_fallback_recall_shares_the_subject_resolver():
     import textwrap
 
     from plugin.plugins.qq_auto_reply import memory_tool_service as mts
-    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
     from plugin.plugins.qq_auto_reply import session_instruction_service as sis
 
     def _calls_resolver(func) -> bool:
@@ -2066,9 +2016,6 @@ async def test_fallback_recall_shares_the_subject_resolver():
             for node in ast.walk(tree)
         )
 
-    assert _calls_resolver(
-        rcn.QQReplyContextNode._build_recalled_memory_text
-    ), "回落召回路径没有真正调用共享 resolver"
     assert _calls_resolver(
         mts.QQMemoryToolService.execute_recall
     ), "tool handler 路径没有真正调用共享 resolver"

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -551,163 +551,6 @@ async def test_qq_private_bootstrap_keeps_legacy_behavior():
 
 
 @pytest.mark.asyncio
-async def test_qq_group_recall_passes_group_and_member_subjects():
-    """Fallback recall channel (routes that silently drop ``tools``, i.e.
-    the free proxy): the pre-generation synchronous recall must authorize
-    exactly the group (+ participant) scopes. Tool-capable routes recall
-    via the recall_memory tool instead — the two channels share the
-    subject resolver, covered in test_group_memory_recall_tool.py."""
-    from plugin.plugins.qq_auto_reply.memory_bridge import (
-        QQMemoryBridge,
-        QQMemoryQueryResult,
-    )
-    from plugin.plugins.qq_auto_reply.reply_context_node import QQReplyContextNode
-
-    bridge = MagicMock()
-    bridge.speaker_account_id.side_effect = (
-        lambda sid: f"qq:{str(sid or '').strip()}"
-    )
-    bridge.group_subject.side_effect = QQMemoryBridge.group_subject
-    bridge.group_participant_subject.side_effect = (
-        QQMemoryBridge.group_participant_subject
-    )
-    bridge.query_relevant_memory = AsyncMock(
-        return_value=QQMemoryQueryResult(text="群规是不剧透", hit_count=1),
-    )
-    plugin = SimpleNamespace(
-        memory_bridge=bridge,
-        logger=MagicMock(),
-        _qq_settings={
-            "group_memory_enabled": True,
-            "group_member_memory_enabled": True,
-        },
-        _should_skip_direct_llm_fallback_for_images=lambda **kwargs: False,
-    )
-
-    rendered = await QQReplyContextNode(plugin)._build_recalled_memory_text(
-        her_name="Neko",
-        message="群规是什么？",
-        should_use_memory_context=True,
-        attachments=None,
-        is_group=True,
-        group_id="7788",
-        sender_id="2046",
-    )
-
-    assert "群规是不剧透" in rendered
-    kwargs = bridge.query_relevant_memory.await_args.kwargs
-    assert [s2["subject_kind"] for s2 in kwargs["subjects"]] == [
-        "group_chat", "group_participant",
-    ]
-
-    # Member memory OFF gates the READ too: existing participant memory
-    # must not be recalled into a group reply once the switch is off
-    # (otherwise "stop using member memory" only stopped writing).
-    plugin._qq_settings["group_member_memory_enabled"] = False
-    bridge.query_relevant_memory.reset_mock()
-    await QQReplyContextNode(plugin)._build_recalled_memory_text(
-        her_name="Neko",
-        message="群规是什么？",
-        should_use_memory_context=True,
-        attachments=None,
-        is_group=True,
-        group_id="7788",
-        sender_id="2046",
-    )
-    kwargs = bridge.query_relevant_memory.await_args.kwargs
-    assert [s2["subject_kind"] for s2 in kwargs["subjects"]] == ["group_chat"]
-
-    # sender_id is normalized the same way the write side normalizes it —
-    # a padded id must not land in a different participant bucket.
-    plugin._qq_settings["group_member_memory_enabled"] = True
-    bridge.query_relevant_memory.reset_mock()
-    await QQReplyContextNode(plugin)._build_recalled_memory_text(
-        her_name="Neko",
-        message="群规是什么？",
-        should_use_memory_context=True,
-        attachments=None,
-        is_group=True,
-        group_id="7788",
-        sender_id="  2046  ",
-    )
-    kwargs = bridge.query_relevant_memory.await_args.kwargs
-    assert kwargs["subjects"][1]["subject_id"] == "qq:7788:2046"
-
-    # Member opt-out DURING the recall await: the result mixes group and
-    # participant text and cannot be split afterwards — drop it whole.
-    async def _recall_then_revoke(*args, **kwargs):
-        plugin._qq_settings["group_member_memory_enabled"] = False
-        return QQMemoryQueryResult(text="成员私密偏好", hit_count=1)
-
-    plugin._qq_settings["group_member_memory_enabled"] = True
-    bridge.query_relevant_memory = AsyncMock(side_effect=_recall_then_revoke)
-    assert await QQReplyContextNode(plugin)._build_recalled_memory_text(
-        her_name="Neko",
-        message="群规是什么？",
-        should_use_memory_context=True,
-        attachments=None,
-        is_group=True,
-        group_id="7788",
-        sender_id="2046",
-    ) == ""
-    bridge.query_relevant_memory.assert_awaited_once_with(
-        "Neko",
-        "群规是什么？",
-        subjects=[
-            QQMemoryBridge.group_subject("7788"),
-            QQMemoryBridge.group_participant_subject("7788", "2046"),
-        ],
-    )
-
-
-@pytest.mark.asyncio
-async def test_qq_group_recall_omits_phantom_member_for_empty_sender():
-    """Fallback recall channel: an empty sender must not fabricate a
-    phantom participant subject (the tool channel shares the resolver)."""
-    from plugin.plugins.qq_auto_reply.memory_bridge import (
-        QQMemoryBridge,
-        QQMemoryQueryResult,
-    )
-    from plugin.plugins.qq_auto_reply.reply_context_node import QQReplyContextNode
-
-    bridge = MagicMock()
-    bridge.speaker_account_id.side_effect = (
-        lambda sid: f"qq:{str(sid or '').strip()}"
-    )
-    bridge.group_subject.side_effect = QQMemoryBridge.group_subject
-    bridge.group_participant_subject.side_effect = (
-        QQMemoryBridge.group_participant_subject
-    )
-    bridge.query_relevant_memory = AsyncMock(return_value=QQMemoryQueryResult())
-    plugin = SimpleNamespace(
-        memory_bridge=bridge,
-        logger=MagicMock(),
-        _qq_settings={
-            "group_memory_enabled": True,
-            "group_member_memory_enabled": True,
-        },
-        _should_skip_direct_llm_fallback_for_images=lambda **kwargs: False,
-    )
-
-    await QQReplyContextNode(plugin)._build_recalled_memory_text(
-        her_name="Neko",
-        message="群规是什么？",
-        should_use_memory_context=True,
-        attachments=None,
-        is_group=True,
-        group_id="7788",
-        sender_id="",
-    )
-
-    bridge.query_relevant_memory.assert_awaited_once_with(
-        "Neko",
-        "群规是什么？",
-        subjects=[QQMemoryBridge.group_subject("7788")],
-    )
-    bridge.group_participant_subject.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_qq_recall_with_empty_subjects_never_falls_back_to_private():
     from plugin.plugins.qq_auto_reply.memory_bridge import QQMemoryBridge
 
@@ -6114,89 +5957,14 @@ def test_generation_strips_scoped_sections_when_group_revoked():
     ) == prompt
 
 
-@pytest.mark.asyncio
-async def test_recall_reports_participant_usage_to_caller():
-    """Fallback recall channel: the recall reports whether it actually
-    queried the participant subject, and build() ORs that into the
-    context flag — binding the flag to a nonempty bootstrap section would
-    miss the empty-bootstrap + participant-hit combination. (On the tool
-    channel the equivalent record is the handler's runtime consent
-    entry, covered in test_group_memory_recall_tool.py.)"""
-    import inspect
-
-    from plugin.plugins.qq_auto_reply.memory_bridge import QQMemoryQueryResult
-    from plugin.plugins.qq_auto_reply.reply_context_node import (
-        QQReplyContextNode,
-    )
-
-    bridge = MagicMock()
-    bridge.speaker_account_id.side_effect = (
-        lambda sid: f"qq:{str(sid or '').strip()}"
-    )
-    bridge.group_subject.side_effect = (
-        lambda gid: {"subject_kind": "group_chat", "subject_id": f"qq:{gid}"}
-    )
-    bridge.group_participant_subject.side_effect = (
-        lambda gid, uid: {"subject_kind": "group_participant"}
-    )
-    bridge.query_relevant_memory = AsyncMock(
-        return_value=QQMemoryQueryResult(text="成员偏好", hit_count=1),
-    )
-    plugin = SimpleNamespace(
-        memory_bridge=bridge,
-        logger=MagicMock(),
-        _qq_settings={
-            "group_memory_enabled": True,
-            "group_member_memory_enabled": True,
-        },
-        _should_skip_direct_llm_fallback_for_images=lambda **kwargs: False,
-    )
-    node = QQReplyContextNode(plugin)
-    flag: list = []
-    assert await node._build_recalled_memory_text(
-        used_member_subject_out=flag,
-        her_name="Neko", message="问题",
-        should_use_memory_context=True, attachments=None,
-        is_group=True, group_id="7788", sender_id="2046",
-    ) != ""
-    assert flag == [True]
-
-    # No sender: participant subject absent, nothing reported.
-    flag.clear()
-    await node._build_recalled_memory_text(
-        used_member_subject_out=flag,
-        her_name="Neko", message="问题",
-        should_use_memory_context=True, attachments=None,
-        is_group=True, group_id="7788", sender_id="",
-    )
-    assert flag == []
-
-    # Wiring, behaviourally: an empty scoped bootstrap plus a participant
-    # recall hit must still set context.used_member_subject — a source
-    # substring assert would match the surrounding comments and break on
-    # any rename/reflow.
-    import ast
-    import textwrap
-
-    tree = ast.parse(
-        textwrap.dedent(inspect.getsource(QQReplyContextNode.build))
-    )
-    assert any(
-        isinstance(node, ast.BoolOp)
-        and isinstance(node.op, ast.And)
-        and {getattr(v, "id", "") for v in node.values}
-        >= {"recall_used_member", "recalled_memory_text"}
-        for node in ast.walk(tree)
-    )
-
-
 def test_sanitizer_drops_recall_when_member_revoked_without_bootstrap():
-    """Fallback recall channel: participant authorization must be tracked
-    from the recall itself — an empty scoped bootstrap (no core-memory
-    section) with a participant recall hit still has to lose that recall
-    when member memory is revoked before generation. (The tool channel
-    has no pre-composed recall section; its dual is the in-handler
-    entry/post-fetch gate pair.)"""
+    """Participant authorization is tracked from the recall itself, not
+    from the bootstrap section: an empty scoped bootstrap (no core-memory
+    section) whose recall hit the participant scope still has to lose
+    that recall when member memory is revoked before generation. The
+    recall text reaching here comes from the tool handler's back-fill
+    (execute_recall sets recalled_memory_text + used_member_subject when
+    it really read scoped content); the direct-fallback reply carries it."""
     from plugin.plugins.qq_auto_reply.reply_generation_service import (
         QQReplyGenerationService,
     )
@@ -6231,10 +5999,9 @@ def test_sanitizer_drops_recall_when_member_revoked_without_bootstrap():
 async def test_generation_recheck_wiring_drops_scoped_prompt():
     """Wiring guard for the generation-time recheck: the stripped prompt
     and the emptied recall must actually reach _apply_turn_memory_context
-    (a correct helper nobody calls is dead code). The recalled-text leg
-    only exists on the fallback recall channel — tool-channel turns carry
-    an empty recalled_memory_text and rely on the runtime consent record
-    instead."""
+    (a correct helper nobody calls is dead code). Turns whose model never
+    called the tool carry an empty recalled_memory_text and rely on the
+    runtime consent record instead."""
     from plugin.plugins.qq_auto_reply.reply_generation_service import (
         QQReplyGenerationService,
     )
@@ -7316,16 +7083,12 @@ def test_double_off_stamp_preserves_first_epoch_cutoff():
 @pytest.mark.asyncio
 async def test_scoped_reads_recheck_live_policy_before_fetch():
     """A group request can capture use_memory_context=True and then await
-    (login fetch, first memory call) while the admin opts the group out:
-    both scoped read points must recheck the live setting immediately
-    before fetching — persistence is already re-gated at prime time, reads
-    must not inject scoped context into a reply after opt-out. The recall
-    leg here is the fallback channel; the tool channel's read-point
-    rechecks live inside the handler (entry + post-fetch), covered in
-    test_group_memory_recall_tool.py."""
-    from plugin.plugins.qq_auto_reply.reply_context_node import (
-        QQReplyContextNode,
-    )
+    (login fetch, bootstrap fetch) while the admin opts the group out: the
+    scoped read point must recheck the live setting immediately before
+    fetching — persistence is already re-gated at prime time, reads must
+    not inject scoped context into a reply after opt-out. The recall leg's
+    dual lives inside the tool handler (entry + post-fetch rechecks),
+    covered in test_group_memory_recall_tool.py."""
     from plugin.plugins.qq_auto_reply.session_instruction_service import (
         QQSessionInstructionService,
     )
@@ -7343,14 +7106,6 @@ async def test_scoped_reads_recheck_live_policy_before_fetch():
         i18n=_default_i18n(),
         _should_skip_direct_llm_fallback_for_images=lambda **kwargs: False,
     )
-    node = QQReplyContextNode.__new__(QQReplyContextNode)
-    node.plugin = plugin
-    assert await node._build_recalled_memory_text(
-        her_name="Neko", message="hello",
-        should_use_memory_context=True, attachments=None,
-        is_group=True, group_id="7788", sender_id="1",
-    ) == ""
-    bridge.query_relevant_memory.assert_not_awaited()
 
     instruction = QQSessionInstructionService.__new__(QQSessionInstructionService)
     instruction.plugin = plugin
@@ -7370,29 +7125,13 @@ async def test_scoped_reads_recheck_live_policy_before_fetch():
 
     # Post-await recheck: the opt-out can land while the fetch itself is on
     # the wire — data already read back must be dropped, not injected.
-    from plugin.plugins.qq_auto_reply.memory_bridge import QQMemoryQueryResult
-
     plugin._qq_settings["group_memory_enabled"] = True
-
-    async def _recall_and_flip(*args, **kwargs):
-        plugin._qq_settings["group_memory_enabled"] = False
-        return QQMemoryQueryResult(text="群规是不剧透", hit_count=1)
-
-    bridge.query_relevant_memory = AsyncMock(side_effect=_recall_and_flip)
     bridge.group_subject.side_effect = (
         lambda gid: {"subject_kind": "group_chat", "subject_id": f"qq:{gid}"}
     )
     bridge.group_participant_subject.side_effect = (
         lambda gid, sid: {"subject_kind": "group_participant"}
     )
-    assert await node._build_recalled_memory_text(
-        her_name="Neko", message="hello",
-        should_use_memory_context=True, attachments=None,
-        is_group=True, group_id="7788", sender_id="1",
-    ) == ""
-    bridge.query_relevant_memory.assert_awaited_once()
-
-    plugin._qq_settings["group_memory_enabled"] = True
 
     async def _bootstrap_and_flip(*args, **kwargs):
         plugin._qq_settings["group_memory_enabled"] = False

--- a/tests/unit/test_participant_memory_and_display_name.py
+++ b/tests/unit/test_participant_memory_and_display_name.py
@@ -3107,55 +3107,6 @@ async def test_bootstrap_section_participant_post_fetch_revocation():
 
 
 @pytest.mark.asyncio
-async def test_fallback_recall_participant_subjects_and_recheck():
-    """回落召回（不支持 tool call 的线路）：participant 轮 subjects=
-    [participant]；读后开关撤销时整段丢弃。admin 私聊仍 subjects=None。"""  # noqa: DOCSTRING_CJK
-    from plugin.plugins.qq_auto_reply.reply_context_node import (
-        QQReplyContextNode,
-    )
-
-    plugin = _read_path_plugin()
-    node = QQReplyContextNode(plugin)
-
-    text = await node._build_recalled_memory_text(
-        her_name="Neko", message="猫", should_use_memory_context=True,
-        attachments=None, is_group=False, group_id=None,
-        sender_id="1001", participant_memory=True,
-    )
-    assert "召回内容" in text
-    assert plugin.memory_bridge.query_relevant_memory.await_args.kwargs[
-        "subjects"
-    ] == [{"subject_kind": "participant", "subject_id": "qq:1001"}]
-
-    # admin 私聊：subjects=None（legacy 契约不动）
-    plugin.memory_bridge.query_relevant_memory.reset_mock()
-    await node._build_recalled_memory_text(
-        her_name="Neko", message="猫", should_use_memory_context=True,
-        attachments=None, is_group=False, group_id=None,
-        sender_id="9", participant_memory=False,
-    )
-    assert plugin.memory_bridge.query_relevant_memory.await_args.kwargs[
-        "subjects"
-    ] is None
-
-    # 读后撤销
-    async def _revoke(*args, **kwargs):
-        plugin._qq_settings["private_participant_memory_enabled"] = False
-        return SimpleNamespace(
-            text="泄漏", hit_count=1, elapsed_ms=1.0,
-            rendered_count=1, raw_results=[],
-        )
-
-    plugin.memory_bridge.query_relevant_memory = AsyncMock(side_effect=_revoke)
-    text = await node._build_recalled_memory_text(
-        her_name="Neko", message="猫", should_use_memory_context=True,
-        attachments=None, is_group=False, group_id=None,
-        sender_id="1001", participant_memory=True,
-    )
-    assert text == ""
-
-
-@pytest.mark.asyncio
 async def test_participant_mentions_bind_to_delivery_and_fail_closed():
     """mention 计数（防重复 suppression 的输入）：participant 轮按对方
     subject 记；合成轮/空 sender/开关关闭/会话停写时一概不记。"""  # noqa: DOCSTRING_CJK


### PR DESCRIPTION
## 回归报告

### 改了什么

两件事，一个因一个果：

1. **删掉 `route_supports_tool_calls` 这道路由门控**（`main_logic/omni_offline_client`）。它把 `lanlan.app` / `lanlan.tech` 域名或 `free-model` 模型名判成"这条线路会静默丢 tools"，返回 False。免费代理现在透传 `tools`，前提不成立了。连同 `_is_free_route_host`、`_FREE_ROUTE_BASE_URL_HINTS`、`_FREE_ROUTE_MODEL_NAME` 与 `__init__` 导出一起删。

2. **删掉它唯一在挡的那条路径：构建期同步召回**（`reply_context_node._build_recalled_memory_text`）。QQ 自动回复的记忆召回现在只剩 `recall_memory` 工具这一条通道。`recall_via_tool` 字段随之删除，`_arm_recall_tool` 不再看路由、只看本轮记忆政策。

### 为什么

门控是 #2585（2026-07-30）引入的，当时的判断是免费代理只暴露 OpenAI-compat 表面且会丢 `tools`，所以那批用户必须回落到宿主驱动的同步召回，否则群记忆静默归零。这个判断现在不成立。

但更主要的原因是回落路径本身不该存在：它在上下文构建期**无条件**发一次检索 HTTP，并把结果无条件塞进 system prompt。构建期拿不到"这轮回复到底需不需要记忆"的信息，所以这笔开销每轮都付，而且常常白付——检索往返 + prompt token 都是。

顺带，被门控降级的用户还损失了两样东西：工具 schema 里的 `time` 参数（同步路径压根不传，"上周说的那事"这类时间回溯查不了），以及模型自己构造检索词的能力（同步路径拿用户消息原文当 query）。

一个不对称值得记一笔：主程序 `main_logic/core/tool_calling.py` 注册 builtin `recall_memory` 时**从来没查过**这个门控，只看 `NEKO_DISABLE_BUILTIN_TOOLS`。也就是说桌宠对话在免费路由上一直是 tool 召回，从没降级过——这本身就是"免费代理支持 tools"的旁证。

### 改动前后

| | 改动前 | 改动后 |
|---|---|---|
| 免费路由 QQ 轮的召回通道 | 构建期同步召回 | `recall_memory` 工具 |
| 其他路由 QQ 轮 | `recall_memory` 工具 | 不变 |
| 构建期检索 HTTP | 免费路由每轮一次 | 任何路由都不发 |
| `time` 时间回溯 | 免费路由用不了 | 全部可用 |
| trace `context_memory_recall` | `tool_deferred` / `used` / `skipped` | `tool_deferred` / `skipped` |
| 工具挂载失败时 | 记 warning，本轮无召回 | 不变（仍无召回，且刻意不回补同步召回） |

`_arm_recall_tool` 挂载失败（client 没有 tooling surface、`set_tools` 抛异常）时本轮就是没有召回——这是刻意的，回补一次同步召回等于把每轮无条件检索从后门放回来。

### 潜在回归

- **隐私 / 授权域**：删掉的同步召回带着一整套 subject 解析与 opt-out 复检（读前、读后、member 域、fail-closed 无 group_id）。这些判据在 `execute_recall` 侧有完整对偶实现，且已有对应用例（`test_execute_recall_missing_group_id_fails_closed`、`test_participant_subject_gating_matches_write_side`、`test_handler_entry_gate_blocks_revoked_group_read`、`test_handler_postfetch_gate_drops_inflight_optout`、`test_recall_tool_participant_post_read_revocation_drops_result`、`test_recall_tool_admin_private_keeps_legacy_none`），subject resolver 另有直测。删掉的测试没有留下未覆盖的判据。
- **顺带修掉的一个真缺陷**：原来两个调用点输入源不同——`reply_context_node` 读当前配置，`_arm_recall_tool` 读缓存会话冻结的路由。当前配置判 True（跳过同步召回）而缓存会话判 False（拒绝挂工具）时，本轮召回彻底归零，只留一条 warning。门控没了，这个窗口一并消失。
- **模型行为**：免费路由用户的 QQ 轮从"记忆已在 prompt 里"变成"要记忆得自己调工具"。人格卡的 Memory Integrity 条目（`config/prompts/prompts_chara.py`）本来就写着"不记得就调 recall_memory"，此前在这些轮里是悬空的，现在指令与实际能力一致了。
- **遥测**：这批用户的 `context_memory_recall` trace 从 `used`/`skipped` 变成 `tool_deferred`，历史数据不可比。

### 验证

- `tests/unit/test_group_memory_recall_tool.py`、`test_group_memory_scopes.py`、`test_participant_memory_and_display_name.py`、`plugin/tests/unit/plugins/test_qq_pre_tool_text_contract.py`：447 passed, 2 skipped
- `tests/unit/test_tool_calling.py`、`test_tool_call_leak_filter.py`、`test_tool_call_thought_signature.py`、`plugin/tests/unit/plugins/test_qq_permission_nickname.py`：152 passed
- `scripts/check_docstring_no_cjk.py --base origin/main`：exit 0

两条新护栏都做了变异验证（改完确认回滚干净、`git diff` 为空）：

- `test_context_build_never_spends_a_retrieval`（三种路由参数化：免费代理 / tool-capable / 配置读不出来）——把一次 `query_relevant_memory` 加回构建期，三个 case 全红。
- `test_offline_client_grows_no_route_capability_gate`——把一个 route-shaped 谓词加回 `_genai_support` 并导出，红。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 记忆召回统一通过模型工具执行，支持所有模型线路。
  * 每轮检索使用固定预算，并持续进行权限与策略校验。

* **改进**
  * 关闭记忆上下文时不再挂载召回工具。
  * 未成功挂载工具时不再执行隐藏的同步回退召回，避免产生不一致结果。

* **测试**
  * 补充并更新工具召回、权限校验、超时预算及历史清理等场景覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->