### PR TITLE
修复 PNGTuber 无法拖动到副屏的问题，补全跨屏切换、拖动状态同步及回归测试

### DIFF
--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -204,6 +204,7 @@
             this._listenersAttached = false;
             this._dragListenersAttached = false;
             this._dragState = null;
+            this._dragSequence = 0;
             this._isDraggingModel = false;
             this.isDragging = false;
             this._saveInFlight = null;
@@ -324,6 +325,7 @@
             window.removeEventListener('pointercancel', this._boundDragEnd);
             this._dragListenersAttached = false;
             this._dragState = null;
+            this._dragSequence += 1;
             this._touchZoomState = null;
             this.setModelDraggingState(false);
         }
@@ -2731,21 +2733,33 @@
             return point;
         }
 
+        isDragCompletionCurrent(state) {
+            return !!state
+                && state.dragSequence === this._dragSequence
+                && this._dragState === null;
+        }
+
         async recordDragHintPointerEdgeApproach(state) {
             const helper = window.NekoAvatarMultiScreenDragHint;
             const start = state?.dragHintStartPointer;
             const pointer = state?.dragHintLastPointer;
             if (!helper || typeof helper.recordPointerEdgeApproach !== 'function'
-                || state?.dragHintApproachShown || !start || !pointer) return false;
-            const shown = await helper.recordPointerEdgeApproach('pngtuber', {
-                startedAt: start.startedAt,
-                startScreenX: start.x,
-                startScreenY: start.y,
-                screenX: pointer.x,
-                screenY: pointer.y
-            });
-            if (shown) state.dragHintApproachShown = true;
-            return shown;
+                || state?.dragHintApproachShown || state?.dragHintApproachPending
+                || !start || !pointer) return false;
+            state.dragHintApproachPending = true;
+            try {
+                const shown = await helper.recordPointerEdgeApproach('pngtuber', {
+                    startedAt: start.startedAt,
+                    startScreenX: start.x,
+                    startScreenY: start.y,
+                    screenX: pointer.x,
+                    screenY: pointer.y
+                });
+                if (shown) state.dragHintApproachShown = true;
+                return shown;
+            } finally {
+                state.dragHintApproachPending = false;
+            }
         }
 
         async recordDragHintPointerEdgeRelease(state) {
@@ -2818,9 +2832,13 @@
             const hasPointer = pointer && Number.isFinite(pointer.x) && Number.isFinite(pointer.y);
 
             try {
-                const [rawDisplays, rawCurrentDisplay] = await Promise.all([
+                const coordinateSnapshotRequest = typeof bridge.getDesktopCoordinateSnapshot === 'function'
+                    ? Promise.resolve().then(() => bridge.getDesktopCoordinateSnapshot()).catch(() => null)
+                    : Promise.resolve(null);
+                const [rawDisplays, rawCurrentDisplay, coordinateSnapshot] = await Promise.all([
                     bridge.getAllDisplays(),
-                    bridge.getCurrentDisplay()
+                    bridge.getCurrentDisplay(),
+                    coordinateSnapshotRequest
                 ]);
                 const displays = Array.isArray(rawDisplays)
                     ? rawDisplays.map((display) => this.normalizeDisplayBounds(display)).filter(Boolean)
@@ -2830,11 +2848,27 @@
 
                 const windowWidth = Number(window.innerWidth);
                 const windowHeight = Number(window.innerHeight);
-                const modelCenterInsideWindow = Number.isFinite(windowWidth) && Number.isFinite(windowHeight)
-                    && center.x >= 0 && center.x < windowWidth
+                if (!Number.isFinite(windowWidth) || !Number.isFinite(windowHeight)
+                    || windowWidth <= 0 || windowHeight <= 0) return false;
+
+                // screenOrigin matches renderer-local coordinates. It is the actual BrowserWindow
+                // origin normally and the virtual origin when physical crop mode remaps the renderer.
+                const rendererOrigin = coordinateSnapshot?.renderer?.screenOrigin;
+                const actualWindowBounds = coordinateSnapshot?.window?.actualBounds;
+                const rendererOriginX = Number(rendererOrigin?.x);
+                const rendererOriginY = Number(rendererOrigin?.y);
+                const actualWindowX = Number(actualWindowBounds?.x);
+                const actualWindowY = Number(actualWindowBounds?.y);
+                const currentWindowOriginX = Number.isFinite(rendererOriginX)
+                    ? rendererOriginX
+                    : (Number.isFinite(actualWindowX) ? actualWindowX : currentDisplay.x);
+                const currentWindowOriginY = Number.isFinite(rendererOriginY)
+                    ? rendererOriginY
+                    : (Number.isFinite(actualWindowY) ? actualWindowY : currentDisplay.y);
+                const modelCenterInsideWindow = center.x >= 0 && center.x < windowWidth
                     && center.y >= 0 && center.y < windowHeight;
-                const pointerWindowX = hasPointer ? pointer.x - currentDisplay.x : null;
-                const pointerWindowY = hasPointer ? pointer.y - currentDisplay.y : null;
+                const pointerWindowX = hasPointer ? pointer.x - currentWindowOriginX : null;
+                const pointerWindowY = hasPointer ? pointer.y - currentWindowOriginY : null;
                 const pointerOutsideCurrentWindow = hasPointer && !(
                     pointerWindowX >= 0 && pointerWindowX < windowWidth
                     && pointerWindowY >= 0 && pointerWindowY < windowHeight
@@ -2844,8 +2878,8 @@
                     return false;
                 }
 
-                const modelScreenX = currentDisplay.x + center.x;
-                const modelScreenY = currentDisplay.y + center.y;
+                const modelScreenX = currentWindowOriginX + center.x;
+                const modelScreenY = currentWindowOriginY + center.y;
                 const usePointer = hasPointer && pointerOutsideCurrentWindow;
                 const switchScreenX = usePointer ? pointer.x : modelScreenX;
                 const switchScreenY = usePointer ? pointer.y : modelScreenY;
@@ -2856,6 +2890,7 @@
                 if (!targetDisplay) return false;
                 if (currentDisplay.id !== undefined && targetDisplay.id !== undefined
                     && String(currentDisplay.id) === String(targetDisplay.id)) return false;
+                if (!this.isDragCompletionCurrent(state)) return false;
 
                 const result = await bridge.moveWindowToDisplay(switchScreenX, switchScreenY);
                 if (!(result && result.success && !result.sameDisplay)) return false;
@@ -2879,7 +2914,9 @@
 
                 await new Promise((resolve) => requestAnimationFrame(resolve));
                 await new Promise((resolve) => requestAnimationFrame(resolve));
-                this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);
+                if (this.isDragCompletionCurrent(state)) {
+                    this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);
+                }
 
                 const helper = window.NekoAvatarMultiScreenDragHint;
                 if (helper && typeof helper.markDisplaySwitchSuccess === 'function') {
@@ -2900,7 +2937,9 @@
             event.preventDefault();
             event.stopPropagation();
             const placement = this.getActivePlacement();
+            this._dragSequence += 1;
             this._dragState = {
+                dragSequence: this._dragSequence,
                 pointerId: event.pointerId,
                 startX: event.clientX,
                 startY: event.clientY,
@@ -2914,7 +2953,8 @@
                 modelCenterPointerOffset: { x: 0, y: 0 },
                 dragHintStartPointer: null,
                 dragHintLastPointer: null,
-                dragHintApproachShown: false
+                dragHintApproachShown: false,
+                dragHintApproachPending: false
             };
             this.rememberDragScreenPoint(this._dragState, event, { start: true });
             this.resetLayeredDragVelocity();
@@ -2974,9 +3014,11 @@
             if (state.moved) {
                 this._suppressNextClick = true;
                 const displaySwitched = await this.checkAndSwitchDisplayAfterDrag(state);
+                if (!this.isDragCompletionCurrent(state)) return;
                 if (!displaySwitched) {
                     await this.recordDragHintPointerEdgeRelease(state);
                 }
+                if (!this.isDragCompletionCurrent(state)) return;
                 await this.saveCurrentConfig();
             }
         }
@@ -3037,6 +3079,7 @@
             event.stopPropagation();
             const center = this.getTouchCenter(event.touches[0], event.touches[1]);
             const placement = this.getActivePlacement();
+            this._dragSequence += 1;
             this._dragState = null;
             this._touchZoomState = {
                 initialDistance: this.getTouchDistance(event.touches[0], event.touches[1]),

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -204,6 +204,8 @@
             this._listenersAttached = false;
             this._dragListenersAttached = false;
             this._dragState = null;
+            this._isDraggingModel = false;
+            this.isDragging = false;
             this._saveInFlight = null;
             this._lastSavedPositionKey = '';
             this._saveTimer = null;
@@ -323,8 +325,7 @@
             this._dragListenersAttached = false;
             this._dragState = null;
             this._touchZoomState = null;
-            document.body.classList.remove('neko-model-dragging');
-            if (this.image) this.image.classList.remove('is-dragging');
+            this.setModelDraggingState(false);
         }
 
         attachSpeechListeners() {
@@ -2671,6 +2672,226 @@
             }
         }
 
+        setModelDraggingState(active, moved = false) {
+            const dragging = !!active;
+            this._isDraggingModel = dragging;
+            this.isDragging = dragging;
+            document.body?.classList.toggle('neko-model-dragging', dragging);
+            if (!this.image) return;
+
+            this.image.dragging = dragging;
+            this.image.isDragging = dragging;
+            this.image._isDraggingModel = dragging;
+            this.image.classList.toggle('is-dragging', dragging);
+            if (dragging) {
+                this.image.setAttribute('data-dragging', moved ? 'true' : 'pending');
+            } else {
+                this.image.removeAttribute('data-dragging');
+            }
+        }
+
+        getModelCenterInWindow() {
+            if (!this.image || typeof this.image.getBoundingClientRect !== 'function') return null;
+            const rect = this.image.getBoundingClientRect();
+            const left = Number(rect?.left);
+            const top = Number(rect?.top);
+            const width = Number(rect?.width);
+            const height = Number(rect?.height);
+            if (![left, top, width, height].every(Number.isFinite) || width <= 0 || height <= 0) {
+                return null;
+            }
+            return {
+                x: left + width / 2,
+                y: top + height / 2
+            };
+        }
+
+        captureDragScreenPoint(event) {
+            const screenX = Number(event?.screenX);
+            const screenY = Number(event?.screenY);
+            if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) return null;
+            return { x: screenX, y: screenY };
+        }
+
+        rememberDragScreenPoint(state, event, { start = false } = {}) {
+            if (!state) return null;
+            const point = this.captureDragScreenPoint(event);
+            if (!point) return null;
+            state.lastScreenPoint = point;
+            state.dragHintLastPointer = point;
+            if (!start) return point;
+
+            const center = this.getModelCenterInWindow();
+            const clientX = Number(event?.clientX);
+            const clientY = Number(event?.clientY);
+            state.modelCenterPointerOffset = center && Number.isFinite(clientX) && Number.isFinite(clientY)
+                ? { x: center.x - clientX, y: center.y - clientY }
+                : { x: 0, y: 0 };
+            state.dragHintStartPointer = Object.assign({ startedAt: Date.now() }, point);
+            return point;
+        }
+
+        async recordDragHintPointerEdgeApproach(state) {
+            const helper = window.NekoAvatarMultiScreenDragHint;
+            const start = state?.dragHintStartPointer;
+            const pointer = state?.dragHintLastPointer;
+            if (!helper || typeof helper.recordPointerEdgeApproach !== 'function'
+                || state?.dragHintApproachShown || !start || !pointer) return false;
+            const shown = await helper.recordPointerEdgeApproach('pngtuber', {
+                startedAt: start.startedAt,
+                startScreenX: start.x,
+                startScreenY: start.y,
+                screenX: pointer.x,
+                screenY: pointer.y
+            });
+            if (shown) state.dragHintApproachShown = true;
+            return shown;
+        }
+
+        async recordDragHintPointerEdgeRelease(state) {
+            const helper = window.NekoAvatarMultiScreenDragHint;
+            const start = state?.dragHintStartPointer;
+            const pointer = state?.dragHintLastPointer;
+            if (!helper || typeof helper.recordPointerEdgeRelease !== 'function' || !start || !pointer) {
+                return false;
+            }
+            return await helper.recordPointerEdgeRelease('pngtuber', {
+                startedAt: start.startedAt,
+                startScreenX: start.x,
+                startScreenY: start.y,
+                screenX: pointer.x,
+                screenY: pointer.y
+            });
+        }
+
+        normalizeDisplayBounds(display) {
+            if (!display || typeof display !== 'object') return null;
+            const x = Number.isFinite(Number(display.screenX))
+                ? Number(display.screenX)
+                : Number(display.bounds?.x);
+            const y = Number.isFinite(Number(display.screenY))
+                ? Number(display.screenY)
+                : Number(display.bounds?.y);
+            const width = Number.isFinite(Number(display.width))
+                ? Number(display.width)
+                : Number(display.bounds?.width);
+            const height = Number.isFinite(Number(display.height))
+                ? Number(display.height)
+                : Number(display.bounds?.height);
+            if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) {
+                return null;
+            }
+            return { id: display.id, x, y, width, height };
+        }
+
+        moveModelCenterToWindowPoint(targetX, targetY) {
+            const x = Number(targetX);
+            const y = Number(targetY);
+            const center = this.getModelCenterInWindow();
+            if (!center || !Number.isFinite(x) || !Number.isFinite(y)) return false;
+
+            const placement = this.getActivePlacement();
+            this.setActiveOffsets(
+                placement.offsetX + x - center.x,
+                placement.offsetY + y - center.y
+            );
+            this.applyTransform();
+            if (this.isLayeredActive()) this.drawLayeredState();
+            this.syncGlobalConfig();
+            if (typeof this.updateFloatingButtonsPosition === 'function') {
+                this.updateFloatingButtonsPosition();
+            }
+            this.updateLockIconPosition();
+            return true;
+        }
+
+        async checkAndSwitchDisplayAfterDrag(state) {
+            const bridge = window.electronScreen;
+            if (isModelManagerPage() || !bridge
+                || typeof bridge.getAllDisplays !== 'function'
+                || typeof bridge.getCurrentDisplay !== 'function'
+                || typeof bridge.moveWindowToDisplay !== 'function') return false;
+
+            const center = this.getModelCenterInWindow();
+            if (!center) return false;
+            const pointer = state?.lastScreenPoint;
+            const hasPointer = pointer && Number.isFinite(pointer.x) && Number.isFinite(pointer.y);
+
+            try {
+                const [rawDisplays, rawCurrentDisplay] = await Promise.all([
+                    bridge.getAllDisplays(),
+                    bridge.getCurrentDisplay()
+                ]);
+                const displays = Array.isArray(rawDisplays)
+                    ? rawDisplays.map((display) => this.normalizeDisplayBounds(display)).filter(Boolean)
+                    : [];
+                const currentDisplay = this.normalizeDisplayBounds(rawCurrentDisplay);
+                if (displays.length <= 1 || !currentDisplay) return false;
+
+                const windowWidth = Number(window.innerWidth);
+                const windowHeight = Number(window.innerHeight);
+                const modelCenterInsideWindow = Number.isFinite(windowWidth) && Number.isFinite(windowHeight)
+                    && center.x >= 0 && center.x < windowWidth
+                    && center.y >= 0 && center.y < windowHeight;
+                const pointerWindowX = hasPointer ? pointer.x - currentDisplay.x : null;
+                const pointerWindowY = hasPointer ? pointer.y - currentDisplay.y : null;
+                const pointerOutsideCurrentWindow = hasPointer && !(
+                    pointerWindowX >= 0 && pointerWindowX < windowWidth
+                    && pointerWindowY >= 0 && pointerWindowY < windowHeight
+                );
+                if ((!hasPointer && modelCenterInsideWindow)
+                    || (hasPointer && !pointerOutsideCurrentWindow && modelCenterInsideWindow)) {
+                    return false;
+                }
+
+                const modelScreenX = currentDisplay.x + center.x;
+                const modelScreenY = currentDisplay.y + center.y;
+                const usePointer = hasPointer && pointerOutsideCurrentWindow;
+                const switchScreenX = usePointer ? pointer.x : modelScreenX;
+                const switchScreenY = usePointer ? pointer.y : modelScreenY;
+                const targetDisplay = displays.find((display) => (
+                    switchScreenX >= display.x && switchScreenX < display.x + display.width
+                    && switchScreenY >= display.y && switchScreenY < display.y + display.height
+                ));
+                if (!targetDisplay) return false;
+                if (currentDisplay.id !== undefined && targetDisplay.id !== undefined
+                    && String(currentDisplay.id) === String(targetDisplay.id)) return false;
+
+                const result = await bridge.moveWindowToDisplay(switchScreenX, switchScreenY);
+                if (!(result && result.success && !result.sameDisplay)) return false;
+
+                const resultWindowBounds = result.windowBounds && typeof result.windowBounds === 'object'
+                    ? result.windowBounds
+                    : null;
+                const targetOriginX = Number.isFinite(Number(resultWindowBounds?.x))
+                    ? Number(resultWindowBounds.x)
+                    : targetDisplay.x;
+                const targetOriginY = Number.isFinite(Number(resultWindowBounds?.y))
+                    ? Number(resultWindowBounds.y)
+                    : targetDisplay.y;
+                const pointerOffset = state?.modelCenterPointerOffset || { x: 0, y: 0 };
+                const desiredCenterX = usePointer
+                    ? switchScreenX - targetOriginX + (Number(pointerOffset.x) || 0)
+                    : modelScreenX - targetOriginX;
+                const desiredCenterY = usePointer
+                    ? switchScreenY - targetOriginY + (Number(pointerOffset.y) || 0)
+                    : modelScreenY - targetOriginY;
+
+                await new Promise((resolve) => requestAnimationFrame(resolve));
+                await new Promise((resolve) => requestAnimationFrame(resolve));
+                this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);
+
+                const helper = window.NekoAvatarMultiScreenDragHint;
+                if (helper && typeof helper.markDisplaySwitchSuccess === 'function') {
+                    helper.markDisplaySwitchSuccess('pngtuber');
+                }
+                return true;
+            } catch (error) {
+                console.error('[PNGTuber] Failed to switch display after drag:', error);
+                return false;
+            }
+        }
+
         startDrag(event) {
             if (!canInteractWithAvatar()) return;
             if (this.isLocked) return;
@@ -2688,15 +2909,20 @@
                 lastX: event.clientX,
                 lastY: event.clientY,
                 lastAt: performance.now(),
-                moved: false
+                moved: false,
+                lastScreenPoint: null,
+                modelCenterPointerOffset: { x: 0, y: 0 },
+                dragHintStartPointer: null,
+                dragHintLastPointer: null,
+                dragHintApproachShown: false
             };
