### PR TITLE
贴边模型变猫时保留边缘位置并恢复正立，不影响猫形态自身的贴边倾斜效果；同步更新回归测试

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -768,28 +768,10 @@ body.neko-game-active [id$="-lock-icon"] {
     --neko-idle-return-facing-transform: scaleX(1);
 }
 
-[data-neko-live2d-peek-anchor="left"] .neko-idle-return-art {
-    --neko-idle-return-edge-transform: rotate(60deg);
-}
-
-[data-neko-live2d-peek-anchor="right"] .neko-idle-return-art {
-    --neko-idle-return-edge-transform: rotate(-60deg);
-}
-
-[data-neko-live2d-peek-anchor="top-left"] .neko-idle-return-art {
-    --neko-idle-return-edge-transform: rotate(45deg);
-}
-
-[data-neko-live2d-peek-anchor="top-right"] .neko-idle-return-art {
-    --neko-idle-return-edge-transform: rotate(-45deg);
-}
-
-[data-neko-live2d-peek-anchor="bottom-left"] .neko-idle-return-art {
-    --neko-idle-return-edge-transform: rotate(45deg);
-}
-
-[data-neko-live2d-peek-anchor="bottom-right"] .neko-idle-return-art {
-    --neko-idle-return-edge-transform: rotate(-45deg);
+[data-neko-live2d-peek-anchor] .neko-idle-return-art {
+    /* The transferred Live2D anchor controls placement only. Cat edge-peek
+       rotation is reserved for a drag performed after entering cat form. */
+    --neko-idle-return-edge-transform: rotate(0deg);
 }
 
 .neko-idle-thought-bubble {

--- a/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
+++ b/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
@@ -47,17 +47,14 @@ def test_blocked_model_restore_keeps_the_live2d_peek_return_ball_anchor():
     assert "showReturnBallContainer(container, returnRect);" in restore_block
 
 
-def test_live2d_peek_return_ball_uses_60_degree_sides_and_45_degree_corners():
+def test_live2d_peek_return_ball_keeps_edge_position_without_model_tilt():
     css = INDEX_CSS_PATH.read_text(encoding="utf-8")
 
-    expected_rules = {
-        'data-neko-live2d-peek-anchor="left"': "rotate(60deg)",
-        'data-neko-live2d-peek-anchor="right"': "rotate(-60deg)",
-        'data-neko-live2d-peek-anchor="top-left"': "rotate(45deg)",
-        'data-neko-live2d-peek-anchor="top-right"': "rotate(-45deg)",
-        'data-neko-live2d-peek-anchor="bottom-left"': "rotate(45deg)",
-        'data-neko-live2d-peek-anchor="bottom-right"': "rotate(-45deg)",
-    }
-    for selector, rotation in expected_rules.items():
-        rule = css.split(f"[{selector}]", 1)[1].split("}", 1)[0]
-        assert rotation in rule
+    rule = css.split("[data-neko-live2d-peek-anchor] .neko-idle-return-art", 1)[1].split("}", 1)[0]
+    assert "--neko-idle-return-edge-transform: rotate(0deg);" in rule
+
+    transferred_anchor_styles = css.split(
+        '[data-neko-live2d-peek-anchor$="left"] .neko-idle-return-art', 1
+    )[1].split(".neko-idle-thought-bubble", 1)[0]
+    for rotation in ("rotate(60deg)", "rotate(-60deg)", "rotate(45deg)", "rotate(-45deg)"):
+        assert rotation not in transferred_anchor_styles


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

贴边模型变猫时保留边缘位置并恢复正立，不影响猫形态自身的贴边倾斜效果；同步更新回归测试

## 测试 / Testing

调整自动变猫等待时间测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 统一 Live2D 返回球在边缘锚点的旋转角度，提升不同位置下的显示一致性。
  * 修正左右移动锚点的视觉表现，避免出现不必要的倾斜。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->