### PR TITLE
fix(tutorial): 统一新手教程模型探身与过渡动画

### DIFF
--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1490,7 +1490,7 @@ I.mod = window.appInterpage;
                                 window.lanlan_config.model_type = newModelType;
                                 window.lanlan_config.live3d_sub_type = live3dSubType;
                             }
-                            if (typeof window.showLive2d === 'function') {
+                            if (!deferRevealPrepared && typeof window.showLive2d === 'function') {
                                 window.showLive2d();
                             }
                             if (window.live2dManager && typeof window.live2dManager.resumeRendering === 'function') {

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -256,7 +256,8 @@
         const container = document.getElementById('live2d-container');
         console.log('[App] showLive2d调用前，容器类列表:', container.classList.toString());
         const preserveYuiGuidePreparing = shouldPreserveYuiGuideLive2DPreparing();
-        if (preserveYuiGuidePreparing) {
+        const preserveYuiGuideAvatarMotion = window.nekoYuiGuideAvatarCornerPeekActive === true;
+        if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion) {
             hideYuiGuideLive2DPreparingControls();
         }
 
@@ -287,7 +288,7 @@
         }
 
         // 确保浮动按钮显示
-        if (!preserveYuiGuidePreparing && floatingButtons) {
+        if (!preserveYuiGuidePreparing && !preserveYuiGuideAvatarMotion && floatingButtons) {
             floatingButtons.style.setProperty('display', 'flex', 'important');
             floatingButtons.style.setProperty('visibility', 'visible', 'important');
             floatingButtons.style.setProperty('opacity', '1', 'important');
@@ -295,12 +296,12 @@
         }
 
         const lockIcon = document.getElementById('live2d-lock-icon');
-        if (!preserveYuiGuidePreparing && lockIcon) {
+        if (!preserveYuiGuidePreparing && !preserveYuiGuideAvatarMotion && lockIcon) {
             lockIcon.style.removeProperty('display');
             lockIcon.style.removeProperty('visibility');
             lockIcon.style.removeProperty('opacity');
             lockIcon.style.removeProperty('pointer-events');
-        } else if (preserveYuiGuidePreparing) {
+        } else if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion) {
             hideYuiGuideLive2DPreparingControls();
         }
 
@@ -332,6 +333,17 @@
             statusElement.style.setProperty('display', 'none', 'important');
             statusElement.style.setProperty('visibility', 'hidden', 'important');
             statusElement.style.setProperty('opacity', '0', 'important');
+        }
+
+        if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion) {
+            // 教程准备/探身演出期间只恢复渲染宿主，不启动普通半身淡入；演出负责逐帧揭示。
+            const reason = preserveYuiGuideAvatarMotion
+                ? 'show-live2d-yui-guide-avatar-motion'
+                : 'show-live2d-yui-guide-preparing';
+            restoreLive2DDisplaySurface(reason);
+            activateLive2DRenderForDisplay(reason);
+            console.log('[App] showLive2d: YUI 教程显示演出中，跳过普通模型淡入');
+            return;
         }
 
         // 取消"请她离开"的延迟隐藏定时器

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -335,17 +335,6 @@
             statusElement.style.setProperty('opacity', '0', 'important');
         }
 
