### PR TITLE
fix(tutorial): 修复 Day4 教程光标衔接与动画节奏

### DIFF
--- a/static/tutorial-settings-tour-flow.test.cjs
+++ b/static/tutorial-settings-tour-flow.test.cjs
@@ -32,7 +32,10 @@ test('SettingsTourFlow exposes declarative schemas for day four panel tours', ()
         panelMinDurationMs: 4200,
         openWithSettingsCursor: true,
         settingsCursorIdSuffix: '_settings_button',
-        settingsCursorMoveDurationMs: 560,
+        settingsCursorStartDelayMs: 300,
+        settingsCursorMoveDurationMs: 760,
+        settingsCursorClickDurationMs: 520,
+        exactCursorDuration: true,
         openFailureMessage: '[YuiGuide] 第4天对话设置打开设置面板失败:'
     });
     assert.deepEqual(flow.getPanelTourSchema({ id: 'day4_model_behavior' }), {
@@ -44,6 +47,7 @@ test('SettingsTourFlow exposes declarative schemas for day four panel tours', ()
         cursorMoveDurationMs: 620,
         collapseBeforeAnchorHighlight: true,
         openWithAnchorCursor: true,
+        waitForVisibleAnchor: true,
         panelEllipseDurationMs: 3200,
         panelMinDurationMs: 3200
     });
@@ -158,8 +162,14 @@ test('SettingsTourFlow owns day three personalization detail scene body after da
 
 test('SettingsTourFlow reuses day four animation panel from its anchor cursor click', async () => {
     const calls = [];
+    let anchorReady = false;
     const settingsButton = { id: 'settings-button' };
-    const animationButton = { id: 'animation-settings-button' };
+    const animationButton = {
+        id: 'animation-settings-button',
+        getBoundingClientRect() {
+            return { left: 100, top: 140, width: 120, height: 44 };
+        }
+    };
     const animationPanel = {
         id: 'animation-settings-panel',
         _anchorElement: animationButton,
@@ -183,6 +193,11 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
         getAvatarFloatingSidePanel(panelId) {
             calls.push(['get-panel', panelId]);
             return panelId === 'animation-settings' ? animationPanel : null;
+        },
+        waitForElement(resolveElement, timeoutMs) {
+            calls.push(['wait-anchor', timeoutMs]);
+            anchorReady = true;
+            return Promise.resolve(resolveElement());
         },
         collapseAvatarFloatingSidePanelsExcept(panel) {
             calls.push(['collapse-except', panel]);
@@ -223,6 +238,9 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
             return Promise.resolve(animationPanel);
         },
         getElementRect(target) {
+            if (target === animationButton) {
+                return anchorReady ? { left: 100, top: 140, width: 120, height: 44 } : null;
+            }
             return target.getBoundingClientRect();
         },
         cursor: {
@@ -248,6 +266,8 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
     assert.equal(result, true);
     assert.deepEqual(calls, [
         ['prepare', 'day4_model_behavior'],
+        ['get-panel', 'animation-settings'],
+        ['wait-anchor', 1200],
         ['get-panel', 'animation-settings'],
         ['collapse-except', null],
         ['highlight', 'day4_model_behavior-animation-settings-button', 'animation-settings-button', 'settings-button'],
@@ -1119,7 +1139,12 @@ test('SettingsTourFlow keeps panel ellipse alive for configured minimum duration
 test('SettingsTourFlow stops day four panel tour when anchor click makes scene stale', async () => {
     const calls = [];
     const settingsButton = { id: 'settings-button' };
-    const animationButton = { id: 'animation-settings-button' };
+    const animationButton = {
+        id: 'animation-settings-button',
+        getBoundingClientRect() {
+            return { left: 100, top: 140, width: 120, height: 44 };
+        }
+    };
     const animationPanel = {
         id: 'animation-settings-panel',
         _anchorElement: animationButton,
@@ -1141,6 +1166,9 @@ test('SettingsTourFlow stops day four panel tour when anchor click makes scene s
         },
         getAvatarFloatingSidePanel() {
             return animationPanel;
+        },
+        waitForElement(resolveElement) {
+            return Promise.resolve(resolveElement());
         },
         collapseAvatarFloatingSidePanelsExcept() {},
         applyGuideHighlights(config) {

--- a/static/tutorial-settings-tour-flow.test.cjs
+++ b/static/tutorial-settings-tour-flow.test.cjs
@@ -196,6 +196,9 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
         },
         waitForElement(resolveElement, timeoutMs) {
             calls.push(['wait-anchor', timeoutMs]);
+            const unresolvedAnchor = resolveElement();
+            calls.push(['anchor-unready', unresolvedAnchor]);
+            assert.equal(unresolvedAnchor, null);
             anchorReady = true;
             return Promise.resolve(resolveElement());
         },
@@ -268,6 +271,8 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
         ['prepare', 'day4_model_behavior'],
         ['get-panel', 'animation-settings'],
         ['wait-anchor', 1200],
+        ['get-panel', 'animation-settings'],
+        ['anchor-unready', null],
         ['get-panel', 'animation-settings'],
         ['collapse-except', null],
         ['highlight', 'day4_model_behavior-animation-settings-button', 'animation-settings-button', 'settings-button'],

--- a/static/tutorial-visual-runtime.test.cjs
+++ b/static/tutorial-visual-runtime.test.cjs
@@ -963,11 +963,15 @@ test('VisualRuntime routes day3 galgame wheel rotation command to the existing d
     ]);
 });
 
-test('VisualRuntime clears day four externalized chat cursor before settings tour playback', async () => {
+test('VisualRuntime releases day four externalized chat cursor ownership without hiding the PC cursor', async () => {
     const calls = [];
     const director = {
         clearExternalizedChatGuideTarget(options) {
-            calls.push(['clear-externalized-chat', options.clearCursor]);
+            calls.push([
+                'clear-externalized-chat',
+                options.clearCursor,
+                options.preservePcOverlayCursor
+            ]);
         },
         settingsTourFlow: {
             play(scene, context) {
@@ -1012,7 +1016,7 @@ test('VisualRuntime clears day four externalized chat cursor before settings tou
 
     assert.equal(result, true);
     assert.deepEqual(calls, [
-        ['clear-externalized-chat', true],
+        ['clear-externalized-chat', true, true],
         ['settings-tour', 'day4_chat_settings', 41, 'day4_intro_companion', 1, 6]
     ]);
 });

--- a/static/tutorial/core/settings-tour-flow.js
+++ b/static/tutorial/core/settings-tour-flow.js
@@ -32,7 +32,12 @@
             panelMinDurationMs: 4200,
             openWithSettingsCursor: true,
             settingsCursorIdSuffix: '_settings_button',
-            settingsCursorMoveDurationMs: 560,
+            // 修改原因：第 4 天这句旁白需要让用户看清“移动到设置并点击”，但整段动作不能拖过旁白。
+            settingsCursorStartDelayMs: 300,
+            settingsCursorMoveDurationMs: 760,
+            settingsCursorClickDurationMs: 520,
+            // 修改原因：该场景的时长已经按旁白重新编排，禁止通用光标逻辑额外放慢动画。
+            exactCursorDuration: true,
             openFailureMessage: '[YuiGuide] 第4天对话设置打开设置面板失败:'
         }),
         day4_model_behavior: Object.freeze({
@@ -44,6 +49,8 @@
             cursorMoveDurationMs: 620,
             collapseBeforeAnchorHighlight: true,
             openWithAnchorCursor: true,
+            // 修改原因：设置弹窗切换过程中锚点可能已经创建但还没有有效坐标，需等到可见后再接管光标。
+            waitForVisibleAnchor: true,
             panelEllipseDurationMs: 3200,
             panelMinDurationMs: 3200
         })
@@ -186,9 +193,25 @@
                     primary: settingsButton
                 });
             }
-            const anchorButton = sidePanel && sidePanel._anchorElement
+            let anchorButton = sidePanel && sidePanel._anchorElement
                 ? sidePanel._anchorElement
                 : null;
+            if (normalizedSchema.waitForVisibleAnchor) {
+                anchorButton = await director.waitForElement(() => {
+                    const currentPanel = director.getAvatarFloatingSidePanel(panelId) || sidePanel;
+                    const candidate = currentPanel && currentPanel._anchorElement
+                        ? currentPanel._anchorElement
+                        : null;
+                    if (!candidate || !director.getElementRect(candidate)) {
+                        return null;
+                    }
+                    sidePanel = currentPanel;
+                    return candidate;
+                }, 1200);
+                if (this.isSceneStale(sceneRunId)) {
+                    return false;
+                }
+            }
             if (normalizedSchema.collapseBeforeAnchorHighlight) {
                 director.collapseAvatarFloatingSidePanelsExcept(null);
             }
@@ -205,7 +228,10 @@
                 minDurationMs: normalizedSchema.panelMinDurationMs
             });
 
-            await director.waitForSceneDelay(220);
+            const settingsCursorStartDelayMs = Number.isFinite(normalizedSchema.settingsCursorStartDelayMs)
+                ? Math.max(0, Math.floor(normalizedSchema.settingsCursorStartDelayMs))
+                : 220;
+            await director.waitForSceneDelay(settingsCursorStartDelayMs);
             if (this.isSceneStale(sceneRunId)) {
                 return false;
             }
@@ -214,7 +240,9 @@
                 await director.moveAvatarFloatingCursor({
                     id: scene.id + normalizedSchema.settingsCursorIdSuffix,
                     cursorAction: 'click',
-                    cursorMoveDurationMs: normalizedSchema.settingsCursorMoveDurationMs
+                    cursorMoveDurationMs: normalizedSchema.settingsCursorMoveDurationMs,
+                    cursorClickDurationMs: normalizedSchema.settingsCursorClickDurationMs,
+                    exactDuration: normalizedSchema.exactCursorDuration === true
                 }, settingsButton, null, previousSceneId, {
                     onClickStart: () => director.openSettingsPanel().catch((error) => {
                         console.warn(normalizedSchema.openFailureMessage, error);
@@ -263,7 +291,11 @@
                     persistent: settingsButton || null,
                     primary: resolvedAnchorButton
                 });
-                await director.moveCursorToElement(resolvedAnchorButton, normalizedSchema.cursorMoveDurationMs);
+                await director.moveCursorToElement(
+                    resolvedAnchorButton,
+                    normalizedSchema.cursorMoveDurationMs,
+                    { exactDuration: normalizedSchema.exactCursorDuration === true }
+                );
             }
             if (this.isSceneStale(sceneRunId)) {
                 return false;

--- a/static/tutorial/core/settings-tour-flow.js
+++ b/static/tutorial/core/settings-tour-flow.js
@@ -241,9 +241,9 @@
                     id: scene.id + normalizedSchema.settingsCursorIdSuffix,
                     cursorAction: 'click',
                     cursorMoveDurationMs: normalizedSchema.settingsCursorMoveDurationMs,
-                    cursorClickDurationMs: normalizedSchema.settingsCursorClickDurationMs,
-                    exactDuration: normalizedSchema.exactCursorDuration === true
+                    cursorClickDurationMs: normalizedSchema.settingsCursorClickDurationMs
                 }, settingsButton, null, previousSceneId, {
+                    exactDuration: normalizedSchema.exactCursorDuration === true,
                     onClickStart: () => director.openSettingsPanel().catch((error) => {
                         console.warn(normalizedSchema.openFailureMessage, error);
                     })

--- a/static/tutorial/core/visual-runtime.js
+++ b/static/tutorial/core/visual-runtime.js
@@ -589,7 +589,12 @@
                 && legacyScene.id.indexOf('day4_') === 0
                 && typeof director.clearExternalizedChatGuideTarget === 'function'
             ) {
-                director.clearExternalizedChatGuideTarget({ clearCursor: true });
+                // 修改原因：这里只需要释放独立聊天窗对光标的控制权；保留全局光标当前位置，
+                // 让下一句设置教程可以从上一句的位置继续移动，避免光标和高亮等待真实鼠标唤醒。
+                director.clearExternalizedChatGuideTarget({
+                    clearCursor: true,
+                    preservePcOverlayCursor: true
+                });
             }
             return await director.settingsTourFlow.play(legacyScene, {
                 sceneRunId: context ? context.sceneRunId : undefined,

--- a/static/tutorial/yui-guide/director/avatar-rounds.js
+++ b/static/tutorial/yui-guide/director/avatar-rounds.js
@@ -2411,7 +2411,11 @@
                     continue;
                 }
                 if (action === 'click' && index === 0) {
-                    const clickPromise = this.clickCursorAndWait(DEFAULT_CURSOR_CLICK_VISIBLE_MS);
+                    // 修改原因：允许特定教程场景单独延长点击反馈，避免关键按钮的模拟点击一闪而过。
+                    const clickDurationMs = Number.isFinite(scene.cursorClickDurationMs)
+                        ? Math.max(120, Math.floor(scene.cursorClickDurationMs))
+                        : DEFAULT_CURSOR_CLICK_VISIBLE_MS;
+                    const clickPromise = this.clickCursorAndWait(clickDurationMs);
                     if (typeof normalizedOptions.onClickStart === 'function') {
                         normalizedOptions.onClickStart({
                             scene,

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -2324,8 +2324,13 @@ def test_day4_chat_settings_opens_settings_then_tours_sidebar(mock_page: Page):
                     secondary: config.secondary || null,
                 };
             };
-            director.moveCursorToElement = async (element, durationMs) => {
-                calls.push({ type: 'move', id: element && element.id, durationMs });
+            director.moveCursorToElement = async (element, durationMs, options) => {
+                calls.push({
+                    type: 'move',
+                    id: element && element.id,
+                    durationMs,
+                    exactDuration: !!(options && options.exactDuration),
+                });
                 return true;
             };
             director.cursor = {
@@ -2378,6 +2383,12 @@ def test_day4_chat_settings_opens_settings_then_tours_sidebar(mock_page: Page):
         "persistentId": "live2d-btn-settings",
         "primaryId": "chat-settings-button",
     })
+    assert {
+        "type": "move",
+        "id": "live2d-btn-settings",
+        "durationMs": 760,
+        "exactDuration": True,
+    } in result
     assert {"type": "click"} in result
     assert any(call["type"] == "ellipse" and call["radiusX"] > 0 and call["radiusY"] > 0 for call in result)
 

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -2402,7 +2402,11 @@ def test_day4_model_behavior_moves_from_chat_sidebar_to_animation_sidebar(mock_p
             };
             document.getElementById('animation-settings-panel')._anchorElement = document.getElementById('animation-settings-button');
         """,
-        script_names=("tutorial/yui-guide/overlay.js", *_YUI_DIRECTOR_SCRIPTS),
+        script_names=(
+            "tutorial/yui-guide/overlay.js",
+            *_YUI_DIRECTOR_SCRIPTS,
+            "tutorial/yui-guide/days/day4-companion-guide.js",
+        ),
     )
 
     result = mock_page.evaluate(
@@ -2410,7 +2414,18 @@ def test_day4_model_behavior_moves_from_chat_sidebar_to_animation_sidebar(mock_p
         async () => {
             window.__calls = [];
             const director = window.createYuiGuideDirector({ page: 'home' });
+            const modelBehaviorScene = window.YuiGuideDailyGuides[4].round.scenes.find(
+                (candidate) => candidate.id === 'day4_model_behavior'
+            );
             let releaseNarration;
+            director.currentSceneId = 'day4_chat_settings';
+            director.clearExternalizedChatGuideTarget = (options) => {
+                window.__calls.push({
+                    type: 'clear-external',
+                    clearCursor: !!(options && options.clearCursor),
+                    preservePcOverlayCursor: !!(options && options.preservePcOverlayCursor),
+                });
+            };
             director.appendGuideChatMessage = () => window.__calls.push({ type: 'message' });
             director.applyGuideEmotion = (emotion) => window.__calls.push({ type: 'emotion', emotion });
             director.enableInterrupts = () => window.__calls.push({ type: 'interrupts' });
@@ -2472,14 +2487,7 @@ def test_day4_model_behavior_moves_from_chat_sidebar_to_animation_sidebar(mock_p
                 }, 20);
             });
 
-            await director.playAvatarFloatingScene({
-                id: 'day4_model_behavior',
-                text: '如果你想要看到更精致、细节更满满的我，或者想要更丝滑、更流畅的动作体验，都可以在这里进行调整哦！不管哪一种，我都会展现出最可爱的一面哒~',
-                voiceKey: 'avatar_floating_day4_model_behavior',
-                target: 'settings-sidepanel:animation-settings',
-                cursorAction: 'tour',
-                operation: 'show-settings-sidepanel:animation-settings',
-            }, 4, 2, 8);
+            await director.playAvatarFloatingScene(modelBehaviorScene, 4, 2, 8);
             return window.__calls;
         }
         """
@@ -2500,6 +2508,11 @@ def test_day4_model_behavior_moves_from_chat_sidebar_to_animation_sidebar(mock_p
         ("highlight", "day4_model_behavior-animation-settings-button", "animation-settings-button", "live2d-btn-settings"),
         ("highlight", "day4_model_behavior-animation-settings-panel", "animation-settings-panel", "live2d-btn-settings"),
     ]
+    assert {
+        "type": "clear-external",
+        "clearCursor": True,
+        "preservePcOverlayCursor": True,
+    } in result
     assert result.index({"type": "move", "id": "animation-settings-button", "durationMs": 620}) < result.index({
         "type": "api:ensureSidePanel",
         "panelType": "animation-settings",


### PR DESCRIPTION
## 改动概述 / Summary

- 调整 Day4「对话设置」场景的 ghost cursor 起始延迟、移动时长和点击反馈，使关键操作清晰可见且不超出旁白。
- Day4 设置教程切换时只释放独立聊天窗的光标控制权，保留 PC 全局光标当前位置，使下一句动画自然继承上一句光标。
- 「模型行为」场景等待【动画设置】锚点具有有效坐标后，再显示高亮并执行 ghost cursor 移动和模拟点击，避免必须移动真实鼠标才能唤醒动画。
- 补充真实 Day4 timeline、光标所有权交接和锚点就绪等待的回归测试。

根因是场景切换时把“释放旧窗口控制权”和“隐藏全局 ghost cursor”作为同一操作处理，同时后一句没有等待设置锚点坐标稳定；真实鼠标移动触发轻微对抗时会重新同步完整覆盖层状态，因此此前看起来必须移动鼠标后光标和高亮才出现。

## 回归报告 / Regression Report

不适用：本次未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本次仅修改 3 个教程实现文件和 3 个直接测试文件，属于同一段 Day4 教程动画链路。

## 测试 / Testing

- `node --test static/tutorial-visual-runtime.test.cjs static/tutorial-settings-tour-flow.test.cjs`（41 项通过）
- `node --test static/yui-guide-scene-orchestrator.test.cjs`（22 项通过）
- `.venv/bin/python -m pytest tests/frontend/test_home_prompt_flow.py::test_day4_model_behavior_moves_from_chat_sidebar_to_animation_sidebar -q`（1 项通过）
- `PR_BODY=... .venv/bin/python scripts/check_pr_report.py --base upstream/main`（通过，6 个文件、3 个计数文件、0 个高风险模块）
- `git diff --check upstream/main...HEAD`（通过）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化第 4 天设置导览的光标移动、点击时序与视觉反馈，使引导过程更加精准、连贯。
  - 在模型行为导览中等待目标锚点可见且位置有效后再继续，提升引导稳定性。
  - 切换至动画设置时保留全局光标位置，同时正确清理聊天窗口的光标控制。
- **测试**
  - 补充并更新相关场景测试，覆盖锚点等待、场景过期及光标状态清理等流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->