### PR TITLE
调整锻造券获得动画到模型右下方

### DIFF
--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -560,7 +560,8 @@
         'userLanguage',
         'textGuardMaxLength',
         'renderQuality',
-        'targetFrameRate'
+        'targetFrameRate',
+        'forgeDropEffectsEnabled'
     ];
 
     function _defaultConversationSettingsForReset() {

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -1647,6 +1647,9 @@
         const currentLockedHoverFade = typeof window.lockedHoverFadeEnabled !== 'undefined'
             ? window.lockedHoverFadeEnabled
             : true;
+        const currentForgeDropEffects = typeof window.forgeDropEffectsEnabled !== 'undefined'
+            ? window.forgeDropEffectsEnabled
+            : true;
 
         // 读取字幕设置（统一走 subtitle-shared store，避免多处直接写 localStorage）
         const subtitleStore = window.nekoSubtitleShared;
@@ -1687,6 +1690,7 @@
             live2dFullscreenTrackingEnabled: currentLive2dFullscreenTracking,
             humanoidLocalTrackingEnabled: currentHumanoidLocalTracking,
             lockedHoverFadeEnabled: currentLockedHoverFade,
+            forgeDropEffectsEnabled: currentForgeDropEffects,
             subtitleEnabled: currentSubtitleEnabled,
             userLanguage: currentUserLanguage
         };
@@ -1943,6 +1947,15 @@
                     window.lockedHoverFadeEnabled = true;
                 }
 
+                // 锻造券掉落动画与音效设置
+                if (typeof settings.forgeDropEffectsEnabled === 'boolean') {
+                    window.forgeDropEffectsEnabled = settings.forgeDropEffectsEnabled;
+                } else if (typeof settings.forgeDropEffectsEnabled === 'string') {
+                    window.forgeDropEffectsEnabled = settings.forgeDropEffectsEnabled === 'true';
+                } else {
+                    window.forgeDropEffectsEnabled = true;
+                }
+
                 // 同步到运行中的实例
                 if (typeof window.live2dManager !== 'undefined' && window.live2dManager && typeof window.live2dManager.setFullscreenTrackingEnabled === 'function') {
                     window.live2dManager.setFullscreenTrackingEnabled(window.live2dFullscreenTrackingEnabled === true);
@@ -1991,6 +2004,7 @@
                 window.live2dFullscreenTrackingEnabled = false;
                 window.humanoidLocalTrackingEnabled = false;
                 window.lockedHoverFadeEnabled = true;
+                window.forgeDropEffectsEnabled = true;
 
                 // 首启专属 marker：告诉下方异步合并块「这次仍在等首次 settings/telemetry
                 // 决议」。升级用户走的是 if (saved) 分支不会写这个，于是不会被误判成首启
@@ -2013,6 +2027,7 @@
             window.live2dFullscreenTrackingEnabled = false;
             window.humanoidLocalTrackingEnabled = false;
             window.lockedHoverFadeEnabled = true;
+            window.forgeDropEffectsEnabled = true;
         }
 
         // 以下逻辑不依赖本地 JSON 解析结果，始终执行

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1536,6 +1536,66 @@ function createAnimationSettingsSidePanel(manager, prefix) {
 
     trackingRow.appendChild(hoverFadeRow);
 
+    // ── 锻造券掉落动画与音效开关 ──
+    const forgeDropEffectsRow = document.createElement('div');
+    Object.assign(forgeDropEffectsRow.style, trackingToggleRowStyle);
+
+    const forgeDropEffectsCheckbox = document.createElement('input');
+    forgeDropEffectsCheckbox.type = 'checkbox';
+    forgeDropEffectsCheckbox.style.display = 'none';
+    forgeDropEffectsCheckbox.checked = window.forgeDropEffectsEnabled !== false;
+
+    const {
+        indicator: forgeDropEffectsIndicator,
+        updateStyle: updateForgeDropEffectsIndicatorStyle
+    } = manager._createCheckIndicator();
+    Object.assign(forgeDropEffectsIndicator.style, { width: '20px', height: '20px', flexShrink: '0' });
+
+    const updateForgeDropEffectsRowStyle = () => {
+        updateForgeDropEffectsIndicatorStyle(forgeDropEffectsCheckbox.checked);
+        updateTrackingToggleRowBackground(forgeDropEffectsRow, forgeDropEffectsCheckbox.checked);
+        forgeDropEffectsRow.setAttribute('aria-checked', String(forgeDropEffectsCheckbox.checked));
+    };
+    forgeDropEffectsCheckbox.updateStyle = updateForgeDropEffectsRowStyle;
+
+    const forgeDropEffectsLabel = document.createElement('span');
+    forgeDropEffectsLabel.textContent = window.t
+        ? window.t('settings.toggles.forgeDropEffects')
+        : '掉券动画与音效';
+    forgeDropEffectsLabel.setAttribute('data-i18n', 'settings.toggles.forgeDropEffects');
+    Object.assign(forgeDropEffectsLabel.style, { userSelect: 'none', fontSize: '12px', flex: '1' });
+
+    forgeDropEffectsRow.appendChild(forgeDropEffectsCheckbox);
+    forgeDropEffectsRow.appendChild(forgeDropEffectsIndicator);
+    forgeDropEffectsRow.appendChild(forgeDropEffectsLabel);
+    bindTrackingToggleRowHover(forgeDropEffectsRow, () => forgeDropEffectsCheckbox.checked);
+    updateForgeDropEffectsRowStyle();
+
+    const handleForgeDropEffectsChange = () => {
+        const enabled = !forgeDropEffectsCheckbox.checked;
+        forgeDropEffectsCheckbox.checked = enabled;
+        window.forgeDropEffectsEnabled = enabled;
+        updateForgeDropEffectsRowStyle();
+        if (typeof window.saveNEKOSettings === 'function') window.saveNEKOSettings();
+        window.dispatchEvent(new CustomEvent('neko-forge-drop-effects-changed', { detail: { enabled } }));
+    };
+
+    forgeDropEffectsRow.addEventListener('click', (e) => {
+        e.stopPropagation();
+        handleForgeDropEffectsChange();
+    });
+    forgeDropEffectsRow.setAttribute('role', 'switch');
+    forgeDropEffectsRow.tabIndex = 0;
+    forgeDropEffectsRow.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            handleForgeDropEffectsChange();
+        }
+    });
+
+    trackingRow.appendChild(forgeDropEffectsRow);
+
     document.body.appendChild(container);
     return container;
 }

