### PR TITLE
feat(server): 插件静态 UI 通用 SSE 实时推送通道

### DIFF
--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -17,12 +17,14 @@
     GET /plugin/{plugin_id}/ui/main.js   -> static/main.js
     GET /plugin/{plugin_id}/ui/style.css -> static/style.css
 """
+import asyncio
+import json
 import mimetypes
 import re
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from plugin.logging_config import get_logger
@@ -39,6 +41,46 @@ _I18N_LOCALE_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]{0,15}$")
 # and only change when the plugin author edits a translation file, so we keep
 # the parsed bytes in process memory and revalidate via mtime on each hit.
 _I18N_BUNDLE_CACHE: dict[Path, tuple[float, bytes]] = {}
+
+# ---- 插件静态 UI 的 SSE 实时推送通道（强化后端 → 前端通信）----
+# plugin_id -> list[asyncio.Queue]；每个 SSE 连接一个队列，POST /ui-api/push 广播。
+# 任意插件/后端往 /ui-api/push 推送，前端页面连 /ui-api/events 即时接收实时更新。
+_sse_clients: dict[str, list[asyncio.Queue]] = {}
+_sse_clients_lock = asyncio.Lock()
+
+
+def _parse_push_payload(body: bytes) -> dict:
+    """POST /ui-api/push 入参解析：支持 {"type":..., "text":..., ...} 或纯文本。
+
+    type 为调用方（插件）自定义的消息类别，server 原样透传、不预设分类；
+    text 为必填正文；style / avatar 等为可选扩展元数据。返回空 dict 表示无内容。
+    """
+    raw = body.decode("utf-8", "replace").strip()
+    if not raw:
+        return {}
+    if raw.startswith("{"):
+        try:
+            payload = json.loads(raw)
+            if isinstance(payload, dict) and payload.get("text"):
+                result: dict = {"text": str(payload["text"]).strip()}
+                if not result["text"]:
+                    return {}
+                msg_type = str(payload.get("type") or "").strip()
+                if msg_type:
+                    result["type"] = msg_type
+                style = str(payload.get("style") or "").strip()
+                if style in ("catgirl", "narration"):
+                    result["style"] = style
+                placement = str(payload.get("placement") or "").strip()
+                if placement in ("scrolling", "top"):
+                    result["placement"] = placement
+                avatar = str(payload.get("avatar") or "").strip()
+                if avatar:
+                    result["avatar"] = avatar
+                return result
+        except Exception:
+            pass
+    return {"text": raw}
 
 
 class HostedUiActionRequest(BaseModel):
@@ -212,6 +254,84 @@ async def plugin_ui_api_i18n_bundle(plugin_id: str, locale: str) -> Response:
             "ETag": f'W/"{plugin_id}-{locale}-{int(mtime)}"',
         },
     )
+
+
+@router.get("/plugin/{plugin_id}/ui-api/events")
+async def plugin_ui_sse_events(plugin_id: str):
+    """插件静态 UI 的 SSE 事件流（后端 → 前端实时推送）。
+
+    前端页面用 EventSource 连这里，即时接收 /ui-api/push 广播的实时更新。
+    """
+    queue_obj: asyncio.Queue = asyncio.Queue()
+
+    async def event_stream():
+        await _sse_clients_lock.acquire()
+        try:
+            _sse_clients.setdefault(plugin_id, []).append(queue_obj)
+        finally:
+            _sse_clients_lock.release()
+        try:
+            yield "data: " + json.dumps({"type": "hello", "lanes": 12}, ensure_ascii=False) + "\n\n"
+            while True:
+                try:
+                    payload = await asyncio.wait_for(queue_obj.get(), timeout=15.0)
+                    yield payload
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"
+        finally:
+            await _sse_clients_lock.acquire()
+            try:
+                clients = _sse_clients.get(plugin_id)
+                if clients and queue_obj in clients:
+                    clients.remove(queue_obj)
+            finally:
+                _sse_clients_lock.release()
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/plugin/{plugin_id}/ui-api/push")
+async def plugin_ui_push(plugin_id: str, request: Request):
+    """向插件静态 UI 的所有 SSE 客户端广播一条实时消息（后端 → 前端推送）。
+
+    入参：{"text": "..."} 或纯文本。任意插件/后端调用，推送到已订阅的前端页面。
+    """
+    body = await request.body()
+    payload = _parse_push_payload(body)
+    if not payload.get("text"):
+        return JSONResponse({"ok": False, "error": "empty"}, status_code=400)
+    # type 由插件自定义并原样透传（server 不预设分类）；未指定则不带 type 字段
+    event: dict = {"text": payload["text"]}
+    if payload.get("type"):
+        event["type"] = payload["type"]
+    if payload.get("style"):
+        event["style"] = payload["style"]
+    if payload.get("placement"):
+        event["placement"] = payload["placement"]
+    if payload.get("avatar"):
+        event["avatar"] = payload["avatar"]
+    data = "data: " + json.dumps(event, ensure_ascii=False) + "\n\n"
+    delivered = 0
+    await _sse_clients_lock.acquire()
+    try:
+        clients = _sse_clients.get(plugin_id, [])
+        for c in list(clients):
+            try:
+                c.put_nowait(data)
+                delivered += 1
+            except Exception:
+                pass
+    finally:
+        _sse_clients_lock.release()
+    return JSONResponse({"ok": True, "delivered": delivered})
 
 
 @router.get("/plugin/{plugin_id}/ui/{file_path:path}")

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -51,6 +51,8 @@ _sse_clients: dict[str, list[asyncio.Queue]] = {}
 _sse_clients_lock = asyncio.Lock()
 # 每个客户端队列的最大缓冲（慢/阻塞客户端不使其无限膨胀）；满时丢弃新消息
 _SSE_QUEUE_MAX = 100
+# push 请求体大小上限（字节）：1MB，足够 catgirl 带头像弹幕，同时限制本机恶意分块请求占内存
+_PUSH_MAX_BODY = 1024 * 1024
 # 可信 Origin 主机（本机回环）：push 广播只接受无 Origin（插件后端/非浏览器）或本机页面
 _TRUSTED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
@@ -359,9 +361,13 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     # 只接受无 Origin（插件后端/curl）或本机回环 Origin
     if not _origin_is_trusted(request.headers.get("origin", "")):
         return JSONResponse({"ok": False, "error": "invalid origin"}, status_code=403)
-    # 流式读取请求体（不设大小上限；仅本机回环可推送，SSE 队列满会丢弃）
+    # 流式读取请求体：累计字节数，超过固定上限立即 413，避免本机恶意分块请求占内存
     chunks: list[bytes] = []
+    total = 0
     async for chunk in request.stream():
+        total += len(chunk)
+        if total > _PUSH_MAX_BODY:
+            return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
         chunks.append(chunk)
     body = b"".join(chunks)
     payload = _parse_push_payload(body)

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -75,12 +75,6 @@ def _origin_is_trusted(origin: str) -> bool:
     return host in _TRUSTED_ORIGIN_HOSTS
 
 
-def _client_is_loopback(request: Request) -> bool:
-    """客户端是否来自本机回环（127.0.0.1/::1/localhost）。"""
-    host = str(request.client.host or "") if request.client is not None else ""
-    return host in ("127.0.0.1", "::1", "localhost") or host.startswith("127.")
-
-
 def _parse_push_payload(body: bytes) -> dict:
     """POST /ui-api/push 入参解析：支持 {"type":..., "text":..., ...} 或纯文本。
 
