### PR TITLE
fix: polish credential deletion and QR dark theme

### DIFF
--- a/static/js/cookies_login.js
+++ b/static/js/cookies_login.js
@@ -454,47 +454,6 @@ document.addEventListener('visibilitychange', () => {
     }
 });
 
-/**
- * 降低十六进制颜色的明度
- * @param {string} hexColor - 输入的十六进制颜色，如 #fff 或 #ffffff
- * @param {number} lightnessPercent - 降低明度的百分比（0-100），100 表示完全变黑
- * @returns {string} 调整后的十六进制颜色
- */
-function decreaseColorLightness(hexColor, lightnessPercent) {
-    // 验证输入的明度值
-    const percent = Math.max(0, Math.min(100, Number(lightnessPercent)));
-    const decreaseRatio = 1 - percent / 100;
-
-    // 清洗并验证十六进制颜色
-    let hex = hexColor.replace(/^#/, '');
-    // 处理简写形式 (#fff -> #ffffff)
-    if (hex.length === 3) {
-        hex = hex.split('').map(char => char + char).join('');
-    }
-
-    // 验证十六进制格式
-    if (!/^[0-9A-Fa-f]{6}$/.test(hex)) {
-        throw new Error('请输入有效的十六进制颜色，如 #fff 或 #ffffff');
-    }
-
-    // 十六进制转 RGB
-    const r = parseInt(hex.substring(0, 2), 16);
-    const g = parseInt(hex.substring(2, 4), 16);
-    const b = parseInt(hex.substring(4, 6), 16);
-
-    // 降低明度（按比例减少每个通道的值）
-    const newR = Math.max(0, Math.round(r * decreaseRatio));
-    const newG = Math.max(0, Math.round(g * decreaseRatio));
-    const newB = Math.max(0, Math.round(b * decreaseRatio));
-
-    // RGB 转回十六进制（确保两位，不足补0）
-    const toHex = (num) => num.toString(16).padStart(2, '0');
-    const newHex = `#${toHex(newR)}${toHex(newG)}${toHex(newB)}`;
-
-    return newHex.toUpperCase(); // 统一返回大写格式，也可以改为 toLowerCase()
-}
-
-
 let qrSupportedPlatforms = null;
 let qrSupportedPlatformsRequest = null;
 let qrEntryGeneration = 0;
@@ -545,19 +504,18 @@ async function showQRLogin(config, platformKey) {
     if (isSupported){
         const QRinfo =  document.createElement("div");
         const butt = document.createElement("button");
-        const rootStyle = getComputedStyle(document.documentElement);
-        const pagePrimary = rootStyle.getPropertyValue('--primary').trim();
-        const pageButtonBg = rootStyle.getPropertyValue('--button-bg').trim() || pagePrimary;
-        const buttonTheme = platformKey === 'bilibili' && pageButtonBg ? pageButtonBg : config["theme"];
-        const buttonBorder = platformKey === 'bilibili' && pagePrimary ? pagePrimary : buttonTheme;
+        // Keep QR entry buttons on each platform's own color; inherited app variables
+        // can resolve to light values and previously left a white button in dark mode.
+        const buttonTheme = config["theme"];
+        const buttonBorder = buttonTheme;
         QRinfo.dataset.i18n = 'cookiesLogin.qrLogin.tryQR';
         QRinfo.textContent = safeT('cookiesLogin.qrLogin.tryQR', '或者...试试扫码登录?');
-        QRinfo.style = 'margin-bottom: 10px;color: #64748b;font-size: 14px';
+        QRinfo.className = 'qr-login-hint';
         butt.dataset.i18n = 'cookiesLogin.qrLogin.openQR';
         butt.textContent = safeT('cookiesLogin.qrLogin.openQR', '打开扫码登录');
-        butt.style.cssText = `width: 100%; padding: 12px; margin-top: 10px; font-size: 14px; font-weight: 600; border-radius: 10px; border: 2px dashed ${buttonBorder}; background: ${buttonTheme} ; color: #f8fafc; cursor: pointer; transition: all 0.2s;`;
-        butt.onmouseover = function() { butt.style.background = decreaseColorLightness(buttonTheme,20); };
-        butt.onmouseout = function() { butt.style.background = buttonTheme; };
+        butt.className = 'qr-open-btn';
+        butt.style.setProperty('--qr-platform-color', buttonTheme);
+        butt.style.setProperty('--qr-platform-border', buttonBorder);
         butt.onclick = function(){requestQR(config, platformKey)};
         qrLoginBox.appendChild(QRinfo);
         qrLoginBox.appendChild(butt);
@@ -633,8 +591,8 @@ async function requestQR(config, platformKey) {
     qrRequestAbortController = abortController;
     const qrLoginBox = document.getElementById('QRLogin');
     qrLoginBox.innerHTML = `
-        <div style="text-align: center; padding: 20px;">
-            <div data-i18n="cookiesLogin.qrLogin.loading" style="color: #64748b; margin-bottom: 10px;">${safeT('cookiesLogin.qrLogin.loading', '正在获取二维码...')}</div>
+        <div class="qr-session-loading">
+            <div data-i18n="cookiesLogin.qrLogin.loading">${safeT('cookiesLogin.qrLogin.loading', '正在获取二维码...')}</div>
         </div>
     `;
     
@@ -663,16 +621,16 @@ async function requestQR(config, platformKey) {
             const timeout = result.data.timeout || 180;
             
             qrLoginBox.innerHTML = `
-                <div style="text-align: center; padding: 15px; background: #f8fafc; border-radius: 12px; border: 1px solid #e2e8f0; position: relative;">
+                <div class="qr-session">
                     <button id="qr-collapse-action" class="qr-collapse-btn">
                         <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                         <span data-i18n="common.collapse">${safeT('common.collapse', '收起')}</span>
                     </button>
-                    <div id="qr-scan-title" style="font-weight: 600; color: #334155; margin-bottom: 12px; margin-top: 5px;">${safeT('cookiesLogin.qrLogin.scanTitle', '扫码登录 {{platform}}').replace('{{platform}}', PLATFORM_CONFIG[platformKey]?.name || config["name"])}</div>
-                    <img src="${result.data.qrcode_image}" alt="${safeT('cookiesLogin.qrLogin.qrCodeAlt', 'QR code')}" style="width: 200px; height: 200px; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
-                    <div id="qr-status" style="margin-top: 12px; font-size: 13px; color: #64748b;">${safeT('cookiesLogin.qrLogin.waiting', '等待扫码...')}</div>
-                    <div id="qr-valid-for" data-seconds="${timeout}" style="margin-top: 10px; font-size: 12px; color: #94a3b8;">${safeT('cookiesLogin.qrLogin.validFor', '二维码有效期: {{seconds}}秒').replace('{{seconds}}', timeout)}</div>
-                    <button id="qr-refresh-btn" data-i18n="cookiesLogin.qrLogin.refreshQR" style="margin-top: 12px; padding: 8px 16px; font-size: 13px; border-radius: 8px; border: 1px solid #e2e8f0; background: white; color: #475569; cursor: pointer;">${safeT('cookiesLogin.qrLogin.refreshQR', '刷新二维码')}</button>
+                    <div id="qr-scan-title" class="qr-session-title">${safeT('cookiesLogin.qrLogin.scanTitle', '扫码登录 {{platform}}').replace('{{platform}}', PLATFORM_CONFIG[platformKey]?.name || config["name"])}</div>
+                    <img class="qr-session-image" src="${result.data.qrcode_image}" alt="${safeT('cookiesLogin.qrLogin.qrCodeAlt', 'QR code')}">
+                    <div id="qr-status" class="qr-session-status">${safeT('cookiesLogin.qrLogin.waiting', '等待扫码...')}</div>
+                    <div id="qr-valid-for" class="qr-session-validity" data-seconds="${timeout}">${safeT('cookiesLogin.qrLogin.validFor', '二维码有效期: {{seconds}}秒').replace('{{seconds}}', timeout)}</div>
+                    <button id="qr-refresh-btn" class="qr-session-refresh" data-i18n="cookiesLogin.qrLogin.refreshQR">${safeT('cookiesLogin.qrLogin.refreshQR', '刷新二维码')}</button>
                 </div>
             `;
             
@@ -691,9 +649,9 @@ async function requestQR(config, platformKey) {
             startQrPoll(config, platformKey);
         } else {
             qrLoginBox.innerHTML = `
-                <div style="text-align: center; padding: 20px; color: #ef4444;">
+                <div class="qr-session-error">
                     ${safeT('cookiesLogin.qrLogin.fetchFailed', '获取二维码失败，请稍后重试')}
-                    <button id="qr-retry-btn" style="display: block; margin: 10px auto 0; padding: 8px 16px; border-radius: 8px; border: 1px solid #ef4444; background: white; color: #ef4444; cursor: pointer;">${safeT('cookiesLogin.qrLogin.retry', '重试')}</button>
+                    <button id="qr-retry-btn" class="qr-session-retry">${safeT('cookiesLogin.qrLogin.retry', '重试')}</button>
                 </div>
             `;
             document.getElementById('qr-retry-btn').onclick = function() {
@@ -708,9 +666,9 @@ async function requestQR(config, platformKey) {
             ? err.message
             : safeT('cookiesLogin.qrLogin.networkError', '网络请求失败，请检查连接');
         qrLoginBox.innerHTML = `
-            <div style="text-align: center; padding: 20px; color: #ef4444;">
+            <div class="qr-session-error">
                 ${errorMessage}
-                <button id="qr-retry-btn-err" style="display: block; margin: 10px auto 0; padding: 8px 16px; border-radius: 8px; border: 1px solid #ef4444; background: white; color: #ef4444; cursor: pointer;">${safeT('cookiesLogin.qrLogin.retry', '重试')}</button>
+                <button id="qr-retry-btn-err" class="qr-session-retry">${safeT('cookiesLogin.qrLogin.retry', '重试')}</button>
             </div>
         `;
         document.getElementById('qr-retry-btn-err').onclick = function() {

--- a/static/js/cookies_login.js
+++ b/static/js/cookies_login.js
@@ -1388,6 +1388,7 @@ async function refreshStatusList({ reveal = false } = {}) {
                 const delBtn = document.createElement('button');
                 delBtn.className = 'del-btn';
                 delBtn.title = safeT('cookiesLogin.removeCredentials', '清除凭证');
+                delBtn.setAttribute('aria-label', safeT('cookiesLogin.removeCredentials', '清除凭证'));
                 delBtn.innerHTML = `<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>`;
                 delBtn.addEventListener('click', () => deleteCookie(key));
                 actionsWrapper.appendChild(delBtn);

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -748,6 +748,63 @@
             margin-bottom: 0;
             padding: 0;
         }
+        .qr-login-hint {
+            margin-bottom: 10px;
+            color: var(--muted);
+            font-size: 14px;
+        }
+        .qr-open-btn {
+            width: 100%;
+            margin-top: 10px;
+            padding: 12px;
+            border: 2px dashed var(--qr-platform-border, var(--accent));
+            border-radius: 10px;
+            background: var(--qr-platform-color, var(--accent));
+            color: #f8fafc;
+            font: 600 14px/1.2 var(--font-ui);
+            cursor: pointer;
+            transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+        .qr-open-btn:hover {
+            transform: translateY(-1px);
+            background: color-mix(in oklch, var(--qr-platform-color, var(--accent)) 80%, black);
+            box-shadow: 0 8px 18px color-mix(in oklch, var(--qr-platform-color, var(--accent)) 28%, transparent);
+        }
+        .qr-open-btn:active { transform: translateY(0); }
+        .qr-open-btn:focus-visible,
+        .qr-session-refresh:focus-visible,
+        .qr-session-retry:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+        .qr-session {
+            position: relative;
+            padding: 15px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: var(--surface-raised);
+            color: var(--fg);
+            text-align: center;
+            box-shadow: inset 0 1px color-mix(in oklch, white 26%, transparent);
+        }
+        .qr-session-title { margin: 5px 0 12px; color: var(--fg); font-size: 14px; font-weight: 600; }
+        .qr-session-image { width: 200px; height: 200px; border-radius: 8px; box-shadow: 0 2px 8px rgb(0 0 0 / 0.1); }
+        .qr-session-status { margin-top: 12px; color: var(--muted); font-size: 13px; }
+        .qr-session-validity { margin-top: 10px; color: color-mix(in oklch, var(--muted) 76%, transparent); font-size: 12px; }
+        .qr-session-refresh,
+        .qr-session-retry {
+            margin-top: 12px;
+            padding: 8px 16px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--surface);
+            color: var(--fg);
+            font: 600 13px/1 var(--font-ui);
+            cursor: pointer;
+            transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+        }
+        .qr-session-refresh:hover { border-color: var(--accent); background: var(--accent-soft); }
+        .qr-session-retry { display: block; margin-right: auto; margin-left: auto; border-color: oklch(0.62 0.19 28 / 0.72); color: oklch(0.55 0.19 28); }
+        .qr-session-retry:hover { background: oklch(0.94 0.06 28 / 0.65); }
+        .qr-session-error { padding: 20px; color: oklch(0.59 0.2 28); text-align: center; }
+        .qr-session-loading { padding: 20px; color: var(--muted); text-align: center; }
 
         .encrypt-row {
             display: flex;
@@ -1068,9 +1125,10 @@
             animation: pulse 2s ease-in-out infinite;
         }
         .status-tag.inactive { background: var(--border); color: var(--muted); }
-        .sta…84 tokens truncated…
-            cursor: pointer;
-            transition: background 0.15s;
+        .del-btn {
+            border: 0;
+            background: transparent;
+            color: oklch(0.55 0.19 28);
         }
         .del-btn:hover { background: oklch(0.92 0.06 30); }
         /* Compact danger action: visually distinct without competing with the status badge. */
@@ -1235,6 +1293,15 @@
         [data-theme="dark"] .tab-btn:hover { border-color: var(--accent); background: var(--accent-soft); }
         [data-theme="dark"] .qr-collapse-btn { background: var(--accent-soft); color: var(--accent); }
         [data-theme="dark"] .qr-collapse-btn:hover { background: oklch(0.3 0.04 230); }
+        [data-theme="dark"] .qr-open-btn {
+            background: color-mix(in oklch, var(--qr-platform-color, var(--accent)) 66%, var(--surface-raised));
+            border-color: color-mix(in oklch, var(--qr-platform-border, var(--accent)) 72%, var(--border));
+            box-shadow: inset 0 1px rgb(255 255 255 / 0.08);
+        }
+        [data-theme="dark"] .qr-open-btn:hover { background: color-mix(in oklch, var(--qr-platform-color, var(--accent)) 78%, var(--surface-raised)); }
+        [data-theme="dark"] .qr-session { box-shadow: inset 0 1px rgb(255 255 255 / 0.05); }
+        [data-theme="dark"] .qr-session-retry { color: oklch(0.8 0.14 28); }
+        [data-theme="dark"] .qr-session-retry:hover { background: oklch(0.31 0.07 28); }
         [data-theme="dark"] .status-tag.active { background: oklch(0.28 0.08 150); color: var(--success); }
         [data-theme="dark"] .status-tag.inactive { background: var(--border); color: var(--muted); }
         [data-theme="dark"] .del-btn {

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -1073,6 +1073,35 @@
             transition: background 0.15s;
         }
         .del-btn:hover { background: oklch(0.92 0.06 30); }
+        /* Compact danger action: visually distinct without competing with the status badge. */
+        .del-btn {
+            display: inline-grid;
+            width: 34px;
+            height: 34px;
+            padding: 0;
+            place-items: center;
+            border: 1px solid oklch(0.72 0.1 28 / 0.32);
+            border-radius: 10px;
+            background: oklch(0.97 0.025 28 / 0.72);
+            color: oklch(0.53 0.18 28);
+            box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.65);
+            cursor: pointer;
+            transition: transform 0.16s ease, background 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease, color 0.16s ease;
+        }
+        .del-btn svg { width: 17px; height: 17px; transition: transform 0.16s ease; }
+        .del-btn:hover {
+            transform: translateY(-1px);
+            border-color: oklch(0.61 0.18 28 / 0.64);
+            background: oklch(0.93 0.065 28);
+            color: oklch(0.45 0.19 28);
+            box-shadow: 0 5px 12px oklch(0.52 0.18 28 / 0.16);
+        }
+        .del-btn:hover svg { transform: scale(1.08); }
+        .del-btn:active { transform: translateY(0) scale(0.96); box-shadow: none; }
+        .del-btn:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+        }
 
         /* ==============================
            QR COLLAPSE BUTTON
@@ -1208,8 +1237,18 @@
         [data-theme="dark"] .qr-collapse-btn:hover { background: oklch(0.3 0.04 230); }
         [data-theme="dark"] .status-tag.active { background: oklch(0.28 0.08 150); color: var(--success); }
         [data-theme="dark"] .status-tag.inactive { background: var(--border); color: var(--muted); }
-        [data-theme="dark"] .del-btn { color: oklch(0.65 0.14 30); }
-        [data-theme="dark"] .del-btn:hover { background: oklch(0.25 0.04 30); }
+        [data-theme="dark"] .del-btn {
+            border-color: oklch(0.58 0.13 28 / 0.34);
+            background: oklch(0.28 0.045 28 / 0.72);
+            color: oklch(0.76 0.14 28);
+            box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
+        }
+        [data-theme="dark"] .del-btn:hover {
+            border-color: oklch(0.69 0.17 28 / 0.7);
+            background: oklch(0.36 0.075 28);
+            color: oklch(0.91 0.1 28);
+            box-shadow: 0 5px 14px oklch(0.08 0.02 28 / 0.42);
+        }
         [data-theme="dark"] .close-btn:hover { background: rgba(255,255,255,0.08); }
         [data-theme="dark"] .plat-icon svg [stroke="#000"] { stroke: var(--fg) !important; }
         [data-theme="dark"] .plat-icon svg [fill="#000"] { fill: var(--fg) !important; }


### PR DESCRIPTION
## Summary
- Polish the credential delete action and add keyboard-accessible labeling.
- Theme Bilibili and Heybox QR login entry/session controls for dark mode.
- Restore the malformed delete-button CSS rule that caused an IDE stylesheet error.

<img width="347" height="114" alt="image" src="https://github.com/user-attachments/assets/fabc8eec-c081-4d8e-bbd9-f4ef851d6919" />

<img width="623" height="329" alt="image" src="https://github.com/user-attachments/assets/99ad3c3b-7de5-4d0f-bcfc-a38f12cf9ff7" />

## Validation
- `git diff --check`
- `node --check static/js/cookies_login.js`
- Opened the local credential management page at `/api/auth/page`.

## UI verification
- Dark-mode styling is implemented through shared theme tokens for QR entry, session, refresh, retry, loading, and error states.
- A local screenshot could not be persisted from this environment; please verify the Bilibili and Heybox QR flows in dark mode during review.

## 回归报告 / Regression Report
不适用 / N/A：未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split
不适用 / N/A：仅修改 2 个前端文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化二维码登录区域，新增提示、打开、刷新和重试控件。
  * 增加二维码加载中、展示及错误状态反馈。
  * 补充深色主题适配，提升二维码登录界面的一致性。

* **改进**
  * 删除操作按钮改为更紧凑的图标样式，并增强悬停、按下和键盘焦点状态。
  * 为删除凭证按钮补充无障碍标签，改善辅助功能支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->