### PR TITLE
fix(forge): 下调高稀有度掉率并加固本机券账本

### DIFF
--- a/main_logic/forge_credit_ledger.py
+++ b/main_logic/forge_credit_ledger.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 DAILY_CAP = 6
 TRIGGER_LIMITS = {"emotion_combo": None, "5rounds": 2, "idle": 2, "minigame": 1}
-RARITY_WEIGHTS = {"UR": 0, "SSR": 1, "SR": 7, "R": 22, "N": 70}
+RARITY_WEIGHTS = {"UR": 0, "SSR": 0.5, "SR": 3.5, "R": 26, "N": 70}
 _LOCK = threading.RLock()
 
 

--- a/main_logic/forge_credit_ledger.py
+++ b/main_logic/forge_credit_ledger.py
@@ -19,6 +19,8 @@ RARITY_WEIGHTS = {"UR": 0, "SSR": 0.5, "SR": 3.5, "R": 26, "N": 70}
 LEDGER_VERSION = 2
 _INTEGRITY_ALGORITHM = "hmac-sha256"
 _SIGNING_KEY_BYTES = 32
+_KEY_PENDING_PREFIX = b"\x00"
+_KEY_ESTABLISHED_PREFIX = b"\x01"
 _LOCK = threading.RLock()
 
 
@@ -58,7 +60,7 @@ def _empty() -> dict:
     return {"version": LEDGER_VERSION, "credits": []}
 
 
-def _read_or_create_signing_key() -> tuple[bytes, bool]:
+def _read_or_create_signing_key() -> tuple[bytes, bool, bool]:
     path = _signing_key_path()
     try:
         key = path.read_bytes()
@@ -67,19 +69,45 @@ def _read_or_create_signing_key() -> tuple[bytes, bool]:
         key = secrets.token_bytes(_SIGNING_KEY_BYTES)
         try:
             with path.open("xb") as handle:
-                handle.write(key)
+                handle.write(_KEY_PENDING_PREFIX + key)
             try:
                 path.chmod(0o600)
             except OSError:
                 pass
-            return key, True
+            return key, True, False
         except FileExistsError:
             key = path.read_bytes()
     except OSError as exc:
         raise LedgerIntegrityError("ledger_signing_key_unavailable") from exc
-    if len(key) != _SIGNING_KEY_BYTES:
+    if len(key) == _SIGNING_KEY_BYTES:
+        # Compatibility with the original v2 key format. Any such key already
+        # authenticated a successfully persisted ledger.
+        return key, False, True
+    if len(key) != _SIGNING_KEY_BYTES + 1 or key[:1] not in {
+        _KEY_PENDING_PREFIX,
+        _KEY_ESTABLISHED_PREFIX,
+    }:
         raise LedgerIntegrityError("ledger_signing_key_invalid")
-    return key, False
+    return key[1:], False, key[:1] == _KEY_ESTABLISHED_PREFIX
+
+
+def _mark_signing_key_established(key: bytes) -> None:
+    path = _signing_key_path()
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    try:
+        tmp.write_bytes(_KEY_ESTABLISHED_PREFIX + key)
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        tmp.replace(path)
+    except OSError as exc:
+        raise LedgerIntegrityError("ledger_signing_key_unavailable") from exc
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def _canonical_ledger(data: dict) -> bytes:
@@ -146,12 +174,14 @@ def _load() -> dict:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         if _signing_key_path().exists():
-            raise LedgerIntegrityError("ledger_missing")
+            _key, _created, established = _read_or_create_signing_key()
+            if established:
+                raise LedgerIntegrityError("ledger_missing")
         return _empty()
     except (OSError, ValueError, TypeError) as exc:
         raise LedgerIntegrityError("ledger_unreadable") from exc
 
-    key, key_created = _read_or_create_signing_key()
+    key, key_created, key_established = _read_or_create_signing_key()
     version = data.get("version") if isinstance(data, dict) else None
     if version == 1 and key_created:
         # One-time upgrade path. Once the key exists, an unsigned/version-1
@@ -170,6 +200,8 @@ def _load() -> dict:
     if not isinstance(digest, str) or not hmac.compare_digest(digest, expected):
         raise LedgerIntegrityError("ledger_integrity_failed")
     _validate_ledger(data)
+    if not key_established:
+        _mark_signing_key_established(key)
     return data
 
 
@@ -191,6 +223,7 @@ def _save(data: dict, *, signing_key: bytes | None = None) -> None:
         except OSError:
             pass
         tmp.replace(path)
+        _mark_signing_key_established(key)
     finally:
         try:
             tmp.unlink(missing_ok=True)