@@ -344,19 +338,14 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
     配置了 ``NEKO_SSE_PUSH_TOKEN`` 时要求 ``Authorization: Bearer <token>``。
     """
-    # 非回环部署（远程/容器访问，如 Compose 暴露）必须配置共享密钥；
-    # 本机回环无 token 时向后兼容
-    if not _client_is_loopback(request) and not _PUSH_TOKEN:
-        return JSONResponse(
-            {"ok": False, "error": "token required for non-loopback deployment"},
-            status_code=403,
-        )
-    # 鉴权：配置共享密钥后强制校验 Authorization: Bearer <token>
-    if _PUSH_TOKEN:
-        auth = request.headers.get("authorization", "")
-        scheme, _, presented = auth.partition(" ")
-        if scheme.lower() != "bearer" or presented.strip() != _PUSH_TOKEN:
-            return JSONResponse({"ok": False, "error": "unauthorized"}, status_code=401)
+    # 鉴权：push 一律要求共享密钥（NEKO_SSE_PUSH_TOKEN），不做回环豁免；
+    # 未配置 token 则拒绝（部署方必须配置）
+    if not _PUSH_TOKEN:
+        return JSONResponse({"ok": False, "error": "token not configured"}, status_code=503)
+    auth = request.headers.get("authorization", "")
+    scheme, _, presented = auth.partition(" ")
+    if scheme.lower() != "bearer" or presented.strip() != _PUSH_TOKEN:
+        return JSONResponse({"ok": False, "error": "unauthorized"}, status_code=401)
     # Origin 校验：浏览器跨站表单 POST（no-cors）可向 loopback 注入 SSE；
     # 只接受无 Origin（插件后端/curl）或本机回环 Origin
     if not _origin_is_trusted(request.headers.get("origin", "")):

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -75,6 +75,12 @@ def _origin_is_trusted(origin: str) -> bool:
     return host in _TRUSTED_ORIGIN_HOSTS
 
 
+def _client_is_loopback(request: Request) -> bool:
+    """客户端是否来自本机回环（127.0.0.1/::1/localhost）。"""
+    host = str(request.client.host or "") if request.client is not None else ""
+    return host in ("127.0.0.1", "::1", "localhost") or host.startswith("127.")
+
+
 def _parse_push_payload(body: bytes) -> dict:
     """POST /ui-api/push 入参解析：支持 {"type":..., "text":..., ...} 或纯文本。
 