+            this.rememberDragScreenPoint(this._dragState, event, { start: true });
             this.resetLayeredDragVelocity();
             if (this.layeredPointer) this.layeredPointer.active = false;
             if (this.image && typeof this.image.setPointerCapture === 'function') {
                 try { this.image.setPointerCapture(event.pointerId); } catch (_) {}
             }
-            document.body.classList.add('neko-model-dragging');
-            if (this.image) this.image.classList.add('is-dragging');
+            this.setModelDraggingState(true, false);
         }
 
         moveDrag(event) {
@@ -2709,10 +2935,13 @@
             state.lastX = event.clientX;
             state.lastY = event.clientY;
             state.lastAt = now;
+            this.rememberDragScreenPoint(state, event);
             if (Math.hypot(dx, dy) > 4 && !state.moved) {
                 state.moved = true;
+                this.setModelDraggingState(true, true);
                 this.showDragImage();
             }
+            if (state.moved) void this.recordDragHintPointerEdgeApproach(state);
             this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);
             this.applyTransform();
             if (this.isLayeredActive()) this.drawLayeredState();
@@ -2726,6 +2955,7 @@
         async endDrag(event) {
             const state = this._dragState;
             if (!state || (state.pointerId !== undefined && event.pointerId !== state.pointerId)) return;
+            this.rememberDragScreenPoint(state, event);
             this._dragState = null;
             // 拖拽释放后的物理回摆窗口保持满帧：Plus 模型物理状态的内部字段
             // （draggerX/Y）不走 remix 形状探测，用时间窗兜底两种物理形态
@@ -2734,8 +2964,7 @@
             if (this.image && typeof this.image.releasePointerCapture === 'function') {
                 try { this.image.releasePointerCapture(event.pointerId); } catch (_) {}
             }
-            document.body.classList.remove('neko-model-dragging');
-            if (this.image) this.image.classList.remove('is-dragging');
+            this.setModelDraggingState(false);
             this.restoreStateImage();
             this.restartLayeredAnimationLoop();
             if (typeof this.updateFloatingButtonsPosition === 'function') {
@@ -2744,6 +2973,10 @@
             this.updateLockIconPosition();
             if (state.moved) {
                 this._suppressNextClick = true;
+                const displaySwitched = await this.checkAndSwitchDisplayAfterDrag(state);
+                if (!displaySwitched) {
+                    await this.recordDragHintPointerEdgeRelease(state);
+                }
                 await this.saveCurrentConfig();
             }
         }
@@ -2819,8 +3052,7 @@
             };
             this.resetLayeredDragVelocity();
             if (this.layeredPointer) this.layeredPointer.active = false;
