### PR TITLE
fix: adapt package manager to dark mode

### DIFF
--- a/frontend/plugin-manager/src/components/plugin/PackageManagerPanel.vue
+++ b/frontend/plugin-manager/src/components/plugin/PackageManagerPanel.vue
@@ -374,7 +374,11 @@ const {
   padding: 14px 16px;
   border-radius: 18px;
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--el-color-primary) 10%, white), color-mix(in srgb, var(--el-color-info) 9%, white));
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--el-color-primary) 10%, var(--el-bg-color)),
+      color-mix(in srgb, var(--el-color-info) 9%, var(--el-bg-color))
+    );
   border: 1px solid color-mix(in srgb, var(--el-color-primary) 12%, var(--el-border-color));
 }
 
@@ -409,7 +413,7 @@ const {
   flex-wrap: wrap;
   padding: 12px 14px;
   border-radius: 16px;
-  background: color-mix(in srgb, var(--el-fill-color-light) 78%, white);
+  background: color-mix(in srgb, var(--el-fill-color-light) 78%, var(--el-bg-color));
   border: 1px solid color-mix(in srgb, var(--el-color-info) 10%, var(--el-border-color));
 }
 


### PR DESCRIPTION
## 改动概述 / Summary

修复嵌入式包管理面板在深色模式下仍混合固定白色背景的问题，使标题区域与已选摘要使用当前 Element 主题背景变量。

修改前：
<img width="1338" height="422" alt="image" src="https://github.com/user-attachments/assets/9be0a103-8889-46dc-9f86-bee43b917551" />
修改后：
<img width="452" height="139" alt="image" src="https://github.com/user-attachments/assets/fa2ad1b5-475c-4835-aacd-d23e02e2cff4" />


## 回归报告 / Regression Report

不适用（未修改 `app/`、`main_logic/` 或 `memory/` 中的 Python 文件）。

## 不拆分理由 / Why Not Split

不适用（改动文件数不超过 20 个）。

## 测试 / Testing

- `npm run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化插件包管理面板的渐变背景，使其自动适配当前主题背景色。
  * 提升浅色和深色主题下的视觉一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->