@@ -338,7 +344,14 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
     配置了 ``NEKO_SSE_PUSH_TOKEN`` 时要求 ``Authorization: Bearer <token>``。
     """
-    # 鉴权：本机其他进程/本地网页可能调用本路由注入消息，配置共享密钥后强制校验
+    # 非回环部署（远程/容器访问，如 Compose 暴露）必须配置共享密钥；
+    # 本机回环无 token 时向后兼容
+    if not _client_is_loopback(request) and not _PUSH_TOKEN:
+        return JSONResponse(
+            {"ok": False, "error": "token required for non-loopback deployment"},
+            status_code=403,
+        )
+    # 鉴权：配置共享密钥后强制校验 Authorization: Bearer <token>
     if _PUSH_TOKEN:
         auth = request.headers.get("authorization", "")
         scheme, _, presented = auth.partition(" ")

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -336,7 +336,9 @@ async def plugin_ui_push(plugin_id: str, request: Request):
 
     入参：{"text": "..."} 或纯文本。任意插件/后端调用，推送到已订阅的前端页面。
     返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
-    配置了 ``NEKO_SSE_PUSH_TOKEN`` 时要求 ``Authorization: Bearer <token>``。
+
+    鉴权：一律要求共享密钥（环境变量 ``NEKO_SSE_PUSH_TOKEN``）。
+    未配置时返回 503（不允许推送）；配置后必须带 ``Authorization: Bearer <token>``，否则 401。
     """
     # 鉴权：push 一律要求共享密钥（NEKO_SSE_PUSH_TOKEN），不做回环豁免；
     # 未配置 token 则拒绝（部署方必须配置）

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -20,8 +20,10 @@
 import asyncio
 import json
 import mimetypes
+import os
 import re
 from pathlib import Path
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
@@ -51,6 +53,26 @@ _sse_clients_lock = asyncio.Lock()
 _SSE_QUEUE_MAX = 100
 # push 请求体大小上限（字节）；读取前按 Content-Length 校验，避免大 body 直接进内存
 _PUSH_MAX_BODY = 16 * 1024
