### PR TITLE
fix(topic): 深话题 analyzer 失败退避 + 富化失败原因可见化（不泄漏对话原文）

### DIFF
--- a/main_logic/activity/llm_enrichment.py
+++ b/main_logic/activity/llm_enrichment.py
@@ -60,7 +60,14 @@ from config.prompts.prompts_activity import (
 from utils.file_utils import robust_json_loads
 from utils.tokenize import truncate_to_tokens
 
-logger = logging.getLogger(__name__)
+# Named into the Main service tree, not __name__. setup_logging(service_name=
+# "Main") installs handlers on "N.E.K.O.Main" with propagate=False, and nothing
+# is installed on root — so a `main_logic.*` logger reaches no handler at all
+# and its records fall through to logging.lastResort (bare text on stderr,
+# WARNING and above, never the log file). The sibling main_logic/topic modules
+# already name themselves this way; this module did not, which is why its
+# failure reasons were invisible even before they were only at debug level.
+logger = logging.getLogger("N.E.K.O.Main.activity.llm_enrichment")
 
 
 # Input cap: the emotion tier is small and cheap, but we still don't

--- a/main_logic/activity/llm_enrichment.py
+++ b/main_logic/activity/llm_enrichment.py
@@ -47,6 +47,7 @@ import asyncio
 import json
 import logging
 import re
+import threading
 import time
 from typing import Any
 
@@ -88,6 +89,63 @@ _SCORED_STATES: tuple[str, ...] = (
 
 # Prompt templates moved to config/prompts/prompts_activity.py per the project's
 # i18n convention (multi-language str→str dicts must live in config/prompts/prompts_*).
+
+
+# ── Failure reporting ───────────────────────────────────────────────
+#
+# Enrichment failures used to land on logger.debug, so a permanently
+# misconfigured tier showed up only as the caller's "no result" symptom with
+# no visible cause. Reporting them costs two constraints:
+#
+#   1. No conversation text, ever. Both the prompt and the model's reply are
+#      built from the user's own turns, so neither may reach a log line.
+#      Reports carry a fixed reason slug plus, at most, an exception class
+#      name and an HTTP status code.
+#   2. Throttle per (label, reason). These calls hang off 20s / 40s
+#      heartbeats — logging every failure would just move the flood from
+#      INFO to WARNING. One line per window, and the next line to get
+#      through says how many were suppressed behind it.
+_FAILURE_LOG_INTERVAL_SECONDS = 300.0
+# {(label, reason): [last_emitted_monotonic, suppressed_since]}
+_failure_log_state: dict[tuple[str, str], list[float]] = {}
+_failure_log_lock = threading.Lock()
+
+
+def _failure_detail(exc: BaseException) -> str:
+    """Exception class name plus HTTP status when present — never its message.
+
+    Provider exception messages routinely echo back a slice of the request
+    body, which here is the conversation itself.
+    """
+    status = getattr(exc, 'status_code', None)
+    if status is None:
+        status = getattr(getattr(exc, 'response', None), 'status_code', None)
+    if isinstance(status, int):
+        return f'{type(exc).__name__} HTTP {status}'
+    return type(exc).__name__
+
+
+def _report_failure(label: str, reason: str, detail: str = '') -> None:
+    """Log one enrichment failure, throttled per (label, reason)."""
+    key = (label, reason)
+    now = time.monotonic()
+    with _failure_log_lock:
+        state = _failure_log_state.get(key)
+        if state is not None and now - state[0] < _FAILURE_LOG_INTERVAL_SECONDS:
+            state[1] += 1
+            return
+        suppressed = int(state[1]) if state is not None else 0
+        _failure_log_state[key] = [now, 0]
+    logger.warning(
+        'enrichment %s failed: %s%s%s',
+        label,
+        reason,
+        f' ({detail})' if detail else '',
+        (
+            f'; {suppressed} more suppressed in the last '
+            f'{int(_FAILURE_LOG_INTERVAL_SECONDS)}s'
+        ) if suppressed else '',
+    )
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
@@ -234,13 +292,13 @@ async def call_activity_guess(
 
     parsed = _safe_parse_json(raw)
     if not isinstance(parsed, dict):
-        logger.debug('activity_guess: LLM did not return a JSON object: %r', raw[:200])
+        _report_failure('activity_guess', 'reply_not_json_object')
         return None
 
     raw_scores = parsed.get('scores')
     guess = parsed.get('guess', '') or ''
     if not isinstance(raw_scores, dict) or not isinstance(guess, str):
-        logger.debug('activity_guess: malformed JSON shape: %r', parsed)
+        _report_failure('activity_guess', 'reply_shape_unexpected')
         return None
 
     # Sanitise: keep only allowed state keys and clamp to [0, 1].
@@ -284,11 +342,12 @@ async def call_open_threads(
 
     parsed = _safe_parse_json(raw)
     if not isinstance(parsed, dict):
-        logger.debug('open_threads: LLM did not return a JSON object: %r', raw[:200])
+        _report_failure('open_threads', 'reply_not_json_object')
         return None
 
     threads = parsed.get('open_threads')
     if not isinstance(threads, list):
+        _report_failure('open_threads', 'reply_missing_open_threads')
         return None
     cleaned: list[str] = []
     for entry in threads[:5]:
@@ -325,11 +384,12 @@ async def call_topic_candidates(
 
     parsed = _safe_parse_json(raw)
     if not isinstance(parsed, dict):
-        logger.debug('topic_candidates: LLM did not return a JSON object: %r', raw[:200])
+        _report_failure('topic_candidates', 'reply_not_json_object')
         return None
 
     topics = parsed.get('topics')
     if not isinstance(topics, list):
+        _report_failure('topic_candidates', 'reply_missing_topics')
         return None
 
     cleaned: list[dict[str, Any]] = []
@@ -396,13 +456,13 @@ async def _invoke_emotion_tier(prompt: str, *, timeout: float, label: str) -> st
         cfg_mgr = get_config_manager()
         cfg = await cfg_mgr.aget_model_api_config('emotion')
     except Exception as e:
-        logger.debug('emotion config fetch failed: %s', e)
+        _report_failure(label, 'emotion_config_unavailable', _failure_detail(e))
         return None
     model = cfg.get('model')
     api_key = cfg.get('api_key')
     base_url = cfg.get('base_url')
     if not model or not api_key:
-        logger.debug('emotion tier model/api_key missing — enrichment disabled')
+        _report_failure(label, 'emotion_model_or_api_key_missing')
         return None
 
     set_call_type('activity_enrichment')
@@ -415,7 +475,7 @@ async def _invoke_emotion_tier(prompt: str, *, timeout: float, label: str) -> st
             provider_type=cfg.get('provider_type'),
         )
     except Exception as e:
-        logger.debug('emotion-tier llm init failed: %s', e)
+        _report_failure(label, 'emotion_llm_init_failed', _failure_detail(e))
         return None
 
     try:
@@ -426,10 +486,10 @@ async def _invoke_emotion_tier(prompt: str, *, timeout: float, label: str) -> st
             )
         return getattr(resp, 'content', '') or ''
     except asyncio.TimeoutError:
-        logger.debug('emotion-tier %s call timed out (%ss)', label, timeout)
+        _report_failure(label, 'emotion_call_timed_out', f'{timeout}s')
         return None
     except Exception as e:
-        logger.debug('emotion-tier %s call failed: %s', label, e)
+        _report_failure(label, 'emotion_call_failed', _failure_detail(e))
         return None
 
 
@@ -449,13 +509,13 @@ async def _invoke_capable_tier(prompt: str, *, timeout: float, label: str) -> st
         cfg_mgr = get_config_manager()
         cfg = await cfg_mgr.aget_model_api_config('summary')
     except Exception as e:
-        logger.debug('summary config fetch failed: %s', e)
+        _report_failure(label, 'summary_config_unavailable', _failure_detail(e))
         return None
     model = cfg.get('model')
     api_key = cfg.get('api_key')
     base_url = cfg.get('base_url')
     if not model or not api_key:
-        logger.debug('summary tier model/api_key missing — deep search disabled')
+        _report_failure(label, 'summary_model_or_api_key_missing')
         return None
 
     set_call_type('topic_deep_search')
@@ -468,7 +528,7 @@ async def _invoke_capable_tier(prompt: str, *, timeout: float, label: str) -> st
             provider_type=cfg.get('provider_type'),
         )
     except Exception as e:
-        logger.debug('summary-tier llm init failed: %s', e)
+        _report_failure(label, 'summary_llm_init_failed', _failure_detail(e))
         return None
 
     try:
@@ -479,10 +539,10 @@ async def _invoke_capable_tier(prompt: str, *, timeout: float, label: str) -> st
             )
         return getattr(resp, 'content', '') or ''
     except asyncio.TimeoutError:
-        logger.debug('summary-tier %s call timed out (%ss)', label, timeout)
+        _report_failure(label, 'summary_call_timed_out', f'{timeout}s')
         return None
     except Exception as e:
-        logger.debug('summary-tier %s call failed: %s', label, e)
+        _report_failure(label, 'summary_call_failed', _failure_detail(e))
         return None
 
 

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -333,7 +333,26 @@ class TopicHookPool:
             _ANALYZER_RETRY_CAP_SECONDS,
         )
 
-    def _note_analyzer_failure(self, name: str, now: float, *, reason: str) -> None:
+    def _note_analyzer_failure(
+        self,
+        name: str,
+        now: float,
+        *,
+        reason: str,
+        seen_purge_generation: int | None = None,
+    ) -> None:
+        if (
+            seen_purge_generation is not None
+            and self._purge_generation.get(name, 0) != seen_purge_generation
+        ):
+            # An explicit purge landed while this call was in flight. The state
+            # it failed against is gone, so arming a retry window now would
+            # re-impose the old backoff on evidence the purge just cleared —
+            # the same reason the success path drops a stale result.
+            logger.debug(
+                "[%s] topic analyzer failure discarded: purged mid-flight", name
+            )
+            return
         self._analyzer_failures[name] += 1
         failures = self._analyzer_failures[name]
         delay = self._analyzer_retry_delay(failures)
@@ -369,6 +388,12 @@ class TopicHookPool:
         had_dirty = name in self._dirty
         changed = self._signal_store.clear(name)
         self._dirty.discard(name)
+        # Same reset as _purge_character_state: an explicit purge is a user
+        # action, and leaving a 30min retry window armed behind it would stall
+        # analysis of whatever they say next with nothing on screen to explain
+        # it. The cost of clearing is one more failing call, which re-arms the
+        # backoff immediately.
+        self._clear_analyzer_failures(name)
         if changed or had_dirty:
             self._purge_generation[name] += 1
         if changed and flush:
@@ -542,6 +567,13 @@ class TopicHookPool:
         signal_cutoff_at = self._signal_store.last_turn_at(name)
         global_signals = self._signal_store.format_global_signals(name, lang=topic_lang)
         current_time = time.time() if now is None else float(now)