-        if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion) {
-            // 教程准备/探身演出期间只恢复渲染宿主，不启动普通半身淡入；演出负责逐帧揭示。
-            const reason = preserveYuiGuideAvatarMotion
-                ? 'show-live2d-yui-guide-avatar-motion'
-                : 'show-live2d-yui-guide-preparing';
-            restoreLive2DDisplaySurface(reason);
-            activateLive2DRenderForDisplay(reason);
-            console.log('[App] showLive2d: YUI 教程显示演出中，跳过普通模型淡入');
-            return;
-        }
-
         // 取消"请她离开"的延迟隐藏定时器
         if (window._goodbyeHideTimerId) {
             clearTimeout(window._goodbyeHideTimerId);
@@ -357,6 +346,17 @@
         if (window._returnFadeTimer) {
             clearTimeout(window._returnFadeTimer);
             window._returnFadeTimer = null;
+        }
+
+        if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion) {
+            // 教程准备/探身演出期间只恢复渲染宿主，不启动普通半身淡入；演出负责逐帧揭示。
+            const reason = preserveYuiGuideAvatarMotion
+                ? 'show-live2d-yui-guide-avatar-motion'
+                : 'show-live2d-yui-guide-preparing';
+            restoreLive2DDisplaySurface(reason);
+            activateLive2DRenderForDisplay(reason);
+            console.log('[App] showLive2d: YUI 教程显示演出中，跳过普通模型淡入');
+            return;
         }
 
         // 如果模型已经可见，跳过淡入动画

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -114,7 +114,7 @@
     function restoreLive2DDisplaySurface(reason) {
         const preserveAvatarCornerPeekOpacity = window.nekoYuiGuideAvatarCornerPeekActive === true;
         const preserveYuiGuidePreparing = shouldPreserveYuiGuideLive2DPreparing();
-        if (!preserveYuiGuidePreparing) {
+        if (!preserveYuiGuidePreparing && !preserveAvatarCornerPeekOpacity) {
             restoreYuiGuideLive2DPreparingControls();
         }
         if (document.body && document.body.classList) {

--- a/static/live2d/live2d-init.js
+++ b/static/live2d/live2d-init.js
@@ -138,6 +138,14 @@ function _nekoIsLive2DContainerHidden() {
 function ensureLive2DVisibleOnce(reason) {
     try {
         if (window.nekoYuiGuideAvatarCornerPeekActive === true) return;
+        if (
+            window.nekoYuiGuideLive2dPreparing === true
+            || (
+                document.body
+                && document.body.classList
+                && document.body.classList.contains('yui-guide-live2d-preparing')
+            )
+        ) return;
         if (!_nekoShouldSelfHealLive2D()) return;
         // goodbye / 切换中属于合法隐藏，交给各自链路，不打扰。
         if (window.live2dManager && window.live2dManager._goodbyeClicked) return;
@@ -168,6 +176,16 @@ function revealInitialLive2DModelWhenUiReady(reason) {
     const reveal = () => {
         if (revealed) {
             return true;
+        }
+        if (
+            window.nekoYuiGuideLive2dPreparing === true
+            || (
+                document.body
+                && document.body.classList
+                && document.body.classList.contains('yui-guide-live2d-preparing')
+            )
+        ) {
+            return false;
         }
         if (typeof window.showLive2d !== 'function') {
             return false;

--- a/static/live2d/live2d-init.js
+++ b/static/live2d/live2d-init.js
@@ -173,7 +173,19 @@ function ensureLive2DVisibleSoon(reason) {
 
 function revealInitialLive2DModelWhenUiReady(reason) {
     let revealed = false;
-    const reveal = () => {
+    let preparingObserver = null;
+    function revealAfterPreparing() {
+        reveal();
+    }
+    function clearPreparingRevealWatch() {
+        window.removeEventListener('neko:yui-guide:live2d-prepared-revealed', revealAfterPreparing);
+        window.removeEventListener('neko:yui-guide:tutorial-lifecycle-ended', revealAfterPreparing);
+        if (preparingObserver) {
+            preparingObserver.disconnect();
+            preparingObserver = null;
+        }
+    }
+    function reveal() {
         if (revealed) {
             return true;
         }
@@ -197,8 +209,9 @@ function revealInitialLive2DModelWhenUiReady(reason) {
             return false;
         }
         revealed = true;
+        clearPreparingRevealWatch();
         return true;
-    };
+    }
 
     if (reveal()) {
         return;
@@ -209,6 +222,16 @@ function revealInitialLive2DModelWhenUiReady(reason) {
             reveal();
         }, delayMs);
     });
+
+    window.addEventListener('neko:yui-guide:live2d-prepared-revealed', revealAfterPreparing);
+    window.addEventListener('neko:yui-guide:tutorial-lifecycle-ended', revealAfterPreparing);
+    if (typeof MutationObserver === 'function' && document.body) {
+        preparingObserver = new MutationObserver(revealAfterPreparing);
+        preparingObserver.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['class']
+        });
+    }
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', reveal, { once: true });

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -3529,7 +3529,21 @@ Live2DManager.prototype.playTutorialMotion = async function() {
         return false;
     }
 
-    const group = this.getRandomElement(motionGroups);
+    // 教程随机动作偏向更轻松的 happy，降低 surprised 的出现频率。
+    const weightedGroups = motionGroups.map(group => ({
+        group,
+        weight: group === 'happy' ? 3 : (group === 'surprised' ? 0.5 : 1)
+    }));
+    const totalWeight = weightedGroups.reduce((sum, item) => sum + item.weight, 0);
+    let randomWeight = Math.random() * totalWeight;
+    let group = weightedGroups[weightedGroups.length - 1].group;
+    for (const item of weightedGroups) {
+        randomWeight -= item.weight;
+        if (randomWeight <= 0) {
+            group = item.group;
+            break;
+        }
+    }
     if (!group) return false;
 
     const groupList =
@@ -3593,7 +3607,10 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
                 const playedMotion = await this.playTutorialMotion();
 
                 if (!playedMotion && !this.hasActiveActionMotion(this.currentModel)) {
-                    const fallbackEmotion = this.getRandomElement(['happy', 'sad', 'angry', 'surprised']);
+                    const fallbackEmotion = this.getRandomElement([
+                        'happy', 'happy', 'happy',
+                        'sad', 'angry', 'surprised'
+                    ]);
                     this.playSimpleMotion(fallbackEmotion);
                 }
             }

--- a/static/tutorial/avatar/standin-controller.js
+++ b/static/tutorial/avatar/standin-controller.js
@@ -11,6 +11,48 @@
 })(typeof window !== 'undefined' ? window : globalThis, function (root) {
     'use strict';
 
+    const TUTORIAL_STAND_IN_FADE_OUT_MS = 1500;
+    const TUTORIAL_STAND_IN_APPROACH_MS = 2000;
+    const TUTORIAL_STAND_IN_HOLD_MS = 2500;
+    const TUTORIAL_STAND_IN_RETURN_MS = 2000;
+
+    function resolveCueDuration(value, fallback) {
+        return Number.isFinite(Number(value))
+            ? Math.max(0, Math.floor(Number(value)))
+            : fallback;
+    }
+
+    function resolveCueTiming(cue, scene, director) {
+        const narrationDurationMs = director && typeof director.getAvatarFloatingNarrationDurationMs === 'function'
+            ? resolveCueDuration(director.getAvatarFloatingNarrationDurationMs(
+                scene && scene.voiceKey,
+                scene && scene.text
+            ), 0)
+            : 0;
+        const hideMs = TUTORIAL_STAND_IN_FADE_OUT_MS;
+        const appearMs = TUTORIAL_STAND_IN_APPROACH_MS;
+        const holdMs = TUTORIAL_STAND_IN_HOLD_MS;
+        const entryMs = hideMs + appearMs;
+        const exitMs = hideMs + TUTORIAL_STAND_IN_RETURN_MS;
+        const totalDurationMs = entryMs + holdMs;
+        const fullDurationMs = totalDurationMs + exitMs;
+        const rawDelayMs = Number.isFinite(Number(cue.delay))
+            ? Number(cue.delay)
+            : Number(cue.delayMs);
+        const preferredDelayMs = Math.max(0, Number.isFinite(rawDelayMs) ? rawDelayMs : 0);
+        const delayMs = narrationDurationMs > 0
+            ? Math.min(preferredDelayMs, Math.max(0, narrationDurationMs - fullDurationMs))
+            : preferredDelayMs;
+        return Object.assign({}, cue, {
+            delay: delayMs,
+            hideMs: hideMs,
+            appearMs: appearMs,
+            holdMs: holdMs,
+            totalDurationMs: totalDurationMs,
+            fullDurationMs: fullDurationMs
+        });
+    }
+
     class AvatarStandInController {
         constructor(director) {
             this.director = director;
@@ -33,10 +75,11 @@
                 this.clear({ clearPending: true, restoreModel: true });
                 return false;
             }
-            const cue = this.getCue(day, scene.id);
-            if (!cue) {
+            const rawCue = this.getCue(day, scene.id);
+            if (!rawCue) {
                 return false;
             }
+            const cue = resolveCueTiming(rawCue, scene, director);
             this.clear({ clearPending: true, restoreModel: true });
             const token = director.avatarStandInToken + 1;
             director.avatarStandInToken = token;
@@ -86,6 +129,7 @@
     }
 
     return {
-        AvatarStandInController
+        AvatarStandInController,
+        resolveCueTiming
     };
 });

--- a/static/tutorial/avatar/standin-controller.js
+++ b/static/tutorial/avatar/standin-controller.js
@@ -11,15 +11,40 @@
 })(typeof window !== 'undefined' ? window : globalThis, function (root) {
     'use strict';
 
-    const TUTORIAL_STAND_IN_FADE_OUT_MS = 1500;
-    const TUTORIAL_STAND_IN_APPROACH_MS = 2000;
-    const TUTORIAL_STAND_IN_HOLD_MS = 2500;
-    const TUTORIAL_STAND_IN_RETURN_MS = 2000;
+    const DEFAULT_TUTORIAL_STAND_IN_TIMING = Object.freeze({
+        fadeOutMs: 1500,
+        approachMs: 2000,
+        holdMs: 2500,
+        returnMs: 2000
+    });
 
     function resolveCueDuration(value, fallback) {
         return Number.isFinite(Number(value))
             ? Math.max(0, Math.floor(Number(value)))
             : fallback;
+    }
+
+    function resolveTutorialStandInTiming() {
+        const avatarStage = root && root.YuiGuideAvatarStage;
+        const sharedTiming = avatarStage && avatarStage.TUTORIAL_AVATAR_PROBE_TIMING;
+        return {
+            fadeOutMs: resolveCueDuration(
+                sharedTiming && sharedTiming.fadeOutMs,
+                DEFAULT_TUTORIAL_STAND_IN_TIMING.fadeOutMs
+            ),
+            approachMs: resolveCueDuration(
+                sharedTiming && sharedTiming.approachMs,
+                DEFAULT_TUTORIAL_STAND_IN_TIMING.approachMs
+            ),
+            holdMs: resolveCueDuration(
+                sharedTiming && sharedTiming.holdMs,
+                DEFAULT_TUTORIAL_STAND_IN_TIMING.holdMs
+            ),
+            returnMs: resolveCueDuration(
+                sharedTiming && sharedTiming.returnMs,
+                DEFAULT_TUTORIAL_STAND_IN_TIMING.returnMs
+            )
+        };
     }
 
     function resolveCueTiming(cue, scene, director) {
@@ -29,11 +54,12 @@
                 scene && scene.text
             ), 0)
             : 0;
-        const hideMs = TUTORIAL_STAND_IN_FADE_OUT_MS;
-        const appearMs = TUTORIAL_STAND_IN_APPROACH_MS;
-        const holdMs = TUTORIAL_STAND_IN_HOLD_MS;
+        const timing = resolveTutorialStandInTiming();
+        const hideMs = timing.fadeOutMs;
+        const appearMs = timing.approachMs;
+        const holdMs = timing.holdMs;
         const entryMs = hideMs + appearMs;
-        const exitMs = hideMs + TUTORIAL_STAND_IN_RETURN_MS;
+        const exitMs = hideMs + timing.returnMs;
         const totalDurationMs = entryMs + holdMs;
         const fullDurationMs = totalDurationMs + exitMs;
         const rawDelayMs = Number.isFinite(Number(cue.delay))

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -6629,6 +6629,14 @@
         activeAvatarMotionSession = session;
         await session.waitForFinish();
         if (session.result !== 'played') {
+            if (!isOpeningProbe) {
+                writeAvatarMotionVisibleOpacity(context, originalTargets, originalAlpha, originalDisplayAlpha);
+                originalTargets.forEach((target) => {
+                    if (target.element && target.element.style) {
+                        target.element.style.transition = target.transition || '';
+                    }
+                });
+            }
             return {
                 result: session.result || 'cancelled',
                 reason: session.result || 'cancelled'

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -65,6 +65,12 @@
     const TUTORIAL_AVATAR_PROBE_APPROACH_MS = 2000;
     const TUTORIAL_AVATAR_PROBE_HOLD_MS = 2500;
     const TUTORIAL_AVATAR_PROBE_RETURN_MS = 2000;
+    const TUTORIAL_AVATAR_PROBE_TIMING = Object.freeze({
+        fadeOutMs: TUTORIAL_AVATAR_PROBE_FADE_OUT_MS,
+        approachMs: TUTORIAL_AVATAR_PROBE_APPROACH_MS,
+        holdMs: TUTORIAL_AVATAR_PROBE_HOLD_MS,
+        returnMs: TUTORIAL_AVATAR_PROBE_RETURN_MS
+    });
     const AVATAR_CORNER_PEEK_EDGE_INSET_RATIO = 0.18;
     const AVATAR_CORNER_PEEK_REGION_HEIGHT_RATIO = 0.36;
     const PLUGIN_DASHBOARD_CORNER_ELEVATED_Z_INDEX = '2147483647';
@@ -6588,7 +6594,7 @@
             initialAlphaOverride: originalAlpha,
             motionFromAlpha: 0,
             motionToAlpha: originalAlpha,
-            useCompositorOpacity: isOpeningProbe,
+            useCompositorOpacity: true,
             restoreMode: normalizedOptions.restore || normalizedOptions.restoreMode || 'half-body',
             performanceLockKey: normalizedOptions.performanceLockKey || 'home-yui-guide-avatar-motion-frame'
         });
@@ -6830,6 +6836,7 @@
         computeInterruptResistPose: computeInterruptResistPose,
         computeAngryExitPose: computeAngryExitPose,
         waitForLive2DContext: waitForLive2DContext,
+        TUTORIAL_AVATAR_PROBE_TIMING: TUTORIAL_AVATAR_PROBE_TIMING,
         YUI_WAKEUP_PARAMS: YUI_WAKEUP_PARAMS,
         YUI_INTRO_GREETING_HUG_PARAMS: YUI_INTRO_GREETING_HUG_PARAMS,
         YUI_INTRO_GIFT_HEART_PARAMS: YUI_INTRO_GIFT_HEART_PARAMS,

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -3325,7 +3325,7 @@
                 return Promise.resolve();
             }
             if (this.reducedMotion || !animateReturn || !this.isCurrentModel()) {
-                this.finish(reason || 'stopped');
+                this.finish(reason || 'stopped', animateReturn);
                 return Promise.resolve();
             }
             if (this.phase === 'exit') {
@@ -3344,7 +3344,7 @@
             return this.waitForFinish();
         }
 
-        finish(reason) {
+        finish(reason, keepVisible) {
             this.active = false;
             this.finished = true;
             this.phase = 'finished';
@@ -3362,7 +3362,10 @@
             this.restoreFloatingButtonsRotation();
             this.restoreContainerZIndex();
             this.restoreModelFrame();
-            this.restoreDisplayOpacity(this.restoreMode === 'half-body');
+            const forceVisible = typeof keepVisible === 'boolean'
+                ? keepVisible
+                : this.restoreMode === 'half-body';
+            this.restoreDisplayOpacity(forceVisible);
             if (this.faceForwardLock && typeof this.faceForwardLock.release === 'function') {
                 this.faceForwardLock.release(reason || 'stopped');
                 this.faceForwardLock = null;
@@ -6645,14 +6648,36 @@
         if (isOpeningProbe) {
             return { result: 'played', reason: '' };
         }
+        const restoreToHalfBody = normalizedOptions.restore === 'half-body'
+            || normalizedOptions.restoreMode === 'half-body'
+            || (!normalizedOptions.restore && !normalizedOptions.restoreMode);
         const finalFadedOut = await fadeOutAvatarMotionVisibleLayer(Object.assign({}, normalizedOptions, {
             halfBodyFadeOutMs: TUTORIAL_AVATAR_PROBE_FADE_OUT_MS
         }));
         if (!finalFadedOut) {
+            const currentModel = context.manager ? getCurrentLive2DModel(context.manager) : context.model;
+            if (currentModel === context.model && !context.model.destroyed) {
+                if (restoreToHalfBody) {
+                    await fadeInAvatarMotionHalfBodyPlacement(Object.assign({}, normalizedOptions, {
+                        reducedMotion: true,
+                        halfBodyFadeInMs: 0,
+                        baseFrame: originalFrame || session.initialModelFrame
+                    }));
+                } else {
+                    if (originalFrame) {
+                        writeIntroGreetingHugModelFrame(context.model, originalFrame);
+                    }
+                    writeAvatarMotionVisibleOpacity(context, originalTargets, originalAlpha, originalDisplayAlpha);
+                    originalTargets.forEach((target) => {
+                        if (target.element && target.element.style) {
+                            target.element.style.transition = target.transition || '';
+                        }
+                    });
+                }
+            }
             return { result: 'cancelled', reason: 'avatar_motion_fade_out_cancelled' };
         }
-        if (normalizedOptions.restore === 'half-body' || normalizedOptions.restoreMode === 'half-body'
-                || (!normalizedOptions.restore && !normalizedOptions.restoreMode)) {
+        if (restoreToHalfBody) {
             await fadeInAvatarMotionHalfBodyPlacement(Object.assign({}, normalizedOptions, {
                 halfBodyFadeInMs: TUTORIAL_AVATAR_PROBE_RETURN_MS,
                 baseFrame: originalFrame || session.initialModelFrame

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -61,6 +61,10 @@
     const PLUGIN_DASHBOARD_CORNER_APPEAR_MS = 1000;
     const AVATAR_MOTION_HALF_BODY_FADE_OUT_MS = 420;
     const AVATAR_MOTION_HALF_BODY_FADE_IN_MS = 900;
+    const TUTORIAL_AVATAR_PROBE_FADE_OUT_MS = 1500;
+    const TUTORIAL_AVATAR_PROBE_APPROACH_MS = 2000;
+    const TUTORIAL_AVATAR_PROBE_HOLD_MS = 2500;
+    const TUTORIAL_AVATAR_PROBE_RETURN_MS = 2000;
     const AVATAR_CORNER_PEEK_EDGE_INSET_RATIO = 0.18;
     const AVATAR_CORNER_PEEK_REGION_HEIGHT_RATIO = 0.36;
     const PLUGIN_DASHBOARD_CORNER_ELEVATED_Z_INDEX = '2147483647';
@@ -1688,6 +1692,19 @@
         return true;
     }
 
+    function writeAvatarMotionPrimaryDisplayOpacity(targets, alpha) {
+        const opacity = clamp(Number(alpha), 0, 1);
+        const opacityText = String(Math.round(opacity * 1000) / 1000);
+        (Array.isArray(targets) ? targets : []).forEach((target, index) => {
+            const element = target && target.element ? target.element : target;
+            if (!element || !element.style) {
+                return;
+            }
+            element.style.transition = 'none';
+            element.style.opacity = index > 0 ? '1' : opacityText;
+        });
+    }
+
     function writeLookAtCenter(coreModel) {
         if (!coreModel || typeof coreModel.setParameterValueById !== 'function') {
             return false;
@@ -1863,6 +1880,8 @@
             this.performanceLock = null;
             this.initialModelFrame = null;
             this.initialAlpha = 1;
+            this.useCompositorOpacity = normalizedOptions.useCompositorOpacity === true;
+            this.compositorOpacityTargets = [];
             this.startedAt = 0;
             this.active = false;
             this.finished = false;
@@ -1937,7 +1956,10 @@
             if (!this.isCurrentModel() || !frame) {
                 return false;
             }
-            if (Number.isFinite(Number(alpha))) {
+            if (this.useCompositorOpacity && Number.isFinite(Number(alpha))) {
+                writeModelAlpha(this.model, 1);
+                writeAvatarMotionPrimaryDisplayOpacity(this.compositorOpacityTargets, alpha);
+            } else if (Number.isFinite(Number(alpha))) {
                 writeModelAlpha(this.model, alpha);
             }
             centerLive2DLookAt(this);
@@ -1964,6 +1986,18 @@
             this.finished = true;
             this.result = reason || this.result || 'stopped';
             this.detachTicker();
+            if (this.useCompositorOpacity) {
+                this.compositorOpacityTargets.forEach((target) => {
+                    if (!target || !target.element || !target.element.style) {
+                        return;
+                    }
+                    if (this.result !== 'played') {
+                        target.element.style.opacity = String(target.opacity);
+                    }
+                    target.element.style.transition = target.transition || '';
+                });
+                this.compositorOpacityTargets = [];
+            }
             if (this.performanceLock && typeof this.performanceLock.release === 'function') {
                 this.performanceLock.release(reason || 'stopped');
                 this.performanceLock = null;
@@ -2009,6 +2043,17 @@
             this.frameY = Number.isFinite(Number(normalizedOptions.frameY))
                 ? Number(normalizedOptions.frameY)
                 : resolveIntroGreetingHugFrameShift(this.container);
+            this.initialAlphaOverride = Number.isFinite(Number(normalizedOptions.initialAlphaOverride))
+                ? clamp(Number(normalizedOptions.initialAlphaOverride), 0, 1)
+                : null;
+            this.motionFromAlpha = Number.isFinite(Number(normalizedOptions.motionFromAlpha))
+                ? clamp(Number(normalizedOptions.motionFromAlpha), 0, 1)
+                : null;
+            this.motionToAlpha = Number.isFinite(Number(normalizedOptions.motionToAlpha))
+                ? clamp(Number(normalizedOptions.motionToAlpha), 0, 1)
+                : null;
+            this.fromAlpha = 1;
+            this.toAlpha = 1;
             this.fromFrame = null;
             this.toFrame = null;
         }
@@ -2053,17 +2098,28 @@
             if (!this.isCurrentModel() || !this.captureInitialState()) {
                 return false;
             }
+            if (this.useCompositorOpacity) {
+                this.compositorOpacityTargets = collectAvatarMotionVisibleOpacityTargets(this, {
+                    document: this.document,
+                    container: this.container
+                });
+            }
+            if (this.initialAlphaOverride !== null) {
+                this.initialAlpha = this.initialAlphaOverride;
+            }
+            this.fromAlpha = this.motionFromAlpha === null ? this.initialAlpha : this.motionFromAlpha;
+            this.toAlpha = this.motionToAlpha === null ? this.initialAlpha : this.motionToAlpha;
             this.fromFrame = this.resolveTargetFrame(this.fromKind);
             this.toFrame = this.resolveTargetFrame(this.toKind);
             this.acquirePerformanceLock();
             this.active = true;
             this.startedAt = performance.now();
             if (this.reducedMotion) {
-                this.applyFrame(this.toFrame, this.initialAlpha);
+                this.applyFrame(this.toFrame, this.toAlpha);
                 this.finish('played');
                 return true;
             }
-            this.applyFrame(this.fromFrame, this.initialAlpha);
+            this.applyFrame(this.fromFrame, this.fromAlpha);
             this.attachTicker();
             return true;
         }
@@ -2082,15 +2138,18 @@
             }
             const elapsed = Math.max(0, performance.now() - this.startedAt);
             const enterProgress = this.enterMs > 0 ? clamp(elapsed / this.enterMs, 0, 1) : 1;
-            this.applyFrame(this.blendFrame(this.fromFrame, this.toFrame, enterProgress), this.initialAlpha);
+            this.applyFrame(
+                this.blendFrame(this.fromFrame, this.toFrame, enterProgress),
+                lerp(this.fromAlpha, this.toAlpha, enterProgress)
+            );
             if (elapsed >= this.enterMs + this.holdMs) {
                 if (this.restoreMode === 'commit-final') {
-                    this.applyFrame(this.toFrame, this.initialAlpha);
+                    this.applyFrame(this.toFrame, this.toAlpha);
                     this.finish('played');
                     return;
                 }
                 if (this.restoreMode === 'half-body') {
-                    this.applyFrame(this.toFrame, this.initialAlpha);
+                    this.applyFrame(this.toFrame, this.toAlpha);
                 } else if (this.restoreMode === 'initial') {
                     this.restoreModelFrame();
                 }
@@ -3085,10 +3144,22 @@
             this.ticker = context.ticker || null;
             this.container = normalizedOptions.container || getLive2DContainer(this.document);
             this.reducedMotion = !!normalizedOptions.reducedMotion;
+            this.startFromHidden = normalizedOptions.startFromHidden === true;
             this.hideMs = normalizeDuration(normalizedOptions.hideMs, PLUGIN_DASHBOARD_CORNER_HIDE_MS);
+            this.entryHideMs = this.startFromHidden ? 0 : this.hideMs;
             this.appearMs = normalizeDuration(normalizedOptions.appearMs, PLUGIN_DASHBOARD_CORNER_APPEAR_MS);
             this.holdMs = normalizeDuration(normalizedOptions.holdMs, 0);
-            this.totalDurationMs = this.reducedMotion ? 0 : this.hideMs + this.appearMs;
+            this.totalDurationMs = this.reducedMotion ? 0 : this.entryHideMs + this.appearMs;
+            this.exitDurationMs = this.reducedMotion ? 0 : this.hideMs + this.appearMs;
+            this.restoreMode = normalizedOptions.restoreMode === 'half-body' ? 'half-body' : 'initial';
+            this.useCompositorOpacity = normalizedOptions.useCompositorOpacity === true
+                || this.restoreMode === 'half-body';
+            this.restoreFrameScale = Number.isFinite(Number(normalizedOptions.frameScale))
+                ? Number(normalizedOptions.frameScale)
+                : INTRO_GREETING_HUG_CLOSE_SCALE;
+            this.restoreFrameY = Number.isFinite(Number(normalizedOptions.frameY))
+                ? Number(normalizedOptions.frameY)
+                : resolveIntroGreetingHugFrameShift(this.container);
             this.targetPosition = normalizeAvatarCornerPeekPosition(
                 normalizedOptions.position
                 || normalizedOptions.targetPosition
@@ -3104,6 +3175,8 @@
             this.result = 'idle';
             this.initialModelFrame = null;
             this.initialAlpha = 1;
+            this.restoreModelTargetFrame = null;
+            this.restoreAlpha = 1;
             this.initialBounds = null;
             this.peekRegionBounds = null;
             this.hiddenFrame = null;
@@ -3125,6 +3198,10 @@
             this.performanceLockCapabilities = Array.isArray(normalizedOptions.performanceLockCapabilities)
                 ? normalizedOptions.performanceLockCapabilities.slice()
                 : YUI_AVATAR_CORNER_PEEK_CAPABILITIES.slice();
+            this.onPeekReady = typeof normalizedOptions.onPeekReady === 'function'
+                ? normalizedOptions.onPeekReady
+                : null;
+            this.peekReadyNotified = false;
             this.phase = 'idle';
             this.tickerAttached = false;
             this.interruptSuspendedAt = 0;
@@ -3152,6 +3229,8 @@
                 return false;
             }
             this.initialAlpha = readModelAlpha(this.model);
+            this.restoreModelTargetFrame = this.resolveRestoreModelFrame();
+            this.restoreAlpha = this.restoreMode === 'half-body' ? 1 : this.initialAlpha;
             this.captureDisplayOpacityTargets();
             this.initialBounds = this.readBounds();
             this.peekRegionBounds = this.resolvePeekRegionBounds();
@@ -3172,8 +3251,14 @@
             this.active = true;
             this.phase = 'enter';
             this.startedAt = performance.now();
-            this.applyFrame(this.reducedMotion ? this.cornerFrame : this.initialModelFrame, this.reducedMotion ? 1 : this.initialAlpha);
+            this.applyFrame(
+                this.reducedMotion
+                    ? this.cornerFrame
+                    : (this.startFromHidden ? this.cornerHiddenFrame : this.initialModelFrame),
+                this.reducedMotion ? 1 : (this.startFromHidden ? 0 : this.initialAlpha)
+            );
             if (this.reducedMotion) {
+                this.notifyPeekReady();
                 this.elevateContainerZIndex();
                 if (this.holdMs > 0) {
                     this.phase = 'hold';
@@ -3196,6 +3281,17 @@
             } else {
                 this.frameId = window.requestAnimationFrame(this.tick);
             }
+            return true;
+        }
+
+        notifyPeekReady() {
+            if (this.peekReadyNotified || typeof this.onPeekReady !== 'function') {
+                return false;
+            }
+            this.peekReadyNotified = true;
+            try {
+                this.onPeekReady();
+            } catch (_) {}
             return true;
         }
 
@@ -3246,7 +3342,7 @@
             this.restoreFloatingButtonsRotation();
             this.restoreContainerZIndex();
             this.restoreModelFrame();
-            this.restoreDisplayOpacity();
+            this.restoreDisplayOpacity(this.restoreMode === 'half-body');
             if (this.faceForwardLock && typeof this.faceForwardLock.release === 'function') {
                 this.faceForwardLock.release(reason || 'stopped');
                 this.faceForwardLock = null;
@@ -3328,27 +3424,32 @@
             return targets.length > 0;
         }
 
-        writeDisplayOpacity(alpha) {
+        writeDisplayOpacity(alpha, primaryOnly) {
             const opacity = clamp(Number(alpha), 0, 1);
             const opacityText = String(Math.round(opacity * 1000) / 1000);
             if (!Array.isArray(this.displayOpacityTargets) || this.displayOpacityTargets.length === 0) {
                 this.captureDisplayOpacityTargets();
             }
+            if (primaryOnly) {
+                writeAvatarMotionPrimaryDisplayOpacity(this.displayOpacityTargets, opacity);
+                return;
+            }
             this.displayOpacityTargets.forEach((element) => {
                 if (!element || !element.style) {
                     return;
                 }
+                element.style.transition = 'none';
                 element.style.opacity = opacityText;
             });
         }
 
-        restoreDisplayOpacity() {
+        restoreDisplayOpacity(keepVisible) {
             if (!Array.isArray(this.displayOpacitySnapshots)) {
                 return;
             }
             this.displayOpacitySnapshots.forEach((snapshot) => {
                 if (snapshot && snapshot.element && snapshot.element.style) {
-                    snapshot.element.style.opacity = snapshot.opacity || '';
+                    snapshot.element.style.opacity = keepVisible ? '1' : (snapshot.opacity || '');
                     snapshot.element.style.transition = snapshot.transition || '';
                 }
             });
@@ -3709,20 +3810,45 @@
             };
         }
 
+        resolveRestoreModelFrame() {
+            if (this.restoreMode !== 'half-body' || !this.initialModelFrame) {
+                return this.initialModelFrame;
+            }
+            const frame = resolveIntroGreetingHugModelFrame(
+                this.initialModelFrame,
+                this.manager,
+                this.container,
+                this.restoreFrameScale,
+                this.restoreFrameY
+            );
+            if (frame) {
+                frame.rotation = this.initialModelFrame.rotation;
+            }
+            return frame || this.initialModelFrame;
+        }
+
         restoreModelFrame() {
             if (!this.isCurrentModel() || !this.initialModelFrame) {
                 return false;
             }
-            writeModelAlpha(this.model, this.initialAlpha);
-            return writeIntroGreetingHugModelFrame(this.model, this.initialModelFrame);
+            writeModelAlpha(this.model, this.restoreAlpha);
+            return writeIntroGreetingHugModelFrame(
+                this.model,
+                this.restoreModelTargetFrame || this.initialModelFrame
+            );
         }
 
         applyFrame(frame, alpha) {
             if (!this.isCurrentModel() || !frame) {
                 return false;
             }
-            writeModelAlpha(this.model, alpha);
-            this.writeDisplayOpacity(alpha);
+            if (this.useCompositorOpacity) {
+                writeModelAlpha(this.model, 1);
+                this.writeDisplayOpacity(alpha, true);
+            } else {
+                writeModelAlpha(this.model, alpha);
+                this.writeDisplayOpacity(1);
+            }
             centerLive2DLookAt(this);
             const applied = writeIntroGreetingHugModelFrame(this.model, frame);
             if (applied) {
@@ -3780,15 +3906,19 @@
         }
 
         tickEnter(elapsed) {
-            if (elapsed <= this.hideMs) {
-                const progress = this.hideMs > 0 ? easeInOutCubic(elapsed / this.hideMs) : 1;
+            if (!this.startFromHidden && elapsed <= this.entryHideMs) {
+                const progress = this.entryHideMs > 0 ? easeInOutCubic(elapsed / this.entryHideMs) : 1;
                 this.applyFrame(
                     this.initialModelFrame,
                     lerp(this.initialAlpha, 0, progress)
                 );
             } else if (elapsed <= this.totalDurationMs) {
-                const progress = this.appearMs > 0 ? easeOutCubic((elapsed - this.hideMs) / this.appearMs) : 1;
+                const progress = this.appearMs > 0 ? easeOutCubic((elapsed - this.entryHideMs) / this.appearMs) : 1;
                 this.elevateContainerZIndex();
+                if (!this.peekReadyNotified) {
+                    this.applyFrame(this.cornerHiddenFrame, 0);
+                    this.notifyPeekReady();
+                }
                 this.applyFrame(
                     this.blendFrame(this.cornerHiddenFrame, this.cornerFrame, progress),
                     lerp(0, 1, progress)
@@ -3816,12 +3946,12 @@
                     this.cornerFrame,
                     lerp(1, 0, progress)
                 );
-            } else if (elapsed <= this.totalDurationMs) {
+            } else if (elapsed <= this.exitDurationMs) {
                 const progress = this.appearMs > 0 ? easeOutCubic((elapsed - this.hideMs) / this.appearMs) : 1;
                 this.restoreContainerZIndex();
                 this.applyFrame(
-                    this.initialModelFrame,
-                    lerp(0, this.initialAlpha, progress)
+                    this.restoreModelTargetFrame || this.initialModelFrame,
+                    lerp(0, this.restoreAlpha, progress)
                 );
             } else {
                 this.finish(this.result || 'stopped');
@@ -5958,7 +6088,13 @@
             freezeFloatingButtons: normalizedOptions.freezeFloatingButtons,
             rotateFloatingButtons: normalizedOptions.rotateFloatingButtons,
             performanceLockKey: normalizedOptions.performanceLockKey,
-            performanceLockCapabilities: normalizedOptions.performanceLockCapabilities
+            performanceLockCapabilities: normalizedOptions.performanceLockCapabilities,
+            startFromHidden: normalizedOptions.startFromHidden,
+            restoreMode: normalizedOptions.restoreMode,
+            frameScale: normalizedOptions.frameScale,
+            frameY: normalizedOptions.frameY,
+            onPeekReady: normalizedOptions.onPeekReady,
+            useCompositorOpacity: normalizedOptions.useCompositorOpacity
         });
         if (!session.start()) {
             return null;
@@ -6044,11 +6180,12 @@
         const frameY = Number.isFinite(Number(normalizedOptions.frameY))
             ? Number(normalizedOptions.frameY)
             : resolveIntroGreetingHugFrameShift(container);
+        const baseFrame = normalizedOptions.baseFrame || null;
         return applyIntroGreetingHugFramePlacementToModel(
             context.model,
             context.manager,
             container,
-            null,
+            baseFrame,
             frameScale,
             frameY
         );
@@ -6072,7 +6209,7 @@
             }
             targets.push(element);
         };
-        pushTarget(getLive2DContainer(doc));
+        pushTarget(normalizedOptions.container || getLive2DContainer(doc));
         try {
             pushTarget(doc.getElementById('live2d-canvas'));
         } catch (_) {}
@@ -6149,6 +6286,14 @@
         const toDisplayAlpha = Number.isFinite(Number(normalizedOptions.toDisplayAlpha))
             ? clamp(Number(normalizedOptions.toDisplayAlpha), 0, 1)
             : fromDisplayAlpha;
+        const writeOpacity = normalizedOptions.primaryDisplayOnly === true
+            ? (modelAlpha, displayAlpha) => {
+                writeModelAlpha(context.model, 1);
+                writeAvatarMotionPrimaryDisplayOpacity(targets, displayAlpha);
+            }
+            : (modelAlpha, displayAlpha) => {
+                writeAvatarMotionVisibleOpacity(context, targets, modelAlpha, displayAlpha);
+            };
         const restoreTransitions = () => {
             targets.forEach((target) => {
                 if (target.element && target.element.style) {
@@ -6157,7 +6302,7 @@
             });
         };
         if (normalizedOptions.reducedMotion || durationMs <= 0) {
-            writeAvatarMotionVisibleOpacity(context, targets, toModelAlpha, toDisplayAlpha);
+            writeOpacity(toModelAlpha, toDisplayAlpha);
             restoreTransitions();
             return true;
         }
@@ -6167,14 +6312,14 @@
                 const current = context.manager ? getCurrentLive2DModel(context.manager) : context.model;
                 if (current !== context.model || context.model.destroyed) {
                     if (!context.model.destroyed) {
-                        writeAvatarMotionVisibleOpacity(context, targets, toModelAlpha, toDisplayAlpha);
+                        writeOpacity(toModelAlpha, toDisplayAlpha);
                     }
                     restoreTransitions();
                     resolve(false);
                     return;
                 }
                 if (typeof normalizedOptions.isCancelled === 'function' && normalizedOptions.isCancelled()) {
-                    writeAvatarMotionVisibleOpacity(context, targets, toModelAlpha, toDisplayAlpha);
+                    writeOpacity(toModelAlpha, toDisplayAlpha);
                     restoreTransitions();
                     resolve(false);
                     return;
@@ -6183,9 +6328,9 @@
                 const eased = easeInOutCubic(progress);
                 const modelAlpha = lerp(fromModelAlpha, toModelAlpha, eased);
                 const displayAlpha = lerp(fromDisplayAlpha, toDisplayAlpha, eased);
-                writeAvatarMotionVisibleOpacity(context, targets, modelAlpha, displayAlpha);
+                writeOpacity(modelAlpha, displayAlpha);
                 if (progress >= 1) {
-                    writeAvatarMotionVisibleOpacity(context, targets, toModelAlpha, toDisplayAlpha);
+                    writeOpacity(toModelAlpha, toDisplayAlpha);
                     restoreTransitions();
                     resolve(true);
                     return;
@@ -6202,9 +6347,12 @@
         if (!context || !context.model || context.model.destroyed) {
             return false;
         }
+        const fadeOutMs = Number.isFinite(Number(normalizedOptions.halfBodyFadeOutMs))
+            ? Number(normalizedOptions.halfBodyFadeOutMs)
+            : normalizedOptions.fadeOutMs;
         return animateAvatarMotionVisibleOpacity(Object.assign({}, normalizedOptions, {
             context: context,
-            durationMs: normalizedOptions.halfBodyFadeOutMs || normalizedOptions.fadeOutMs || AVATAR_MOTION_HALF_BODY_FADE_OUT_MS,
+            durationMs: normalizeDuration(fadeOutMs, AVATAR_MOTION_HALF_BODY_FADE_OUT_MS),
             fromModelAlpha: readModelAlpha(context.model),
             toModelAlpha: 0,
             toDisplayAlpha: 0
@@ -6232,8 +6380,11 @@
                 target.element.style.transition = 'none';
             }
         });
+        const fadeInOption = Number.isFinite(Number(normalizedOptions.halfBodyFadeInMs))
+            ? Number(normalizedOptions.halfBodyFadeInMs)
+            : normalizedOptions.fadeInMs;
         const fadeInMs = normalizeDuration(
-            normalizedOptions.halfBodyFadeInMs || normalizedOptions.fadeInMs,
+            fadeInOption,
             AVATAR_MOTION_HALF_BODY_FADE_IN_MS
         );
         if (!normalizedOptions.reducedMotion && fadeInMs > 0) {
@@ -6281,62 +6432,49 @@
 
     async function playTimedAvatarCornerPeek(options, position) {
         const normalizedOptions = options || {};
-        const restoreMode = normalizedOptions.restore || normalizedOptions.restoreMode || 'half-body';
-        const handle = await startAvatarCornerPeek(Object.assign({}, normalizedOptions, {
-            position: position,
-            targetPreset: position,
-            freezeFloatingButtons: normalizedOptions.freezeFloatingButtons,
-            rotateFloatingButtons: normalizedOptions.rotateFloatingButtons,
-            performanceLockKey: normalizedOptions.performanceLockKey || 'home-yui-guide-avatar-motion-corner'
-        }));
-        if (!handle || typeof handle.stop !== 'function') {
-            revealAvatarMotionPrepared(normalizedOptions, 'corner_peek_unavailable');
-            return { result: 'fallback', reason: 'corner_peek_unavailable' };
-        }
-        let revealTimer = 0;
+        const isOpeningProbe = normalizedOptions.isOpeningProbe === true;
         let revealed = false;
         const revealPrepared = (reason) => {
             if (revealed) {
                 return false;
             }
             revealed = true;
-            if (revealTimer) {
-                window.clearTimeout(revealTimer);
-                revealTimer = 0;
-            }
             const revealedNow = revealAvatarMotionPrepared(normalizedOptions, reason);
             if (revealedNow) {
                 showAvatarMotionFloatingButtons(normalizedOptions);
             }
             return revealedNow;
         };
-        if (typeof normalizedOptions.revealPrepared === 'function') {
-            const revealDelayMs = normalizedOptions.reducedMotion
-                ? 0
-                : normalizeDuration(normalizedOptions.revealDelayMs, PLUGIN_DASHBOARD_CORNER_HIDE_MS);
-            if (revealDelayMs <= 0) {
-                revealPrepared('avatar_motion_reduced_ready');
-            } else {
-                revealTimer = window.setTimeout(() => {
-                    revealPrepared('avatar_motion_corner_peek_ready');
-                }, revealDelayMs);
-            }
+        const handle = await startAvatarCornerPeek(Object.assign({}, normalizedOptions, {
+            position: position,
+            targetPreset: position,
+            startFromHidden: isOpeningProbe,
+            hideMs: TUTORIAL_AVATAR_PROBE_FADE_OUT_MS,
+            appearMs: TUTORIAL_AVATAR_PROBE_APPROACH_MS,
+            holdMs: TUTORIAL_AVATAR_PROBE_HOLD_MS,
+            restoreMode: normalizedOptions.restore || normalizedOptions.restoreMode || 'half-body',
+            freezeFloatingButtons: normalizedOptions.freezeFloatingButtons,
+            rotateFloatingButtons: normalizedOptions.rotateFloatingButtons,
+            performanceLockKey: normalizedOptions.performanceLockKey || 'home-yui-guide-avatar-motion-corner',
+            onPeekReady: () => revealPrepared('avatar_motion_corner_peek_ready')
+        }));
+        if (!handle || typeof handle.stop !== 'function') {
+            revealPrepared('corner_peek_unavailable');
+            return { result: 'fallback', reason: 'corner_peek_unavailable' };
         }
-        await waitForAvatarMotionDelay(normalizedOptions.durationMs, normalizedOptions.isCancelled);
+        const entryMs = normalizedOptions.reducedMotion
+            ? 0
+            : (isOpeningProbe
+                ? TUTORIAL_AVATAR_PROBE_APPROACH_MS
+                : TUTORIAL_AVATAR_PROBE_FADE_OUT_MS + TUTORIAL_AVATAR_PROBE_APPROACH_MS);
+        const handoffDelayMs = entryMs + TUTORIAL_AVATAR_PROBE_HOLD_MS;
+        await waitForAvatarMotionDelay(handoffDelayMs, normalizedOptions.isCancelled);
         if (typeof normalizedOptions.isCancelled === 'function' && normalizedOptions.isCancelled()) {
-            if (revealTimer) {
-                window.clearTimeout(revealTimer);
-                revealTimer = 0;
-            }
             await handle.stop('avatar_motion_cancelled');
             return { result: 'cancelled', reason: 'cancelled' };
         }
         revealPrepared('avatar_motion_complete_before_handoff');
-        await fadeOutAvatarMotionVisibleLayer(normalizedOptions);
-        await handle.stop('avatar_motion_complete', { animateReturn: false });
-        if (restoreMode === 'half-body') {
-            await fadeInAvatarMotionHalfBodyPlacement(normalizedOptions);
-        }
+        await handle.stop('avatar_motion_complete');
         return { result: 'played', reason: '' };
     }
 
@@ -6391,6 +6529,114 @@
         return session.waitForFinish();
     }
 
+    async function playTutorialAvatarProbeFrameMotion(options, preset) {
+        const normalizedOptions = options || {};
+        const waitMs = normalizeDuration(normalizedOptions.readyWaitMs, PLUGIN_DASHBOARD_CORNER_READY_WAIT_MS);
+        const context = await waitForLive2DContext(waitMs);
+        if (!context) {
+            return { result: 'fallback', reason: 'live2d_unavailable' };
+        }
+        if (activeAvatarMotionSession && activeAvatarMotionSession.active) {
+            await activeAvatarMotionSession.stop('replaced');
+        }
+        const isOpeningProbe = normalizedOptions.isOpeningProbe === true;
+        const frameScale = Number.isFinite(Number(normalizedOptions.frameScale))
+            ? Number(normalizedOptions.frameScale)
+            : INTRO_GREETING_HUG_CLOSE_SCALE;
+        const originalAlpha = readModelAlpha(context.model);
+        const originalFrame = readIntroGreetingHugModelFrame(context.model);
+        const originalTargets = collectAvatarMotionVisibleOpacityTargets(context, normalizedOptions);
+        const originalDisplayAlpha = originalTargets.length > 0 ? originalTargets[0].opacity : 1;
+        if (!isOpeningProbe) {
+            const fadedOut = await animateAvatarMotionVisibleOpacity({
+                context: context,
+                document: normalizedOptions.document || document,
+                reducedMotion: !!normalizedOptions.reducedMotion,
+                isCancelled: normalizedOptions.isCancelled,
+                durationMs: TUTORIAL_AVATAR_PROBE_FADE_OUT_MS,
+                fromModelAlpha: originalAlpha,
+                toModelAlpha: 0,
+                fromDisplayAlpha: originalDisplayAlpha,
+                toDisplayAlpha: 0
+            });
+            if (!fadedOut) {
+                writeAvatarMotionVisibleOpacity(context, originalTargets, originalAlpha, originalDisplayAlpha);
+                return {
+                    result: normalizedOptions.isCancelled && normalizedOptions.isCancelled()
+                        ? 'cancelled'
+                        : 'fallback',
+                    reason: normalizedOptions.isCancelled && normalizedOptions.isCancelled()
+                        ? 'cancelled'
+                        : 'avatar_motion_fade_out_failed'
+                };
+            }
+        }
+        const session = new Live2DFrameMotionSession(context, {
+            document: normalizedOptions.document || document,
+            reducedMotion: !!normalizedOptions.reducedMotion,
+            token: normalizedOptions.token || Date.now(),
+            isCancelled: normalizedOptions.isCancelled,
+            preset: preset,
+            from: 'offscreen-bottom',
+            to: 'close-up',
+            frameScale: frameScale,
+            frameY: Number.isFinite(Number(normalizedOptions.frameY))
+                ? Number(normalizedOptions.frameY)
+                : undefined,
+            enterMs: TUTORIAL_AVATAR_PROBE_APPROACH_MS,
+            holdMs: TUTORIAL_AVATAR_PROBE_HOLD_MS,
+            initialAlphaOverride: originalAlpha,
+            motionFromAlpha: 0,
+            motionToAlpha: originalAlpha,
+            useCompositorOpacity: isOpeningProbe,
+            restoreMode: normalizedOptions.restore || normalizedOptions.restoreMode || 'half-body',
+            performanceLockKey: normalizedOptions.performanceLockKey || 'home-yui-guide-avatar-motion-frame'
+        });
+        if (!session.start()) {
+            writeAvatarMotionVisibleOpacity(context, originalTargets, originalAlpha, originalDisplayAlpha);
+            revealAvatarMotionPrepared(normalizedOptions, 'avatar_motion_start_failed');
+            return { result: 'fallback', reason: 'avatar_motion_start_failed' };
+        }
+        revealAvatarMotionPrepared(normalizedOptions, 'avatar_motion_frame_started');
+        activeAvatarMotionSession = session;
+        await session.waitForFinish();
+        if (session.result !== 'played') {
+            return {
+                result: session.result || 'cancelled',
+                reason: session.result || 'cancelled'
+            };
+        }
+        if (isOpeningProbe) {
+            return { result: 'played', reason: '' };
+        }
+        const finalFadedOut = await fadeOutAvatarMotionVisibleLayer(Object.assign({}, normalizedOptions, {
+            halfBodyFadeOutMs: TUTORIAL_AVATAR_PROBE_FADE_OUT_MS
+        }));
+        if (!finalFadedOut) {
+            return { result: 'cancelled', reason: 'avatar_motion_fade_out_cancelled' };
+        }
+        if (normalizedOptions.restore === 'half-body' || normalizedOptions.restoreMode === 'half-body'
+                || (!normalizedOptions.restore && !normalizedOptions.restoreMode)) {
+            await fadeInAvatarMotionHalfBodyPlacement(Object.assign({}, normalizedOptions, {
+                halfBodyFadeInMs: TUTORIAL_AVATAR_PROBE_RETURN_MS,
+                baseFrame: originalFrame || session.initialModelFrame
+            }));
+        } else {
+            await animateAvatarMotionVisibleOpacity({
+                context: context,
+                document: normalizedOptions.document || document,
+                reducedMotion: !!normalizedOptions.reducedMotion,
+                isCancelled: normalizedOptions.isCancelled,
+                durationMs: TUTORIAL_AVATAR_PROBE_RETURN_MS,
+                fromModelAlpha: 0,
+                toModelAlpha: originalAlpha,
+                fromDisplayAlpha: 0,
+                toDisplayAlpha: originalDisplayAlpha
+            });
+        }
+        return { result: 'played', reason: '' };
+    }
+
     async function playAvatarMotion(options) {
         const normalizedOptions = options || {};
         const preset = normalizeAvatarMotionPreset(normalizedOptions.preset);
@@ -6409,6 +6655,9 @@
                 normalizedOptions,
                 normalizedOptions.position || normalizedOptions.targetPosition || 'bottom-right'
             );
+        }
+        if (normalizedOptions.narrationBudgeted === true) {
+            return playTutorialAvatarProbeFrameMotion(normalizedOptions, preset);
         }
         return playFrameAvatarMotion(normalizedOptions, preset);
     }

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -850,7 +850,13 @@
         );
     }
 
-    function waitForLive2DContext(timeoutMs) {
+    function waitForLive2DContext(timeoutMs, isCancelled) {
+        const cancelCheck = typeof isCancelled === 'function'
+            ? isCancelled
+            : function () { return false; };
+        if (cancelCheck()) {
+            return Promise.resolve(null);
+        }
         const immediate = getLive2DContext();
         if (immediate) {
             return Promise.resolve(immediate);
@@ -864,6 +870,10 @@
         return new Promise((resolve) => {
             const startedAt = performance.now();
             const check = () => {
+                if (cancelCheck()) {
+                    resolve(null);
+                    return;
+                }
                 const context = getLive2DContext();
                 if (context) {
                     resolve(context);
@@ -1888,6 +1898,7 @@
             this.initialAlpha = 1;
             this.useCompositorOpacity = normalizedOptions.useCompositorOpacity === true;
             this.compositorOpacityTargets = [];
+            this.previousAvatarMotionActiveValue = false;
             this.startedAt = 0;
             this.active = false;
             this.finished = false;
@@ -2004,6 +2015,7 @@
                 });
                 this.compositorOpacityTargets = [];
             }
+            setAvatarCornerPeekActiveFlag(this.previousAvatarMotionActiveValue);
             if (this.performanceLock && typeof this.performanceLock.release === 'function') {
                 this.performanceLock.release(reason || 'stopped');
                 this.performanceLock = null;
@@ -2118,6 +2130,8 @@
             this.fromFrame = this.resolveTargetFrame(this.fromKind);
             this.toFrame = this.resolveTargetFrame(this.toKind);
             this.acquirePerformanceLock();
+            this.previousAvatarMotionActiveValue = window.nekoYuiGuideAvatarCornerPeekActive === true;
+            setAvatarCornerPeekActiveFlag(true);
             this.active = true;
             this.startedAt = performance.now();
             if (this.reducedMotion) {
@@ -6073,7 +6087,7 @@
     async function startAvatarCornerPeek(options) {
         const normalizedOptions = options || {};
         const waitMs = normalizeDuration(normalizedOptions.readyWaitMs, PLUGIN_DASHBOARD_CORNER_READY_WAIT_MS);
-        const context = await waitForLive2DContext(waitMs);
+        const context = await waitForLive2DContext(waitMs, normalizedOptions.isCancelled);
         if (!context) {
             return null;
         }
@@ -6538,9 +6552,14 @@
     async function playTutorialAvatarProbeFrameMotion(options, preset) {
         const normalizedOptions = options || {};
         const waitMs = normalizeDuration(normalizedOptions.readyWaitMs, PLUGIN_DASHBOARD_CORNER_READY_WAIT_MS);
-        const context = await waitForLive2DContext(waitMs);
+        const context = await waitForLive2DContext(waitMs, normalizedOptions.isCancelled);
         if (!context) {
-            return { result: 'fallback', reason: 'live2d_unavailable' };
+            const cancelled = typeof normalizedOptions.isCancelled === 'function'
+                && normalizedOptions.isCancelled();
+            return {
+                result: cancelled ? 'cancelled' : 'fallback',
+                reason: cancelled ? 'cancelled' : 'live2d_unavailable'
+            };
         }
         if (activeAvatarMotionSession && activeAvatarMotionSession.active) {
             await activeAvatarMotionSession.stop('replaced');

--- a/static/tutorial/avatar/yui-stage.js
+++ b/static/tutorial/avatar/yui-stage.js
@@ -6479,6 +6479,9 @@
             onPeekReady: () => revealPrepared('avatar_motion_corner_peek_ready')
         }));
         if (!handle || typeof handle.stop !== 'function') {
+            if (typeof normalizedOptions.isCancelled === 'function' && normalizedOptions.isCancelled()) {
+                return { result: 'cancelled', reason: 'cancelled' };
+            }
             revealPrepared('corner_peek_unavailable');
             return { result: 'fallback', reason: 'corner_peek_unavailable' };
         }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -2485,6 +2485,7 @@ class UniversalTutorialManager {
         if (typeof document === 'undefined' || typeof document.getElementById !== 'function') {
             return;
         }
+        const preserveAvatarMotionOpacity = window.nekoYuiGuideAvatarCornerPeekActive === true;
         if (document.body && document.body.classList) {
             document.body.classList.remove('yui-guide-return-petal-fade');
         }
@@ -2512,8 +2513,10 @@ class UniversalTutorialManager {
             ) {
                 element.style.removeProperty('display');
             }
-            element.style.removeProperty('opacity');
-            element.style.removeProperty('transition');
+            if (!preserveAvatarMotionOpacity || (id !== 'live2d-container' && id !== 'live2d-canvas')) {
+                element.style.removeProperty('opacity');
+                element.style.removeProperty('transition');
+            }
             element.style.removeProperty('visibility');
             element.style.removeProperty('pointer-events');
         });

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -2128,7 +2128,7 @@ class UniversalTutorialManager {
             window.LanLan1.live2dModel = loadedModel;
             window.LanLan1.currentModel = loadedModel;
         }
-        if (typeof window.showLive2d === 'function') {
+        if (!deferRevealPrepared && typeof window.showLive2d === 'function') {
             window.showLive2d();
         }
         if (window.live2dManager && typeof window.live2dManager.resumeRendering === 'function') {

--- a/static/tutorial/yui-guide/days/day3-interaction-guide.js
+++ b/static/tutorial/yui-guide/days/day3-interaction-guide.js
@@ -54,7 +54,6 @@
                     operation: 'daily-intro-avatar-performance',
                     introAvatarPerformance: {
                         preset: 'bottom-rise',
-                        approachMs: 1500,
                         restore: 'half-body'
                     }
                 },

--- a/static/tutorial/yui-guide/director/chat-performance.js
+++ b/static/tutorial/yui-guide/director/chat-performance.js
@@ -563,7 +563,12 @@
             const isCornerPeekPerformance = normalizedPreset === 'corner-peek'
                 || normalizedPreset === 'top-peek';
             let revealed = false;
+            let revealReadyTimedOut = false;
             const resolveOnReveal = normalizedOptions.isFirstDailyScene === true;
+            const externalCancelCheck = typeof normalizedOptions.isCancelled === 'function'
+                ? normalizedOptions.isCancelled
+                : () => this.isStopping();
+            const isMotionCancelled = () => revealReadyTimedOut || externalCancelCheck();
             let revealReadyResolve = null;
             let revealReadySettled = false;
             let revealReadyFallbackTimer = 0;
@@ -648,13 +653,12 @@
                 reducedMotion: typeof normalizedOptions.reducedMotion === 'boolean'
                     ? normalizedOptions.reducedMotion
                     : this.shouldReduceTutorialMotion(),
-                isCancelled: typeof normalizedOptions.isCancelled === 'function'
-                    ? normalizedOptions.isCancelled
-                    : () => this.isStopping()
+                isCancelled: isMotionCancelled
             });
             if (resolveOnReveal) {
                 if (!revealReadySettled && revealReadyFallbackMs > 0 && typeof window.setTimeout === 'function') {
                     revealReadyFallbackTimer = window.setTimeout(() => {
+                        revealReadyTimedOut = true;
                         if (revealPrepared) {
                             revealPrepared('daily-intro-avatar-reveal-timeout');
                             return;

--- a/static/tutorial/yui-guide/director/chat-performance.js
+++ b/static/tutorial/yui-guide/director/chat-performance.js
@@ -549,7 +549,19 @@
 
         async runDailyIntroAvatarPerformance(scene, day, options) {
             const normalizedOptions = options || {};
+            const tutorialDay = Number.isFinite(Number(day))
+                ? Number(day)
+                : Number(normalizedOptions.day);
             const api = window.YuiGuideAvatarStage;
+            const performance = scene && scene.introAvatarPerformance
+                ? scene.introAvatarPerformance
+                : {};
+            const normalizedPreset = String(performance.preset || 'wave-zoom')
+                .trim()
+                .toLowerCase()
+                .replace(/_/g, '-');
+            const isCornerPeekPerformance = normalizedPreset === 'corner-peek'
+                || normalizedPreset === 'top-peek';
             let revealed = false;
             const resolveOnReveal = normalizedOptions.isFirstDailyScene === true;
             let revealReadyResolve = null;
@@ -560,7 +572,7 @@
             });
             const revealReadyFallbackMs = Number.isFinite(Number(normalizedOptions.revealReadyFallbackMs))
                 ? Math.max(0, Math.floor(Number(normalizedOptions.revealReadyFallbackMs)))
-                : 1600;
+                : (resolveOnReveal ? 0 : (isCornerPeekPerformance ? 0 : 1600));
             const resolveRevealReady = (value) => {
                 if (revealReadySettled) {
                     return;
@@ -591,9 +603,6 @@
                 resolveRevealReady(false);
                 return resolveOnReveal ? revealReadyPromise : null;
             }
-            const performance = scene && scene.introAvatarPerformance
-                ? scene.introAvatarPerformance
-                : {};
             const voiceKey = scene && scene.voiceKey ? scene.voiceKey : '';
             const text = scene && scene.text ? scene.text : '';
             const durationMs = Number.isFinite(Number(performance.durationMs))
@@ -603,6 +612,10 @@
                 preset: performance.preset || 'wave-zoom',
                 position: performance.position || performance.targetPosition || '',
                 durationMs: durationMs,
+                narrationBudgeted: tutorialDay >= 2 && tutorialDay <= 7,
+                isOpeningProbe: tutorialDay >= 2
+                    && tutorialDay <= 7
+                    && resolveOnReveal,
                 restore: performance.restore || 'half-body',
                 approachMs: Number.isFinite(Number(performance.approachMs))
                     ? Math.max(0, Math.floor(Number(performance.approachMs)))
@@ -628,7 +641,7 @@
                     : undefined,
                 readyWaitMs: Number.isFinite(Number(performance.readyWaitMs))
                     ? Math.max(0, Math.floor(Number(performance.readyWaitMs)))
-                    : undefined,
+                    : (resolveOnReveal ? 12000 : undefined),
                 freezeFloatingButtons: performance.freezeFloatingButtons === false ? false : undefined,
                 rotateFloatingButtons: performance.rotateFloatingButtons === true,
                 revealPrepared: revealPrepared,
@@ -650,7 +663,16 @@
                     }, revealReadyFallbackMs);
                 }
                 motionPromise.then(
-                    () => {
+                    (result) => {
+                        if (result && result.result === 'fallback') {
+                            console.warn('[YuiGuide] 首日开场模型演出不可用，显示普通半身兜底:', result.reason || 'unknown');
+                            if (revealPrepared) {
+                                revealPrepared('daily-intro-avatar-motion-fallback');
+                                return;
+                            }
+                            resolveRevealReady(false);
+                            return;
+                        }
                         resolveRevealReady(true);
                     },
                     (error) => {
@@ -861,7 +883,11 @@
                 return await api.startAvatarCornerPeek({
                     position: normalizedOptions.position,
                     targetPreset: normalizedOptions.targetPreset,
+                    hideMs: normalizedOptions.hideMs,
+                    appearMs: normalizedOptions.appearMs,
+                    holdMs: normalizedOptions.holdMs,
                     performanceLockKey: normalizedOptions.performanceLockKey,
+                    useCompositorOpacity: true,
                     reducedMotion: normalizedOptions.reducedMotion === true || this.shouldReduceTutorialMotion(),
                     isCancelled: typeof normalizedOptions.isCancelled === 'function'
                         ? normalizedOptions.isCancelled

--- a/static/tutorial/yui-guide/director/chat-performance.js
+++ b/static/tutorial/yui-guide/director/chat-performance.js
@@ -572,7 +572,7 @@
             });
             const revealReadyFallbackMs = Number.isFinite(Number(normalizedOptions.revealReadyFallbackMs))
                 ? Math.max(0, Math.floor(Number(normalizedOptions.revealReadyFallbackMs)))
-                : (resolveOnReveal ? 0 : (isCornerPeekPerformance ? 0 : 1600));
+                : (resolveOnReveal ? 3000 : (isCornerPeekPerformance ? 0 : 1600));
             const resolveRevealReady = (value) => {
                 if (revealReadySettled) {
                     return;

--- a/static/tutorial/yui-guide/director/director-core.js
+++ b/static/tutorial/yui-guide/director/director-core.js
@@ -450,6 +450,9 @@
             this.avatarStandInActive = true;
             Promise.resolve(this.startAvatarCornerPeekPerformance({
                 position: cue.position,
+                hideMs: cue.hideMs,
+                appearMs: cue.appearMs,
+                holdMs: cue.holdMs,
                 isCancelled: () => token !== this.avatarStandInToken
                     || this.isStopping()
                     || this.destroyed
@@ -467,9 +470,11 @@
                     return;
                 }
                 this.avatarStandInPerformanceHandle = handle;
-                const rawDurationMs = Number.isFinite(Number(cue.duration))
+                const rawDurationMs = Number.isFinite(Number(cue.totalDurationMs))
+                    ? Number(cue.totalDurationMs)
+                    : (Number.isFinite(Number(cue.duration))
                     ? Number(cue.duration)
-                    : Number(cue.durationMs);
+                    : Number(cue.durationMs));
                 const durationMs = Math.max(0, Number.isFinite(rawDurationMs) ? rawDurationMs : 0);
                 this.avatarStandInHideTimer = window.setTimeout(() => {
                     if (token === this.avatarStandInToken) {

--- a/static/tutorial/yui-guide/wakeup.js
+++ b/static/tutorial/yui-guide/wakeup.js
@@ -71,6 +71,7 @@
 
     function revealPreparedTutorialLive2D(reason) {
         try {
+            window.nekoYuiGuideLive2dPreparing = false;
             if (document && document.body) {
                 document.body.classList.remove('yui-guide-live2d-preparing');
             }

--- a/static/yui-guide-avatar-standin.test.cjs
+++ b/static/yui-guide-avatar-standin.test.cjs
@@ -974,6 +974,25 @@ test('daily opening reveal keeps a bounded fallback while preserving explicit ov
     assert.match(directorSource, /daily-intro-avatar-reveal-timeout/);
 });
 
+test('cancelled opening corner peek stays hidden when the Live2D context is unavailable', async () => {
+    const api = loadAvatarStageApi();
+    let revealCount = 0;
+
+    const result = await api.playAvatarMotion({
+        preset: 'corner-peek',
+        isOpeningProbe: true,
+        readyWaitMs: 0,
+        isCancelled: () => true,
+        revealPrepared() {
+            revealCount += 1;
+        }
+    });
+
+    assert.equal(result.result, 'cancelled');
+    assert.equal(result.reason, 'cancelled');
+    assert.equal(revealCount, 0);
+});
+
 test('Live2D corner peek can continue across scene boundaries until its cue duration ends', () => {
     const showBlock = directorSource
         .split('        showAvatarStandIn(cue, token) {')[1]

--- a/static/yui-guide-avatar-standin.test.cjs
+++ b/static/yui-guide-avatar-standin.test.cjs
@@ -7,6 +7,7 @@ const vm = require('node:vm');
 const { readJsParts } = require('./app-part-test-utils.cjs');
 
 const standIn = require('./tutorial/avatar/yui-standin.js');
+const standInController = require('./tutorial/avatar/standin-controller.js');
 const directorSource = readDirectorSource(__dirname);
 const avatarStageSource = fs.readFileSync(path.join(__dirname, 'tutorial/avatar/yui-stage.js'), 'utf8');
 const controllerSource = fs.readFileSync(path.join(__dirname, 'tutorial/avatar/standin-controller.js'), 'utf8');
@@ -115,6 +116,15 @@ function createCornerPeekSession(position, options) {
     }, {
         position,
         isCancelled: normalizedOptions.isCancelled,
+        onPeekReady: normalizedOptions.onPeekReady,
+        startFromHidden: normalizedOptions.startFromHidden,
+        hideMs: normalizedOptions.hideMs,
+        appearMs: normalizedOptions.appearMs,
+        holdMs: normalizedOptions.holdMs,
+        restoreMode: normalizedOptions.restoreMode,
+        useCompositorOpacity: normalizedOptions.useCompositorOpacity,
+        frameScale: normalizedOptions.frameScale,
+        frameY: normalizedOptions.frameY,
         container: normalizedOptions.container || {
             style: {}
         }
@@ -127,6 +137,8 @@ function createCornerPeekSession(position, options) {
         rotation: 0
     };
     session.initialAlpha = model.alpha;
+    session.restoreModelTargetFrame = session.initialModelFrame;
+    session.restoreAlpha = session.initialAlpha;
     session.initialBounds = model.getBounds();
     session.hiddenFrame = session.resolveHiddenFrame();
     session.peekRegionBounds = session.resolvePeekRegionBounds();
@@ -135,6 +147,78 @@ function createCornerPeekSession(position, options) {
     return {
         session,
         model,
+        window: context.window
+    };
+}
+
+function createFrameMotionSession(options) {
+    const normalizedOptions = options || {};
+    const container = normalizedOptions.container || { style: {} };
+    const canvas = normalizedOptions.canvas || { style: {} };
+    const context = loadAvatarStageContext({
+        elements: {
+            'live2d-container': container,
+            'live2d-canvas': canvas
+        }
+    });
+    const coreModel = {};
+    const model = {
+        x: 512,
+        y: 384,
+        rotation: 0,
+        alpha: 0.8,
+        destroyed: false,
+        scale: {
+            x: 1,
+            y: 1,
+            set(x, y) {
+                this.x = x;
+                this.y = y;
+            }
+        },
+        internalModel: {
+            coreModel
+        },
+        getBounds() {
+            return {
+                x: 362,
+                y: 84,
+                width: 300,
+                height: 600
+            };
+        }
+    };
+    const manager = {
+        currentModel: model,
+        pixi_app: {
+            renderer: {
+                screen: {
+                    width: 1024,
+                    height: 768
+                }
+            }
+        }
+    };
+    const session = new context.api.Live2DFrameMotionSession({
+        manager,
+        model,
+        coreModel
+    }, {
+        container,
+        from: 'offscreen-bottom',
+        to: 'close-up',
+        enterMs: 2000,
+        holdMs: 2500,
+        motionFromAlpha: 0,
+        motionToAlpha: 1,
+        restoreMode: 'half-body',
+        useCompositorOpacity: true
+    });
+    return {
+        session,
+        model,
+        container,
+        canvas,
         window: context.window
     };
 }
@@ -335,13 +419,46 @@ test('avatar stage exposes reusable motion core and preset playback entry', () =
     assert.match(avatarStageSource, /Live2DFrameMotionSession: Live2DFrameMotionSession/);
 });
 
+test('day two through seven avatar probes keep fixed phases and move short-line cues earlier', () => {
+    assert.match(avatarStageSource, /const TUTORIAL_AVATAR_PROBE_FADE_OUT_MS = 1500;/);
+    assert.match(avatarStageSource, /const TUTORIAL_AVATAR_PROBE_APPROACH_MS = 2000;/);
+    assert.match(avatarStageSource, /const TUTORIAL_AVATAR_PROBE_HOLD_MS = 2500;/);
+    assert.match(avatarStageSource, /startFromHidden: isOpeningProbe/);
+    assert.match(avatarStageSource, /holdMs: TUTORIAL_AVATAR_PROBE_HOLD_MS/);
+    assert.match(directorSource, /isOpeningProbe: tutorialDay >= 2[\s\S]*resolveOnReveal/);
+
+    const resolvedCue = standInController.resolveCueTiming(
+        { delay: 900, duration: 5000, position: 'top-right' },
+        { voiceKey: 'day2_galgame_entry', text: 'test' },
+        { getAvatarFloatingNarrationDurationMs: () => 4500 }
+    );
+    assert.equal(resolvedCue.delay, 0);
+    assert.equal(resolvedCue.hideMs, 1500);
+    assert.equal(resolvedCue.appearMs, 2000);
+    assert.equal(resolvedCue.holdMs, 2500);
+    assert.equal(resolvedCue.totalDurationMs, 6000);
+    assert.equal(resolvedCue.fullDurationMs, 9500);
+
+    const longLineCue = standInController.resolveCueTiming(
+        { delay: 900, duration: 5000, position: 'top-right' },
+        { voiceKey: 'day2_galgame_entry', text: 'test' },
+        { getAvatarFloatingNarrationDurationMs: () => 12000 }
+    );
+    assert.equal(longLineCue.delay, 900);
+});
+
 test('bottom-rise intro avatar motion approaches and holds the first-day half-body frame', () => {
-    assert.match(avatarStageSource, /to:\s*isBottomRise\s*\?\s*'close-up'\s*:/);
+    assert.match(avatarStageSource, /from:\s*'offscreen-bottom'/);
+    assert.match(avatarStageSource, /to:\s*'close-up'/);
     assert.match(avatarStageSource, /frameScale[\s\S]*:\s*INTRO_GREETING_HUG_CLOSE_SCALE/);
     assert.match(avatarStageSource, /frameY[\s\S]*resolveIntroGreetingHugFrameShift\(this\.container\)/);
     assert.match(avatarStageSource, /frameY[\s\S]*:\s*undefined/);
     assert.match(avatarStageSource, /restoreMode[\s\S]*normalizedOptions\.restore[\s\S]*\|\|\s*'half-body'/);
-    assert.match(avatarStageSource, /this\.restoreMode === 'half-body'[\s\S]*this\.applyFrame\(this\.toFrame, this\.initialAlpha\)/);
+    assert.match(avatarStageSource, /this\.restoreMode === 'half-body'[\s\S]*this\.applyFrame\(this\.toFrame, this\.toAlpha\)/);
+    assert.match(avatarStageSource, /initialAlphaOverride/);
+    assert.match(avatarStageSource, /motionFromAlpha/);
+    assert.match(avatarStageSource, /const originalFrame = readIntroGreetingHugModelFrame\(context\.model\)/);
+    assert.match(avatarStageSource, /baseFrame: originalFrame \|\| session\.initialModelFrame/);
 });
 
 test('corner and top peek intro avatar motions settle on the first-day half-body frame', () => {
@@ -349,7 +466,8 @@ test('corner and top peek intro avatar motions settle on the first-day half-body
     assert.match(avatarStageSource, /INTRO_GREETING_HUG_CLOSE_SCALE/);
     assert.match(avatarStageSource, /const container = getLive2DContainer/);
     assert.match(avatarStageSource, /resolveIntroGreetingHugFrameShift\(container\)/);
-    assert.match(avatarStageSource, /await handle\.stop\('avatar_motion_complete', \{ animateReturn: false \}\);[\s\S]*if \(restoreMode === 'half-body'\)/);
+    assert.match(avatarStageSource, /restoreMode: normalizedOptions\.restore \|\| normalizedOptions\.restoreMode \|\| 'half-body'/);
+    assert.match(avatarStageSource, /await handle\.stop\('avatar_motion_complete'\);/);
     assert.match(avatarStageSource, /applyAvatarMotionHalfBodyPlacement\(normalizedOptions\)/);
 });
 
@@ -380,10 +498,10 @@ test('corner and top peek intro avatar motions fade in the half-body handoff', (
     assert.match(avatarStageSource, /async function fadeInAvatarMotionHalfBodyPlacement\(options\)/);
     assert.match(avatarStageSource, /const targetAlpha = 1;/);
     assert.match(avatarStageSource, /const targetDisplayAlpha = 1;/);
-    assert.match(avatarStageSource, /await fadeOutAvatarMotionVisibleLayer\(normalizedOptions\)/);
+    assert.match(avatarStageSource, /await fadeOutAvatarMotionVisibleLayer\(/);
     assert.match(avatarStageSource, /writeAvatarMotionVisibleOpacity\(context, targets, 0, 0\)/);
     assert.match(avatarStageSource, /writeAvatarMotionVisibleOpacity\(context, targets, lerp\(0, targetAlpha, eased\), displayAlpha\)/);
-    assert.match(avatarStageSource, /await fadeInAvatarMotionHalfBodyPlacement\(normalizedOptions\)/);
+    assert.match(avatarStageSource, /await fadeInAvatarMotionHalfBodyPlacement\(/);
 });
 
 test('soft approach intro avatar motion uses the first-day half-body scale', () => {
@@ -397,6 +515,7 @@ test('Live2D corner peek keeps center model still while fading and uses one seco
     assert.equal(session.hideMs, 1000);
     assert.equal(session.appearMs, 1000);
     assert.equal(session.totalDurationMs, 2000);
+    assert.equal(session.exitDurationMs, 2000);
 
     session.tickEnter(500);
     assert.equal(model.x, 512);
@@ -421,7 +540,232 @@ test('Live2D corner peek keeps center model still while fading and uses one seco
     assert.ok(model.alpha < 0.8);
 });
 
-test('Live2D corner peek fades the visible layer and centers look-at during playback', () => {
+test('Live2D corner peek notifies reveal only after preparing the corner-hidden frame', () => {
+    let readyFrame = null;
+    let readyAlpha = null;
+    const { session, model } = createCornerPeekSession('bottom-left', {
+        onPeekReady: () => {
+            readyFrame = {
+                x: model.x,
+                y: model.y,
+                rotation: model.rotation
+            };
+            readyAlpha = model.alpha;
+        }
+    });
+
+    assert.equal(session.start(), true);
+    assert.equal(readyFrame, null);
+
+    session.tickEnter(500);
+    assert.equal(readyFrame, null);
+
+    session.tickEnter(1001);
+    assert.deepEqual(readyFrame, {
+        x: session.cornerHiddenFrame.x,
+        y: session.cornerHiddenFrame.y,
+        rotation: session.cornerHiddenFrame.rotation
+    });
+    assert.equal(readyAlpha, 0);
+});
+
+test('Live2D corner peek can start from the screen-out frame while fully transparent', () => {
+    let readyFrame = null;
+    let readyAlpha = null;
+    const { session, model } = createCornerPeekSession('bottom-left', {
+        startFromHidden: true,
+        onPeekReady: () => {
+            readyFrame = {
+                x: model.x,
+                y: model.y,
+                rotation: model.rotation
+            };
+            readyAlpha = model.alpha;
+        }
+    });
+
+    assert.equal(session.start(), true);
+    assert.equal(model.x, session.cornerHiddenFrame.x);
+    assert.equal(model.y, session.cornerHiddenFrame.y);
+    assert.equal(model.alpha, 0);
+
+    session.tickEnter(0);
+    assert.deepEqual(readyFrame, {
+        x: session.cornerHiddenFrame.x,
+        y: session.cornerHiddenFrame.y,
+        rotation: session.cornerHiddenFrame.rotation
+    });
+    assert.equal(readyAlpha, 0);
+
+    session.tickEnter(500);
+    assert.notEqual(model.x, session.cornerHiddenFrame.x);
+    assert.notEqual(model.y, session.cornerHiddenFrame.y);
+    assert.ok(model.alpha > 0);
+    assert.ok(model.alpha < 1);
+});
+
+test('Live2D opening corner peek uses one compositor layer and completes the full return fade', () => {
+    const canvas = { style: { opacity: '0' } };
+    const container = { style: { opacity: '0' } };
+    const { session, model } = createCornerPeekSession('bottom-left', {
+        startFromHidden: true,
+        hideMs: 1500,
+        appearMs: 2000,
+        restoreMode: 'half-body',
+        container,
+        elements: {
+            'live2d-canvas': canvas
+        }
+    });
+
+    assert.equal(session.totalDurationMs, 2000);
+    assert.equal(session.exitDurationMs, 3500);
+    assert.equal(session.start(), true);
+    container.style.transition = '';
+    canvas.style.transition = '';
+
+    session.tickEnter(1000);
+    assert.equal(model.alpha, 1);
+    assert.ok(Number(container.style.opacity) > 0);
+    assert.ok(Number(container.style.opacity) < 1);
+    assert.equal(canvas.style.opacity, '1');
+    assert.equal(container.style.transition, 'none');
+    assert.equal(canvas.style.transition, 'none');
+
+    session.tickExit(750);
+    assert.equal(model.alpha, 1);
+    assert.ok(Number(container.style.opacity) > 0);
+    assert.ok(Number(container.style.opacity) < 1);
+    assert.equal(canvas.style.opacity, '1');
+
+    session.tickExit(2000);
+    assert.equal(session.finished, false);
+    assert.equal(model.x, session.restoreModelTargetFrame.x);
+    assert.equal(model.y, session.restoreModelTargetFrame.y);
+    assert.equal(model.scale.x, session.initialModelFrame.scaleX * 1.38);
+    assert.equal(model.scale.y, session.initialModelFrame.scaleY * 1.38);
+    assert.equal(model.rotation, session.initialModelFrame.rotation);
+    assert.equal(model.alpha, 1);
+    assert.ok(Number(container.style.opacity) > 0);
+    assert.ok(Number(container.style.opacity) < 1);
+    assert.equal(canvas.style.opacity, '1');
+
+    session.tickExit(3500);
+    assert.equal(session.finished, false);
+    assert.equal(model.alpha, session.restoreAlpha);
+
+    session.tickExit(3501);
+    assert.equal(session.finished, true);
+    assert.equal(model.x, session.restoreModelTargetFrame.x);
+    assert.equal(model.y, session.restoreModelTargetFrame.y);
+    assert.equal(model.scale.x, session.initialModelFrame.scaleX * 1.38);
+    assert.equal(model.scale.y, session.initialModelFrame.scaleY * 1.38);
+    assert.equal(model.alpha, session.restoreAlpha);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
+});
+
+test('Live2D non-opening corner peek uses one compositor layer for the full probe cycle', () => {
+    const canvas = { style: { opacity: '1', transition: 'opacity 900ms ease' } };
+    const container = { style: { opacity: '1', transition: 'opacity 900ms ease' } };
+    const { session, model } = createCornerPeekSession('top-left', {
+        hideMs: 1500,
+        appearMs: 2000,
+        holdMs: 2500,
+        useCompositorOpacity: true,
+        container,
+        elements: {
+            'live2d-canvas': canvas
+        }
+    });
+    model.alpha = 1;
+
+    assert.equal(session.totalDurationMs, 3500);
+    assert.equal(session.holdMs, 2500);
+    assert.equal(session.exitDurationMs, 3500);
+    assert.equal(session.start(), true);
+    container.style.transition = '';
+    canvas.style.transition = '';
+
+    session.tickEnter(750);
+    assert.equal(model.alpha, 1);
+    assert.equal(container.style.opacity, '0.5');
+    assert.equal(canvas.style.opacity, '1');
+    assert.equal(container.style.transition, 'none');
+    assert.equal(canvas.style.transition, 'none');
+
+    session.tickEnter(2500);
+    assert.notEqual(model.x, session.initialModelFrame.x);
+    assert.notEqual(model.y, session.initialModelFrame.y);
+    assert.ok(Number(container.style.opacity) > 0);
+    assert.ok(Number(container.style.opacity) < 1);
+    assert.equal(canvas.style.opacity, '1');
+
+    session.tickExit(750);
+    assert.equal(model.alpha, 1);
+    assert.equal(container.style.opacity, '0.5');
+    assert.equal(canvas.style.opacity, '1');
+
+    session.tickExit(1750);
+    assert.equal(model.x, session.initialModelFrame.x);
+    assert.equal(model.y, session.initialModelFrame.y);
+    assert.ok(Number(container.style.opacity) > 0);
+    assert.ok(Number(container.style.opacity) < 1);
+    assert.equal(canvas.style.opacity, '1');
+
+    session.tickExit(3501);
+    assert.equal(session.finished, true);
+    assert.equal(model.x, session.initialModelFrame.x);
+    assert.equal(model.y, session.initialModelFrame.y);
+    assert.equal(model.alpha, 1);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
+    assert.equal(container.style.transition, 'opacity 900ms ease');
+    assert.equal(canvas.style.transition, 'opacity 900ms ease');
+    assert.match(directorSource, /startAvatarCornerPeek[\s\S]*useCompositorOpacity: true/);
+});
+
+test('Live2D opening frame motion reuses the corner peek compositor fade', () => {
+    const { session, model, container, canvas, window } = createFrameMotionSession();
+
+    assert.equal(session.start(), true);
+    const hiddenY = model.y;
+    assert.equal(model.alpha, 1);
+    assert.equal(container.style.opacity, '0');
+    assert.equal(canvas.style.opacity, '1');
+
+    container.style.transition = '';
+    canvas.style.transition = '';
+    window.__setNow(1000);
+    session.tick();
+
+    assert.equal(model.alpha, 1);
+    assert.ok(model.y < hiddenY);
+    assert.ok(Number(container.style.opacity) > 0);
+    assert.ok(Number(container.style.opacity) < 1);
+    assert.equal(canvas.style.opacity, '1');
+    assert.equal(container.style.transition, 'none');
+    assert.equal(canvas.style.transition, 'none');
+
+    window.__setNow(4501);
+    session.tick();
+    assert.equal(session.finished, true);
+    assert.equal(model.alpha, 1);
+    assert.equal(model.scale.x, 1.38);
+    assert.equal(model.scale.y, 1.38);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
+});
+
+test('tutorial opening frame motion stays at the default placement without a fade handoff', () => {
+    assert.match(avatarStageSource, /useCompositorOpacity: isOpeningProbe/);
+    assert.match(
+        avatarStageSource,
+        /if \(isOpeningProbe\) \{\s*return \{ result: 'played', reason: '' \};\s*\}/
+    );
+});
+
+test('Live2D corner peek fades only the model and centers look-at during playback', () => {
     const acquiredLocks = [];
     const releasedLocks = [];
     const paramWrites = [];
@@ -468,8 +812,9 @@ test('Live2D corner peek fades the visible layer and centers look-at during play
     ]);
 
     session.tickEnter(500);
-    assert.equal(container.style.opacity, '0.4');
-    assert.equal(canvas.style.opacity, '0.4');
+    assert.equal(session.model.alpha, 0.4);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
 
     session.finish('test_complete');
     assert.equal(window.nekoYuiGuideAvatarCornerPeekActive, false);
@@ -492,8 +837,8 @@ test('Live2D corner peek disables opacity transitions while it owns the visible 
     assert.equal(session.start(), true);
     session.tickEnter(500);
 
-    assert.equal(container.style.opacity, '0.4');
-    assert.equal(canvas.style.opacity, '0.4');
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
     assert.equal(container.style.transition, 'none');
     assert.equal(canvas.style.transition, 'none');
 
@@ -528,6 +873,7 @@ test('Live2D corner peek does not self-cancel its return fade after stand-in tok
 
 test('Live2D visibility recovery preserves opacity while avatar corner peek is active', () => {
     assert.match(live2dInitSource, /nekoYuiGuideAvatarCornerPeekActive[\s\S]{0,120}return;/);
+    assert.match(live2dInitSource, /nekoYuiGuideLive2dPreparing[\s\S]{0,220}yui-guide-live2d-preparing/);
     assert.match(appUiSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,240}model\.alpha = 1;/);
     assert.match(appInterpageSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,240}currentModel\.alpha = 1;/);
     assert.match(universalManagerSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,360}restoreTutorialLive2dDisplayState/);

--- a/static/yui-guide-avatar-standin.test.cjs
+++ b/static/yui-guide-avatar-standin.test.cjs
@@ -229,6 +229,43 @@ function createFrameMotionSession(options) {
     };
 }
 
+function createControlledNonOpeningFramePlayback() {
+    const frameCallbacks = [];
+    let cancelled = false;
+    const context = createFrameMotionSession({
+        container: { style: { opacity: '1', transition: 'opacity 900ms ease' } },
+        canvas: { style: { opacity: '1', transition: 'opacity 900ms ease' } },
+        configureWindow(targetWindow) {
+            targetWindow.requestAnimationFrame = (callback) => {
+                frameCallbacks.push(callback);
+                return frameCallbacks.length;
+            };
+            targetWindow.cancelAnimationFrame = () => {};
+        }
+    });
+    const playback = context.api.playAvatarMotion({
+        preset: 'bottom-rise',
+        narrationBudgeted: true,
+        isOpeningProbe: false,
+        isCancelled: () => cancelled
+    });
+
+    return Object.assign({}, context, {
+        playback,
+        cancel() {
+            cancelled = true;
+        },
+        async flushFrameAt(now) {
+            await Promise.resolve();
+            await Promise.resolve();
+            context.window.__setNow(now);
+            frameCallbacks.splice(0).forEach((callback) => callback());
+            await Promise.resolve();
+            await Promise.resolve();
+        }
+    });
+}
+
 function createHeadAnchoredCornerPeekSession(position) {
     const api = loadAvatarStageApi();
     const coreModel = {};
@@ -702,6 +739,29 @@ test('Live2D opening corner peek uses one compositor layer and completes the ful
     assert.equal(canvas.style.opacity, '1');
 });
 
+test('Live2D cancelled hidden opening corner peek preserves the prepared opacity snapshot', () => {
+    const canvas = { style: { opacity: '0', transition: 'opacity 900ms ease' } };
+    const container = { style: { opacity: '0', transition: 'opacity 900ms ease' } };
+    const { session } = createCornerPeekSession('bottom-left', {
+        startFromHidden: true,
+        restoreMode: 'half-body',
+        container,
+        elements: {
+            'live2d-canvas': canvas
+        }
+    });
+
+    assert.equal(session.start(), true);
+    session.cancel('cancelled');
+
+    assert.equal(session.finished, true);
+    assert.equal(session.result, 'cancelled');
+    assert.equal(container.style.opacity, '0');
+    assert.equal(canvas.style.opacity, '0');
+    assert.equal(container.style.transition, 'opacity 900ms ease');
+    assert.equal(canvas.style.transition, 'opacity 900ms ease');
+});
+
 test('Live2D non-opening corner peek uses one compositor layer for the full probe cycle', () => {
     const canvas = { style: { opacity: '1', transition: 'opacity 900ms ease' } };
     const container = { style: { opacity: '1', transition: 'opacity 900ms ease' } };
@@ -824,44 +884,39 @@ test('Live2D opening frame motion restores its original state when reveal fallba
 });
 
 test('Live2D non-opening frame motion restores display opacity when cancelled', async () => {
-    const frameCallbacks = [];
-    let cancelled = false;
-    const { api, model, container, canvas, window } = createFrameMotionSession({
-        container: { style: { opacity: '1', transition: 'opacity 900ms ease' } },
-        canvas: { style: { opacity: '1', transition: 'opacity 900ms ease' } },
-        configureWindow(targetWindow) {
-            targetWindow.requestAnimationFrame = (callback) => {
-                frameCallbacks.push(callback);
-                return frameCallbacks.length;
-            };
-            targetWindow.cancelAnimationFrame = () => {};
-        }
-    });
+    const context = createControlledNonOpeningFramePlayback();
+    const { model, container, canvas, playback } = context;
 
-    const playback = api.playAvatarMotion({
-        preset: 'bottom-rise',
-        narrationBudgeted: true,
-        isOpeningProbe: false,
-        isCancelled: () => cancelled
-    });
-
-    await Promise.resolve();
-    await Promise.resolve();
-    window.__setNow(1500);
-    frameCallbacks.splice(0).forEach((callback) => callback());
-    await Promise.resolve();
-    await Promise.resolve();
+    await context.flushFrameAt(1500);
     assert.equal(container.style.opacity, '0');
 
-    cancelled = true;
-    window.__setNow(1600);
-    frameCallbacks.splice(0).forEach((callback) => callback());
-    await Promise.resolve();
-    await Promise.resolve();
+    context.cancel();
+    await context.flushFrameAt(1600);
 
     const result = await playback;
     assert.equal(result.result, 'cancelled');
     assert.equal(model.alpha, 0.8);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
+    assert.equal(container.style.transition, 'opacity 900ms ease');
+    assert.equal(canvas.style.transition, 'opacity 900ms ease');
+});
+
+test('Live2D non-opening frame motion restores half-body visibility when final fade is cancelled', async () => {
+    const context = createControlledNonOpeningFramePlayback();
+    const { model, container, canvas, playback } = context;
+
+    await context.flushFrameAt(1500);
+    await context.flushFrameAt(6001);
+    context.cancel();
+    await context.flushFrameAt(6100);
+
+    const result = await playback;
+    assert.equal(result.result, 'cancelled');
+    assert.equal(result.reason, 'avatar_motion_fade_out_cancelled');
+    assert.equal(model.alpha, 1);
+    assert.equal(model.scale.x, 1.38);
+    assert.equal(model.scale.y, 1.38);
     assert.equal(container.style.opacity, '1');
     assert.equal(canvas.style.opacity, '1');
     assert.equal(container.style.transition, 'opacity 900ms ease');

--- a/static/yui-guide-avatar-standin.test.cjs
+++ b/static/yui-guide-avatar-standin.test.cjs
@@ -161,7 +161,8 @@ function createFrameMotionSession(options) {
         elements: {
             'live2d-container': container,
             'live2d-canvas': canvas
-        }
+        },
+        configureWindow: normalizedOptions.configureWindow
     });
     const coreModel = {};
     const model = {
@@ -201,6 +202,7 @@ function createFrameMotionSession(options) {
             }
         }
     };
+    context.window.live2dManager = manager;
     const session = new context.api.Live2DFrameMotionSession({
         manager,
         model,
@@ -218,6 +220,7 @@ function createFrameMotionSession(options) {
         useCompositorOpacity: true
     });
     return {
+        api: context.api,
         session,
         model,
         container,
@@ -820,6 +823,51 @@ test('Live2D opening frame motion restores its original state when reveal fallba
     assert.equal(window.nekoYuiGuideAvatarCornerPeekActive, false);
 });
 
+test('Live2D non-opening frame motion restores display opacity when cancelled', async () => {
+    const frameCallbacks = [];
+    let cancelled = false;
+    const { api, model, container, canvas, window } = createFrameMotionSession({
+        container: { style: { opacity: '1', transition: 'opacity 900ms ease' } },
+        canvas: { style: { opacity: '1', transition: 'opacity 900ms ease' } },
+        configureWindow(targetWindow) {
+            targetWindow.requestAnimationFrame = (callback) => {
+                frameCallbacks.push(callback);
+                return frameCallbacks.length;
+            };
+            targetWindow.cancelAnimationFrame = () => {};
+        }
+    });
+
+    const playback = api.playAvatarMotion({
+        preset: 'bottom-rise',
+        narrationBudgeted: true,
+        isOpeningProbe: false,
+        isCancelled: () => cancelled
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    window.__setNow(1500);
+    frameCallbacks.splice(0).forEach((callback) => callback());
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(container.style.opacity, '0');
+
+    cancelled = true;
+    window.__setNow(1600);
+    frameCallbacks.splice(0).forEach((callback) => callback());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const result = await playback;
+    assert.equal(result.result, 'cancelled');
+    assert.equal(model.alpha, 0.8);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(canvas.style.opacity, '1');
+    assert.equal(container.style.transition, 'opacity 900ms ease');
+    assert.equal(canvas.style.transition, 'opacity 900ms ease');
+});
+
 test('tutorial frame motion keeps one visible compositor and opening motion skips the fade handoff', () => {
     const frameMotionSource = avatarStageSource
         .split('async function playFrameAvatarMotion(options, preset) {')[1]
@@ -945,6 +993,9 @@ test('Live2D visibility recovery preserves opacity while avatar corner peek is a
     const wakeupRevealSource = wakeupSource
         .split('function revealPreparedTutorialLive2D(reason) {')[1]
         .split('function normalizeDuration(value, fallback) {')[0];
+    const restoreDisplaySurfaceSource = modelDisplaySource
+        .split('function restoreLive2DDisplaySurface(reason) {')[1]
+        .split('function activateLive2DRenderForDisplay(reason) {')[0];
     const preparingCommentIndex = showLive2dSource.indexOf('// 教程准备/探身演出期间');
     const preparingFastPathIndex = showLive2dSource.lastIndexOf(
         'if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion)',
@@ -966,6 +1017,10 @@ test('Live2D visibility recovery preserves opacity while avatar corner peek is a
     assert.match(universalManagerSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,360}restoreTutorialLive2dDisplayState/);
     assert.match(universalManagerSource, /preserveOpacity[\s\S]{0,360}live2dCanvas\.style\.setProperty\('opacity', '1', 'important'\)/);
     assert.match(universalManagerSource, /preserveAvatarMotionOpacity[\s\S]{0,500}id !== 'live2d-container'[\s\S]{0,120}id !== 'live2d-canvas'/);
+    assert.match(
+        restoreDisplaySurfaceSource,
+        /if \(!preserveYuiGuidePreparing && !preserveAvatarCornerPeekOpacity\) \{\s*restoreYuiGuideLive2DPreparingControls\(\);/
+    );
 });
 
 test('daily opening reveal keeps a bounded fallback while preserving explicit overrides', () => {

--- a/static/yui-guide-avatar-standin.test.cjs
+++ b/static/yui-guide-avatar-standin.test.cjs
@@ -19,6 +19,7 @@ const modelDisplaySource = fs.readFileSync(path.join(__dirname, 'app/app-ui/mode
 const appUiSource = readJsParts(path.join(__dirname, 'app/app-ui'));
 const appInterpageSource = readJsParts(path.join(__dirname, 'app/app-interpage'));
 const universalManagerSource = fs.readFileSync(path.join(__dirname, 'tutorial/core/universal-manager.js'), 'utf8');
+const wakeupSource = fs.readFileSync(path.join(__dirname, 'tutorial/yui-guide/wakeup.js'), 'utf8');
 
 function loadAvatarStageContext(options) {
     const normalizedOptions = options || {};
@@ -213,6 +214,7 @@ function createFrameMotionSession(options) {
         motionFromAlpha: 0,
         motionToAlpha: 1,
         restoreMode: 'half-body',
+        isCancelled: normalizedOptions.isCancelled,
         useCompositorOpacity: true
     });
     return {
@@ -516,7 +518,8 @@ test('corner peek can rotate floating buttons only when intro motion opts in', (
     assert.match(avatarStageSource, /this\.syncFloatingButtonsRotation\(frame\)/);
     assert.match(avatarStageSource, /manager\._floatingButtonsRotationRadians = rotation;/);
     assert.match(live2dButtonsSource, /const rotation = Number\(this\._floatingButtonsRotationRadians\) \|\| 0;/);
-    assert.match(live2dButtonsSource, /buttonsContainer\.style\.transform = `scale\(\$\{scale\}\)\$\{rotateTransform\}`;/);
+    assert.match(live2dButtonsSource, /const nextTransform = `scale\(\$\{scale\}\)\$\{rotateTransform\}`;/);
+    assert.match(live2dButtonsSource, /buttonsContainer\.style\.transform = nextTransform;/);
     assert.match(directorSource, /rotateFloatingButtons: performance\.rotateFloatingButtons === true/);
 });
 
@@ -759,6 +762,7 @@ test('Live2D opening frame motion reuses the corner peek compositor fade', () =>
     const { session, model, container, canvas, window } = createFrameMotionSession();
 
     assert.equal(session.start(), true);
+    assert.equal(window.nekoYuiGuideAvatarCornerPeekActive, true);
     const hiddenY = model.y;
     assert.equal(model.alpha, 1);
     assert.equal(container.style.opacity, '0');
@@ -785,6 +789,35 @@ test('Live2D opening frame motion reuses the corner peek compositor fade', () =>
     assert.equal(model.scale.y, 1.38);
     assert.equal(container.style.opacity, '1');
     assert.equal(canvas.style.opacity, '1');
+    assert.equal(window.nekoYuiGuideAvatarCornerPeekActive, false);
+});
+
+test('Live2D opening frame motion restores its original state when reveal fallback cancels it', () => {
+    let cancelled = false;
+    const { session, model, container, window } = createFrameMotionSession({
+        isCancelled: () => cancelled
+    });
+    const originalFrame = {
+        x: model.x,
+        y: model.y,
+        scaleX: model.scale.x,
+        scaleY: model.scale.y,
+        alpha: model.alpha
+    };
+
+    assert.equal(session.start(), true);
+    cancelled = true;
+    session.tick();
+
+    assert.equal(session.finished, true);
+    assert.equal(session.result, 'cancelled');
+    assert.equal(model.x, originalFrame.x);
+    assert.equal(model.y, originalFrame.y);
+    assert.equal(model.scale.x, originalFrame.scaleX);
+    assert.equal(model.scale.y, originalFrame.scaleY);
+    assert.equal(model.alpha, originalFrame.alpha);
+    assert.equal(container.style.opacity, '1');
+    assert.equal(window.nekoYuiGuideAvatarCornerPeekActive, false);
 });
 
 test('tutorial frame motion keeps one visible compositor and opening motion skips the fade handoff', () => {
@@ -909,6 +942,9 @@ test('Live2D visibility recovery preserves opacity while avatar corner peek is a
     const showLive2dSource = modelDisplaySource
         .split('I.showLive2d = function showLive2d() {')[1]
         .split('I.mod.showLive2d = I.showLive2d;')[0];
+    const wakeupRevealSource = wakeupSource
+        .split('function revealPreparedTutorialLive2D(reason) {')[1]
+        .split('function normalizeDuration(value, fallback) {')[0];
     const preparingCommentIndex = showLive2dSource.indexOf('// 教程准备/探身演出期间');
     const preparingFastPathIndex = showLive2dSource.lastIndexOf(
         'if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion)',
@@ -920,10 +956,16 @@ test('Live2D visibility recovery preserves opacity while avatar corner peek is a
     assert.match(live2dInitSource, /nekoYuiGuideLive2dPreparing[\s\S]{0,220}yui-guide-live2d-preparing/);
     assert.match(live2dInitSource, /neko:yui-guide:live2d-prepared-revealed/);
     assert.match(live2dInitSource, /new MutationObserver\(revealAfterPreparing\)/);
+    assert.match(wakeupRevealSource, /window\.nekoYuiGuideLive2dPreparing = false;/);
+    assert.ok(
+        wakeupRevealSource.indexOf('window.nekoYuiGuideLive2dPreparing = false;')
+        < wakeupRevealSource.indexOf('neko:yui-guide:live2d-prepared-revealed')
+    );
     assert.match(appUiSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,240}model\.alpha = 1;/);
     assert.match(appInterpageSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,240}currentModel\.alpha = 1;/);
     assert.match(universalManagerSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,360}restoreTutorialLive2dDisplayState/);
     assert.match(universalManagerSource, /preserveOpacity[\s\S]{0,360}live2dCanvas\.style\.setProperty\('opacity', '1', 'important'\)/);
+    assert.match(universalManagerSource, /preserveAvatarMotionOpacity[\s\S]{0,500}id !== 'live2d-container'[\s\S]{0,120}id !== 'live2d-canvas'/);
 });
 
 test('daily opening reveal keeps a bounded fallback while preserving explicit overrides', () => {

--- a/static/yui-guide-avatar-standin.test.cjs
+++ b/static/yui-guide-avatar-standin.test.cjs
@@ -15,6 +15,7 @@ const overlaySource = fs.readFileSync(path.join(__dirname, 'tutorial/yui-guide/o
 const live2dInteractionSource = fs.readFileSync(path.join(__dirname, 'live2d', 'live2d-interaction.js'), 'utf8');
 const live2dInitSource = fs.readFileSync(path.join(__dirname, 'live2d', 'live2d-init.js'), 'utf8');
 const live2dButtonsSource = fs.readFileSync(path.join(__dirname, 'live2d', 'live2d-ui-buttons.js'), 'utf8');
+const modelDisplaySource = fs.readFileSync(path.join(__dirname, 'app/app-ui/model-display.js'), 'utf8');
 const appUiSource = readJsParts(path.join(__dirname, 'app/app-ui'));
 const appInterpageSource = readJsParts(path.join(__dirname, 'app/app-interpage'));
 const universalManagerSource = fs.readFileSync(path.join(__dirname, 'tutorial/core/universal-manager.js'), 'utf8');
@@ -396,6 +397,7 @@ test('director routes avatar stand-ins through Live2D corner peek, not overlay i
     assert.match(directorSource, /this\.startAvatarCornerPeekPerformance\({[\s\S]*position: cue\.position/);
     assert.match(controllerSource, /Number\.isFinite\(Number\(cue\.delay\)\)/);
     assert.match(directorSource, /Number\.isFinite\(Number\(cue\.duration\)\)/);
+    assert.match(directorSource, /startAvatarCornerPeek[\s\S]*useCompositorOpacity: true/);
     assert.match(directorSource, /await this\.stopAvatarCornerPeekPerformance\(handle,\s*reason \|\| 'avatar_standin_clear'\);/);
     assert.doesNotMatch(directorSource, /overlay\.showAvatarStandIn/);
     assert.doesNotMatch(overlaySource, /showAvatarStandIn/);
@@ -423,6 +425,8 @@ test('day two through seven avatar probes keep fixed phases and move short-line 
     assert.match(avatarStageSource, /const TUTORIAL_AVATAR_PROBE_FADE_OUT_MS = 1500;/);
     assert.match(avatarStageSource, /const TUTORIAL_AVATAR_PROBE_APPROACH_MS = 2000;/);
     assert.match(avatarStageSource, /const TUTORIAL_AVATAR_PROBE_HOLD_MS = 2500;/);
+    assert.match(avatarStageSource, /TUTORIAL_AVATAR_PROBE_TIMING: TUTORIAL_AVATAR_PROBE_TIMING/);
+    assert.match(controllerSource, /root && root\.YuiGuideAvatarStage/);
     assert.match(avatarStageSource, /startFromHidden: isOpeningProbe/);
     assert.match(avatarStageSource, /holdMs: TUTORIAL_AVATAR_PROBE_HOLD_MS/);
     assert.match(directorSource, /isOpeningProbe: tutorialDay >= 2[\s\S]*resolveOnReveal/);
@@ -445,6 +449,33 @@ test('day two through seven avatar probes keep fixed phases and move short-line 
         { getAvatarFloatingNarrationDurationMs: () => 12000 }
     );
     assert.equal(longLineCue.delay, 900);
+
+    const previousAvatarStage = globalThis.YuiGuideAvatarStage;
+    globalThis.YuiGuideAvatarStage = {
+        TUTORIAL_AVATAR_PROBE_TIMING: {
+            fadeOutMs: 1400,
+            approachMs: 1900,
+            holdMs: 2400,
+            returnMs: 1800
+        }
+    };
+    try {
+        const sharedTimingCue = standInController.resolveCueTiming(
+            { delay: 0, position: 'top-right' },
+            { voiceKey: 'day2_galgame_entry', text: 'test' },
+            { getAvatarFloatingNarrationDurationMs: () => 10000 }
+        );
+        assert.equal(sharedTimingCue.hideMs, 1400);
+        assert.equal(sharedTimingCue.appearMs, 1900);
+        assert.equal(sharedTimingCue.holdMs, 2400);
+        assert.equal(sharedTimingCue.fullDurationMs, 8900);
+    } finally {
+        if (typeof previousAvatarStage === 'undefined') {
+            delete globalThis.YuiGuideAvatarStage;
+        } else {
+            globalThis.YuiGuideAvatarStage = previousAvatarStage;
+        }
+    }
 });
 
 test('bottom-rise intro avatar motion approaches and holds the first-day half-body frame', () => {
@@ -722,7 +753,6 @@ test('Live2D non-opening corner peek uses one compositor layer for the full prob
     assert.equal(canvas.style.opacity, '1');
     assert.equal(container.style.transition, 'opacity 900ms ease');
     assert.equal(canvas.style.transition, 'opacity 900ms ease');
-    assert.match(directorSource, /startAvatarCornerPeek[\s\S]*useCompositorOpacity: true/);
 });
 
 test('Live2D opening frame motion reuses the corner peek compositor fade', () => {
@@ -757,11 +787,15 @@ test('Live2D opening frame motion reuses the corner peek compositor fade', () =>
     assert.equal(canvas.style.opacity, '1');
 });
 
-test('tutorial opening frame motion stays at the default placement without a fade handoff', () => {
-    assert.match(avatarStageSource, /useCompositorOpacity: isOpeningProbe/);
+test('tutorial frame motion keeps one visible compositor and opening motion skips the fade handoff', () => {
+    const frameMotionSource = avatarStageSource
+        .split('async function playFrameAvatarMotion(options, preset) {')[1]
+        .split('async function playAvatarMotion(options) {')[0];
+    assert.match(frameMotionSource, /useCompositorOpacity:\s*true/);
+    assert.doesNotMatch(frameMotionSource, /useCompositorOpacity:\s*isOpeningProbe/);
     assert.match(
-        avatarStageSource,
-        /if \(isOpeningProbe\) \{\s*return \{ result: 'played', reason: '' \};\s*\}/
+        frameMotionSource,
+        /if\s*\(\s*isOpeningProbe\s*\)\s*\{[\s\S]{0,160}result:\s*'played'/
     );
 });
 
@@ -872,12 +906,30 @@ test('Live2D corner peek does not self-cancel its return fade after stand-in tok
 });
 
 test('Live2D visibility recovery preserves opacity while avatar corner peek is active', () => {
+    const showLive2dSource = modelDisplaySource
+        .split('I.showLive2d = function showLive2d() {')[1]
+        .split('I.mod.showLive2d = I.showLive2d;')[0];
+    const preparingCommentIndex = showLive2dSource.indexOf('// 教程准备/探身演出期间');
+    const preparingFastPathIndex = showLive2dSource.lastIndexOf(
+        'if (preserveYuiGuidePreparing || preserveYuiGuideAvatarMotion)',
+        preparingCommentIndex
+    );
+    assert.ok(showLive2dSource.indexOf('if (window._goodbyeHideTimerId)') < preparingFastPathIndex);
+    assert.ok(showLive2dSource.indexOf('if (window._returnFadeTimer)') < preparingFastPathIndex);
     assert.match(live2dInitSource, /nekoYuiGuideAvatarCornerPeekActive[\s\S]{0,120}return;/);
     assert.match(live2dInitSource, /nekoYuiGuideLive2dPreparing[\s\S]{0,220}yui-guide-live2d-preparing/);
+    assert.match(live2dInitSource, /neko:yui-guide:live2d-prepared-revealed/);
+    assert.match(live2dInitSource, /new MutationObserver\(revealAfterPreparing\)/);
     assert.match(appUiSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,240}model\.alpha = 1;/);
     assert.match(appInterpageSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,240}currentModel\.alpha = 1;/);
     assert.match(universalManagerSource, /preserveAvatarCornerPeekOpacity[\s\S]{0,360}restoreTutorialLive2dDisplayState/);
     assert.match(universalManagerSource, /preserveOpacity[\s\S]{0,360}live2dCanvas\.style\.setProperty\('opacity', '1', 'important'\)/);
+});
+
+test('daily opening reveal keeps a bounded fallback while preserving explicit overrides', () => {
+    assert.match(directorSource, /normalizedOptions\.revealReadyFallbackMs/);
+    assert.match(directorSource, /resolveOnReveal \? 3000/);
+    assert.match(directorSource, /daily-intro-avatar-reveal-timeout/);
 });
 
 test('Live2D corner peek can continue across scene boundaries until its cue duration ends', () => {

--- a/static/yui-guide-director-parts.test.cjs
+++ b/static/yui-guide-director-parts.test.cjs
@@ -203,3 +203,43 @@ test('director Node harness keeps cross-page handoff routed through the existing
     );
     assert.deepEqual(handoffCalls, [['memory_browser', { token: 'node-harness' }]]);
 });
+
+test('daily opening reveal fallback cancels the pending avatar motion', async () => {
+    const { window } = createHarness();
+    let motionOptions = null;
+    let resolveMotion = null;
+    const revealReasons = [];
+    window.YuiGuideAvatarStage = {
+        playAvatarMotion(options) {
+            motionOptions = options;
+            return new Promise((resolve) => {
+                resolveMotion = resolve;
+            });
+        }
+    };
+    const director = window.createYuiGuideDirector({ page: 'home' });
+
+    const revealed = await director.runDailyIntroAvatarPerformance({
+        id: 'day2_daily_intro',
+        text: 'test',
+        introAvatarPerformance: {
+            preset: 'bottom-rise',
+            durationMs: 6000
+        }
+    }, 2, {
+        isFirstDailyScene: true,
+        revealReadyFallbackMs: 1,
+        reducedMotion: false,
+        revealPrepared(reason) {
+            revealReasons.push(reason);
+        }
+    });
+
+    assert.equal(revealed, true);
+    assert.deepEqual(revealReasons, ['daily-intro-avatar-reveal-timeout']);
+    assert.equal(typeof motionOptions.isCancelled, 'function');
+    assert.equal(motionOptions.isCancelled(), true);
+
+    resolveMotion({ result: 'cancelled', reason: 'cancelled' });
+    await Promise.resolve();
+});

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -1169,14 +1169,31 @@ def test_daily_intro_avatar_motion_presets_are_fixed_per_day():
 def test_day3_intro_bottom_rise_uses_shared_two_second_opening_motion_after_day_swap():
     source = DAY3_GUIDE_PATH.read_text(encoding="utf-8")
     avatar_stage_source = (ROOT / "static" / "tutorial/avatar/yui-stage.js").read_text(encoding="utf-8")
+    director_source = read_director_source(ROOT)
     scene_block = source.split("id: 'day3_intro_context'", 1)[1].split(
         "id: 'day3_personalization_space'",
+        1,
+    )[0]
+    daily_intro_block = director_source.split("async runDailyIntroAvatarPerformance(scene, day, options)", 1)[1].split(
+        "async runIntroGreetingHugPerformance()",
+        1,
+    )[0]
+    probe_motion_block = avatar_stage_source.split(
+        "async function playTutorialAvatarProbeFrameMotion(options, preset)",
+        1,
+    )[1].split("async function playAvatarMotion(options)", 1)[0]
+    play_motion_block = avatar_stage_source.split("async function playAvatarMotion(options)", 1)[1].split(
+        "async function playSettingsPeekPanic(options)",
         1,
     )[0]
 
     assert "preset: 'bottom-rise'" in scene_block
     assert "approachMs:" not in scene_block
+    assert "narrationBudgeted: tutorialDay >= 2 && tutorialDay <= 7" in daily_intro_block
+    assert "if (normalizedOptions.narrationBudgeted === true)" in play_motion_block
+    assert "return playTutorialAvatarProbeFrameMotion(normalizedOptions, preset);" in play_motion_block
     assert "const TUTORIAL_AVATAR_PROBE_APPROACH_MS = 2000;" in avatar_stage_source
+    assert "enterMs: TUTORIAL_AVATAR_PROBE_APPROACH_MS" in probe_motion_block
     assert "restore: 'half-body'" in scene_block
 
 

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -1166,15 +1166,17 @@ def test_daily_intro_avatar_motion_presets_are_fixed_per_day():
         assert "{ at: 0, command: 'operation.run', operation: 'daily-intro-avatar-performance', blocking: false }" in scene_block
 
 
-def test_day3_intro_bottom_rise_uses_slow_half_body_motion_after_day_swap():
+def test_day3_intro_bottom_rise_uses_shared_two_second_opening_motion_after_day_swap():
     source = DAY3_GUIDE_PATH.read_text(encoding="utf-8")
+    avatar_stage_source = (ROOT / "static" / "tutorial/avatar/yui-stage.js").read_text(encoding="utf-8")
     scene_block = source.split("id: 'day3_intro_context'", 1)[1].split(
         "id: 'day3_personalization_space'",
         1,
     )[0]
 
     assert "preset: 'bottom-rise'" in scene_block
-    assert "approachMs: 1500" in scene_block
+    assert "approachMs:" not in scene_block
+    assert "const TUTORIAL_AVATAR_PROBE_APPROACH_MS = 2000;" in avatar_stage_source
     assert "restore: 'half-body'" in scene_block
 
 
@@ -1248,23 +1250,22 @@ def test_corner_intro_avatar_motions_rotate_floating_buttons_with_model_when_mod
     assert "rotateFloatingButtons: performance.rotateFloatingButtons === true" in director_source
 
 
-def test_peek_intro_half_body_fade_in_restores_full_opacity_after_fadeout():
+def test_peek_intro_half_body_session_fades_out_and_restores_full_opacity():
     source = (ROOT / "static" / "tutorial/avatar/yui-stage.js").read_text(encoding="utf-8")
     corner_block = source.split("async function playTimedAvatarCornerPeek(options, position)", 1)[1].split(
         "async function playFrameAvatarMotion",
         1,
     )[0]
-    fade_in_block = source.split("async function fadeInAvatarMotionHalfBodyPlacement(options)", 1)[1].split(
-        "async function playTimedAvatarCornerPeek",
+    corner_session_block = source.split("class Live2DAvatarCornerPeekSession", 1)[1].split(
+        "class Live2DSettingsPeekPanicSession",
         1,
     )[0]
 
-    assert "const targetAlpha = 1;" in fade_in_block
-    assert "const targetDisplayAlpha = 1;" in fade_in_block
-    assert "readModelAlpha(context.model)" not in fade_in_block
-    assert "captureAvatarMotionHalfBodyFadeTarget" not in source
-    assert "await fadeOutAvatarMotionVisibleLayer(normalizedOptions);" in corner_block
-    assert "await fadeInAvatarMotionHalfBodyPlacement(normalizedOptions);" in corner_block
+    assert "restoreMode: normalizedOptions.restore || normalizedOptions.restoreMode || 'half-body'" in corner_block
+    assert "await handle.stop('avatar_motion_complete');" in corner_block
+    assert "this.restoreAlpha = this.restoreMode === 'half-body' ? 1 : this.initialAlpha;" in corner_session_block
+    assert "lerp(1, 0, progress)" in corner_session_block
+    assert "lerp(0, this.restoreAlpha, progress)" in corner_session_block
 
 
 def test_avatar_floating_intro_motion_reveals_prepared_tutorial_model():

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -757,8 +757,14 @@ def test_tutorial_live2d_preparing_hides_model_side_controls():
     assert "'live2d-floating-buttons'" in restore_controls_block
     assert "'live2d-lock-icon'" in restore_controls_block
     assert "'live2d-return-button-container'" not in restore_controls_block
-    assert "if (!preserveYuiGuidePreparing && floatingButtons) {" in app_ui_source
-    assert "if (!preserveYuiGuidePreparing && lockIcon) {" in app_ui_source
+    assert (
+        "if (!preserveYuiGuidePreparing && !preserveYuiGuideAvatarMotion && floatingButtons) {"
+        in app_ui_source
+    )
+    assert (
+        "if (!preserveYuiGuidePreparing && !preserveYuiGuideAvatarMotion && lockIcon) {"
+        in app_ui_source
+    )
 
     assert "function isYuiGuideLive2DPreparing()" in live2d_buttons_source
     assert "if (isYuiGuideLive2DPreparing() || isYuiGuideFloatingToolbarSuppressed()) {" in live2d_buttons_source


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 统一 Day2–7 新手教程的 Live2D 开场与非开场探身动画，并修复桌面端模型加载、普通显示恢复与教程演出同时写入透明度时造成的直接出现、闪现和渐变延迟问题。

主要改动：

- Day1 保持原有流程不变。
- Day2、Day5、Day6 的开场使用角落/顶部探身：从屏幕外移动并淡入，停留后平滑淡出，再回到 1.38 倍的新手教程默认半身位置。
- Day3、Day4、Day7 的开场从屏幕外移动并淡入到默认位置，停留后直接保持，不再执行多余的淡出与再次淡入。
- 非开场探身统一为：默认位置淡出 1500ms → 探出并淡入 2000ms → 停留 2500ms → 探身位置淡出 1500ms → 回到原位并淡入 2000ms。
- 当台词剩余时长不足完整 9500ms 探身流程时，在当前台词范围内提前触发。
- 使用单一桌面合成层控制透明度，避免同时修改模型、canvas 和容器造成的叠加渐变；教程准备和演出期间阻止普通显示链路抢写。
- 教程随机表情动作提高 `happy` 权重并降低 `surprised` 权重。
- 补充开场、非开场完整周期、回位缩放、模型重载和可见性恢复测试。

## 回归报告 / Regression Report

不适用：本 PR 未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本 PR 共修改 11 个文件，其中测试文件不计入上限，计入上限的文件数未超过 20。

## 测试 / Testing

- 对全部 11 个变更 JavaScript 文件执行 `node --check`，全部通过。
- 运行新手教程模型探身相关 Node 定向测试：11/11 通过。
- 运行 `node --test static/yui-guide-avatar-reload-controller.test.cjs`：5/5 通过。
- 运行 `tests/unit/test_avatar_floating_day1_round_contracts.py` 的每日开场 preset 合约测试：1/1 通过。
- 执行 `git diff --check`，通过。
- PC 端实际验证 Day2、Day3 开场及非开场完整 9500ms 探身周期：移动与透明度连续，隐身后换位，最终位置、旋转、缩放和透明度均恢复正确。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 教程头像新增更自然的探身、淡入淡出、停留及半身恢复动画。
  * 提示展示时长可根据旁白长度自动适配，提升动画与讲解同步性。
  * 教程模式优化动作选择，增加更生动的表情动作概率。

* **问题修复**
  * 优化 Live2D 模型重载与延迟显示，避免打断头像准备流程。
  * 修复探身动画期间模型意外显示、隐藏或恢复时机不正确的问题。
  * 改进动画取消、模型切换及减少动态效果模式下的收尾表现。
  * 增加动画准备超时后的安全回退，确保头像能够正常显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->