+# push 鉴权共享密钥（环境变量 NEKO_SSE_PUSH_TOKEN）：非空时要求 Authorization: Bearer <token>
+# 未配置则不鉴权（向后兼容）。danmu_bridge 等插件推送侧读取同一变量自动带上。
+_PUSH_TOKEN = os.environ.get("NEKO_SSE_PUSH_TOKEN", "").strip()
+# 可信 Origin 主机（本机回环）：push 广播只接受无 Origin（插件后端/非浏览器）或本机页面
+_TRUSTED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _origin_is_trusted(origin: str) -> bool:
+    """push 广播的 Origin 校验：无 Origin（插件后端/curl）或本机回环放行。
+
+    防止恶意网站通过浏览器表单 POST（no-cors）向 loopback 注入 SSE 消息。
+    """
+    origin = (origin or "").strip()
+    if not origin:
+        return True
+    try:
+        host = (urlparse(origin).hostname or "").lower()
+    except Exception:
+        return False
+    return host in _TRUSTED_ORIGIN_HOSTS
 
 
 def _parse_push_payload(body: bytes) -> dict:
@@ -314,8 +336,19 @@ async def plugin_ui_push(plugin_id: str, request: Request):
 
     入参：{"text": "..."} 或纯文本。任意插件/后端调用，推送到已订阅的前端页面。
     返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
+    配置了 ``NEKO_SSE_PUSH_TOKEN`` 时要求 ``Authorization: Bearer <token>``。
     """
-    # 读取 body 前按 Content-Length 校验大小，避免超大请求直接进内存
+    # 鉴权：本机其他进程/本地网页可能调用本路由注入消息，配置共享密钥后强制校验
+    if _PUSH_TOKEN:
+        auth = request.headers.get("authorization", "")
+        scheme, _, presented = auth.partition(" ")
+        if scheme.lower() != "bearer" or presented.strip() != _PUSH_TOKEN:
+            return JSONResponse({"ok": False, "error": "unauthorized"}, status_code=401)
+    # Origin 校验：浏览器跨站表单 POST（no-cors）可向 loopback 注入 SSE；
+    # 只接受无 Origin（插件后端/curl）或本机回环 Origin
+    if not _origin_is_trusted(request.headers.get("origin", "")):
+        return JSONResponse({"ok": False, "error": "invalid origin"}, status_code=403)
+    # Content-Length 预检（快速失败）；无 Content-Length / 分块传输时靠流式读取兜底
     content_length = request.headers.get("content-length")
     if content_length:
         try:
@@ -323,9 +356,15 @@ async def plugin_ui_push(plugin_id: str, request: Request):
                 return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
         except ValueError:
             pass
-    body = await request.body()
-    if len(body) > _PUSH_MAX_BODY:
-        return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
+    # 流式读取请求体：逐块累计，超过上限立即 413，避免超大请求整段进内存
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > _PUSH_MAX_BODY:
+            return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
+        chunks.append(chunk)
+    body = b"".join(chunks)
     payload = _parse_push_payload(body)
     if not payload.get("text"):
         return JSONResponse({"ok": False, "error": "empty"}, status_code=400)

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -47,6 +47,10 @@ _I18N_BUNDLE_CACHE: dict[Path, tuple[float, bytes]] = {}
 # 任意插件/后端往 /ui-api/push 推送，前端页面连 /ui-api/events 即时接收实时更新。
 _sse_clients: dict[str, list[asyncio.Queue]] = {}
 _sse_clients_lock = asyncio.Lock()
+# 每个客户端队列的最大缓冲（慢/阻塞客户端不使其无限膨胀）；满时丢弃新消息
+_SSE_QUEUE_MAX = 100
+# push 请求体大小上限（字节）；读取前按 Content-Length 校验，避免大 body 直接进内存
+_PUSH_MAX_BODY = 16 * 1024
 
 
 def _parse_push_payload(body: bytes) -> dict:
@@ -61,25 +65,27 @@ def _parse_push_payload(body: bytes) -> dict:
     if raw.startswith("{"):
         try:
             payload = json.loads(raw)
-            if isinstance(payload, dict) and payload.get("text"):
-                result: dict = {"text": str(payload["text"]).strip()}
-                if not result["text"]:
-                    return {}
-                msg_type = str(payload.get("type") or "").strip()
-                if msg_type:
-                    result["type"] = msg_type
-                style = str(payload.get("style") or "").strip()
-                if style in ("catgirl", "narration"):
-                    result["style"] = style
-                placement = str(payload.get("placement") or "").strip()
-                if placement in ("scrolling", "top"):
-                    result["placement"] = placement
-                avatar = str(payload.get("avatar") or "").strip()
-                if avatar:
-                    result["avatar"] = avatar
-                return result
         except Exception:
-            pass
+            return {"text": raw}  # 非合法 JSON → 回退纯文本
+        if not isinstance(payload, dict):
+            return {}  # JSON 但不是对象 → 拒绝
+        text = str(payload.get("text") or "").strip()
+        if not text:
+            return {}  # 缺 text / 空 text → 拒绝（不回退纯文本，避免原始 JSON 被当正文）
+        result: dict = {"text": text}
+        msg_type = str(payload.get("type") or "").strip()
+        if msg_type:
+            result["type"] = msg_type
+        style = str(payload.get("style") or "").strip()
+        if style in ("catgirl", "narration"):
+            result["style"] = style
+        placement = str(payload.get("placement") or "").strip()
+        if placement in ("scrolling", "top"):
+            result["placement"] = placement
+        avatar = str(payload.get("avatar") or "").strip()
+        if avatar:
+            result["avatar"] = avatar
+        return result
     return {"text": raw}
 
 
@@ -262,7 +268,8 @@ async def plugin_ui_sse_events(plugin_id: str):
 
     前端页面用 EventSource 连这里，即时接收 /ui-api/push 广播的实时更新。
     """
