### PR TITLE
fix(chat): prevent compact text selection from dragging window

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -8367,9 +8367,43 @@ describe('App', () => {
     expect(queryAvatarToolVisualOverlay()).not.toBeNull();
   });
 
-  it('dispatches compact surface drag prime and renderer drag events from the input body', () => {
+  it('keeps compact text input pointer drags reserved for text selection', () => {
     render(<App chatSurfaceMode="compact" compactChatState="input" />);
     const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: '第一行\n第二行\n第三行' } });
+    const dragEvents: Event[] = [];
+    const recordDragEvent = (event: Event) => dragEvents.push(event);
+    const eventNames = [
+      'neko:compact-surface-drag-prime',
+      'neko:compact-surface-drag-grab',
+      'neko:compact-surface-drag-move',
+      'neko:compact-surface-drag-end',
+      'neko:compact-surface-drag-prime-end',
+    ];
+    eventNames.forEach((eventName) => window.addEventListener(eventName, recordDragEvent));
+    try {
+      fireEvent.pointerDown(input, {
+        pointerId: 50, clientX: 120, clientY: 40, screenX: 420, screenY: 340,
+        button: 0, buttons: 1, pointerType: 'mouse',
+      });
+      fireEvent.pointerMove(document, {
+        pointerId: 50, clientX: 190, clientY: 62, screenX: 490, screenY: 362,
+        buttons: 1, pointerType: 'mouse',
+      });
+      fireEvent.pointerUp(document, {
+        pointerId: 50, clientX: 190, clientY: 62, screenX: 490, screenY: 362,
+        buttons: 0, pointerType: 'mouse',
+      });
+
+      expect(dragEvents).toHaveLength(0);
+    } finally {
+      eventNames.forEach((eventName) => window.removeEventListener(eventName, recordDragEvent));
+    }
+  });
+
+  it('dispatches compact surface drag prime and renderer drag events from the input frame', () => {
+    render(<App chatSurfaceMode="compact" compactChatState="input" />);
+    const inputFrame = document.body.querySelector('.compact-chat-surface-frame') as HTMLDivElement;
     const primes: Array<Record<string, number>> = [];
     const primeEnds: Array<Record<string, number>> = [];
     const grabs: Array<Record<string, number>> = [];
@@ -8386,7 +8420,7 @@ describe('App', () => {
     window.addEventListener('neko:compact-surface-drag-move', onMove);
     window.addEventListener('neko:compact-surface-drag-end', onEnd);
     try {
-      fireEvent.pointerDown(input, {
+      fireEvent.pointerDown(inputFrame, {
         pointerId: 51, clientX: 160, clientY: 46, screenX: 460, screenY: 340,
         button: 0, buttons: 1, pointerType: 'mouse',
       });
@@ -8451,7 +8485,7 @@ describe('App', () => {
 
   it('dispatches compact surface drag cleanup from document pointercancel', () => {
     render(<App chatSurfaceMode="compact" compactChatState="input" />);
-    const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
+    const inputFrame = document.body.querySelector('.compact-chat-surface-frame') as HTMLDivElement;
     const primeEnds: Array<Record<string, number>> = [];
     const ends: Array<Record<string, number | string>> = [];
     const onPrimeEnd = (event: Event) => primeEnds.push((event as CustomEvent).detail);
@@ -8459,7 +8493,7 @@ describe('App', () => {
     window.addEventListener('neko:compact-surface-drag-prime-end', onPrimeEnd);
     window.addEventListener('neko:compact-surface-drag-end', onEnd);
     try {
-      fireEvent.pointerDown(input, {
+      fireEvent.pointerDown(inputFrame, {
         pointerId: 61, clientX: 120, clientY: 40, screenX: 320, screenY: 240,
         button: 0, buttons: 1, pointerType: 'mouse',
       });
@@ -8489,7 +8523,7 @@ describe('App', () => {
 
   it('finishes a replaced compact surface drag before priming the next pointer', () => {
     render(<App chatSurfaceMode="compact" compactChatState="input" />);
-    const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
+    const inputFrame = document.body.querySelector('.compact-chat-surface-frame') as HTMLDivElement;
     const minimize = document.body.querySelector('.compact-chat-minimize-ball') as HTMLButtonElement;
     const primes: Array<Record<string, number>> = [];
     const primeEnds: Array<Record<string, number>> = [];
@@ -8514,7 +8548,7 @@ describe('App', () => {
     window.addEventListener('neko:compact-surface-drag-prime-end', onPrimeEnd);
     window.addEventListener('neko:compact-surface-drag-end', onEnd);
     try {
-      fireEvent.pointerDown(input, {
+      fireEvent.pointerDown(inputFrame, {
         pointerId: 71, clientX: 150, clientY: 50, screenX: 450, screenY: 340,
         button: 0, buttons: 1, pointerType: 'mouse',
       });

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -8367,10 +8367,15 @@ describe('App', () => {
     expect(queryAvatarToolVisualOverlay()).not.toBeNull();
   });
 
-  it('keeps compact text input pointer drags reserved for text selection', () => {
+  it('keeps compact editable pointer drags reserved for text selection', () => {
     render(<App chatSurfaceMode="compact" compactChatState="input" />);
-    const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
-    fireEvent.change(input, { target: { value: '第一行\n第二行\n第三行' } });
+    const textarea = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
+    const input = document.createElement('input');
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    const inputFrame = document.body.querySelector('.compact-chat-surface-frame') as HTMLDivElement;
+    inputFrame.append(input, editable);
+    fireEvent.change(textarea, { target: { value: '第一行\n第二行\n第三行' } });
     const dragEvents: Event[] = [];
     const recordDragEvent = (event: Event) => dragEvents.push(event);
     const eventNames = [
@@ -8382,17 +8387,20 @@ describe('App', () => {
     ];
     eventNames.forEach((eventName) => window.addEventListener(eventName, recordDragEvent));
     try {
-      fireEvent.pointerDown(input, {
-        pointerId: 50, clientX: 120, clientY: 40, screenX: 420, screenY: 340,
-        button: 0, buttons: 1, pointerType: 'mouse',
-      });
-      fireEvent.pointerMove(document, {
-        pointerId: 50, clientX: 190, clientY: 62, screenX: 490, screenY: 362,
-        buttons: 1, pointerType: 'mouse',
-      });
-      fireEvent.pointerUp(document, {
-        pointerId: 50, clientX: 190, clientY: 62, screenX: 490, screenY: 362,
-        buttons: 0, pointerType: 'mouse',
+      [textarea, input, editable].forEach((target, index) => {
+        const pointerId = 50 + index;
+        fireEvent.pointerDown(target, {
+          pointerId, clientX: 120, clientY: 40, screenX: 420, screenY: 340,
+          button: 0, buttons: 1, pointerType: 'mouse',
+        });
+        fireEvent.pointerMove(document, {
+          pointerId, clientX: 190, clientY: 62, screenX: 490, screenY: 362,
+          buttons: 1, pointerType: 'mouse',
+        });
+        fireEvent.pointerUp(document, {
+          pointerId, clientX: 190, clientY: 62, screenX: 490, screenY: 362,
+          buttons: 0, pointerType: 'mouse',
+        });
       });
 
       expect(dragEvents).toHaveLength(0);

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4032,11 +4032,12 @@ function CompactChatApp({
   }, [closeCompactInputToolFanFromUserClick]);
 
   // ── compact surface 控件「按住拖动对话框」手势 ────────────────────────────
-  // 在 toggle / fan 中心 / 毛球 / 胶囊 / textarea 按下后移动超阈值 → 把 surface
+  // 在 toggle / fan 中心 / 毛球 / 胶囊按下后移动超阈值 → 把 surface
   // 拖拽交给宿主（web: app-react-chat-window / Electron: preload-chat-react.js）经
   // neko:compact-surface-drag-grab 接管。
   // 点按（无移动）语义保持原样：toggle 展开/关闭，fan 原点收起，毛球折叠，胶囊进入 input，
-  // textarea 正常聚焦输入。
+  // textarea 正常聚焦输入。文本编辑控件中的指针移动始终留给光标与文本选择，
+  // 不能被父层冒泡的 pointer 事件重新解释为窗口拖拽。
   // 用独立的 compactToolOriginSuppressClickRef 抑制拖动后补发的 click——不能复用
   // compactInputToolWheelSuppressClickRef，因为关闭轮盘的 effect 会把它清掉（见下方 fan 关闭 effect）。
   const clearCompactToolOriginDocumentListeners = useCallback(() => {
@@ -4206,6 +4207,8 @@ function CompactChatApp({
 
   const beginCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
     if (event.pointerType === 'mouse' && event.button !== 0) return;
+    const eventTarget = event.target instanceof Element ? event.target : null;
+    if (eventTarget?.closest('textarea, input, [contenteditable]:not([contenteditable="false"])')) return;
     const existing = compactToolOriginDragRef.current;
     if (existing && existing.pointerId === event.pointerId) return;
     if (existing) {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4036,7 +4036,7 @@ function CompactChatApp({
   // 拖拽交给宿主（web: app-react-chat-window / Electron: preload-chat-react.js）经
   // neko:compact-surface-drag-grab 接管。
   // 点按（无移动）语义保持原样：toggle 展开/关闭，fan 原点收起，毛球折叠，胶囊进入 input，
-  // textarea 正常聚焦输入。文本编辑控件中的指针移动始终留给光标与文本选择，
+  // textarea、input 与 contenteditable 正常聚焦/选择。文本编辑控件中的指针移动始终留给光标与文本选择，
   // 不能被父层冒泡的 pointer 事件重新解释为窗口拖拽。
   // 用独立的 compactToolOriginSuppressClickRef 抑制拖动后补发的 click——不能复用
   // compactInputToolWheelSuppressClickRef，因为关闭轮盘的 effect 会把它清掉（见下方 fan 关闭 effect）。


### PR DESCRIPTION
## Summary
- prevent pointer drags that start in textarea, input, or editable controls from becoming compact window drags
- preserve compact surface dragging from the surrounding frame
- add a regression test for multiline text selection

## Verification
- `npm test -- --run src/App.test.tsx` (261 passed)
- `npm run typecheck`
- `bash build_frontend.sh`
- `uv run pytest tests/unit/test_react_chat_window_static.py -k "compact_input_geometry_preserves_drag_surface_native_region or compact_surface_drag_uses_declared_surface_and_no_drag_exclusions"`
- `node --test test/react-chat-compact-surface-drag-contract.test.js` (27 passed)
- manual Chromium drag-selection check confirmed no compact surface drag events

Closes #2783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复紧凑界面中操作文本输入框、原生输入框或可编辑区域时意外触发窗口拖拽的问题。
  - 文本编辑、光标移动和文本选择现在不会启动窗口拖动。
  - 保留输入区域外部的正常拖拽行为，并改善拖拽取消后的状态清理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->