### PR TITLE
fix(tts): preserve Step speech across reconnect failures

### DIFF
--- a/main_logic/tts_client/workers/_step_protocol.py
+++ b/main_logic/tts_client/workers/_step_protocol.py
@@ -889,6 +889,8 @@ def run_step_protocol_tts_worker(
                         ws = None
                         session_id = None
                         logger.error(f"重新建立连接失败: {e}")
+                        if _defer_queued_work_until_control():
+                            continue
                         if 'HTTP 503' in str(e):
                             _enqueue_error(response_queue, json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
                         response_queue.put(("__reconnecting__", "TTS_RECONNECTING"))

--- a/main_logic/tts_client/workers/_step_protocol.py
+++ b/main_logic/tts_client/workers/_step_protocol.py
@@ -756,7 +756,6 @@ def run_step_protocol_tts_worker(
                                     event = json.loads(message)
                                     if event.get("type") == "tts.connection.done":
                                         candidate_session_id = event.get("data", {}).get("session_id")
-                                        session_ready.set()
                                         break
                             except Exception as e:
                                 # The timeout/session_id checks below own the
@@ -817,6 +816,7 @@ def run_step_protocol_tts_worker(
                         ws = candidate_ws
                         candidate_ws = None
                         session_id = candidate_session_id
+                        session_ready.set()
 
                         # 延迟 tts.create 到首批文本到达后，由 _flush_deferred_create
                         # 发送（带语言提示）。此处仅启动接收任务消费服务端事件。

--- a/main_logic/tts_client/workers/_step_protocol.py
+++ b/main_logic/tts_client/workers/_step_protocol.py
@@ -337,6 +337,37 @@ def run_step_protocol_tts_worker(
             pending_finish_retry_speech_id = speech_id
             await asyncio.sleep(1.0)
 
+        def _defer_queued_work_until_control() -> bool:
+            """Move an already-queued control request ahead of recovery work."""
+            control_request = None
+            while True:
+                try:
+                    queued_request = request_queue.get_nowait()
+                except queue_module.Empty:
+                    break
+                except (AttributeError, NotImplementedError):
+                    break
+                if queued_request[0] in {
+                    TTS_SHUTDOWN_SENTINEL,
+                    "__interrupt__",
+                }:
+                    control_request = queued_request
+                    break
+                deferred_requests.append(queued_request)
+            if control_request is None:
+                return False
+            deferred_requests.appendleft(control_request)
+            return True
+
+        async def _close_candidate_best_effort(candidate, context: str) -> None:
+            """Retire an unpublished socket without changing recovery policy."""
+            if candidate is None:
+                return
+            try:
+                await candidate.close()
+            except Exception as close_exc:
+                logger.debug("%s: %s", context, close_exc)
+
         async def _flush_deferred_create(
             force: bool = False,
             *,
@@ -583,6 +614,7 @@ def run_step_protocol_tts_worker(
                     except Exception:
                         break
                 finish_requested = False
+                text_staged_for_reconnect = False
 
                 if sid == TTS_SHUTDOWN_SENTINEL:
                     break
@@ -664,10 +696,28 @@ def run_step_protocol_tts_worker(
                     session_created = False
                     if is_new_speech:
                         pending_text_buffer = ""
+                    # Retain this request before any network await.  A connect
+                    # exception otherwise continues the loop before the normal
+                    # buffering path below and silently drops the opening text.
+                    if (
+                        not finish_requested
+                        and tts_text
+                        and tts_text.strip()
+                    ):
+                        pending_text_buffer += tts_text
+                        text_staged_for_reconnect = True
                     response_done.clear()
-                    if ws:
+                    # Revoke the old socket/session ownership synchronously.
+                    # ``ws = await connect(...)`` doesn't assign on exception,
+                    # so leaving these globals intact would make the closed old
+                    # socket look reusable to the next chunk of the same SID.
+                    old_ws = ws
+                    ws = None
+                    session_id = None
+                    session_ready.clear()
+                    if old_ws:
                         try:
-                            await ws.close()
+                            await old_ws.close()
                         except Exception as e:
                             # Reconnect below replaces this socket, so close
                             # failures are non-fatal; cancellation still
@@ -689,20 +739,23 @@ def run_step_protocol_tts_worker(
                         audio_done.reset()  # 新轮次重置 audio_done 去重标记
 
                     # 建立新连接
+                    candidate_ws = None
                     try:
-                        ws = await websockets.connect(tts_url, additional_headers=headers)
+                        candidate_ws = await websockets.connect(
+                            tts_url,
+                            additional_headers=headers,
+                        )
 
                         # 等待连接成功
-                        session_id = None
-                        session_ready.clear()
+                        candidate_session_id = None
 
                         async def wait_conn():
-                            nonlocal session_id
+                            nonlocal candidate_session_id
                             try:
-                                async for message in ws:
+                                async for message in candidate_ws:
                                     event = json.loads(message)
                                     if event.get("type") == "tts.connection.done":
-                                        session_id = event.get("data", {}).get("session_id")
+                                        candidate_session_id = event.get("data", {}).get("session_id")
                                         session_ready.set()
                                         break
                             except Exception as e:
@@ -715,24 +768,65 @@ def run_step_protocol_tts_worker(
                             await asyncio.wait_for(wait_conn(), timeout=1.0)
                         except asyncio.TimeoutError:
                             logger.warning("新连接超时")
+                            control_preempted = _defer_queued_work_until_control()
+                            retired_candidate_ws = candidate_ws
+                            candidate_ws = None
+                            await _close_candidate_best_effort(
+                                retired_candidate_ws,
+                                "关闭握手超时的 TTS socket 失败",
+                            )
+                            if not control_preempted:
+                                control_preempted = _defer_queued_work_until_control()
+                            if control_preempted:
+                                continue
                             if finish_requested:
                                 await _queue_finish_retry(current_speech_id)
                             continue
 
-                        if not session_id:
+                        if not candidate_session_id:
+                            control_preempted = _defer_queued_work_until_control()
+                            retired_candidate_ws = candidate_ws
+                            candidate_ws = None
+                            await _close_candidate_best_effort(
+                                retired_candidate_ws,
+                                "关闭缺少 session_id 的 TTS socket 失败",
+                            )
+                            if not control_preempted:
+                                control_preempted = _defer_queued_work_until_control()
+                            if control_preempted:
+                                continue
                             if finish_requested:
                                 await _queue_finish_retry(current_speech_id)
                             continue
+
+                        # An interrupt/shutdown queued while connect or its
+                        # handshake was in flight owns the boundary.  Do not
+                        # publish the recovered socket or replay stale text.
+                        if _defer_queued_work_until_control():
+                            control_candidate_ws = candidate_ws
+                            candidate_ws = None
+                            # Control already owns this boundary.  A cleanup
+                            # failure must not re-enter reconnect/backoff before
+                            # the queued interrupt or shutdown is processed.
+                            await _close_candidate_best_effort(
+                                control_candidate_ws,
+                                "关闭被控制消息抢占的 TTS socket 失败",
+                            )
+                            continue
+
+                        ws = candidate_ws
+                        candidate_ws = None
+                        session_id = candidate_session_id
 
                         # 延迟 tts.create 到首批文本到达后，由 _flush_deferred_create
                         # 发送（带语言提示）。此处仅启动接收任务消费服务端事件。
                         _text_done_error_suppressed = False  # 重连后重置错误抑制标记
 
-                        async def receive_messages(bound_speech_id):
+                        async def receive_messages(bound_ws, bound_speech_id):
                             nonlocal _text_done_error_suppressed
                             cancelled = False
                             try:
-                                async for message in ws:
+                                async for message in bound_ws:
                                     event = json.loads(message)
                                     event_type = event.get("type")
 
@@ -781,9 +875,19 @@ def run_step_protocol_tts_worker(
                                 if not cancelled:
                                     audio_jitter.flush()
 
-                        receive_task = asyncio.create_task(receive_messages(current_speech_id))
+                        receive_task = asyncio.create_task(
+                            receive_messages(ws, current_speech_id)
+                        )
 
                     except Exception as e:
+                        failed_candidate_ws = candidate_ws
+                        candidate_ws = None
+                        await _close_candidate_best_effort(
+                            failed_candidate_ws,
+                            "关闭失败的新 TTS socket 失败",
+                        )
+                        ws = None
+                        session_id = None
                         logger.error(f"重新建立连接失败: {e}")
                         if 'HTTP 503' in str(e):
                             _enqueue_error(response_queue, json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
@@ -792,6 +896,7 @@ def run_step_protocol_tts_worker(
                             await _queue_finish_retry(current_speech_id)
                         else:
                             await asyncio.sleep(1.0)
+                            _defer_queued_work_until_control()
                         continue
 
                 if finish_requested:
@@ -813,7 +918,8 @@ def run_step_protocol_tts_worker(
 
                 # 尚未发送 tts.create 时，先缓冲 MIN_CHARS 个字符用于语言检测
                 if not session_created:
-                    pending_text_buffer += tts_text
+                    if not text_staged_for_reconnect:
+                        pending_text_buffer += tts_text
                     ready = await _flush_deferred_create(force=False)
                     if not ready:
                         continue

--- a/tests/unit/test_step_tts_reconnect.py
+++ b/tests/unit/test_step_tts_reconnect.py
@@ -1,12 +1,21 @@
 import json
 import queue
+import threading
 
 from main_logic.tts_client._infra import TTS_SHUTDOWN_SENTINEL
 from main_logic.tts_client.workers import _step_protocol
 
 
 class _FakeTtsSocket:
-    def __init__(self, events, *, fail_send_at=None, fail_send_from=None):
+    def __init__(
+        self,
+        events,
+        *,
+        fail_send_at=None,
+        fail_send_from=None,
+        close_error=None,
+        before_close=None,
+    ):
         self._events = queue.SimpleQueue()
         for event in events:
             self._events.put(json.dumps(event))
@@ -14,6 +23,9 @@ class _FakeTtsSocket:
         self._send_count = 0
         self._fail_send_at = fail_send_at
         self._fail_send_from = fail_send_from
+        self._close_error = close_error
+        self._before_close = before_close
+        self.close_attempts = 0
         self.sent = []
 
     def __aiter__(self):
@@ -33,6 +45,8 @@ class _FakeTtsSocket:
 
     async def send(self, payload):
         self._send_count += 1
+        if self._closed:
+            raise RuntimeError("sent 1000 (OK); no close frame received")
         if (
             self._send_count == self._fail_send_at
             or (
@@ -44,6 +58,11 @@ class _FakeTtsSocket:
         self.sent.append(json.loads(payload))
 
     async def close(self):
+        self.close_attempts += 1
+        if self._before_close is not None:
+            self._before_close()
+        if self._close_error is not None:
+            raise self._close_error
         self._closed = True
         self._events.put(None)
 
@@ -68,6 +87,129 @@ class _AutoShutdownQueue:
         raise queue.Empty
 
 
+def _run_control_arriving_during_replacement_connect(
+    monkeypatch,
+    control_sid,
+    *,
+    candidate_close_error=None,
+    handshake_outcome="success",
+    control_arrival="connect",
+):
+    control_boundary_reached = threading.Event()
+    control_queued = threading.Event()
+    coordination_errors = []
+
+    def coordinate_candidate_close():
+        if control_arrival != "close":
+            return
+        control_boundary_reached.set()
+        if not control_queued.wait(timeout=2.0):
+            coordination_errors.append("control request was not queued")
+
+    initial = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "warmup"}},
+        {"type": "tts.response.created"},
+    ])
+    previous = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "previous"}},
+    ])
+    candidate_session_id = (
+        None if handshake_outcome == "missing_session" else "candidate"
+    )
+    candidate = _FakeTtsSocket(
+        [{
+            "type": "tts.connection.done",
+            "data": {"session_id": candidate_session_id},
+        }],
+        close_error=candidate_close_error,
+        before_close=coordinate_candidate_close,
+    )
+    sockets = [initial, previous, candidate]
+    connect_attempt = 0
+
+    requests = queue.Queue()
+
+    def enqueue_control():
+        if not control_boundary_reached.wait(timeout=2.0):
+            coordination_errors.append("control boundary was not reached")
+            requests.put((TTS_SHUTDOWN_SENTINEL, None))
+            return
+        requests.put((control_sid, None))
+        if control_sid == "__interrupt__":
+            requests.put((TTS_SHUTDOWN_SENTINEL, None))
+        control_queued.set()
+
+    producer = threading.Thread(target=enqueue_control)
+    producer.start()
+
+    async def connect(*_args, **_kwargs):
+        nonlocal connect_attempt
+        connect_attempt += 1
+        if connect_attempt == 3 and control_arrival == "connect":
+            control_boundary_reached.set()
+            if not control_queued.wait(timeout=2.0):
+                coordination_errors.append("control request was not queued")
+        return sockets[connect_attempt - 1]
+
+    monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
+
+    if handshake_outcome == "timeout":
+        real_wait_for = _step_protocol.asyncio.wait_for
+
+        async def timeout_replacement_handshake(awaitable, timeout):
+            if (
+                connect_attempt == 3
+                and getattr(getattr(awaitable, "cr_code", None), "co_name", "")
+                == "wait_conn"
+            ):
+                awaitable.close()
+                raise _step_protocol.asyncio.TimeoutError
+            return await real_wait_for(awaitable, timeout)
+
+        monkeypatch.setattr(
+            _step_protocol.asyncio,
+            "wait_for",
+            timeout_replacement_handshake,
+        )
+
+    real_sleep = _step_protocol.asyncio.sleep
+    retry_backoffs = []
+
+    async def record_retry_backoff(seconds):
+        if seconds == 1.0:
+            retry_backoffs.append(seconds)
+        await real_sleep(0)
+
+    monkeypatch.setattr(_step_protocol.asyncio, "sleep", record_retry_backoff)
+
+    responses = queue.Queue()
+    requests.put(("speech-a", "previous speech"))
+    requests.put((None, None))
+    requests.put(("speech-b", "stale opening"))
+
+    _step_protocol.run_step_protocol_tts_worker(
+        requests,
+        responses,
+        "test-key",
+        "test-voice",
+        provider_key="step",
+    )
+
+    producer.join(timeout=2.0)
+    assert not producer.is_alive()
+    assert coordination_errors == []
+    assert connect_attempt == 3
+    assert candidate.sent == []
+    assert candidate.close_attempts == 1
+    assert retry_backoffs == []
+    assert not any(
+        item == ("__reconnecting__", "TTS_RECONNECTING")
+        for item in list(responses.queue)
+    )
+    if candidate_close_error is None:
+        assert candidate._closed is True
+
+
 def test_buffered_delta_failure_reconnects_and_replays_text(monkeypatch):
     initial = _FakeTtsSocket([
         {"type": "tts.connection.done", "data": {"session_id": "warmup"}},
@@ -87,12 +229,11 @@ def test_buffered_delta_failure_reconnects_and_replays_text(monkeypatch):
 
     monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
 
-    requests = queue.Queue()
+    requests = _AutoShutdownQueue()
     responses = queue.Queue()
     text = "This buffered first chunk is long enough for language detection."
     requests.put(("speech-1", text))
     requests.put((None, None))
-    requests.put((TTS_SHUTDOWN_SENTINEL, None))
 
     _step_protocol.run_step_protocol_tts_worker(
         requests,
@@ -134,14 +275,13 @@ def test_replay_create_failure_invalidates_replacement_socket(monkeypatch):
 
     monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
 
-    requests = queue.Queue()
+    requests = _AutoShutdownQueue()
     responses = queue.Queue()
     first = "The first buffered chunk is long enough to trigger create."
     second = "A later chunk on the same speech id must reconnect cleanly."
     requests.put(("speech-1", first))
     requests.put(("speech-1", second))
     requests.put((None, None))
-    requests.put((TTS_SHUTDOWN_SENTINEL, None))
 
     _step_protocol.run_step_protocol_tts_worker(
         requests,
@@ -183,12 +323,11 @@ def test_turn_end_reconnects_retained_prefix_after_replay_create_failure(monkeyp
 
     monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
 
-    requests = queue.Queue()
+    requests = _AutoShutdownQueue()
     responses = queue.Queue()
     text = "The only buffered chunk must survive through the turn boundary."
     requests.put(("speech-1", text))
     requests.put((None, None))
-    requests.put((TTS_SHUTDOWN_SENTINEL, None))
 
     _step_protocol.run_step_protocol_tts_worker(
         requests,
@@ -369,3 +508,298 @@ def test_interrupt_preempts_finish_retry_after_backoff(monkeypatch):
     assert connect_attempts == 2
     assert unexpected_retry.sent == []
     assert old_broken._closed is True
+
+
+def test_new_speech_connect_exception_replays_opening_with_same_sid_chunk(monkeypatch):
+    initial = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "warmup"}},
+        {"type": "tts.response.created"},
+    ])
+    previous = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "previous"}},
+    ])
+    recovered = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "recovered"}},
+    ])
+    connect_attempt = 0
+
+    async def connect(*_args, **_kwargs):
+        nonlocal connect_attempt
+        connect_attempt += 1
+        if connect_attempt == 3:
+            raise TimeoutError("timed out during opening handshake")
+        return {
+            1: initial,
+            2: previous,
+            4: recovered,
+        }[connect_attempt]
+
+    real_sleep = _step_protocol.asyncio.sleep
+
+    async def no_delay(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
+    monkeypatch.setattr(_step_protocol.asyncio, "sleep", no_delay)
+
+    requests = _AutoShutdownQueue()
+    responses = queue.Queue()
+    opening = "The opening text must survive the failed replacement handshake."
+    continuation = " The same speech continues after recovery."
+    requests.put(("speech-a", "previous speech"))
+    requests.put((None, None))
+    requests.put(("speech-b", opening))
+    requests.put(("speech-b", continuation))
+    requests.put((None, None))
+
+    _step_protocol.run_step_protocol_tts_worker(
+        requests,
+        responses,
+        "test-key",
+        "test-voice",
+        provider_key="step",
+    )
+
+    assert previous._closed is True
+    assert [event["type"] for event in recovered.sent] == [
+        "tts.create",
+        "tts.text.delta",
+        "tts.text.done",
+    ]
+    assert recovered.sent[1]["data"]["text"] == opening + continuation
+
+
+def test_turn_end_recovers_opening_after_new_speech_connect_exception(monkeypatch):
+    initial = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "warmup"}},
+        {"type": "tts.response.created"},
+    ])
+    previous = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "previous"}},
+    ])
+    recovered = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "recovered"}},
+    ])
+    connect_attempt = 0
+
+    async def connect(*_args, **_kwargs):
+        nonlocal connect_attempt
+        connect_attempt += 1
+        if connect_attempt == 3:
+            raise TimeoutError("timed out during opening handshake")
+        return {
+            1: initial,
+            2: previous,
+            4: recovered,
+        }[connect_attempt]
+
+    real_sleep = _step_protocol.asyncio.sleep
+
+    async def no_delay(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
+    monkeypatch.setattr(_step_protocol.asyncio, "sleep", no_delay)
+
+    requests = _AutoShutdownQueue()
+    responses = queue.Queue()
+    opening = "This only chunk must be replayed when turn-end arrives."
+    requests.put(("speech-a", "previous speech"))
+    requests.put((None, None))
+    requests.put(("speech-b", opening))
+    requests.put((None, None))
+
+    _step_protocol.run_step_protocol_tts_worker(
+        requests,
+        responses,
+        "test-key",
+        "test-voice",
+        provider_key="step",
+    )
+
+    assert [event["type"] for event in recovered.sent] == [
+        "tts.create",
+        "tts.text.delta",
+        "tts.text.done",
+    ]
+    assert recovered.sent[1]["data"]["text"] == opening
+
+
+def test_control_preempts_recovery_after_new_speech_connect_exception(monkeypatch):
+    initial = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "warmup"}},
+        {"type": "tts.response.created"},
+    ])
+    previous = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "previous"}},
+    ])
+    unexpected_recovery = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "unexpected"}},
+    ])
+    connect_attempt = 0
+
+    async def connect(*_args, **_kwargs):
+        nonlocal connect_attempt
+        connect_attempt += 1
+        if connect_attempt == 3:
+            requests.put(("__interrupt__", None))
+            raise TimeoutError("timed out during opening handshake")
+        return [initial, previous, unexpected_recovery][connect_attempt - 1]
+
+    real_sleep = _step_protocol.asyncio.sleep
+
+    async def no_delay(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
+    monkeypatch.setattr(_step_protocol.asyncio, "sleep", no_delay)
+
+    requests = _AutoShutdownQueue()
+    responses = queue.Queue()
+    requests.put(("speech-a", "previous speech"))
+    requests.put((None, None))
+    requests.put(("speech-b", "stale opening"))
+    requests.put(("speech-b", "stale continuation"))
+
+    _step_protocol.run_step_protocol_tts_worker(
+        requests,
+        responses,
+        "test-key",
+        "test-voice",
+        provider_key="step",
+    )
+
+    assert connect_attempt == 3
+    assert unexpected_recovery.sent == []
+
+
+def test_control_preempts_recovery_when_handshake_has_no_session_id(monkeypatch):
+    initial = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "warmup"}},
+        {"type": "tts.response.created"},
+    ])
+    previous = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "previous"}},
+    ])
+    missing_session = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {}},
+    ])
+    unexpected_recovery = _FakeTtsSocket([
+        {"type": "tts.connection.done", "data": {"session_id": "unexpected"}},
+    ])
+    connect_attempt = 0
+
+    async def connect(*_args, **_kwargs):
+        nonlocal connect_attempt
+        connect_attempt += 1
+        if connect_attempt == 3:
+            for index in range(1000):
+                requests.put(("speech-b", f"stale continuation {index}"))
+            requests.put(("__interrupt__", None))
+        return [
+            initial,
+            previous,
+            missing_session,
+            unexpected_recovery,
+        ][connect_attempt - 1]
+
+    monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
+
+    requests = _AutoShutdownQueue()
+    responses = queue.Queue()
+    requests.put(("speech-a", "previous speech"))
+    requests.put((None, None))
+    requests.put(("speech-b", "stale opening"))
+
+    _step_protocol.run_step_protocol_tts_worker(
+        requests,
+        responses,
+        "test-key",
+        "test-voice",
+        provider_key="step",
+    )
+
+    assert connect_attempt == 3
+    assert missing_session._closed is True
+    assert unexpected_recovery.sent == []
+
+
+def test_interrupt_arriving_during_replacement_connect_preempts_candidate(monkeypatch):
+    _run_control_arriving_during_replacement_connect(monkeypatch, "__interrupt__")
+
+
+def test_shutdown_arriving_during_replacement_connect_preempts_candidate(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        TTS_SHUTDOWN_SENTINEL,
+    )
+
+
+def test_interrupt_preempts_when_candidate_close_fails(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        "__interrupt__",
+        candidate_close_error=RuntimeError("close failed"),
+    )
+
+
+def test_shutdown_preempts_when_candidate_close_fails(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        TTS_SHUTDOWN_SENTINEL,
+        candidate_close_error=RuntimeError("close failed"),
+    )
+
+
+def test_interrupt_preempts_missing_session_close_failure(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        "__interrupt__",
+        candidate_close_error=RuntimeError("close failed"),
+        handshake_outcome="missing_session",
+    )
+
+
+def test_shutdown_preempts_missing_session_close_failure(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        TTS_SHUTDOWN_SENTINEL,
+        candidate_close_error=RuntimeError("close failed"),
+        handshake_outcome="missing_session",
+    )
+
+
+def test_interrupt_preempts_handshake_timeout_close_failure(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        "__interrupt__",
+        candidate_close_error=RuntimeError("close failed"),
+        handshake_outcome="timeout",
+    )
+
+
+def test_shutdown_preempts_handshake_timeout_close_failure(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        TTS_SHUTDOWN_SENTINEL,
+        candidate_close_error=RuntimeError("close failed"),
+        handshake_outcome="timeout",
+    )
+
+
+def test_interrupt_arriving_during_missing_session_close_preempts(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        "__interrupt__",
+        handshake_outcome="missing_session",
+        control_arrival="close",
+    )
+
+
+def test_shutdown_arriving_during_handshake_timeout_close_preempts(monkeypatch):
+    _run_control_arriving_during_replacement_connect(
+        monkeypatch,
+        TTS_SHUTDOWN_SENTINEL,
+        handshake_outcome="timeout",
+        control_arrival="close",
+    )

