### PR TITLE
feat(plugin-manager): create default config profile

### DIFF
--- a/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
@@ -176,6 +176,10 @@ const selectedProfileName = ref<string | null>(null)
 const profileDraftConfig = ref<Record<string, any> | null>(null)
 const originalProfileConfig = ref<Record<string, any> | null>(null)
 
+// Every plugin gets an editable starting point the first time its configuration
+// page is opened. Existing profiles are always preserved.
+const DEFAULT_PROFILE_NAME = 'default'
+
 function cloneDeep<T>(input: T, seen = new WeakMap<object, any>()): T {
   if (input === null || typeof input !== 'object') return input
 
@@ -467,6 +471,24 @@ async function loadAll() {
     baseConfig.value = (baseRes.config || {}) as Record<string, any>
     effectiveConfig.value = (effectiveRes.config || {}) as Record<string, any>
     profilesState.value = profilesRes
+
+    // A plugin without profiles used to leave the configuration form empty and
+    // required users to manually create one before they could edit anything.
+    // Persist an empty default profile and make it active so subsequent saves
+    // immediately affect the plugin's effective configuration.
+    if (profileNames.value.length === 0) {
+      await upsertPluginProfileConfig(props.pluginId, DEFAULT_PROFILE_NAME, {}, true)
+      if (currentVersion !== loadVersion) return
+
+      const [defaultEffectiveRes, defaultProfilesRes] = await Promise.all([
+        getPluginConfig(props.pluginId),
+        getPluginProfilesState(props.pluginId)
+      ])
+      if (currentVersion !== loadVersion) return
+
+      effectiveConfig.value = (defaultEffectiveRes.config || {}) as Record<string, any>
+      profilesState.value = defaultProfilesRes
+    }
 
     const names = profileNames.value
     const active = activeProfileName.value

--- a/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
@@ -66,6 +66,7 @@
               {{ t('plugins.active') }}
             </el-tag>
             <el-button
+              v-if="!isVirtualDefaultProfile(name)"
               type="danger"
               text
               size="small"
@@ -176,8 +177,8 @@ const selectedProfileName = ref<string | null>(null)
 const profileDraftConfig = ref<Record<string, any> | null>(null)
 const originalProfileConfig = ref<Record<string, any> | null>(null)
 
-// Every plugin gets an editable starting point the first time its configuration
-// page is opened. Existing profiles are always preserved.
+// Plugins without persisted profiles expose an editable default draft. It is
+// persisted only when the user saves, keeping configuration page loading read-only.
 const DEFAULT_PROFILE_NAME = 'default'
 
 function cloneDeep<T>(input: T, seen = new WeakMap<object, any>()): T {
@@ -235,17 +236,28 @@ function deepClone<T>(v: T): T {
   return cloneDeep(v)
 }
 
-const profileNames = computed<string[]>(() => {
+const persistedProfileNames = computed<string[]>(() => {
   const cfg = profilesState.value?.config_profiles
   if (!cfg || !cfg.files || typeof cfg.files !== 'object') return []
   return Object.keys(cfg.files).sort()
 })
 
+const profileNames = computed<string[]>(() =>
+  persistedProfileNames.value.length > 0
+    ? persistedProfileNames.value
+    : [DEFAULT_PROFILE_NAME]
+)
+
 const activeProfileName = computed<string | null>(() => {
   const cfg = profilesState.value?.config_profiles
   const name = cfg?.active
-  return typeof name === 'string' ? name : null
+  if (typeof name === 'string' && name) return name
+  return persistedProfileNames.value.length === 0 ? DEFAULT_PROFILE_NAME : null
 })
+
+function isVirtualDefaultProfile(name: string) {
+  return name === DEFAULT_PROFILE_NAME && persistedProfileNames.value.length === 0
+}
 
 const hasChanges = computed(() => {
   if (!selectedProfileName.value) return false
@@ -432,6 +444,11 @@ const previewConfigJson = computed(() => {
 
 async function loadProfileDraft(name: string, expectedVersion = loadVersion) {
   if (!props.pluginId) return
+  if (isVirtualDefaultProfile(name)) {
+    originalProfileConfig.value = {}
+    profileDraftConfig.value = {}
+    return
+  }
   try {
     const res = await getPluginProfileConfig(props.pluginId, name)
     if (expectedVersion !== loadVersion) return
@@ -471,24 +488,6 @@ async function loadAll() {
     baseConfig.value = (baseRes.config || {}) as Record<string, any>
     effectiveConfig.value = (effectiveRes.config || {}) as Record<string, any>
     profilesState.value = profilesRes
-
-    // A plugin without profiles used to leave the configuration form empty and
-    // required users to manually create one before they could edit anything.
-    // Persist an empty default profile and make it active so subsequent saves
-    // immediately affect the plugin's effective configuration.
-    if (profileNames.value.length === 0) {
-      await upsertPluginProfileConfig(props.pluginId, DEFAULT_PROFILE_NAME, {}, true)
-      if (currentVersion !== loadVersion) return
-
-      const [defaultEffectiveRes, defaultProfilesRes] = await Promise.all([
-        getPluginConfig(props.pluginId),
-        getPluginProfilesState(props.pluginId)
-      ])
-      if (currentVersion !== loadVersion) return
-
-      effectiveConfig.value = (defaultEffectiveRes.config || {}) as Record<string, any>
-      profilesState.value = defaultProfilesRes
-    }
 
     const names = profileNames.value
     const active = activeProfileName.value
@@ -550,7 +549,7 @@ async function addProfile() {
     if (!props.pluginId) return
 
     // 立即在后端创建一个空的 profile 映射，方便左侧列表立刻出现该 profile
-    await upsertPluginProfileConfig(props.pluginId, name, {}, false)
+    await upsertPluginProfileConfig(props.pluginId, name, {}, true)
 
     // 重新加载所有配置与 profiles 状态，并选中新建的 profile
     await loadAll()
@@ -588,28 +587,36 @@ function resetDraft() {
 async function save() {
   if (!props.pluginId || !selectedProfileName.value) return
 
+  const pluginId = props.pluginId
+  const profileName = selectedProfileName.value
+  const saveLoadVersion = loadVersion
+  const shouldActivate = isVirtualDefaultProfile(profileName)
+
   saving.value = true
   error.value = null
   try {
     await upsertPluginProfileConfig(
-      props.pluginId,
-      selectedProfileName.value,
+      pluginId,
+      profileName,
       (profileDraftConfig.value || {}) as Record<string, any>,
-      false
+      shouldActivate
     )
+
+    if (saveLoadVersion !== loadVersion || pluginId !== props.pluginId || profileName !== selectedProfileName.value) return
 
     ElMessage.success(t('common.success'))
 
     const [effectiveRes, profilesRes] = await Promise.all([
-      getPluginConfig(props.pluginId),
-      getPluginProfilesState(props.pluginId)
+      getPluginConfig(pluginId),
+      getPluginProfilesState(pluginId)
     ])
+    if (saveLoadVersion !== loadVersion || pluginId !== props.pluginId || profileName !== selectedProfileName.value) return
     effectiveConfig.value = (effectiveRes.config || {}) as Record<string, any>
     profilesState.value = profilesRes
     originalProfileConfig.value = deepClone(profileDraftConfig.value || {})
 
     // 仅当当前浏览的 profile 正好是激活中的 profile 时，才提示热更新或重载插件
-    const isActive = activeProfileName.value === selectedProfileName.value
+    const isActive = activeProfileName.value === profileName
     if (isActive) {
       try {
         // 提供热更新选项

--- a/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
@@ -19,7 +19,14 @@
         <el-button size="small" @click="resetDraft" :disabled="!hasChanges" :loading="saving">
           {{ t('common.reset') }}
         </el-button>
-        <el-button type="primary" :icon="Check" size="small" @click="save" :loading="saving">
+        <el-button
+          type="primary"
+          :icon="Check"
+          size="small"
+          @click="save"
+          :loading="saving"
+          :disabled="!profilesStateLoaded || !selectedProfileName"
+        >
           {{ t('common.save') }}
         </el-button>
       </div>
@@ -41,7 +48,13 @@
       <div class="profiles-pane">
         <div class="profiles-header">
           <span class="profiles-title">{{ t('plugins.profiles') }}</span>
-          <el-button type="primary" size="small" :icon="Plus" @click="addProfile">
+          <el-button
+            type="primary"
+            size="small"
+            :icon="Plus"
+            @click="addProfile"
+            :disabled="!profilesStateLoaded"
+          >
             {{ t('common.add') }}
           </el-button>
         </div>
@@ -172,6 +185,7 @@ const lastModified = ref<string | undefined>(undefined)
 const baseConfig = ref<Record<string, any> | null>(null)
 const effectiveConfig = ref<Record<string, any> | null>(null)
 const profilesState = ref<any | null>(null)
+const profilesStateLoaded = ref(false)
 
 const selectedProfileName = ref<string | null>(null)
 const profileDraftConfig = ref<Record<string, any> | null>(null)
@@ -237,18 +251,22 @@ function deepClone<T>(v: T): T {
 }
 
 const persistedProfileNames = computed<string[]>(() => {
+  if (!profilesStateLoaded.value) return []
   const cfg = profilesState.value?.config_profiles
   if (!cfg || !cfg.files || typeof cfg.files !== 'object') return []
   return Object.keys(cfg.files).sort()
 })
 
 const profileNames = computed<string[]>(() =>
-  persistedProfileNames.value.length > 0
+  !profilesStateLoaded.value
+    ? []
+    : persistedProfileNames.value.length > 0
     ? persistedProfileNames.value
     : [DEFAULT_PROFILE_NAME]
 )
 
 const activeProfileName = computed<string | null>(() => {
+  if (!profilesStateLoaded.value) return null
   const cfg = profilesState.value?.config_profiles
   const name = cfg?.active
   if (typeof name === 'string' && name) return name
@@ -256,7 +274,7 @@ const activeProfileName = computed<string | null>(() => {
 })
 
 function isVirtualDefaultProfile(name: string) {
-  return name === DEFAULT_PROFILE_NAME && persistedProfileNames.value.length === 0
+  return profilesStateLoaded.value && name === DEFAULT_PROFILE_NAME && persistedProfileNames.value.length === 0
 }
 
 const hasChanges = computed(() => {
@@ -472,6 +490,7 @@ async function loadAll() {
 
   loading.value = true
   error.value = null
+  profilesStateLoaded.value = false
   try {
     const prevSelected = selectedProfileName.value
     const [baseRes, effectiveRes, profilesRes] = await Promise.all([
@@ -488,6 +507,7 @@ async function loadAll() {
     baseConfig.value = (baseRes.config || {}) as Record<string, any>
     effectiveConfig.value = (effectiveRes.config || {}) as Record<string, any>
     profilesState.value = profilesRes
+    profilesStateLoaded.value = !!profilesRes && typeof profilesRes === 'object'
 
     const names = profileNames.value
     const active = activeProfileName.value
@@ -539,6 +559,20 @@ async function selectProfile(name: string) {
 }
 
 async function addProfile() {
+  if (!props.pluginId || !profilesStateLoaded.value) return
+  if (hasChanges.value) {
+    try {
+      await ElMessageBox.confirm(
+        t('plugins.unsavedChangesWarning'),
+        t('common.warning'),
+        { type: 'warning' }
+      )
+    } catch {
+      return
+    }
+  }
+
+  const pluginId = props.pluginId
   try {
     const { value } = await ElMessageBox.prompt(t('plugin.addProfile.prompt'), t('plugin.addProfile.title'), {
       inputPattern: /^(?!\s*$).+/u,
@@ -546,13 +580,21 @@ async function addProfile() {
     })
     const name = String(value || '').trim()
     if (!name) return
-    if (!props.pluginId) return
+    if (pluginId !== props.pluginId || !profilesStateLoaded.value) return
+    if (persistedProfileNames.value.includes(name)) {
+      ElMessage.error(t('plugin.addProfile.inputError'))
+      return
+    }
 
     // 立即在后端创建一个空的 profile 映射，方便左侧列表立刻出现该 profile
-    await upsertPluginProfileConfig(props.pluginId, name, {}, true)
+    // Without an active profile the backend activates this first profile;
+    // otherwise the current active profile remains unchanged until the user saves edits.
+    await upsertPluginProfileConfig(pluginId, name, {}, false)
+    if (pluginId !== props.pluginId) return
 
     // 重新加载所有配置与 profiles 状态，并选中新建的 profile
     await loadAll()
+    if (pluginId !== props.pluginId) return
     await selectProfile(name)
   } catch (e: any) {
     // 用户取消或请求失败时忽略，由上层错误提示负责
@@ -585,12 +627,17 @@ function resetDraft() {
 }
 
 async function save() {
-  if (!props.pluginId || !selectedProfileName.value) return
+  if (!props.pluginId || !selectedProfileName.value || !profilesStateLoaded.value) return
 
   const pluginId = props.pluginId
   const profileName = selectedProfileName.value
   const saveLoadVersion = loadVersion
+  const draftToSave = deepClone(profileDraftConfig.value || {}) as Record<string, any>
   const shouldActivate = isVirtualDefaultProfile(profileName)
+  const isCurrentSave = () =>
+    saveLoadVersion === loadVersion &&
+    pluginId === props.pluginId &&
+    profileName === selectedProfileName.value
 
   saving.value = true
   error.value = null
@@ -598,11 +645,11 @@ async function save() {
     await upsertPluginProfileConfig(
       pluginId,
       profileName,
-      (profileDraftConfig.value || {}) as Record<string, any>,
+      draftToSave,
       shouldActivate
     )
 
-    if (saveLoadVersion !== loadVersion || pluginId !== props.pluginId || profileName !== selectedProfileName.value) return
+    if (!isCurrentSave()) return
 
     ElMessage.success(t('common.success'))
 
@@ -610,10 +657,11 @@ async function save() {
       getPluginConfig(pluginId),
       getPluginProfilesState(pluginId)
     ])
-    if (saveLoadVersion !== loadVersion || pluginId !== props.pluginId || profileName !== selectedProfileName.value) return
+    if (!isCurrentSave()) return
     effectiveConfig.value = (effectiveRes.config || {}) as Record<string, any>
     profilesState.value = profilesRes
-    originalProfileConfig.value = deepClone(profileDraftConfig.value || {})
+    profilesStateLoaded.value = !!profilesRes && typeof profilesRes === 'object'
+    originalProfileConfig.value = deepClone(draftToSave)
 
     // 仅当当前浏览的 profile 正好是激活中的 profile 时，才提示热更新或重载插件
     const isActive = activeProfileName.value === profileName
@@ -631,12 +679,14 @@ async function save() {
           }
         )
         // 用户点击了"热更新"
-        await hotUpdateConfig()
+        if (!isCurrentSave()) return
+        await hotUpdateConfig(pluginId, profileName, draftToSave)
       } catch (e: any) {
         if (e === 'cancel') {
           // 用户点击了"重启插件"
           try {
-            await pluginStore.reload(props.pluginId)
+            if (!isCurrentSave()) return
+            await pluginStore.reload(pluginId)
             ElMessage.success(t('messages.pluginReloaded'))
           } catch (reloadErr: any) {
             ElMessage.error(reloadErr?.message || t('messages.reloadFailed'))
@@ -652,16 +702,18 @@ async function save() {
   }
 }
 
-async function hotUpdateConfig() {
-  if (!props.pluginId || !selectedProfileName.value) return
-  
+async function hotUpdateConfig(
+  pluginId: string,
+  profileName: string,
+  config: Record<string, any>
+) {
   try {
     const { hotUpdatePluginConfig } = await import('@/api/config')
     const result = await hotUpdatePluginConfig(
-      props.pluginId,
-      (profileDraftConfig.value || {}) as Record<string, any>,
+      pluginId,
+      config,
       'permanent',
-      selectedProfileName.value
+      profileName
     )
     
     if (result.success) {


### PR DESCRIPTION
## 改动概述 / Summary

- 打开无 profile 的插件配置页时，自动创建并激活空的 `default` profile。
- 自动选中该 profile，用户可直接使用可视化表单调整参数，无需先手动创建 profile。
- 已有 profile 不受影响。

## 回归报告 / Regression Report

不适用（未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件）。

## 不拆分理由 / Why Not Split

不适用（本 PR 仅修改 1 个计入上限的文件）。

## 测试 / Testing

- `npm run type-check`（在 `frontend/plugin-manager` 目录）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 无持久化配置档案时，自动展示可编辑的空白 `default` 档案。
  * `default` 档案保存后会自动创建并激活，且不可删除。
  * 新增配置档案后会立即创建并激活。
* **问题修复**
  * 配置保存后会刷新生效配置及档案状态。
  * 增加版本、插件和当前档案校验，避免过期的异步结果覆盖最新状态。
  * 加载或状态未就绪时，保存和新增操作会自动禁用。
  * 热更新与重载将基于保存时的配置上下文执行，避免操作对象错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->