### PR TITLE
docs(websocket): 修正二进制帧上限与 engaged 声明语义（#2740 文档组，摘自 #2837）

### DIFF
--- a/docs/api/websocket/audio-streaming.md
+++ b/docs/api/websocket/audio-streaming.md
@@ -24,6 +24,7 @@ session:
 {
   "action": "voice_input_control",
   "event": "lease_sync",
+  "engaged": true,
   "owner": "core",
   "hard_muted": false,
   "focus_suppressed": false,
@@ -34,6 +35,18 @@ session:
 `lease_generation` is scoped to one WebSocket and must increase monotonically.
 Start a fresh sequence after reconnecting. The server rejects invalid or stale
 control messages with status code `VOICE_INPUT_CONTROL_REJECTED`.
+
+`engaged` has the following wire-level claim semantics:
+
+| JSON value | Window state | Voice-connection claim |
+| --- | --- | --- |
+| `true` | Active recording or reconnecting an active recording | Claims |
+| `false` | Passive auxiliary window | Does not claim |
+| omitted | Legacy-client compatibility | Claims |
+
+Only the literal JSON value `false` suppresses the claim. Passive windows must
+therefore send it explicitly to avoid taking the microphone lease from the
+active window.
 
 For compatibility, an older client that sends no `voice_input_control` message
 can still start one ordinary `audio` session. Immediately before that session
@@ -86,8 +99,9 @@ chunk per binary frame: 480 samples (10 ms) at 48 kHz on desktop, 512 samples
 | 8 | remaining bytes | Mono signed PCM16 samples in little-endian order |
 
 The PCM payload must be non-empty, have an even byte length, and represent at
-most one second of audio at the declared rate. No JSON `action` accompanies
-this frame; the server decodes it as `stream_data` with `input_type: "audio"`.
+most 120 ms of audio at the declared rate. Normal clients should keep using
+10-32 ms frames as described above. No JSON `action` accompanies this frame;
+the server decodes it as `stream_data` with `input_type: "audio"`.
 
 For compatibility, clients may instead send a JSON text frame:
 

--- a/docs/api/websocket/message-types.md
+++ b/docs/api/websocket/message-types.md
@@ -26,6 +26,7 @@ compatibility path.
 {
   "action": "voice_input_control",
   "event": "lease_sync",
+  "engaged": true,
   "owner": "core",
   "hard_muted": false,
   "focus_suppressed": false,
@@ -37,6 +38,16 @@ compatibility path.
 `focus_suppress`, `focus_resume`, `game_takeover`, or `game_release`.
 `lease_sync` requires the complete `owner`, `hard_muted`, and
 `focus_suppressed` snapshot. `owner` is `none`, `core`, or `game`.
+`engaged` uses this exact claim matrix:
+
+| JSON value | Window state | Voice-connection claim |
+| --- | --- | --- |
+| `true` | Active recording or reconnecting an active recording | Claims |
+| `false` | Passive auxiliary window | Does not claim |
+| omitted | Legacy-client compatibility | Claims |
+
+Only the literal JSON value `false` suppresses the claim. New passive clients
+must send it explicitly.
 
 Generations are scoped to one WebSocket, strictly increase, and restart after
 reconnection. Any explicit control attempt permanently selects this strict
@@ -78,8 +89,9 @@ bytes 4..7   uint32 little-endian sample rate (16000 or 48000)
 bytes 8..N   mono signed PCM16, little-endian
 ```
 
-The PCM payload must be non-empty, even-sized, and no longer than one second.
-The server treats this frame as `stream_data` with `input_type: "audio"`.
+The PCM payload must be non-empty, even-sized, and no longer than 120 ms.
+Normal clients should send 10-32 ms frames. The server treats this frame as
+`stream_data` with `input_type: "audio"`.
 
 For compatibility, clients may send a JSON array of signed 16-bit PCM sample
 values instead. Audio is **not base64**:

--- a/docs/api/websocket/protocol.md
+++ b/docs/api/websocket/protocol.md
@@ -71,6 +71,17 @@ restarts after reconnecting. Invalid or stale control messages produce
 `VOICE_INPUT_CONTROL_REJECTED` and permanently disable legacy fallback for that
 connection.
 
+The snapshot's `engaged` field uses this exact claim matrix:
+
+| JSON value | Window state | Voice-connection claim |
+| --- | --- | --- |
+| `true` | Active recording or reconnecting an active recording | Claims |
+| `false` | Passive auxiliary window | Does not claim |
+| omitted | Legacy-client compatibility | Claims |
+
+Only the literal JSON value `false` suppresses the claim. New passive clients
+must send it explicitly.
+
 For compatibility, a connection that has sent no control message can acquire a
 generation-0 Core lease immediately before its first ordinary audio session
 starts. This does not run on the game route and cannot override an explicit

--- a/scripts/evaluate_speech_presence.py
+++ b/scripts/evaluate_speech_presence.py
@@ -282,6 +282,20 @@ def split_calibration_holdout(
             "in one label/device/scenario/locale stratum; singleton-only "
             "strata cannot be split without leakage"
         )
+    incomplete_splits = []
+    for split_name, split_clips in (
+        ("calibration", calibration),
+        ("holdout", holdout),
+    ):
+        labels = {bool(clip.label) for clip in split_clips}
+        if labels != {False, True}:
+            missing = "speech" if True not in labels else "negative"
+            incomplete_splits.append(f"{split_name} missing {missing}")
+    if incomplete_splits:
+        raise ValueError(
+            "calibration/holdout split requires speech and negative classes "
+            "in both splits; " + ", ".join(incomplete_splits)
+        )
     return calibration, holdout
 
 

--- a/tests/unit/test_websocket_binary_audio.py
+++ b/tests/unit/test_websocket_binary_audio.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import struct
+from pathlib import Path
 
 import pytest
 
@@ -262,6 +264,66 @@ def test_binary_audio_frame_accepts_real_and_boundary_frame_sizes(
 
     assert len(message["data"]) == samples
     assert message["sample_rate_hz"] == sample_rate_hz
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "docs/api/websocket/audio-streaming.md",
+        "docs/api/websocket/message-types.md",
+    ),
+)
+def test_public_audio_docs_match_the_120_ms_frame_limit(relative_path: str) -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    text = (project_root / relative_path).read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+
+    assert re.search(
+        r"\b(?:at most|no longer than) 120 ms\b",
+        normalized,
+        re.IGNORECASE,
+    )
+    assert re.search(r"\b10\s*[-–]\s*32 ms\b", normalized)
+    assert not re.search(
+        r"\b(?:at most|no longer than) one second\b",
+        normalized,
+        re.IGNORECASE,
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "docs/api/websocket/audio-streaming.md",
+        "docs/api/websocket/message-types.md",
+        "docs/api/websocket/protocol.md",
+    ),
+)
+def test_public_lease_docs_explain_engaged_claim_semantics(
+    relative_path: str,
+) -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    text = (project_root / relative_path).read_text(encoding="utf-8")
+    rows: dict[str, str] = {}
+    for line in text.splitlines():
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) == 3 and cells[0] in {"`true`", "`false`", "omitted"}:
+            rows[cells[0]] = " ".join(cells[1:]).lower()
+
+    assert "active recording" in rows["`true`"]
+    assert "reconnecting" in rows["`true`"]
+    assert "claims" in rows["`true`"]
+    assert "does not claim" not in rows["`true`"]
+
+    assert "passive" in rows["`false`"]
+    assert "does not claim" in rows["`false`"]
+
+    assert "legacy" in rows["omitted"]
+    assert "claims" in rows["omitted"]
+    assert "does not claim" not in rows["omitted"]
+
+    normalized = " ".join(text.split()).lower()
+    assert "only the literal json value `false` suppresses the claim" in normalized
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_websocket_binary_audio.py
+++ b/tests/unit/test_websocket_binary_audio.py
@@ -284,8 +284,13 @@ def test_public_audio_docs_match_the_120_ms_frame_limit(relative_path: str) -> N
         re.IGNORECASE,
     )
     assert re.search(r"\b10\s*[-–]\s*32 ms\b", normalized)
+    # Negative guard against the retired 1 s cap coming back. It has to cover
+    # every spelling of the same bound, not just the one the old docs used
+    # ("one second"): a reintroduction is just as likely to be written "1
+    # second" or "1s", and a guard that only knows the historical wording
+    # stops being a guard the moment someone rephrases it.
     assert not re.search(
-        r"\b(?:at most|no longer than) one second\b",
+        r"\b(?:at most|no longer than)\s+(?:one|1)\s*(?:s|secs?|seconds?)\b",
         normalized,
         re.IGNORECASE,
     )

--- a/tests/unit/voice_turn/test_speech_presence_evaluation.py
+++ b/tests/unit/voice_turn/test_speech_presence_evaluation.py
@@ -562,6 +562,28 @@ def test_calibration_holdout_keeps_source_variants_together() -> None:
     }
 
 
+def test_calibration_holdout_preserves_truthy_label_conversion() -> None:
+    clips = [
+        SimpleNamespace(
+            clip_id=f"compat/{label}/{index}",
+            label=label,
+            locale="en" if label else None,
+            scenario="speech" if label else "idle",
+            device_id=None,
+        )
+        for label in (0, 1)
+        for index in range(2)
+    ]
+
+    calibration, holdout = evaluation.split_calibration_holdout(
+        clips,
+        seed=2398,
+    )
+
+    assert {bool(clip.label) for clip in calibration} == {False, True}
+    assert {bool(clip.label) for clip in holdout} == {False, True}
+
+
 def test_calibration_holdout_rejects_singleton_only_strata_explicitly() -> None:
     clips = [
         SimpleNamespace(
@@ -595,6 +617,71 @@ def test_calibration_holdout_rejects_singleton_only_strata_explicitly() -> None:
     ]
 
     with pytest.raises(ValueError, match="singleton-only strata"):
+        evaluation.split_calibration_holdout(clips, seed=2398)
+
+
+@pytest.mark.parametrize(
+    "singleton_label, missing_class",
+    ((False, "negative"), (True, "speech")),
+)
+def test_calibration_holdout_rejects_a_split_missing_one_class(
+    singleton_label: bool,
+    missing_class: str,
+) -> None:
+    paired_label = not singleton_label
+    clips = [
+        SimpleNamespace(
+            clip_id=f"paired/{index:02d}",
+            label=paired_label,
+            locale="en" if paired_label else None,
+            scenario="speech" if paired_label else "idle",
+            device_id=None,
+        )
+        for index in range(2)
+    ]
+    clips.append(
+        SimpleNamespace(
+            clip_id="singleton/00",
+            label=singleton_label,
+            locale="en" if singleton_label else None,
+            scenario="speech" if singleton_label else "idle",
+            device_id=None,
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=rf"both splits; holdout missing {missing_class}",
+    ):
+        evaluation.split_calibration_holdout(clips, seed=2398)
+
+
+@pytest.mark.parametrize(
+    "label, missing_class",
+    ((True, "negative"), (False, "speech")),
+)
+def test_calibration_holdout_rejects_a_single_class_corpus(
+    label: bool,
+    missing_class: str,
+) -> None:
+    clips = [
+        SimpleNamespace(
+            clip_id=f"single-class/{index:02d}",
+            label=label,
+            locale="en" if label else None,
+            scenario="speech" if label else "idle",
+            device_id=None,
+        )
+        for index in range(2)
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"both splits; calibration missing {missing_class}, "
+            rf"holdout missing {missing_class}"
+        ),
+    ):
         evaluation.split_calibration_holdout(clips, seed=2398)
 
 


### PR DESCRIPTION
承接 #2740 的「D. 协议文档与离线评估」组（条目 16 / 17 / 18）。

**代码逐字取自 @CN-Zephyr 的 #2837，未做任何改动。** 这里只是把该 PR 中与运行时所有权论证无关的一刀单独提前，#2837 合并时 drop 掉这 6 个文件即可。

## 改动概述 / Summary

- **条目 16** — 二进制 PCM 帧文档写「最多 1 秒」，实现只接受 120 ms（`main_routers/websocket_router.py` 的 `_VOICE_BINARY_MAX_DURATION_MS = 120`，与 `_QueuedMicFrame.MAX_DURATION_MS` 对偶）。第三方按文档发 200 ms–1 s 帧会被直接拒。改为 120 ms 并补上「建议 10–32 ms」。
- **条目 17** — `lease_sync` 示例缺 `engaged`。实现判据是 `message.get("engaged") is not False`，即**只有字面 `false` 才放弃声明**；照抄旧示例的第三方辅助窗口会接管主录音窗口的租约，使排队 PCM / ASR start 失效。三处文档补上同一张声明矩阵。
- **条目 18** — speech-presence 切分补 calibration / holdout 双侧类别校验。缺类时旧代码仍会产出看似有效的 recall / specificity / 阈值。

## 回归报告 / Regression Report

### 改动与必要性

前两条是**对外契约与实现不一致**：文档承诺的行为会被服务端拒绝或造成租约误抢，属于第三方接入面的正确性问题，与本仓库运行时无关。第三条是离线评估工具的静默失效：切分缺类不报错，产出的阈值无法用于判断。

### 改动前后行为

- 改动前：文档允许 1 s 帧 → 服务端拒；`engaged` 未文档化 → 第三方默认声明语音连接；单类别语料能跑完评估并给出阈值。
- 改动后：文档与 `_VOICE_BINARY_MAX_DURATION_MS` / `is not False` 判据逐字对齐；切分缺类当场 `ValueError`。

### 潜在回归点与验证

- **运行时零影响**：不含任何 `app/` `main_logic/` `main_routers/` `memory/` 改动。
- `scripts/evaluate_speech_presence.py` 在 `main_logic` / `main_routers` 下零引用，无 CI workflow 消费，唯一行为变化是让单类别语料当场失败——这正是条目 18 想要的。
- 唯一二进制帧发送者是第一方 `static/app/app-audio-capture.js`，固定 10 / 32 ms，本改动不触及。
- **变异验证**（差分守卫非空转）：
  - 三个 `.md` 回退到 `main` → `test_websocket_binary_audio.py` 红 5 个
  - `evaluate_speech_presence.py` 回退到 `main` → `test_speech_presence_evaluation.py` 红 4 个

## 不拆分理由 / Why Not Split

本 PR 本身就是 #2837 的拆分产物，已是最小自洽单元。这三条同属「文档与离线评估」，共享同一条判断：运行时零消费方，因此可以与 #2740 的 ASR / realtime 所有权改动解耦。反过来这三条彼此再拆没有意义——16 与 17 改的是同一批 `.md` 且由同一个测试文件覆盖。

依赖检查：这 6 个文件与 #2837 其余部分**无代码依赖**（新增符号 `_ToolTaskOwner` / `_advance_tool_scope` / `_detach_independent_asr` 等在此零出现），先合不会半实现任何所有权合同。

## 测试 / Testing

```
uv run pytest tests/unit/test_websocket_binary_audio.py \
              tests/unit/voice_turn/test_speech_presence_evaluation.py -q
83 passed
```

- `ruff check`：passed
- `scripts/check_docstring_no_cjk.py --base origin/main`：passed
- `scripts/check_docs_no_relative_paths.py`：passed
- VitePress `npm run build`：见下方评论

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 新增语音输入 `engaged` 状态说明，明确麦克风租约声明及旧客户端兼容行为。
  - 音频二进制帧上限由 1 秒调整为 120 毫秒，并建议使用 10–32 毫秒的常规帧。

- **错误修复**
  - 校准集与留出集会验证是否同时包含语音和非语音类别，缺失时提供明确错误。

- **测试**
  - 增加对音频帧限制、租约语义及语音数据集划分规则的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->