-    queue_obj: asyncio.Queue = asyncio.Queue()
+    # 有界队列：慢/阻塞客户端不被无限缓冲（满时由 push 侧丢弃新消息）
+    queue_obj: asyncio.Queue = asyncio.Queue(maxsize=_SSE_QUEUE_MAX)
 
     async def event_stream():
         await _sse_clients_lock.acquire()
@@ -284,6 +291,9 @@ async def plugin_ui_sse_events(plugin_id: str):
                 clients = _sse_clients.get(plugin_id)
                 if clients and queue_obj in clients:
                     clients.remove(queue_obj)
+                # 列表空则删除 plugin_id，避免任意路径参数留下永久空条目
+                if clients is not None and not clients:
+                    _sse_clients.pop(plugin_id, None)
             finally:
                 _sse_clients_lock.release()
 
@@ -303,8 +313,19 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     """向插件静态 UI 的所有 SSE 客户端广播一条实时消息（后端 → 前端推送）。
 
     入参：{"text": "..."} 或纯文本。任意插件/后端调用，推送到已订阅的前端页面。
+    返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
     """
+    # 读取 body 前按 Content-Length 校验大小，避免超大请求直接进内存
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > _PUSH_MAX_BODY:
+                return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
+        except ValueError:
+            pass
     body = await request.body()
+    if len(body) > _PUSH_MAX_BODY:
+        return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
     payload = _parse_push_payload(body)
     if not payload.get("text"):
         return JSONResponse({"ok": False, "error": "empty"}, status_code=400)
@@ -319,19 +340,19 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     if payload.get("avatar"):
         event["avatar"] = payload["avatar"]
     data = "data: " + json.dumps(event, ensure_ascii=False) + "\n\n"
-    delivered = 0
+    queued = 0
     await _sse_clients_lock.acquire()
     try:
         clients = _sse_clients.get(plugin_id, [])
         for c in list(clients):
             try:
-                c.put_nowait(data)
-                delivered += 1
+                c.put_nowait(data)  # 队列满（QueueFull）→ 丢弃新消息，不计入 queued
+                queued += 1
             except Exception:
                 pass
     finally:
         _sse_clients_lock.release()
-    return JSONResponse({"ok": True, "delivered": delivered})
+    return JSONResponse({"ok": True, "queued": queued})
 
 
 @router.get("/plugin/{plugin_id}/ui/{file_path:path}")

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -53,9 +53,6 @@ _sse_clients_lock = asyncio.Lock()
 _SSE_QUEUE_MAX = 100
 # push 请求体大小上限（字节）；读取前按 Content-Length 校验，避免大 body 直接进内存
 _PUSH_MAX_BODY = 16 * 1024
