### PR TITLE
fix(plugin-market): bind release evidence to tag

### DIFF
--- a/.github/workflows/plugin-market-release.yml
+++ b/.github/workflows/plugin-market-release.yml
@@ -105,6 +105,8 @@ jobs:
           evidence = {
               "schema_version": 1,
               "mode": "release",
+              "ref_type": os.environ["GITHUB_REF_TYPE"],
+              "ref_name": os.environ["GITHUB_REF_NAME"],
               "plugin_id": os.environ["PLUGIN_ID"],
               "version": os.environ["GITHUB_REF_NAME"].removeprefix("v"),
               "source_commit": os.environ["GITHUB_SHA"],

--- a/plugin/tests/unit/test_plugin_market_workflows.py
+++ b/plugin/tests/unit/test_plugin_market_workflows.py
@@ -42,6 +42,8 @@ def test_reusable_release_workflow_publishes_package_digest_evidence() -> None:
     assert "NEKO_REPOSITORY: ${{ inputs.neko-repository }}" in workflow
     assert "check -r --market-release" in workflow
     assert "market-evidence.json" in workflow
+    assert '"ref_type": os.environ["GITHUB_REF_TYPE"]' in workflow
+    assert '"ref_name": os.environ["GITHUB_REF_NAME"]' in workflow
     assert "softprops/action-gh-release" in workflow
     assert "fail_on_unmatched_files: true" in workflow
     assert '[[ ! "$PLUGIN_ID" =~ ^[a-z][a-z0-9_]*$ ]]' in workflow


### PR DESCRIPTION
## 改动概述 / Summary

补齐官方 `plugin-market-release.yml` 生成的 `market-evidence.json`：写入 GitHub 已验证的 `ref_type` 与完整 `ref_name`，使默认发布 Workflow 与 Plugin Market 当前严格发布证据契约一致。保留现有 reusable workflow 与插件仓库 `release.yml` 编排，不修改 CLI 生成目录或其他发布行为。

## 回归报告 / Regression Report

不适用。

## 不拆分理由 / Why Not Split

不适用。

## 测试 / Testing

- `uv run pytest -q plugin/tests/unit/test_plugin_market_workflows.py plugin/tests/unit/test_neko_plugin_cli_cli.py plugin/tests/integration/test_neko_plugin_cli_workflow.py plugin/tests/integration/test_neko_plugin_cli_repo_plugins.py`
- 结果：`91 passed`
- 已对照 Plugin Market 当前验证器要求：`mode=release`、`ref_type=tag`、`ref_name=<完整 GitHub Release tag>`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 市场证据现会记录发布工作流中的 GitHub 引用类型和引用名称，提升发布信息的完整性与可追溯性。

- **测试**
  - 新增工作流验证，确保引用类型和引用名称能够正确写入证据数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->