### PR TITLE
fix: retain static main in plugin panels

### DIFF
--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -590,10 +590,19 @@ onUnmounted(() => {
 })
 
 watch(
-  () => [props.pluginId, props.surface.kind, props.surface.id, props.surface.mode, props.surface.entry, props.surface.available, locale.value],
+  // Static iframe messages must be queued again only when its document is
+  // actually replaced. Locale changes leave a static iframe in place.
+  () => [props.pluginId, props.surface.mode, surfaceUrl.value],
   () => {
     staticSurfaceReady.value = false
     pendingStaticSurfaceMessages.length = 0
+  },
+)
+
+watch(
+  () => [props.pluginId, props.surface.kind, props.surface.id, props.surface.mode, props.surface.entry, props.surface.available, surfaceUrl.value, locale.value],
+  () => {
+    if (props.surface.mode === 'static') return
     loadHostedTsx()
   },
 )

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -81,6 +81,9 @@ const emit = defineEmits<{
 const { locale, t } = useI18n()
 const iframeRef = ref<HTMLIFrameElement | null>(null)
 const iframeKey = ref(0)
+const staticSurfaceReady = ref(false)
+const pendingStaticSurfaceMessages: unknown[] = []
+const maxPendingStaticSurfaceMessages = 100
 const hostedDocument = ref('')
 const loading = ref(false)
 const error = ref('')
@@ -366,13 +369,39 @@ function buildMarkdownDocument(source: string, title: string) {
 }
 
 function handleLoad() {
+  if (props.surface.mode === 'static') {
+    staticSurfaceReady.value = true
+    flushStaticSurfaceMessages()
+  }
   emit('load')
 }
 
 function handleError() {
   loading.value = false
+  staticSurfaceReady.value = false
   error.value = t('plugins.ui.loadError')
   emit('error', t('plugins.ui.loadError'))
+}
+
+function flushStaticSurfaceMessages() {
+  const target = iframeRef.value?.contentWindow
+  if (!target || !staticSurfaceReady.value) return
+  for (const message of pendingStaticSurfaceMessages.splice(0)) {
+    target.postMessage(message, trustedIframeOrigin.value)
+  }
+}
+
+function sendSurfaceMessage(message: unknown) {
+  if (props.surface.mode !== 'static') return
+  const target = iframeRef.value?.contentWindow
+  if (target && staticSurfaceReady.value) {
+    target.postMessage(message, trustedIframeOrigin.value)
+    return
+  }
+  if (pendingStaticSurfaceMessages.length >= maxPendingStaticSurfaceMessages) {
+    pendingStaticSurfaceMessages.shift()
+  }
+  pendingStaticSurfaceMessages.push(message)
 }
 
 async function loadHostedTsx() {
@@ -563,9 +592,15 @@ onUnmounted(() => {
 watch(
   () => [props.pluginId, props.surface.kind, props.surface.id, props.surface.mode, props.surface.entry, props.surface.available, locale.value],
   () => {
+    staticSurfaceReady.value = false
+    pendingStaticSurfaceMessages.length = 0
     loadHostedTsx()
   },
 )
+
+defineExpose({
+  sendSurfaceMessage,
+})
 </script>
 
 <style scoped>

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -82,10 +82,6 @@
           </div>
         </el-tab-pane>
 
-        <el-tab-pane v-if="showLegacyStaticUi" :label="$t('plugins.ui.title')" name="ui">
-          <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
-        </el-tab-pane>
-
         <el-tab-pane :label="$t('plugins.basicInfo')" name="info">
           <div class="info-section" data-yui-guide-id="plugin-detail-info">
             <el-descriptions :column="2" border>
@@ -136,9 +132,6 @@
         </el-tab-pane>
 
       </el-tabs>
-      <div v-if="needsLegacyStaticUiRelay" class="static-ui-relay" aria-hidden="true">
-        <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
-      </div>
     </el-card>
 
     <EmptyState v-else-if="!loading" :description="$t('plugins.pluginNotFound')" />
@@ -158,9 +151,7 @@ import PluginConfigEditor from '@/components/plugin/PluginConfigEditor.vue'
 import LogViewer from '@/components/logs/LogViewer.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import HostedSurfaceFrame from '@/components/plugin/HostedSurfaceFrame.vue'
-import PluginUIFrame from '@/components/plugin/PluginUIFrame.vue'
 import { getPluginUiSurfaceInfo } from '@/api/plugins'
-import { get } from '@/api'
 import { resolvePluginDisplayText, type PluginDisplayText } from '@/utils/pluginDisplay'
 import { useI18n } from 'vue-i18n'
 import type { PluginUiSurface, PluginUiWarning } from '@/types/api'
@@ -177,7 +168,6 @@ const surfaces = ref<PluginUiSurface[]>([])
 const surfaceWarnings = ref<PluginUiWarning[]>([])
 const activePanelSurfaceId = ref('')
 const activeGuideSurfaceId = ref('')
-const staticUiFrameRef = ref<InstanceType<typeof PluginUIFrame> | null>(null)
 type SurfaceMessageReceiver = {
   sendSurfaceMessage: (data: unknown) => void
 }
@@ -185,15 +175,6 @@ const panelSurfaceFrameRefs = new Map<string, SurfaceMessageReceiver>()
 const hostedSurfaceFrameHeight = 'clamp(560px, calc(100vh - 220px), 1200px)'
 const allowedTabs = new Set(['panel', 'guide', 'ui', 'info', 'entries', 'metrics', 'config', 'logs'])
 let currentSurfaceLoadId = 0
-// fetchStaticUI 也需要和 fetchSurfaces 一样的 stale-response guard：用户快速
-// 切换 plugin detail 页时，旧 plugin 的 /ui-info 响应可能在新 plugin 加载后
-// 才到达，覆盖 hasStaticUI 导致 UI tab 显示状态错位。
-let currentStaticUiLoadId = 0
-const hasStaticUI = ref(false)
-// Keep a confirmed legacy UI relay mounted while this same plugin's surfaces
-// are refreshed (for example after a locale change), but never reuse it for a
-// different plugin while its /ui-info probe is still in flight.
-const staticUiPluginId = ref('')
 
 const plugin = computed(() => {
   return pluginStore.pluginsWithStatus.find(p => p.id === pluginId.value)
@@ -228,13 +209,7 @@ const defaultPanelSurface = computed(() => {
     ?? availableDeclaredPanelSurfaces.value[0]
     ?? displayedPanelSurfaces.value[0]
 })
-const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))
 const hasDisplayablePanelSurface = computed(() => displayedPanelSurfaces.value.length > 0)
-const hasCurrentStaticUI = computed(() => hasStaticUI.value && staticUiPluginId.value === pluginId.value)
-// Preserve the legacy iframe only as a hidden message receiver when it is an
-// automatically injected compatibility surface alongside a newer declared UI.
-const needsLegacyStaticUiRelay = computed(() => hasCurrentStaticUI.value && hasStaticCompatPanel.value && availableDeclaredPanelSurfaces.value.length > 0)
-const showLegacyStaticUi = computed(() => hasCurrentStaticUI.value && !hasDisplayablePanelSurface.value)
 
 const isAdapter = computed(() => plugin.value?.type === 'adapter')
 
@@ -273,7 +248,7 @@ function resolveDefaultTab(value: unknown): string {
   if (requested === 'panel' && !hasDisplayablePanelSurface.value) return 'info'
   if (requested === 'guide' && guideSurfaces.value.length === 0) return 'info'
   if (requested === 'ui' && hasDisplayablePanelSurface.value) return 'panel'
-  if (requested === 'ui' && !showLegacyStaticUi.value) return 'info'
+  if (requested === 'ui') return 'info'
   return requested
 }
 
@@ -385,13 +360,14 @@ function relayHostedSurfaceMessageToStaticUi(data: unknown) {
   }
   // Hosted surface messages have already been source/origin checked by the
   // frame. Keep every mounted static panel current, including a `main` tab
-  // that is temporarily off-screen while a hosted surface is active.
+  // that is temporarily off-screen while a hosted surface is active. Static
+  // panels are the only legacy-UI iframe owners; do not mount a duplicate
+  // hidden relay for the same /ui/ document.
   for (const surface of displayedPanelSurfaces.value) {
     if (surface.mode === 'static') {
       panelSurfaceFrameRefs.get(surface.id)?.sendSurfaceMessage(data)
     }
   }
-  staticUiFrameRef.value?.sendSurfaceMessage(data)
 }
 
 async function fetchSurfaces(): Promise<boolean> {
@@ -402,12 +378,6 @@ async function fetchSurfaces(): Promise<boolean> {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
     surfaces.value = info.surfaces
     surfaceWarnings.value = info.warnings
-    if (hasDisplayablePanelSurface.value) {
-      // Prefer the declared panel and invalidate a possible in-flight legacy
-      // static-UI probe from the previous request. Keep an already-confirmed
-      // relay mounted for this plugin until the replacement probe completes.
-      currentStaticUiLoadId += 1
-    }
   } catch (caught: any) {
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return false
     surfaces.value = []
@@ -423,35 +393,8 @@ async function fetchSurfaces(): Promise<boolean> {
   return true
 }
 
-async function fetchStaticUI(): Promise<boolean> {
-  // The legacy /ui-info route serves static/index.html.  A modern panel may
-  // intentionally point at that same file, so probing it would only create a
-  // duplicate "界面" tab.
-  if (hasDisplayablePanelSurface.value && !hasStaticCompatPanel.value) {
-    hasStaticUI.value = false
-    staticUiPluginId.value = pluginId.value
-    return true
-  }
-  const loadId = ++currentStaticUiLoadId
-  const currentPluginId = pluginId.value
-  try {
-    const info = await get<{ has_ui: boolean }>(`/plugin/${encodeURIComponent(currentPluginId)}/ui-info`)
-    if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return false
-    hasStaticUI.value = info?.has_ui ?? false
-    staticUiPluginId.value = currentPluginId
-    return true
-  } catch {
-    if (loadId !== currentStaticUiLoadId || currentPluginId !== pluginId.value) return false
-    hasStaticUI.value = false
-    staticUiPluginId.value = currentPluginId
-    return true
-  }
-}
-
 async function refreshPluginUi(): Promise<boolean> {
-  const surfacesApplied = await fetchSurfaces()
-  if (!surfacesApplied) return false
-  return fetchStaticUI()
+  return fetchSurfaces()
 }
 
 onMounted(async () => {
@@ -495,10 +438,6 @@ watch(locale, () => {
 <style scoped>
 .plugin-detail {
   padding: 0;
-}
-
-.static-ui-relay {
-  display: none;
 }
 
 .loading-container {

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -384,12 +384,12 @@ function relayHostedSurfaceMessageToStaticUi(data: unknown) {
     return
   }
   // Hosted surface messages have already been source/origin checked by the
-  // frame. Send them to the visible static panel as well as the hidden relay:
-  // otherwise a plugin with both kinds of surface updates an off-screen copy
-  // while the legacy page the user is looking at remains stale.
-  const activeSurface = displayedPanelSurfaces.value.find((surface) => surface.id === activePanelSurfaceId.value)
-  if (activeSurface?.mode === 'static') {
-    panelSurfaceFrameRefs.get(activeSurface.id)?.sendSurfaceMessage(data)
+  // frame. Keep every mounted static panel current, including a `main` tab
+  // that is temporarily off-screen while a hosted surface is active.
+  for (const surface of displayedPanelSurfaces.value) {
+    if (surface.mode === 'static') {
+      panelSurfaceFrameRefs.get(surface.id)?.sendSurfaceMessage(data)
+    }
   }
   staticUiFrameRef.value?.sendSurfaceMessage(data)
 }

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -44,10 +44,10 @@
                 :label="surface.title || surface.id"
                 :name="surface.id"
               >
-                <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+                <HostedSurfaceFrame :ref="(instance) => setPanelSurfaceFrameRef(surface.id, instance)" :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
             </el-tabs>
-            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="displayedPanelSurfaces[0]!" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+            <HostedSurfaceFrame v-else :ref="(instance) => setPanelSurfaceFrameRef(displayedPanelSurfaces[0]?.id || '', instance)" :plugin-id="pluginId" :surface="displayedPanelSurfaces[0]!" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
           </div>
         </el-tab-pane>
 
@@ -178,6 +178,10 @@ const surfaceWarnings = ref<PluginUiWarning[]>([])
 const activePanelSurfaceId = ref('')
 const activeGuideSurfaceId = ref('')
 const staticUiFrameRef = ref<InstanceType<typeof PluginUIFrame> | null>(null)
+type SurfaceMessageReceiver = {
+  sendSurfaceMessage: (data: unknown) => void
+}
+const panelSurfaceFrameRefs = new Map<string, SurfaceMessageReceiver>()
 const hostedSurfaceFrameHeight = 'clamp(560px, calc(100vh - 220px), 1200px)'
 const allowedTabs = new Set(['panel', 'guide', 'ui', 'info', 'entries', 'metrics', 'config', 'logs'])
 let currentSurfaceLoadId = 0
@@ -216,6 +220,14 @@ const availableDeclaredPanelSurfaces = computed(() => renderablePanelSurfaces.va
 // compatibility surface. The separate legacy "界面" tab is what gets hidden
 // when panels exist; filtering main here would make that page unreachable.
 const displayedPanelSurfaces = computed(() => renderablePanelSurfaces.value)
+// A generated static `main` is inserted before declared panels by the backend.
+// Keep it accessible in the list, but let generic `?tab=panel` entry points
+// select the first declared hosted panel when one exists.
+const defaultPanelSurface = computed(() => {
+  return availableDeclaredPanelSurfaces.value.find((surface) => surface.mode === 'hosted-tsx')
+    ?? availableDeclaredPanelSurfaces.value[0]
+    ?? displayedPanelSurfaces.value[0]
+})
 const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))
 const hasDisplayablePanelSurface = computed(() => displayedPanelSurfaces.value.length > 0)
 const hasCurrentStaticUI = computed(() => hasStaticUI.value && staticUiPluginId.value === pluginId.value)
@@ -295,8 +307,8 @@ function syncSurfaceTabs() {
       activeGuideSurfaceId.value = guide.id
     }
   }
-  if (!activePanelSurfaceId.value && displayedPanelSurfaces.value[0]) {
-    activePanelSurfaceId.value = displayedPanelSurfaces.value[0].id
+  if (!activePanelSurfaceId.value && defaultPanelSurface.value) {
+    activePanelSurfaceId.value = defaultPanelSurface.value.id
   }
   if (!activeGuideSurfaceId.value && guideSurfaces.value[0]) {
     activeGuideSurfaceId.value = guideSurfaces.value[0].id
@@ -356,14 +368,29 @@ function isLegacyOpenSurfaceMessage(data: unknown): data is {
     && (!payload.kind || typeof payload.kind === 'string')
 }
 
+function setPanelSurfaceFrameRef(surfaceId: string, instance: unknown) {
+  if (!surfaceId) return
+  const receiver = instance as SurfaceMessageReceiver | null
+  if (receiver && typeof receiver.sendSurfaceMessage === 'function') {
+    panelSurfaceFrameRefs.set(surfaceId, receiver)
+  } else {
+    panelSurfaceFrameRefs.delete(surfaceId)
+  }
+}
+
 function relayHostedSurfaceMessageToStaticUi(data: unknown) {
   if (isLegacyOpenSurfaceMessage(data)) {
     openHostedSurfaceFromStaticUi(data.payload)
     return
   }
   // Hosted surface messages have already been source/origin checked by the
-  // frame. Forward them unchanged so legacy static UIs from any plugin can
-  // opt into their own message contract without host-side plugin allowlists.
+  // frame. Send them to the visible static panel as well as the hidden relay:
+  // otherwise a plugin with both kinds of surface updates an off-screen copy
+  // while the legacy page the user is looking at remains stale.
+  const activeSurface = displayedPanelSurfaces.value.find((surface) => surface.id === activePanelSurfaceId.value)
+  if (activeSurface?.mode === 'static') {
+    panelSurfaceFrameRefs.get(activeSurface.id)?.sendSurfaceMessage(data)
+  }
   staticUiFrameRef.value?.sendSurfaceMessage(data)
 }
 

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -212,19 +212,10 @@ const availablePanelSurfaces = computed(() => panelSurfaces.value.filter((surfac
 // let its placeholder hide a working legacy static UI.
 const renderablePanelSurfaces = computed(() => availablePanelSurfaces.value.filter((surface) => surface.mode !== 'auto'))
 const availableDeclaredPanelSurfaces = computed(() => renderablePanelSurfaces.value.filter((surface) => !surface.legacy_static_compat))
-const availableHostedPanelSurfaces = computed(() => availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode === 'hosted-tsx'))
-// Prefer usable hosted TSX panels without hiding other declared panels. Only
-// fall back to a host-generated compatibility panel when the plugin did not
-// declare any usable panel of its own.
-const displayedPanelSurfaces = computed(() => {
-  if (availableDeclaredPanelSurfaces.value.length > 0) {
-    return [
-      ...availableHostedPanelSurfaces.value,
-      ...availableDeclaredPanelSurfaces.value.filter((surface) => surface.mode !== 'hosted-tsx'),
-    ]
-  }
-  return renderablePanelSurfaces.value
-})
+// Keep every renderable panel, including the host-generated static `main`
+// compatibility surface. The separate legacy "界面" tab is what gets hidden
+// when panels exist; filtering main here would make that page unreachable.
+const displayedPanelSurfaces = computed(() => renderablePanelSurfaces.value)
 const hasStaticCompatPanel = computed(() => panelSurfaces.value.some((surface) => surface.legacy_static_compat))
 const hasDisplayablePanelSurface = computed(() => displayedPanelSurfaces.value.length > 0)
 const hasCurrentStaticUI = computed(() => hasStaticUI.value && staticUiPluginId.value === pluginId.value)

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5261,9 +5261,12 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
     assert "studySurfaceRelayMessageTypes" not in plugin_detail
     assert "staticUiFrameRef.value?.sendSurfaceMessage(data)" in plugin_detail
+    assert "panelSurfaceFrameRefs.get(activeSurface.id)?.sendSurfaceMessage(data)" in plugin_detail
     assert "const staticUiPluginId = ref('')" in plugin_detail
     assert "const hasCurrentStaticUI = computed" in plugin_detail
     assert "const displayedPanelSurfaces = computed(() => renderablePanelSurfaces.value)" in plugin_detail
+    assert "const defaultPanelSurface = computed(() =>" in plugin_detail
+    assert "availableDeclaredPanelSurfaces.value.find((surface) => surface.mode === 'hosted-tsx')" in plugin_detail
     assert "const preferGuide = payload.kind === 'guide' || payload.kind === 'docs'" in plugin_detail
     assert "activeGuideSurfaceId.value = guide.id" in plugin_detail
     assert "surface: activeSurfaceId" in plugin_detail

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5261,7 +5261,7 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
     assert "studySurfaceRelayMessageTypes" not in plugin_detail
     assert "staticUiFrameRef.value?.sendSurfaceMessage(data)" in plugin_detail
-    assert "panelSurfaceFrameRefs.get(activeSurface.id)?.sendSurfaceMessage(data)" in plugin_detail
+    assert "panelSurfaceFrameRefs.get(surface.id)?.sendSurfaceMessage(data)" in plugin_detail
     assert "const staticUiPluginId = ref('')" in plugin_detail
     assert "const hasCurrentStaticUI = computed" in plugin_detail
     assert "const displayedPanelSurfaces = computed(() => renderablePanelSurfaces.value)" in plugin_detail

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5257,13 +5257,11 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert "flushSurfaceMessages()" in plugin_ui_frame
     assert "iframeGeneration" in plugin_ui_frame
     assert "isCurrentIframeEvent" in plugin_ui_frame
-    assert '@open-surface="openHostedSurfaceFromStaticUi"' in plugin_detail
     assert '@message="relayHostedSurfaceMessageToStaticUi"' in plugin_detail
     assert "studySurfaceRelayMessageTypes" not in plugin_detail
-    assert "staticUiFrameRef.value?.sendSurfaceMessage(data)" in plugin_detail
     assert "panelSurfaceFrameRefs.get(surface.id)?.sendSurfaceMessage(data)" in plugin_detail
-    assert "const staticUiPluginId = ref('')" in plugin_detail
-    assert "const hasCurrentStaticUI = computed" in plugin_detail
+    assert "PluginUIFrame" not in plugin_detail
+    assert "needsLegacyStaticUiRelay" not in plugin_detail
     assert "const displayedPanelSurfaces = computed(() => renderablePanelSurfaces.value)" in plugin_detail
     assert "const defaultPanelSurface = computed(() =>" in plugin_detail
     assert "availableDeclaredPanelSurfaces.value.find((surface) => surface.mode === 'hosted-tsx')" in plugin_detail

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -5263,6 +5263,7 @@ def test_study_companion_ui_refactor_static_and_hosted_contracts() -> None:
     assert "staticUiFrameRef.value?.sendSurfaceMessage(data)" in plugin_detail
     assert "const staticUiPluginId = ref('')" in plugin_detail
     assert "const hasCurrentStaticUI = computed" in plugin_detail
+    assert "const displayedPanelSurfaces = computed(() => renderablePanelSurfaces.value)" in plugin_detail
     assert "const preferGuide = payload.kind === 'guide' || payload.kind === 'docs'" in plugin_detail
     assert "activeGuideSurfaceId.value = guide.id" in plugin_detail
     assert "surface: activeSurfaceId" in plugin_detail


### PR DESCRIPTION
## 改动概述 / Summary

- 保留后端为旧式 `ui` 生成的静态兼容 `main` 面板，不再在插件同时声明 Hosted TSX 面板时将其过滤掉。
- 插件仍然在存在面板时隐藏独立的旧版“界面”标签；旧插件无需修改即可从“面板”的 `main` 条目访问原有页面。
- 增加 study_companion 的契约回归断言，防止兼容 `main` 再次丢失。

## 回归报告 / Regression Report

不适用：未修改 app/、main_logic/ 或 memory 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：仅修改 2 个文件。

## 测试 / Testing

- `.venv\\Scripts\\python.exe -m pytest plugin/tests/unit/plugins/test_study_companion.py::test_study_companion_ui_refactor_static_and_hosted_contracts plugin/tests/unit/server/test_plugin_ui_manifest.py -q --basetemp D:\\xxynet\\N.E.K.O\\.pytest-run-codex`
- `npm run type-check`（`frontend/plugin-manager`）
- `npm run build-only`（`frontend/plugin-manager`）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化插件详情页面板展示，兼容静态面板与托管面板。
  * 优先选择已声明的托管面板，并完善单面板模式下的默认面板选择。
  * 静态面板消息现会转发至所有可见面板。
  * 静态面板加载完成前会暂存待发送消息；加载失败或内容切换时自动清理。
  * 切换语言时不再重置静态面板或重新加载托管内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->