+        # The retry window has to start when the call FAILED, not when the tick
+        # began: a slow failure (config read + client construction + the 8s
+        # call timeout) would otherwise be subtracted from every delay, and a
+        # failure slower than the delay itself would land already-expired.
+        # `current_time` may also be the tracker's heartbeat stamp, taken
+        # earlier still, so measure the call with a monotonic clock and add it.
+        started_at = time.monotonic()
         try:
             raw_materials = await self._analyzer(
                 lang=topic_lang,
@@ -555,10 +587,20 @@ class TopicHookPool:
             # the 20s hot loop this backoff exists to prevent. Report the
             # exception type only — its message can carry the prompt, i.e. the
             # conversation itself.
-            self._note_analyzer_failure(name, current_time, reason=type(exc).__name__)
+            self._note_analyzer_failure(
+                name,
+                current_time + (time.monotonic() - started_at),
+                reason=type(exc).__name__,
+                seen_purge_generation=seen_purge_generation,
+            )
             return
         if raw_materials is None:
-            self._note_analyzer_failure(name, current_time, reason="no result")
+            self._note_analyzer_failure(
+                name,
+                current_time + (time.monotonic() - started_at),
+                reason="no result",
+                seen_purge_generation=seen_purge_generation,
+            )
             return
         self._clear_analyzer_failures(name)
         if (

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -333,12 +333,19 @@ class TopicHookPool:
             _ANALYZER_RETRY_CAP_SECONDS,
         )
 
-    def _note_analyzer_failure(self, name: str, now: float) -> tuple[int, float]:
+    def _note_analyzer_failure(self, name: str, now: float, *, reason: str) -> None:
         self._analyzer_failures[name] += 1
         failures = self._analyzer_failures[name]
         delay = self._analyzer_retry_delay(failures)
         self._analyzer_retry_not_before[name] = now + delay
-        return failures, delay
+        logger.info(
+            "[%s] topic analyzer failed (%s, consecutive failures: %d); "
+            "keeping dirty, next attempt in %ds",
+            name,
+            reason,
+            failures,
+            int(delay),
+        )
 
     def _clear_analyzer_failures(self, name: str) -> None:
         self._analyzer_failures.pop(name, None)
@@ -534,22 +541,24 @@ class TopicHookPool:
         )
         signal_cutoff_at = self._signal_store.last_turn_at(name)
         global_signals = self._signal_store.format_global_signals(name, lang=topic_lang)
-        raw_materials = await self._analyzer(
-            lang=topic_lang,
-            global_signals=global_signals,
-        )
+        current_time = time.time() if now is None else float(now)
+        try:
+            raw_materials = await self._analyzer(
+                lang=topic_lang,
+                global_signals=global_signals,
+            )
+        except Exception as exc:
+            # An analyzer that raises is an analyzer that failed, and it has to
+            # arm the same backoff as one that returns None. Letting the
+            # exception reach process_ready_topics instead only logs it: the
+            # character stays dirty with no retry window set, which is exactly
+            # the 20s hot loop this backoff exists to prevent. Report the
+            # exception type only — its message can carry the prompt, i.e. the
+            # conversation itself.
+            self._note_analyzer_failure(name, current_time, reason=type(exc).__name__)
+            return
         if raw_materials is None:
-            failures, delay = self._note_analyzer_failure(
-                name,
-                time.time() if now is None else float(now),
-            )
-            logger.info(
-                "[%s] topic analyzer returned no result (consecutive failures: %d); "
-                "keeping dirty, next attempt in %ds",
-                name,
-                failures,
-                int(delay),
-            )
+            self._note_analyzer_failure(name, current_time, reason="no result")
             return
         self._clear_analyzer_failures(name)
         if (

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -454,13 +454,29 @@ class TopicHookPool:
 
     def purge_all_accumulated_signals(self) -> None:
         """Drop accumulated candidate evidence for every known character."""
-        names = set(self._signal_store.names()) | set(self._dirty)
+        # A character can hold backoff state and nothing else: the readiness
+        # path drops it from _dirty, and its evidence can later age out of the
+        # store, leaving it in neither set. A global purge that skipped it
+        # would leave a retry window armed with no way to reach it again.
+        names = (
+            set(self._signal_store.names())
+            | set(self._dirty)
+            | set(self._analyzer_retry_not_before)
+        )
         for name in names:
             self._purge_accumulated_signals(name)
 
     async def purge_all_accumulated_signals_async(self) -> None:
         """Async hook for explicit cleanup across every known character."""
-        names = set(self._signal_store.names()) | set(self._dirty)
+        # A character can hold backoff state and nothing else: the readiness
+        # path drops it from _dirty, and its evidence can later age out of the
+        # store, leaving it in neither set. A global purge that skipped it
+        # would leave a retry window armed with no way to reach it again.
+        names = (
+            set(self._signal_store.names())
+            | set(self._dirty)
+            | set(self._analyzer_retry_not_before)
+        )
         should_flush = False
         for name in names:
             should_flush = self._purge_accumulated_signals(name, flush=False) or should_flush

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -613,6 +613,14 @@ class TopicHookPool:
                 self._signal_store.readiness_percent(name),
             )
             self._dirty.discard(name)
+            # Dropping out of _dirty here also drops the character out of the
+            # process_ready_topics walk, which is where the aged-out branch
+            # clears this state. Without clearing it now, a character that
+            # falls below the threshold and only later loses its remaining
+            # signals is never revisited, and a corpus accumulated afterwards
+            # inherits the old count. Analysis has stopped for this character
+            # either way, so the streak ends with it.
+            self._clear_analyzer_failures(name)
             return
         stored_lang = self._langs.get(name)
         topic_lang = (

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -675,11 +675,17 @@ class TopicHookPool:
                 seen_purge_generation=seen_purge_generation,
             )
             return
-        self._clear_analyzer_failures(name)
-        if (
-            self._seq.get(name, 0) != seen_seq
-            or self._purge_generation.get(name, 0) != seen_purge_generation
-        ):
+        purged = self._purge_generation.get(name, 0) != seen_purge_generation
+        if not purged:
+            # A success proves the analyzer is healthy, so the streak ends even
+            # when a new turn arrived mid-flight and the result itself is stale.
+            # A purge is different: it reset this state, and a replacement call
+            # may already have failed and armed a fresh window behind us —
+            # clearing it here would hand the next tick a free extra request.
+            # This is the mirror of the seen_purge_generation guard on the
+            # failure path.
+            self._clear_analyzer_failures(name)
+        if purged or self._seq.get(name, 0) != seen_seq:
             return
         cleaned = [
             material

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -51,7 +51,14 @@ _CANDIDATE_MATURE_SECONDS = 60.0
 # misconfiguration turns into a billable hot loop. Back off exponentially
 # instead, and reset the moment the analyzer answers at all (an empty result is
 # an answer: it takes the discard path, not this one).
-_ANALYZER_RETRY_BASE_SECONDS = 60.0
+#
+# The base matches the heartbeat period on purpose: the first retry is NOT
+# delayed, it is the very next tick. That first step is a free immediate retry
+# for a blip (one timeout, one 5xx), not a backoff — the backoff starts from
+# the second failure. Total cost over a long outage is set by the cap, not by
+# this value: 20s and 60s bases both land within a couple of calls of each
+# other across 12h, so the cheaper-to-recover one wins.
+_ANALYZER_RETRY_BASE_SECONDS = 20.0
 _ANALYZER_RETRY_CAP_SECONDS = 30 * 60.0
 # Clamps the doubling itself, so a long-lived failure can't overflow the shift.
 _ANALYZER_RETRY_MAX_DOUBLINGS = 10

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -44,6 +44,17 @@ _MAX_TEXT_TOKENS = 1000
 _TOKEN_PRECAP_CHARS_PER_TOKEN = 8
 _TRIGGER_RETRY_DELAY_SECONDS = 60.0
 _CANDIDATE_MATURE_SECONDS = 60.0
+# An analyzer failure (tier down, bad key, timeout, unparseable reply) keeps the
+# character dirty so a transient blip still gets retried. Without a backoff that
+# retry rides the 20s activity heartbeat indefinitely — thousands of LLM calls
+# before the 12h signal retention finally starves it, which is how a permanent
+# misconfiguration turns into a billable hot loop. Back off exponentially
+# instead, and reset the moment the analyzer answers at all (an empty result is
+# an answer: it takes the discard path, not this one).
+_ANALYZER_RETRY_BASE_SECONDS = 60.0
+_ANALYZER_RETRY_CAP_SECONDS = 30 * 60.0
+# Clamps the doubling itself, so a long-lived failure can't overflow the shift.
+_ANALYZER_RETRY_MAX_DOUBLINGS = 10
 _MIN_TOPIC_TRIGGER_GAP_SECONDS = 4 * 60 * 60
 _MAX_DAILY_TOPIC_TRIGGERS = 2
 _USED_TOPIC_RECENT_SECONDS = 48 * 60 * 60
@@ -310,6 +321,28 @@ class TopicHookPool:
         self._dirty: set[str] = set(self._signal_store.names())
         self._seq: dict[str, int] = defaultdict(int)
         self._purge_generation: dict[str, int] = defaultdict(int)
+        # Consecutive analyzer failures per character, and the wall-clock
+        # instant before which the next attempt is pointless.
+        self._analyzer_failures: dict[str, int] = defaultdict(int)
+        self._analyzer_retry_not_before: dict[str, float] = {}
+
+    def _analyzer_retry_delay(self, failures: int) -> float:
+        doublings = min(max(0, failures - 1), _ANALYZER_RETRY_MAX_DOUBLINGS)
+        return min(
+            _ANALYZER_RETRY_BASE_SECONDS * (2 ** doublings),
+            _ANALYZER_RETRY_CAP_SECONDS,
+        )
+
+    def _note_analyzer_failure(self, name: str, now: float) -> tuple[int, float]:
+        self._analyzer_failures[name] += 1
+        failures = self._analyzer_failures[name]
+        delay = self._analyzer_retry_delay(failures)
+        self._analyzer_retry_not_before[name] = now + delay
+        return failures, delay
+
+    def _clear_analyzer_failures(self, name: str) -> None:
+        self._analyzer_failures.pop(name, None)
+        self._analyzer_retry_not_before.pop(name, None)
 
     def _purge_character_state(self, name: str) -> None:
         """Drop all topic state for a character."""
@@ -317,6 +350,7 @@ class TopicHookPool:
         self._signal_store.clear(name)
         self._materials.pop(name, None)
         self._dirty.discard(name)
+        self._clear_analyzer_failures(name)
         self._awaiting_response.pop(name, None)
         with self._used_topics_lock:
             self._used_topics.pop(name, None)
@@ -476,6 +510,7 @@ class TopicHookPool:
         lanlan_name: str,
         *,
         lang: str | None = None,
+        now: float | None = None,
     ) -> None:
         name = str(lanlan_name or "default")
         seen_seq = self._seq.get(name, 0)
@@ -504,8 +539,19 @@ class TopicHookPool:
             global_signals=global_signals,
         )
         if raw_materials is None:
-            logger.info("[%s] topic analyzer returned no result; keeping dirty for retry", name)
+            failures, delay = self._note_analyzer_failure(
+                name,
+                time.time() if now is None else float(now),
+            )
+            logger.info(
+                "[%s] topic analyzer returned no result (consecutive failures: %d); "
+                "keeping dirty, next attempt in %ds",
+                name,
+                failures,
+                int(delay),
+            )
             return