-# push 鉴权共享密钥（环境变量 NEKO_SSE_PUSH_TOKEN）：非空时要求 Authorization: Bearer <token>
-# 未配置则不鉴权（向后兼容）。danmu_bridge 等插件推送侧读取同一变量自动带上。
-_PUSH_TOKEN = os.environ.get("NEKO_SSE_PUSH_TOKEN", "").strip()
 # 可信 Origin 主机（本机回环）：push 广播只接受无 Origin（插件后端/非浏览器）或本机页面
 _TRUSTED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
@@ -337,17 +334,8 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     入参：{"text": "..."} 或纯文本。任意插件/后端调用，推送到已订阅的前端页面。
     返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
 
-    鉴权：一律要求共享密钥（环境变量 ``NEKO_SSE_PUSH_TOKEN``）。
-    未配置时返回 503（不允许推送）；配置后必须带 ``Authorization: Bearer <token>``，否则 401。
+    鉴权：本机回环可直接推送（不再要求共享密钥；Origin 校验仍防跨站注入）。
     """
-    # 鉴权：push 一律要求共享密钥（NEKO_SSE_PUSH_TOKEN），不做回环豁免；
-    # 未配置 token 则拒绝（部署方必须配置）
-    if not _PUSH_TOKEN:
-        return JSONResponse({"ok": False, "error": "token not configured"}, status_code=503)
-    auth = request.headers.get("authorization", "")
-    scheme, _, presented = auth.partition(" ")
-    if scheme.lower() != "bearer" or presented.strip() != _PUSH_TOKEN:
-        return JSONResponse({"ok": False, "error": "unauthorized"}, status_code=401)
     # Origin 校验：浏览器跨站表单 POST（no-cors）可向 loopback 注入 SSE；
     # 只接受无 Origin（插件后端/curl）或本机回环 Origin
     if not _origin_is_trusted(request.headers.get("origin", "")):

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -51,8 +51,6 @@ _sse_clients: dict[str, list[asyncio.Queue]] = {}
 _sse_clients_lock = asyncio.Lock()
 # 每个客户端队列的最大缓冲（慢/阻塞客户端不使其无限膨胀）；满时丢弃新消息
 _SSE_QUEUE_MAX = 100
-# push 请求体大小上限（字节）；读取前按 Content-Length 校验，避免大 body 直接进内存
-_PUSH_MAX_BODY = 16 * 1024
 # 可信 Origin 主机（本机回环）：push 广播只接受无 Origin（插件后端/非浏览器）或本机页面
 _TRUSTED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
@@ -361,21 +359,9 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     # 只接受无 Origin（插件后端/curl）或本机回环 Origin
     if not _origin_is_trusted(request.headers.get("origin", "")):
         return JSONResponse({"ok": False, "error": "invalid origin"}, status_code=403)
-    # Content-Length 预检（快速失败）；无 Content-Length / 分块传输时靠流式读取兜底
-    content_length = request.headers.get("content-length")
-    if content_length:
-        try:
-            if int(content_length) > _PUSH_MAX_BODY:
-                return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
-        except ValueError:
-            pass
-    # 流式读取请求体：逐块累计，超过上限立即 413，避免超大请求整段进内存
+    # 流式读取请求体（不设大小上限；仅本机回环可推送，SSE 队列满会丢弃）
     chunks: list[bytes] = []
-    total = 0
     async for chunk in request.stream():
-        total += len(chunk)
-        if total > _PUSH_MAX_BODY:
-            return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
         chunks.append(chunk)
     body = b"".join(chunks)
     payload = _parse_push_payload(body)

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -72,6 +72,18 @@ def _origin_is_trusted(origin: str) -> bool:
     return host in _TRUSTED_ORIGIN_HOSTS
 
 
+def _is_loopback_host(host: str) -> bool:
+    """判断对端主机是否本机回环（含 IPv4-mapped IPv6 形式 ::ffff:127.x.x.x）。
+
+    push 移除共享密钥后，以此作为「仅本机回环可推送」的边界：不信任
+    X-Forwarded-For 等转发头，直接看直连对端 request.client.host。
+    """
+    host = (host or "").strip().lower()
+    if host in ("localhost", "127.0.0.1", "::1"):
+        return True
+    return host.startswith("::ffff:127.")
+
+
 def _parse_push_payload(body: bytes) -> dict:
     """POST /ui-api/push 入参解析：支持 {"type":..., "text":..., ...} 或纯文本。
 