-            document.body.classList.add('neko-model-dragging');
-            if (this.image) this.image.classList.add('is-dragging');
+            this.setModelDraggingState(true, true);
             this.showDragImage();
         }
 
@@ -2849,8 +3081,7 @@
             if (!state) return;
             this._touchZoomState = null;
             this.resetLayeredDragVelocity();
-            document.body.classList.remove('neko-model-dragging');
-            if (this.image) this.image.classList.remove('is-dragging');
+            this.setModelDraggingState(false);
             this.restoreStateImage();
             this.restartLayeredAnimationLoop();
             if (typeof this.updateFloatingButtonsPosition === 'function') {

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1,5 +1,11 @@
+import json
+import shutil
 from pathlib import Path
+
+import pytest
+
 from tests.static_app_parts import read_js_parts
+from tests.node_harness import run_node_script
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -93,6 +99,189 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
     assert "this.config.mobile_scale" in save_block
     assert "this.config.position_anchor" in save_block
     assert "apply_runtime: false" in save_block
+
+
+def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    drag_block = source[
+        source.index("        setModelDraggingState(active, moved = false) {"):
+        source.index("        handleClick(event) {")
+    ]
+
+    assert "this._isDraggingModel = dragging;" in drag_block
+    assert "this.image.setAttribute('data-dragging', moved ? 'true' : 'pending');" in drag_block
+    assert "this.rememberDragScreenPoint(this._dragState, event, { start: true });" in drag_block
+    assert "this.rememberDragScreenPoint(state, event);" in drag_block
+    assert "void this.recordDragHintPointerEdgeApproach(state);" in drag_block
+    assert "const displaySwitched = await this.checkAndSwitchDisplayAfterDrag(state);" in drag_block
+    assert "await this.recordDragHintPointerEdgeRelease(state);" in drag_block
+    assert "bridge.getAllDisplays()" in drag_block
+    assert "bridge.getCurrentDisplay()" in drag_block
+    assert "bridge.moveWindowToDisplay(switchScreenX, switchScreenY)" in drag_block
+    assert "result.windowBounds" in drag_block
+    assert "this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);" in drag_block
+    assert "helper.markDisplaySwitchSuccess('pngtuber');" in drag_block
+
+
+def test_pngtuber_drag_switches_to_the_pointer_display_without_losing_the_grab_point():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for PNGTuber multiscreen drag tests")
+
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const bodyClasses = new Set();
+const bodyClassList = {{
+  contains(name) {{ return bodyClasses.has(name); }},
+  add(name) {{ bodyClasses.add(name); }},
+  remove(name) {{ bodyClasses.delete(name); }},
+  toggle(name, active) {{
+    if (active) bodyClasses.add(name);
+    else bodyClasses.delete(name);
+  }},
+}};
+const document = {{
+  body: {{ classList: bodyClassList }},
+  getElementById() {{ return null; }},
+  querySelectorAll() {{ return []; }},
+}};
+
+const primary = {{ id: 'primary', screenX: 0, screenY: 0, width: 1707, height: 1067 }};
+const secondary = {{ id: 'secondary', screenX: -2560, screenY: 0, width: 2560, height: 1440 }};
+let currentDisplay = primary;
+let movedPoint = null;
+let saves = 0;
+const markedSwitches = [];
+
+const requestAnimationFrame = (callback) => {{ callback(0); return 1; }};
+const window = {{
+  location: {{ pathname: '/' }},
+  innerWidth: primary.width,
+  innerHeight: primary.height,
+  __LANLAN_IS_ELECTRON_PET__: true,
+  lanlan_config: {{ model_type: 'pngtuber' }},
+  requestAnimationFrame,
+  electronScreen: {{
+    async getAllDisplays() {{ return [primary, secondary]; }},
+    async getCurrentDisplay() {{ return currentDisplay; }},
+    async moveWindowToDisplay(x, y) {{
+      movedPoint = {{ x, y }};
+      currentDisplay = secondary;
+      window.innerWidth = secondary.width;
+      window.innerHeight = secondary.height;
+      return {{
+        success: true,
+        sameDisplay: false,
+        windowBounds: {{ x: secondary.screenX, y: secondary.screenY, width: secondary.width, height: secondary.height }},
+      }};
+    }},
+  }},
+  NekoAvatarMultiScreenDragHint: {{
+    async recordPointerEdgeApproach() {{ return false; }},
+    async recordPointerEdgeRelease() {{ return false; }},
+    markDisplaySwitchSuccess(source) {{ markedSwitches.push(source); }},
+  }},
+}};
+
+const context = {{
+  console,
+  document,
+  window,
+  performance: {{ now: () => 0 }},
+  requestAnimationFrame,
+}};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
+
+let manager = new window.PNGTuberManager();
+const attributes = new Map();
+const imageClasses = new Set();
+const image = {{
+  style: {{}},
+  classList: {{
+    toggle(name, active) {{
+      if (active) imageClasses.add(name);
+      else imageClasses.delete(name);
+    }},
+  }},
+  closest() {{ return null; }},
+  setAttribute(name, value) {{ attributes.set(name, String(value)); }},
+  removeAttribute(name) {{ attributes.delete(name); }},
+  setPointerCapture() {{}},
+  releasePointerCapture() {{}},
+  getBoundingClientRect() {{
+    const centerX = window.innerWidth / 2 + manager.config.offset_x;
+    const centerY = window.innerHeight / 2 + manager.config.offset_y;
+    return {{ left: centerX - 100, top: centerY - 100, width: 200, height: 200 }};
+  }},
+}};
+manager.image = image;
+manager.container = {{ style: {{}} }};
+manager.config = {{
+  scale: 1,
+  offset_x: -700,
+  offset_y: 0,
+  mobile_scale: 1,
+  mobile_offset_x: 0,
+  mobile_offset_y: 0,
+  position_anchor: 'center',
+  mirror: false,
+}};
+manager.resetLayeredDragVelocity = () => {{}};
+manager.isLayeredActive = () => false;
+manager.showDragImage = () => {{}};
+manager.restoreStateImage = () => {{}};
+manager.restartLayeredAnimationLoop = () => {{}};
+manager.applyTransform = () => {{}};
+manager.syncGlobalConfig = () => {{}};
+manager.updateFloatingButtonsPosition = () => {{}};
+manager.updateLockIconPosition = () => {{}};
+manager.saveCurrentConfig = async () => {{ saves += 1; return true; }};
+
+function pointer(type, clientX, clientY, screenX, screenY) {{
+  return {{
+    type,
+    target: image,
+    button: 0,
+    pointerId: 7,
+    clientX,
+    clientY,
+    screenX,
+    screenY,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }};
+}}
+
+(async () => {{
+  manager.startDrag(pointer('pointerdown', 154, 534, 154, 534));
+  assert.equal(manager._isDraggingModel, true);
+  assert.equal(attributes.get('data-dragging'), 'pending');
+
+  manager.moveDrag(pointer('pointermove', -200, 534, -200, 534));
+  assert.equal(attributes.get('data-dragging'), 'true');
+
+  await manager.endDrag(pointer('pointerup', -200, 534, -200, 534));
+
+  assert.deepEqual(movedPoint, {{ x: -200, y: 534 }});
+  assert.equal(currentDisplay.id, 'secondary');
+  assert.equal(manager.getModelCenterInWindow().x, 2359.5);
+  assert.equal(manager.getModelCenterInWindow().y, 533.5);
+  assert.equal(manager.config.offset_x, 1079.5);
+  assert.equal(manager.config.offset_y, -186.5);
+  assert.equal(saves, 1);
+  assert.deepEqual(markedSwitches, ['pngtuber']);
+  assert.equal(manager._isDraggingModel, false);
+  assert.equal(attributes.has('data-dragging'), false);
+  assert.equal(bodyClasses.has('neko-model-dragging'), false);
+}})().catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
 
 
 def test_pngtuber_model_manager_preview_centering_does_not_mutate_saved_offsets():

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -117,10 +117,73 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
     assert "await this.recordDragHintPointerEdgeRelease(state);" in drag_block
     assert "bridge.getAllDisplays()" in drag_block
     assert "bridge.getCurrentDisplay()" in drag_block
+    assert "bridge.getDesktopCoordinateSnapshot()" in drag_block
+    assert "coordinateSnapshot?.renderer?.screenOrigin" in drag_block
+    assert "state?.dragHintApproachPending" in drag_block
+    assert "state.dragHintApproachPending = true;" in drag_block
+    assert "state.dragHintApproachPending = false;" in drag_block
+    assert "this.isDragCompletionCurrent(state)" in drag_block
     assert "bridge.moveWindowToDisplay(switchScreenX, switchScreenY)" in drag_block
     assert "result.windowBounds" in drag_block
     assert "this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);" in drag_block
     assert "helper.markDisplaySwitchSuccess('pngtuber');" in drag_block
+
+
+def test_pngtuber_drag_hint_edge_approach_allows_only_one_in_flight_call():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for PNGTuber drag hint tests")
+
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+let approachCalls = 0;
+let resolveApproach;
+const window = {{
+  location: {{ pathname: '/' }},
+  lanlan_config: {{ model_type: 'pngtuber' }},
+  NekoAvatarMultiScreenDragHint: {{
+    recordPointerEdgeApproach() {{
+      approachCalls += 1;
+      return new Promise((resolve) => {{ resolveApproach = resolve; }});
+    }},
+  }},
+}};
+const document = {{
+  body: {{ classList: {{ contains() {{ return false; }} }} }},
+  getElementById() {{ return null; }},
+  querySelectorAll() {{ return []; }},
+}};
+const context = {{ console, document, window }};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
+
+(async () => {{
+  const manager = new window.PNGTuberManager();
+  const state = {{
+    dragHintStartPointer: {{ x: 10, y: 20, startedAt: 1 }},
+    dragHintLastPointer: {{ x: 30, y: 40 }},
+    dragHintApproachShown: false,
+    dragHintApproachPending: false,
+  }};
+  const first = manager.recordDragHintPointerEdgeApproach(state);
+  const second = manager.recordDragHintPointerEdgeApproach(state);
+
+  assert.equal(approachCalls, 1);
+  assert.equal(await second, false);
+  resolveApproach(true);
+  assert.equal(await first, true);
+  assert.equal(state.dragHintApproachPending, false);
+  assert.equal(state.dragHintApproachShown, true);
+  assert.equal(await manager.recordDragHintPointerEdgeApproach(state), false);
+  assert.equal(approachCalls, 1);
+}})().catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
 
 
 def test_pngtuber_drag_switches_to_the_pointer_display_without_losing_the_grab_point():
@@ -151,31 +214,52 @@ const document = {{
 
 const primary = {{ id: 'primary', screenX: 0, screenY: 0, width: 1707, height: 1067 }};
 const secondary = {{ id: 'secondary', screenX: -2560, screenY: 0, width: 2560, height: 1440 }};
+const primaryWindowBounds = {{ x: 1, y: 1, width: 1706, height: 1066 }};
+const secondaryWindowBounds = {{ x: -2559, y: 1, width: 2559, height: 1439 }};
 let currentDisplay = primary;
+let currentWindowBounds = {{ ...primaryWindowBounds }};
 let movedPoint = null;
 let saves = 0;
+let snapshotCalls = 0;
+let deferredFrames = null;
 const markedSwitches = [];
 
-const requestAnimationFrame = (callback) => {{ callback(0); return 1; }};
+const requestAnimationFrame = (callback) => {{
+  if (deferredFrames) {{
+    deferredFrames.push(callback);
+    return deferredFrames.length;
+  }}
+  callback(0);
+  return 1;
+}};
 const window = {{
   location: {{ pathname: '/' }},
-  innerWidth: primary.width,
-  innerHeight: primary.height,
+  innerWidth: primaryWindowBounds.width,
+  innerHeight: primaryWindowBounds.height,
   __LANLAN_IS_ELECTRON_PET__: true,
   lanlan_config: {{ model_type: 'pngtuber' }},
   requestAnimationFrame,
   electronScreen: {{
     async getAllDisplays() {{ return [primary, secondary]; }},
     async getCurrentDisplay() {{ return currentDisplay; }},
+    async getDesktopCoordinateSnapshot() {{
+      snapshotCalls += 1;
+      return {{
+        version: 2,
+        window: {{ actualBounds: {{ ...currentWindowBounds }} }},
+        renderer: {{ screenOrigin: {{ x: currentWindowBounds.x, y: currentWindowBounds.y }} }},
+      }};
+    }},
     async moveWindowToDisplay(x, y) {{
       movedPoint = {{ x, y }};
       currentDisplay = secondary;
-      window.innerWidth = secondary.width;
-      window.innerHeight = secondary.height;
+      currentWindowBounds = {{ ...secondaryWindowBounds }};
+      window.innerWidth = currentWindowBounds.width;
+      window.innerHeight = currentWindowBounds.height;
       return {{
         success: true,
         sameDisplay: false,
-        windowBounds: {{ x: secondary.screenX, y: secondary.screenY, width: secondary.width, height: secondary.height }},
+        windowBounds: {{ ...currentWindowBounds }},
       }};
     }},
   }},
@@ -240,12 +324,12 @@ manager.updateFloatingButtonsPosition = () => {{}};
 manager.updateLockIconPosition = () => {{}};
 manager.saveCurrentConfig = async () => {{ saves += 1; return true; }};
 
-function pointer(type, clientX, clientY, screenX, screenY) {{
+function pointer(type, clientX, clientY, screenX, screenY, pointerId = 7) {{
   return {{
     type,
     target: image,
     button: 0,
-    pointerId: 7,
+    pointerId,
     clientX,
     clientY,
     screenX,
@@ -256,26 +340,95 @@ function pointer(type, clientX, clientY, screenX, screenY) {{
 }}
 
 (async () => {{
-  manager.startDrag(pointer('pointerdown', 154, 534, 154, 534));
+  manager.startDrag(pointer('pointerdown', 154, 534, 155, 535));
   assert.equal(manager._isDraggingModel, true);
   assert.equal(attributes.get('data-dragging'), 'pending');
 
-  manager.moveDrag(pointer('pointermove', -200, 534, -200, 534));
+  manager.moveDrag(pointer('pointermove', -201, 534, -200, 535));
   assert.equal(attributes.get('data-dragging'), 'true');
 
-  await manager.endDrag(pointer('pointerup', -200, 534, -200, 534));
+  await manager.endDrag(pointer('pointerup', -201, 534, -200, 535));
 
-  assert.deepEqual(movedPoint, {{ x: -200, y: 534 }});
+  assert.deepEqual(movedPoint, {{ x: -200, y: 535 }});
   assert.equal(currentDisplay.id, 'secondary');
-  assert.equal(manager.getModelCenterInWindow().x, 2359.5);
-  assert.equal(manager.getModelCenterInWindow().y, 533.5);
-  assert.equal(manager.config.offset_x, 1079.5);
+  // -200 - secondary origin(-2559) + grab offset(-1) = 2358.
+  assert.equal(manager.getModelCenterInWindow().x, 2358);
+  // 535 - secondary origin(1) + grab offset(-1) = 533.
+  assert.equal(manager.getModelCenterInWindow().y, 533);
+  // 2358 - secondary window center(2559 / 2) = 1078.5.
+  assert.equal(manager.config.offset_x, 1078.5);
+  // 533 - secondary window center(1439 / 2) = -186.5.
   assert.equal(manager.config.offset_y, -186.5);
   assert.equal(saves, 1);
+  assert.ok(snapshotCalls >= 1);
   assert.deepEqual(markedSwitches, ['pngtuber']);
   assert.equal(manager._isDraggingModel, false);
   assert.equal(attributes.has('data-dragging'), false);
   assert.equal(bodyClasses.has('neko-model-dragging'), false);
+
+  currentDisplay = primary;
+  currentWindowBounds = {{ ...primaryWindowBounds }};
+  window.innerWidth = currentWindowBounds.width;
+  window.innerHeight = currentWindowBounds.height;
+  manager.config.offset_x = -855;
+  manager.config.offset_y = 0;
+  movedPoint = null;
+  manager._dragSequence += 1;
+  const modelOnlyState = {{
+    dragSequence: manager._dragSequence,
+    lastScreenPoint: null,
+    modelCenterPointerOffset: {{ x: 0, y: 0 }},
+  }};
+  assert.equal(await manager.checkAndSwitchDisplayAfterDrag(modelOnlyState), true);
+  // Primary actual origin(1) + local model center(-2) = screen x(-1).
+  assert.deepEqual(movedPoint, {{ x: -1, y: 534 }});
+
+  currentDisplay = primary;
+  currentWindowBounds = {{ ...primaryWindowBounds }};
+  window.innerWidth = Number.NaN;
+  window.innerHeight = currentWindowBounds.height;
+  movedPoint = null;
+  const getModelCenterInWindow = manager.getModelCenterInWindow.bind(manager);
+  manager.getModelCenterInWindow = () => ({{ x: 100, y: 100 }});
+  manager._dragSequence += 1;
+  const invalidWindowState = {{
+    dragSequence: manager._dragSequence,
+    lastScreenPoint: {{ x: -200, y: 100 }},
+    modelCenterPointerOffset: {{ x: 0, y: 0 }},
+  }};
+  assert.equal(await manager.checkAndSwitchDisplayAfterDrag(invalidWindowState), false);
+  assert.equal(movedPoint, null);
+  manager.getModelCenterInWindow = getModelCenterInWindow;
+
+  currentDisplay = primary;
+  currentWindowBounds = {{ ...primaryWindowBounds }};
+  window.innerWidth = currentWindowBounds.width;
+  window.innerHeight = currentWindowBounds.height;
+  manager.config.offset_x = -700;
+  manager.config.offset_y = 0;
+  movedPoint = null;
+  saves = 0;
+  deferredFrames = [];
+  manager.startDrag(pointer('pointerdown', 154, 534, 155, 535));
+  manager.moveDrag(pointer('pointermove', -201, 534, -200, 535));
+  const staleEnd = manager.endDrag(pointer('pointerup', -201, 534, -200, 535));
+  while (deferredFrames.length === 0) await new Promise(setImmediate);
+
+  manager.startDrag(pointer('pointerdown', 100, 100, -2459, 101, 8));
+  manager.moveDrag(pointer('pointermove', 120, 100, -2439, 101, 8));
+  const activeDragOffsets = {{
+    x: manager.config.offset_x,
+    y: manager.config.offset_y,
+  }};
+  deferredFrames.shift()(0);
+  await new Promise(setImmediate);
+  deferredFrames.shift()(0);
+  await staleEnd;
+
+  assert.equal(manager._dragState.pointerId, 8);
+  assert.equal(manager.config.offset_x, activeDragOffsets.x);
+  assert.equal(manager.config.offset_y, activeDragOffsets.y);
+  assert.equal(saves, 0);
 }})().catch((error) => {{
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 PNGTuber 无法拖动到副屏的问题，补全跨屏切换、拖动状态同步及回归测试

## 测试 / Testing

手动尝试切换副屏


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持桌面端跨显示器拖拽模型，并在切换屏幕后保持模型位置和拖拽偏移。
  * 新增屏幕边缘检测及跨屏拖拽提示。

* **改进**
  * 统一管理鼠标拖拽与触摸缩放状态，提升交互一致性。
  * 优化拖拽过程中的位置记录、边界处理及状态清理。
  * 跨屏拖拽失败时提供释放提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->