--- a/tests/unit/test_step_tts_reconnect.py
+++ b/tests/unit/test_step_tts_reconnect.py
@@ -648,7 +648,11 @@ def test_control_preempts_recovery_after_new_speech_connect_exception(monkeypatc
 
     real_sleep = _step_protocol.asyncio.sleep
 
-    async def no_delay(_seconds):
+    retry_backoffs = []
+
+    async def no_delay(seconds):
+        if seconds == 1.0:
+            retry_backoffs.append(seconds)
         await real_sleep(0)
 
     monkeypatch.setattr(_step_protocol.websockets, "connect", connect)
@@ -671,6 +675,11 @@ def test_control_preempts_recovery_after_new_speech_connect_exception(monkeypatc
 
     assert connect_attempt == 3
     assert unexpected_recovery.sent == []
+    assert retry_backoffs == []
+    assert not any(
+        item == ("__reconnecting__", "TTS_RECONNECTING")
+        for item in list(responses.queue)
+    )
 
 
 def test_control_preempts_recovery_when_handshake_has_no_session_id(monkeypatch):


### PR DESCRIPTION
## 改动概述 / Summary

- 在等待替代连接前撤销旧 Step 协议 WebSocket/session 的所有权
- 连接或握手恢复失败时保留并重放语音开头文本
- 在成功、超时、缺少 session 和清理失败的恢复路径中，让 interrupt/shutdown 始终优先于延迟语音
- 将接收任务绑定到其实际拥有的 socket，并补充确定性的并发回归测试

Closes #2829

## 回归报告 / Regression Report

- **改动与必要性：** 旧实现先关闭前一个 socket，再执行 `ws = await websockets.connect(...)`。当替代连接抛异常时，赋值不会发生，已关闭的旧 `ws` 和旧 `session_id` 仍保持 truthy；同一 speech ID 的下一段文本会误把死连接当成可复用连接，对其发送 `tts.create`，出现 `sent 1000`，而开头文本已被异常分支跳过。
- **改动前：** Step、free、free_intl 共用的 Step 协议 worker 在重连握手失败后可能复用已关闭 socket，并永久丢失该轮首段文本；连接期间到达的 interrupt/shutdown 还可能落后于恢复中的普通语音。
- **改动后：** worker 在任何网络等待前同步清空旧 socket/session 所有权并暂存当前文本；新连接只在握手有效且没有控制消息抢占后发布。超时、缺少 session、连接异常与候选 socket 关闭失败均保留一致的恢复和控制优先级。
- **潜在回归点：** 主要风险是文本重复、跨轮次文本串流、控制消息被延后、候选连接泄漏、额外重连通知或退避。新增测试覆盖同 SID 续段、直接 turn-end、连接异常、握手超时、缺少 session、连接/关闭窗口内到达的 interrupt/shutdown，以及候选 close 失败；测试使用 `threading.Event` 等确定性同步，不依赖任意 sleep 猜测时序。
- **影响范围：** 仅修改 Step 协议 worker 的重连所有权、待发文本恢复和控制消息排序，影响使用该 worker 的 Step、free、free_intl 路由；没有新增依赖、配置、API 或服务端协议变化。

## 测试 / Testing

- `uv run pytest tests/unit/test_step_tts_reconnect.py -q` — 20 passed
- 相关 TTS 单元测试 — 394 passed（与目标文件合计 414）
- 目标重连测试连续重复 10 次 — 10/10 passed
- `uv run ruff check main_logic/tts_client/workers/_step_protocol.py tests/unit/test_step_tts_reconnect.py` — passed
- `uv run python -m py_compile main_logic/tts_client/workers/_step_protocol.py tests/unit/test_step_tts_reconnect.py` — passed
- `git diff --check` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 提升 TTS 断线重连稳定性，减少连接切换期间的文本丢失。
  - 优先处理暂停、停止等控制操作，避免被重连流程延迟。
  - 改善握手超时、连接关闭及重连失败时的异常处理。
  - 清理失败的候选连接，降低重复连接或资源残留问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->