### PR TITLE
fix(tests): 修复凭证 tab 数硬编码与音频证据落盘竞态两条 CI 红

### DIFF
--- a/tests/unit/asr_client/endpointing/test_audio_evidence.py
+++ b/tests/unit/asr_client/endpointing/test_audio_evidence.py
@@ -13,20 +13,48 @@ from main_logic.asr_client.endpointing.smart_turn_audio_evidence import (
 )
 
 
-def _wait_for_written_run_dir(target: Path, timeout_s: float = 10.0) -> list[Path]:
+def _complete_record_count(index_path: Path) -> int:
+    # 只认已经 flush 完整的整行 JSON：写线程是先 open 再 write 再 flush，
+    # 光看文件存在会读到空文件或半行。
+    try:
+        lines = index_path.read_text("utf-8").splitlines()
+    except OSError:
+        return 0
+    complete = 0
+    for line in lines:
+        try:
+            json.loads(line)
+        except ValueError:
+            return complete
+        complete += 1
+    return complete
+
+
+def _wait_for_written_run_dir(
+    target: Path,
+    expected_records: int = 1,
+    timeout_s: float = 10.0,
+) -> list[Path]:
     # 等落盘：close() 只给写线程一个很短的确认窗口，不是落盘保证。正常路径下写线程
     # 几毫秒就写完了，但 Windows CI 上磁盘会抖到超过那个窗口，close() 一返回就
-    # iterdir 会撞上还没建出来的目录。
+    # iterdir 会撞上还没建出来的目录、或是刚 open 出来的空 index。
     deadline = time.monotonic() + timeout_s
     while True:
         try:
             run_dirs = list(target.iterdir())
         except FileNotFoundError:
             run_dirs = []
-        if run_dirs and all((d / "index.jsonl").exists() for d in run_dirs):
+        if run_dirs and all(
+            _complete_record_count(d / "index.jsonl") >= expected_records
+            for d in run_dirs
+        ):
             return run_dirs
         if time.monotonic() >= deadline:
-            return run_dirs
+            raise AssertionError(
+                f"等待 {target} 落盘超时（{timeout_s}s）："
+                f"run_dirs={[d.name for d in run_dirs]}，"
+                f"records={[_complete_record_count(d / 'index.jsonl') for d in run_dirs]}"
+            )
         time.sleep(0.01)
 
 

--- a/tests/unit/asr_client/endpointing/test_audio_evidence.py
+++ b/tests/unit/asr_client/endpointing/test_audio_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 import wave
 from pathlib import Path
 
@@ -10,6 +11,23 @@ from main_logic.asr_client.endpointing.smart_turn_audio_evidence import (
     SMART_TURN_AUDIO_EVIDENCE_ENABLED_ENV,
     create_smart_turn_audio_evidence_recorder,
 )
+
+
+def _wait_for_written_run_dir(target: Path, timeout_s: float = 10.0) -> list[Path]:
+    # 等落盘：close() 只给写线程一个很短的确认窗口，不是落盘保证。正常路径下写线程
+    # 几毫秒就写完了，但 Windows CI 上磁盘会抖到超过那个窗口，close() 一返回就
+    # iterdir 会撞上还没建出来的目录。
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            run_dirs = list(target.iterdir())
+        except FileNotFoundError:
+            run_dirs = []
+        if run_dirs and all((d / "index.jsonl").exists() for d in run_dirs):
+            return run_dirs
+        if time.monotonic() >= deadline:
+            return run_dirs
+        time.sleep(0.01)
 
 
 async def test_audio_evidence_is_off_without_explicit_opt_in(tmp_path: Path) -> None:
@@ -54,7 +72,7 @@ async def test_audio_evidence_writes_local_wav_and_index_under_data(
     )
     await recorder.close()
 
-    run_dirs = list(target.iterdir())
+    run_dirs = _wait_for_written_run_dir(target)
     assert recorder.enabled is True
     assert len(run_dirs) == 1
     run_dir = run_dirs[0]