@@ -334,8 +346,14 @@ async def plugin_ui_push(plugin_id: str, request: Request):
     入参：{"text": "..."} 或纯文本。任意插件/后端调用，推送到已订阅的前端页面。
     返回 ``queued``：成功写入各客户端缓冲队列的数目（排队计数，非客户端实际送达确认）。
 
-    鉴权：本机回环可直接推送（不再要求共享密钥；Origin 校验仍防跨站注入）。
+    鉴权：仅本机回环客户端可直接推送（不再要求共享密钥；对端非回环一律拒绝，
+    伪造 Origin / 转发头均无法绕过；Origin 校验仍防跨站注入）。
     """
+    # 回环校验：只接受本机回环客户端。用直连对端 request.client.host，不信任
+    # X-Forwarded-For，避免伪造转发头绕过（非回环部署应保留其他鉴权/可信代理）。
+    client_host = request.client.host if request.client else ""
+    if not _is_loopback_host(client_host):
+        return JSONResponse({"ok": False, "error": "non-loopback push rejected"}, status_code=403)
     # Origin 校验：浏览器跨站表单 POST（no-cors）可向 loopback 注入 SSE；
     # 只接受无 Origin（插件后端/curl）或本机回环 Origin
     if not _origin_is_trusted(request.headers.get("origin", "")):
@@ -379,8 +397,10 @@ async def plugin_ui_push(plugin_id: str, request: Request):
             try:
                 c.put_nowait(data)  # 队列满（QueueFull）→ 丢弃新消息，不计入 queued
                 queued += 1
-            except Exception:
-                pass
+            except asyncio.QueueFull:
+                pass  # 预期：队列满丢弃该条，不计入 queued
+            except Exception as exc:  # 其他运行时故障（如队列已关闭）记录，不阻断其它客户端
+                logger.warning("[plugin-ui] SSE push 队列写入失败: %s", exc)
     finally:
         _sse_clients_lock.release()
     return JSONResponse({"ok": True, "queued": queued})

--- a/plugin/server/routes/plugin_ui.py
+++ b/plugin/server/routes/plugin_ui.py
@@ -73,13 +73,16 @@ def _origin_is_trusted(origin: str) -> bool:
 
 
 def _is_loopback_host(host: str) -> bool:
-    """判断对端主机是否本机回环（含 IPv4-mapped IPv6 形式 ::ffff:127.x.x.x）。
+    """判断对端主机是否本机回环：localhost、整个 IPv4 回环网段 127.0.0.0/8、
+    IPv6 ::1，以及 IPv4-mapped IPv6 形式 ::ffff:127.x.x.x。
 
     push 移除共享密钥后，以此作为「仅本机回环可推送」的边界：不信任
     X-Forwarded-For 等转发头，直接看直连对端 request.client.host。
     """
     host = (host or "").strip().lower()
-    if host in ("localhost", "127.0.0.1", "::1"):
+    if host in ("localhost", "::1"):
+        return True
+    if host.startswith("127."):  # 整个 127.0.0.0/8 都是 IPv4 回环（本机后端可能绑 127.0.0.2 等）
         return True
     return host.startswith("::ffff:127.")
 


### PR DESCRIPTION
## 为什么

插件静态 UI（含 Hosted TSX 面板）之前的通信模型是纯"请求-响应"——前端单方面发起，后端只能被动响应，后端没有任何通道能主动通知前端。凡是"后端产生内容、前端即时看到"的场景（状态流、事件通知）都做不到：

  - 轮询（前端定时问"有新内容吗"）→ 浪费带宽、有秒级延迟
  - WebSocket → 双向长连接，但对"服务器单向推送"场景过重、复杂度高
  - SSE → 正好匹配：普通 HTTP + EventSource，后端一有内容就主动推，前端即时收

 SSE 打开的是插件生态里此前完全缺失的"后端 → 前端主动"单向通道（连 Hosted TSX都只能靠前端拉取）。它是通用基础设施，不绑定任何业务——弹幕只是第一个使用场景，任何插件都能复用。

