### PR TITLE
为云端锻造扣券确认添加签名凭证

### DIFF
--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -289,13 +289,13 @@ async def get_card_drop_active_character(
     if cors is None:
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
     name = str(_card_drop_active_character.get("name", "") or "").strip()
-    master_name = ""
+    configured_name, master_name = await _fallback_active_character_identity()
     # Community forge used to treat an empty live snapshot as "本体未连接" even
     # when the local ledger/credits were healthy. Fall back to the configured
     # current catgirl so ticket selection can proceed before Pet avatar sync.
     used_fallback = False
     if not name:
-        name, master_name = await _fallback_active_character_identity()
+        name = configured_name
         used_fallback = True
     payload: dict[str, str] = {"name": name}
     if master_name:

--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -289,13 +289,13 @@ async def get_card_drop_active_character(
     if cors is None:
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
     name = str(_card_drop_active_character.get("name", "") or "").strip()
-    configured_name, master_name = await _fallback_active_character_identity()
+    master_name = ""
     # Community forge used to treat an empty live snapshot as "本体未连接" even
     # when the local ledger/credits were healthy. Fall back to the configured
     # current catgirl so ticket selection can proceed before Pet avatar sync.
     used_fallback = False
     if not name:
-        name = configured_name
+        name, master_name = await _fallback_active_character_identity()
         used_fallback = True
     payload: dict[str, str] = {"name": name}
     if master_name:

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import hmac
 import html
 import json
 import logging
@@ -279,6 +280,7 @@ async def _confirm_cloud_forge_debit(
     operation_id: str,
     credit_id: str,
     card_id: str,
+    credit: dict,
 ) -> dict:
     """Tell the cloud about a debit only after the local ledger has committed it."""
     credentials = await asyncio.to_thread(_get_client_credentials)
@@ -289,15 +291,13 @@ async def _confirm_cloud_forge_debit(
     try:
         parsed_base_url = urlparse(base_url)
         base_hostname = parsed_base_url.hostname
-        if parsed_base_url.scheme == "https" and base_hostname:
-            send_client_proof = True
-        elif (
+        valid_https = parsed_base_url.scheme == "https" and bool(base_hostname)
+        valid_loopback_http = (
             parsed_base_url.scheme == "http"
             and base_hostname
             and base_hostname.lower() in _LOOPBACK_HOSTS
-        ):
-            send_client_proof = False
-        else:
+        )
+        if not (valid_https or valid_loopback_http):
             return {"confirmed": False, "detail": "invalid_cloud_base_url"}
     except ValueError:
         return {"confirmed": False, "detail": "invalid_cloud_base_url"}
@@ -307,11 +307,18 @@ async def _confirm_cloud_forge_debit(
     )
     request_payload = {
         "client_id": client_id,
+        "client_proof": client_proof,
         "credit_id": credit_id,
         "card_id": card_id,
+        "voucher": _forge_voucher_attestation(
+            client_id=client_id,
+            client_proof=client_proof,
+            operation_id=operation_id,
+            credit_id=credit_id,
+            card_id=card_id,
+            credit=credit,
+        ),
     }
-    if send_client_proof:
-        request_payload["client_proof"] = client_proof
 
     async def _post() -> tuple[httpx.Response | None, dict | None]:
         try:
@@ -330,9 +337,8 @@ async def _confirm_cloud_forge_debit(
 
     # A rejection naming an unknown client is usually this install's first cloud
     # call after the cloud lost (or never had) the row. Register, then retry once.
-    # Not gated on send_client_proof: loopback HTTP omits the proof from this
-    # request, yet ensure_client_registered() may still register over it, so
-    # gating here would leave loopback debits unconfirmed until a restart.
+    # The voucher signature requires the binding proof even on loopback. HTTPS
+    # remains mandatory for every non-loopback cloud endpoint.
     detail = payload.get("detail") if isinstance(payload, dict) else None
     if client_registration.looks_unregistered(response.status_code, detail):
         if await client_registration.ensure_client_registered(base_url, force=True):
@@ -354,6 +360,53 @@ async def _confirm_cloud_forge_debit(
         and bool(payload.get("confirmed_at"))
     )
     return {"confirmed": confirmed}
+
+
+_FORGE_VOUCHER_KEY_CONTEXT = b"N.E.K.O forge voucher attestation v1"
+
+
+def _forge_voucher_timestamp(value: object) -> str:
+    from datetime import UTC, datetime
+
+    if not isinstance(value, str):
+        raise ValueError("invalid_forge_voucher_timestamp")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("invalid_forge_voucher_timestamp")
+    return parsed.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _forge_voucher_attestation(
+    *,
+    client_id: str,
+    client_proof: str,
+    operation_id: str,
+    credit_id: str,
+    card_id: str,
+    credit: dict,
+) -> dict:
+    voucher = {
+        "version": 1,
+        "operation_id": operation_id,
+        "credit_id": credit_id,
+        "card_id": card_id,
+        "rarity": str(credit.get("rarity") or ""),
+        "created_at": _forge_voucher_timestamp(credit.get("created_at")),
+        "expires_at": _forge_voucher_timestamp(credit.get("expires_at")),
+        "reserved_at": _forge_voucher_timestamp(credit.get("reserved_at")),
+        "consumed_at": _forge_voucher_timestamp(credit.get("consumed_at")),
+    }
+    document = {**voucher, "client_id": client_id}
+    message = json.dumps(
+        document, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    signing_key = hmac.new(
+        client_proof.encode("utf-8"),
+        _FORGE_VOUCHER_KEY_CONTEXT,
+        hashlib.sha256,
+    ).digest()
+    voucher["signature"] = hmac.new(signing_key, message, hashlib.sha256).hexdigest()
+    return voucher
 
 
 def _origin_port(parsed) -> int | None:
@@ -2154,6 +2207,7 @@ async def commit_credit_endpoint(
         operation_id=operation_id,
         credit_id=credit_id,
         card_id=str(payload.get("card_id") or ""),
+        credit=result["credit"],
     )
     return JSONResponse(
         {

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -305,19 +305,26 @@ async def _confirm_cloud_forge_debit(
         f"{base_url}/api/cards/forge-operations/"
         f"{operation_id}/debit-confirmation"
     )
-    request_payload = {
-        "client_id": client_id,
-        "client_proof": client_proof,
-        "credit_id": credit_id,
-        "card_id": card_id,
-        "voucher": _forge_voucher_attestation(
+    try:
+        voucher = _forge_voucher_attestation(
             client_id=client_id,
             client_proof=client_proof,
             operation_id=operation_id,
             credit_id=credit_id,
             card_id=card_id,
             credit=credit,
-        ),
+        )
+    except (TypeError, ValueError, OverflowError):
+        # The local ledger has already committed at this point. A malformed
+        # legacy timestamp must not turn that successful debit into an HTTP 500;
+        # leave cloud confirmation pending so a repaired record can be replayed.
+        return {"confirmed": False, "detail": "invalid_forge_voucher"}
+    request_payload = {
+        "client_id": client_id,
+        "client_proof": client_proof,
+        "credit_id": credit_id,
+        "card_id": card_id,
+        "voucher": voucher,
     }
 
     async def _post() -> tuple[httpx.Response | None, dict | None]:

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -22,6 +22,18 @@ USER_A_ID = "11111111-1111-4111-8111-111111111111"
 USER_B_ID = "22222222-2222-4222-8222-222222222222"
 
 
+def _voucher_credit(**over):
+    credit = {
+        "rarity": "R",
+        "created_at": "2026-08-09T00:00:00Z",
+        "expires_at": "2026-08-10T00:00:00Z",
+        "reserved_at": "2026-08-09T01:00:00Z",
+        "consumed_at": "2026-08-09T01:01:00Z",
+    }
+    credit.update(over)
+    return credit
+
+
 @pytest.mark.parametrize(
     "malformed_origin",
     [
@@ -316,6 +328,7 @@ async def test_confirm_cloud_forge_debit_rejects_redirect_response(monkeypatch):
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": False, "detail": "http_302"}
@@ -345,13 +358,14 @@ async def test_confirm_cloud_forge_debit_rejects_unsafe_cloud_base_url(
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": False, "detail": "invalid_cloud_base_url"}
 
 
 @pytest.mark.asyncio
-async def test_confirm_cloud_forge_debit_omits_proof_for_local_http(monkeypatch):
+async def test_confirm_cloud_forge_debit_includes_signed_voucher_for_local_http(monkeypatch):
     monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://localhost:48911")
     monkeypatch.setattr(
         C,
@@ -381,13 +395,23 @@ async def test_confirm_cloud_forge_debit_omits_proof_for_local_http(monkeypatch)
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": False, "detail": "http_204"}
     assert captured["json"] == {
         "client_id": "client-id",
+        "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
+        "voucher": C._forge_voucher_attestation(
+            client_id="client-id",
+            client_proof="client-proof",
+            operation_id="operation-id",
+            credit_id="credit-id",
+            card_id="card-id",
+            credit=_voucher_credit(),
+        ),
     }
 
 
@@ -441,6 +465,7 @@ async def test_confirm_cloud_forge_debit_retries_for_loopback_unregistered(monke
         operation_id="operation-id",
         credit_id="credit-id",
         card_id="card-id",
+        credit=_voucher_credit(),
     )
 
     assert result == {"confirmed": True}
@@ -450,8 +475,17 @@ async def test_confirm_cloud_forge_debit_retries_for_loopback_unregistered(monke
     assert call_log[2][0] == "post"
     assert call_log[0][2] == {
         "client_id": "client-id",
+        "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
+        "voucher": C._forge_voucher_attestation(
+            client_id="client-id",
+            client_proof="client-proof",
+            operation_id="operation-id",
+            credit_id="credit-id",
+            card_id="card-id",
+            credit=_voucher_credit(),
+        ),
     }
     assert call_log[1][1] == ("http://localhost:48911",)
     assert call_log[1][2] == {"force": True}
@@ -1266,11 +1300,13 @@ def test_refreshed_desktop_bearer_keeps_same_owner_reservation(
             "operation_id": operation_id,
             "credit_id": credit_id,
             "card_id": card_id,
+            "credit": committed.json()["credit"],
         },
         {
             "operation_id": operation_id,
             "credit_id": credit_id,
             "card_id": card_id,
+            "credit": commit_replay.json()["credit"],
         },
     ]
 

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -132,44 +132,6 @@ async def test_main_active_character_get_falls_back_to_configured_catgirl(monkey
     assert "characterReferenceDataUrl" not in payload
 
 
-@pytest.mark.asyncio
-async def test_main_active_character_get_merges_master_into_live_snapshot(monkeypatch):
-    from app.main_server import web_app
-
-    monkeypatch.setattr(
-        web_app,
-        "_card_drop_active_character",
-        {
-            "name": "YUI",
-            "dataUrl": "avatar",
-            "characterReferenceDataUrl": "reference",
-        },
-    )
-
-    async def fallback_identity():
-        return "Configured Character", "max"
-
-    monkeypatch.setattr(
-        web_app,
-        "_fallback_active_character_identity",
-        fallback_identity,
-    )
-
-    response = await web_app.get_card_drop_active_character(
-        _main_server_request(),
-        include_avatar=True,
-    )
-
-    assert response.status_code == 200
-    assert response.body
-    assert json.loads(response.body.decode("utf-8")) == {
-        "name": "YUI",
-        "master_name": "max",
-        "dataUrl": "avatar",
-        "characterReferenceDataUrl": "reference",
-    }
-
-
 def test_main_active_character_exposes_only_canonical_card_drop_routes():
     from app.main_server import web_app
 
@@ -420,6 +382,44 @@ async def test_confirm_cloud_forge_debit_includes_signed_voucher_for_local_http(
         "credit_id": "credit-id",
         "card_id": "card-id",
         "voucher": _fixed_expected_voucher(),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timestamp_update",
+    [
+        {"reserved_at": None},
+        {"consumed_at": "not-a-timestamp"},
+        {"created_at": "2026-08-09T00:00:00"},
+    ],
+)
+async def test_confirm_cloud_forge_debit_leaves_malformed_voucher_unconfirmed(
+    monkeypatch, timestamp_update,
+):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://localhost:48911")
+    monkeypatch.setattr(
+        C,
+        "_get_client_credentials",
+        lambda: ("client-id", "client-proof"),
+    )
+
+    class UnexpectedAsyncClient:
+        def __init__(self, **_kwargs):
+            raise AssertionError("malformed voucher must not be sent")
+
+    monkeypatch.setattr(C.httpx, "AsyncClient", UnexpectedAsyncClient)
+
+    result = await C._confirm_cloud_forge_debit(
+        operation_id="operation-id",
+        credit_id="credit-id",
+        card_id="card-id",
+        credit=_voucher_credit(**timestamp_update),
+    )
+
+    assert result == {
+        "confirmed": False,
+        "detail": "invalid_forge_voucher",
     }
 
 

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -105,6 +105,44 @@ async def test_main_active_character_get_falls_back_to_configured_catgirl(monkey
     assert "characterReferenceDataUrl" not in payload
 
 
+@pytest.mark.asyncio
+async def test_main_active_character_get_merges_master_into_live_snapshot(monkeypatch):
+    from app.main_server import web_app
+
+    monkeypatch.setattr(
+        web_app,
+        "_card_drop_active_character",
+        {
+            "name": "YUI",
+            "dataUrl": "avatar",
+            "characterReferenceDataUrl": "reference",
+        },
+    )
+
+    async def fallback_identity():
+        return "Configured Character", "max"
+
+    monkeypatch.setattr(
+        web_app,
+        "_fallback_active_character_identity",
+        fallback_identity,
+    )
+
+    response = await web_app.get_card_drop_active_character(
+        _main_server_request(),
+        include_avatar=True,
+    )
+
+    assert response.status_code == 200
+    assert response.body
+    assert json.loads(response.body.decode("utf-8")) == {
+        "name": "YUI",
+        "master_name": "max",
+        "dataUrl": "avatar",
+        "characterReferenceDataUrl": "reference",
+    }
+
+
 def test_main_active_character_exposes_only_canonical_card_drop_routes():
     from app.main_server import web_app
 

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -34,6 +34,21 @@ def _voucher_credit(**over):
     return credit
 
 
+def _fixed_expected_voucher():
+    return {
+        "version": 1,
+        "operation_id": "operation-id",
+        "credit_id": "credit-id",
+        "card_id": "card-id",
+        "rarity": "R",
+        "created_at": "2026-08-09T00:00:00.000000Z",
+        "expires_at": "2026-08-10T00:00:00.000000Z",
+        "reserved_at": "2026-08-09T01:00:00.000000Z",
+        "consumed_at": "2026-08-09T01:01:00.000000Z",
+        "signature": "5e95eb9dfe25de5ad5ee661e7e47817f1ce4f4a91103572dcc574961c6ec98ab",
+    }
+
+
 @pytest.mark.parametrize(
     "malformed_origin",
     [
@@ -404,14 +419,7 @@ async def test_confirm_cloud_forge_debit_includes_signed_voucher_for_local_http(
         "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
-        "voucher": C._forge_voucher_attestation(
-            client_id="client-id",
-            client_proof="client-proof",
-            operation_id="operation-id",
-            credit_id="credit-id",
-            card_id="card-id",
-            credit=_voucher_credit(),
-        ),
+        "voucher": _fixed_expected_voucher(),
     }
 
 
@@ -478,14 +486,7 @@ async def test_confirm_cloud_forge_debit_retries_for_loopback_unregistered(monke
         "client_proof": "client-proof",
         "credit_id": "credit-id",
         "card_id": "card-id",
-        "voucher": C._forge_voucher_attestation(
-            client_id="client-id",
-            client_proof="client-proof",
-            operation_id="operation-id",
-            credit_id="credit-id",
-            card_id="card-id",
-            credit=_voucher_credit(),
-        ),
+        "voucher": _fixed_expected_voucher(),
     }
     assert call_log[1][1] == ("http://localhost:48911",)
     assert call_log[1][2] == {"force": True}


### PR DESCRIPTION
## 改动概述 / Summary

- 为本体完成本地锻造券消费后的云端确认请求添加安装级 `client_proof`。
- 使用 `client_proof` 派生 HMAC-SHA256 密钥，对券的创建、过期、预占、消费时间及绑定 ID 生成签名 voucher。
- HTTPS 与 loopback HTTP 使用同一签名确认协议，并保留未知客户端注册后的幂等重试。
- malformed/legacy 时间戳不会让已成功的本地扣券返回 500；该次云端确认保持未完成，可在修复记录后重放。

## 配套变更

与 [N.E.K.O.Verse #192](https://github.com/Project-N-E-K-O/N.E.K.O.Verse/pull/192) 的云端 voucher 校验契约配套。主人显示名已不参与故事生成或名称锁定，因此本 PR 不再修改活动角色快照中的 `master_name`。

## 回归报告 / Regression Report

- **必要性：** 社区端现在验证本机券签名凭证。旧本体只发送 `client_id / credit_id / card_id`，确认接口会返回 422，导致卡牌生成后无法完成云端扣券确认。
- **失败保护：** 对已有账本中的缺失、非法或无时区时间戳，保留本地 commit 成功结果并返回 `debit_confirmed: false`，避免重复请求持续 500。
- **安全边界：** 非 loopback 端点仍强制 HTTPS；voucher 与 client、operation、credit、card、rarity 和完整时间线绑定。

## 测试 / Testing

- `uv run pytest tests/unit/test_card_drop_session_facts.py -q`：81 passed。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **安全性**
  - 本地凭证扣款确认现支持签名凭证与客户端证明，增强交易校验能力。
  - 凭证包含操作、卡片及状态等信息，降低凭证被篡改的风险。

- **可靠性**
  - 无效凭证时间戳将保持确认待处理，并返回明确的无效凭证结果。
  - 重试及会话刷新后的扣款确认可正确沿用对应凭证信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->