--- a/main_logic/forge_credit_ledger.py
+++ b/main_logic/forge_credit_ledger.py
@@ -356,8 +356,8 @@ def reserve_credit(
     current = now or _now()
     owner_id = _require_owner_id(reservation_owner_id)
     try:
-        uuid.UUID(credit_id)
-        uuid.UUID(operation_id)
+        credit_id = str(uuid.UUID(credit_id))
+        operation_id = str(uuid.UUID(operation_id))
     except ValueError as exc:
         raise ValueError("invalid_credit_or_operation_id") from exc
     with _LOCK:
@@ -402,7 +402,9 @@ def commit_credit(
     current = now or _now()
     owner_id = _require_owner_id(reservation_owner_id)
     try:
-        uuid.UUID(card_id)
+        credit_id = str(uuid.UUID(credit_id))
+        operation_id = str(uuid.UUID(operation_id))
+        card_id = str(uuid.UUID(card_id))
     except ValueError as exc:
         raise ValueError("invalid_card_id") from exc
     with _LOCK:
@@ -433,6 +435,11 @@ def release_credit(
 ) -> dict:
     current = now or _now()
     owner_id = _require_owner_id(reservation_owner_id)
+    try:
+        credit_id = str(uuid.UUID(credit_id))
+        operation_id = str(uuid.UUID(operation_id))
+    except ValueError as exc:
+        raise ValueError("invalid_credit_or_operation_id") from exc
     with _LOCK:
         data = _load()
         if _expire(data, current):

--- a/main_logic/forge_credit_ledger.py
+++ b/main_logic/forge_credit_ledger.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import hashlib
+import hmac
 import os
 import random
 import secrets
@@ -14,7 +16,14 @@ from pathlib import Path
 DAILY_CAP = 6
 TRIGGER_LIMITS = {"emotion_combo": None, "5rounds": 2, "idle": 2, "minigame": 1}
 RARITY_WEIGHTS = {"UR": 0, "SSR": 0.5, "SR": 3.5, "R": 26, "N": 70}
+LEDGER_VERSION = 2
+_INTEGRITY_ALGORITHM = "hmac-sha256"
+_SIGNING_KEY_BYTES = 32
 _LOCK = threading.RLock()
+
+
+class LedgerIntegrityError(RuntimeError):
+    """The persisted credit ledger cannot be authenticated safely."""
 
 
 def _ledger_path() -> Path:
@@ -24,6 +33,10 @@ def _ledger_path() -> Path:
     from utils.config_manager import get_config_manager
 
     return Path(get_config_manager().memory_dir).parent / "forge_credits.json"
+
+
+def _signing_key_path() -> Path:
+    return _ledger_path().with_name("forge_credits.key")
 
 
 def _now() -> datetime:
@@ -42,23 +55,134 @@ def _parse(value: object) -> datetime | None:
 
 
 def _empty() -> dict:
-    return {"version": 1, "credits": []}
+    return {"version": LEDGER_VERSION, "credits": []}
+
+
+def _read_or_create_signing_key() -> tuple[bytes, bool]:
+    path = _signing_key_path()
+    try:
+        key = path.read_bytes()
+    except FileNotFoundError:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        key = secrets.token_bytes(_SIGNING_KEY_BYTES)
+        try:
+            with path.open("xb") as handle:
+                handle.write(key)
+            try:
+                path.chmod(0o600)
+            except OSError:
+                pass
+            return key, True
+        except FileExistsError:
+            key = path.read_bytes()
+    except OSError as exc:
+        raise LedgerIntegrityError("ledger_signing_key_unavailable") from exc
+    if len(key) != _SIGNING_KEY_BYTES:
+        raise LedgerIntegrityError("ledger_signing_key_invalid")
+    return key, False
+
+
+def _canonical_ledger(data: dict) -> bytes:
+    payload = {
+        "credits": data.get("credits"),
+        "version": LEDGER_VERSION,
+    }
+    return json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _ledger_mac(data: dict, key: bytes) -> str:
+    return hmac.new(key, _canonical_ledger(data), hashlib.sha256).hexdigest()
+
+
+def _valid_uuid(value: object) -> bool:
+    try:
+        return str(uuid.UUID(str(value))) == str(value).strip().lower()
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _validate_ledger(data: dict) -> None:
+    if not isinstance(data, dict) or not isinstance(data.get("credits"), list):
+        raise LedgerIntegrityError("ledger_schema_invalid")
+    seen_ids: set[str] = set()
+    seen_idem_keys: set[str] = set()
+    for credit in data["credits"]:
+        if not isinstance(credit, dict):
+            raise LedgerIntegrityError("ledger_credit_schema_invalid")
+        credit_id = credit.get("id")
+        idem_key = credit.get("idem_key")
+        if not _valid_uuid(credit_id) or credit_id in seen_ids:
+            raise LedgerIntegrityError("ledger_credit_id_invalid")
+        if not isinstance(idem_key, str) or not 8 <= len(idem_key) <= 128:
+            raise LedgerIntegrityError("ledger_credit_idem_invalid")
+        if idem_key in seen_idem_keys:
+            raise LedgerIntegrityError("ledger_credit_idem_duplicate")
+        if credit.get("rarity") not in RARITY_WEIGHTS:
+            raise LedgerIntegrityError("ledger_credit_rarity_invalid")
+        if credit.get("trigger_type") not in TRIGGER_LIMITS:
+            raise LedgerIntegrityError("ledger_credit_trigger_invalid")
+        if credit.get("status") not in {"active", "reserved", "consumed", "expired"}:
+            raise LedgerIntegrityError("ledger_credit_status_invalid")
+        if _parse(credit.get("created_at")) is None or _parse(credit.get("expires_at")) is None:
+            raise LedgerIntegrityError("ledger_credit_timestamp_invalid")
+        for field in ("operation_id", "reservation_owner_id", "card_id"):
+            if field in credit and not _valid_uuid(credit.get(field)):
+                raise LedgerIntegrityError(f"ledger_credit_{field}_invalid")
+        for field in ("reserved_at", "consumed_at", "expired_at"):
+            if field in credit and _parse(credit.get(field)) is None:
+                raise LedgerIntegrityError(f"ledger_credit_{field}_invalid")
+        seen_ids.add(credit_id)
+        seen_idem_keys.add(idem_key)
 
 
 def _load() -> dict:
     path = _ledger_path()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, TypeError):
+    except FileNotFoundError:
+        if _signing_key_path().exists():
+            raise LedgerIntegrityError("ledger_missing")
         return _empty()
-    if not isinstance(data, dict) or not isinstance(data.get("credits"), list):
-        return _empty()
+    except (OSError, ValueError, TypeError) as exc:
+        raise LedgerIntegrityError("ledger_unreadable") from exc
+
+    key, key_created = _read_or_create_signing_key()
+    version = data.get("version") if isinstance(data, dict) else None
+    if version == 1 and key_created:
+        # One-time upgrade path. Once the key exists, an unsigned/version-1
+        # ledger is a downgrade attempt and must fail closed.
+        migrated = {"version": LEDGER_VERSION, "credits": data.get("credits")}
+        _validate_ledger(migrated)
+        _save(migrated, signing_key=key)
+        return migrated
+    if version != LEDGER_VERSION:
+        raise LedgerIntegrityError("ledger_version_invalid")
+    supplied = data.get("integrity")
+    if not isinstance(supplied, dict) or supplied.get("algorithm") != _INTEGRITY_ALGORITHM:
+        raise LedgerIntegrityError("ledger_integrity_missing")
+    digest = supplied.get("digest")
+    expected = _ledger_mac(data, key)
+    if not isinstance(digest, str) or not hmac.compare_digest(digest, expected):
+        raise LedgerIntegrityError("ledger_integrity_failed")
+    _validate_ledger(data)
     return data
 
 
-def _save(data: dict) -> None:
+def _save(data: dict, *, signing_key: bytes | None = None) -> None:
     path = _ledger_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    data["version"] = LEDGER_VERSION
+    _validate_ledger(data)
+    key = signing_key or _read_or_create_signing_key()[0]
+    data["integrity"] = {
+        "algorithm": _INTEGRITY_ALGORITHM,
+        "digest": _ledger_mac(data, key),
+    }
     tmp = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
     try:
         tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/main_logic/forge_credit_ledger.py
+++ b/main_logic/forge_credit_ledger.py
@@ -134,6 +134,28 @@ def _valid_uuid(value: object) -> bool:
         return False
 
 
+def _normalize_legacy_credit(credit: object) -> object:
+    if not isinstance(credit, dict):
+        return credit
+    normalized = dict(credit)
+    for field in (
+        "id",
+        "operation_id",
+        "reservation_owner_id",
+        "card_id",
+        "last_released_operation_id",
+        "last_released_owner_id",
+    ):
+        if field not in normalized:
+            continue
+        try:
+            normalized[field] = str(uuid.UUID(str(normalized[field]).strip()))
+        except (ValueError, AttributeError, TypeError):
+            # Preserve invalid legacy values so schema validation still fails closed.
+            pass
+    return normalized
+
+
 def _validate_ledger(data: dict) -> None:
     if not isinstance(data, dict) or not isinstance(data.get("credits"), list):
         raise LedgerIntegrityError("ledger_schema_invalid")
@@ -183,10 +205,20 @@ def _load() -> dict:
 
     key, key_created, key_established = _read_or_create_signing_key()
     version = data.get("version") if isinstance(data, dict) else None
-    if version == 1 and key_created:
+    if version == 1 and (key_created or not key_established):
         # One-time upgrade path. Once the key exists, an unsigned/version-1
-        # ledger is a downgrade attempt and must fail closed.
-        migrated = {"version": LEDGER_VERSION, "credits": data.get("credits")}
+        # ledger is a downgrade attempt and must fail closed. A pending key is
+        # also accepted here because it means the first migration was interrupted
+        # before the signed ledger and established-key marker were both durable.
+        legacy_credits = data.get("credits")
+        migrated = {
+            "version": LEDGER_VERSION,
+            "credits": (
+                [_normalize_legacy_credit(credit) for credit in legacy_credits]
+                if isinstance(legacy_credits, list)
+                else legacy_credits
+            ),
+        }
         _validate_ledger(migrated)
         _save(migrated, signing_key=key)
         return migrated

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -483,9 +483,17 @@ def _require_forge_grant_secret(request: Request) -> None:
     """Authenticate the private Electron dropper before mutating the ledger."""
     expected = str(os.environ.get(_FORGE_GRANT_SECRET_ENV) or "").strip()
     supplied = (request.headers.get("x-neko-forge-grant-secret") or "").strip()
-    if len(expected) < 32:
+    try:
+        expected_bytes = expected.encode("ascii")
+    except UnicodeEncodeError:
+        expected_bytes = b""
+    if len(expected_bytes) < 32:
         raise HTTPException(status_code=503, detail="forge_grant_secret_unavailable")
-    if not supplied or not secrets.compare_digest(supplied, expected):
+    try:
+        supplied_bytes = supplied.encode("ascii")
+    except UnicodeEncodeError:
+        supplied_bytes = b""
+    if not supplied_bytes or not secrets.compare_digest(supplied_bytes, expected_bytes):
         raise HTTPException(status_code=403, detail="invalid_forge_grant_secret")
 
 

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import hmac
 import html
 import json
 import logging
@@ -280,6 +281,7 @@ async def _confirm_cloud_forge_debit(
     operation_id: str,
     credit_id: str,
     card_id: str,
+    credit: dict,
 ) -> dict:
     """Tell the cloud about a debit only after the local ledger has committed it."""
     credentials = await asyncio.to_thread(_get_client_credentials)
@@ -290,15 +292,13 @@ async def _confirm_cloud_forge_debit(
     try:
         parsed_base_url = urlparse(base_url)
         base_hostname = parsed_base_url.hostname
-        if parsed_base_url.scheme == "https" and base_hostname:
-            send_client_proof = True
-        elif (
+        valid_https = parsed_base_url.scheme == "https" and bool(base_hostname)
+        valid_loopback_http = (
             parsed_base_url.scheme == "http"
             and base_hostname
             and base_hostname.lower() in _LOOPBACK_HOSTS
-        ):
-            send_client_proof = False
-        else:
+        )
+        if not (valid_https or valid_loopback_http):
             return {"confirmed": False, "detail": "invalid_cloud_base_url"}
     except ValueError:
         return {"confirmed": False, "detail": "invalid_cloud_base_url"}
@@ -308,11 +308,18 @@ async def _confirm_cloud_forge_debit(
     )
     request_payload = {
         "client_id": client_id,
+        "client_proof": client_proof,
         "credit_id": credit_id,
         "card_id": card_id,
+        "voucher": _forge_voucher_attestation(
+            client_id=client_id,
+            client_proof=client_proof,
+            operation_id=operation_id,
+            credit_id=credit_id,
+            card_id=card_id,
+            credit=credit,
+        ),
     }
-    if send_client_proof:
-        request_payload["client_proof"] = client_proof
 
     async def _post() -> tuple[httpx.Response | None, dict | None]:
         try:
@@ -331,9 +338,8 @@ async def _confirm_cloud_forge_debit(
 
     # A rejection naming an unknown client is usually this install's first cloud
     # call after the cloud lost (or never had) the row. Register, then retry once.
-    # Not gated on send_client_proof: loopback HTTP omits the proof from this
-    # request, yet ensure_client_registered() may still register over it, so
-    # gating here would leave loopback debits unconfirmed until a restart.
+    # The voucher signature requires the binding proof even on loopback. HTTPS
+    # remains mandatory for every non-loopback cloud endpoint.
     detail = payload.get("detail") if isinstance(payload, dict) else None
     if client_registration.looks_unregistered(response.status_code, detail):
         if await client_registration.ensure_client_registered(base_url, force=True):
@@ -355,6 +361,53 @@ async def _confirm_cloud_forge_debit(
         and bool(payload.get("confirmed_at"))
     )
     return {"confirmed": confirmed}
+
+
+_FORGE_VOUCHER_KEY_CONTEXT = b"N.E.K.O forge voucher attestation v1"
+
+
+def _forge_voucher_timestamp(value: object) -> str:
+    from datetime import UTC, datetime
+
+    if not isinstance(value, str):
+        raise ValueError("invalid_forge_voucher_timestamp")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("invalid_forge_voucher_timestamp")
+    return parsed.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _forge_voucher_attestation(
+    *,
+    client_id: str,
+    client_proof: str,
+    operation_id: str,
+    credit_id: str,
+    card_id: str,
+    credit: dict,
+) -> dict:
+    voucher = {
+        "version": 1,
+        "operation_id": operation_id,
+        "credit_id": credit_id,
+        "card_id": card_id,
+        "rarity": str(credit.get("rarity") or ""),
+        "created_at": _forge_voucher_timestamp(credit.get("created_at")),
+        "expires_at": _forge_voucher_timestamp(credit.get("expires_at")),
+        "reserved_at": _forge_voucher_timestamp(credit.get("reserved_at")),
+        "consumed_at": _forge_voucher_timestamp(credit.get("consumed_at")),
+    }
+    document = {**voucher, "client_id": client_id}
+    message = json.dumps(
+        document, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    signing_key = hmac.new(
+        client_proof.encode("utf-8"),
+        _FORGE_VOUCHER_KEY_CONTEXT,
+        hashlib.sha256,
+    ).digest()
+    voucher["signature"] = hmac.new(signing_key, message, hashlib.sha256).hexdigest()
+    return voucher
 
 
 def _origin_port(parsed) -> int | None:
@@ -2166,6 +2219,7 @@ async def commit_credit_endpoint(
         operation_id=operation_id,
         credit_id=credit_id,
         card_id=str(payload.get("card_id") or ""),
+        credit=result["credit"],
     )
     return JSONResponse(
         {

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -2223,11 +2223,12 @@ async def commit_credit_endpoint(
     except (ValueError, LookupError, RuntimeError) as exc:
         error = _credit_error(exc)
         return JSONResponse({"detail": error.detail}, status_code=error.status_code, headers=cors)
+    committed_credit = result["credit"]
     confirmation = await _confirm_cloud_forge_debit(
-        operation_id=operation_id,
-        credit_id=credit_id,
-        card_id=str(payload.get("card_id") or ""),
-        credit=result["credit"],
+        operation_id=committed_credit["operation_id"],
+        credit_id=committed_credit["id"],
+        card_id=committed_credit["card_id"],
+        credit=committed_credit,
     )
     return JSONResponse(
         {

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -58,6 +58,7 @@ _FACT_QUERY_MAX_EXCLUSIONS = 200
 _FACT_QUERY_MAX_EXCLUSION_LENGTH = 128
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 _SUPPORTED_AUTH_SOURCES = frozenset({"legacy", "oauth"})
+_FORGE_GRANT_SECRET_ENV = "NEKO_FORGE_GRANT_SECRET"
 _native_sync_tickets: dict[str, float] = {}
 # digest -> {expires_at, scopes, local_user_id, audience, session_fingerprint}
 _native_delegates: dict[str, dict] = {}
@@ -423,6 +424,16 @@ def _local_mutation_origin_allowed(request: Request) -> bool:
         and request_host in _LOOPBACK_HOSTS
         and _same_originish(origin, request_base)
     )
+
+
+def _require_forge_grant_secret(request: Request) -> None:
+    """Authenticate the private Electron dropper before mutating the ledger."""
+    expected = str(os.environ.get(_FORGE_GRANT_SECRET_ENV) or "").strip()
+    supplied = (request.headers.get("x-neko-forge-grant-secret") or "").strip()
+    if len(expected) < 32:
+        raise HTTPException(status_code=503, detail="forge_grant_secret_unavailable")
+    if not supplied or not secrets.compare_digest(supplied, expected):
+        raise HTTPException(status_code=403, detail="invalid_forge_grant_secret")
 
 
 def _require_local_mutation_ticket(request: Request, payload: dict | None) -> None:
@@ -2061,6 +2072,7 @@ async def credit_options(request: Request, credit_id: str = "", operation_id: st
 async def grant_credit_endpoint(request: Request, payload: dict = Body(...)):
     if not _local_mutation_origin_allowed(request):
         raise HTTPException(status_code=403, detail="origin_not_allowed")
+    _require_forge_grant_secret(request)
     from main_logic.forge_credit_ledger import grant_credit
 
     try:

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -34,10 +34,17 @@ def test_same_originish_rejects_malformed_ports(malformed_origin):
     assert C._same_originish(malformed_origin, "http://localhost:48911") is False
 
 
-def _main_server_request(*, method: str = "POST", origin: str = "") -> Request:
+def _main_server_request(
+    *,
+    method: str = "POST",
+    origin: str = "",
+    extra_headers: dict[str, str] | None = None,
+) -> Request:
     headers = [(b"host", b"127.0.0.1:48911")]
     if origin:
         headers.append((b"origin", origin.encode("ascii")))
+    for name, value in (extra_headers or {}).items():
+        headers.append((name.lower().encode("ascii"), value.encode("ascii")))
     return Request(
         {
             "type": "http",
@@ -53,6 +60,25 @@ def _main_server_request(*, method: str = "POST", origin: str = "") -> Request:
             "headers": headers,
         }
     )
+
+
+def test_forge_grant_requires_the_electron_runtime_secret(monkeypatch):
+    request = _main_server_request()
+    monkeypatch.delenv("NEKO_FORGE_GRANT_SECRET", raising=False)
+    with pytest.raises(C.HTTPException) as unavailable:
+        C._require_forge_grant_secret(request)
+    assert unavailable.value.status_code == 503
+
+    secret = "a" * 64
+    monkeypatch.setenv("NEKO_FORGE_GRANT_SECRET", secret)
+    with pytest.raises(C.HTTPException) as rejected:
+        C._require_forge_grant_secret(request)
+    assert rejected.value.status_code == 403
+
+    authorized = _main_server_request(
+        extra_headers={"x-neko-forge-grant-secret": secret},
+    )
+    C._require_forge_grant_secret(authorized)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1311,18 +1311,18 @@ def test_refreshed_desktop_bearer_keeps_same_owner_reservation(
     )
     committed = client.post(
         (
-            f"/api/card-drop/credits/{credit_id}/reservations/"
-            f"{operation_id}/commit"
+            f"/api/card-drop/credits/{credit_id.upper()}/reservations/"
+            f"{operation_id.replace('-', '').upper()}/commit"
         ),
-        json={"card_id": card_id},
+        json={"card_id": card_id.replace("-", "").upper()},
         headers=bearer_headers("browser-token-after-refresh"),
     )
     commit_replay = client.post(
         (
-            f"/api/card-drop/credits/{credit_id}/reservations/"
-            f"{operation_id}/commit"
+            f"/api/card-drop/credits/{credit_id.upper()}/reservations/"
+            f"{operation_id.replace('-', '').upper()}/commit"
         ),
-        json={"card_id": card_id},
+        json={"card_id": card_id.replace("-", "").upper()},
         headers=bearer_headers("browser-token-after-refresh"),
     )
 

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -34,6 +34,21 @@ def _voucher_credit(**over):
     return credit
 
 
+def _fixed_expected_voucher():
+    return {
+        "version": 1,
+        "operation_id": "operation-id",
+        "credit_id": "credit-id",
+        "card_id": "card-id",
+        "rarity": "R",
+        "created_at": "2026-08-09T00:00:00.000000Z",
+        "expires_at": "2026-08-10T00:00:00.000000Z",
+        "reserved_at": "2026-08-09T01:00:00.000000Z",
+        "consumed_at": "2026-08-09T01:01:00.000000Z",
+        "signature": "5e95eb9dfe25de5ad5ee661e7e47817f1ce4f4a91103572dcc574961c6ec98ab",
+    }
+
+
 @pytest.mark.parametrize(
     "malformed_origin",
     [
@@ -56,7 +71,7 @@ def _main_server_request(
     if origin:
         headers.append((b"origin", origin.encode("ascii")))
     for name, value in (extra_headers or {}).items():
-        headers.append((name.lower().encode("ascii"), value.encode("ascii")))
+        headers.append((name.lower().encode("ascii"), value.encode("latin-1")))
     return Request(
         {
             "type": "http",
@@ -81,16 +96,65 @@ def test_forge_grant_requires_the_electron_runtime_secret(monkeypatch):
         C._require_forge_grant_secret(request)
     assert unavailable.value.status_code == 503
 
+    monkeypatch.setenv("NEKO_FORGE_GRANT_SECRET", "é" * 32)
+    with pytest.raises(C.HTTPException) as non_ascii_config:
+        C._require_forge_grant_secret(request)
+    assert non_ascii_config.value.status_code == 503
+
     secret = "a" * 64
     monkeypatch.setenv("NEKO_FORGE_GRANT_SECRET", secret)
     with pytest.raises(C.HTTPException) as rejected:
         C._require_forge_grant_secret(request)
     assert rejected.value.status_code == 403
 
+    non_ascii_header = _main_server_request(
+        extra_headers={"x-neko-forge-grant-secret": "é" * 32},
+    )
+    with pytest.raises(C.HTTPException) as non_ascii_supplied:
+        C._require_forge_grant_secret(non_ascii_header)
+    assert non_ascii_supplied.value.status_code == 403
+
     authorized = _main_server_request(
         extra_headers={"x-neko-forge-grant-secret": secret},
     )
     C._require_forge_grant_secret(authorized)
+
+
+def test_forge_grant_endpoint_authenticates_before_ledger_mutation(
+    client, monkeypatch
+):
+    from main_logic import forge_credit_ledger
+
+    calls = []
+
+    def fake_grant(payload):
+        calls.append(payload)
+        return {"granted": True, "reason": "ok"}
+
+    monkeypatch.setattr(forge_credit_ledger, "grant_credit", fake_grant)
+    monkeypatch.delenv("NEKO_FORGE_GRANT_SECRET", raising=False)
+    payload = {"trigger_type": "emotion_combo", "idem_key": "endpoint-auth"}
+    endpoint = "/api/card-drop/credits/grant"
+
+    missing = client.post(endpoint, json=payload)
+    secret = "a" * 64
+    monkeypatch.setenv("NEKO_FORGE_GRANT_SECRET", secret)
+    incorrect = client.post(
+        endpoint,
+        json=payload,
+        headers={"x-neko-forge-grant-secret": "b" * 64},
+    )
+    accepted = client.post(
+        endpoint,
+        json=payload,
+        headers={"x-neko-forge-grant-secret": secret},
+    )
+
+    assert missing.status_code == 503
+    assert incorrect.status_code == 403
+    assert calls == [payload]
+    assert accepted.status_code == 200
+    assert accepted.json() == {"granted": True, "reason": "ok"}
 
 
 @pytest.mark.asyncio
@@ -392,14 +456,7 @@ async def test_confirm_cloud_forge_debit_includes_signed_voucher_for_local_http(
         "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
-        "voucher": C._forge_voucher_attestation(
-            client_id="client-id",
-            client_proof="client-proof",
-            operation_id="operation-id",
-            credit_id="credit-id",
-            card_id="card-id",
-            credit=_voucher_credit(),
-        ),
+        "voucher": _fixed_expected_voucher(),
     }
 
 
@@ -466,14 +523,7 @@ async def test_confirm_cloud_forge_debit_retries_for_loopback_unregistered(monke
         "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
-        "voucher": C._forge_voucher_attestation(
-            client_id="client-id",
-            client_proof="client-proof",
-            operation_id="operation-id",
-            credit_id="credit-id",
-            card_id="card-id",
-            credit=_voucher_credit(),
-        ),
+        "voucher": _fixed_expected_voucher(),
     }
     assert call_log[1][1] == ("http://localhost:48911",)
     assert call_log[1][2] == {"force": True}

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -22,6 +22,18 @@ USER_A_ID = "11111111-1111-4111-8111-111111111111"
 USER_B_ID = "22222222-2222-4222-8222-222222222222"
 
 
+def _voucher_credit(**over):
+    credit = {
+        "rarity": "R",
+        "created_at": "2026-08-09T00:00:00Z",
+        "expires_at": "2026-08-10T00:00:00Z",
+        "reserved_at": "2026-08-09T01:00:00Z",
+        "consumed_at": "2026-08-09T01:01:00Z",
+    }
+    credit.update(over)
+    return credit
+
+
 @pytest.mark.parametrize(
     "malformed_origin",
     [
@@ -304,6 +316,7 @@ async def test_confirm_cloud_forge_debit_rejects_redirect_response(monkeypatch):
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": False, "detail": "http_302"}
@@ -333,13 +346,14 @@ async def test_confirm_cloud_forge_debit_rejects_unsafe_cloud_base_url(
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": False, "detail": "invalid_cloud_base_url"}
 
 
 @pytest.mark.asyncio
-async def test_confirm_cloud_forge_debit_omits_proof_for_local_http(monkeypatch):
+async def test_confirm_cloud_forge_debit_includes_signed_voucher_for_local_http(monkeypatch):
     monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://localhost:48911")
     monkeypatch.setattr(
         C,
@@ -369,13 +383,23 @@ async def test_confirm_cloud_forge_debit_omits_proof_for_local_http(monkeypatch)
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": False, "detail": "http_204"}
     assert captured["json"] == {
         "client_id": "client-id",
+        "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
+        "voucher": C._forge_voucher_attestation(
+            client_id="client-id",
+            client_proof="client-proof",
+            operation_id="operation-id",
+            credit_id="credit-id",
+            card_id="card-id",
+            credit=_voucher_credit(),
+        ),
     }
 
 
@@ -429,6 +453,7 @@ async def test_confirm_cloud_forge_debit_retries_for_loopback_unregistered(monke
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": True}
@@ -438,8 +463,17 @@ async def test_confirm_cloud_forge_debit_retries_for_loopback_unregistered(monke
     assert call_log[2][0] == "post"
     assert call_log[0][2] == {
         "client_id": "client-id",
+        "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
+        "voucher": C._forge_voucher_attestation(
+            client_id="client-id",
+            client_proof="client-proof",
+            operation_id="operation-id",
+            credit_id="credit-id",
+            card_id="card-id",
+            credit=_voucher_credit(),
+        ),
     }
     assert call_log[1][1] == ("http://localhost:48911",)
     assert call_log[1][2] == {"force": True}
@@ -1254,11 +1288,13 @@ def test_refreshed_desktop_bearer_keeps_same_owner_reservation(
             "operation_id": operation_id,
             "credit_id": credit_id,
             "card_id": card_id,
+            "credit": committed.json()["credit"],
         },
         {
             "operation_id": operation_id,
             "credit_id": credit_id,
             "card_id": card_id,
+            "credit": commit_replay.json()["credit"],
         },
     ]
 

--- a/tests/unit/test_forge_credit_ledger.py
+++ b/tests/unit/test_forge_credit_ledger.py
@@ -15,6 +15,20 @@ def isolated_ledger(tmp_path, monkeypatch):
     monkeypatch.setenv("NEKO_USER_DATA_DIR", str(tmp_path))
 
 
+def test_high_rarity_drop_weight_is_four_percent() -> None:
+    assert sum(ledger.RARITY_WEIGHTS.values()) == 100
+    assert sum(
+        ledger.RARITY_WEIGHTS[rarity] for rarity in ("SR", "SSR", "UR")
+    ) == 4
+    assert ledger.RARITY_WEIGHTS == {
+        "UR": 0,
+        "SSR": 0.5,
+        "SR": 3.5,
+        "R": 26,
+        "N": 70,
+    }
+
+
 def test_grant_is_installation_local_and_idempotent() -> None:
     now = datetime(2026, 7, 13, 8, tzinfo=UTC)
     payload = {"trigger_type": "emotion_combo", "idem_key": "drop-idem-1"}

--- a/tests/unit/test_forge_credit_ledger.py
+++ b/tests/unit/test_forge_credit_ledger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -96,7 +97,8 @@ def test_unsigned_legacy_ledger_is_migrated_only_before_signing_key_exists() -> 
     migrated = json.loads(path.read_text(encoding="utf-8"))
     assert migrated["version"] == ledger.LEDGER_VERSION
     assert migrated["integrity"]["algorithm"] == "hmac-sha256"
-    assert ledger._signing_key_path().stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert ledger._signing_key_path().stat().st_mode & 0o777 == 0o600
 
     migrated.pop("integrity")
     migrated["version"] = 1
@@ -160,6 +162,36 @@ def test_reserve_commit_and_replay_are_idempotent() -> None:
         OWNER_A_ID,
         now=now,
     )["committed"]
+
+
+def test_operation_uuid_inputs_are_canonicalized_before_signing() -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    ledger.grant_credit(
+        {"trigger_type": "emotion_combo", "idem_key": "uuid-normalization"},
+        now=now,
+        rarity="R",
+    )
+    credit_id = ledger.list_credits(now)["credits"][0]["id"]
+    operation_id = "33333333-3333-4333-8333-333333333333"
+    card_id = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"
+
+    reserved = ledger.reserve_credit(
+        credit_id.replace("-", ""),
+        operation_id.replace("-", ""),
+        OWNER_A_ID.replace("-", ""),
+        now=now,
+    )
+    committed = ledger.commit_credit(
+        credit_id.upper(),
+        operation_id.upper(),
+        card_id.replace("-", ""),
+        OWNER_A_ID,
+        now=now,
+    )
+
+    assert reserved["operation_id"] == operation_id
+    assert reserved["credit"]["operation_id"] == operation_id
+    assert committed["credit"]["card_id"] == card_id.lower()
     assert ledger.commit_credit(
         credit_id,
         operation_id,

--- a/tests/unit/test_forge_credit_ledger.py
+++ b/tests/unit/test_forge_credit_ledger.py
@@ -80,20 +80,26 @@ def test_unsigned_legacy_ledger_is_migrated_only_before_signing_key_exists() -> 
         "version": 1,
         "credits": [
             {
-                "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                "id": "AAAAAAAAAAAA4AAA8AAAAAAAAAAAAAAA",
                 "rarity": "R",
                 "trigger_type": "emotion_combo",
                 "idem_key": "legacy-credit-idem",
-                "status": "active",
+                "status": "reserved",
                 "created_at": ledger._iso(now),
                 "expires_at": ledger._iso(now + timedelta(hours=16)),
+                "operation_id": "BBBBBBBBBBBB4BBB8BBBBBBBBBBBBBBB",
+                "reservation_owner_id": OWNER_A_ID.replace("-", "").upper(),
+                "reserved_at": ledger._iso(now),
             }
         ],
     }
     path = ledger._ledger_path()
     path.write_text(json.dumps(legacy), encoding="utf-8")
 
-    assert ledger.list_credits(now)["count"] == 1
+    snapshot = ledger.list_credits(now, reservation_owner_id=OWNER_A_ID)
+    assert snapshot["count"] == 0
+    assert snapshot["reservations"][0]["id"] == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    assert snapshot["reservations"][0]["operation_id"] == "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
     migrated = json.loads(path.read_text(encoding="utf-8"))
     assert migrated["version"] == ledger.LEDGER_VERSION
     assert migrated["integrity"]["algorithm"] == "hmac-sha256"
@@ -168,7 +174,37 @@ def test_pending_key_without_ledger_retries_initial_save() -> None:
     )
 
     assert result["granted"] is True
+    assert ledger._signing_key_path().read_bytes().startswith(
+        ledger._KEY_ESTABLISHED_PREFIX
+    )
     assert ledger.list_credits(now)["count"] == 1
+
+
+def test_pending_key_retries_interrupted_legacy_migration() -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    legacy = {
+        "version": 1,
+        "credits": [
+            {
+                "id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                "rarity": "N",
+                "trigger_type": "emotion_combo",
+                "idem_key": "interrupted-legacy-migration",
+                "status": "active",
+                "created_at": ledger._iso(now),
+                "expires_at": ledger._iso(now + timedelta(hours=16)),
+            }
+        ],
+    }
+    ledger._ledger_path().write_text(json.dumps(legacy), encoding="utf-8")
+    _key, created, established = ledger._read_or_create_signing_key()
+    assert created is True
+    assert established is False
+
+    assert ledger.list_credits(now)["count"] == 1
+    assert ledger._signing_key_path().read_bytes().startswith(
+        ledger._KEY_ESTABLISHED_PREFIX
+    )
 
 
 def test_reserve_commit_and_replay_are_idempotent() -> None:

--- a/tests/unit/test_forge_credit_ledger.py
+++ b/tests/unit/test_forge_credit_ledger.py
@@ -126,6 +126,51 @@ def test_deleting_a_signed_ledger_does_not_reset_the_daily_cap() -> None:
         )
 
 
+def test_interrupted_first_save_recovers_from_pending_key(monkeypatch) -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    original_mark = ledger._mark_signing_key_established
+    interrupted = True
+
+    def fail_before_established(key):
+        nonlocal interrupted
+        if interrupted:
+            interrupted = False
+            raise ledger.LedgerIntegrityError("simulated_interruption")
+        original_mark(key)
+
+    monkeypatch.setattr(ledger, "_mark_signing_key_established", fail_before_established)
+    with pytest.raises(ledger.LedgerIntegrityError, match="simulated_interruption"):
+        ledger.grant_credit(
+            {"trigger_type": "emotion_combo", "idem_key": "interrupted-first-save"},
+            now=now,
+            rarity="N",
+        )
+
+    # The signed ledger was already replaced before the simulated interruption.
+    # A pending key must authenticate it and promote itself instead of bricking
+    # the installation as an apparent deleted-ledger event.
+    assert ledger.list_credits(now)["count"] == 1
+    raw_key = ledger._signing_key_path().read_bytes()
+    assert raw_key[:1] == ledger._KEY_ESTABLISHED_PREFIX
+
+
+def test_pending_key_without_ledger_retries_initial_save() -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    _key, created, established = ledger._read_or_create_signing_key()
+    assert created is True
+    assert established is False
+    assert not ledger._ledger_path().exists()
+
+    result = ledger.grant_credit(
+        {"trigger_type": "emotion_combo", "idem_key": "pending-key-retry"},
+        now=now,
+        rarity="N",
+    )
+
+    assert result["granted"] is True
+    assert ledger.list_credits(now)["count"] == 1
+
+
 def test_reserve_commit_and_replay_are_idempotent() -> None:
     now = datetime(2026, 7, 13, 8, tzinfo=UTC)
     ledger.grant_credit(

--- a/tests/unit/test_forge_credit_ledger.py
+++ b/tests/unit/test_forge_credit_ledger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -39,6 +40,88 @@ def test_grant_is_installation_local_and_idempotent() -> None:
     assert duplicate["reason"] == "duplicate"
     assert duplicate["rarity"] == "SR"
     assert ledger.list_credits(now)["count"] == 1
+
+
+@pytest.mark.parametrize("mutation", ["rarity", "inject", "delete"])
+def test_signed_ledger_rejects_out_of_band_credit_tampering(mutation: str) -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    ledger.grant_credit(
+        {"trigger_type": "emotion_combo", "idem_key": "signed-ledger-credit"},
+        now=now,
+        rarity="N",
+    )
+    path = ledger._ledger_path()
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if mutation == "rarity":
+        raw["credits"][0]["rarity"] = "UR"
+    elif mutation == "inject":
+        injected = dict(raw["credits"][0])
+        injected["id"] = "99999999-9999-4999-8999-999999999999"
+        injected["idem_key"] = "injected-credit-idem"
+        raw["credits"].append(injected)
+    else:
+        raw["credits"].clear()
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ledger.LedgerIntegrityError, match="ledger_integrity_failed"):
+        ledger.list_credits(now)
+    with pytest.raises(ledger.LedgerIntegrityError, match="ledger_integrity_failed"):
+        ledger.grant_credit(
+            {"trigger_type": "emotion_combo", "idem_key": "cannot-reset-after-tamper"},
+            now=now,
+            rarity="N",
+        )
+
+
+def test_unsigned_legacy_ledger_is_migrated_only_before_signing_key_exists() -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    legacy = {
+        "version": 1,
+        "credits": [
+            {
+                "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                "rarity": "R",
+                "trigger_type": "emotion_combo",
+                "idem_key": "legacy-credit-idem",
+                "status": "active",
+                "created_at": ledger._iso(now),
+                "expires_at": ledger._iso(now + timedelta(hours=16)),
+            }
+        ],
+    }
+    path = ledger._ledger_path()
+    path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    assert ledger.list_credits(now)["count"] == 1
+    migrated = json.loads(path.read_text(encoding="utf-8"))
+    assert migrated["version"] == ledger.LEDGER_VERSION
+    assert migrated["integrity"]["algorithm"] == "hmac-sha256"
+    assert ledger._signing_key_path().stat().st_mode & 0o777 == 0o600
+
+    migrated.pop("integrity")
+    migrated["version"] = 1
+    path.write_text(json.dumps(migrated), encoding="utf-8")
+    with pytest.raises(ledger.LedgerIntegrityError, match="ledger_version_invalid"):
+        ledger.list_credits(now)
+
+
+def test_deleting_a_signed_ledger_does_not_reset_the_daily_cap() -> None:
+    now = datetime(2026, 7, 13, 8, tzinfo=UTC)
+    ledger.grant_credit(
+        {"trigger_type": "emotion_combo", "idem_key": "delete-ledger-idem"},
+        now=now,
+        rarity="N",
+    )
+    ledger._ledger_path().unlink()
+
+    with pytest.raises(ledger.LedgerIntegrityError, match="ledger_missing"):
+        ledger.list_credits(now)
+    with pytest.raises(ledger.LedgerIntegrityError, match="ledger_missing"):
+        ledger.grant_credit(
+            {"trigger_type": "emotion_combo", "idem_key": "delete-reset-idem"},
+            now=now,
+            rarity="N",
+        )
 
 
 def test_reserve_commit_and_replay_are_idempotent() -> None:

--- a/tests/unit/test_forge_credit_ledger.py
+++ b/tests/unit/test_forge_credit_ledger.py
@@ -205,6 +205,10 @@ def test_pending_key_retries_interrupted_legacy_migration() -> None:
     assert ledger._signing_key_path().read_bytes().startswith(
         ledger._KEY_ESTABLISHED_PREFIX
     )
+    migrated = json.loads(ledger._ledger_path().read_text(encoding="utf-8"))
+    assert migrated["version"] == ledger.LEDGER_VERSION
+    assert migrated["integrity"]["algorithm"] == "hmac-sha256"
+    assert ledger.list_credits(now)["count"] == 1
 
 
 def test_reserve_commit_and_replay_are_idempotent() -> None:


### PR DESCRIPTION
## 改动概述 / Summary

- SR 权重从 7% 下调至 3.5%，SSR 从 1% 下调至 0.5%
- SR 以上合计概率从 8% 下调至 4%；UR 保持 0%，N 保持 70%，差额补入 R
- 账本升级为 v2，使用安装级 256-bit 密钥对完整账本做 HMAC-SHA256 完整性认证
- 严格校验券 UUID、幂等键、稀有度、触发类型、状态和时间字段
- 修改稀有度、注入券、删除记录、删除已签名账本或降级为未签名格式时 fail closed
- `/credits/grant` 要求 Electron 启动期共享密钥，拒绝无认证的本机请求
- 合法 v1 账本仅在首次创建签名密钥时迁移一次，之后拒绝 downgrade

## 回归报告 / Regression Report

- **改动内容：** 调整高稀有度权重；为本机券账本增加版本化 HMAC 完整性认证、严格 schema 校验与一次性 v1 迁移；为发券入口增加 Electron 运行期密钥认证。
- **理由 / 必要性：** 原账本是无签名 JSON，本机用户可直接改 rarity、注入或删除券；发券入口也只校验 Origin，无 Origin 的本机程序可调用。需要在不改变正常掉券、预占和消费协议的前提下阻止静默篡改与伪造请求。
- **改动前后表现：** 调整前 SR 以上为 8%，账本篡改会被正常读取；调整后 SR 以上为 4%，所有合法写入都会重签，任何未认证变更均返回完整性错误并停止读取、发券或消费。未携带正确运行期密钥的发券请求返回 403；密钥未配置时返回 503。
- **潜在回归点：** 影响首次 v1 账本迁移、本机发券入口、券过期/预占/释放/消费后的重签流程。通过篡改、注入、删除、downgrade、跨账号归属、幂等重放及既有生命周期测试覆盖。

## 不拆分理由 / Why Not Split

不适用：安全校验、入口认证及对应测试属于同一个本机券信任边界修复。

## 测试 / Testing

- `uv run pytest tests/unit/test_forge_credit_ledger.py tests/unit/test_card_drop_session_facts.py`（93 passed）
- `uv run ruff check main_logic/forge_credit_ledger.py main_routers/card_drop_router.py tests/unit/test_forge_credit_ledger.py tests/unit/test_card_drop_session_facts.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增强账本完整性保护，可检测篡改、损坏及无效数据。
  - 为信用发放与扣款确认增加安全密钥和签名凭证校验。
  - 支持符合条件的旧版账本安全迁移。
  - 统一规范操作请求中的 UUID。

- **调整**
  - 更新物品稀有度掉落权重。
  - 云端扣款确认统一要求安全连接。

- **问题修复**
  - 删除已签名账本不再重置每日发放额度。
  - 无效或缺失安全配置时，相关请求会被正确拒绝。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->