+        self._clear_analyzer_failures(name)
         if (
             self._seq.get(name, 0) != seen_seq
             or self._purge_generation.get(name, 0) != seen_purge_generation
@@ -571,8 +617,11 @@ class TopicHookPool:
             current_time = time.time() if now is None else float(now)
             if current_time - float(last_turn_at) < _CANDIDATE_MATURE_SECONDS:
                 continue
+            retry_not_before = self._analyzer_retry_not_before.get(name)
+            if retry_not_before is not None and current_time < retry_not_before:
+                continue
             try:
-                await self.process_now(name, lang=lang)
+                await self.process_now(name, lang=lang, now=current_time)
             except Exception as exc:
                 logger.warning("[%s] topic background processing failed: %s", name, exc)
 

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -345,6 +345,7 @@ class TopicHookPool:
         name: str,
         now: float,
         *,
+        elapsed: float,
         reason: str,
         seen_purge_generation: int | None = None,
     ) -> None:
@@ -363,7 +364,15 @@ class TopicHookPool:
         self._analyzer_failures[name] += 1
         failures = self._analyzer_failures[name]
         delay = self._analyzer_retry_delay(failures)
-        self._analyzer_retry_not_before[name] = now + delay
+        # The first step is not a backoff — it is the free immediate retry the
+        # base is sized for, so it anchors at the tick stamp and lands on the
+        # very next heartbeat. Adding the call's runtime here would push a
+        # normal 8s timeout past that tick and delay recovery to the one after.
+        # From the second consecutive failure on it IS a backoff, so it anchors
+        # at completion instead: otherwise the runtime and a stale tick stamp
+        # get subtracted out of every window.
+        anchor = now if failures == 1 else now + elapsed
+        self._analyzer_retry_not_before[name] = anchor + delay
         logger.info(
             "[%s] topic analyzer failed (%s, consecutive failures: %d); "
             "keeping dirty, next attempt in %ds",
@@ -609,6 +618,14 @@ class TopicHookPool:
                 lang=topic_lang,
                 global_signals=global_signals,
             )
+            if raw_materials is not None:
+                # The Analyzer contract allows any Iterable, and a lazy one
+                # raises when it is consumed, not when it is awaited. Drain it
+                # here so an iteration failure lands in the same handler as a
+                # call failure — left to the comprehension below it would
+                # escape to process_ready_topics, which merely logs, and by
+                # then the failure state has already been cleared.
+                raw_materials = list(raw_materials)
         except Exception as exc:
             # An analyzer that raises is an analyzer that failed, and it has to
             # arm the same backoff as one that returns None. Letting the
@@ -619,7 +636,8 @@ class TopicHookPool:
             # conversation itself.
             self._note_analyzer_failure(
                 name,
-                current_time + self._elapsed_since_tick(current_time, started_at),
+                current_time,
+                elapsed=self._elapsed_since_tick(current_time, started_at),
                 reason=type(exc).__name__,
                 seen_purge_generation=seen_purge_generation,
             )
@@ -627,7 +645,8 @@ class TopicHookPool:
         if raw_materials is None:
             self._note_analyzer_failure(
                 name,
-                current_time + self._elapsed_since_tick(current_time, started_at),
+                current_time,
+                elapsed=self._elapsed_since_tick(current_time, started_at),
                 reason="no result",
                 seen_purge_generation=seen_purge_generation,
             )

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -366,6 +366,30 @@ class TopicHookPool:
             int(delay),
         )
 
+    @staticmethod
+    def _elapsed_since_tick(current_time: float, started_at: float) -> float:
+        """How long ago the failure's tick stamp was taken, in seconds.
+
+        Two independent sources, and the deadline has to clear both:
+
+        * the analyzer's own runtime — config read, client construction, the
+          8s call timeout — measured on a monotonic clock;
+        * however long the caller's tick had already been running before it
+          handed over ``now``. The activity heartbeat stamps ``ts`` and then
+          awaits a WebSocket drain before reaching the topic pool, so a
+          backpressured send makes that stamp arrive seconds stale. That gap
+          is measurable precisely because ``now`` lives in the same wall-clock
+          domain as ``time.time()``.
+
+        An injected future ``now`` (tests, replayed ticks) makes the wall-clock
+        term negative; the floor keeps the window deterministic there.
+        """
+        return max(
+            time.monotonic() - started_at,
+            time.time() - current_time,
+            0.0,
+        )
+
     def _clear_analyzer_failures(self, name: str) -> None:
         self._analyzer_failures.pop(name, None)
         self._analyzer_retry_not_before.pop(name, None)
@@ -568,11 +592,10 @@ class TopicHookPool:
         global_signals = self._signal_store.format_global_signals(name, lang=topic_lang)
         current_time = time.time() if now is None else float(now)
         # The retry window has to start when the call FAILED, not when the tick
