### PR TITLE
fix(vision): 修复截图 Avatar 水印在三条链路上不生效

### DIFF
--- a/main_logic/core/__init__.py
+++ b/main_logic/core/__init__.py
@@ -229,6 +229,7 @@ from ._shared import (  # noqa: F401
     _get_chat_locale_text,
     _START_LLM_CONCURRENT_ABORTED,
     ContextAppendResult,
+    FreshScreenshot,
     _purge_closed_tool_calls,
 )
 from .callback_render import (  # noqa: F401

--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -232,6 +232,28 @@ class ContextAppendResult:
     reason: str | None = None
 
 
+@dataclass(frozen=True)
+class FreshScreenshot:
+    """One Phase-2 screenshot fetch, tagged with where the image came from.
+
+    ``source`` is the caller's only way to tell apart two situations that a plain
+    base64 return conflated:
+
+    - ``'websocket'``: the frontend answered. ``avatar_position`` is its verdict
+      about THIS image. ``None`` means the frontend deliberately decided the image
+      must not be annotated (window capture, camera, avatar collapsed, multi-monitor);
+      the caller must not substitute a position from anywhere else.
+    - ``'backend_fallback'``: the frontend never answered and the backend grabbed
+      the screen itself. The frontend had no opinion about this image, so the
+      caller MAY fall back to the position that came with the original request.
+    - ``''``: nothing was captured.
+    """
+
+    b64: str = ""
+    source: str = ""
+    avatar_position: dict | None = None
+
+
 def _purge_closed_tool_calls(history: list, *, start: int = 0) -> int:
     """Remove every CLOSED tool-call pair from the conversation history: an
     assistant message (role=assistant, carrying tool_calls) plus the tool-result

--- a/main_logic/core/manager.py
+++ b/main_logic/core/manager.py
@@ -109,6 +109,12 @@ class LLMSessionManager(
         self._bg_tasks: set = set()  # 防止 fire-and-forget 任务被 GC 回收
         self._screenshot_future: asyncio.Future | None = None
         self._avatar_position: dict | None = None  # 前端传来的 Avatar 归一化坐标 {centerX, centerY, width, height}
+        # request_fresh_screenshot 与 resolve_screenshot_request 之间的一次性交接槽。
+        # 与 _avatar_position 分开是刻意的：后者被每一条 stream_data 覆写（屏幕分享帧、
+        # 主动视觉单帧都会写），拿它去配对 Phase 2 的那张截图，坐标会被中途到达的
+        # 别的帧换掉或抹成 None。只有 resolve_screenshot_request 写、只有配对的那一次
+        # request 读。
+        self._pending_screenshot_avatar_position: dict | None = None
         self.current_speech_id = None
         self._speech_output_total = 0  # diagnostic: chunks actually sent to frontend playback
         self._last_speech_output_time = 0.0

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -40,7 +40,12 @@ from main_logic.proactive_delivery import (
 from config import ANTI_REPEAT_EXEMPT_SOURCE_TAGS
 from utils.language_utils import normalize_language_code, get_global_language_full
 from uuid import uuid4
-from ._shared import _VOICE_PROACTIVE_ACK_GRACE_S, logger, _proactive_expected_sid
+from ._shared import (
+    _VOICE_PROACTIVE_ACK_GRACE_S,
+    logger,
+    _proactive_expected_sid,
+    FreshScreenshot,
+)
 from .callback_render import _build_callback_instruction, _select_callbacks_within_token_budget
 
 
@@ -133,20 +138,32 @@ class ProactiveMixin:
     # Proactive streaming helpers (Phase 2 流式 TTS + 完整文本投递)
     # ------------------------------------------------------------------
 
-    async def request_fresh_screenshot(self, timeout: float = 3.0) -> str:
+    async def request_fresh_screenshot(self, timeout: float = 3.0) -> FreshScreenshot:
         """Request the latest screenshot from the frontend over WebSocket, falling back to backend pyautogui on failure.
 
         Both paths normalize the screenshot down to 720p/JPEG-80 and return the
         normalized base64 (without prefix), so a native-resolution frontend image
         never goes straight to the vision LLM and trips the proxy's 413.
+
+        Returns a ``FreshScreenshot`` rather than the bare base64: the caller has to
+        know which path produced the image before it can decide whether an absent
+        avatar position means "the frontend said don't annotate" or merely "the
+        frontend was never asked".
+
+        Neither path draws the avatar annotation; the caller owns that step.
         """
         # 策略1: 前端 WebSocket 截图
         if self.websocket:
             try:
                 loop = asyncio.get_running_loop()
+                # 先清槽再 arm future：上一次请求的残留坐标绝不能被这次读到。
+                self._pending_screenshot_avatar_position = None
                 self._screenshot_future = loop.create_future()
                 await self.websocket.send_json({"type": "request_screenshot"})
                 b64 = await asyncio.wait_for(self._screenshot_future, timeout=timeout)
+                # 紧贴 await 取走，中间不再 await → 事件循环插不进别的帧来改写它。
+                # getattr 守卫与本文件其余部分一致：窄 manager double 不一定带这个字段。
+                ws_av_pos = getattr(self, "_pending_screenshot_avatar_position", None)
                 if b64:
                     # 前端有的截图路径（如 Electron 主进程直捕 captureSourceAsDataUrl）
                     # 返回原生分辨率，未走 720p 缩放，base64 可达 ~1.4MB，直接发给
@@ -167,11 +184,14 @@ class ProactiveMixin:
                             "[%s] request_fresh_screenshot WS compress failed, using raw: %s",
                             self.lanlan_name, comp_err,
                         )
-                    return b64
+                    return FreshScreenshot(
+                        b64=b64, source="websocket", avatar_position=ws_av_pos,
+                    )
             except (asyncio.TimeoutError, Exception) as e:
                 logger.warning("[%s] request_fresh_screenshot WS failed: %s", self.lanlan_name, e)
             finally:
                 self._screenshot_future = None
+                self._pending_screenshot_avatar_position = None
 
         # 策略2: 后端 pyautogui 兜底（仅限本机连接，远程服务器截图无意义）
         is_local = False
@@ -200,15 +220,27 @@ class ProactiveMixin:
                 jpg_bytes = await asyncio.to_thread(_capture_and_compress)
                 b64_str = b64mod.b64encode(jpg_bytes).decode('utf-8')
                 logger.info("[%s] request_fresh_screenshot: 后端 pyautogui 兜底成功 (%dKB)", self.lanlan_name, len(jpg_bytes) // 1024)
-                return b64_str
+                # 这里不叠水印：后端手里没有任何属于这张图的 Avatar 坐标。谁有资格
+                # 补坐标由调用方按 source 判断（见 FreshScreenshot 的说明）。
+                return FreshScreenshot(b64=b64_str, source="backend_fallback")
             except Exception as e2:
                 logger.warning("[%s] request_fresh_screenshot backend fallback failed: %s", self.lanlan_name, e2)
 
-        return ''
+        return FreshScreenshot()
 
-    def resolve_screenshot_request(self, b64: str):
-        """Called by the WebSocket router to hand the frontend's returned screenshot to the waiting future."""
+    def resolve_screenshot_request(self, b64: str, avatar_position: dict | None = None):
+        """Called by the WebSocket router to hand the frontend's returned screenshot -- and its avatar verdict -- to the waiting future.
+
+        The position travels with the image instead of through ``_avatar_position``
+        on purpose: that field is rewritten by every stream_data frame, so a screen
+        share frame arriving between this call and the requester waking up would
+        silently swap the coordinates.
+        """
         if self._screenshot_future and not self._screenshot_future.done():
+            # 顺序要紧：先落坐标再 resolve，等待方被唤醒时槽里一定是配对好的值。
+            self._pending_screenshot_avatar_position = (
+                avatar_position if isinstance(avatar_position, dict) and avatar_position else None
+            )
             self._screenshot_future.set_result(b64)
 
     async def prepare_proactive_delivery(self, min_idle_secs: float = 10.0) -> bool:

--- a/main_logic/proactive_chat/service.py
+++ b/main_logic/proactive_chat/service.py
@@ -372,6 +372,30 @@ def _new_dialog_locale_params(
     return {"language": declared} if declared else None
 
 
+def _resolve_phase2_avatar_position(fresh, request_avatar_position):
+    """Pick the avatar position to annotate a freshly fetched Phase 2 screenshot with.
+
+    Who is allowed to place the annotation depends on how the image was produced:
+
+    - ``'websocket'``: the frontend already judged THIS image. A position means
+      "annotate here"; ``None`` means it deliberately decided not to annotate
+      (window capture, camera, avatar collapsed, multi-monitor). Never substitute
+      the request's older position for that ``None`` -- it is a verdict, not a
+      missing value. Same rule as ``main_logic.core.streaming``, which refuses to
+      fall back to the cached position for exactly this reason.
+    - ``'backend_fallback'``: the frontend never saw this image, so it cannot have
+      objected. The position carried by the original request is the only avatar
+      information that exists for this path.
+
+    Neither branch of ``request_fresh_screenshot`` draws the annotation itself;
+    the caller does it with whatever this returns.
+    """
+    source = getattr(fresh, "source", "")
+    if source == "backend_fallback":
+        return request_avatar_position
+    return getattr(fresh, "avatar_position", None)
+
+
 async def handle_proactive_chat(
     command: ProactiveChatCommand,
     *,
@@ -1987,13 +2011,15 @@ async def handle_proactive_chat(
         # --- 向前端请求最新截图，替换 Phase 1 时拿到的旧截图 ---
         screenshot_b64_for_phase2 = ""
         if vision_content and model_config.has_vision_model:
-            fresh_b64 = await mgr.request_fresh_screenshot(timeout=3.0)
-            if fresh_b64:
-                # 如果 request_fresh_screenshot 走了 WebSocket 路径，screenshot_response
-                # 已经在 websocket_router 中更新了 mgr._avatar_position，这里用最新的位置叠加。
-                # 如果走了 pyautogui 路径，overlay 已在 request_fresh_screenshot 内部完成。
-                # 为安全起见：若 WS 路径返回的 fresh_b64 尚未叠加，在此补叠。
-                av_pos = getattr(mgr, "_avatar_position", None) or avatar_position
+            fresh = await mgr.request_fresh_screenshot(timeout=3.0)
+            if fresh.b64:
+                fresh_b64 = fresh.b64
+                # 判据见 _resolve_phase2_avatar_position：WS 路径不给坐标 = 前端明确
+                # 说「别叠」，绝不回退请求里的旧坐标；pyautogui 兜底才用 Phase 1 坐标。
+                # ⚠️ request_fresh_screenshot 两条路径都不叠加，overlay 只在这里做。
+                # ⚠️ 已知上限：Phase1→Phase2 之间隔了一整轮 LLM（数秒），兜底路径复用
+                #    的坐标可能已经陈旧。
+                av_pos = _resolve_phase2_avatar_position(fresh, avatar_position)
                 if av_pos and isinstance(av_pos, dict):
                     try:
                         from utils.screenshot_utils import overlay_avatar_annotation

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -1077,11 +1077,12 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                 b64 = raw.split(",", 1)[1] if "," in raw else raw
                 # Extract and store avatar position metadata (paired with fresh screenshot)
                 av_pos = message.get("avatar_position")
-                if av_pos and isinstance(av_pos, dict):
-                    session_manager[lanlan_name]._avatar_position = av_pos
-                else:
-                    session_manager[lanlan_name]._avatar_position = None
-                session_manager[lanlan_name].resolve_screenshot_request(b64)
+                if not (av_pos and isinstance(av_pos, dict)):
+                    # 前端明确说这张图不该叠（窗口截图 / 相机 / Avatar 已折叠 / 多屏）。
+                    av_pos = None
+                session_manager[lanlan_name]._avatar_position = av_pos
+                # 坐标随图一起交给等待方，不让它去读会被别的帧改写的 _avatar_position。
+                session_manager[lanlan_name].resolve_screenshot_request(b64, av_pos)
 
             elif action == "greeting_check":
                 # 首次连接或切换角色时，前端请求检查是否需要主动搭话

--- a/static/app/app-proactive.js
+++ b/static/app/app-proactive.js
@@ -1274,23 +1274,10 @@
                     var screenshotDataUrl = screenshotResult.dataUrl;
                     if (screenshotDataUrl) {
                         requestBody.screenshot_data = screenshotDataUrl;
-                        // Determine capture type: cached stream → check displaySurface;
-                        // null 表示窗口截图或无法确定 → 不叠加
-                        var captureType = null;
-                        if (screenshotResult.via === 'backend') {
-                            // 后端 pyautogui 抓的是整屏，与残留的 window:* 源无关；
-                            // 不显式定成 'screen' 会被 detect 判成不叠加而漏标。
-                            captureType = 'screen';
-                        } else if (typeof window.detectScreenshotCaptureType === 'function') {
-                            captureType = window.detectScreenshotCaptureType(
-                                S.screenCaptureStream, S.selectedScreenSourceId
-                            );
-                        } else if (!S.screenCaptureStream && !S.selectedScreenSourceId) {
-                            // detect 因加载顺序拿不到时的降级兜底：无流无源即整屏。
-                            // 这条不能删——后端现在把「不带坐标」当成明确的否定信号，
-                            // 拿不到函数会从「默认整屏叠」静默变成「永久不叠」。
-                            captureType = 'screen';
-                        }
+                        // captureType 由截图函数在抓帧那一刻定好（见 resolveCaptureTypeFor）。
+                        // 这里不再二次推断：抓帧是异步的，等到这一步 S 里的流 / 源
+                        // 可能已经换人，拿它解释这张旧图会叠错或漏叠。
+                        var captureType = screenshotResult.captureType || null;
                         var avatarPos = typeof window.getAvatarScreenPosition === 'function'
                             ? window.getAvatarScreenPosition(captureType) : null;
                         if (avatarPos) {
@@ -2147,18 +2134,44 @@
      * 返回整屏的问题；同时也改善此函数走 WS_HOOK / CHAT_CHANNELS.REQUEST_SCREENSHOT
      * 路径时的准确性。
      */
+    /**
+     * 把「这一帧是怎么抓来的」翻译成 Avatar 坐标的映射方式。
+     *
+     * 必须在**抓帧的那一刻**用当时的流 / 源算出来：抓帧是异步的，调用方事后再读
+     * S.screenCaptureStream / S.selectedScreenSourceId 可能已经换人，会拿新源去
+     * 解释旧帧。原生帧的调用点传 stream=null——那条缓存流描述的是另一次捕获，
+     * 源被清空时会替原生帧答出 'screen'，给一张窗口图叠上不存在的 Avatar。
+     */
+    function resolveCaptureTypeFor(via, stream, sourceId) {
+        // pyautogui 抓的是整屏桌面，与流 / 已选源都无关。
+        if (via === 'backend') return 'screen';
+        if (typeof window.detectScreenshotCaptureType === 'function') {
+            return window.detectScreenshotCaptureType(stream, sourceId);
+        }
+        // detect 因加载顺序拿不到时的降级兜底：无流无源即整屏。这条不能删——
+        // 后端把「不带坐标」当成明确的否定信号，删了会从「默认整屏叠」静默
+        // 变成「永久不叠」。
+        return (!stream && !sourceId) ? 'screen' : null;
+    }
+
     async function captureProactiveChatScreenshotWithSource() {
         // 策略 0a: 复用有效缓存流（避免打扰正在进行的屏幕共享）
         if (S.screenCaptureStream && S.screenCaptureStream.active) {
             try {
-                var tracks = S.screenCaptureStream.getVideoTracks();
+                var cachedStream = S.screenCaptureStream;
+                var cachedSourceId = S.selectedScreenSourceId;
+                var tracks = cachedStream.getVideoTracks();
                 if (tracks.length > 0 && tracks.some(function (t) { return t.readyState === 'live'; })) {
-                    var cachedFrame = await captureFrameFromStream(S.screenCaptureStream, 0.85);
+                    var cachedFrame = await captureFrameFromStream(cachedStream, 0.85);
                     if (cachedFrame && cachedFrame.dataUrl) {
                         S.screenCaptureStreamLastUsed = Date.now();
                         if (window.scheduleScreenCaptureIdleCheck) window.scheduleScreenCaptureIdleCheck();
                         console.log('[主动搭话截图] 缓存流截图成功');
-                        return { dataUrl: cachedFrame.dataUrl, via: 'stream' };
+                        return {
+                            dataUrl: cachedFrame.dataUrl,
+                            via: 'stream',
+                            captureType: resolveCaptureTypeFor('stream', cachedStream, cachedSourceId)
+                        };
                     }
                 }
             } catch (e) { console.warn('[主动搭话截图] 缓存流截图失败，继续:', e); }
@@ -2168,15 +2181,21 @@
         var desktopProvider = getDesktopProvider();
         if (S.selectedScreenSourceId && desktopProvider
             && typeof desktopProvider.captureSourceAsDataUrl === 'function') {
+            // 捕获前钉住源 ID：下面是异步的，事后再读会拿新源解释旧帧。
+            var nativeSourceId = S.selectedScreenSourceId;
             try {
                 var direct = await window.captureDesktopSourceWithTimeout(
                     desktopProvider,
                     'captureSourceAsDataUrl',
-                    S.selectedScreenSourceId
+                    nativeSourceId
                 );
                 if (direct && direct.success && direct.dataUrl) {
-                    console.log('[主动搭话截图] 主进程直接捕获成功:', S.selectedScreenSourceId);
-                    return { dataUrl: direct.dataUrl, via: 'native' };
+                    console.log('[主动搭话截图] 主进程直接捕获成功:', nativeSourceId);
+                    return {
+                        dataUrl: direct.dataUrl,
+                        via: 'native',
+                        captureType: resolveCaptureTypeFor('native', null, nativeSourceId)
+                    };
                 } else if (direct && direct.error) {
                     console.warn('[主动搭话截图] 主进程直接捕获失败，将回退到流路径:', direct.error);
                     if (typeof window.maybeClearSourceOnNotFound === 'function') {
@@ -2189,10 +2208,16 @@
         // 策略1: 缓存流 / Electron窗口ID / getDisplayMedia（非user gesture不弹窗）
         var stream = await acquireOrReuseCachedStream({ allowPrompt: false });
         if (stream) {
+            // 快照必须取在 acquireOrReuseCachedStream 之后——它自己就会改写这个字段。
+            var streamSourceId = S.selectedScreenSourceId;
             var frame = await captureFrameFromStream(stream, 0.85);
             if (frame && frame.dataUrl) {
                 console.log('[主动搭话截图] 前端截图成功');
-                return { dataUrl: frame.dataUrl, via: 'stream' };
+                return {
+                    dataUrl: frame.dataUrl,
+                    via: 'stream',
+                    captureType: resolveCaptureTypeFor('stream', stream, streamSourceId)
+                };
             }
             // 黑帧或抓帧失败 → 废弃流，重试一次
             console.warn('[主动搭话截图] 帧提取失败或纯黑帧，废弃缓存流并重试');
@@ -2204,8 +2229,15 @@
             // 重试：会走 Electron sourceId 路径
             stream = await acquireOrReuseCachedStream({ allowPrompt: false });
             if (stream) {
+                var retrySourceId = S.selectedScreenSourceId;
                 frame = await captureFrameFromStream(stream, 0.85);
-                if (frame && frame.dataUrl) return { dataUrl: frame.dataUrl, via: 'stream' };
+                if (frame && frame.dataUrl) {
+                    return {
+                        dataUrl: frame.dataUrl,
+                        via: 'stream',
+                        captureType: resolveCaptureTypeFor('stream', stream, retrySourceId)
+                    };
+                }
                 // 二次重试仍然失败，废弃这个流
                 console.warn('[主动搭话截图] 二次重试仍失败，废弃流');
                 if (S.screenCaptureStream === stream) {
@@ -2220,11 +2252,15 @@
         var backendResult = await fetchBackendScreenshot();
         if (backendResult.dataUrl) {
             console.log('[主动搭话截图] 后端截图成功');
-            return { dataUrl: backendResult.dataUrl, via: 'backend' };
+            return {
+                dataUrl: backendResult.dataUrl,
+                via: 'backend',
+                captureType: resolveCaptureTypeFor('backend', null, null)
+            };
         }
 
         console.warn('[主动搭话截图] 所有截图方式均失败');
-        return { dataUrl: null, via: null };
+        return { dataUrl: null, via: null, captureType: null };
     }
     mod.captureProactiveChatScreenshotWithSource = captureProactiveChatScreenshotWithSource;
 

--- a/static/app/app-proactive.js
+++ b/static/app/app-proactive.js
@@ -493,6 +493,14 @@
         return window.appScreen.scheduleScreenCaptureIdleCheck();
     }
 
+    function normalizeNativeCaptureDataUrlForStream(dataUrl) {
+        return window.appScreen.normalizeNativeCaptureDataUrlForStream(dataUrl);
+    }
+
+    function buildStreamDataMessage(dataUrl, inputType, sourceId, explicitCaptureType) {
+        return window.appScreen.buildStreamDataMessage(dataUrl, inputType, sourceId, explicitCaptureType);
+    }
+
     // ======================== syncProactiveFlags (no-op) ========================
     // app-state.js 使用 Object.defineProperty 进行双向绑定，
     // 因此不再需要手动同步 window.xxx <-> 本地变量。
@@ -1206,7 +1214,9 @@
 
                 if (availableModes.includes('vision')) {
                     screenshotIndex = fetchTasks.length;
-                    fetchTasks.push(captureProactiveChatScreenshot());
+                    // 带来源版：下面要靠 via 区分「后端整屏兜底」与「流/原生源」，
+                    // 光看发送时的 S.selectedScreenSourceId 会把整屏图误判成窗口截图。
+                    fetchTasks.push(captureProactiveChatScreenshotWithSource());
                 }
 
                 if (availableModes.includes('window')) {
@@ -1260,20 +1270,26 @@
                 }
 
                 if (screenshotIndex !== -1 && availableModes.includes('vision')) {
-                    var screenshotDataUrl = results[screenshotIndex];
+                    var screenshotResult = results[screenshotIndex] || {};
+                    var screenshotDataUrl = screenshotResult.dataUrl;
                     if (screenshotDataUrl) {
                         requestBody.screenshot_data = screenshotDataUrl;
                         // Determine capture type: cached stream → check displaySurface;
                         // null 表示窗口截图或无法确定 → 不叠加
-                        // 仅当完全没有流/源（pyautogui 兜底）时才默认 'screen'
                         var captureType = null;
-                        if (typeof window.detectScreenshotCaptureType === 'function') {
+                        if (screenshotResult.via === 'backend') {
+                            // 后端 pyautogui 抓的是整屏，与残留的 window:* 源无关；
+                            // 不显式定成 'screen' 会被 detect 判成不叠加而漏标。
+                            captureType = 'screen';
+                        } else if (typeof window.detectScreenshotCaptureType === 'function') {
                             captureType = window.detectScreenshotCaptureType(
                                 S.screenCaptureStream, S.selectedScreenSourceId
                             );
-                        }
-                        if (captureType === null && !S.screenCaptureStream && !S.selectedScreenSourceId) {
-                            captureType = 'screen'; // 无流无源 → pyautogui 全屏兜底
+                        } else if (!S.screenCaptureStream && !S.selectedScreenSourceId) {
+                            // detect 因加载顺序拿不到时的降级兜底：无流无源即整屏。
+                            // 这条不能删——后端现在把「不带坐标」当成明确的否定信号，
+                            // 拿不到函数会从「默认整屏叠」静默变成「永久不叠」。
+                            captureType = 'screen';
                         }
                         var avatarPos = typeof window.getAvatarScreenPosition === 'function'
                             ? window.getAvatarScreenPosition(captureType) : null;
@@ -1904,6 +1920,11 @@
             if (!S.socket || S.socket.readyState !== WebSocket.OPEN) return;
 
             var dataUrl = null;
+            // 这一帧来自哪种画面来源，决定 Avatar 坐标怎么映射到截图坐标系。
+            // 三条来源判据各不相同且逐级回退，必须在取到画面的那一步就定下来——
+            // 发送时的 S.screenCaptureStream / S.selectedScreenSourceId 描述的是
+            // 「本会话配置抓什么」，不是「这一帧抓到了什么」。
+            var captureType = null;
 
             // 优先前端流（缓存流 → Electron源 → 不弹窗）
             var stream = await acquireOrReuseCachedStream({ allowPrompt: false });
@@ -1911,6 +1932,7 @@
                 var frame = await captureFrameFromStream(stream, 0.8);
                 if (frame && frame.dataUrl) {
                     dataUrl = frame.dataUrl;
+                    captureType = window.detectScreenshotCaptureType(stream, S.selectedScreenSourceId);
                 } else if (S.screenCaptureStream === stream) {
                     // 空帧（黑帧或空壳流），废弃缓存流
                     console.warn('[ProactiveVision] 缓存流提取帧失败，废弃该流');
@@ -1934,7 +1956,16 @@
                             S.selectedScreenSourceId
                         );
                         if (direct && direct.success && direct.dataUrl) {
-                            dataUrl = direct.dataUrl;
+                            // 桌面壳的 NativeImage.toDataURL() 通常出 PNG，而后端屏幕数据
+                            // 校验只接受 data:image/jpeg;base64,（utils/screenshot_utils.py:120），
+                            // 不转码会让整帧被判为「无效的屏幕数据格式」直接丢掉。
+                            var nativeDataUrl = await normalizeNativeCaptureDataUrlForStream(direct.dataUrl);
+                            if (nativeDataUrl) {
+                                dataUrl = nativeDataUrl;
+                                captureType = window.detectScreenshotCaptureType(null, S.selectedScreenSourceId);
+                            } else {
+                                console.warn('[ProactiveVision] 原生帧转 JPEG 失败，尝试后端兜底');
+                            }
                         } else if (typeof window.maybeClearSourceOnNotFound === 'function') {
                             window.maybeClearSourceOnNotFound(direct, '主动视觉原生捕获源已失效');
                         }
@@ -1954,6 +1985,12 @@
             if (!dataUrl) {
                 var backendResult = await fetchBackendScreenshot();
                 dataUrl = backendResult.dataUrl;
+                if (dataUrl) {
+                    // pyautogui 抓的是整屏桌面，与已选窗口源 / 缓存流都无关，必须显式
+                    // 定成 'screen'，否则会被残留的 window:* 源判成不叠加。
+                    // 多屏下由 getAvatarScreenPosition 的闸门兜底返回 null。
+                    captureType = 'screen';
+                }
                 // macOS 403 权限提示
                 if (backendResult.status === 403 && !S.screenRecordingPermissionHintShown) {
                     S.screenRecordingPermissionHintShown = true;
@@ -1969,11 +2006,12 @@
                 return;
             }
             if (dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
-                S.socket.send(JSON.stringify({
-                    action: 'stream_data',
-                    data: dataUrl,
-                    input_type: (window.appUtils && window.appUtils.isMobile) ? (window.appUtils.isMobile() ? 'camera' : 'screen') : 'screen'
-                }));
+                var visionInputType = (window.appUtils && window.appUtils.isMobile) ? (window.appUtils.isMobile() ? 'camera' : 'screen') : 'screen';
+                // 与持续屏幕分享共用同一个构造函数，避免两条链路的 avatar_position 口径分叉。
+                // 第 3 参传 null：来源已由 captureType 显式给出，不需要再按 sourceId 推断。
+                S.socket.send(JSON.stringify(
+                    buildStreamDataMessage(dataUrl, visionInputType, null, captureType)
+                ));
                 console.log('[ProactiveVision] 发送单帧屏幕数据');
             }
         } catch (e) {
@@ -2102,7 +2140,7 @@
      * 返回整屏的问题；同时也改善此函数走 WS_HOOK / CHAT_CHANNELS.REQUEST_SCREENSHOT
      * 路径时的准确性。
      */
-    async function captureProactiveChatScreenshot() {
+    async function captureProactiveChatScreenshotWithSource() {
         // 策略 0a: 复用有效缓存流（避免打扰正在进行的屏幕共享）
         if (S.screenCaptureStream && S.screenCaptureStream.active) {
             try {
@@ -2113,7 +2151,7 @@
                         S.screenCaptureStreamLastUsed = Date.now();
                         if (window.scheduleScreenCaptureIdleCheck) window.scheduleScreenCaptureIdleCheck();
                         console.log('[主动搭话截图] 缓存流截图成功');
-                        return cachedFrame.dataUrl;
+                        return { dataUrl: cachedFrame.dataUrl, via: 'stream' };
                     }
                 }
             } catch (e) { console.warn('[主动搭话截图] 缓存流截图失败，继续:', e); }
@@ -2131,7 +2169,7 @@
                 );
                 if (direct && direct.success && direct.dataUrl) {
                     console.log('[主动搭话截图] 主进程直接捕获成功:', S.selectedScreenSourceId);
-                    return direct.dataUrl;
+                    return { dataUrl: direct.dataUrl, via: 'native' };
                 } else if (direct && direct.error) {
                     console.warn('[主动搭话截图] 主进程直接捕获失败，将回退到流路径:', direct.error);
                     if (typeof window.maybeClearSourceOnNotFound === 'function') {
@@ -2147,7 +2185,7 @@
             var frame = await captureFrameFromStream(stream, 0.85);
             if (frame && frame.dataUrl) {
                 console.log('[主动搭话截图] 前端截图成功');
-                return frame.dataUrl;
+                return { dataUrl: frame.dataUrl, via: 'stream' };
             }
             // 黑帧或抓帧失败 → 废弃流，重试一次
             console.warn('[主动搭话截图] 帧提取失败或纯黑帧，废弃缓存流并重试');
@@ -2160,7 +2198,7 @@
             stream = await acquireOrReuseCachedStream({ allowPrompt: false });
             if (stream) {
                 frame = await captureFrameFromStream(stream, 0.85);
-                if (frame && frame.dataUrl) return frame.dataUrl;
+                if (frame && frame.dataUrl) return { dataUrl: frame.dataUrl, via: 'stream' };
                 // 二次重试仍然失败，废弃这个流
                 console.warn('[主动搭话截图] 二次重试仍失败，废弃流');
                 if (S.screenCaptureStream === stream) {
@@ -2175,11 +2213,18 @@
         var backendResult = await fetchBackendScreenshot();
         if (backendResult.dataUrl) {
             console.log('[主动搭话截图] 后端截图成功');
-            return backendResult.dataUrl;
+            return { dataUrl: backendResult.dataUrl, via: 'backend' };
         }
 
         console.warn('[主动搭话截图] 所有截图方式均失败');
-        return null;
+        return { dataUrl: null, via: null };
+    }
+    mod.captureProactiveChatScreenshotWithSource = captureProactiveChatScreenshotWithSource;
+
+    // 旧契约薄封装：只要 dataUrl 的调用方继续用这个。
+    async function captureProactiveChatScreenshot() {
+        var res = await captureProactiveChatScreenshotWithSource();
+        return res && res.dataUrl ? res.dataUrl : null;
     }
     mod.captureProactiveChatScreenshot = captureProactiveChatScreenshot;
 

--- a/static/app/app-proactive.js
+++ b/static/app/app-proactive.js
@@ -1929,10 +1929,13 @@
             // 优先前端流（缓存流 → Electron源 → 不弹窗）
             var stream = await acquireOrReuseCachedStream({ allowPrompt: false });
             if (stream) {
+                // 同上：抓帧是异步的，源 ID 要跟这条流一起钉住，事后再读可能已经换人。
+                // 必须在 acquireOrReuseCachedStream 之后取——它自己就会改写这个字段。
+                var streamSourceId = S.selectedScreenSourceId;
                 var frame = await captureFrameFromStream(stream, 0.8);
                 if (frame && frame.dataUrl) {
                     dataUrl = frame.dataUrl;
-                    captureType = window.detectScreenshotCaptureType(stream, S.selectedScreenSourceId);
+                    captureType = window.detectScreenshotCaptureType(stream, streamSourceId);
                 } else if (S.screenCaptureStream === stream) {
                     // 空帧（黑帧或空壳流），废弃缓存流
                     console.warn('[ProactiveVision] 缓存流提取帧失败，废弃该流');
@@ -1949,11 +1952,15 @@
                 if (desktopProvider
                     && desktopProvider.nativeFrameCapture
                     && typeof desktopProvider.captureSourceAsDataUrl === 'function') {
+                    // 捕获前先钉住源 ID：下面隔着两个 await，期间用户换源会让
+                    // S.selectedScreenSourceId 变掉，事后再读就会拿新源去解释旧帧
+                    // （窗口换成屏幕 → 给一张没有 Avatar 的窗口图叠字）。
+                    var nativeSourceId = S.selectedScreenSourceId;
                     try {
                         var direct = await window.captureDesktopSourceWithTimeout(
                             desktopProvider,
                             'captureSourceAsDataUrl',
-                            S.selectedScreenSourceId
+                            nativeSourceId
                         );
                         if (direct && direct.success && direct.dataUrl) {
                             // 桌面壳的 NativeImage.toDataURL() 通常出 PNG，而后端屏幕数据
@@ -1962,7 +1969,7 @@
                             var nativeDataUrl = await normalizeNativeCaptureDataUrlForStream(direct.dataUrl);
                             if (nativeDataUrl) {
                                 dataUrl = nativeDataUrl;
-                                captureType = window.detectScreenshotCaptureType(null, S.selectedScreenSourceId);
+                                captureType = window.detectScreenshotCaptureType(null, nativeSourceId);
                             } else {
                                 console.warn('[ProactiveVision] 原生帧转 JPEG 失败，尝试后端兜底');
                             }

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -2081,9 +2081,12 @@
     var MULTI_DISPLAY_CACHE_TTL_MS = 5000;
 
     function refreshMultiDisplayCache() {
+        // 无条件先打时间戳，失败/没有桥时也算「这一轮问过了」：否则查询失败会让
+        // multiDisplayCache 一直是 null，下面的节流判据就永远放行，持续分享时
+        // 变成每帧一次 IPC（还会叠出多个在途请求）。
+        multiDisplayCacheAt = Date.now();
         var bridge = window.electronScreen;
         if (!bridge || typeof bridge.getAllDisplays !== 'function') return;
-        multiDisplayCacheAt = Date.now();
         try {
             Promise.resolve(bridge.getAllDisplays()).then(function (list) {
                 if (list && typeof list.length === 'number') {
@@ -2102,7 +2105,9 @@
         }
         // 刷新是 fire-and-forget：本次仍用上一轮的值，拓扑变化最多晚 TTL + 一次 IPC
         // 生效。不 await 是因为这条在截图路径上，持续分享时每秒都会问一次。
-        if (multiDisplayCache === null
+        // 节流只看时间戳，不看缓存是否还是未知——查询失败时 multiDisplayCache 会
+        // 一直是 null，若把它放进判据就等于不节流。
+        if (multiDisplayCacheAt === 0
             || (Date.now() - multiDisplayCacheAt) > MULTI_DISPLAY_CACHE_TTL_MS) {
             refreshMultiDisplayCache();
         }

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -2073,27 +2073,39 @@
     // 显示器标识，运行时又不能重新 getSources（Linux Portal 会再弹系统窗口）。
     // 所以这里只做闸门：确认是多屏就不叠。宁可不叠，也不叠到错误的屏上。
     var multiDisplayCache = null;   // true / false / null(未知)
+    var multiDisplayCacheAt = 0;
+    // 桥上没有显示器拓扑变更事件（electronScreen 只有 getAllDisplays /
+    // getCurrentDisplay / getCursorPoint / getDesktopCoordinateSnapshot /
+    // getPrimaryDisplayInfo / moveWindowToDisplay），只能按 TTL 重查：一次查完就
+    // 永久缓存的话，笔记本插上外接屏之后闸门会一直按单屏放行。
+    var MULTI_DISPLAY_CACHE_TTL_MS = 5000;
 
     function refreshMultiDisplayCache() {
         var bridge = window.electronScreen;
         if (!bridge || typeof bridge.getAllDisplays !== 'function') return;
+        multiDisplayCacheAt = Date.now();
         try {
             Promise.resolve(bridge.getAllDisplays()).then(function (list) {
                 if (list && typeof list.length === 'number') {
                     multiDisplayCache = list.length > 1;
                 }
-            }).catch(function () { /* 拿不到就保持未知 */ });
-        } catch (e) { /* 拿不到就保持未知 */ }
+            }).catch(function () { /* 拿不到就保持上一次的判断 */ });
+        } catch (e) { /* 拿不到就保持上一次的判断 */ }
     }
 
     function isKnownMultiDisplay() {
-        // Chromium 的 Screen.isExtended 不需要权限，是最直接的信号。
+        // Chromium 的 Screen.isExtended 不需要权限，且随拓扑实时变化，是最直接的信号。
         // 拿不到时退回 electronScreen 缓存；两者都拿不到就返回 false，
         // 即逐字沿用改动前的行为（单屏用户与纯浏览器场景不受本闸门影响）。
         if (window.screen && typeof window.screen.isExtended === 'boolean') {
             return window.screen.isExtended;
         }
-        if (multiDisplayCache === null) refreshMultiDisplayCache();
+        // 刷新是 fire-and-forget：本次仍用上一轮的值，拓扑变化最多晚 TTL + 一次 IPC
+        // 生效。不 await 是因为这条在截图路径上，持续分享时每秒都会问一次。
+        if (multiDisplayCache === null
+            || (Date.now() - multiDisplayCacheAt) > MULTI_DISPLAY_CACHE_TTL_MS) {
+            refreshMultiDisplayCache();
+        }
         return multiDisplayCache === true;
     }
     mod.isKnownMultiDisplay = isKnownMultiDisplay;

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -805,18 +805,34 @@
      * 构造屏幕/相机分享的 stream_data 消息，并在适用时附带 Avatar 位置元数据。
      * 与主动搭话截图（app-proactive.js）口径保持一致：仅桌面/全屏分享叠加注解，
      * 窗口分享 / 移动相机不含 Avatar（captureType 为 null → 不附带）。
+     *
+     * @param {string} dataUrl 已归一化成 JPEG 的画面数据
+     * @param {string} input_type 'screen' | 'camera'
+     * @param {string|null} [sourceId] 原生帧的显式源 ID
+     * @param {'screen'|'viewport'|null} [explicitCaptureType]
+     *        调用方已经知道这一帧来自哪种画面来源时显式传入；传 null 表示
+     *        「已确认无法判定」→ 不叠加。省略时按 sourceId / 缓存流推断。
      */
-    function buildStreamDataMessage(dataUrl, input_type, sourceId) {
+    function buildStreamDataMessage(dataUrl, input_type, sourceId, explicitCaptureType) {
         var msg = { action: 'stream_data', data: dataUrl, input_type: input_type };
         // 仅屏幕分享可能包含 Avatar；移动相机拍的是现实画面，无 Avatar
         if (input_type === 'screen') {
-            // 原生帧按显式源判定；有前端流时按流/已选源判定。
-            // 两者都没有时按全屏处理；持续屏幕分享不会再进入后端整屏截图轮询。
-            var captureType = sourceId
-                ? detectScreenshotCaptureType(null, sourceId)
-                : (S.screenCaptureStream
+            var captureType;
+            if (typeof explicitCaptureType !== 'undefined') {
+                // 单帧路径的画面可能来自缓存流 / 原生帧 / 后端整屏兜底，三者互相回退。
+                // 发送时的 S.screenCaptureStream / S.selectedScreenSourceId 描述的是
+                // 「本会话配置抓什么」，不是「这一帧抓到了什么」，推不出来。
+                captureType = explicitCaptureType;
+            } else if (sourceId) {
+                // 原生帧按显式源判定。
+                captureType = detectScreenshotCaptureType(null, sourceId);
+            } else {
+                // 有前端流时按流/已选源判定；两者都没有时按全屏处理，
+                // 持续屏幕分享不会再进入后端整屏截图轮询。
+                captureType = S.screenCaptureStream
                     ? detectScreenshotCaptureType(S.screenCaptureStream, S.selectedScreenSourceId)
-                    : 'screen');
+                    : 'screen';
+            }
             var avatarPos = getAvatarScreenPosition(captureType);
             if (avatarPos) {
                 msg.avatar_position = avatarPos;
@@ -2045,6 +2061,43 @@
     }
     mod.detectScreenshotCaptureType = detectScreenshotCaptureType;
 
+    // ======================== 多显示器闸门 ========================
+    // getAvatarScreenPosition 的 'screen' 分支用 window.screenX（虚拟桌面全局坐标）
+    // 当原点、用 window.screen.width（当前所在显示器尺寸）当归一化分母，两个参考系
+    // 差一个「当前显示器 bounds 原点」。单屏下该原点恒为 0 所以结果正确；多屏下
+    // 「捕获副屏 / Pet 窗口在主屏」会算出一个落在 [0,1] 内的错误坐标，把注解叠到
+    // 另一块屏的截图上。
+    //
+    // 要把参考系修对，必须知道「被捕获的是哪块屏」，而整条链路都不携带这个信息：
+    // sourceId 只被 startsWith('screen:') 判一下就丢弃，getSettings() 里没有任何
+    // 显示器标识，运行时又不能重新 getSources（Linux Portal 会再弹系统窗口）。
+    // 所以这里只做闸门：确认是多屏就不叠。宁可不叠，也不叠到错误的屏上。
+    var multiDisplayCache = null;   // true / false / null(未知)
+
+    function refreshMultiDisplayCache() {
+        var bridge = window.electronScreen;
+        if (!bridge || typeof bridge.getAllDisplays !== 'function') return;
+        try {
+            Promise.resolve(bridge.getAllDisplays()).then(function (list) {
+                if (list && typeof list.length === 'number') {
+                    multiDisplayCache = list.length > 1;
+                }
+            }).catch(function () { /* 拿不到就保持未知 */ });
+        } catch (e) { /* 拿不到就保持未知 */ }
+    }
+
+    function isKnownMultiDisplay() {
+        // Chromium 的 Screen.isExtended 不需要权限，是最直接的信号。
+        // 拿不到时退回 electronScreen 缓存；两者都拿不到就返回 false，
+        // 即逐字沿用改动前的行为（单屏用户与纯浏览器场景不受本闸门影响）。
+        if (window.screen && typeof window.screen.isExtended === 'boolean') {
+            return window.screen.isExtended;
+        }
+        if (multiDisplayCache === null) refreshMultiDisplayCache();
+        return multiDisplayCache === true;
+    }
+    mod.isKnownMultiDisplay = isKnownMultiDisplay;
+
     // ======================== getAvatarScreenPosition ========================
     /**
      * 获取 Avatar 模型在截图图片坐标系中的归一化位置（0-1）。
@@ -2144,6 +2197,9 @@
         var refW, refH; // 截图所覆盖区域的 CSS 尺寸（用于归一化分母）
 
         if (captureType === 'screen') {
+            // 多屏下无法判断截的是哪块屏，下面的坐标换算会算错屏，直接不叠。
+            if (isKnownMultiDisplay()) return null;
+
             // 截图覆盖整个屏幕 → 坐标需加上浏览器窗口在屏幕上的偏移
             // viewportOrigin = windowOuter 的左上角 + chrome 偏移
             var chromeLeft = Math.round((window.outerWidth - window.innerWidth) / 2);
@@ -2195,6 +2251,10 @@
     window.detectScreenshotCaptureType = detectScreenshotCaptureType;
     window.clearSelectedScreenSource = clearSelectedScreenSource;
     window.maybeClearSourceOnNotFound = maybeClearSourceOnNotFound;
+
+    // 预热多显示器缓存：electronScreen 桥是异步的，等到第一次截图再问就来不及，
+    // 那一帧会按「未知 → 单屏」处理。screen.isExtended 可用时这一步是多余的。
+    refreshMultiDisplayCache();
 
     // ======================== Export module ========================
     window.appScreen = mod;

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -3529,20 +3529,30 @@
                     (async function () {
                         try {
                             var dataUrl = null;
-                            if (typeof window.captureProactiveChatScreenshot === 'function') {
+                            var shotVia = null;
+                            if (window.appProactive
+                                && typeof window.appProactive.captureProactiveChatScreenshotWithSource === 'function') {
+                                var shot = await window.appProactive.captureProactiveChatScreenshotWithSource();
+                                dataUrl = shot && shot.dataUrl ? shot.dataUrl : null;
+                                shotVia = shot ? shot.via : null;
+                            } else if (typeof window.captureProactiveChatScreenshot === 'function') {
                                 dataUrl = await window.captureProactiveChatScreenshot();
                             }
                             if (dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
                                 var respMsg = { action: 'screenshot_response', data: dataUrl };
                                 // Determine capture type for correct coordinate mapping
-                                // null = 窗口截图或无法确定 → 不叠加；仅无流无源时默认 'screen'
+                                // null = 窗口截图或无法确定 → 不叠加
                                 var captureType = null;
-                                if (typeof window.detectScreenshotCaptureType === 'function') {
+                                if (shotVia === 'backend') {
+                                    // 后端 pyautogui 抓的是整屏，与残留的 window:* 源无关。
+                                    captureType = 'screen';
+                                } else if (typeof window.detectScreenshotCaptureType === 'function') {
                                     captureType = window.detectScreenshotCaptureType(
                                         S.screenCaptureStream, S.selectedScreenSourceId
                                     );
-                                }
-                                if (captureType === null && !S.screenCaptureStream && !S.selectedScreenSourceId) {
+                                } else if (!S.screenCaptureStream && !S.selectedScreenSourceId) {
+                                    // detect 拿不到时的降级兜底，不能删：后端现在把「不带坐标」
+                                    // 当明确的否定信号，删了会从「默认整屏叠」变成「永久不叠」。
                                     captureType = 'screen';
                                 }
                                 var avatarPos = typeof window.getAvatarScreenPosition === 'function'

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -3529,29 +3529,32 @@
                     (async function () {
                         try {
                             var dataUrl = null;
-                            var shotVia = null;
+                            // captureType 由截图函数在抓帧那一刻定好，这里不再二次推断：
+                            // 抓帧是异步的，等到这一步 S 里的流 / 源可能已经换人。
+                            var shotCaptureType = null;
+                            var hasPairedCaptureType = false;
                             if (window.appProactive
                                 && typeof window.appProactive.captureProactiveChatScreenshotWithSource === 'function') {
                                 var shot = await window.appProactive.captureProactiveChatScreenshotWithSource();
                                 dataUrl = shot && shot.dataUrl ? shot.dataUrl : null;
-                                shotVia = shot ? shot.via : null;
+                                shotCaptureType = shot ? (shot.captureType || null) : null;
+                                hasPairedCaptureType = true;
                             } else if (typeof window.captureProactiveChatScreenshot === 'function') {
                                 dataUrl = await window.captureProactiveChatScreenshot();
                             }
                             if (dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
                                 var respMsg = { action: 'screenshot_response', data: dataUrl };
-                                // Determine capture type for correct coordinate mapping
                                 // null = 窗口截图或无法确定 → 不叠加
                                 var captureType = null;
-                                if (shotVia === 'backend') {
-                                    // 后端 pyautogui 抓的是整屏，与残留的 window:* 源无关。
-                                    captureType = 'screen';
+                                if (hasPairedCaptureType) {
+                                    captureType = shotCaptureType;
                                 } else if (typeof window.detectScreenshotCaptureType === 'function') {
+                                    // 旧契约兜底：拿不到带来源的截图函数时只能就地推断。
                                     captureType = window.detectScreenshotCaptureType(
                                         S.screenCaptureStream, S.selectedScreenSourceId
                                     );
                                 } else if (!S.screenCaptureStream && !S.selectedScreenSourceId) {
-                                    // detect 拿不到时的降级兜底，不能删：后端现在把「不带坐标」
+                                    // detect 也拿不到时的降级兜底，不能删：后端把「不带坐标」
                                     // 当明确的否定信号，删了会从「默认整屏叠」变成「永久不叠」。
                                     captureType = 'screen';
                                 }

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -3548,15 +3548,21 @@
                                 var captureType = null;
                                 if (hasPairedCaptureType) {
                                     captureType = shotCaptureType;
-                                } else if (typeof window.detectScreenshotCaptureType === 'function') {
+                                } else {
                                     // 旧契约兜底：拿不到带来源的截图函数时只能就地推断。
-                                    captureType = window.detectScreenshotCaptureType(
-                                        S.screenCaptureStream, S.selectedScreenSourceId
-                                    );
-                                } else if (!S.screenCaptureStream && !S.selectedScreenSourceId) {
-                                    // detect 也拿不到时的降级兜底，不能删：后端把「不带坐标」
-                                    // 当明确的否定信号，删了会从「默认整屏叠」变成「永久不叠」。
-                                    captureType = 'screen';
+                                    if (typeof window.detectScreenshotCaptureType === 'function') {
+                                        captureType = window.detectScreenshotCaptureType(
+                                            S.screenCaptureStream, S.selectedScreenSourceId
+                                        );
+                                    }
+                                    // 这一步必须是独立判断而不是 else：detect 存在但判不出
+                                    // （无流无源的后端整屏兜底）时也要提升成 'screen'。写成
+                                    // else if 会让它只在 detect 缺席时生效，后端把「不带坐标」
+                                    // 当明确的否定信号，于是整屏图变成永久不叠。
+                                    if (captureType === null
+                                        && !S.screenCaptureStream && !S.selectedScreenSourceId) {
+                                        captureType = 'screen';
+                                    }
                                 }
                                 var avatarPos = typeof window.getAvatarScreenPosition === 'function'
                                     ? window.getAvatarScreenPosition(captureType) : null;

--- a/tests/unit/test_avatar_annotation_frontend.py
+++ b/tests/unit/test_avatar_annotation_frontend.py
@@ -395,3 +395,82 @@ def test_window_source_frame_is_not_annotated():
     msg = json.loads(out["sent"][0])
     assert msg["data"].endswith("NATIVE")
     assert "avatar_position" not in msg
+
+
+# Capture succeeds, but the user switches from the window source to a full
+# screen while the grab is still in flight.
+_NATIVE_OK_THEN_SWITCH = (
+    "(function () {"
+    " S.selectedScreenSourceId = 'screen:0:0';"
+    " return { success: true, dataUrl: 'data:image/png;base64,PNG' };"
+    " })()"
+)
+
+
+@pytest.mark.unit
+def test_native_frame_keeps_the_source_it_was_captured_from():
+    """Switching source mid-capture must not re-label the frame already in hand.
+
+    The frame was grabbed from a window; re-reading the (now changed) selected
+    source would call it a full-screen grab and annotate an image that contains
+    no avatar at all.
+    """
+    out = _run(_frame_script(
+        source_id="'window:9'", stream="null", native=_NATIVE_OK_THEN_SWITCH,
+    ))
+    msg = json.loads(out["sent"][0])
+    assert msg["data"].endswith("NATIVE")
+    # Captured from window:9, so it must stay unannotated despite the switch.
+    assert "avatar_position" not in msg
+
+
+@pytest.mark.unit
+def test_display_topology_change_is_picked_up_after_the_cache_ttl():
+    """A monitor attached after startup must re-arm the gate, not stay cached forever.
+
+    Only reachable when ``screen.isExtended`` is unavailable, which is exactly
+    when the Electron bridge fallback is in use.
+    """
+    src = _screen_src()
+    multi = (
+        "var multiDisplayCache = null;\nvar multiDisplayCacheAt = 0;\n"
+        + [line for line in src.splitlines()
+           if "MULTI_DISPLAY_CACHE_TTL_MS =" in line][0].strip() + "\n"
+        + _fn(src, "refreshMultiDisplayCache") + "\n"
+        + _fn(src, "isKnownMultiDisplay")
+    )
+    script = """
+const results = {};
+let displayCount = 1;
+let now = 1000;
+Date.now = () => now;
+const window = {
+  screen: { width: 1920, height: 1080 },   // no isExtended -> bridge fallback
+  electronScreen: { getAllDisplays: async () => new Array(displayCount).fill({}) }
+};
+__MULTI__
+const settle = () => new Promise((r) => setImmediate(r));
+(async () => {
+  isKnownMultiDisplay();
+  await settle();
+  results.singleDisplay = isKnownMultiDisplay();
+
+  // A second monitor is attached; without a TTL the cached false sticks forever.
+  displayCount = 2;
+  now += 100;
+  isKnownMultiDisplay();
+  await settle();
+  results.withinTtl = isKnownMultiDisplay();
+
+  now += 60000;
+  isKnownMultiDisplay();
+  await settle();
+  results.afterTtl = isKnownMultiDisplay();
+  console.log(JSON.stringify(results));
+})();
+""".replace("__MULTI__", multi)
+    out = _run(script)
+    assert out["singleDisplay"] is False
+    # Still stale inside the TTL -- documents the bounded self-heal window.
+    assert out["withinTtl"] is False
+    assert out["afterTtl"] is True

--- a/tests/unit/test_avatar_annotation_frontend.py
+++ b/tests/unit/test_avatar_annotation_frontend.py
@@ -1,0 +1,397 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Frontend half of the avatar annotation chain, driven through real module code.
+
+Three behaviours are pinned here, each by running the actual function bodies out
+of ``static/app/`` under node rather than asserting on source text:
+
+* the multi-display gate, which refuses to place an annotation when it cannot
+  tell which monitor a full-screen capture covers;
+* the proactive single frame carrying ``avatar_position`` at all;
+* the explicit capture-type argument overriding a stale selected source id.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_stdin
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+APP_SCREEN_PATH = PROJECT_ROOT / "static" / "app" / "app-screen.js"
+APP_PROACTIVE_PATH = PROJECT_ROOT / "static" / "app" / "app-proactive.js"
+
+
+def _node() -> str:
+    found = shutil.which("node")
+    if not found:
+        pytest.skip("node not available")
+    return found
+
+
+def _balanced_block_end(source: str, brace: int) -> int:
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = brace
+    while index < len(source):
+        char = source[index]
+        nxt = source[index + 1] if index + 1 < len(source) else ""
+        if line_comment:
+            if char in "\r\n":
+                line_comment = False
+            index += 1
+            continue
+        if block_comment:
+            if char == "*" and nxt == "/":
+                block_comment = False
+                index += 2
+                continue
+            index += 1
+            continue
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char == "/" and nxt == "/":
+            line_comment = True
+            index += 2
+            continue
+        if char == "/" and nxt == "*":
+            block_comment = True
+            index += 2
+            continue
+        if char in "'\"`":
+            quote = char
+            index += 1
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    raise AssertionError("unbalanced block")
+
+
+def _fn(source: str, name: str) -> str:
+    """Extract one function declaration, keeping an ``async`` prefix if present."""
+    marker = f"function {name}("
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing JS function {name}")
+    prefix = ""
+    head = source[max(0, start - 6):start]
+    if head.endswith("async "):
+        prefix = "async "
+    brace = source.find("{", start)
+    end = _balanced_block_end(source, brace)
+    return prefix + source[start:end + 1]
+
+
+def _run(script: str) -> dict:
+    proc = run_node_stdin(_node(), script, capture_output=True)
+    assert proc.returncode == 0, f"node failed:\n{proc.stdout}\n{proc.stderr}"
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _screen_src() -> str:
+    return APP_SCREEN_PATH.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Multi-display gate
+# --------------------------------------------------------------------------
+
+_GATE_PRELUDE = """
+const results = {};
+function makeEnv(isExtended) {
+  const win = {
+    screen: { width: 1920, height: 1080 },
+    outerWidth: 1200, innerWidth: 1200,
+    outerHeight: 900, innerHeight: 860,
+    screenX: 0, screenY: 0,
+    live2dManager: {
+      getModelScreenBounds() {
+        return { centerX: 400, centerY: 500, width: 200, height: 400 };
+      }
+    }
+  };
+  if (typeof isExtended === 'boolean') win.screen.isExtended = isExtended;
+  return win;
+}
+"""
+
+_GATE_BODY = """
+function build(win) {
+  const window = win;
+  const document = { getElementById() { return null; } };
+  const getComputedStyle = () => ({ visibility: 'visible' });
+  const mod = {};
+  __MULTI_DISPLAY__
+  __GET_POS__
+  return { getAvatarScreenPosition, isKnownMultiDisplay };
+}
+"""
+
+
+def _gate_script(tail: str) -> str:
+    src = _screen_src()
+    multi = (
+        "var multiDisplayCache = null;\n"
+        + _fn(src, "refreshMultiDisplayCache") + "\n"
+        + _fn(src, "isKnownMultiDisplay")
+    )
+    body = _GATE_BODY.replace("__MULTI_DISPLAY__", multi).replace(
+        "__GET_POS__", _fn(src, "getAvatarScreenPosition")
+    )
+    return _GATE_PRELUDE + body + tail
+
+
+@pytest.mark.unit
+def test_multi_display_screen_capture_is_not_annotated():
+    """Extended desktop: the coordinate math cannot tell which monitor was captured."""
+    script = _gate_script("""
+const api = build(makeEnv(true));
+results.pos = api.getAvatarScreenPosition('screen');
+console.log(JSON.stringify(results));
+""")
+    assert _run(script)["pos"] is None
+
+
+@pytest.mark.unit
+def test_single_display_screen_capture_is_unchanged():
+    """The gate must be invisible to single-monitor users -- the common case."""
+    script = _gate_script("""
+const api = build(makeEnv(false));
+results.pos = api.getAvatarScreenPosition('screen');
+console.log(JSON.stringify(results));
+""")
+    pos = _run(script)["pos"]
+    assert pos is not None
+    # centerX 400/1920; centerY (500 + chromeTop 40)/1080 -- unchanged by the gate.
+    assert abs(pos["centerX"] - 400 / 1920) < 1e-9
+    assert abs(pos["centerY"] - 540 / 1080) < 1e-9
+
+
+@pytest.mark.unit
+def test_unknown_display_count_keeps_the_previous_behaviour():
+    """No isExtended and no Electron bridge -> behave exactly as before the gate."""
+    script = _gate_script("""
+const api = build(makeEnv(undefined));
+results.pos = api.getAvatarScreenPosition('screen');
+console.log(JSON.stringify(results));
+""")
+    assert _run(script)["pos"] is not None
+
+
+@pytest.mark.unit
+def test_viewport_capture_is_untouched_by_the_gate():
+    """Browser-tab capture normalizes against the viewport; monitors are irrelevant."""
+    script = _gate_script("""
+const api = build(makeEnv(true));
+results.pos = api.getAvatarScreenPosition('viewport');
+console.log(JSON.stringify(results));
+""")
+    assert _run(script)["pos"] is not None
+
+
+# --------------------------------------------------------------------------
+# buildStreamDataMessage: explicit capture type
+# --------------------------------------------------------------------------
+
+_BUILD_TMPL = """
+const results = {};
+function build(selectedSourceId) {
+  const window = { screen: { width: 1920, height: 1080, isExtended: false } };
+  const S = { screenCaptureStream: null, selectedScreenSourceId: selectedSourceId };
+  const getAvatarScreenPosition = (captureType) =>
+    captureType === 'screen' ? { centerX: 0.5, centerY: 0.5, width: 0.1, height: 0.2 } : null;
+  __DETECT__
+  __BUILD__
+  return buildStreamDataMessage;
+}
+__TAIL__
+"""
+
+
+def _build_script(tail: str) -> str:
+    src = _screen_src()
+    return (
+        _BUILD_TMPL
+        .replace("__DETECT__", _fn(src, "detectScreenshotCaptureType"))
+        .replace("__BUILD__", _fn(src, "buildStreamDataMessage"))
+        .replace("__TAIL__", tail)
+    )
+
+
+@pytest.mark.unit
+def test_explicit_capture_type_overrides_a_stale_window_source():
+    """A leftover window:* source must not suppress a genuine full-screen frame.
+
+    The default branch is deliberately pinned to the opposite answer, so a fix
+    that ignores the explicit argument cannot pass by coincidence.
+    """
+    script = _build_script("""
+const fn = build('window:9');
+const explicit = fn('data:image/jpeg;base64,AAA', 'screen', 'window:9', 'screen');
+const inferred = fn('data:image/jpeg;base64,AAA', 'screen', 'window:9');
+results.explicitHasPos = Object.prototype.hasOwnProperty.call(explicit, 'avatar_position');
+results.inferredHasPos = Object.prototype.hasOwnProperty.call(inferred, 'avatar_position');
+console.log(JSON.stringify(results));
+""")
+    out = _run(script)
+    assert out["explicitHasPos"] is True
+    # Identical arguments minus the explicit type: the window source still wins,
+    # so the assertion above cannot pass by falling through to inference.
+    assert out["inferredHasPos"] is False
+
+
+@pytest.mark.unit
+def test_explicit_null_capture_type_suppresses_the_position():
+    """Passing null means "confirmed unknowable", not "fall back to inference"."""
+    script = _build_script("""
+const fn = build(null);
+const msg = fn('data:image/jpeg;base64,AAA', 'screen', null, null);
+results.hasPos = Object.prototype.hasOwnProperty.call(msg, 'avatar_position');
+console.log(JSON.stringify(results));
+""")
+    assert _run(script)["hasPos"] is False
+
+
+@pytest.mark.unit
+def test_camera_frames_never_carry_a_position():
+    """Mobile camera shoots the real world; there is no avatar in frame."""
+    script = _build_script("""
+const fn = build(null);
+const msg = fn('data:image/jpeg;base64,AAA', 'camera', null, 'screen');
+results.hasPos = Object.prototype.hasOwnProperty.call(msg, 'avatar_position');
+console.log(JSON.stringify(results));
+""")
+    assert _run(script)["hasPos"] is False
+
+
+# --------------------------------------------------------------------------
+# Proactive single frame
+# --------------------------------------------------------------------------
+
+_FRAME_TMPL = """
+const results = { sent: [] };
+const window = {
+  screen: { width: 1920, height: 1080, isExtended: false },
+  appUtils: { isMobile: () => false },
+  detectScreenshotCaptureType: (stream, sourceId) => {
+    if (sourceId) return sourceId.indexOf('screen:') === 0 ? 'screen' : null;
+    return stream ? 'screen' : null;
+  },
+  captureDesktopSourceWithTimeout: async () => __NATIVE__,
+  maybeClearSourceOnNotFound: () => {}
+};
+const WebSocket = { OPEN: 1 };
+const S = {
+  isRecording: true,
+  socket: { readyState: 1, send: (payload) => results.sent.push(payload) },
+  screenCaptureStream: null,
+  screenCaptureStreamLastUsed: null,
+  selectedScreenSourceId: __SOURCE_ID__
+};
+let proactiveVisionFrameInFlight = false;
+const isProactiveVisionEnabledNow = () => true;
+const stopProactiveVisionDuringSpeech = () => {};
+const getDesktopProvider = () => ({ nativeFrameCapture: true, captureSourceAsDataUrl: () => {} });
+const acquireOrReuseCachedStream = async () => __STREAM__;
+const captureFrameFromStream = async () => ({ dataUrl: 'data:image/jpeg;base64,STREAM' });
+const fetchBackendScreenshot = async () => ({ dataUrl: 'data:image/jpeg;base64,BACKEND' });
+const normalizeNativeCaptureDataUrlForStream = async () => 'data:image/jpeg;base64,NATIVE';
+const getAvatarScreenPosition = (captureType) =>
+  captureType === 'screen' ? { centerX: 0.5, centerY: 0.5, width: 0.1, height: 0.2 } : null;
+__DETECT__
+__BUILD__
+__FRAME__
+sendOneProactiveVisionFrame().then(() => {
+  console.log(JSON.stringify(results));
+});
+"""
+
+
+_NATIVE_OK = "({ success: true, dataUrl: 'data:image/png;base64,PNG' })"
+_NATIVE_FAIL = "({ success: false, error: 'capture timed out' })"
+
+
+def _frame_script(*, source_id: str, stream: str, native: str = _NATIVE_OK) -> str:
+    screen_src = _screen_src()
+    proactive_src = APP_PROACTIVE_PATH.read_text(encoding="utf-8")
+    return (
+        _FRAME_TMPL
+        .replace("__SOURCE_ID__", source_id)
+        .replace("__STREAM__", stream)
+        .replace("__NATIVE__", native)
+        .replace("__DETECT__", _fn(screen_src, "detectScreenshotCaptureType"))
+        .replace("__BUILD__", _fn(screen_src, "buildStreamDataMessage"))
+        .replace("__FRAME__", _fn(proactive_src, "sendOneProactiveVisionFrame"))
+    )
+
+
+@pytest.mark.unit
+def test_backend_fallback_frame_carries_avatar_position():
+    """Native capture failed but a window:* source lingers, so the grab is the whole desktop.
+
+    The avatar is necessarily in that image, and the leftover source id must not
+    demote it to "window capture, do not annotate".
+    """
+    out = _run(_frame_script(
+        source_id="'window:9'", stream="null", native=_NATIVE_FAIL,
+    ))
+    assert len(out["sent"]) == 1
+    msg = json.loads(out["sent"][0])
+    assert msg["input_type"] == "screen"
+    assert msg["data"].endswith("BACKEND")
+    assert msg["avatar_position"] is not None
+
+
+@pytest.mark.unit
+def test_stream_frame_carries_avatar_position():
+    out = _run(_frame_script(source_id="null", stream="({})"))
+    msg = json.loads(out["sent"][0])
+    assert msg["data"].endswith("STREAM")
+    assert msg["avatar_position"] is not None
+
+
+@pytest.mark.unit
+def test_native_frame_is_converted_to_jpeg_before_sending():
+    """Backend screen-data validation hard-rejects anything that is not JPEG."""
+    out = _run(_frame_script(source_id="'screen:0:0'", stream="null"))
+    msg = json.loads(out["sent"][0])
+    assert msg["data"].startswith("data:image/jpeg;base64,")
+    assert msg["data"].endswith("NATIVE")
+    assert msg["avatar_position"] is not None
+
+
+@pytest.mark.unit
+def test_window_source_frame_is_not_annotated():
+    """A genuine window capture has no avatar in it; annotating would be a lie."""
+    out = _run(_frame_script(source_id="'window:9'", stream="null"))
+    msg = json.loads(out["sent"][0])
+    assert msg["data"].endswith("NATIVE")
+    assert "avatar_position" not in msg

--- a/tests/unit/test_avatar_annotation_frontend.py
+++ b/tests/unit/test_avatar_annotation_frontend.py
@@ -157,14 +157,24 @@ function build(win) {
 """
 
 
-def _gate_script(tail: str) -> str:
-    src = _screen_src()
-    multi = (
-        "var multiDisplayCache = null;\n"
+def _ttl_line(src: str) -> str:
+    return [line for line in src.splitlines()
+            if "MULTI_DISPLAY_CACHE_TTL_MS =" in line][0].strip()
+
+
+def _multi_display_block(src: str) -> str:
+    """The gate's real module state plus its two functions, ready to paste."""
+    return (
+        "var multiDisplayCache = null;\nvar multiDisplayCacheAt = 0;\n"
+        + _ttl_line(src) + "\n"
         + _fn(src, "refreshMultiDisplayCache") + "\n"
         + _fn(src, "isKnownMultiDisplay")
     )
-    body = _GATE_BODY.replace("__MULTI_DISPLAY__", multi).replace(
+
+
+def _gate_script(tail: str) -> str:
+    src = _screen_src()
+    body = _GATE_BODY.replace("__MULTI_DISPLAY__", _multi_display_block(src)).replace(
         "__GET_POS__", _fn(src, "getAvatarScreenPosition")
     )
     return _GATE_PRELUDE + body + tail
@@ -528,20 +538,13 @@ def test_display_topology_change_is_picked_up_after_the_cache_ttl():
     when the Electron bridge fallback is in use.
     """
     src = _screen_src()
-    ttl_line = [line for line in src.splitlines()
-                if "MULTI_DISPLAY_CACHE_TTL_MS =" in line][0].strip()
-    ttl_ms = int(re.search(r"=\s*(\d+)", ttl_line).group(1))
+    ttl_ms = int(re.search(r"=\s*(\d+)", _ttl_line(src)).group(1))
     # Pin the value itself. The harness below reads the constant out of the
     # module, so a test driven purely by derived timings would keep passing if
     # the TTL were changed to a minute -- the assertion has to name the number.
     assert ttl_ms == 5000, f"multi-display cache TTL changed to {ttl_ms}ms"
 
-    multi = (
-        "var multiDisplayCache = null;\nvar multiDisplayCacheAt = 0;\n"
-        + ttl_line + "\n"
-        + _fn(src, "refreshMultiDisplayCache") + "\n"
-        + _fn(src, "isKnownMultiDisplay")
-    )
+    multi = _multi_display_block(src)
     script = """
 const results = {};
 const TTL = __TTL__;
@@ -582,3 +585,52 @@ const settle = () => new Promise((r) => setImmediate(r));
     # Bounded self-heal window: stale right up to the boundary, fresh just past it.
     assert out["atTtl"] is False
     assert out["pastTtl"] is True
+
+
+@pytest.mark.unit
+def test_failing_display_bridge_is_still_throttled():
+    """A rejecting bridge leaves the value unknown; that must not defeat the TTL.
+
+    The gate sits on the screenshot path, which runs about once a second during
+    continuous sharing, so an unthrottled retry means one IPC per frame plus
+    overlapping in-flight requests.
+    """
+    src = _screen_src()
+    ttl_ms = int(re.search(r"=\s*(\d+)", _ttl_line(src)).group(1))
+    multi = _multi_display_block(src)
+    script = """
+const results = {};
+const TTL = __TTL__;
+let calls = 0;
+let now = 1000;
+Date.now = () => now;
+const window = {
+  screen: { width: 1920, height: 1080 },   // no isExtended -> bridge fallback
+  electronScreen: {
+    getAllDisplays: async () => { calls += 1; throw new Error('bridge down'); }
+  }
+};
+__MULTI__
+const settle = () => new Promise((r) => setImmediate(r));
+(async () => {
+  // Twenty frames inside one TTL window: the bridge must be asked exactly once.
+  for (let i = 0; i < 20; i += 1) {
+    isKnownMultiDisplay();
+    await settle();
+    now += 100;
+  }
+  results.callsWithinWindow = calls;
+  results.stillFalse = isKnownMultiDisplay();
+
+  now += TTL;
+  isKnownMultiDisplay();
+  await settle();
+  results.callsAfterTtl = calls;
+  console.log(JSON.stringify(results));
+})();
+""".replace("__MULTI__", multi).replace("__TTL__", str(ttl_ms))
+    out = _run(script)
+    assert out["callsWithinWindow"] == 1
+    # Unknown stays unknown, and unknown means "behave as before the gate".
+    assert out["stillFalse"] is False
+    assert out["callsAfterTtl"] == 2

--- a/tests/unit/test_avatar_annotation_frontend.py
+++ b/tests/unit/test_avatar_annotation_frontend.py
@@ -23,6 +23,7 @@ of ``static/app/`` under node rather than asserting on source text:
 """
 
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -432,15 +433,23 @@ def test_display_topology_change_is_picked_up_after_the_cache_ttl():
     when the Electron bridge fallback is in use.
     """
     src = _screen_src()
+    ttl_line = [line for line in src.splitlines()
+                if "MULTI_DISPLAY_CACHE_TTL_MS =" in line][0].strip()
+    ttl_ms = int(re.search(r"=\s*(\d+)", ttl_line).group(1))
+    # Pin the value itself. The harness below reads the constant out of the
+    # module, so a test driven purely by derived timings would keep passing if
+    # the TTL were changed to a minute -- the assertion has to name the number.
+    assert ttl_ms == 5000, f"multi-display cache TTL changed to {ttl_ms}ms"
+
     multi = (
         "var multiDisplayCache = null;\nvar multiDisplayCacheAt = 0;\n"
-        + [line for line in src.splitlines()
-           if "MULTI_DISPLAY_CACHE_TTL_MS =" in line][0].strip() + "\n"
+        + ttl_line + "\n"
         + _fn(src, "refreshMultiDisplayCache") + "\n"
         + _fn(src, "isKnownMultiDisplay")
     )
     script = """
 const results = {};
+const TTL = __TTL__;
 let displayCount = 1;
 let now = 1000;
 Date.now = () => now;
@@ -457,20 +466,24 @@ const settle = () => new Promise((r) => setImmediate(r));
 
   // A second monitor is attached; without a TTL the cached false sticks forever.
   displayCount = 2;
-  now += 100;
-  isKnownMultiDisplay();
-  await settle();
-  results.withinTtl = isKnownMultiDisplay();
 
-  now += 60000;
+  // Exactly TTL since the last lookup: the check is strictly greater-than, so
+  // this must still serve the cached answer.
+  now += TTL;
   isKnownMultiDisplay();
   await settle();
-  results.afterTtl = isKnownMultiDisplay();
+  results.atTtl = isKnownMultiDisplay();
+
+  // One millisecond past it: the very first instant a refresh is allowed.
+  now += 1;
+  isKnownMultiDisplay();
+  await settle();
+  results.pastTtl = isKnownMultiDisplay();
   console.log(JSON.stringify(results));
 })();
-""".replace("__MULTI__", multi)
+""".replace("__MULTI__", multi).replace("__TTL__", str(ttl_ms))
     out = _run(script)
     assert out["singleDisplay"] is False
-    # Still stale inside the TTL -- documents the bounded self-heal window.
-    assert out["withinTtl"] is False
-    assert out["afterTtl"] is True
+    # Bounded self-heal window: stale right up to the boundary, fresh just past it.
+    assert out["atTtl"] is False
+    assert out["pastTtl"] is True

--- a/tests/unit/test_avatar_annotation_frontend.py
+++ b/tests/unit/test_avatar_annotation_frontend.py
@@ -294,6 +294,115 @@ console.log(JSON.stringify(results));
 
 
 # --------------------------------------------------------------------------
+# Shared screenshot helper: capture type is decided at capture time
+# --------------------------------------------------------------------------
+
+_NATIVE_OK = "({ success: true, dataUrl: 'data:image/png;base64,PNG' })"
+_NATIVE_FAIL = "({ success: false, error: 'capture timed out' })"
+# Capture succeeds, but the user switches from the window source to a full
+# screen while the grab is still in flight.
+_NATIVE_OK_THEN_SWITCH = (
+    "(function () {"
+    " S.selectedScreenSourceId = 'screen:0:0';"
+    " return { success: true, dataUrl: 'data:image/png;base64,PNG' };"
+    " })()"
+)
+
+_HELPER_TMPL = """
+const results = {};
+let selected = __SOURCE_ID__;
+const S = {
+  screenCaptureStream: null,
+  screenCaptureStreamLastUsed: null,
+  get selectedScreenSourceId() { return selected; },
+  set selectedScreenSourceId(v) { selected = v; }
+};
+const window = {
+  detectScreenshotCaptureType: (stream, sourceId) => {
+    if (sourceId) return sourceId.indexOf('screen:') === 0 ? 'screen' : null;
+    return stream ? 'screen' : null;
+  },
+  captureDesktopSourceWithTimeout: async () => __NATIVE__,
+  maybeClearSourceOnNotFound: () => {},
+  scheduleScreenCaptureIdleCheck: () => {}
+};
+const getDesktopProvider = () => ({ captureSourceAsDataUrl: () => {} });
+const acquireOrReuseCachedStream = async () => __STREAM__;
+const captureFrameFromStream = async () => ({ dataUrl: 'data:image/jpeg;base64,STREAM' });
+const fetchBackendScreenshot = async () => ({ dataUrl: 'data:image/jpeg;base64,BACKEND' });
+__RESOLVE__
+__HELPER__
+captureProactiveChatScreenshotWithSource().then((shot) => {
+  results.via = shot.via;
+  results.captureType = shot.captureType === undefined ? '<missing>' : shot.captureType;
+  results.data = shot.dataUrl;
+  console.log(JSON.stringify(results));
+});
+"""
+
+
+def _helper_script(*, source_id: str, stream: str, native: str = _NATIVE_OK) -> str:
+    proactive_src = APP_PROACTIVE_PATH.read_text(encoding="utf-8")
+    return (
+        _HELPER_TMPL
+        .replace("__SOURCE_ID__", source_id)
+        .replace("__STREAM__", stream)
+        .replace("__NATIVE__", native)
+        .replace("__RESOLVE__", _fn(proactive_src, "resolveCaptureTypeFor"))
+        .replace("__HELPER__", _fn(proactive_src, "captureProactiveChatScreenshotWithSource"))
+    )
+
+
+@pytest.mark.unit
+def test_helper_pairs_capture_type_with_the_native_frame_it_grabbed():
+    """Switching source while the native grab is in flight must not re-label it."""
+    out = _run(_helper_script(
+        source_id="'window:9'", stream="null", native=_NATIVE_OK_THEN_SWITCH,
+    ))
+    assert out["via"] == "native"
+    # Grabbed from window:9 -> must stay unannotatable even though S now says screen:0:0.
+    assert out["captureType"] is None
+
+
+@pytest.mark.unit
+def test_helper_marks_backend_fallback_as_full_screen():
+    """pyautogui grabs the whole desktop, whatever stale source id is lying around."""
+    out = _run(_helper_script(
+        source_id="'window:9'", stream="null", native=_NATIVE_FAIL,
+    ))
+    assert out["via"] == "backend"
+    assert out["captureType"] == "screen"
+    assert out["data"].endswith("BACKEND")
+
+
+# The source is cleared mid-capture (what maybeClearSourceOnNotFound does) while
+# a cached stream is left behind -- the one combination where handing the stream
+# to the classifier flips the answer.
+_NATIVE_OK_THEN_CLEAR_SOURCE = (
+    "(function () {"
+    " S.selectedScreenSourceId = null;"
+    " S.screenCaptureStream = {};"
+    " return { success: true, dataUrl: 'data:image/png;base64,PNG' };"
+    " })()"
+)
+
+
+@pytest.mark.unit
+def test_helper_never_classifies_a_native_frame_by_a_leftover_stream():
+    """A native grab must be judged by the source id it was captured from.
+
+    With the source cleared and a stale stream around, classifying from live
+    state answers "full screen" for a frame that actually holds one window --
+    i.e. annotates an image with no avatar in it.
+    """
+    out = _run(_helper_script(
+        source_id="'window:9'", stream="null", native=_NATIVE_OK_THEN_CLEAR_SOURCE,
+    ))
+    assert out["via"] == "native"
+    assert out["captureType"] is None
+
+
+# --------------------------------------------------------------------------
 # Proactive single frame
 # --------------------------------------------------------------------------
 
@@ -334,10 +443,6 @@ sendOneProactiveVisionFrame().then(() => {
   console.log(JSON.stringify(results));
 });
 """
-
-
-_NATIVE_OK = "({ success: true, dataUrl: 'data:image/png;base64,PNG' })"
-_NATIVE_FAIL = "({ success: false, error: 'capture timed out' })"
 
 
 def _frame_script(*, source_id: str, stream: str, native: str = _NATIVE_OK) -> str:
@@ -396,16 +501,6 @@ def test_window_source_frame_is_not_annotated():
     msg = json.loads(out["sent"][0])
     assert msg["data"].endswith("NATIVE")
     assert "avatar_position" not in msg
-
-
-# Capture succeeds, but the user switches from the window source to a full
-# screen while the grab is still in flight.
-_NATIVE_OK_THEN_SWITCH = (
-    "(function () {"
-    " S.selectedScreenSourceId = 'screen:0:0';"
-    " return { success: true, dataUrl: 'data:image/png;base64,PNG' };"
-    " })()"
-)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_avatar_annotation_pairing.py
+++ b/tests/unit/test_avatar_annotation_pairing.py
@@ -1,0 +1,172 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Avatar annotation: how a Phase 2 screenshot gets paired with its coordinates.
+
+The rule these tests pin down is that "the frontend sent no avatar_position" is a
+verdict ("do not annotate this image"), not a missing value, and must never be
+back-filled with the position that arrived with the original request. The one
+exception is the backend pyautogui fallback, where the frontend never saw the
+image at all and therefore cannot have objected.
+"""
+
+import asyncio
+import base64
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from main_logic.core import LLMSessionManager
+from main_logic.core._shared import FreshScreenshot
+from main_logic.proactive_chat.service import _resolve_phase2_avatar_position
+
+POS_A = {"centerX": 0.25, "centerY": 0.5, "width": 0.1, "height": 0.2}
+POS_B = {"centerX": 0.75, "centerY": 0.5, "width": 0.1, "height": 0.2}
+
+
+def _png_b64(width: int, height: int) -> str:
+    buf = BytesIO()
+    Image.new("RGB", (width, height), (10, 20, 30)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def _fake_manager() -> SimpleNamespace:
+    return SimpleNamespace(
+        _screenshot_future=None,
+        _pending_screenshot_avatar_position=None,
+        _avatar_position=None,
+        lanlan_name="桃奈",
+        websocket=None,
+    )
+
+
+@pytest.mark.unit
+def test_ws_reply_carries_its_own_avatar_position():
+    """The position handed to resolve_screenshot_request rides back with the image."""
+    shot = _png_b64(640, 360)
+
+    async def _run() -> FreshScreenshot:
+        fake = _fake_manager()
+
+        async def _send_json(payload):
+            assert payload == {"type": "request_screenshot"}
+            LLMSessionManager.resolve_screenshot_request(fake, shot, POS_A)
+
+        fake.websocket = SimpleNamespace(send_json=_send_json)
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+
+    fresh = asyncio.run(_run())
+    assert fresh.source == "websocket"
+    assert fresh.avatar_position == POS_A
+
+
+@pytest.mark.unit
+def test_ws_reply_without_position_stays_none():
+    """No position from the frontend must surface as None, not as some fallback."""
+    shot = _png_b64(640, 360)
+
+    async def _run() -> FreshScreenshot:
+        fake = _fake_manager()
+        # A stale coordinate from an earlier frame sits in the broadcast field;
+        # it must not leak into this image's verdict.
+        fake._avatar_position = POS_B
+
+        async def _send_json(_payload):
+            LLMSessionManager.resolve_screenshot_request(fake, shot, None)
+
+        fake.websocket = SimpleNamespace(send_json=_send_json)
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+
+    fresh = asyncio.run(_run())
+    assert fresh.source == "websocket"
+    assert fresh.avatar_position is None
+
+
+@pytest.mark.unit
+def test_interleaved_stream_frame_cannot_swap_the_paired_position():
+    """A stream_data frame landing mid-flight must not rewrite this image's position.
+
+    This is why the pairing uses its own one-shot slot instead of the broadcast
+    ``_avatar_position`` field, which every stream_data frame overwrites.
+    """
+    shot = _png_b64(640, 360)
+
+    async def _run() -> FreshScreenshot:
+        fake = _fake_manager()
+
+        async def _send_json(_payload):
+            LLMSessionManager.resolve_screenshot_request(fake, shot, POS_A)
+            # Exactly what a concurrent screen-share frame does to the manager
+            # between resolve and the requester waking up.
+            fake._avatar_position = POS_B
+
+        fake.websocket = SimpleNamespace(send_json=_send_json)
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+
+    fresh = asyncio.run(_run())
+    assert fresh.avatar_position == POS_A
+
+
+@pytest.mark.unit
+def test_stale_slot_is_cleared_before_the_next_request():
+    """A position left by an earlier request must not be reused by the next one."""
+    shot = _png_b64(640, 360)
+
+    async def _run() -> FreshScreenshot:
+        fake = _fake_manager()
+        # Residue from a previous round.
+        fake._pending_screenshot_avatar_position = POS_B
+
+        async def _send_json(_payload):
+            LLMSessionManager.resolve_screenshot_request(fake, shot, None)
+
+        fake.websocket = SimpleNamespace(send_json=_send_json)
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+
+    fresh = asyncio.run(_run())
+    assert fresh.avatar_position is None
+
+
+@pytest.mark.unit
+def test_backend_fallback_is_tagged_as_such():
+    """No websocket at all -> pyautogui path, tagged so the caller may fall back."""
+
+    async def _run() -> FreshScreenshot:
+        fake = _fake_manager()
+        fake.websocket = None
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=0.1)
+
+    fresh = asyncio.run(_run())
+    # Without a websocket the loopback guard rejects the fallback, so nothing is
+    # captured; what matters is that it never claims to be a websocket answer.
+    assert fresh.source != "websocket"
+    assert fresh.avatar_position is None
+
+
+@pytest.mark.unit
+def test_websocket_verdict_wins_over_the_request_position():
+    """The Phase 2 decision must not resurrect the request position on a WS answer."""
+    fresh = FreshScreenshot(b64="x", source="websocket", avatar_position=None)
+    assert _resolve_phase2_avatar_position(fresh, POS_B) is None
+
+    fresh_with_pos = FreshScreenshot(b64="x", source="websocket", avatar_position=POS_A)
+    assert _resolve_phase2_avatar_position(fresh_with_pos, POS_B) == POS_A
+
+
+@pytest.mark.unit
+def test_backend_fallback_keeps_the_request_position_as_its_only_source():
+    """Tightening both branches to fresh.avatar_position would silently kill this."""
+    fresh = FreshScreenshot(b64="x", source="backend_fallback", avatar_position=None)
+    assert _resolve_phase2_avatar_position(fresh, POS_B) == POS_B

--- a/tests/unit/test_request_fresh_screenshot.py
+++ b/tests/unit/test_request_fresh_screenshot.py
@@ -44,7 +44,7 @@ def test_ws_screenshot_is_downscaled_to_720p():
             fake._screenshot_future.set_result(big_b64)
 
         fake.websocket = SimpleNamespace(send_json=_send_json)
-        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+        return (await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)).b64
 
     out_b64 = asyncio.run(_run())
 
@@ -69,7 +69,7 @@ def test_ws_screenshot_already_small_stays_under_limit():
             fake._screenshot_future.set_result(small_b64)
 
         fake.websocket = SimpleNamespace(send_json=_send_json)
-        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+        return (await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)).b64
 
     out_b64 = asyncio.run(_run())
 


### PR DESCRIPTION
截图发给视觉模型前会在 Avatar 位置叠一行「这是{name}在桌面上的虚拟形象, 请{name}不要主动提及」，用来阻止角色把自己的立绘当成用户屏幕上的内容来评论。核查后发现四条投喂路径里只有**持续屏幕分享**是完整的，其余三条各有断点。

水印代码本身近两个月零改动（最后一次逻辑改动是 #2003），所以这不是新引入的回归——更可能是 #2763 让 Electron 原生帧第一次真正流到后端（在那之前 PNG 帧被 `screenshot_utils.py` 的严格 JPEG 前缀校验拒收），把一直存在的漏标格暴露了出来。

## 回归报告

### 1. 主动搭话 HTTP 两阶段

**改了什么** — Phase 2 原来用 `mgr._avatar_position or command.avatar_position` 取坐标。`websocket_router` 在前端不带坐标时是**显式写 None** 的（注释写明「前端不发 avatar_position = 不应叠加」），`or` 把这个否定信号吞掉，退回 Phase 1 几秒前的旧坐标。而 `_avatar_position` 又被每一条 `stream_data` 帧覆写（语音会话里音频帧同样走这个分支），resolve 与等待方唤醒之间隔着一次 `to_thread` 压缩，坐标可能被中途到达的帧换掉。

改为 `request_fresh_screenshot` 返回带来源标签的 `FreshScreenshot(b64, source, avatar_position)`，并新增一个只由 `resolve_screenshot_request` 写、只由配对那一次 request 读的一次性槽 `_pending_screenshot_avatar_position`。判据提成模块级 `_resolve_phase2_avatar_position`（跟随本文件已有的 `_resolve_*` 惯例）。

**为什么必要** — 「前端不给坐标」在前端是三处显式 `return null`（Avatar 折叠 / 中心出屏 / captureType 判不出），是判断不是遗漏。`main_logic/core/streaming.py` 对同一语义写死了相反做法并有明文注释，两者不可能同时正确。

**前后行为** — 窗口分享 / 相机 / Avatar 折叠时，Phase 2 从「叠（且可能错位）」变成「不叠」。

**⚠️ 特意没做的收紧** — 没有把两条路径统一成 `fresh.avatar_position`。`main_logic/core/proactive.py` 的 pyautogui 兜底分支**不叠加**，`or` 是那条路径上唯一的水印来源；一并收紧会把「窄场景错位」换成「常见场景完全无水印」。`test_backend_fallback_keeps_the_request_position_as_its_only_source` 专门守这一条。

**潜在回归** — `request_fresh_screenshot` 返回类型变了；全仓唯一调用点是 `service.py`（已 grep 确认），`test_request_fresh_screenshot.py` 两处跟随改为取 `.b64`。`resolve_screenshot_request` 加了个默认 `None` 的参数，唯一调用点在 `websocket_router`，向后兼容。

### 2. 语音期主动视觉单帧

**改了什么** — `sendOneProactiveVisionFrame` 原来手写 `{action:'stream_data', data, input_type}` 字面量，绕过 `buildStreamDataMessage`，**永远不带 avatar_position**。改为共用同一个构造函数；`buildStreamDataMessage` 加可选第 4 参 `explicitCaptureType`。同一函数的原生分支补上 `normalizeNativeCaptureDataUrlForStream`。

**为什么要加第 4 参而不是复用推断** — 这条路径的画面来自缓存流 / 原生帧 / 后端整屏兜底三选一且逐级回退，而发送时的 `S.screenCaptureStream` / `S.selectedScreenSourceId` 描述的是「本会话配置抓什么」，不是「这一帧抓到了什么」。后端整屏兜底时 `S.selectedScreenSourceId` 常常还留着上次那个 `window:*` 源，按它推断会把一张整屏图判成窗口截图而漏标。

**为什么补转码** — 桌面壳 `NativeImage.toDataURL()` 出 PNG，`utils/screenshot_utils.py` 的 `process_screen_data` 严格要求 `data:image/jpeg;base64,` 前缀，不转码整帧会被判为「无效的屏幕数据格式」直接丢弃（模型压根收不到画面）。持续流路径 #2763 已经这么防了，单帧路径漏了。

**前后行为** — 这条路径的帧开始携带 `avatar_position`；Electron 原生帧从「被后端静默丢弃」变成正常送达。

**潜在回归** — 原生帧多一次 `await`；函数尾部原有的 `isProactiveVisionEnabledNow + S.isRecording + socket.readyState` 复检在其之后，已覆盖。转码失败保持 `dataUrl` 为 null，自然落到后端兜底（与本函数既有的「原生捕获失败，尝试后端兜底」语义一致，不像持续路径那样 throw 停止分享）。`app-screen.js` 的两个既有调用点未改签名，`test_desktop_capture_provider_static.py` 的字面量断言不受影响。

**顺带** — Phase 1（`app-proactive.js`）与 legacy `screenshot_response`（`app-websocket.js`）也接上了 `via` 来源判据，堵掉「残留 window:* 源 + 实际走了后端整屏兜底」那一格。`captureProactiveChatScreenshot` 拆成带来源的 `captureProactiveChatScreenshotWithSource` + 薄 wrapper 维持旧 window 契约。两处原有的「detect 拿不到时无流无源默认 screen」降级兜底**特意保留**：本 PR 之后「不带坐标」成了有语义的否定信号，前端一旦因加载顺序拿不到函数，会从「默认整屏叠」静默变成「永久不叠」。

### 3. 多显示器（横切所有链路，best effort）

**问题** — `getAvatarScreenPosition` 的 `'screen'` 分支，分子（原点）用 `window.screenX`（**虚拟桌面**全局坐标），分母（归一化）用 `window.screen.width`（**当前所在显示器**尺寸），差一个显示器 bounds 原点。单屏下该原点恒为 0 所以正确。

| 场景 | 修复前 |
|---|---|
| 单屏 | ✅ 正确 |
| 捕获副屏，Pet 在副屏 | ❌ 漏标（越界 return null） |
| 捕获主屏，Pet 在副屏 | ✅ 碰巧正确（同样越界，而 Avatar 确实不在画面里） |
| 捕获副屏，Pet 在主屏 | ❌ **叠错屏**（通过边界检查，把水印画到另一块屏的截图上） |

**改了什么** — 只加 `isKnownMultiDisplay()` 闸门（`screen.isExtended`，回退 `electronScreen.getAllDisplays()` 缓存，两者都拿不到返回 false）：确认是多屏就不叠。

**⚠️ 为什么不用 `availLeft` 把参考系修对** — 那会精确地把上表第三行「唯一碰巧正确的格」从 null 变成叠错屏。要真正修对必须知道「被捕获的是哪块屏」，而整条链路都不携带这个信息（sourceId 只被 `startsWith('screen:')` 判一下就丢弃，`getSettings()` 里没有显示器标识，运行时不能重新 `getSources()` —— Linux Portal 会再弹系统窗口）。见 #2841。

**前后行为** — **多显示器用户在所有链路上都不再有水印**。这是有意选的下界（叠错比不叠更糟）。单显示器 / 纯浏览器 / 信号拿不到时逐字沿用原行为，`test_single_display_screen_capture_is_unchanged` 与 `test_unknown_display_count_keeps_the_previous_behaviour` 守这一点。

**潜在回归** — 对手动截图按钮**无影响**：Electron 框选路径在算坐标前就 return，浏览器内裁剪路径的坐标在 `app-buttons.js` 的 `dataUrl === originalDataUrl` 判据处必然被置 null。

### 不在本次范围

- **手动截图按钮不叠水印**：既有设计（裁剪使归一化坐标失效），已确认不改。
- **主对话链路（realtime / 文本）没有逐次 ignore hint**：只靠人设模板里那行英文兜底，用户改过人设就没有了。独立问题，记在 #2841。
- **zh-TW 繁简错配**：叠加侧用 `get_global_language_full()` 画繁体，取 hint 用 `get_global_language()` 引简体。记在 #2841。

## 测试

新增 18 条，**全部做过变异验证**——撤掉对应修复会变红：

| 变异 | 变红 |
|---|---|
| `_resolve_phase2_avatar_position` 还原成 `or` 语义 | 1 条 |
| 配对槽改回读 `_avatar_position` | 3 条 |
| 移除多显示器闸门 | 1 条 |
| 单帧还原成手写字面量 | 3 条 |
| 去掉原生帧 JPEG 转码 | 2 条 |
| 第 4 参分支改成 `if (false)` | 3 条 |

前端三条走 `tests/node_harness.py` 真跑模块函数体（不是源码字符串断言）。

本地：329 passed / 1 skipped；`check_core_contracts.py`、`check_docstring_no_cjk.py --base origin/main`、`check_async_blocking.py` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 截图结果新增来源标识和头像位置数据，提升主动视觉交互准确性。
  - 支持流式、原生、窗口及后端整屏截图，并保留兼容调用方式。
  - 自动识别多显示器环境，避免错误添加头像位置标注。
  - 原生截图统一规范化为 JPEG，提升不同捕获方式的一致性。

- **问题修复**
  - 修复并发截图或后续画面导致头像坐标错配、过期及覆盖的问题。
  - 改善截图失败和后端回退场景下的坐标处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->