### PR TITLE
fix(screen-sharing): keep Linux sharing on persistent streams

### DIFF
--- a/main_routers/system_router/screenshot.py
+++ b/main_routers/system_router/screenshot.py
@@ -117,7 +117,10 @@ async def get_window_title_api():
 @router.post('/screenshot')
 async def backend_screenshot(request: Request):
     """
-    Backend screenshot fallback: when all frontend screen-capture APIs fail, the backend captures the local screen with pyautogui.
+    One-shot backend screenshot fallback for explicit screenshot/proactive-vision
+    requests. Continuous screen sharing must use a persistent MediaStream and
+    must not poll this endpoint because system screenshot helpers can produce
+    visible/audible feedback and cannot preserve a selected-window boundary.
     Security restriction: only requests from loopback addresses are allowed. Returns a JPEG base64 DataURL.
     """
     validation_error = _validate_local_mutation_request(

--- a/main_routers/system_router/screenshot.py
+++ b/main_routers/system_router/screenshot.py
@@ -118,9 +118,10 @@ async def get_window_title_api():
 async def backend_screenshot(request: Request):
     """
     One-shot backend screenshot fallback for explicit screenshot/proactive-vision
-    requests. Continuous screen sharing must use a persistent MediaStream and
-    must not poll this endpoint because system screenshot helpers can produce
-    visible/audible feedback and cannot preserve a selected-window boundary.
+    requests. Continuous screen sharing must keep using the user-selected
+    client-side capture path and must not poll this endpoint because system
+    screenshot helpers can produce visible/audible feedback and cannot preserve a
+    selected-window boundary.
     Security restriction: only requests from loopback addresses are allowed. Returns a JPEG base64 DataURL.
     """
     validation_error = _validate_local_mutation_request(

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -3754,7 +3754,8 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 return panel;
             }
 
-            function createMainActionButton(iconText, label, subLabel, actionKey, onClick) {
+            function createMainActionButton(iconText, label, subLabel, actionKey, onClick, interactionOptions) {
+                interactionOptions = interactionOptions || {};
                 var button = document.createElement('button');
                 button.type = 'button';
                 button.dataset.nekoMicMainAction = actionKey;
@@ -3816,10 +3817,20 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     });
                 }
 
-                // Hover-to-expand like settings side panels.
-                button.addEventListener('mouseenter', function (event) {
-                    openActionPanel(event);
-                });
+                // Most settings side panels may expand on hover. Screen-source
+                // enumeration is different: on Linux it can invoke
+                // xdg-desktop-portal and show an OS sharing dialog, so that
+                // action must require an explicit click/user gesture.
+                if (interactionOptions.openOnHover !== false) {
+                    button.addEventListener('mouseenter', function (event) {
+                        openActionPanel(event);
+                    });
+                } else {
+                    button.addEventListener('mouseenter', function () {
+                        clearMicActionHoverCollapseTimer();
+                        actionSurface().style.background = 'var(--neko-popup-hover)';
+                    });
+                }
                 button.addEventListener('mouseleave', function () {
                     // Shared rows own the full hover surface, including any
                     // sibling toggle. Their mouseleave handler closes the panel.
@@ -4057,7 +4068,8 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 screenButtonLabel,
                 window.t ? window.t('app.screenSource.screens') : 'Screens',
                 'screen',
-                openScreenSourceSubwindow
+                openScreenSourceSubwindow,
+                { openOnHover: false }
             );
             var shareToggleButton = createScreenShareToggleButton({ mini: true });
             var screenActionRow = createMainActionRow(

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -31,6 +31,10 @@
             && typeof provider.captureSourceAsDataUrl === 'function');
     }
 