-        # began: a slow failure (config read + client construction + the 8s
-        # call timeout) would otherwise be subtracted from every delay, and a
-        # failure slower than the delay itself would land already-expired.
-        # `current_time` may also be the tracker's heartbeat stamp, taken
-        # earlier still, so measure the call with a monotonic clock and add it.
+        # began — otherwise every delay silently loses that gap, and a gap
+        # wider than the delay itself lands the deadline already expired,
+        # which puts the heartbeat straight back into the hot loop this
+        # backoff exists to stop. See _elapsed_since_tick for the two sources.
         started_at = time.monotonic()
         try:
             raw_materials = await self._analyzer(
@@ -589,7 +612,7 @@ class TopicHookPool:
             # conversation itself.
             self._note_analyzer_failure(
                 name,
-                current_time + (time.monotonic() - started_at),
+                current_time + self._elapsed_since_tick(current_time, started_at),
                 reason=type(exc).__name__,
                 seen_purge_generation=seen_purge_generation,
             )
@@ -597,7 +620,7 @@ class TopicHookPool:
         if raw_materials is None:
             self._note_analyzer_failure(
                 name,
-                current_time + (time.monotonic() - started_at),
+                current_time + self._elapsed_since_tick(current_time, started_at),
                 reason="no result",
                 seen_purge_generation=seen_purge_generation,
             )

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -713,6 +713,14 @@ class TopicHookPool:
             last_turn_at = self._signal_store.last_turn_at(name)
             if last_turn_at is None:
                 self._dirty.discard(name)
+                # Every signal aged out of the 12h retention window, so this
+                # character is back to its initial state. The failure count has
+                # to go with it: a corpus accumulated later starts a new
+                # sequence, and carrying a count across that gap would spend
+                # its first blip at whatever cap the old outage had reached
+                # instead of on the free immediate retry. A failure streak that
+                # matters is one where evidence is still arriving.
+                self._clear_analyzer_failures(name)
                 continue
             current_time = time.time() if now is None else float(now)
             if current_time - float(last_turn_at) < _CANDIDATE_MATURE_SECONDS:

--- a/tests/unit/test_topic_llm_enrichment.py
+++ b/tests/unit/test_topic_llm_enrichment.py
@@ -383,7 +383,11 @@ def _capture_enrichment_logs():
     """
     from main_logic.activity import llm_enrichment
 
-    log = logging.getLogger(llm_enrichment.__name__)
+    # The module's own logger object, not getLogger(__name__): the module is
+    # deliberately named into the "N.E.K.O.Main" tree so its records reach the
+    # service handlers, and looking it up by module path would silently attach
+    # to a different, handler-less logger.
+    log = llm_enrichment.logger
     sink = _WarningSink()
     prior_level, prior_propagate = log.level, log.propagate
     llm_enrichment._failure_log_state.clear()
@@ -504,3 +508,38 @@ async def test_enrichment_failure_log_separates_reasons_and_labels(monkeypatch):
     assert "8.0s" in messages[0]
     assert "reply_not_json_object" in messages[1]
     assert "activity_guess" in messages[2]
+
+
+def test_enrichment_failure_reports_reach_the_main_service_handlers():
+    """The whole point of these warnings is that they land in the log file.
+
+    setup_logging(service_name="Main") installs handlers on "N.E.K.O.Main" with
+    propagate=False and installs nothing on root, so a logger named after
+    __name__ reaches no handler: its records fall through to
+    logging.lastResort — bare text on stderr, never the log file. Asserting the
+    logger's *name* would be weaker than the claim; this drives a real record
+    through and checks a handler on the service logger receives it.
+    """
+    from main_logic.activity import llm_enrichment
+
+    records = []
+
+    class _Sink(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    main_logger = logging.getLogger("N.E.K.O.Main")
+    sink = _Sink()
+    prior_level = main_logger.level
+    main_logger.addHandler(sink)
+    main_logger.setLevel(logging.DEBUG)
+    llm_enrichment._failure_log_state.clear()
+    try:
+        llm_enrichment._report_failure("topic_candidates", "emotion_call_timed_out", "8.0s")
+    finally:
+        main_logger.removeHandler(sink)
+        main_logger.setLevel(prior_level)
+        llm_enrichment._failure_log_state.clear()
+
+    messages = [r.getMessage() for r in records]
+    assert any("emotion_call_timed_out" in m for m in messages), messages

--- a/tests/unit/test_topic_llm_enrichment.py
+++ b/tests/unit/test_topic_llm_enrichment.py
@@ -1,3 +1,6 @@
+import contextlib
+import logging
+
 import pytest
 
 
@@ -359,3 +362,145 @@ async def test_invoke_emotion_tier_uses_project_message_classes(monkeypatch):
     assert raw == '{"topics":[]}'
     assert isinstance(captured["messages"][0], HumanMessage)
     assert captured["messages"][0].content == "提炼一个深话题"
+
+
+class _WarningSink(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@contextlib.contextmanager
+def _capture_enrichment_logs():
+    """Collect everything the enrichment logger emits, at any level.
+
+    Deliberately not clamped to WARNING: these tests assert that conversation
+    text reaches NO log line, so a regression that demotes the leak back to
+    logger.debug has to fail here rather than slip under the level filter.
+    """
+    from main_logic.activity import llm_enrichment
+
+    log = logging.getLogger(llm_enrichment.__name__)
+    sink = _WarningSink()
+    prior_level, prior_propagate = log.level, log.propagate
+    llm_enrichment._failure_log_state.clear()
+    log.addHandler(sink)
+    log.setLevel(logging.DEBUG)
+    try:
+        yield sink
+    finally:
+        log.removeHandler(sink)
+        log.setLevel(prior_level)
+        log.propagate = prior_propagate
+        llm_enrichment._failure_log_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_enrichment_failure_log_never_carries_the_model_reply(monkeypatch):
+    """The reply is a rewrite of the user's own turns — it cannot reach a log.
+
+    This used to be `logger.debug('...: %r', raw[:200])`, i.e. 200 characters of
+    conversation-derived text on every malformed reply.
+    """
+    from main_logic.activity import llm_enrichment
+
+    secret = "用户说他下周要去梅奥诊所复查"
+
+    async def fake_invoke(prompt, *, timeout, label):
+        return f"这不是 JSON。{secret}"
+
+    monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
+
+    with _capture_enrichment_logs() as sink:
+        result = await llm_enrichment.call_topic_candidates(
+            lang="zh-CN",
+            global_signals="- [1min前] 用户: 我最近一直在纠结要不要换工作",
+        )
+
+    assert result is None
+    messages = [r.getMessage() for r in sink.records]
+    assert any("reply_not_json_object" in m for m in messages), messages
+    assert not any(secret in m for m in messages), messages
+    assert not any("这不是 JSON" in m for m in messages), messages
+    # 提示语本身也是对话原文拼出来的，同样不能出现。
+    assert not any("换工作" in m for m in messages), messages
+
+
+def test_failure_detail_reports_the_exception_class_not_its_message():
+    from main_logic.activity import llm_enrichment
+
+    class _ProviderError(Exception):
+        status_code = 400
+
+    # 供应商 400 的 message 经常把请求体（也就是对话）原样回显出来。
+    leaky = _ProviderError("invalid request body: 我最近一直在纠结要不要换工作")
+    detail = llm_enrichment._failure_detail(leaky)
+    assert detail == "_ProviderError HTTP 400"
+    assert "换工作" not in detail
+
+    class _Response:
+        status_code = 429
+
+    class _WrappedError(Exception):
+        response = _Response()
+
+    assert llm_enrichment._failure_detail(_WrappedError("...")) == "_WrappedError HTTP 429"
+    assert llm_enrichment._failure_detail(ValueError("我最近一直在纠结")) == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_failure_log_throttles_repeats_of_the_same_reason(monkeypatch):
+    """These calls hang off a 20s heartbeat: one line per reason per window.
+
+    Without the throttle, promoting these from debug to warning would just move
+    the flood the topic pipeline was already producing from INFO to WARNING.
+    """
+    from main_logic.activity import llm_enrichment
+
+    async def fake_invoke(prompt, *, timeout, label):
+        return "not json at all"
+
+    monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
+
+    with _capture_enrichment_logs() as sink:
+        for _ in range(12):
+            await llm_enrichment.call_topic_candidates(
+                lang="zh-CN", global_signals="- [1min前] 用户: 换工作的事",
+            )
+
+        first_round = [r.getMessage() for r in sink.records]
+        assert len(first_round) == 1, first_round
+        assert "11 more suppressed" not in first_round[0]
+
+        # 窗口翻篇后重新放行一条，并把期间压掉的次数带出来。
+        monkeypatch.setattr(llm_enrichment, "_FAILURE_LOG_INTERVAL_SECONDS", 0.0)
+        await llm_enrichment.call_topic_candidates(
+            lang="zh-CN", global_signals="- [1min前] 用户: 换工作的事",
+        )
+
+    messages = [r.getMessage() for r in sink.records]
+    assert len(messages) == 2, messages
+    assert "11 more suppressed" in messages[1], messages[1]
+
+
+@pytest.mark.asyncio
+async def test_enrichment_failure_log_separates_reasons_and_labels(monkeypatch):
+    """One throttle bucket per (label, reason) — a new failure mode is not hidden."""
+    from main_logic.activity import llm_enrichment
+
+    with _capture_enrichment_logs() as sink:
+        llm_enrichment._report_failure("topic_candidates", "emotion_call_timed_out", "8.0s")
+        llm_enrichment._report_failure("topic_candidates", "emotion_call_timed_out", "8.0s")
+        llm_enrichment._report_failure("topic_candidates", "reply_not_json_object")
+        llm_enrichment._report_failure("activity_guess", "emotion_call_timed_out", "8.0s")
+
+    messages = [r.getMessage() for r in sink.records]
+    assert len(messages) == 3, messages
+    assert all(r.levelno == logging.WARNING for r in sink.records)
+    assert "topic_candidates" in messages[0] and "emotion_call_timed_out" in messages[0]
+    assert "8.0s" in messages[0]
+    assert "reply_not_json_object" in messages[1]
+    assert "activity_guess" in messages[2]

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2886,10 +2886,19 @@ async def test_topic_pool_retry_window_absorbs_a_stale_tick_stamp():
 
 
 def test_elapsed_since_tick_floors_at_zero_for_an_injected_future_stamp():
-    """Injected future `now` (tests, replayed ticks) must not rewind the window."""
+    """Injected future `now` (tests, replayed ticks) must not rewind the window.
+
+    Both terms have to be pinned negative to isolate the floor. Passing a
+    freshly sampled `time.monotonic()` as `started_at` does not: the helper
+    samples the same clock again, later, so the duration term is positive by
+    however much the clock resolves. That is ~0 on Windows (GetTickCount64,
+    ~15.6ms granularity, so both samples usually read identical) but strictly
+    positive on Linux — the assertion would pass here and fail in CI.
+    """
     pool = TopicHookPool(auto_schedule=False)
     future_tick = time.time() + 3600.0
-    assert pool._elapsed_since_tick(future_tick, time.monotonic()) == 0.0
+    started_in_the_future = time.monotonic() + 3600.0
+    assert pool._elapsed_since_tick(future_tick, started_in_the_future) == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import json
+import logging
 import threading
 import time
 from datetime import datetime
@@ -1354,12 +1355,25 @@ async def test_topic_pool_debounce_retries_after_background_analyzer_failure():
     assert last_turn_at is not None
 
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 61)
+    assert calls == 1
+
+    # 抛异常和返回 None 是同一件事——analyzer 失败了——所以必须走同一个退避。
+    # 异常若逃到 process_ready_topics 的 except 只打日志，dirty 还在、退避没设，
+    # 下一跳就又打一次 LLM，正是这个退避要挡的热循环。
+    assert pool._analyzer_failures["妮可"] == 1
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 62)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 81)
+    assert calls == 1
+    assert "妮可" in pool._dirty
+
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 122)
     await asyncio.wait_for(retried.wait(), timeout=1.0)
     materials = pool.get_ready_materials("妮可")
 
     assert calls == 2
     assert materials[0]["interest"] == "稳定转职话题"
+    # 恢复后计数清零，下一次偶发异常从头退避而不是接着翻倍。
+    assert "妮可" not in pool._analyzer_failures
 
 
 @pytest.mark.asyncio
@@ -2631,3 +2645,81 @@ async def test_topic_pool_empty_analyzer_result_is_an_answer_not_a_failure():
     assert len(calls) == 1
     assert "妮可" not in pool._analyzer_retry_not_before
     assert "妮可" not in pool._analyzer_failures
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_analyzer_exception_arms_the_same_backoff_as_a_none_result():
+    """A raising analyzer must back off exactly like one returning None.
+
+    `_analyzer` is a constructor-injected callable whose contract never promised
+    not to raise, and the default one reaches a third-party LLM client. Handling
+    only the None path would leave a second route back into the 20s hot loop.
+    """
+    calls = []
+
+    async def exploding_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        raise RuntimeError("provider said: 我最近一直在纠结要不要换工作")
+
+    pool = TopicHookPool(
+        analyzer=exploding_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert len(calls) == 1
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 121)
+
+    for tick in (62, 81, 101):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+    assert len(calls) == 1
+
+    # 退避照样翻倍：第二次失败后要等 120s，而不是回到 60s。
+    await pool.process_ready_topics(now=base + 122, lang="zh-CN")
+    assert len(calls) == 2
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 242)
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_analyzer_exception_log_omits_the_exception_message():
+    """Provider error messages routinely echo the request body — the prompt."""
+    class _Sink(logging.Handler):
+        def __init__(self):
+            super().__init__(level=logging.DEBUG)
+            self.records = []
+
+        def emit(self, record):
+            self.records.append(record)
+
+    secret = "我最近一直在纠结要不要换工作"
+
+    async def exploding_analyzer(*, lang, **kwargs):
+        raise RuntimeError(f"invalid request body: {secret}")
+
+    pool = TopicHookPool(
+        analyzer=exploding_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", secret)
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    log = logging.getLogger("N.E.K.O.Main.topic.pipeline")
+    sink = _Sink()
+    prior = log.level
+    log.addHandler(sink)
+    log.setLevel(logging.DEBUG)
+    try:
+        await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    finally:
+        log.removeHandler(sink)
+        log.setLevel(prior)
+
+    messages = [r.getMessage() for r in sink.records]
+    assert any("RuntimeError" in m for m in messages), messages
+    assert not any(secret in m for m in messages), messages

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2945,3 +2945,55 @@ async def test_topic_pool_lazy_analyzer_iterable_that_raises_still_backs_off():
     for tick in (92, 110, 121):
         await pool.process_ready_topics(now=base + tick, lang="zh-CN")
     assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_failure_count_does_not_survive_evidence_aging_out(tmp_path):
+    """A count carried across a 12h gap would spend the next blip at the cap.
+
+    When every signal ages out, `last_turn_at` goes None and the character is
+    back to its initial state — that branch sits ahead of the backoff gate, so
+    it is reachable while a deadline is armed. Keeping the count there means a
+    corpus accumulated later starts its first transient failure at whatever
+    step the old outage had climbed to, instead of at the free immediate retry.
+    """
+    calls = []
+
+    async def failing_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        return None
+
+    path = tmp_path / "topic_signals.json"
+    pool = TopicHookPool(
+        analyzer=failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+        signal_store_path=path,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    # 攒出一段失败史，档位爬到第 3 档。
+    for tick, expected in ((61, 1), (82, 2), (123, 3)):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+        assert len(calls) == expected
+    assert pool._analyzer_failures["妮可"] == 3
+
+    # 证据整段老化掉（12h retention）：这一跳只会走到 last_turn_at is None。
+    pool._signal_store.clear("妮可")
+    await pool.process_ready_topics(now=base + 3000, lang="zh-CN")
+    assert len(calls) == 3
+    assert "妮可" not in pool._analyzer_failures
+    assert "妮可" not in pool._analyzer_retry_not_before
+
+    # 新语料的第一次失败要拿回那次免费立即重试，而不是从旧档位续。
+    pool.note_user_message("妮可", "换个话题，我最近在学做菜")
+    fresh = pool._signal_store.last_turn_at("妮可")
+    assert fresh is not None
+    await pool.process_ready_topics(now=fresh + 61, lang="zh-CN")
+    assert len(calls) == 4
+    assert pool._analyzer_failures["妮可"] == 1
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(
+        fresh + 61 + _ANALYZER_RETRY_BASE_SECONDS, abs=1e-3
+    )

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -3036,3 +3036,73 @@ async def test_global_purge_reaches_a_character_holding_only_backoff_state(use_a
 
     assert "妮可" not in pool._analyzer_retry_not_before
     assert "妮可" not in pool._analyzer_failures
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_failure_count_ends_when_the_character_drops_below_ready():
+    """The readiness exit is the other way out of the walk, and it must clear too.
+
+    Sequence the aged-out branch alone does not cover: fail → signals fall
+    below the readiness threshold → the rest expire → fresh corpus. The
+    readiness exit discards the character from `_dirty`, which is exactly the
+    set process_ready_topics walks, so the aged-out branch never revisits it —
+    the count would survive to the fresh corpus and spend its first blip at
+    the old step instead of on the free immediate retry.
+    """
+    calls = []
+
+    async def failing_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        return None
+
+    pool = TopicHookPool(
+        analyzer=failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=2,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    pool.note_user_message("妮可", "换工作这件事我反复想了好几周了")
+
+    # 两条 turn 要能分开剪，所以显式给时间戳：note_user_message 走 time.time()，
+    # 相邻两次调用在本机会落在同一个刻度上，cutoff 就无处可放。
+    store = pool._signal_store
+    store.clear("妮可")
+    first_at = time.time()
+    store.note_turn("妮可", actor="user", text="我最近一直在纠结要不要换工作", now=first_at)
+    store.note_turn("妮可", actor="user", text="换工作这件事我反复想了好几周了", now=first_at + 1.0)
+    pool._dirty.add("妮可")
+    base = store.last_turn_at("妮可")
+    assert base == pytest.approx(first_at + 1.0, abs=1e-6)
+
+    for tick, expected in ((61, 1), (82, 2), (123, 3)):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+        assert len(calls) == expected
+    assert pool._analyzer_failures["妮可"] == 3
+
+    # 老信号先掉一部分：有效轮数跌到阈值以下，但证据还在。
+    # clear_until 保留 timestamp > cutoff 的条目，拿第一条的时间戳当 cutoff
+    # 正好剪掉它、留下第二条。
+    store.clear_until("妮可", timestamp=first_at)
+    assert not store.is_ready("妮可")
+    assert store.last_turn_at("妮可") is not None
+
+    await pool.process_ready_topics(now=base + 204, lang="zh-CN")
+    assert len(calls) == 3
+    assert "妮可" not in pool._dirty
+    # 这一步是关键：此刻不清，之后角色已不在 _dirty 里，过期清理分支再也够不到。
+    assert "妮可" not in pool._analyzer_failures
+    assert "妮可" not in pool._analyzer_retry_not_before
+
+    # 剩下的信号也过期，然后来了新语料。
+    store.clear("妮可")
+    pool.note_user_message("妮可", "换个话题，我最近在学做菜")
+    pool.note_user_message("妮可", "做菜比想象中费时间")
+    fresh = pool._signal_store.last_turn_at("妮可")
+    assert fresh is not None
+
+    await pool.process_ready_topics(now=fresh + 61, lang="zh-CN")
+    assert len(calls) == 4
+    assert pool._analyzer_failures["妮可"] == 1
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(
+        fresh + 61 + _ANALYZER_RETRY_BASE_SECONDS, abs=1e-3
+    )

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -9,6 +9,8 @@ import pytest
 
 from main_logic.topic.pipeline import (
     TopicHookPool,
+    _ANALYZER_RETRY_BASE_SECONDS,
+    _ANALYZER_RETRY_CAP_SECONDS,
     _clean_material,
     _UNANSWERED_TOPIC_WEIGHT,
     _record_weight,
@@ -1397,7 +1399,16 @@ async def test_topic_pool_keeps_dirty_when_analyzer_returns_none():
     assert last_turn_at is not None
 
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 61)
+    assert calls == 1
+
+    # 失败后仍然 dirty，但重试要等退避到期：紧接着的那一跳（心跳 20s 一次）
+    # 必须空转，否则就退回到"每 20 秒打一次失败的 LLM"的热循环。
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 62)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 81)
+    assert calls == 1
+    assert "妮可" in pool._dirty
+
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 122)
     await asyncio.wait_for(retried.wait(), timeout=1.0)
     materials = pool.get_ready_materials("妮可")
 
@@ -2498,3 +2509,125 @@ def test_used_topics_persist_failure_is_visible(tmp_path):
         r.getMessage() for r in sink.records if r.levelno >= logging.WARNING
     ]
     assert any("used-history" in m for m in warnings), warnings
+
+
+def test_analyzer_retry_delay_doubles_from_the_base_and_saturates_at_the_cap():
+    # 常量一并断死。只断 _analyzer_retry_delay(2) == 2 * BASE 这类派生式的话，
+    # 把 BASE 从 60 改成 1 秒（等于取消退避）测试照样绿。
+    assert _ANALYZER_RETRY_BASE_SECONDS == 60.0
+    assert _ANALYZER_RETRY_CAP_SECONDS == 1800.0
+
+    pool = TopicHookPool(auto_schedule=False)
+    assert pool._analyzer_retry_delay(1) == 60.0
+    assert pool._analyzer_retry_delay(2) == 120.0
+    assert pool._analyzer_retry_delay(3) == 240.0
+    assert pool._analyzer_retry_delay(5) == 960.0
+    # 60 * 2**5 = 1920 > cap.
+    assert pool._analyzer_retry_delay(6) == 1800.0
+    # 退避封顶后计数还在涨，指数不能跟着涨到溢出。
+    assert pool._analyzer_retry_delay(500) == 1800.0
+    # 防御性：第一次失败之前不该有人问，问了也不能算出 0 延迟。
+    assert pool._analyzer_retry_delay(0) == 60.0
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_backs_off_instead_of_retrying_failed_analyzer_every_heartbeat():
+    """A failing analyzer must not ride the 20s heartbeat forever.
+
+    The analyzer returning None means "the call failed", not "no topic here"
+    (that is an empty list, which takes the discard path). The failure keeps the
+    character dirty so a transient blip recovers, and before the backoff that
+    dirty flag meant one LLM call every 20s until the 12h signal retention
+    starved it.
+    """
+    calls = []
+
+    async def failing_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        return None
+
+    pool = TopicHookPool(
+        analyzer=failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    # 成熟窗口一过就跑第一次，失败后退避 60s。
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert len(calls) == 1
+
+    # 心跳 20s 一跳，退避期内的每一跳都必须空转。
+    for tick in (81, 101, 111):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+    assert len(calls) == 1
+    assert "妮可" in pool._dirty  # 仍然 dirty：是延后重试，不是放弃
+
+    # 61 + 60 之后放行第二次，这次退避翻倍到 120s。
+    await pool.process_ready_topics(now=base + 122, lang="zh-CN")
+    assert len(calls) == 2
+    for tick in (142, 182, 222):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+    assert len(calls) == 2
+
+    # 122 + 120 之后第三次。
+    await pool.process_ready_topics(now=base + 243, lang="zh-CN")
+    assert len(calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_clears_analyzer_backoff_once_the_analyzer_answers():
+    outcomes = [None, [{"interest": "恢复后的换工作话题", "relevance": 90}]]
+    calls = []
+
+    async def flaky_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        return outcomes[min(len(calls) - 1, len(outcomes) - 1)]
+
+    pool = TopicHookPool(
+        analyzer=flaky_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert len(calls) == 1
+    assert pool._analyzer_failures["妮可"] == 1
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 121)
+
+    await pool.process_ready_topics(now=base + 122, lang="zh-CN")
+    assert len(calls) == 2
+    # 一旦 analyzer 真的答了话，计数与闸门都必须归零，否则下一次偶发失败会
+    # 从上一次的退避档位继续翻倍。
+    assert "妮可" not in pool._analyzer_failures
+    assert "妮可" not in pool._analyzer_retry_not_before
+    assert pool.get_ready_materials("妮可")[0]["interest"] == "恢复后的换工作话题"
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_empty_analyzer_result_is_an_answer_not_a_failure():
+    """`[]` means "analysed, nothing worth saying" — it must not arm the backoff."""
+    calls = []
+
+    async def empty_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        return []
+
+    pool = TopicHookPool(
+        analyzer=empty_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert len(calls) == 1
+    assert "妮可" not in pool._analyzer_retry_not_before
+    assert "妮可" not in pool._analyzer_failures

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2997,3 +2997,42 @@ async def test_topic_pool_failure_count_does_not_survive_evidence_aging_out(tmp_
     assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(
         fresh + 61 + _ANALYZER_RETRY_BASE_SECONDS, abs=1e-3
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [False, True])
+async def test_global_purge_reaches_a_character_holding_only_backoff_state(use_async):
+    """Backoff state can outlive both the store entry and the dirty flag.
+
+    The readiness path drops the character from `_dirty` while its evidence is
+    still short of the threshold; that evidence can then age out of the store.
+    Neither set names it any more, so a global purge built from
+    `names() | _dirty` would walk straight past an armed retry window.
+    """
+    async def failing_analyzer(*, lang, **kwargs):
+        return None
+
+    pool = TopicHookPool(
+        analyzer=failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert "妮可" in pool._analyzer_retry_not_before
+
+    # 落到"只剩退避状态"：dirty 没了，store 里也没了。
+    pool._dirty.discard("妮可")
+    pool._signal_store.clear("妮可")
+    assert "妮可" not in pool._signal_store.names()
+    assert "妮可" not in pool._dirty
+
+    if use_async:
+        await pool.purge_all_accumulated_signals_async()
+    else:
+        pool.purge_all_accumulated_signals()
+
+    assert "妮可" not in pool._analyzer_retry_not_before
+    assert "妮可" not in pool._analyzer_failures

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1357,16 +1357,17 @@ async def test_topic_pool_debounce_retries_after_background_analyzer_failure():
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 61)
     assert calls == 1
 
-    # 抛异常和返回 None 是同一件事——analyzer 失败了——所以必须走同一个退避。
+    # 抛异常和返回 None 是同一件事——analyzer 失败了——所以必须走同一个退避记账。
     # 异常若逃到 process_ready_topics 的 except 只打日志，dirty 还在、退避没设，
-    # 下一跳就又打一次 LLM，正是这个退避要挡的热循环。
+    # 每一跳都会再打一次 LLM，正是这个退避要挡的热循环。第一档等于心跳周期，
+    # 所以下一跳放行是预期的；窗口在第二次失败后才真正拉开。
     assert pool._analyzer_failures["妮可"] == 1
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 62)
-    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 81)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 80)
     assert calls == 1
     assert "妮可" in pool._dirty
 
-    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 122)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 82)
     await asyncio.wait_for(retried.wait(), timeout=1.0)
     materials = pool.get_ready_materials("妮可")
 
@@ -1415,14 +1416,14 @@ async def test_topic_pool_keeps_dirty_when_analyzer_returns_none():
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 61)
     assert calls == 1
 
-    # 失败后仍然 dirty，但重试要等退避到期：紧接着的那一跳（心跳 20s 一次）
-    # 必须空转，否则就退回到"每 20 秒打一次失败的 LLM"的热循环。
+    # 失败后仍然 dirty，重试要等退避到期。第一档等于心跳周期（20s），所以窗口
+    # 内的跳是 +62/+80，到 +82 才放行；真正拉开距离要到第二次失败之后。
     await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 62)
-    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 81)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 80)
     assert calls == 1
     assert "妮可" in pool._dirty
 
-    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 122)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 82)
     await asyncio.wait_for(retried.wait(), timeout=1.0)
     materials = pool.get_ready_materials("妮可")
 
@@ -2527,21 +2528,23 @@ def test_used_topics_persist_failure_is_visible(tmp_path):
 
 def test_analyzer_retry_delay_doubles_from_the_base_and_saturates_at_the_cap():
     # 常量一并断死。只断 _analyzer_retry_delay(2) == 2 * BASE 这类派生式的话，
-    # 把 BASE 从 60 改成 1 秒（等于取消退避）测试照样绿。
-    assert _ANALYZER_RETRY_BASE_SECONDS == 60.0
+    # 把 BASE 改成 1 秒（等于取消退避）测试照样绿。
+    # BASE 等于心跳周期是有意的：第一档不延后，是给抖动的一次立即重试。
+    assert _ANALYZER_RETRY_BASE_SECONDS == 20.0
     assert _ANALYZER_RETRY_CAP_SECONDS == 1800.0
 
     pool = TopicHookPool(auto_schedule=False)
-    assert pool._analyzer_retry_delay(1) == 60.0
-    assert pool._analyzer_retry_delay(2) == 120.0
-    assert pool._analyzer_retry_delay(3) == 240.0
-    assert pool._analyzer_retry_delay(5) == 960.0
-    # 60 * 2**5 = 1920 > cap.
-    assert pool._analyzer_retry_delay(6) == 1800.0
+    assert pool._analyzer_retry_delay(1) == 20.0
+    assert pool._analyzer_retry_delay(2) == 40.0
+    assert pool._analyzer_retry_delay(3) == 80.0
+    assert pool._analyzer_retry_delay(5) == 320.0
+    assert pool._analyzer_retry_delay(7) == 1280.0
+    # 20 * 2**7 = 2560 > cap.
+    assert pool._analyzer_retry_delay(8) == 1800.0
     # 退避封顶后计数还在涨，指数不能跟着涨到溢出。
     assert pool._analyzer_retry_delay(500) == 1800.0
     # 防御性：第一次失败之前不该有人问，问了也不能算出 0 延迟。
-    assert pool._analyzer_retry_delay(0) == 60.0
+    assert pool._analyzer_retry_delay(0) == 20.0
 
 
 @pytest.mark.asyncio
@@ -2569,26 +2572,30 @@ async def test_topic_pool_backs_off_instead_of_retrying_failed_analyzer_every_he
     base = pool._signal_store.last_turn_at("妮可")
     assert base is not None
 
-    # 成熟窗口一过就跑第一次，失败后退避 60s。
+    # 成熟窗口一过就跑第一次。第一档 = 心跳周期，所以下一跳就放行——这一档是
+    # 给抖动的免费立即重试，真正的退避从第二次失败起。
     await pool.process_ready_topics(now=base + 61, lang="zh-CN")
     assert len(calls) == 1
 
-    # 心跳 20s 一跳，退避期内的每一跳都必须空转。
-    for tick in (81, 101, 111):
-        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
-    assert len(calls) == 1
+    await pool.process_ready_topics(now=base + 82, lang="zh-CN")
+    assert len(calls) == 2
     assert "妮可" in pool._dirty  # 仍然 dirty：是延后重试，不是放弃
 
-    # 61 + 60 之后放行第二次，这次退避翻倍到 120s。
-    await pool.process_ready_topics(now=base + 122, lang="zh-CN")
-    assert len(calls) == 2
-    for tick in (142, 182, 222):
+    # 第二次失败后退避翻倍到 40s，期间的每一跳都必须空转。
+    for tick in (92, 110, 121):
         await pool.process_ready_topics(now=base + tick, lang="zh-CN")
     assert len(calls) == 2
 
-    # 122 + 120 之后第三次。
-    await pool.process_ready_topics(now=base + 243, lang="zh-CN")
+    # 82 + 40 之后放行第三次，退避再翻倍到 80s。
+    await pool.process_ready_topics(now=base + 123, lang="zh-CN")
     assert len(calls) == 3
+    for tick in (143, 183, 202):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+    assert len(calls) == 3
+
+    # 123 + 80 之后第四次。
+    await pool.process_ready_topics(now=base + 204, lang="zh-CN")
+    assert len(calls) == 4
 
 
 @pytest.mark.asyncio
@@ -2612,9 +2619,9 @@ async def test_topic_pool_clears_analyzer_backoff_once_the_analyzer_answers():
     await pool.process_ready_topics(now=base + 61, lang="zh-CN")
     assert len(calls) == 1
     assert pool._analyzer_failures["妮可"] == 1
-    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 121)
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 81)
 
-    await pool.process_ready_topics(now=base + 122, lang="zh-CN")
+    await pool.process_ready_topics(now=base + 82, lang="zh-CN")
     assert len(calls) == 2
     # 一旦 analyzer 真的答了话，计数与闸门都必须归零，否则下一次偶发失败会
     # 从上一次的退避档位继续翻倍。
@@ -2672,16 +2679,16 @@ async def test_topic_pool_analyzer_exception_arms_the_same_backoff_as_a_none_res
 
     await pool.process_ready_topics(now=base + 61, lang="zh-CN")
     assert len(calls) == 1
-    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 121)
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 81)
 
-    for tick in (62, 81, 101):
+    for tick in (62, 71, 80):
         await pool.process_ready_topics(now=base + tick, lang="zh-CN")
     assert len(calls) == 1
 
-    # 退避照样翻倍：第二次失败后要等 120s，而不是回到 60s。
-    await pool.process_ready_topics(now=base + 122, lang="zh-CN")
+    # 退避照样翻倍：第二次失败后要等 40s，而不是回到 20s。
+    await pool.process_ready_topics(now=base + 82, lang="zh-CN")
     assert len(calls) == 2
-    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 242)
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 122)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2619,7 +2619,7 @@ async def test_topic_pool_clears_analyzer_backoff_once_the_analyzer_answers():
     await pool.process_ready_topics(now=base + 61, lang="zh-CN")
     assert len(calls) == 1
     assert pool._analyzer_failures["妮可"] == 1
-    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 81)
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 81, abs=0.05)
 
     await pool.process_ready_topics(now=base + 82, lang="zh-CN")
     assert len(calls) == 2
@@ -2679,7 +2679,7 @@ async def test_topic_pool_analyzer_exception_arms_the_same_backoff_as_a_none_res
 
     await pool.process_ready_topics(now=base + 61, lang="zh-CN")
     assert len(calls) == 1
-    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 81)
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 81, abs=0.05)
 
     for tick in (62, 71, 80):
         await pool.process_ready_topics(now=base + tick, lang="zh-CN")
@@ -2688,7 +2688,7 @@ async def test_topic_pool_analyzer_exception_arms_the_same_backoff_as_a_none_res
     # 退避照样翻倍：第二次失败后要等 40s，而不是回到 20s。
     await pool.process_ready_topics(now=base + 82, lang="zh-CN")
     assert len(calls) == 2
-    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 122)
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(base + 122, abs=0.05)
 
 
 @pytest.mark.asyncio
@@ -2733,14 +2733,16 @@ async def test_topic_pool_analyzer_exception_log_omits_the_exception_message():
 
 
 @pytest.mark.asyncio
-async def test_topic_pool_retry_window_starts_when_the_call_failed_not_when_the_tick_began():
-    """A slow failure must not eat its own backoff.
+async def test_topic_pool_retry_window_anchors_at_the_tick_first_then_at_completion():
+    """The two steps anchor differently, and both matter.
 
-    `current_time` is captured before the await — it is often the tracker's
-    heartbeat stamp, taken earlier still. Anchoring the deadline there
-    subtracts the whole call duration (config read + client construction + the
-    8s call timeout) from every delay, and a failure slower than the delay
-    itself would land already expired.
+    Step 1 is the free immediate retry, so it anchors at the tick stamp and
+    lands on the very next heartbeat — adding the call's runtime there would
+    push a normal 8s timeout past that tick and delay recovery by a whole
+    period. Step 2 onward is a real backoff, so it anchors at completion:
+    otherwise the runtime (config read + client construction + the 8s timeout)
+    is subtracted out of every window, and a failure slower than the delay
+    would land already expired.
     """
     call_seconds = 0.05
 
@@ -2758,9 +2760,18 @@ async def test_topic_pool_retry_window_starts_when_the_call_failed_not_when_the_
     assert base is not None
 
     await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    # 第一档：正好一个心跳周期后，调用耗时不算进去。
+    #
+    # abs= 是必须的：approx 默认走相对容差 1e-6，而这些是 1.7e9 量级的 unix
+    # 时间戳，等于 ±1700 秒——足以把整个 call_seconds 的差异吞掉，让"第一档
+    # 改回锚在完成时刻"的回归照样绿。
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(
+        base + 61 + _ANALYZER_RETRY_BASE_SECONDS, abs=1e-3
+    )
 
-    # 锚在 tick 开始（base + 61 + 60）的话，这次调用的 50ms 就白送掉了。
-    naive_deadline = base + 61 + _ANALYZER_RETRY_BASE_SECONDS
+    await pool.process_ready_topics(now=base + 82, lang="zh-CN")
+    # 第二档起：锚在失败完成时刻，这 50ms 必须体现出来。
+    naive_deadline = base + 82 + _ANALYZER_RETRY_BASE_SECONDS * 2
     assert pool._analyzer_retry_not_before["妮可"] > naive_deadline
     assert pool._analyzer_retry_not_before["妮可"] >= naive_deadline + call_seconds * 0.8
 
@@ -2858,14 +2869,20 @@ async def test_topic_pool_retry_window_absorbs_a_stale_tick_stamp():
     )
     pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
 