--- a/static/forge-avatar-reaction.js
+++ b/static/forge-avatar-reaction.js
@@ -66,6 +66,7 @@
   }
 
   function react(detail) {
+    if (window.forgeDropEffectsEnabled === false) return;
     var now = Date.now();
     if (now - lastReactionAt < DEBOUNCE_MS) return;
     lastReactionAt = now;

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -326,15 +326,18 @@
   /** 读取当前模型的真实屏幕边界，四种模型共用同一套掉券定位。 */
   function getActiveAvatarBounds() {
     var configuredType = String(window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
+    var live3dSubType = String(window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
     var managers = {
       live2d: window.live2dManager,
-      live3d: window.vrmManager,
       vrm: window.vrmManager,
       mmd: window.mmdManager,
     };
-    var order = configuredType && managers[configuredType]
-      ? [managers[configuredType]]
-      : [managers.live2d, managers.vrm, managers.mmd];
+    var activeLive3dManager = live3dSubType === 'mmd' ? managers.mmd : managers.vrm;
+    var order = configuredType === 'live3d'
+      ? [activeLive3dManager, live3dSubType === 'mmd' ? managers.vrm : managers.mmd]
+      : (configuredType && managers[configuredType]
+        ? [managers[configuredType]]
+        : [managers.live2d, managers.vrm, managers.mmd]);
     for (var i = 0; i < order.length; i += 1) {
       var manager = order[i];
       if (!manager || typeof manager.getModelScreenBounds !== 'function') continue;

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -328,6 +328,7 @@
     var configuredType = String(window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
     var managers = {
       live2d: window.live2dManager,
+      live3d: window.vrmManager,
       vrm: window.vrmManager,
       mmd: window.mmdManager,
     };
@@ -354,26 +355,46 @@
     return null;
   }
 
+  function clampCardCoordinate(value, size, viewportSize, margin) {
+    var max = Math.max(0, viewportSize - size);
+    var min = Math.min(margin, max);
+    return Math.round(Math.max(min, Math.min(value, max)));
+  }
+
   function getCardPlacement(cardWidth, cardHeight, avatarBounds) {
     var margin = 12;
     if (!avatarBounds) {
       return {
-        left: Math.round(window.innerWidth * 0.5 - cardWidth / 2),
-        top: Math.round(window.innerHeight * 0.42 - cardHeight / 2),
+        left: clampCardCoordinate(
+          window.innerWidth * 0.5 - cardWidth / 2,
+          cardWidth,
+          window.innerWidth,
+          margin
+        ),
+        top: clampCardCoordinate(
+          window.innerHeight * 0.42 - cardHeight / 2,
+          cardHeight,
+          window.innerHeight,
+          margin
+        ),
       };
     }
     // 券卡从角色右下侧探出：保留少量重叠，视觉上仍与 N.E.K.O 绑定。
     var overlapX = cardWidth * 0.18;
     var liftY = Math.max(28, Math.min(64, avatarBounds.height * 0.08));
     return {
-      left: Math.round(Math.max(margin, Math.min(
+      left: clampCardCoordinate(
         avatarBounds.right - overlapX,
-        window.innerWidth - cardWidth - margin
-      ))),
-      top: Math.round(Math.max(margin, Math.min(
+        cardWidth,
+        window.innerWidth,
+        margin
+      ),
+      top: clampCardCoordinate(
         avatarBounds.bottom - cardHeight - liftY,
-        window.innerHeight - cardHeight - margin
-      ))),
+        cardHeight,
+        window.innerHeight,
+        margin
+      ),
     };
   }
 
@@ -405,10 +426,11 @@
         var CARD_ASPECT = 1192 / 445;
         var avatarBounds = getActiveAvatarBounds();
         var avatarCardWidth = avatarBounds ? avatarBounds.width * 0.55 : CARD_MAX_W;
+        var availableWidth = Math.max(1, window.innerWidth - CARD_MARGIN * 2);
         var CARD_W = Math.max(1, Math.min(
           CARD_MAX_W,
-          Math.max(CARD_MIN_W, avatarCardWidth),
-          window.innerWidth - CARD_MARGIN * 2
+          availableWidth,
+          Math.max(CARD_MIN_W, avatarCardWidth)
         ));
         var CARD_H = Math.round(CARD_W / CARD_ASPECT);
         var placement = getCardPlacement(CARD_W, CARD_H, avatarBounds);

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -26,6 +26,13 @@
   var PASSIVE_REFRESH_MS = 10 * 60 * 1000;
   var INTERACTIVE_REFRESH_THROTTLE_MS = 15 * 1000;
   var STARTUP_RETRY_DELAYS_MS = [2000, 10000, 30000];
+  // 只有这两档贴角色右下方；其余稀有度沿用屏幕中央的原始演出。
+  var AVATAR_ANCHORED_RARITIES = { N: true, R: true };
+  var ANCHOR_CARD_MAX_W = 280;
+  var ANCHOR_CARD_MIN_W = 180;
+  var CENTER_CARD_MAX_W = 360;
+  var CARD_MARGIN = 12;
+  var CARD_ASPECT = 1192 / 445;
   var queue = Promise.resolve();
   var cachedCredits = 0;
   var creditStateRevision = 0;
@@ -373,8 +380,29 @@
     return Math.round(Math.max(min, Math.min(value, max)));
   }
 
+  /**
+   * N/R 是高频掉落，贴到角色右下方以免反复挡住画面中央；
+   * SR 及以上保持原来的屏幕中央大卡演出，保留稀有掉落的仪式感。
+   */
+  function shouldAnchorToAvatar(rarity) {
+    return AVATAR_ANCHORED_RARITIES[String(rarity || '').toUpperCase()] === true;
+  }
+
+  function resolveCardWidth(rarity, avatarBounds) {
+    var availableWidth = Math.max(1, window.innerWidth - CARD_MARGIN * 2);
+    if (!shouldAnchorToAvatar(rarity)) {
+      return Math.max(1, Math.min(CENTER_CARD_MAX_W, availableWidth));
+    }
+    var avatarCardWidth = avatarBounds ? avatarBounds.width * 0.55 : ANCHOR_CARD_MAX_W;
+    return Math.max(1, Math.min(
+      ANCHOR_CARD_MAX_W,
+      availableWidth,
+      Math.max(ANCHOR_CARD_MIN_W, avatarCardWidth)
+    ));
+  }
+
   function getCardPlacement(cardWidth, cardHeight, avatarBounds) {
-    var margin = 12;
+    var margin = CARD_MARGIN;
     if (!avatarBounds) {
       return {
         left: clampCardCoordinate(
@@ -440,18 +468,8 @@
           (document.body || document.documentElement).appendChild(layer);
         }
 
-        var CARD_MAX_W = 280;
-        var CARD_MIN_W = 180;
-        var CARD_MARGIN = 12;
-        var CARD_ASPECT = 1192 / 445;
-        var avatarBounds = getActiveAvatarBounds();
-        var avatarCardWidth = avatarBounds ? avatarBounds.width * 0.55 : CARD_MAX_W;
-        var availableWidth = Math.max(1, window.innerWidth - CARD_MARGIN * 2);
-        var CARD_W = Math.max(1, Math.min(
-          CARD_MAX_W,
-          availableWidth,
-          Math.max(CARD_MIN_W, avatarCardWidth)
-        ));
+        var avatarBounds = shouldAnchorToAvatar(rarity) ? getActiveAvatarBounds() : null;
+        var CARD_W = resolveCardWidth(rarity, avatarBounds);
         var CARD_H = Math.round(CARD_W / CARD_ASPECT);
         var placement = getCardPlacement(CARD_W, CARD_H, avatarBounds);
         var startLeft = placement.left;

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -441,8 +441,12 @@
   function playOne(payload) {
     return new Promise(function (resolve) {
       try {
+        var payloadRevision = Number(payload && payload.__credit_state_revision) || 0;
         if (window.forgeDropEffectsEnabled === false) {
-          if (payload && typeof payload.active_count === 'number') {
+          // 排队期间可能已有权威刷新推进过 revision；此时这张队尾券的
+          // active_count 已经陈旧，不能用它覆盖角标。
+          var entryRevisionFresh = !payloadRevision || payloadRevision === creditStateRevision;
+          if (payload && typeof payload.active_count === 'number' && entryRevisionFresh) {
             renderForgeBadge(payload.active_count, true);
           }
           resolve();
@@ -459,7 +463,6 @@
         var active = typeof (payload && payload.active_count) === 'number'
           ? payload.active_count
           : (cachedCredits > 0 ? cachedCredits + 1 : 1);
-        var payloadRevision = Number(payload && payload.__credit_state_revision) || 0;
 
         var layer = document.querySelector('.neko-forge-drop-layer');
         if (!layer) {

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -334,6 +334,20 @@
       vrm: window.vrmManager,
       mmd: window.mmdManager,
     };
+    function getPngtuberBounds() {
+      var pngAvatar = document.querySelector(
+        '#pngtuber-container .pngtuber-image:not([style*="display: none"]), ' +
+        '#pngtuber-container .pngtuber-layered-canvas:not([style*="display: none"])'
+      );
+      if (!pngAvatar) return null;
+      try { return normalizeAvatarBounds(pngAvatar.getBoundingClientRect()); } catch (_) { return null; }
+    }
+    // 当前配置明确为 PNGtuber 时必须优先使用它的 DOM；其他 manager 可能仍是
+    // 上一次模型切换留下的实例，不能让旧边界抢走当前模型的掉券定位。
+    if (configuredType === 'pngtuber') {
+      var configuredPngBounds = getPngtuberBounds();
+      if (configuredPngBounds) return configuredPngBounds;
+    }
     var activeLive3dManager = live3dSubType === 'mmd' ? managers.mmd : managers.vrm;
     var order = configuredType === 'live3d'
       ? [activeLive3dManager, live3dSubType === 'mmd' ? managers.vrm : managers.mmd]
@@ -350,14 +364,7 @@
     }
 
     // PNGtuber 没有统一的 manager 边界 API，直接使用当前可见形象的 DOM 边界。
-    var pngAvatar = document.querySelector(
-      '#pngtuber-container .pngtuber-image:not([style*="display: none"]), ' +
-      '#pngtuber-container .pngtuber-layered-canvas:not([style*="display: none"])'
-    );
-    if (pngAvatar) {
-      try { return normalizeAvatarBounds(pngAvatar.getBoundingClientRect()); } catch (_) {}
-    }
-    return null;
+    return getPngtuberBounds();
   }
 
   function clampCardCoordinate(value, size, viewportSize, margin) {
@@ -517,6 +524,9 @@
         setTimeout(function () {
           if (playGeneration !== dropEffectsGeneration || window.forgeDropEffectsEnabled === false) {
             try { card.remove(); } catch (_) {}
+            if (!payloadRevision || payloadRevision === creditStateRevision) {
+              renderForgeBadge(active, true);
+            }
             resolve();
             return;
           }

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -104,7 +104,7 @@
   function ensureStyles() {
     // 版本号覆盖，避免 Pet 残留旧样式（右下角 HUD / 错误 transform 飞出）。
     var STYLE_ID = 'neko-forge-drop-styles';
-    var STYLE_VER = 'v9-prominent-hd-ticket';
+    var STYLE_VER = 'v10-avatar-lower-right';
     var existing = document.getElementById(STYLE_ID);
     if (existing && existing.getAttribute('data-ver') === STYLE_VER) return;
     if (existing) try { existing.remove(); } catch (_) {}
@@ -305,6 +305,78 @@
     };
   }
 
+  function normalizeAvatarBounds(bounds) {
+    if (!bounds) return null;
+    var left = Number(bounds.left != null ? bounds.left : bounds.x);
+    var top = Number(bounds.top != null ? bounds.top : bounds.y);
+    var right = Number(bounds.right != null ? bounds.right : left + Number(bounds.width));
+    var bottom = Number(bounds.bottom != null ? bounds.bottom : top + Number(bounds.height));
+    if (![left, top, right, bottom].every(Number.isFinite)) return null;
+    if (right <= left || bottom <= top) return null;
+    return {
+      left: left,
+      top: top,
+      right: right,
+      bottom: bottom,
+      width: right - left,
+      height: bottom - top,
+    };
+  }
+
+  /** 读取当前模型的真实屏幕边界，四种模型共用同一套掉券定位。 */
+  function getActiveAvatarBounds() {
+    var configuredType = String(window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
+    var managers = {
+      live2d: window.live2dManager,
+      vrm: window.vrmManager,
+      mmd: window.mmdManager,
+    };
+    var order = configuredType && managers[configuredType]
+      ? [managers[configuredType]]
+      : [managers.live2d, managers.vrm, managers.mmd];
+    for (var i = 0; i < order.length; i += 1) {
+      var manager = order[i];
+      if (!manager || typeof manager.getModelScreenBounds !== 'function') continue;
+      try {
+        var bounds = normalizeAvatarBounds(manager.getModelScreenBounds());
+        if (bounds) return bounds;
+      } catch (_) {}
+    }
+
+    // PNGtuber 没有统一的 manager 边界 API，直接使用当前可见形象的 DOM 边界。
+    var pngAvatar = document.querySelector(
+      '#pngtuber-container .pngtuber-image:not([style*="display: none"]), ' +
+      '#pngtuber-container .pngtuber-layered-canvas:not([style*="display: none"])'
+    );
+    if (pngAvatar) {
+      try { return normalizeAvatarBounds(pngAvatar.getBoundingClientRect()); } catch (_) {}
+    }
+    return null;
+  }
+
+  function getCardPlacement(cardWidth, cardHeight, avatarBounds) {
+    var margin = 12;
+    if (!avatarBounds) {
+      return {
+        left: Math.round(window.innerWidth * 0.5 - cardWidth / 2),
+        top: Math.round(window.innerHeight * 0.42 - cardHeight / 2),
+      };
+    }
+    // 券卡从角色右下侧探出：保留少量重叠，视觉上仍与 N.E.K.O 绑定。
+    var overlapX = cardWidth * 0.18;
+    var liftY = Math.max(28, Math.min(64, avatarBounds.height * 0.08));
+    return {
+      left: Math.round(Math.max(margin, Math.min(
+        avatarBounds.right - overlapX,
+        window.innerWidth - cardWidth - margin
+      ))),
+      top: Math.round(Math.max(margin, Math.min(
+        avatarBounds.bottom - cardHeight - liftY,
+        window.innerHeight - cardHeight - margin
+      ))),
+    };
+  }
+
   function playOne(payload) {
     return new Promise(function (resolve) {
       try {
@@ -327,15 +399,21 @@
           (document.body || document.documentElement).appendChild(layer);
         }
 
-        var CARD_MAX_W = 360;
+        var CARD_MAX_W = 280;
+        var CARD_MIN_W = 180;
         var CARD_MARGIN = 12;
         var CARD_ASPECT = 1192 / 445;
-        var CARD_W = Math.max(1, Math.min(CARD_MAX_W, window.innerWidth - CARD_MARGIN * 2));
+        var avatarBounds = getActiveAvatarBounds();
+        var avatarCardWidth = avatarBounds ? avatarBounds.width * 0.55 : CARD_MAX_W;
+        var CARD_W = Math.max(1, Math.min(
+          CARD_MAX_W,
+          Math.max(CARD_MIN_W, avatarCardWidth),
+          window.innerWidth - CARD_MARGIN * 2
+        ));
         var CARD_H = Math.round(CARD_W / CARD_ASPECT);
-        var originX = window.innerWidth * 0.5;
-        var originY = window.innerHeight * 0.42;
-        var startLeft = Math.round(originX - CARD_W / 2);
-        var startTop = Math.round(originY - CARD_H / 2);
+        var placement = getCardPlacement(CARD_W, CARD_H, avatarBounds);
+        var startLeft = placement.left;
+        var startTop = placement.top;
 
         var card = document.createElement('div');
         card.className = 'neko-forge-card';

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -38,6 +38,7 @@
   var expiryRefreshTimer = null;
   var forgeBadgeObserver = null;
   var dropSoundAudioByRarity = {};
+  var dropEffectsGeneration = 0;
   // 浮动按钮栏未聚焦时会被 display:none；此时 getBoundingClientRect=0 → 会误飞左上角。
   // 缓存上次可见位置，并在隐藏时用 style.left/top 估算。
   var lastSocialCenter = null;
@@ -90,6 +91,7 @@
 
   function playDropSound(rarity) {
     try {
+      if (window.forgeDropEffectsEnabled === false) return;
       var normalized = tokens().normalizeRarity(rarity);
       var audio = dropSoundAudioByRarity[normalized] || createDropSoundAudio(normalized);
       if (!audio) return;
@@ -404,6 +406,14 @@
   function playOne(payload) {
     return new Promise(function (resolve) {
       try {
+        if (window.forgeDropEffectsEnabled === false) {
+          if (payload && typeof payload.active_count === 'number') {
+            renderForgeBadge(payload.active_count, true);
+          }
+          resolve();
+          return;
+        }
+        var playGeneration = dropEffectsGeneration;
         ensureStyles();
         var t = tokens();
         var rarity = t.normalizeRarity(payload && payload.rarity);
@@ -505,6 +515,11 @@
 
         var hold = reduced ? 1200 : HOLD_MS;
         setTimeout(function () {
+          if (playGeneration !== dropEffectsGeneration || window.forgeDropEffectsEnabled === false) {
+            try { card.remove(); } catch (_) {}
+            resolve();
+            return;
+          }
           var prevBtnStyle = null;
           try {
             // 0) 短暂亮起浮动栏，避免隐藏时 rect=0 飞向左上，也让终点可见
@@ -684,7 +699,31 @@
       // 动画飞入结束后再 bump；这里先缓存，避免角标抢先跳
       cachedCredits = Math.max(0, detail.active_count - 1);
     }
+    if (window.forgeDropEffectsEnabled === false) {
+      if (typeof detail.active_count === 'number') {
+        renderForgeBadge(detail.active_count, true);
+      }
+      return;
+    }
     play(queuedDetail);
+  }
+
+  function onDropEffectsChanged(event) {
+    if (!event || !event.detail || event.detail.enabled !== false) return;
+    dropEffectsGeneration += 1;
+    try {
+      var layer = document.querySelector('.neko-forge-drop-layer');
+      if (layer) layer.replaceChildren();
+    } catch (_) {}
+    Object.keys(dropSoundAudioByRarity).forEach(function (rarity) {
+      try {
+        var audio = dropSoundAudioByRarity[rarity];
+        if (audio) {
+          audio.pause();
+          audio.currentTime = 0;
+        }
+      } catch (_) {}
+    });
   }
 
   function boot() {
@@ -695,6 +734,7 @@
     renderForgeBadge(cachedCredits || 0, false);
     refreshCreditsWithRetry();
     window.addEventListener('neko-forge-credit-drop', onCreditDropEvent);
+    window.addEventListener('neko-forge-drop-effects-changed', onDropEffectsChanged);
     // 从外部社区页兑券返回时尽快校准；节流避免 focus/visibilitychange 连发。
     window.addEventListener('focus', requestInteractiveRefresh);
     window.addEventListener('pageshow', requestInteractiveRefresh);

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "Fullscreen Tracking",
             "localTracking": "Local Tracking",
             "lockedHoverFade": "Locked Hover Fade",
+            "forgeDropEffects": "Ticket Drop Effects",
             "textGuardMaxLength": "Response Length Limit",
             "unlimited": "Unlimited",
             "characters": "chars",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "Seguimiento de pantalla completa",
             "localTracking": "Seguimiento local",
             "lockedHoverFade": "Desvanecimiento de desplazamiento bloqueado",
+            "forgeDropEffects": "Efectos al recibir cupón",
             "textGuardMaxLength": "Límite de longitud de respuesta",
             "unlimited": "Ilimitado",
             "characters": "caracteres",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "フルスクリーン追跡",
             "localTracking": "ローカル追跡",
             "lockedHoverFade": "ロック時ホバー透過",
+            "forgeDropEffects": "チケット獲得演出・効果音",
             "textGuardMaxLength": "返信長さ上限",
             "unlimited": "無制限",
             "characters": "文字",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "전체 화면 추적",
             "localTracking": "로컬 추적",
             "lockedHoverFade": "잠금 호버 페이드",
+            "forgeDropEffects": "티켓 획득 연출 및 효과음",
             "textGuardMaxLength": "응답 길이 상한",
             "unlimited": "무제한",
             "characters": "자",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "Rastreamento em tela cheia",
             "localTracking": "Rastreamento Local",
             "lockedHoverFade": "Desbotamento de foco bloqueado",
+            "forgeDropEffects": "Efeitos ao receber bilhete",
             "textGuardMaxLength": "Limite de comprimento de resposta",
             "unlimited": "Ilimitado",
             "characters": "caracteres",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "Полноэкранное отслеживание",
             "localTracking": "Локальное отслеживание",
             "lockedHoverFade": "Затухание при наведении (заблокировано)",
+            "forgeDropEffects": "Эффекты получения билета",
             "textGuardMaxLength": "Ограничение длины ответа",
             "unlimited": "Без ограничений",
             "characters": "символов",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "全屏跟踪",
             "localTracking": "局部跟踪",
             "lockedHoverFade": "锁定悬停淡化",
+            "forgeDropEffects": "掉券动画与音效",
             "textGuardMaxLength": "回复长度上限",
             "unlimited": "无限制",
             "characters": "字",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2901,6 +2901,7 @@
             "fullscreenTracking": "全屏跟蹤",
             "localTracking": "局部跟蹤",
             "lockedHoverFade": "鎖定懸停淡化",
+            "forgeDropEffects": "掉券動畫與音效",
             "textGuardMaxLength": "回覆長度上限",
             "unlimited": "無限制",
             "characters": "字",

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -190,10 +190,16 @@ def test_credit_drop_uses_yui_ticket_art_for_every_drop_rarity():
 
     assert "ticketArt.className = 'ticket-art';" in overlay
     assert "t.ticketPath(rarity)" in overlay
-    assert "var CARD_MAX_W = 360;" in overlay
+    assert "var CARD_MAX_W = 280;" in overlay
+    assert "var CARD_MIN_W = 180;" in overlay
     assert "var CARD_MARGIN = 12;" in overlay
     assert "var CARD_ASPECT = 1192 / 445;" in overlay
     assert "window.innerWidth - CARD_MARGIN * 2" in overlay
+    assert "function getActiveAvatarBounds()" in overlay
+    assert "manager.getModelScreenBounds()" in overlay
+    assert "function getCardPlacement(cardWidth, cardHeight, avatarBounds)" in overlay
+    assert "avatarBounds.right - overlapX" in overlay
+    assert "avatarBounds.bottom - cardHeight - liftY" in overlay
     assert "ticketAuraArt.className = 'ticket-aura-art';" in overlay
     assert "spark.textContent" not in overlay
     assert "className = 'rk'" not in overlay

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -1,8 +1,10 @@
 import re
+import shutil
 import struct
 from pathlib import Path
 
 import pytest
+from tests.node_harness import run_node_stdin
 from tests.static_app_parts import read_js_parts
 
 
@@ -14,6 +16,33 @@ FORGE_DROP_OVERLAY_PATH = PROJECT_ROOT / "static" / "forge-drop-overlay.js"
 FORGE_AVATAR_REACTION_PATH = PROJECT_ROOT / "static" / "forge-avatar-reaction.js"
 FORGE_DROP_TOKENS_PATH = PROJECT_ROOT / "static" / "forge-drop-tokens.js"
 FORGE_SOUND_DIR = PROJECT_ROOT / "static" / "sounds" / "forge"
+
+
+def _extract_js_function(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    quote = None
+    escaped = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in ("'", '"', "`"):
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+    raise AssertionError(f"unterminated JavaScript function: {signature}")
 
 
 @pytest.mark.unit
@@ -198,16 +227,78 @@ def test_forge_drop_effects_can_be_disabled_without_hiding_credit_updates():
     assert "neko-forge-drop-effects-changed" in popup
     assert "forgeDropEffectsEnabled: currentForgeDropEffects" in settings
     assert "window.forgeDropEffectsEnabled = settings.forgeDropEffectsEnabled;" in settings
-    assert "window.forgeDropEffectsEnabled === false" in overlay
-    assert "renderForgeBadge(detail.active_count, true);" in overlay
-    assert "audio.pause();" in overlay
-    assert "if (window.forgeDropEffectsEnabled === false) return;" in reaction
+    drop_handler = _extract_js_function(overlay, "function onCreditDropEvent(event)")
+    effects_handler = _extract_js_function(overlay, "function onDropEffectsChanged(event)")
+    reaction_handler = _extract_js_function(reaction, "function react(detail)")
+    play_one = _extract_js_function(overlay, "function playOne(payload)")
+    assert "if (window.forgeDropEffectsEnabled === false)" in drop_handler
+    assert "renderForgeBadge(detail.active_count, true);" in drop_handler
+    assert "audio.pause();" in effects_handler
+    assert reaction_handler.index(
+        "if (window.forgeDropEffectsEnabled === false) return;"
+    ) < reaction_handler.index("var now = Date.now();")
+    assert "renderForgeBadge(active, true);" in play_one
+    assert "playGeneration !== dropEffectsGeneration" in play_one
 
     for locale in ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "pt", "es"):
         locale_source = (PROJECT_ROOT / "static" / "locales" / f"{locale}.json").read_text(
             encoding="utf-8"
         )
         assert '"forgeDropEffects"' in locale_source
+
+
+@pytest.mark.unit
+def test_credit_drop_avatar_bounds_and_clamp_execute_for_each_model_type():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not found")
+    overlay = FORGE_DROP_OVERLAY_PATH.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _extract_js_function(overlay, signature)
+        for signature in (
+            "function normalizeAvatarBounds(bounds)",
+            "function getActiveAvatarBounds()",
+            "function clampCardCoordinate(value, size, viewportSize, margin)",
+        )
+    )
+    script = f"""
+const assert = require('node:assert/strict');
+global.window = {{}};
+let pngBounds = null;
+global.document = {{
+  querySelector() {{
+    return pngBounds ? {{ getBoundingClientRect: () => pngBounds }} : null;
+  }}
+}};
+{functions}
+const bounds = (left) => ({{ left, top: 20, right: left + 100, bottom: 220 }});
+const manager = (left) => ({{ getModelScreenBounds: () => bounds(left) }});
+window.live2dManager = manager(10);
+window.vrmManager = manager(110);
+window.mmdManager = manager(210);
+
+window.lanlan_config = {{ model_type: 'live2d' }};
+assert.equal(getActiveAvatarBounds().left, 10);
+window.lanlan_config = {{ model_type: 'live3d', live3d_sub_type: 'vrm' }};
+assert.equal(getActiveAvatarBounds().left, 110);
+window.lanlan_config = {{ model_type: 'live3d', live3d_sub_type: 'mmd' }};
+assert.equal(getActiveAvatarBounds().left, 210);
+pngBounds = bounds(310);
+window.lanlan_config = {{ model_type: 'pngtuber' }};
+assert.equal(getActiveAvatarBounds().left, 310);
+
+window.live2dManager = null;
+window.vrmManager = null;
+window.mmdManager = null;
+window.lanlan_config = {{ model_type: 'unknown' }};
+assert.equal(getActiveAvatarBounds().left, 310);
+pngBounds = null;
+assert.equal(getActiveAvatarBounds(), null);
+assert.equal(clampCardCoordinate(-50, 180, 160, 12), 0);
+assert.equal(clampCardCoordinate(999, 80, 160, 12), 80);
+"""
+    result = run_node_stdin(node, script, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.unit

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -196,7 +196,10 @@ def test_credit_drop_uses_yui_ticket_art_for_every_drop_rarity():
     assert "var CARD_ASPECT = 1192 / 445;" in overlay
     assert "window.innerWidth - CARD_MARGIN * 2" in overlay
     assert "function getActiveAvatarBounds()" in overlay
+    assert "live3d: window.vrmManager" in overlay
     assert "manager.getModelScreenBounds()" in overlay
+    assert "var availableWidth = Math.max(1, window.innerWidth - CARD_MARGIN * 2);" in overlay
+    assert "function clampCardCoordinate(value, size, viewportSize, margin)" in overlay
     assert "function getCardPlacement(cardWidth, cardHeight, avatarBounds)" in overlay
     assert "avatarBounds.right - overlapX" in overlay
     assert "avatarBounds.bottom - cardHeight - liftY" in overlay

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -8,7 +8,10 @@ from tests.static_app_parts import read_js_parts
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_UI_PATH = PROJECT_ROOT / "static" / "app" / "app-ui"
+APP_SETTINGS_PATH = PROJECT_ROOT / "static" / "app" / "app-settings.js"
+AVATAR_UI_POPUP_PATH = PROJECT_ROOT / "static" / "avatar" / "avatar-ui-popup.js"
 FORGE_DROP_OVERLAY_PATH = PROJECT_ROOT / "static" / "forge-drop-overlay.js"
+FORGE_AVATAR_REACTION_PATH = PROJECT_ROOT / "static" / "forge-avatar-reaction.js"
 FORGE_DROP_TOKENS_PATH = PROJECT_ROOT / "static" / "forge-drop-tokens.js"
 FORGE_SOUND_DIR = PROJECT_ROOT / "static" / "sounds" / "forge"
 
@@ -181,6 +184,30 @@ def test_credit_drop_event_plays_forge_overlay_animation():
 
     assert "cachedCredits = Math.max(0, detail.active_count - 1);" in handler
     assert "play(queuedDetail);" in handler
+
+
+@pytest.mark.unit
+def test_forge_drop_effects_can_be_disabled_without_hiding_credit_updates():
+    popup = AVATAR_UI_POPUP_PATH.read_text(encoding="utf-8")
+    settings = APP_SETTINGS_PATH.read_text(encoding="utf-8")
+    overlay = FORGE_DROP_OVERLAY_PATH.read_text(encoding="utf-8")
+    reaction = FORGE_AVATAR_REACTION_PATH.read_text(encoding="utf-8")
+
+    assert "settings.toggles.forgeDropEffects" in popup
+    assert "window.forgeDropEffectsEnabled = enabled;" in popup
+    assert "neko-forge-drop-effects-changed" in popup
+    assert "forgeDropEffectsEnabled: currentForgeDropEffects" in settings
+    assert "window.forgeDropEffectsEnabled = settings.forgeDropEffectsEnabled;" in settings
+    assert "window.forgeDropEffectsEnabled === false" in overlay
+    assert "renderForgeBadge(detail.active_count, true);" in overlay
+    assert "audio.pause();" in overlay
+    assert "if (window.forgeDropEffectsEnabled === false) return;" in reaction
+
+    for locale in ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "pt", "es"):
+        locale_source = (PROJECT_ROOT / "static" / "locales" / f"{locale}.json").read_text(
+            encoding="utf-8"
+        )
+        assert '"forgeDropEffects"' in locale_source
 
 
 @pytest.mark.unit

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -196,7 +196,8 @@ def test_credit_drop_uses_yui_ticket_art_for_every_drop_rarity():
     assert "var CARD_ASPECT = 1192 / 445;" in overlay
     assert "window.innerWidth - CARD_MARGIN * 2" in overlay
     assert "function getActiveAvatarBounds()" in overlay
-    assert "live3d: window.vrmManager" in overlay
+    assert "live3dSubType === 'mmd' ? managers.mmd : managers.vrm" in overlay
+    assert "live3dSubType === 'mmd' ? managers.vrm : managers.mmd" in overlay
     assert "manager.getModelScreenBounds()" in overlay
     assert "var availableWidth = Math.max(1, window.innerWidth - CARD_MARGIN * 2);" in overlay
     assert "function clampCardCoordinate(value, size, viewportSize, margin)" in overlay

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -239,6 +239,12 @@ def test_forge_drop_effects_can_be_disabled_without_hiding_credit_updates():
     ) < reaction_handler.index("var now = Date.now();")
     assert "renderForgeBadge(active, true);" in play_one
     assert "playGeneration !== dropEffectsGeneration" in play_one
+    # 关闭效果的入口分支同样要按 revision 守卫，否则队尾券会用陈旧
+    # active_count 覆盖权威刷新写过的角标。
+    disabled_entry = play_one[play_one.index("if (window.forgeDropEffectsEnabled === false)"):]
+    disabled_entry = disabled_entry[: disabled_entry.index("resolve();")]
+    assert "payloadRevision === creditStateRevision" in disabled_entry
+    assert "renderForgeBadge(payload.active_count, true);" in disabled_entry
 
     for locale in ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "pt", "es"):
         locale_source = (PROJECT_ROOT / "static" / "locales" / f"{locale}.json").read_text(

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -302,17 +302,88 @@ assert.equal(clampCardCoordinate(999, 80, 160, 12), 80);
 
 
 @pytest.mark.unit
+def test_only_low_rarity_drops_anchor_to_avatar_lower_right():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not found")
+    overlay = FORGE_DROP_OVERLAY_PATH.read_text(encoding="utf-8")
+    constants = "\n".join(
+        line.strip()
+        for line in overlay.splitlines()
+        if re.match(
+            r"\s*var (AVATAR_ANCHORED_RARITIES|ANCHOR_CARD_MAX_W|ANCHOR_CARD_MIN_W"
+            r"|CENTER_CARD_MAX_W|CARD_MARGIN|CARD_ASPECT) =",
+            line,
+        )
+    )
+    functions = "\n".join(
+        _extract_js_function(overlay, signature)
+        for signature in (
+            "function clampCardCoordinate(value, size, viewportSize, margin)",
+            "function shouldAnchorToAvatar(rarity)",
+            "function resolveCardWidth(rarity, avatarBounds)",
+            "function getCardPlacement(cardWidth, cardHeight, avatarBounds)",
+        )
+    )
+    script = f"""
+const assert = require('node:assert/strict');
+global.window = {{ innerWidth: 1200, innerHeight: 800 }};
+{constants}
+{functions}
+const avatar = {{ left: 300, top: 100, right: 700, bottom: 620, width: 400, height: 520 }};
+
+// N/R：贴角色右下方，卡宽跟随模型（400 * 0.55 = 220，落在 180–280 之间）。
+for (const rarity of ['N', 'R']) {{
+  assert.equal(shouldAnchorToAvatar(rarity), true, rarity);
+  const width = resolveCardWidth(rarity, avatar);
+  assert.ok(Math.abs(width - 220) < 1e-6, `${{rarity}} width=${{width}}`);
+  const height = Math.round(width / CARD_ASPECT);
+  const placement = getCardPlacement(width, height, avatar);
+  assert.equal(placement.left, Math.round(avatar.right - width * 0.18), rarity);
+  assert.ok(placement.left > avatar.left, rarity);
+  assert.ok(placement.top + height <= avatar.bottom, rarity);
+}}
+
+// SR 及以上：保持屏幕中央的原始大卡演出，且不随模型边界漂移。
+for (const rarity of ['SR', 'SSR', 'UR']) {{
+  assert.equal(shouldAnchorToAvatar(rarity), false, rarity);
+  const width = resolveCardWidth(rarity, avatar);
+  assert.equal(width, 360, rarity);
+  const height = Math.round(width / CARD_ASPECT);
+  const placement = getCardPlacement(width, height, null);
+  assert.equal(placement.left, Math.round(window.innerWidth * 0.5 - width / 2), rarity);
+  assert.equal(placement.top, Math.round(window.innerHeight * 0.42 - height / 2), rarity);
+}}
+
+// 窄窗口下两档都不越界。
+window.innerWidth = 240;
+assert.equal(resolveCardWidth('N', avatar), 216);
+assert.equal(resolveCardWidth('UR', avatar), 216);
+"""
+    result = run_node_stdin(node, script, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
 def test_credit_drop_uses_yui_ticket_art_for_every_drop_rarity():
     overlay = FORGE_DROP_OVERLAY_PATH.read_text(encoding="utf-8")
     tokens = FORGE_DROP_TOKENS_PATH.read_text(encoding="utf-8")
 
     assert "ticketArt.className = 'ticket-art';" in overlay
     assert "t.ticketPath(rarity)" in overlay
-    assert "var CARD_MAX_W = 280;" in overlay
-    assert "var CARD_MIN_W = 180;" in overlay
+    assert "var ANCHOR_CARD_MAX_W = 280;" in overlay
+    assert "var ANCHOR_CARD_MIN_W = 180;" in overlay
+    assert "var CENTER_CARD_MAX_W = 360;" in overlay
     assert "var CARD_MARGIN = 12;" in overlay
     assert "var CARD_ASPECT = 1192 / 445;" in overlay
+    assert "var AVATAR_ANCHORED_RARITIES = { N: true, R: true };" in overlay
     assert "window.innerWidth - CARD_MARGIN * 2" in overlay
+    # SR 及以上不读模型边界，直接走屏幕中央兜底路径。
+    assert (
+        "var avatarBounds = shouldAnchorToAvatar(rarity) ? getActiveAvatarBounds() : null;"
+        in overlay
+    )
+    assert "var CARD_W = resolveCardWidth(rarity, avatarBounds);" in overlay
     assert "function getActiveAvatarBounds()" in overlay
     assert "live3dSubType === 'mmd' ? managers.mmd : managers.vrm" in overlay
     assert "live3dSubType === 'mmd' ? managers.vrm : managers.mmd" in overlay


### PR DESCRIPTION
## 改动概述 / Summary

- 将锻造券获得动画从窗口中央移到当前 N.E.K.O 模型右下方
- 根据 Live2D、VRM、MMD 与 PNGtuber 的实际模型边界动态定位
- 将券卡宽度调整为 180–280px，并在窗口空间不足时自动限制位置避免越界
- 保留无法获取模型边界时的居中兜底逻辑
- 补充静态契约测试，覆盖模型边界读取与右下方定位

## 回归报告 / Regression Report

不适用：整理分支后，本 PR 仅修改前端掉券动画脚本及其静态契约测试，不涉及 `app/`、`main_logic/`、`main_routers/` 或 `memory/`。

## 不拆分理由 / Why Not Split

不适用：本 PR 仅包含一个前端实现文件和一个对应测试文件。

## 测试 / Testing

- `UV_CACHE_DIR=/private/tmp/neko-uv-cache uv run pytest tests/unit/test_social_button_static_contracts.py -q`
- 8 passed
- 已在本地 Electron Pet 页面触发一次 N 券预览动画（仅前端事件，未写入券账本）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“掉券动画与音效”开关，可关闭动画和音效，同时保留数量更新，并自动保存设置。
  * 新增中文、英文、日文、韩文、西班牙文、葡萄牙文和俄文界面文案。
* **改进**
  * 掉落券卡片会根据头像位置动态显示在角色右下方。
  * 支持多种角色模型及 PNGtuber 头像识别。
  * 卡片宽度调整为 180–280px；无法识别头像位置时提供备用定位，并避免超出窗口边缘。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->