+    function desktopSourceEnumerationMayPrompt(provider) {
+        return !!(provider && provider.sourceEnumerationMayPrompt === true);
+    }
+
     function hasVisibleModelSurface() {
         var modelContainerIds = [
             'live2d-container',
@@ -462,26 +466,31 @@
                 var timedOut = false;
                 var newStream = await Promise.race([
                     (async function () {
-                        // 验证源存在
-                        var currentSources = await desktopProvider.getSources({
-                            types: ['window', 'screen'],
-                            thumbnailSize: { width: 1, height: 1 }
-                        });
-                        var sourceExists = currentSources.some(function (s) { return s.id === selectedSourceId; });
-
                         var captureSourceId = selectedSourceId;
-                        if (!sourceExists) {
-                            console.warn('[acquireStream] 选中的源已不可用，尝试回退到全屏源');
-                            // 把失效的 ID 从 state / localStorage / 主进程一起清掉，
-                            // 否则下次截图还会拿这个过期 ID 去走 Priority 1 (主进程
-                            // 直接捕获 "Source not found") 和 Priority 2 的 Electron
-                            // getUserMedia（会跑到 500ms 超时），整条失败链路每次重放。
-                            clearSelectedScreenSource('getSources 未找到该源');
-                            var screenSources = currentSources.filter(function (s) { return s.id.startsWith('screen:'); });
-                            if (screenSources.length > 0) {
-                                captureSourceId = screenSources[0].id;
-                            } else {
-                                return null; // 无可用源
+                        // Linux desktopCapturer may be backed by xdg-desktop-portal;
+                        // even a "validation" enumeration can open another system
+                        // sharing dialog. Trust the source selected by the preceding
+                        // user gesture and let getUserMedia report a stale id instead.
+                        if (!desktopSourceEnumerationMayPrompt(desktopProvider)) {
+                            var currentSources = await desktopProvider.getSources({
+                                types: ['window', 'screen'],
+                                thumbnailSize: { width: 1, height: 1 }
+                            });
+                            var sourceExists = currentSources.some(function (s) { return s.id === selectedSourceId; });
+
+                            if (!sourceExists) {
+                                console.warn('[acquireStream] 选中的源已不可用，尝试回退到全屏源');
+                                // 把失效的 ID 从 state / localStorage / 主进程一起清掉，
+                                // 否则下次截图还会拿这个过期 ID 去走 Priority 1 (主进程
+                                // 直接捕获 "Source not found") 和 Priority 2 的 Electron
+                                // getUserMedia（会跑到 500ms 超时），整条失败链路每次重放。
+                                clearSelectedScreenSource('getSources 未找到该源');
+                                var screenSources = currentSources.filter(function (s) { return s.id.startsWith('screen:'); });
+                                if (screenSources.length > 0) {
+                                    captureSourceId = screenSources[0].id;
+                                } else {
+                                    return null; // 无可用源
+                                }
                             }
                         }
 
@@ -640,7 +649,9 @@
 
     // ======================== fetchBackendScreenshot ========================
     /**
-     * 后端截图兜底：当前端所有屏幕捕获 API 均失败时，请求后端用 pyautogui 截取本机屏幕。
+     * 后端单帧截图兜底：供截图、主动视觉等一次性取帧场景使用。
+     * 持续屏幕分享不得轮询此接口：系统截图工具可能产生闪光/声音，而且全桌面
+     * 截图无法保持用户选择的窗口来源，存在隐私语义变化。
      * 安全限制：仅当页面来自 localhost / 127.0.0.1 / 0.0.0.0 时才调用。
      * @returns {Promise<{dataUrl: string|null, status: number|null, reason: string|null}>}
      */
@@ -679,22 +690,6 @@
         }
     }
     mod.fetchBackendScreenshot = fetchBackendScreenshot;
-
-    function translateBackendScreenshotReason(reason) {
-        var supportedReasons = {
-            AGENT_PYAUTOGUI_NOT_INSTALLED: true,
-            AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE: true,
-            AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING: true,
-            AGENT_PYAUTOGUI_IMPORT_FAILED: true
-        };
-        if (!supportedReasons[reason]) return '';
-        var key = 'agent.precheck.' + reason;
-        if (typeof window.t === 'function') {
-            var translated = window.t(key);
-            if (translated && translated !== key) return translated;
-        }
-        return reason;
-    }
 
     /**
      * 后端系统原生交互截图：触发操作系统级的全桌面框选截图。
@@ -816,9 +811,7 @@
         // 仅屏幕分享可能包含 Avatar；移动相机拍的是现实画面，无 Avatar
         if (input_type === 'screen') {
             // 原生帧按显式源判定；有前端流时按流/已选源判定。
-            // 两者都没有即 pyautogui 全屏兜底（后端截整屏），
-            // 此时忽略可能残留的 selectedScreenSourceId（窗口源捕获失败才会进兜底，
-            // 若仍读旧的 window:* 源会被判为 null 而漏标）
+            // 两者都没有时按全屏处理；持续屏幕分享不会再进入后端整屏截图轮询。
             var captureType = sourceId
                 ? detectScreenshotCaptureType(null, sourceId)
                 : (S.screenCaptureStream
@@ -1233,6 +1226,7 @@
                     // Desktop/laptop: capture the user's chosen screen / window / tab.
                     var selectedSourceId = window.getSelectedScreenSourceId ? window.getSelectedScreenSourceId() : null;
                     var desktopProvider = resolveDesktopCaptureProvider();
+                    var sourceEnumerationMayPrompt = desktopSourceEnumerationMayPrompt(desktopProvider);
 
                     // Native-frame shells do not expose Chromium's picker.
                     // Default to the first monitor when no source is persisted.
@@ -1251,7 +1245,7 @@
                         if (discardCancelledScreenSharingStart(attempt)) return;
                     }
 
-                    if (selectedSourceId && desktopProvider
+                    if (selectedSourceId && desktopProvider && !sourceEnumerationMayPrompt
                         && typeof desktopProvider.getSources === 'function') {
                         // 验证选中的源是否仍然存在（窗口可能已关闭）
                         try {
@@ -1313,36 +1307,40 @@
                             console.warn('[屏幕源] 指定源捕获失败，尝试回退:', captureErr);
                             var fallbackSucceeded = false;
 
-                            // 回退策略1: 尝试其他全屏源（chromeMediaSource 方式）
-                            try {
-                                var fallbackSources = await desktopProvider.getSources({
-                                    types: ['screen'],
-                                    thumbnailSize: { width: 1, height: 1 }
-                                });
-                                if (discardCancelledScreenSharingStart(attempt)) return;
-                                if (fallbackSources.length > 0) {
-                                    captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getUserMedia({
-                                        audio: false,
-                                        video: {
-                                            mandatory: {
-                                                chromeMediaSource: 'desktop',
-                                                chromeMediaSourceId: fallbackSources[0].id,
-                                                maxFrameRate: 1
-                                            }
-                                        }
-                                    }));
+                            // 回退策略1: 非 Portal 平台可静默枚举其它全屏源。
+                            // Linux Portal 每次枚举都可能再次弹系统窗口，因此直接进入
+                            // 一次 getDisplayMedia，让用户重新选择来源。
+                            if (!sourceEnumerationMayPrompt) {
+                                try {
+                                    var fallbackSources = await desktopProvider.getSources({
+                                        types: ['screen'],
+                                        thumbnailSize: { width: 1, height: 1 }
+                                    });
                                     if (discardCancelledScreenSharingStart(attempt)) return;
-                                    S.selectedScreenSourceId = fallbackSources[0].id;
-                                    try { localStorage.setItem('selectedScreenSourceId', fallbackSources[0].id); } catch (e) { }
-                                    pushSelectedSourceToMain(fallbackSources[0].id);
-                                    window.showStatusToast(
-                                        safeT('app.screenSource.sourceLost', '屏幕分享无法找到之前选择窗口，已切换为全屏分享'),
-                                        3000
-                                    );
-                                    fallbackSucceeded = true;
+                                    if (fallbackSources.length > 0) {
+                                        captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getUserMedia({
+                                            audio: false,
+                                            video: {
+                                                mandatory: {
+                                                    chromeMediaSource: 'desktop',
+                                                    chromeMediaSourceId: fallbackSources[0].id,
+                                                    maxFrameRate: 1
+                                                }
+                                            }
+                                        }));
+                                        if (discardCancelledScreenSharingStart(attempt)) return;
+                                        S.selectedScreenSourceId = fallbackSources[0].id;
+                                        try { localStorage.setItem('selectedScreenSourceId', fallbackSources[0].id); } catch (e) { }
+                                        pushSelectedSourceToMain(fallbackSources[0].id);
+                                        window.showStatusToast(
+                                            safeT('app.screenSource.sourceLost', '屏幕分享无法找到之前选择窗口，已切换为全屏分享'),
+                                            3000
+                                        );
+                                        fallbackSucceeded = true;
+                                    }
+                                } catch (fallback1Err) {
+                                    console.warn('[屏幕源] chromeMediaSource 全屏回退也失败:', fallback1Err);
                                 }
-                            } catch (fallback1Err) {
-                                console.warn('[屏幕源] chromeMediaSource 全屏回退也失败:', fallback1Err);
                             }
 
                             // 回退策略2: chromeMediaSource 在该系统上完全不可用，降级到 getDisplayMedia
@@ -1365,7 +1363,7 @@
                             }
 
                             if (!fallbackSucceeded) {
-                                console.warn('[屏幕源] 所有前端流方式均失败，将尝试后端轮询兜底');
+                                console.warn('[屏幕源] 所有前端持续流方式均失败，停止屏幕分享');
                             }
                         }
                         if (captureStream) {
@@ -1385,7 +1383,7 @@
                             if (discardCancelledScreenSharingStart(attempt)) return;
                             // 用户主动取消则直接抛出，不兜底
                             if (displayErr.name === 'NotAllowedError') throw displayErr;
-                            console.warn('[屏幕源] getDisplayMedia 失败，将尝试后端轮询兜底:', displayErr);
+                            console.warn('[屏幕源] getDisplayMedia 失败，停止屏幕分享:', displayErr);
                         }
                     }
                 }
@@ -1455,42 +1453,15 @@
                     }
                 };
             } else {
-                // 回退策略3: 后端 pyautogui 轮询模式（所有前端流方式均失败）
-                var result = await fetchBackendScreenshot();
-                if (discardCancelledScreenSharingStart(attempt)) return;
-                var backendTest = result.dataUrl;
-                if (!backendTest) {
-                    throw new Error(
-                        translateBackendScreenshotReason(result.reason)
-                        || (window.t ? window.t('console.screenShareFailed') : '所有屏幕捕获方式均失败（含后端兜底）')
-                    );
-                }
-                if (await stopLiveVisionStreamIfBlocked('screen')) {
-                    return;
-                }
-                if (discardCancelledScreenSharingStart(attempt)) return;
-                console.log('[屏幕源] 进入后端 pyautogui 轮询模式');
-
-                // 立即发送第一帧
-                if (canSendLiveVisionStreamFrame('screen') && S.socket && S.socket.readyState === WebSocket.OPEN) {
-                    S.socket.send(JSON.stringify(buildStreamDataMessage(backendTest, 'screen')));
-                }
-
-                // 复用 videoSenderInterval，stopScreening() 可统一清理
-                S.videoSenderInterval = setInterval(async function () {
-                    try {
-                        if (await stopLiveVisionStreamIfBlocked('screen')) {
-                            return;
-                        }
-                        var r = await fetchBackendScreenshot();
-                        var frame = r.dataUrl;
-                        if (frame && canSendLiveVisionStreamFrame('screen') && S.socket && S.socket.readyState === WebSocket.OPEN) {
-                            S.socket.send(JSON.stringify(buildStreamDataMessage(frame, 'screen')));
-                        }
-                    } catch (e) {
-                        console.warn('[屏幕源] 后端轮询帧失败:', e);
-                    }
-                }, 1000);
+                // 连续分享必须保持系统/窗口选择器授予的来源。后端 pyautogui 只能
+                // 截取整个桌面，还可能调用带闪光和声音的系统截图工具；在这里静默
+                // 降级既会打扰用户，也可能发送用户没有选择的其它窗口。
+                var streamError = new Error(safeT(
+                    'app.screenSource.captureFailed',
+                    '屏幕捕获已停止，请检查系统权限或重新选择来源'
+                ));
+                streamError.name = 'NotReadableError';
+                throw streamError;
             }
 
             if (discardCancelledScreenSharingStart(attempt)) return;

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -7,7 +7,7 @@ APP_SCREEN_JS = Path(__file__).resolve().parents[2] / "static" / "app" / "app-sc
 
 
 @pytest.mark.unit
-def test_backend_screenshot_reason_is_localized_without_exposing_raw_error():
+def test_backend_screenshot_remains_a_safe_one_shot_fallback():
     source = APP_SCREEN_JS.read_text(encoding="utf-8")
     fallback = source.split("async function fetchBackendScreenshot()", 1)[1].split(
         "mod.fetchBackendScreenshot = fetchBackendScreenshot;",
@@ -18,5 +18,37 @@ def test_backend_screenshot_reason_is_localized_without_exposing_raw_error():
     assert "json.error" not in fallback
     assert "e && e.message" not in fallback
     assert "if (json && json.success && json.data)" in fallback
-    assert "translateBackendScreenshotReason(result.reason)" in source
-    assert "'agent.precheck.' + reason" in source
+    assert "供截图、主动视觉等一次性取帧场景使用" in source
+
+
+@pytest.mark.unit
+def test_manual_screen_share_never_polls_the_backend_screenshot_endpoint():
+    source = APP_SCREEN_JS.read_text(encoding="utf-8")
+    start_once = source.split("async function startScreenSharingOnce(attempt)", 1)[1].split(
+        "mod.startScreenSharing = startScreenSharing;",
+        1,
+    )[0]
+
+    assert "fetchBackendScreenshot()" not in start_once
+    assert "进入后端 pyautogui 轮询模式" not in start_once
+    assert "streamError.name = 'NotReadableError'" in start_once
+    assert "用户没有选择的其它窗口" in start_once
+
+
+@pytest.mark.unit
+def test_linux_portal_screen_share_does_not_reenumerate_sources_during_fallbacks():
+    source = APP_SCREEN_JS.read_text(encoding="utf-8")
+    start_once = source.split("async function startScreenSharingOnce(attempt)", 1)[1].split(
+        "mod.startScreenSharing = startScreenSharing;",
+        1,
+    )[0]
+    acquire_once = source.split("async function acquireOrReuseCachedStream(opts)", 1)[1].split(
+        "mod.acquireOrReuseCachedStream = acquireOrReuseCachedStream;",
+        1,
+    )[0]
+
+    assert "sourceEnumerationMayPrompt = desktopSourceEnumerationMayPrompt" in start_once
+    assert "selectedSourceId && desktopProvider && !sourceEnumerationMayPrompt" in start_once
+    assert "if (!sourceEnumerationMayPrompt)" in start_once
+    assert "if (!desktopSourceEnumerationMayPrompt(desktopProvider))" in acquire_once
+    assert "Linux Portal 每次枚举都可能再次弹系统窗口" in start_once

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -806,6 +806,9 @@ def test_mic_main_action_matches_settings_chevron_and_hover_expands():
     assert "button.dataset.nekoMicMainAction = actionKey;" in action_button
     assert "openMicActionPanel(actionKey, onClick)" in action_button
     assert "button.addEventListener('mouseenter'" in action_button
+    assert "interactionOptions.openOnHover !== false" in action_button
+    assert "xdg-desktop-portal" in action_button
+    assert "button.addEventListener('click'" in action_button
     assert "scheduleMicActionHoverCollapse()" in action_button
     assert "createMainActionButton(" in source
     assert "'screen'" in source
@@ -816,6 +819,11 @@ def test_mic_main_action_matches_settings_chevron_and_hover_expands():
     assert "if (iconText) {" in action_button
     assert "screenActionButton.querySelector('.neko-mic-action-text')" in source
     assert "var screenActionButton = createMainActionButton(\n                null," in source
+    screen_action = source.split(
+        "var screenActionButton = createMainActionButton(", 1
+    )[1].split(");", 1)[0]
+    assert "openScreenSourceSubwindow" in screen_action
+    assert "{ openOnHover: false }" in screen_action
     assert "var micActionButton = createMainActionButton(\n                null," in source
     assert "asrActionButton = createMainActionButton(\n                null," in source
     assert "'voice-recognition'" in source

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -732,7 +732,8 @@ def test_every_screen_share_toggle_treats_a_pending_start_as_on():
     activation_guard = start_once.rfind(
         "discardCancelledScreenSharingStart(attempt)", 0, activate
     )
-    assert activation_guard > start_once.index("fetchBackendScreenshot()")
+    fail_closed = start_once.index("streamError.name = 'NotReadableError'")
+    assert activation_guard > fail_closed
     commit_stream = start_once.index("S.screenCaptureStream = captureStream;")
     first_post_capture_guard = start_once.index(
         "if (discardCancelledScreenSharingStart(attempt)) return;",


### PR DESCRIPTION
## 改动概述 / Summary

Linux 屏幕持续流失败后，旧逻辑会每秒调用 /api/screenshot，并通过 pyautogui/Pillow 触发系统截图工具，造成闪光、提示音或多次系统窗口。GNOME Portal 环境中，来源验证与 UI hover 还会重复枚举桌面来源，进一步产生分享窗口。

- 连续屏幕分享仅使用用户选择的客户端捕获路径（MediaStream 或原生帧捕获），不再轮询后端单帧截图接口
- 所有前端持续流失败时明确停止并返回 NotReadableError
- 保留 /api/screenshot 给主动截图和主动视觉等一次性场景
- Linux Portal 环境复用已选来源，跳过可能再次弹窗的验证/备用枚举
- 屏幕来源菜单改为显式点击才枚举；鼠标悬停不再触发系统分享窗口
- 增加持续流 fail-closed、Portal 单次枚举和 UI 交互回归测试

需要配套合并 Project-N-E-K-O/N.E.K.O.-PC#443，修复 Electron 41 DisplayMedia 请求身份解析并透传 Linux Portal 能力。

Closes #2782

## 回归报告 / Regression Report

- 改动内容：main_routers/system_router/screenshot.py 只澄清 /api/screenshot 是一次性截图接口；持续共享逻辑在前端改为只沿用用户选择的客户端捕获路径，不再轮询后端截图。
- 理由与必要性：轮询系统截图不能维持用户选定窗口的边界，在 Linux 上还可能触发闪光、提示音和系统截图反馈，因此不能充当视频流。
- 改动前：持续流获取失败后每秒请求一次后端截图，界面看似有画面但实际上是离散截图，并可能重复触发系统效果。
- 改动后：持续流失败即明确报错并停止；显式截图与主动视觉仍可调用原有后端接口，路由行为、权限校验和响应格式均未改变。
- 潜在回归点：所有受支持客户端捕获路径均失败时，将不再得到低质量截图伪流，而会看到捕获失败。已覆盖失败收敛、一次性截图保留、Linux Portal 单次枚举及点击交互测试。

## 不拆分理由 / Why Not Split

不适用：计入上限的改动文件不超过 20 个；代码已按持久流修复和 UI 显式点击拆成两个提交。

## 测试 / Testing

- uv run pytest -q tests/unit/test_app_screen_screenshot_fallback_static.py tests/unit/test_voice_start_failure_static.py tests/unit/test_system_screenshot_router.py（70 passed）
- uv run ruff check
- node --check static/app/app-screen.js
- node --check static/app/app-audio-capture.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 屏幕共享按钮现在仅通过明确点击打开屏幕源选择窗口，避免悬停触发系统共享提示。
  * 改进 Linux 桌面门户环境下的屏幕共享处理，减少重复来源检测。

* **问题修复**
  * 持续屏幕共享失败时不再反复请求后端截图，改为直接提示捕获失败。
  * 后端截图仅作为一次性回退方案，避免潜在的系统反馈和窗口边界问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->