## 如何使用

后端推送（任意插件/桥接层，Python）：
  import httpx
  import os

  token = os.environ.get("NEKO_SSE_PUSH_TOKEN", "")   //与 server 同一环境变量
  resp = httpx.post(
      "http://127.0.0.1:48916/plugin/{plugin_id}/ui-api/push",
      json={"type": "my_message", "text": "实时消息"},   // type 由插件自定义，原样透传
  )
  //resp.json() → {"ok": True, "queued": N}  （N = 成功写入客户端缓冲队列数，非送达确认）

  前端订阅（页面 JS，订阅无需 token）：
  const es = new EventSource('/plugin/{plugin_id}/ui-api/events');
  es.onmessage = (e) => {
    const msg = JSON.parse(e.data);
    if (msg.type === 'my_message') {   // 按插件自己定义的 type 分流
      render(msg.text);                 // msg.text 为推送内容
    }
  };

  流程：后端带 token POST /ui-api/push → 该插件所有 EventSource 连接页面立即收到 data: {...} 帧 → 前端按 type处理。

## 改动概述 / Summary

为插件静态 UI 新增通用 SSE 实时推送通道，强化「后端 → 前端」的实时通信能力。

新增两条路由（plugin/server/routes/plugin_ui.py）：

  1. GET /plugin/{plugin_id}/ui-api/events — SSE 事件流
    - 前端页面用 EventSource 订阅，建立长连接
    - 服务器端按 plugin_id 维护连接队列（_sse_clients），断线自动清理
    - 15s 心跳 keepalive，防止代理/中间层断开空闲连接
  2. POST /plugin/{plugin_id}/ui-api/push — 实时广播
    - 任意插件/后端调用即可向该插件所有已订阅的前端推送一条实时消息
    - 入参支持 {"text": "..."} 或纯文本，style/avatar 等为可选扩展元数据
    - 返回 {"ok": true, "delivered": N}（N = 实际送达的客户端数）

  设计要点：
  - 通用能力，不绑定任何具体业务——任何插件都能往后端 push、前端订阅实时收
  - 基于普通 HTTP（SSE），前端 EventSource 一行订阅，无 WebSocket 复杂度
  - 单向实时推送（服务器 → 前端），适合实时更新/事件流场景

## 回归报告 / Regression Report

不适用 —— 本 PR 仅改动 plugin/server/routes/plugin_ui.py，未触碰 app/、main_logic/、memory/。

## 不拆分理由 / Why Not Split

不适用 —— 改动计入上限的文件仅 1 个（plugin/server/routes/plugin_ui.py，116 行新增），远小于 20 上限。

## 测试 / Testing

手动实测（真实运行环境，sts2 agent + N.E.K.O server 均在跑）：
  1. curl /plugin/sts2_autoplay/ui-api/events → 200 OK，content-type: text/event-stream，Transfer-Encoding:
  chunked（SSE 长连接正常建立）
  2. curl -X POST /ui-api/push -d '{"text":"..."}' → {"ok": true, "delivered": 1}（广播送达 1 个已订阅客户端）
  3. 用脚本订阅 SSE → 收到 data: {"type":"hello","lanes":12} 握手帧 → push 后收到 data:
  {"type":"danmu","text":"...","style":"catgirl","placement":"scrolling"} 消息帧
  4. 已订阅客户端存在时 delivered=1，无客户端时 delivered=0（送达计数准确）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件静态 UI 支持按插件隔离的实时事件流，持续接收广播消息。
  * 建立连接时发送欢迎消息，并每 15 秒发送保活信号。
  * 支持通过 JSON 或纯文本推送消息，并筛选允许的消息字段。
  * 推送接口支持本机回环及可信来源校验，并返回实际入队数量。
  * 拒绝空消息及超过 1MB 的请求；连接关闭后自动取消订阅，队列已满时丢弃新增消息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->