### PR TITLE
fix: prefer hosted plugin panels and harden live2d build

### DIFF
--- a/build_frontend.bat
+++ b/build_frontend.bat
@@ -94,7 +94,7 @@ echo [build_frontend] all production frontend projects built successfully.
 exit /b 0
 
 rem --- helper: unpack one built-in Live2D model ---
-rem 每个模型都是 assets\<name>.tar.gz，解到 static\<name>\，marker 是 <name>.moc3。
+rem Each model archive in assets is unpacked into its matching static directory.
 :unpack_live2d
 setlocal
 set "MODEL=%~1"
@@ -108,15 +108,20 @@ if not exist "%YUI_ARCHIVE%" (
 )
 
 set "YUI_NEED_EXTRACT=0"
-if not exist "%YUI_MARKER%" (
-  set "YUI_NEED_EXTRACT=1"
-) else (
-  for /f %%I in ('powershell -NoProfile -Command "if ((Get-Item -LiteralPath $env:YUI_ARCHIVE).LastWriteTime -gt (Get-Item -LiteralPath $env:YUI_MARKER).LastWriteTime) {1} else {0}"') do set "YUI_NEED_EXTRACT=%%I"
-)
+if not exist "%YUI_MARKER%" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" uv run --no-sync python -c "import os, sys; sys.exit(0 if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 1)" "%YUI_ARCHIVE%" "%YUI_MARKER%"
+if "%YUI_NEED_EXTRACT%"=="0" if not errorlevel 1 set "YUI_NEED_EXTRACT=1"
 
 if "%YUI_NEED_EXTRACT%"=="1" (
   echo [build_frontend] unpacking %MODEL%...
-  if exist "%YUI_DIR%" rmdir /s /q "%YUI_DIR%"
+  if exist "%YUI_DIR%" (
+    rmdir /s /q "%YUI_DIR%"
+    if exist "%YUI_DIR%" (
+      echo [build_frontend] cannot remove old %MODEL% directory: %YUI_DIR%
+      echo [build_frontend] Close any process using the model files and try again.
+      endlocal & exit /b 1
+    )
+  )
   tar -xzmf "%YUI_ARCHIVE%" -C "%ROOT_DIR%\static"
   if errorlevel 1 (
     echo [build_frontend] %MODEL% unpack failed

--- a/build_frontend.bat
+++ b/build_frontend.bat
@@ -113,6 +113,11 @@ if not exist "%YUI_ARCHIVE%" (
 
 set "YUI_NEED_EXTRACT=0"
 if not exist "%YUI_COMPLETE_MARKER%" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if not exist "%YUI_DIR%\%MODEL%.moc3" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if not exist "%YUI_DIR%\%MODEL%.model3.json" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if not exist "%YUI_DIR%\%MODEL%.physics3.json" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if not exist "%YUI_DIR%\%MODEL%.vtube.json" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if not exist "%YUI_DIR%\%MODEL%.4096\texture_00.png" set "YUI_NEED_EXTRACT=1"
 if "%YUI_NEED_EXTRACT%"=="0" set "YUI_COMPARE_RESULT_FILE=%TEMP%\neko-live2d-%RANDOM%-%RANDOM%.txt"
 if "%YUI_NEED_EXTRACT%"=="0" call :compare_live2d_timestamps "%YUI_ARCHIVE%" "%YUI_COMPLETE_MARKER%" "%YUI_COMPARE_RESULT_FILE%"
 if "%YUI_NEED_EXTRACT%"=="0" set "YUI_MTIME_STATUS=%ERRORLEVEL%"

--- a/build_frontend.bat
+++ b/build_frontend.bat
@@ -100,7 +100,11 @@ setlocal EnableExtensions
 set "MODEL=%~1"
 set "YUI_ARCHIVE=%ROOT_DIR%\assets\%MODEL%.tar.gz"
 set "YUI_DIR=%ROOT_DIR%\static\%MODEL%"
-set "YUI_MARKER=%YUI_DIR%\%MODEL%.moc3"
+set "YUI_COMPLETE_MARKER=%YUI_DIR%\.unpacked"
+set "YUI_TEMP_ROOT=%ROOT_DIR%\static\.%MODEL%.extract-%RANDOM%-%RANDOM%"
+set "YUI_TEMP_DIR=%YUI_TEMP_ROOT%\%MODEL%"
+set "YUI_TEMP_COMPLETE_MARKER=%YUI_TEMP_DIR%\.unpacked"
+set "YUI_BACKUP_DIR=%ROOT_DIR%\static\.%MODEL%.backup-%RANDOM%-%RANDOM%"
 
 if not exist "%YUI_ARCHIVE%" (
   echo [build_frontend] %MODEL% archive missing: %YUI_ARCHIVE%
@@ -108,9 +112,9 @@ if not exist "%YUI_ARCHIVE%" (
 )
 
 set "YUI_NEED_EXTRACT=0"
-if not exist "%YUI_MARKER%" set "YUI_NEED_EXTRACT=1"
+if not exist "%YUI_COMPLETE_MARKER%" set "YUI_NEED_EXTRACT=1"
 if "%YUI_NEED_EXTRACT%"=="0" set "YUI_COMPARE_RESULT_FILE=%TEMP%\neko-live2d-%RANDOM%-%RANDOM%.txt"
-if "%YUI_NEED_EXTRACT%"=="0" call :compare_live2d_timestamps "%YUI_ARCHIVE%" "%YUI_MARKER%" "%YUI_COMPARE_RESULT_FILE%"
+if "%YUI_NEED_EXTRACT%"=="0" call :compare_live2d_timestamps "%YUI_ARCHIVE%" "%YUI_COMPLETE_MARKER%" "%YUI_COMPARE_RESULT_FILE%"
 if "%YUI_NEED_EXTRACT%"=="0" set "YUI_MTIME_STATUS=%ERRORLEVEL%"
 if "%YUI_NEED_EXTRACT%"=="0" set /p "YUI_MTIME_RESULT="<"%YUI_COMPARE_RESULT_FILE%"
 if "%YUI_NEED_EXTRACT%"=="0" if exist "%YUI_COMPARE_RESULT_FILE%" del /q "%YUI_COMPARE_RESULT_FILE%" >nul 2>&1
@@ -126,23 +130,75 @@ if "%YUI_NEED_EXTRACT%"=="0" if /i not "%YUI_MTIME_RESULT%"=="older" (
 
 if "%YUI_NEED_EXTRACT%"=="1" (
   echo [build_frontend] unpacking %MODEL%...
+  if exist "%YUI_TEMP_ROOT%" rmdir /s /q "%YUI_TEMP_ROOT%"
+  if exist "%YUI_TEMP_ROOT%" (
+    echo [build_frontend] cannot clear temporary %MODEL% directory: %YUI_TEMP_ROOT%
+    endlocal & exit /b 1
+  )
+  if exist "%YUI_BACKUP_DIR%" (
+    echo [build_frontend] backup path already exists for %MODEL%: %YUI_BACKUP_DIR%
+    endlocal & exit /b 1
+  )
+  mkdir "%YUI_TEMP_ROOT%"
+  if errorlevel 1 (
+    echo [build_frontend] cannot create temporary %MODEL% directory: %YUI_TEMP_ROOT%
+    endlocal & exit /b 1
+  )
+  tar -xzmf "%YUI_ARCHIVE%" -C "%YUI_TEMP_ROOT%"
+  if errorlevel 1 (
+    echo [build_frontend] %MODEL% unpack failed
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
+  if not exist "%YUI_TEMP_DIR%\%MODEL%.moc3" (
+    echo [build_frontend] %MODEL% moc3 missing after unpack
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
+  if not exist "%YUI_TEMP_DIR%\%MODEL%.model3.json" (
+    echo [build_frontend] %MODEL% model3 config missing after unpack
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
+  if not exist "%YUI_TEMP_DIR%\%MODEL%.physics3.json" (
+    echo [build_frontend] %MODEL% physics config missing after unpack
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
+  if not exist "%YUI_TEMP_DIR%\%MODEL%.vtube.json" (
+    echo [build_frontend] %MODEL% vtube config missing after unpack
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
+  if not exist "%YUI_TEMP_DIR%\%MODEL%.4096\texture_00.png" (
+    echo [build_frontend] %MODEL% texture missing after unpack
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
+  type nul > "%YUI_TEMP_COMPLETE_MARKER%"
+  if not exist "%YUI_TEMP_COMPLETE_MARKER%" (
+    echo [build_frontend] cannot create completion marker for %MODEL%
+    rmdir /s /q "%YUI_TEMP_ROOT%"
+    endlocal & exit /b 1
+  )
   if exist "%YUI_DIR%" (
-    rmdir /s /q "%YUI_DIR%"
-    if exist "%YUI_DIR%" (
-      echo [build_frontend] cannot remove old %MODEL% directory: %YUI_DIR%
+    move /y "%YUI_DIR%" "%YUI_BACKUP_DIR%" >nul
+    if errorlevel 1 (
+      echo [build_frontend] cannot preserve old %MODEL% directory: %YUI_DIR%
       echo [build_frontend] Close any process using the model files and try again.
+      rmdir /s /q "%YUI_TEMP_ROOT%"
       endlocal & exit /b 1
     )
   )
-  tar -xzmf "%YUI_ARCHIVE%" -C "%ROOT_DIR%\static"
+  move /y "%YUI_TEMP_DIR%" "%YUI_DIR%" >nul
   if errorlevel 1 (
-    echo [build_frontend] %MODEL% unpack failed
+    echo [build_frontend] cannot replace old %MODEL% directory: %YUI_DIR%
+    if exist "%YUI_BACKUP_DIR%" move /y "%YUI_BACKUP_DIR%" "%YUI_DIR%" >nul
+    rmdir /s /q "%YUI_TEMP_ROOT%"
     endlocal & exit /b 1
   )
-  if not exist "%YUI_MARKER%" (
-    echo [build_frontend] %MODEL% marker missing after unpack: %YUI_MARKER%
-    endlocal & exit /b 1
-  )
+  rmdir /s /q "%YUI_TEMP_ROOT%"
+  if exist "%YUI_BACKUP_DIR%" rmdir /s /q "%YUI_BACKUP_DIR%"
   echo [build_frontend] %MODEL% done: %YUI_DIR%
 ) else (
   echo [build_frontend] %MODEL% up to date, skip

--- a/build_frontend.bat
+++ b/build_frontend.bat
@@ -109,12 +109,19 @@ if not exist "%YUI_ARCHIVE%" (
 
 set "YUI_NEED_EXTRACT=0"
 if not exist "%YUI_MARKER%" set "YUI_NEED_EXTRACT=1"
-if "%YUI_NEED_EXTRACT%"=="0" call :compare_live2d_timestamps "%YUI_ARCHIVE%" "%YUI_MARKER%"
+if "%YUI_NEED_EXTRACT%"=="0" set "YUI_COMPARE_RESULT_FILE=%TEMP%\neko-live2d-%RANDOM%-%RANDOM%.txt"
+if "%YUI_NEED_EXTRACT%"=="0" call :compare_live2d_timestamps "%YUI_ARCHIVE%" "%YUI_MARKER%" "%YUI_COMPARE_RESULT_FILE%"
 if "%YUI_NEED_EXTRACT%"=="0" set "YUI_MTIME_STATUS=%ERRORLEVEL%"
-if "%YUI_NEED_EXTRACT%"=="0" if "%YUI_MTIME_STATUS%"=="0" set "YUI_NEED_EXTRACT=1"
-if "%YUI_NEED_EXTRACT%"=="0" if not "%YUI_MTIME_STATUS%"=="0" if not "%YUI_MTIME_STATUS%"=="1" (
+if "%YUI_NEED_EXTRACT%"=="0" set /p "YUI_MTIME_RESULT="<"%YUI_COMPARE_RESULT_FILE%"
+if "%YUI_NEED_EXTRACT%"=="0" if exist "%YUI_COMPARE_RESULT_FILE%" del /q "%YUI_COMPARE_RESULT_FILE%" >nul 2>&1
+if "%YUI_NEED_EXTRACT%"=="0" if not "%YUI_MTIME_STATUS%"=="0" (
   echo [build_frontend] failed to compare timestamps for %MODEL% ^(exit %YUI_MTIME_STATUS%^)
   endlocal & exit /b %YUI_MTIME_STATUS%
+)
+if "%YUI_NEED_EXTRACT%"=="0" if /i "%YUI_MTIME_RESULT%"=="newer" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if /i not "%YUI_MTIME_RESULT%"=="older" (
+  echo [build_frontend] invalid timestamp comparison result for %MODEL%: %YUI_MTIME_RESULT%
+  endlocal & exit /b 1
 )
 
 if "%YUI_NEED_EXTRACT%"=="1" (
@@ -143,5 +150,5 @@ if "%YUI_NEED_EXTRACT%"=="1" (
 endlocal & exit /b 0
 
 :compare_live2d_timestamps
-uv run --no-sync python -c "import os, sys; sys.exit(0 if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 1)" "%~1" "%~2"
+uv run --no-sync python -c "import os, sys; print('newer' if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 'older')" "%~1" "%~2" > "%~3"
 exit /b %ERRORLEVEL%

--- a/build_frontend.bat
+++ b/build_frontend.bat
@@ -96,7 +96,7 @@ exit /b 0
 rem --- helper: unpack one built-in Live2D model ---
 rem Each model archive in assets is unpacked into its matching static directory.
 :unpack_live2d
-setlocal
+setlocal EnableExtensions EnableDelayedExpansion
 set "MODEL=%~1"
 set "YUI_ARCHIVE=%ROOT_DIR%\assets\%MODEL%.tar.gz"
 set "YUI_DIR=%ROOT_DIR%\static\%MODEL%"
@@ -109,10 +109,17 @@ if not exist "%YUI_ARCHIVE%" (
 
 set "YUI_NEED_EXTRACT=0"
 if not exist "%YUI_MARKER%" set "YUI_NEED_EXTRACT=1"
-if "%YUI_NEED_EXTRACT%"=="0" uv run --no-sync python -c "import os, sys; sys.exit(0 if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 1)" "%YUI_ARCHIVE%" "%YUI_MARKER%"
-if "%YUI_NEED_EXTRACT%"=="0" if not errorlevel 1 set "YUI_NEED_EXTRACT=1"
+if "!YUI_NEED_EXTRACT!"=="0" (
+  uv run --no-sync python -c "import os, sys; sys.exit(0 if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 1)" "%YUI_ARCHIVE%" "%YUI_MARKER%"
+  set "YUI_MTIME_STATUS=!ERRORLEVEL!"
+  if "!YUI_MTIME_STATUS!"=="0" set "YUI_NEED_EXTRACT=1"
+  if not "!YUI_MTIME_STATUS!"=="0" if not "!YUI_MTIME_STATUS!"=="1" (
+    echo [build_frontend] failed to compare timestamps for %MODEL% ^(exit !YUI_MTIME_STATUS!^)
+    endlocal & exit /b !YUI_MTIME_STATUS!
+  )
+)
 
-if "%YUI_NEED_EXTRACT%"=="1" (
+if "!YUI_NEED_EXTRACT!"=="1" (
   echo [build_frontend] unpacking %MODEL%...
   if exist "%YUI_DIR%" (
     rmdir /s /q "%YUI_DIR%"

--- a/build_frontend.bat
+++ b/build_frontend.bat
@@ -96,7 +96,7 @@ exit /b 0
 rem --- helper: unpack one built-in Live2D model ---
 rem Each model archive in assets is unpacked into its matching static directory.
 :unpack_live2d
-setlocal EnableExtensions EnableDelayedExpansion
+setlocal EnableExtensions
 set "MODEL=%~1"
 set "YUI_ARCHIVE=%ROOT_DIR%\assets\%MODEL%.tar.gz"
 set "YUI_DIR=%ROOT_DIR%\static\%MODEL%"
@@ -109,17 +109,15 @@ if not exist "%YUI_ARCHIVE%" (
 
 set "YUI_NEED_EXTRACT=0"
 if not exist "%YUI_MARKER%" set "YUI_NEED_EXTRACT=1"
-if "!YUI_NEED_EXTRACT!"=="0" (
-  uv run --no-sync python -c "import os, sys; sys.exit(0 if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 1)" "%YUI_ARCHIVE%" "%YUI_MARKER%"
-  set "YUI_MTIME_STATUS=!ERRORLEVEL!"
-  if "!YUI_MTIME_STATUS!"=="0" set "YUI_NEED_EXTRACT=1"
-  if not "!YUI_MTIME_STATUS!"=="0" if not "!YUI_MTIME_STATUS!"=="1" (
-    echo [build_frontend] failed to compare timestamps for %MODEL% ^(exit !YUI_MTIME_STATUS!^)
-    endlocal & exit /b !YUI_MTIME_STATUS!
-  )
+if "%YUI_NEED_EXTRACT%"=="0" call :compare_live2d_timestamps "%YUI_ARCHIVE%" "%YUI_MARKER%"
+if "%YUI_NEED_EXTRACT%"=="0" set "YUI_MTIME_STATUS=%ERRORLEVEL%"
+if "%YUI_NEED_EXTRACT%"=="0" if "%YUI_MTIME_STATUS%"=="0" set "YUI_NEED_EXTRACT=1"
+if "%YUI_NEED_EXTRACT%"=="0" if not "%YUI_MTIME_STATUS%"=="0" if not "%YUI_MTIME_STATUS%"=="1" (
+  echo [build_frontend] failed to compare timestamps for %MODEL% ^(exit %YUI_MTIME_STATUS%^)
+  endlocal & exit /b %YUI_MTIME_STATUS%
 )
 
-if "!YUI_NEED_EXTRACT!"=="1" (
+if "%YUI_NEED_EXTRACT%"=="1" (
   echo [build_frontend] unpacking %MODEL%...
   if exist "%YUI_DIR%" (
     rmdir /s /q "%YUI_DIR%"
@@ -143,3 +141,7 @@ if "!YUI_NEED_EXTRACT!"=="1" (
   echo [build_frontend] %MODEL% up to date, skip
 )
 endlocal & exit /b 0
+
+:compare_live2d_timestamps
+uv run --no-sync python -c "import os, sys; sys.exit(0 if os.path.getmtime(sys.argv[1]) > os.path.getmtime(sys.argv[2]) else 1)" "%~1" "%~2"
+exit /b %ERRORLEVEL%

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -133,6 +133,7 @@ function normalizeSurface(raw: any, fallbackKind: PluginUiSurface['kind'] = 'pan
     context: typeof raw.context === 'string' ? raw.context : undefined,
     permissions: Array.isArray(raw.permissions) ? raw.permissions.filter((item: unknown) => typeof item === 'string') : undefined,
     available: typeof raw.available === 'boolean' ? raw.available : undefined,
+    legacy_static_compat: raw.legacy_static_compat === true,
   }
 }
 
@@ -201,6 +202,7 @@ export async function getPluginUiSurfaceInfo(pluginId: string, locale?: string):
         ui_path: info.ui_path || `/plugin/${safeId}/ui/`,
         open_in: 'iframe',
         available: true,
+        legacy_static_compat: true,
       }],
       warnings: [],
     }

--- a/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
@@ -64,6 +64,9 @@ const uiCacheBust = ref(Date.now())
 const loading = ref(true)
 const error = ref<string | null>(null)
 const hasUI = ref(false)
+const iframeReady = ref(false)
+const pendingSurfaceMessages: unknown[] = []
+const maxPendingSurfaceMessages = 100
 let currentRequestId = 0
 const expectedOrigin = window.location.origin
 
@@ -88,6 +91,7 @@ async function checkUIAvailability() {
   
   loading.value = true
   error.value = null
+  iframeReady.value = false
   
   try {
     const info = await get(`/plugin/${encodeURIComponent(props.pluginId)}/ui-info`)
@@ -108,12 +112,15 @@ async function checkUIAvailability() {
 function onIframeLoad() {
   loading.value = false
   error.value = null
+  iframeReady.value = true
+  flushSurfaceMessages()
   emit('load')
 }
 
 function onIframeError() {
   loading.value = false
   error.value = t('plugins.ui.loadError')
+  iframeReady.value = false
   emit('error', error.value)
 }
 
@@ -122,6 +129,7 @@ async function reload() {
     // UI availability already confirmed (iframe load failed); skip network call
     error.value = null
     loading.value = true
+    iframeReady.value = false
     uiCacheBust.value = Date.now()
     iframeKey.value++
   } else {
@@ -168,9 +176,27 @@ function sendMessage(payload: any) {
   }, expectedOrigin)
 }
 
+function flushSurfaceMessages() {
+  const target = iframeRef.value?.contentWindow
+  if (!target) return
+  for (const message of pendingSurfaceMessages.splice(0)) {
+    target.postMessage(message, expectedOrigin)
+  }
+}
+
 function sendSurfaceMessage(message: unknown) {
-  if (!iframeRef.value?.contentWindow) return
-  iframeRef.value.contentWindow.postMessage(message, expectedOrigin)
+  const target = iframeRef.value?.contentWindow
+  if (target && iframeReady.value) {
+    target.postMessage(message, expectedOrigin)
+    return
+  }
+  // A hidden compatibility iframe may still be checking /ui-info while the
+  // hosted panel emits its initial state. Keep the newest bounded set until
+  // the iframe load event makes a target available.
+  if (pendingSurfaceMessages.length >= maxPendingSurfaceMessages) {
+    pendingSurfaceMessages.shift()
+  }
+  pendingSurfaceMessages.push(message)
 }
 
 defineExpose({
@@ -190,6 +216,8 @@ onUnmounted(() => {
 })
 
 watch(() => props.pluginId, () => {
+  pendingSurfaceMessages.length = 0
+  iframeReady.value = false
   uiCacheBust.value = Date.now()
   checkUIAvailability()
 })

--- a/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
@@ -30,6 +30,7 @@
       ref="iframeRef"
       :src="uiUrl"
       :title="pluginId"
+      :data-load-generation="iframeGeneration"
       class="plugin-iframe"
       sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
       @load="onIframeLoad"
@@ -65,6 +66,7 @@ const loading = ref(true)
 const error = ref<string | null>(null)
 const hasUI = ref(false)
 const iframeReady = ref(false)
+const iframeGeneration = ref(0)
 const pendingSurfaceMessages: unknown[] = []
 const maxPendingSurfaceMessages = 100
 let currentRequestId = 0
@@ -80,6 +82,7 @@ const uiUrl = computed(() => {
 })
 
 async function checkUIAvailability() {
+  startIframeLoadGeneration()
   if (!props.pluginId) {
     currentRequestId += 1
     hasUI.value = false
@@ -91,8 +94,6 @@ async function checkUIAvailability() {
   
   loading.value = true
   error.value = null
-  iframeReady.value = false
-  
   try {
     const info = await get(`/plugin/${encodeURIComponent(props.pluginId)}/ui-info`)
     if (requestId !== currentRequestId) return
@@ -109,7 +110,20 @@ async function checkUIAvailability() {
   }
 }
 
-function onIframeLoad() {
+function startIframeLoadGeneration() {
+  iframeGeneration.value++
+  iframeReady.value = false
+  iframeKey.value++
+}
+
+function isCurrentIframeEvent(event: Event) {
+  const target = event.currentTarget
+  return target instanceof HTMLIFrameElement
+    && target.dataset.loadGeneration === String(iframeGeneration.value)
+}
+
+function onIframeLoad(event: Event) {
+  if (!isCurrentIframeEvent(event)) return
   loading.value = false
   error.value = null
   iframeReady.value = true
@@ -117,7 +131,8 @@ function onIframeLoad() {
   emit('load')
 }
 
-function onIframeError() {
+function onIframeError(event: Event) {
+  if (!isCurrentIframeEvent(event)) return
   loading.value = false
   error.value = t('plugins.ui.loadError')
   iframeReady.value = false
@@ -129,15 +144,11 @@ async function reload() {
     // UI availability already confirmed (iframe load failed); skip network call
     error.value = null
     loading.value = true
-    iframeReady.value = false
+    startIframeLoadGeneration()
     uiCacheBust.value = Date.now()
-    iframeKey.value++
   } else {
+    uiCacheBust.value = Date.now()
     await checkUIAvailability()
-    if (hasUI.value && !error.value) {
-      uiCacheBust.value = Date.now()
-      iframeKey.value++
-    }
   }
 }
 
@@ -178,7 +189,7 @@ function sendMessage(payload: any) {
 
 function flushSurfaceMessages() {
   const target = iframeRef.value?.contentWindow
-  if (!target) return
+  if (!target || !iframeReady.value) return
   for (const message of pendingSurfaceMessages.splice(0)) {
     target.postMessage(message, expectedOrigin)
   }

--- a/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
@@ -168,7 +168,7 @@ function sendMessage(payload: any) {
   }, expectedOrigin)
 }
 
-function sendStudySurfaceMessage(message: { type: string; payload?: unknown }) {
+function sendSurfaceMessage(message: unknown) {
   if (!iframeRef.value?.contentWindow) return
   iframeRef.value.contentWindow.postMessage(message, expectedOrigin)
 }
@@ -176,7 +176,7 @@ function sendStudySurfaceMessage(message: { type: string; payload?: unknown }) {
 defineExpose({
   reload,
   sendMessage,
-  sendStudySurfaceMessage,
+  sendSurfaceMessage,
   hasUI
 })
 

--- a/frontend/plugin-manager/src/types/api.ts
+++ b/frontend/plugin-manager/src/types/api.ts
@@ -77,6 +77,8 @@ export interface PluginUiSurface {
   context?: string
   permissions?: string[]
   available?: boolean
+  /** Host-generated static/index.html surface retained for legacy UI compatibility. */
+  legacy_static_compat?: boolean
 }
 
 export interface PluginUiWarning {

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -206,12 +206,16 @@ const guideSurfaces = computed(() => surfaces.value.filter((surface) => surface.
 const availablePanelSurfaces = computed(() => panelSurfaces.value.filter((surface) => surface.available !== false))
 const availableDeclaredPanelSurfaces = computed(() => availablePanelSurfaces.value.filter((surface) => !surface.legacy_static_compat))
 const availableHostedPanelSurfaces = computed(() => availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode === 'hosted-tsx'))
-// Prefer usable hosted TSX panels.  A declared non-hosted panel is still a
-// valid modern surface; only fall back to a host-generated compatibility panel
-// when the plugin did not declare any usable panel of its own.
+// Prefer usable hosted TSX panels without hiding other declared panels. Only
+// fall back to a host-generated compatibility panel when the plugin did not
+// declare any usable panel of its own.
 const displayedPanelSurfaces = computed(() => {
-  if (availableHostedPanelSurfaces.value.length > 0) return availableHostedPanelSurfaces.value
-  if (availableDeclaredPanelSurfaces.value.length > 0) return availableDeclaredPanelSurfaces.value
+  if (availableDeclaredPanelSurfaces.value.length > 0) {
+    return [
+      ...availableHostedPanelSurfaces.value,
+      ...availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode !== 'hosted-tsx'),
+    ]
+  }
   return availablePanelSurfaces.value
 })
 const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -20,7 +20,7 @@
       </template>
 
       <el-tabs v-model="activeTab" data-yui-guide-id="plugin-detail-tabs">
-        <el-tab-pane v-if="panelSurfaces.length > 0" :label="$t('plugins.ui.panel')" name="panel">
+        <el-tab-pane v-if="displayedPanelSurfaces.length > 0" :label="$t('plugins.ui.panel')" name="panel">
           <div class="surface-section" data-yui-guide-id="plugin-detail-panel">
             <el-alert
               v-if="surfaceWarnings.length > 0"
@@ -37,9 +37,9 @@
                 </li>
               </ul>
             </el-alert>
-            <el-tabs v-if="panelSurfaces.length > 1" v-model="activePanelSurfaceId" type="border-card">
+            <el-tabs v-if="displayedPanelSurfaces.length > 1" v-model="activePanelSurfaceId" type="border-card">
               <el-tab-pane
-                v-for="surface in panelSurfaces"
+                v-for="surface in displayedPanelSurfaces"
                 :key="surface.id"
                 :label="surface.title || surface.id"
                 :name="surface.id"
@@ -47,7 +47,7 @@
                 <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
             </el-tabs>
-            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="panelSurfaces[0]!" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="displayedPanelSurfaces[0]!" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
           </div>
         </el-tab-pane>
 
@@ -180,11 +180,6 @@ const activeGuideSurfaceId = ref('')
 const staticUiFrameRef = ref<InstanceType<typeof PluginUIFrame> | null>(null)
 const hostedSurfaceFrameHeight = 'clamp(560px, calc(100vh - 220px), 1200px)'
 const allowedTabs = new Set(['panel', 'guide', 'ui', 'info', 'entries', 'metrics', 'config', 'logs'])
-const studySurfaceRelayMessageTypes = new Set([
-  'neko-study-review-completed',
-  'neko-study-refresh-summary',
-  'neko-study-memory-deck-updated',
-])
 let currentSurfaceLoadId = 0
 // fetchStaticUI 也需要和 fetchSurfaces 一样的 stale-response guard：用户快速
 // 切换 plugin detail 页时，旧 plugin 的 /ui-info 响应可能在新 plugin 加载后
@@ -208,13 +203,23 @@ const pluginDisplayText = computed(() => {
 
 const panelSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'panel'))
 const guideSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'guide' || surface.kind === 'docs'))
-const hasAvailablePanelSurface = computed(() => panelSurfaces.value.some((surface) => surface.available !== false))
-// The study plugin's legacy page remains a message relay for its hosted
-// sub-panels. Keep it mounted but hidden while the modern panel is visible.
-const needsLegacyStaticUiRelay = computed(() => pluginId.value === 'study_companion' && hasStaticUI.value && hasAvailablePanelSurface.value)
-// A usable declared panel is the current UI surface API. Unavailable panels
-// must not hide a working legacy static UI fallback.
-const showLegacyStaticUi = computed(() => hasStaticUI.value && !hasAvailablePanelSurface.value)
+const availablePanelSurfaces = computed(() => panelSurfaces.value.filter((surface) => surface.available !== false))
+const availableDeclaredPanelSurfaces = computed(() => availablePanelSurfaces.value.filter((surface) => !surface.legacy_static_compat))
+const availableHostedPanelSurfaces = computed(() => availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode === 'hosted-tsx'))
+// Prefer usable hosted TSX panels.  A declared non-hosted panel is still a
+// valid modern surface; only fall back to a host-generated compatibility panel
+// when the plugin did not declare any usable panel of its own.
+const displayedPanelSurfaces = computed(() => {
+  if (availableHostedPanelSurfaces.value.length > 0) return availableHostedPanelSurfaces.value
+  if (availableDeclaredPanelSurfaces.value.length > 0) return availableDeclaredPanelSurfaces.value
+  return availablePanelSurfaces.value
+})
+const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))
+const hasDisplayablePanelSurface = computed(() => displayedPanelSurfaces.value.length > 0)
+// Preserve the legacy iframe only as a hidden message receiver when it is an
+// automatically injected compatibility surface alongside a newer declared UI.
+const needsLegacyStaticUiRelay = computed(() => hasStaticUI.value && hasStaticCompatPanel.value && availableDeclaredPanelSurfaces.value.length > 0)
+const showLegacyStaticUi = computed(() => hasStaticUI.value && !hasDisplayablePanelSurface.value)
 
 const isAdapter = computed(() => plugin.value?.type === 'adapter')
 
@@ -250,9 +255,9 @@ function resolveActiveTab(value: unknown): string {
 
 function resolveDefaultTab(value: unknown): string {
   const requested = resolveActiveTab(value)
-  if (requested === 'panel' && panelSurfaces.value.length === 0) return 'info'
+  if (requested === 'panel' && !hasDisplayablePanelSurface.value) return 'info'
   if (requested === 'guide' && guideSurfaces.value.length === 0) return 'info'
-  if (requested === 'ui' && hasAvailablePanelSurface.value) return 'panel'
+  if (requested === 'ui' && hasDisplayablePanelSurface.value) return 'panel'
   if (requested === 'ui' && !showLegacyStaticUi.value) return 'info'
   return requested
 }
@@ -275,7 +280,7 @@ function syncSurfaceTabs() {
   const requestedTab = resolveActiveTab(route.query.tab)
   if (requestedSurfaceId) {
     const panel = requestedTab !== 'guide'
-      ? panelSurfaces.value.find((surface) => surface.id === requestedSurfaceId)
+      ? displayedPanelSurfaces.value.find((surface) => surface.id === requestedSurfaceId)
       : undefined
     if (panel) {
       activePanelSurfaceId.value = panel.id
@@ -287,8 +292,8 @@ function syncSurfaceTabs() {
       activeGuideSurfaceId.value = guide.id
     }
   }
-  if (!activePanelSurfaceId.value && panelSurfaces.value[0]) {
-    activePanelSurfaceId.value = panelSurfaces.value[0].id
+  if (!activePanelSurfaceId.value && displayedPanelSurfaces.value[0]) {
+    activePanelSurfaceId.value = displayedPanelSurfaces.value[0].id
   }
   if (!activeGuideSurfaceId.value && guideSurfaces.value[0]) {
     activeGuideSurfaceId.value = guideSurfaces.value[0].id
@@ -311,7 +316,7 @@ function openHostedSurfaceFromStaticUi(payload: { pluginId?: string; surfaceId: 
   const preferPanel = payload.kind === 'panel'
   const preferGuide = payload.kind === 'guide' || payload.kind === 'docs'
   const panel = (preferPanel || !preferGuide)
-    ? panelSurfaces.value.find((surface) => surface.id === payload.surfaceId)
+    ? displayedPanelSurfaces.value.find((surface) => surface.id === payload.surfaceId)
     : undefined
   if (panel) {
     activePanelSurfaceId.value = panel.id
@@ -335,15 +340,7 @@ function openHostedSurfaceFromStaticUi(payload: { pluginId?: string; surfaceId: 
   })
 }
 
-function isStudySurfaceRelayMessage(data: unknown): data is { type: string; payload?: unknown } {
-  return !!data
-    && typeof data === 'object'
-    && 'type' in data
-    && typeof (data as { type?: unknown }).type === 'string'
-    && studySurfaceRelayMessageTypes.has((data as { type: string }).type)
-}
-
-function isStudyOpenSurfaceMessage(data: unknown): data is {
+function isLegacyOpenSurfaceMessage(data: unknown): data is {
   type: 'neko-study-open-surface'
   payload: { pluginId?: string; surfaceId: string; kind?: string }
 } {
@@ -357,12 +354,14 @@ function isStudyOpenSurfaceMessage(data: unknown): data is {
 }
 
 function relayHostedSurfaceMessageToStaticUi(data: unknown) {
-  if (isStudyOpenSurfaceMessage(data)) {
+  if (isLegacyOpenSurfaceMessage(data)) {
     openHostedSurfaceFromStaticUi(data.payload)
     return
   }
-  if (!isStudySurfaceRelayMessage(data)) return
-  staticUiFrameRef.value?.sendStudySurfaceMessage(data)
+  // Hosted surface messages have already been source/origin checked by the
+  // frame. Forward them unchanged so legacy static UIs from any plugin can
+  // opt into their own message contract without host-side plugin allowlists.
+  staticUiFrameRef.value?.sendSurfaceMessage(data)
 }
 
 async function fetchSurfaces(): Promise<boolean> {
@@ -373,13 +372,11 @@ async function fetchSurfaces(): Promise<boolean> {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
     surfaces.value = info.surfaces
     surfaceWarnings.value = info.warnings
-    if (hasAvailablePanelSurface.value) {
+    if (hasDisplayablePanelSurface.value) {
       // Prefer the declared panel and invalidate a possible in-flight legacy
       // static-UI probe from the previous plugin/page state.
       currentStaticUiLoadId += 1
       hasStaticUI.value = false
-      const requestedTab = route.query.tab === 'ui' || activeTab.value === 'ui' ? 'ui' : route.query.tab
-      syncActiveTab(requestedTab)
     }
   } catch (caught: any) {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
@@ -396,37 +393,39 @@ async function fetchSurfaces(): Promise<boolean> {
   return true
 }
 
-async function fetchStaticUI() {
+async function fetchStaticUI(): Promise<boolean> {
   // The legacy /ui-info route serves static/index.html.  A modern panel may
   // intentionally point at that same file, so probing it would only create a
   // duplicate "界面" tab.
-  if (hasAvailablePanelSurface.value && pluginId.value !== 'study_companion') {
+  if (hasDisplayablePanelSurface.value && !hasStaticCompatPanel.value) {
     hasStaticUI.value = false
-    return
+    return true
   }
   const loadId = ++currentStaticUiLoadId
   const currentPluginId = pluginId.value
   try {
     const info = await get<{ has_ui: boolean }>(`/plugin/${encodeURIComponent(currentPluginId)}/ui-info`)
-    if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return
+    if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return false
     hasStaticUI.value = info?.has_ui ?? false
+    return true
   } catch {
-    if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return
+    if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return false
     hasStaticUI.value = false
+    return true
   }
 }
 
-async function refreshPluginUi() {
+async function refreshPluginUi(): Promise<boolean> {
   const surfacesApplied = await fetchSurfaces()
-  if (surfacesApplied) await fetchStaticUI()
+  if (!surfacesApplied) return false
+  return fetchStaticUI()
 }
 
 onMounted(async () => {
   try {
     await pluginStore.fetchPlugins()
     await pluginStore.fetchPluginStatus(pluginId.value)
-    await refreshPluginUi()
-    syncActiveTab(route.query.tab)
+    if (await refreshPluginUi()) syncActiveTab(route.query.tab)
     pluginStore.setSelectedPlugin(pluginId.value)
   } finally {
     loading.value = false
@@ -445,8 +444,7 @@ watch(pluginId, async () => {
   loading.value = true
   try {
     await pluginStore.fetchPluginStatus(pluginId.value)
-    await refreshPluginUi()
-    syncActiveTab(route.query.tab)
+    if (await refreshPluginUi()) syncActiveTab(route.query.tab)
     pluginStore.setSelectedPlugin(pluginId.value)
   } finally {
     loading.value = false
@@ -455,7 +453,9 @@ watch(pluginId, async () => {
 
 watch(locale, () => {
   if (!plugin.value) return
-  void refreshPluginUi()
+  void refreshPluginUi().then((refreshed) => {
+    if (refreshed) syncActiveTab(route.query.tab)
+  })
 })
 </script>
 

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -204,7 +204,10 @@ const pluginDisplayText = computed(() => {
 const panelSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'panel'))
 const guideSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'guide' || surface.kind === 'docs'))
 const availablePanelSurfaces = computed(() => panelSurfaces.value.filter((surface) => surface.available !== false))
-const availableDeclaredPanelSurfaces = computed(() => availablePanelSurfaces.value.filter((surface) => !surface.legacy_static_compat))
+// `auto` is accepted by the manifest but does not have a renderer yet. Do not
+// let its placeholder hide a working legacy static UI.
+const renderablePanelSurfaces = computed(() => availablePanelSurfaces.value.filter((surface) => surface.mode !== 'auto'))
+const availableDeclaredPanelSurfaces = computed(() => renderablePanelSurfaces.value.filter((surface) => !surface.legacy_static_compat))
 const availableHostedPanelSurfaces = computed(() => availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode === 'hosted-tsx'))
 // Prefer usable hosted TSX panels without hiding other declared panels. Only
 // fall back to a host-generated compatibility panel when the plugin did not
@@ -216,7 +219,7 @@ const displayedPanelSurfaces = computed(() => {
       ...availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode !== 'hosted-tsx'),
     ]
   }
-  return availablePanelSurfaces.value
+  return renderablePanelSurfaces.value
 })
 const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))
 const hasDisplayablePanelSurface = computed(() => displayedPanelSurfaces.value.length > 0)

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -136,6 +136,9 @@
         </el-tab-pane>
 
       </el-tabs>
+      <div v-if="needsLegacyStaticUiRelay" class="static-ui-relay" aria-hidden="true">
+        <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
+      </div>
     </el-card>
 
     <EmptyState v-else-if="!loading" :description="$t('plugins.pluginNotFound')" />
@@ -205,10 +208,13 @@ const pluginDisplayText = computed(() => {
 
 const panelSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'panel'))
 const guideSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'guide' || surface.kind === 'docs'))
-// A declared panel is the current UI surface API.  Static UI is retained only
-// for legacy plugins that have not declared a panel yet; otherwise the same
-// static/index.html can be rendered twice under two different tabs.
-const showLegacyStaticUi = computed(() => hasStaticUI.value && panelSurfaces.value.length === 0)
+const hasAvailablePanelSurface = computed(() => panelSurfaces.value.some((surface) => surface.available !== false))
+// The study plugin's legacy page remains a message relay for its hosted
+// sub-panels. Keep it mounted but hidden while the modern panel is visible.
+const needsLegacyStaticUiRelay = computed(() => pluginId.value === 'study_companion' && hasStaticUI.value && hasAvailablePanelSurface.value)
+// A usable declared panel is the current UI surface API. Unavailable panels
+// must not hide a working legacy static UI fallback.
+const showLegacyStaticUi = computed(() => hasStaticUI.value && !hasAvailablePanelSurface.value)
 
 const isAdapter = computed(() => plugin.value?.type === 'adapter')
 
@@ -246,8 +252,22 @@ function resolveDefaultTab(value: unknown): string {
   const requested = resolveActiveTab(value)
   if (requested === 'panel' && panelSurfaces.value.length === 0) return 'info'
   if (requested === 'guide' && guideSurfaces.value.length === 0) return 'info'
+  if (requested === 'ui' && hasAvailablePanelSurface.value) return 'panel'
   if (requested === 'ui' && !showLegacyStaticUi.value) return 'info'
   return requested
+}
+
+function syncActiveTab(requestedTab: unknown) {
+  const nextTab = resolveDefaultTab(requestedTab)
+  activeTab.value = nextTab
+  if (requestedTab === 'ui' && nextTab !== 'ui') {
+    void router.replace({
+      query: {
+        ...route.query,
+        tab: nextTab,
+      },
+    })
+  }
 }
 
 function syncSurfaceTabs() {
@@ -345,22 +365,24 @@ function relayHostedSurfaceMessageToStaticUi(data: unknown) {
   staticUiFrameRef.value?.sendStudySurfaceMessage(data)
 }
 
-async function fetchSurfaces() {
+async function fetchSurfaces(): Promise<boolean> {
   const loadId = ++currentSurfaceLoadId
   const currentPluginId = pluginId.value
   try {
     const info = await getPluginUiSurfaceInfo(currentPluginId, locale.value)
-    if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return
+    if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
     surfaces.value = info.surfaces
     surfaceWarnings.value = info.warnings
-    if (panelSurfaces.value.length > 0) {
+    if (hasAvailablePanelSurface.value) {
       // Prefer the declared panel and invalidate a possible in-flight legacy
       // static-UI probe from the previous plugin/page state.
       currentStaticUiLoadId += 1
       hasStaticUI.value = false
+      const requestedTab = route.query.tab === 'ui' || activeTab.value === 'ui' ? 'ui' : route.query.tab
+      syncActiveTab(requestedTab)
     }
   } catch (caught: any) {
-    if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return
+    if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
     surfaces.value = []
     surfaceWarnings.value = [{
       path: 'plugin.ui',
@@ -371,13 +393,14 @@ async function fetchSurfaces() {
   activePanelSurfaceId.value = ''
   activeGuideSurfaceId.value = ''
   syncSurfaceTabs()
+  return true
 }
 
 async function fetchStaticUI() {
   // The legacy /ui-info route serves static/index.html.  A modern panel may
   // intentionally point at that same file, so probing it would only create a
   // duplicate "界面" tab.
-  if (panelSurfaces.value.length > 0) {
+  if (hasAvailablePanelSurface.value && pluginId.value !== 'study_companion') {
     hasStaticUI.value = false
     return
   }
@@ -393,13 +416,17 @@ async function fetchStaticUI() {
   }
 }
 
+async function refreshPluginUi() {
+  const surfacesApplied = await fetchSurfaces()
+  if (surfacesApplied) await fetchStaticUI()
+}
+
 onMounted(async () => {
   try {
     await pluginStore.fetchPlugins()
     await pluginStore.fetchPluginStatus(pluginId.value)
-    await fetchSurfaces()
-    await fetchStaticUI()
-    activeTab.value = resolveDefaultTab(route.query.tab)
+    await refreshPluginUi()
+    syncActiveTab(route.query.tab)
     pluginStore.setSelectedPlugin(pluginId.value)
   } finally {
     loading.value = false
@@ -410,7 +437,7 @@ watch(
   () => [route.query.tab, route.query.surface],
   ([tab]) => {
     syncSurfaceTabs()
-    activeTab.value = resolveDefaultTab(tab)
+    syncActiveTab(tab)
   },
 )
 
@@ -418,9 +445,8 @@ watch(pluginId, async () => {
   loading.value = true
   try {
     await pluginStore.fetchPluginStatus(pluginId.value)
-    await fetchSurfaces()
-    await fetchStaticUI()
-    activeTab.value = resolveDefaultTab(route.query.tab)
+    await refreshPluginUi()
+    syncActiveTab(route.query.tab)
     pluginStore.setSelectedPlugin(pluginId.value)
   } finally {
     loading.value = false
@@ -429,13 +455,17 @@ watch(pluginId, async () => {
 
 watch(locale, () => {
   if (!plugin.value) return
-  void fetchSurfaces()
+  void refreshPluginUi()
 })
 </script>
 
 <style scoped>
 .plugin-detail {
   padding: 0;
+}
+
+.static-ui-relay {
+  display: none;
 }
 
 .loading-container {

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -186,6 +186,10 @@ let currentSurfaceLoadId = 0
 // 才到达，覆盖 hasStaticUI 导致 UI tab 显示状态错位。
 let currentStaticUiLoadId = 0
 const hasStaticUI = ref(false)
+// Keep a confirmed legacy UI relay mounted while this same plugin's surfaces
+// are refreshed (for example after a locale change), but never reuse it for a
+// different plugin while its /ui-info probe is still in flight.
+const staticUiPluginId = ref('')
 
 const plugin = computed(() => {
   return pluginStore.pluginsWithStatus.find(p => p.id === pluginId.value)
@@ -223,10 +227,11 @@ const displayedPanelSurfaces = computed(() => {
 })
 const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))
 const hasDisplayablePanelSurface = computed(() => displayedPanelSurfaces.value.length > 0)
+const hasCurrentStaticUI = computed(() => hasStaticUI.value && staticUiPluginId.value === pluginId.value)
 // Preserve the legacy iframe only as a hidden message receiver when it is an
 // automatically injected compatibility surface alongside a newer declared UI.
-const needsLegacyStaticUiRelay = computed(() => hasStaticUI.value && hasStaticCompatPanel.value && availableDeclaredPanelSurfaces.value.length > 0)
-const showLegacyStaticUi = computed(() => hasStaticUI.value && !hasDisplayablePanelSurface.value)
+const needsLegacyStaticUiRelay = computed(() => hasCurrentStaticUI.value && hasStaticCompatPanel.value && availableDeclaredPanelSurfaces.value.length > 0)
+const showLegacyStaticUi = computed(() => hasCurrentStaticUI.value && !hasDisplayablePanelSurface.value)
 
 const isAdapter = computed(() => plugin.value?.type === 'adapter')
 
@@ -381,9 +386,9 @@ async function fetchSurfaces(): Promise<boolean> {
     surfaceWarnings.value = info.warnings
     if (hasDisplayablePanelSurface.value) {
       // Prefer the declared panel and invalidate a possible in-flight legacy
-      // static-UI probe from the previous plugin/page state.
+      // static-UI probe from the previous request. Keep an already-confirmed
+      // relay mounted for this plugin until the replacement probe completes.
       currentStaticUiLoadId += 1
-      hasStaticUI.value = false
     }
   } catch (caught: any) {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
@@ -406,6 +411,7 @@ async function fetchStaticUI(): Promise<boolean> {
   // duplicate "界面" tab.
   if (hasDisplayablePanelSurface.value && !hasStaticCompatPanel.value) {
     hasStaticUI.value = false
+    staticUiPluginId.value = pluginId.value
     return true
   }
   const loadId = ++currentStaticUiLoadId
@@ -414,10 +420,12 @@ async function fetchStaticUI(): Promise<boolean> {
     const info = await get<{ has_ui: boolean }>(`/plugin/${encodeURIComponent(currentPluginId)}/ui-info`)
     if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return false
     hasStaticUI.value = info?.has_ui ?? false
+    staticUiPluginId.value = currentPluginId
     return true
   } catch {
     if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return false
     hasStaticUI.value = false
+    staticUiPluginId.value = currentPluginId
     return true
   }
 }

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -82,7 +82,7 @@
           </div>
         </el-tab-pane>
 
-        <el-tab-pane v-if="hasStaticUI" :label="$t('plugins.ui.title')" name="ui">
+        <el-tab-pane v-if="showLegacyStaticUi" :label="$t('plugins.ui.title')" name="ui">
           <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
         </el-tab-pane>
 
@@ -205,6 +205,10 @@ const pluginDisplayText = computed(() => {
 
 const panelSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'panel'))
 const guideSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'guide' || surface.kind === 'docs'))
+// A declared panel is the current UI surface API.  Static UI is retained only
+// for legacy plugins that have not declared a panel yet; otherwise the same
+// static/index.html can be rendered twice under two different tabs.
+const showLegacyStaticUi = computed(() => hasStaticUI.value && panelSurfaces.value.length === 0)
 
 const isAdapter = computed(() => plugin.value?.type === 'adapter')
 
@@ -242,7 +246,7 @@ function resolveDefaultTab(value: unknown): string {
   const requested = resolveActiveTab(value)
   if (requested === 'panel' && panelSurfaces.value.length === 0) return 'info'
   if (requested === 'guide' && guideSurfaces.value.length === 0) return 'info'
-  if (requested === 'ui' && !hasStaticUI.value) return 'info'
+  if (requested === 'ui' && !showLegacyStaticUi.value) return 'info'
   return requested
 }
 
@@ -349,6 +353,12 @@ async function fetchSurfaces() {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return
     surfaces.value = info.surfaces
     surfaceWarnings.value = info.warnings
+    if (panelSurfaces.value.length > 0) {
+      // Prefer the declared panel and invalidate a possible in-flight legacy
+      // static-UI probe from the previous plugin/page state.
+      currentStaticUiLoadId += 1
+      hasStaticUI.value = false
+    }
   } catch (caught: any) {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return
     surfaces.value = []
@@ -364,6 +374,13 @@ async function fetchSurfaces() {
 }
 
 async function fetchStaticUI() {
+  // The legacy /ui-info route serves static/index.html.  A modern panel may
+  // intentionally point at that same file, so probing it would only create a
+  // duplicate "界面" tab.
+  if (panelSurfaces.value.length > 0) {
+    hasStaticUI.value = false
+    return
+  }
   const loadId = ++currentStaticUiLoadId
   const currentPluginId = pluginId.value
   try {

--- a/plugin/_types/models.py
+++ b/plugin/_types/models.py
@@ -105,6 +105,9 @@ class PluginUiSurface(BaseModel):
     context: Optional[str] = None
     permissions: List[str] = Field(default_factory=list)
     available: bool = True
+    # True only for the host-generated static/index.html surface that keeps
+    # legacy static UIs reachable after a plugin declares newer surfaces.
+    legacy_static_compat: bool = False
 
 
 class PluginUiWarning(BaseModel):

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -1177,7 +1177,15 @@ def _add_surface_route_actions(
     plugin_meta: Mapping[str, object],
 ) -> None:
     surfaces, _warnings = _build_surfaces_sync(plugin_id, plugin_meta)
-    has_panel = any(surface.get("kind") == "panel" and surface.get("available") is not False for surface in surfaces)
+    # ``auto`` is accepted as a manifest placeholder, but the frontend has no
+    # renderer for it yet. Do not expose an Open Panel action that would only
+    # route the user back to Basic Info.
+    has_panel = any(
+        surface.get("kind") == "panel"
+        and surface.get("mode") != "auto"
+        and surface.get("available") is not False
+        for surface in surfaces
+    )
     has_guide = any(surface.get("kind") in {"guide", "docs"} and surface.get("available") is not False for surface in surfaces)
     safe_id = plugin_id.replace("/", "%2F")
     if has_panel and "open_panel" not in seen_ids:

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -322,6 +322,7 @@ def _build_static_compat_surface(plugin_id: str, plugin_meta: Mapping[str, objec
         open_in="iframe",
         permissions=["state:read"],
         available=True,
+        legacy_static_compat=True,
     ).model_dump(exclude_none=True)
 
 

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -337,9 +337,19 @@ def _build_surfaces_sync(
     for surface in surfaces:
         surface_warnings = surface.pop("_warnings", None)
         warnings.extend(normalize_warnings(surface_warnings))
-    seen = {(str(surface.get("kind")), str(surface.get("id"))) for surface in surfaces}
     static_surface = _build_static_compat_surface(plugin_id, plugin_meta)
-    if static_surface is not None and ("panel", "main") not in seen:
+    # An unavailable or ``auto`` main panel cannot replace static/index.html:
+    # the former has no usable entry and the latter has no frontend renderer.
+    # Keep the compatibility surface in those cases so legacy UI remains
+    # reachable and generated Open Panel actions have a valid target.
+    has_renderable_main = any(
+        surface.get("kind") == "panel"
+        and surface.get("id") == "main"
+        and surface.get("mode") != "auto"
+        and surface.get("available") is not False
+        for surface in surfaces
+    )
+    if static_surface is not None and not has_renderable_main:
         surfaces.insert(0, static_surface)
     return surfaces, warnings
 

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5252,11 +5252,11 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert "openSurface" in plugin_ui_frame
     assert "payload.pluginId.trim()" in plugin_ui_frame
     assert "payload.kind.trim()" in plugin_ui_frame
-    assert "sendStudySurfaceMessage" in plugin_ui_frame
+    assert "sendSurfaceMessage" in plugin_ui_frame
     assert '@open-surface="openHostedSurfaceFromStaticUi"' in plugin_detail
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
-    assert "studySurfaceRelayMessageTypes" in plugin_detail
-    assert "staticUiFrameRef.value?.sendStudySurfaceMessage(data)" in plugin_detail
+    assert "studySurfaceRelayMessageTypes" not in plugin_detail
+    assert "staticUiFrameRef.value?.sendSurfaceMessage(data)" in plugin_detail
     assert "const preferGuide = payload.kind === 'guide' || payload.kind === 'docs'" in plugin_detail
     assert "activeGuideSurfaceId.value = guide.id" in plugin_detail
     assert "surface: activeSurfaceId" in plugin_detail

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5261,6 +5261,8 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
     assert "studySurfaceRelayMessageTypes" not in plugin_detail
     assert "staticUiFrameRef.value?.sendSurfaceMessage(data)" in plugin_detail
+    assert "const staticUiPluginId = ref('')" in plugin_detail
+    assert "const hasCurrentStaticUI = computed" in plugin_detail
     assert "const preferGuide = payload.kind === 'guide' || payload.kind === 'docs'" in plugin_detail
     assert "activeGuideSurfaceId.value = guide.id" in plugin_detail
     assert "surface: activeSurfaceId" in plugin_detail

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5253,6 +5253,8 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert "payload.pluginId.trim()" in plugin_ui_frame
     assert "payload.kind.trim()" in plugin_ui_frame
     assert "sendSurfaceMessage" in plugin_ui_frame
+    assert "pendingSurfaceMessages" in plugin_ui_frame
+    assert "flushSurfaceMessages()" in plugin_ui_frame
     assert '@open-surface="openHostedSurfaceFromStaticUi"' in plugin_detail
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
     assert "studySurfaceRelayMessageTypes" not in plugin_detail

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5255,6 +5255,8 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert "sendSurfaceMessage" in plugin_ui_frame
     assert "pendingSurfaceMessages" in plugin_ui_frame
     assert "flushSurfaceMessages()" in plugin_ui_frame
+    assert "iframeGeneration" in plugin_ui_frame
+    assert "isCurrentIframeEvent" in plugin_ui_frame
     assert '@open-surface="openHostedSurfaceFromStaticUi"' in plugin_detail
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
     assert "studySurfaceRelayMessageTypes" not in plugin_detail

--- a/plugin/tests/unit/server/test_plugin_ui_manifest.py
+++ b/plugin/tests/unit/server/test_plugin_ui_manifest.py
@@ -234,6 +234,34 @@ def test_auto_only_panel_does_not_get_route_action(tmp_path: Path) -> None:
     assert actions == []
 
 
+def test_static_compat_replaces_auto_main_panel(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "demo"
+    static_dir = plugin_dir / "static"
+    static_dir.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+    config_path = plugin_dir / "plugin.toml"
+    config_path.write_text("[plugin]\nid='demo'\n", encoding="utf-8")
+    plugin_ui = normalize_plugin_ui_manifest(
+        {"plugin": {"ui": {"panel": [{"id": "main", "mode": "auto"}]}}},
+        plugin_id="demo",
+    )
+    meta = {
+        "id": "demo",
+        "config_path": str(config_path),
+        "plugin_ui": plugin_ui,
+    }
+
+    surfaces, warnings = _build_surfaces_sync("demo", meta)
+    actions = _build_plugin_list_actions_from_meta("demo", meta)
+
+    assert warnings == []
+    assert [(surface["mode"], surface["legacy_static_compat"]) for surface in surfaces] == [
+        ("static", True),
+        ("auto", False),
+    ]
+    assert actions == [{"id": "open_panel", "kind": "route", "target": "/plugins/demo?tab=panel"}]
+
+
 def test_surface_action_permission_and_authorized_entry_resolution() -> None:
     assert _surface_allows_action_call({"permissions": ["state:read", "action:call"]})
     assert not _surface_allows_action_call({"permissions": ["state:read"]})

--- a/plugin/tests/unit/server/test_plugin_ui_manifest.py
+++ b/plugin/tests/unit/server/test_plugin_ui_manifest.py
@@ -145,7 +145,42 @@ def test_surfaces_and_actions_use_manifest_and_static_compat(tmp_path: Path) -> 
 
     assert warnings == []
     assert [surface["kind"] for surface in surfaces] == ["panel", "guide"]
+    assert surfaces[0]["legacy_static_compat"] is False
     assert {action["id"] for action in actions} == {"open_panel", "open_guide"}
+
+
+def test_static_compat_surface_is_marked_and_precedes_declared_panels(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "demo"
+    static_dir = plugin_dir / "static"
+    ui_dir = plugin_dir / "ui"
+    static_dir.mkdir(parents=True)
+    ui_dir.mkdir()
+    (static_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+    (ui_dir / "dashboard.tsx").write_text("export default function Panel() { return <Page /> }", encoding="utf-8")
+    config_path = plugin_dir / "plugin.toml"
+    config_path.write_text("[plugin]\\nid='demo'\\n", encoding="utf-8")
+    plugin_ui = normalize_plugin_ui_manifest(
+        {
+            "plugin": {
+                "ui": {
+                    "panel": [{"id": "dashboard", "mode": "hosted-tsx", "entry": "ui/dashboard.tsx"}],
+                }
+            }
+        },
+        plugin_id="demo",
+    )
+
+    surfaces, warnings = _build_surfaces_sync("demo", {
+        "id": "demo",
+        "config_path": str(config_path),
+        "plugin_ui": plugin_ui,
+    })
+
+    assert warnings == []
+    assert [(surface["id"], surface["legacy_static_compat"]) for surface in surfaces] == [
+        ("main", True),
+        ("dashboard", False),
+    ]
 
 
 def test_unavailable_surfaces_do_not_get_route_actions(tmp_path: Path) -> None:

--- a/plugin/tests/unit/server/test_plugin_ui_manifest.py
+++ b/plugin/tests/unit/server/test_plugin_ui_manifest.py
@@ -212,6 +212,28 @@ def test_unavailable_surfaces_do_not_get_route_actions(tmp_path: Path) -> None:
     assert actions == []
 
 
+def test_auto_only_panel_does_not_get_route_action(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "demo"
+    plugin_dir.mkdir()
+    config_path = plugin_dir / "plugin.toml"
+    config_path.write_text("[plugin]\nid='demo'\n", encoding="utf-8")
+    plugin_ui = normalize_plugin_ui_manifest(
+        {"plugin": {"ui": {"panel": [{"id": "main", "mode": "auto"}]}}},
+        plugin_id="demo",
+    )
+    meta = {
+        "id": "demo",
+        "config_path": str(config_path),
+        "plugin_ui": plugin_ui,
+    }
+
+    surfaces, _warnings = _build_surfaces_sync("demo", meta)
+    actions = _build_plugin_list_actions_from_meta("demo", meta)
+
+    assert surfaces[0]["mode"] == "auto"
+    assert actions == []
+
+
 def test_surface_action_permission_and_authorized_entry_resolution() -> None:
     assert _surface_allows_action_call({"permissions": ["state:read", "action:call"]})
     assert not _surface_allows_action_call({"permissions": ["state:read"]})


### PR DESCRIPTION
## 改动概述 / Summary

- 新版插件面板存在时，隐藏并跳过旧版静态‘界面’探测，避免重复页面。
<img width="704" height="143" alt="ui-panel" src="https://github.com/user-attachments/assets/3eeb6186-427f-4290-8972-6428933a5106" />
修改后，“界面”将不会显示

- 修复前端构建脚本的批处理解析问题，并在 Live2D 模型目录无法删除时停止解压并给出明确提示。

## 回归报告 / Regression Report

不适用：未修改 app/、main_logic/ 或 memory 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：仅修改 2 个文件。

## 测试 / Testing

- 
pm run type-check（plugin-manager）
- git diff --check`n- 完整 uild_frontend.bat 未在 Codex 环境运行：该环境缺少 uv；已检查并修复批处理流程。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进

* 优化插件详情页的面板展示顺序，优先呈现现代化托管面板，并兼容旧版静态界面。
* 改进面板加载、切换和语言刷新流程，减少过时或无效内容。
* 增强面板消息传递机制，支持加载完成前暂存消息，提升新旧界面兼容性。

## 问题修复

* 改进 Live2D 模型解包的时间检测、文件校验、备份恢复及异常清理流程，并提供更明确的占用提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->