+    # 第一次失败是免费重试档，锚在 tick 戳上不做补偿；陈旧补偿要从第二次
+    # 失败（真正的退避）起才生效，所以先把第一档用掉。
+    await pool.process_now("妮可", lang="zh-CN", now=time.time())
+    assert pool._analyzer_failures["妮可"] == 1
+
     staleness = 30.0
     stale_tick = time.time() - staleness
     await pool.process_now("妮可", lang="zh-CN", now=stale_tick)
 
     deadline = pool._analyzer_retry_not_before["妮可"]
-    # 锚在陈旧戳上的话 deadline = stale_tick + 60，也就是从现在算只剩 30 秒。
-    assert deadline > stale_tick + _ANALYZER_RETRY_BASE_SECONDS + staleness * 0.8
-    assert deadline >= time.time() + _ANALYZER_RETRY_BASE_SECONDS - 1.0
+    delay = _ANALYZER_RETRY_BASE_SECONDS * 2
+    # 锚在陈旧戳上的话 deadline = stale_tick + 40，也就是从现在算只剩 10 秒。
+    assert deadline > stale_tick + delay + staleness * 0.8
+    assert deadline >= time.time() + delay - 1.0
 
 
 def test_elapsed_since_tick_floors_at_zero_for_an_injected_future_stamp():