--- a/tests/unit/test_window_pin_static_contracts.py
+++ b/tests/unit/test_window_pin_static_contracts.py
@@ -252,7 +252,11 @@ def test_credentials_tabs_are_wired_to_the_single_tab_panel():
     template = read_text("templates/cookies_login.html")
 
     tab_buttons = re.findall(r'<button class="tab-btn[^>]*>', template)
-    assert len(tab_buttons) == 10
+    # 凭证源会持续增删，锁死具体个数只会让每个新增源都红一次；真正要守的是每个按钮的
+    # ARIA 接线。和 switchTab 调用数交叉比对，正则一旦失配就会立刻不等，避免测出 0 个假绿。
+    switch_calls = template.count("switchTab('")
+    assert switch_calls > 0
+    assert len(tab_buttons) == switch_calls
     for button in tab_buttons:
         assert 'role="tab"' in button, button
         assert 'aria-controls="main-panel"' in button, button

--- a/tests/unit/test_window_pin_static_contracts.py
+++ b/tests/unit/test_window_pin_static_contracts.py
@@ -258,6 +258,8 @@ def test_credentials_tabs_are_wired_to_the_single_tab_panel():
     assert switch_calls > 0
     assert len(tab_buttons) == switch_calls
     for button in tab_buttons:
+        # 逐个按钮各带一次调用，才能保证上面那个总数相等不是靠"这里漏一次、别处多一次"凑出来的。
+        assert button.count("switchTab('") == 1, button
         assert 'role="tab"' in button, button
         assert 'aria-controls="main-panel"' in button, button
     assert re.search(


### PR DESCRIPTION
## 背景

main 从 #2819 合入后每次 push 都红，PR 上还叠了一条 Windows 独有的抖动。分诊下来是两条互相独立的测试自身问题，都不是产品缺陷。

## 1. 凭证 tab 数硬编码（main 持续红）

`test_credentials_tabs_are_wired_to_the_single_tab_panel` 把 `tab-btn` 个数锁死成 10。#2819 加了 QQ 音乐凭证源变成 11，之后 main 上连红 4 次以上（#2811 / #2714 / #2823 / #2833 的 push run 全是这一条）。

这个数量断言的真实作用只是防止正则失配测出 0 个按钮的假绿——凭证源本身会持续增删，锁死具体个数只会让每个新源都红一次。改成和 `switchTab('` 调用数交叉比对：正则一失配立刻不等，新增源不再误红，逐按钮的 `role="tab"` / `aria-controls="main-panel"` 校验原样保留。

## 2. 音频证据落盘竞态（Windows flake）

`test_audio_evidence_writes_local_wav_and_index_under_data` 在 `await recorder.close()` 返回后立刻 `target.iterdir()`。但 `close()` 只给写线程 `_ACK_TIMEOUT_SECONDS = 0.05` 的确认窗口，超时静默返回——它本来就不是落盘保证。Windows runner 磁盘一抖，目录还没建出来就 `FileNotFoundError: [WinError 3]`。

改成轮询等 `index.jsonl` 落地（上限 10s，正常路径下几毫秒返回）。**不动生产的短超时语义**：这是 opt-in 的调试功能，宁可丢证据也不卡关闭路径，为了测试把超时拉长会拖慢真实收尾。

## 变异验证

| 变异 | 期望 | 实测 |
| --- | --- | --- |
| tab-btn class 改名（正则失配） | RED | RED |
| 合规新增第 12 个凭证源 | GREEN | GREEN |
| 新增源漏 `aria-controls` | RED | RED |
| ack 超时归零 + 保留轮询 | GREEN | GREEN |
| ack 超时归零 + 撤掉轮询 | RED | RED |

最后两行确认轮询不是空转——撤掉修复确实会变红。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 改进音频证据写入测试，支持异步目录和索引文件生成，减少因写入延迟导致的测试失败。
  - 更新凭证标签页校验，适应按钮数量变化，同时确保标签切换功能及无障碍属性保持正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->