@@ -2873,3 +2890,49 @@ def test_elapsed_since_tick_floors_at_zero_for_an_injected_future_stamp():
     pool = TopicHookPool(auto_schedule=False)
     future_tick = time.time() + 3600.0
     assert pool._elapsed_since_tick(future_tick, time.monotonic()) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_lazy_analyzer_iterable_that_raises_still_backs_off():
+    """`Analyzer` returns an Iterable; a lazy one fails when consumed, not awaited.
+
+    Draining it outside the failure handler puts the exception past the point
+    where the previous failure state was already cleared, so the character
+    would sit dirty with no retry deadline — the hot loop again, reached
+    through the result-consumption path instead of the call path.
+    """
+    calls = []
+
+    async def lazy_exploding_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+
+        def _gen():
+            yield {"interest": "第一条还正常", "relevance": 90}
+            raise RuntimeError("provider stream broke mid-iteration")
+
+        return _gen()
+
+    pool = TopicHookPool(
+        analyzer=lazy_exploding_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert len(calls) == 1
+    assert pool._analyzer_failures["妮可"] == 1
+    assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(
+        base + 61 + _ANALYZER_RETRY_BASE_SECONDS, abs=1e-3
+    )
+    # 半路抛的迭代不该留下半成品素材。
+    assert pool.get_ready_materials("妮可") == []
+
+    # 第二次失败进入真退避，窗口内的跳空转。
+    await pool.process_ready_topics(now=base + 82, lang="zh-CN")
+    assert len(calls) == 2
+    for tick in (92, 110, 121):
+        await pool.process_ready_topics(now=base + tick, lang="zh-CN")
+    assert len(calls) == 2

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -3106,3 +3106,101 @@ async def test_topic_pool_failure_count_ends_when_the_character_drops_below_read
     assert pool._analyzer_retry_not_before["妮可"] == pytest.approx(
         fresh + 61 + _ANALYZER_RETRY_BASE_SECONDS, abs=1e-3
     )
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_pre_purge_success_does_not_clear_post_purge_backoff():
+    """A stale success must not wipe a window a replacement call already armed.
+
+    Mirror of the seen_purge_generation guard on the failure path: a purge
+    lands while an analysis is in flight, a post-purge call fails and arms a
+    window, and only then does the pre-purge call return successfully. Clearing
+    unconditionally there would hand the next tick a free extra request against
+    the very evidence the purge replaced.
+    """
+    release_first = asyncio.Event()
+    first_started = asyncio.Event()
+    calls = []
+
+    async def analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        if len(calls) == 1:
+            first_started.set()
+            await release_first.wait()
+            return [{"interest": "purge 之前那次分析的结果", "relevance": 90}]
+        return None
+
+    pool = TopicHookPool(
+        analyzer=analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    # 第一次分析卡在飞行中。
+    slow = asyncio.create_task(pool.process_ready_topics(now=base + 61, lang="zh-CN"))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    # purge 落地，然后新证据上的第二次分析失败并武装退避。
+    pool.purge_accumulated_signals("妮可")
+    pool.note_user_message("妮可", "换个话题，我最近在学做菜")
+    fresh = pool._signal_store.last_turn_at("妮可")
+    assert fresh is not None
+    await pool.process_ready_topics(now=fresh + 61, lang="zh-CN")
+    assert len(calls) == 2
+    armed = pool._analyzer_retry_not_before["妮可"]
+
+    # 现在放行那次陈旧的成功返回。
+    release_first.set()
+    await asyncio.wait_for(slow, timeout=1.0)
+
+    assert pool._analyzer_retry_not_before.get("妮可") == armed
+    assert pool._analyzer_failures.get("妮可") == 1
+    # 陈旧结果本身照旧被丢弃。
+    assert pool.get_ready_materials("妮可") == []
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_success_still_clears_when_only_a_new_turn_arrived():
+    """A new turn mid-flight discards the result but not the health signal.
+
+    Only a purge blocks the clear. A success is proof the analyzer works, so a
+    stale-by-sequence result must still end the streak — otherwise a chatty
+    user could keep a recovered analyzer stuck behind an old window.
+    """
+    release = asyncio.Event()
+    started = asyncio.Event()
+    calls = []
+
+    async def analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        if len(calls) == 1:
+            return None
+        started.set()
+        await release.wait()
+        return [{"interest": "迟到但成功的结果", "relevance": 90}]
+
+    pool = TopicHookPool(
+        analyzer=analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert pool._analyzer_failures["妮可"] == 1
+
+    slow = asyncio.create_task(pool.process_ready_topics(now=base + 82, lang="zh-CN"))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    pool.note_user_message("妮可", "顺便说，我今天还去跑步了")  # seq++
+    release.set()
+    await asyncio.wait_for(slow, timeout=1.0)
+
+    assert len(calls) == 2
+    assert "妮可" not in pool._analyzer_failures
+    assert "妮可" not in pool._analyzer_retry_not_before
+    assert pool.get_ready_materials("妮可") == []

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2723,3 +2723,109 @@ async def test_topic_pool_analyzer_exception_log_omits_the_exception_message():
     messages = [r.getMessage() for r in sink.records]
     assert any("RuntimeError" in m for m in messages), messages
     assert not any(secret in m for m in messages), messages
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_retry_window_starts_when_the_call_failed_not_when_the_tick_began():
+    """A slow failure must not eat its own backoff.
+
+    `current_time` is captured before the await — it is often the tracker's
+    heartbeat stamp, taken earlier still. Anchoring the deadline there
+    subtracts the whole call duration (config read + client construction + the
+    8s call timeout) from every delay, and a failure slower than the delay
+    itself would land already expired.
+    """
+    call_seconds = 0.05
+
+    async def slow_failing_analyzer(*, lang, **kwargs):
+        await asyncio.sleep(call_seconds)
+        return None
+
+    pool = TopicHookPool(
+        analyzer=slow_failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+
+    # 锚在 tick 开始（base + 61 + 60）的话，这次调用的 50ms 就白送掉了。
+    naive_deadline = base + 61 + _ANALYZER_RETRY_BASE_SECONDS
+    assert pool._analyzer_retry_not_before["妮可"] > naive_deadline
+    assert pool._analyzer_retry_not_before["妮可"] >= naive_deadline + call_seconds * 0.8
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_accumulated_purge_clears_the_analyzer_backoff():
+    """An explicit purge is a user action; a stale retry window must not survive it.
+
+    Otherwise a character sitting at the 30min cap goes quiet for the rest of
+    that window after the user purges and starts talking again, with nothing on
+    screen to explain the silence. Mirrors _purge_character_state, which has
+    cleared this state from the start.
+    """
+    calls = []
+
+    async def failing_analyzer(*, lang, **kwargs):
+        calls.append(lang)
+        return None
+
+    pool = TopicHookPool(
+        analyzer=failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    await pool.process_ready_topics(now=base + 61, lang="zh-CN")
+    assert len(calls) == 1
+    assert "妮可" in pool._analyzer_retry_not_before
+
+    pool.purge_accumulated_signals("妮可")
+    assert "妮可" not in pool._analyzer_retry_not_before
+    assert "妮可" not in pool._analyzer_failures
+
+    # purge 后重新说话，成熟窗口一过就该正常分析，不受旧 deadline 拖累。
+    pool.note_user_message("妮可", "换个话题，我在学做菜")
+    fresh = pool._signal_store.last_turn_at("妮可")
+    assert fresh is not None
+    await pool.process_ready_topics(now=fresh + 61, lang="zh-CN")
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_discards_analyzer_failure_when_purge_lands_midflight():
+    """A purge during the call wins: the failure must not re-arm the old window.
+
+    Same rule the success path already follows when _purge_generation moved.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hanging_failing_analyzer(*, lang, **kwargs):
+        started.set()
+        await release.wait()
+        return None
+
+    pool = TopicHookPool(
+        analyzer=hanging_failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+    base = pool._signal_store.last_turn_at("妮可")
+    assert base is not None
+
+    task = asyncio.create_task(pool.process_ready_topics(now=base + 61, lang="zh-CN"))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    pool.purge_accumulated_signals("妮可")
+    release.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert "妮可" not in pool._analyzer_retry_not_before
+    assert "妮可" not in pool._analyzer_failures

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2829,3 +2829,40 @@ async def test_topic_pool_discards_analyzer_failure_when_purge_lands_midflight()
 
     assert "妮可" not in pool._analyzer_retry_not_before
     assert "妮可" not in pool._analyzer_failures
+
+
+@pytest.mark.asyncio
+async def test_topic_pool_retry_window_absorbs_a_stale_tick_stamp():
+    """A `now` that arrived stale must not eat the backoff either.
+
+    The activity heartbeat stamps `ts` (tracker.py) and only reaches the topic
+    pool after `await self._drain_context_prompt()`, a WebSocket push. Under
+    backpressure that stamp lands seconds — potentially more than a whole
+    backoff delay — in the past, which would write an already-expired deadline
+    and hand the next heartbeat straight back into the hot loop.
+    """
+    async def failing_analyzer(*, lang, **kwargs):
+        return None
+
+    pool = TopicHookPool(
+        analyzer=failing_analyzer,
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "我最近一直在纠结要不要换工作")
+
+    staleness = 30.0
+    stale_tick = time.time() - staleness
+    await pool.process_now("妮可", lang="zh-CN", now=stale_tick)
+
+    deadline = pool._analyzer_retry_not_before["妮可"]
+    # 锚在陈旧戳上的话 deadline = stale_tick + 60，也就是从现在算只剩 30 秒。
+    assert deadline > stale_tick + _ANALYZER_RETRY_BASE_SECONDS + staleness * 0.8
+    assert deadline >= time.time() + _ANALYZER_RETRY_BASE_SECONDS - 1.0
+
+
+def test_elapsed_since_tick_floors_at_zero_for_an_injected_future_stamp():
+    """Injected future `now` (tests, replayed ticks) must not rewind the window."""
+    pool = TopicHookPool(auto_schedule=False)
+    future_tick = time.time() + 3600.0
+    assert pool._elapsed_since_tick(future_tick, time.monotonic()) == 0.0


### PR DESCRIPTION
## 改动概述 / Summary

深话题 analyzer 调用失败后没有退避，靠 20s 活动心跳无限重试，日志里表现为 `topic analyzer returned no result; keeping dirty for retry` 每 20 秒刷一条，同时每一条背后都是一次真实的 LLM 外呼。本 PR 给失败路径加指数退避，并让失败原因真正可见——在不把任何对话原文写进日志的前提下。

## 回归报告 / Regression Report

### 改动了什么

**1. `main_logic/topic/pipeline.py` — analyzer 失败退避**

- 新增按角色的连续失败计数 `_analyzer_failures` 与重试闸门 `_analyzer_retry_not_before`。
- 退避 20s 起步、逐次翻倍、30min 封顶（`_ANALYZER_RETRY_BASE_SECONDS` / `_ANALYZER_RETRY_CAP_SECONDS`），指数本身再夹一层 `_ANALYZER_RETRY_MAX_DOUBLINGS` 防溢出。起步值等于心跳周期是有意的：第一档不延后，是给抖动（一次超时、一次 5xx）的免费立即重试，真正的退避从第二次连续失败开始。长时间故障的总成本由 cap 决定而不是起步值——12h 内 20s 起步约 30 次调用，60s 起步约 28 次。
- analyzer 调用外层加 `except Exception`：抛异常和返回 `None` 走同一个 `_note_analyzer_failure`，退避档位连续；日志只记 `type(exc).__name__`。
- 退避分两档锚：**第一档**锚在 tick 戳（它不是退避，是给抖动的免费立即重试，加耗时补偿会把它推过它该落的那一跳——8s 超时是 emotion tier 失败的常态）；**第二档起**锚在失败完成时刻。
- analyzer 结果在同一个 handler 里物化（`list(...)`）：`Analyzer` 契约允许任何 `Iterable`，惰性的那种在被消费时才抛，而消费点在失败状态已清之后。
- 退避 deadline 锚在**失败时刻**：`_elapsed_since_tick` 取「调用耗时（单调钟）」与「传入 `now` 已陈旧多久（wall clock 同域）」的较大者，零下限挡住注入的未来 `now`。心跳的 `ts` 跨过一个 WebSocket await 才到这里，不补的话 deadline 可能写成已过期的。
- `purge_accumulated_signals` / `purge_all_accumulated_signals` 一并清退避（与 `_purge_character_state` 对齐）；purge 落在调用途中时，失败不再重装旧窗口（`_note_analyzer_failure` 收 `seen_purge_generation`）。
- 闸门放在 `process_ready_topics` 的心跳循环里，与既有的 `_CANDIDATE_MATURE_SECONDS` 判据并列：退避期内那一跳直接空转，不发请求也不打日志。
- `process_now` 加可选 `now` 参数，由 `process_ready_topics` 把同一个 `current_time` 传下去，避免闸门和记账用两个时钟。
- analyzer 只要答了话就 `_clear_analyzer_failures`，`_purge_character_state` 也一并清。

**2. `main_logic/activity/llm_enrichment.py` — 失败原因可见 + 限频**

- **logger 命名进 `N.E.K.O.Main` 树**（`N.E.K.O.Main.activity.llm_enrichment`）。这是让「可见」成立的前提：`setup_logging(service_name="Main")` 只在 `N.E.K.O.Main` 上装 handler 且 `propagate=False`，root 上什么都没装，所以原来按 `__name__` 命名的 logger 一个 handler 都到不了——记录落到 `logging.lastResort`（裸文本、仅 WARNING+、永不进日志文件）。实测：

  ```
  N.E.K.O.Main.topic.pipeline          -> handlers reached: ['N.E.K.O.Main:3']
  main_logic.activity.llm_enrichment   -> handlers reached: NONE
  ```

  这也解释了最初那份日志为何只有 `topic.pipeline` 的行而没有 enrichment 层。

- 新增 `_report_failure(label, reason, detail)` / `_failure_detail(exc)`，把两个 tier driver 和三个 `call_*` 里共 10 个 `logger.debug` 失败点提到 WARNING。
- 每条只带固定 reason 词（`reply_not_json_object` / `emotion_call_timed_out` / `emotion_model_or_api_key_missing` 等）；异常只取类名 + HTTP 状态码。
- 按 `(label, reason)` 限频，5 分钟一条，放行时带上期间被压掉的条数。

### 理由 / 必要性

`raw_materials is None` 的语义是「这次调用失败了」——tier 没配、key 失效、8s 超时、回复解析不出来。它跟「分析过了但没话题」（返回 `[]`，走 `_discard_analyzed_signals_async` 清 dirty）是两条路。失败路径保持 dirty 是对的（偶发抖动要能恢复），但没有退避就意味着它踩着 20s 心跳一直重试，唯一的终止条件是 12h 信号保留期把有效用户轮剪到阈值以下——用户日志里 `topic collection not ready: 87%` 那一条正是这个「饿停」而不是「修好」。也就是说，一个永久性的配置错误会被放大成一整天的 LLM 外呼。

而失败原因当时全在 `logger.debug`，默认 INFO 看不见，症状可见、病因不可见。提级别的同时必须解决两件事：这些调用挂在 20s / 40s 心跳上，不限频只是把刷屏从 INFO 搬到 WARNING；而 prompt 和模型回复都是用户对话原文加工出来的，一个字都不能落进日志。原来有 4 处直接打 `raw[:200]` / `parsed`（`activity_guess` 那处的 `parsed` 里就是「用户在干什么」的描述），本 PR 一并删掉；异常 message 也不取，因为供应商 400 错误经常把请求体原样回显，而请求体就是对话本身。

### 改动前后的表现对比

| | 改动前 | 改动后 |
|---|---|---|
| analyzer 持续失败时的重试节奏 | 每 20s 一次，直到 12h 保留期饿停 | 20s → 40s → 80s → … → 30min 封顶 |
| analyzer 抛异常时 | 逃到 `process_ready_topics` 只打日志，退避完全绕过 | 与返回 `None` 同一条退避 |
| 退避起点 | 锚在 tick 开始的时间戳，慢失败／陈旧心跳戳会吃掉甚至清空整档退避 | 第一档锚 tick（保证落在下一跳），第二档起锚失败时刻 |
| analyzer 返回惰性 iterable 且迭代抛异常 | 逃逸且失败状态已清，回到每跳一次 | 与调用失败同一条退避 |
| 显式 purge 后 | 旧退避窗口残留，最长 30min 静默 | 一并清除；in-flight 失败不重装 |
| 12h 内的失败调用次数 | ~2000 | ~30 |
| 日志 | 每 20s 一条 INFO，只有症状 | 退避后同频；带连续失败次数和下次重试间隔 |
| 失败原因 | 只在 debug（默认不可见） | WARNING，固定 reason 词，5min 限频 |
| 日志里的对话内容 | 4 处会打模型回复片段 | 无；异常只留类名 + HTTP 码 |
| 恢复 | — | analyzer 一旦答话立即清零，退避不残留 |

### 潜在回归点

- **深话题投递变慢**：只影响 analyzer 真的在失败的场景。正常路径（返回候选或返回 `[]`）完全不经过新代码，`test_topic_pool_empty_analyzer_result_is_an_answer_not_a_failure` 钉死了 `[]` 不会误触发退避。
- **退避残留**：失败后恢复却没清计数的话，下次偶发失败会从上一档继续翻倍。`test_topic_pool_clears_analyzer_backoff_once_the_analyzer_answers` 直接断言 `_analyzer_failures` / `_analyzer_retry_not_before` 两个 key 都被清掉；变异（去掉清零调用）验证过能红。
- **异常路径**（评审补收，`330878d8`）：`_analyzer` 是构造注入的、默认实现最终打到第三方 LLM client，抛异常时原先完全绕过退避——现存测试 `test_topic_pool_debounce_retries_after_background_analyzer_failure` 断言的正是「抛异常后下一跳立即重试」，一直是绿的。现已改为推进到退避窗口之后，并断言窗口内每一跳都空转。
- **退避起点与 purge**（评审补收，`93bbad54` / `4c2e2b96`）：deadline 原本锚在 tick 起点，慢失败或陈旧的心跳戳会吃掉整档退避（心跳 `ts` 跨过一个 WebSocket await 才到这里）；显式 purge 后旧窗口还会残留。两处都已修，且 in-flight purge 不再重装旧窗口。
- **测试自身的容差缺陷**（评审补收，`21b52381` / `eb6b883a`）：deadline 断言原本用 `pytest.approx(x)`，而 approx 默认是相对容差 1e-6——对 1.7e9 量级的 unix 时间戳等于 ±1700 秒，足以吞掉这些护栏要抓的差异（变异验证时才暴露）。另有一条断言两次 `time.monotonic()` 采样相等，本机实测 200 次里失败 94 次，是既有 flake 而非平台差异。两处都已收紧。
- **`_invoke_emotion_tier` 是共用的**：`activity_guess` / `open_threads` / `master_emotion` / `topic_deep_query` 四条链路的失败日志一并从 debug 变 WARNING。这是意图之内（同样的哑失败），限频桶按 `(label, reason)` 分开，所以一条链路刷屏不会掩盖另一条的新失败模式；已跑这四条链路的现有测试（145 passed）。
- **失败计数的生命周期**（评审补收，`0db350e9` / `dff9445a1`）：12h retention 清空 store 后走的是「`last_turn_at is None`」分支，它在退避闸门之前，原本会把计数跨过整段静默留下来——新语料的第一次偶发失败直接落在旧故障爬到的档位上。现已在该分支清掉。readiness 那条路径不清（证据还在，只是不够，连击仍是当下信息）。另外「只剩退避状态」的角色不在 `names() | _dirty` 里，全局 purge 够不着，已把 `_analyzer_retry_not_before` 并入工作集。
- **限频器是模块级全局状态**：加了 `threading.Lock`；测试用 contextmanager 显式清 `_failure_log_state`，避免 pytest-randomly 下的顺序污染。
- **既有测试 `test_topic_pool_keeps_dirty_when_analyzer_returns_none` 改了**：它原本断言的正是「失败后下一跳（+1s）立即重试」这个热循环行为。改成推进到退避到期之后，并补了两条断言把「不放弃 dirty」和「不立刻重试」两侧同时钉住。

## 不拆分理由 / Why Not Split

不适用（4 个文件，其中 2 个是测试）。

## 测试 / Testing

```
uv run pytest tests/unit/test_topic_pipeline.py tests/unit/test_topic_llm_enrichment.py -q     # 105 passed
uv run pytest tests/unit/test_master_emotion.py tests/unit/test_activity_narration_suppression.py tests/test_activity_tracker_followup.py -q   # 145 passed
uv run python scripts/check_docstring_no_cjk.py --base origin/main   # exit 0
uv run python scripts/check_async_blocking.py                        # exit 0
```

新增 22 条护栏测试，逐条做了变异验证——以下 22 个变异全部能让测试变红：

1. 删掉 `process_ready_topics` 里的退避闸门
2. `_ANALYZER_RETRY_BASE_SECONDS` 改成 1.0 / 改回 60.0（常量本身也断言了，否则改常量测试会跟着变绿）
3. analyzer 成功后不清失败计数
4. 关掉 `_report_failure` 的限频
5. 把模型原始回复重新打进日志
6. `_failure_detail` 改成返回 `str(exc)`
7. 去掉 analyzer 调用外层的 `try/except`（异常重新逃逸）
8. 异常路径的日志改成记 `str(exc)`
9. 异常路径跳过失败记账
10. 退避 deadline 重新锚回 tick 起点（去掉耗时补偿）
11. `_elapsed_since_tick` 去掉 wall-clock 陈旧项
12. `_elapsed_since_tick` 去掉单调钟调用耗时项
13. `_elapsed_since_tick` 去掉零下限
14. `purge_accumulated_signals` 不清退避
15. in-flight purge 判据短路（失败重装旧窗口）
16. 退避 cap 抬掉（无上限）
17. 第一档改回锚在失败完成时刻（吃掉下一跳重试）
18. 所有档都改成锚在 tick（真退避丢掉调用耗时）
19. 惰性 iterable 不在 handler 内物化
20. logger 名改回 `__name__`（记录到不了任何 handler）
21. 证据整段老化时不清失败计数
22. 全局 purge 的工作集去掉 `_analyzer_retry_not_before`

未做实机验证：需要一个 emotion tier 真在报错的环境才能观察到新的 WARNING 落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 分析失败后将自动延迟重试，等待时间逐步增加并设置上限，减少重复请求。
  * 分析成功或返回空结果后恢复正常重试状态。
  * 分析器异常、超时及无效响应将统一处理，提升运行稳定性。
  * 富化失败告警采用限流机制，避免重复记录。
  * 错误信息经过脱敏，仅保留失败原因、异常类型和 HTTP 状态码，不包含提示词、回复或对话内容。
  * 不同类型的失败将分别统计，便于识别持续性问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
