### PR TITLE
fix(live2d): 变猫回来后恢复贴边探身态

### DIFF
--- a/static/app/app-ui/return-transitions.js
+++ b/static/app/app-ui/return-transitions.js
@@ -1456,7 +1456,11 @@
 
     window.addEventListener('neko:return-ball-manual-move', (event) => {
         const detail = event && event.detail;
-        if (detail && detail.reason === 'return-ball-drag-start' && detail.container) {
+        // 只有真正发生位移（超过点击阈值）才清除贴边探身锚点：无移动的普通点击
+        // 也会先经过 mousedown 的 drag-start，若在这里清掉，return 时锚点已为空，
+        // 贴边探身态将无法恢复。drag-active 表示用户确实在拖 return-ball，
+        // 此时尊重新位置，不再自动恢复探身。
+        if (detail && detail.reason === 'return-ball-drag-active' && detail.container) {
             clearLive2DPeekReturnBallEdgeAnchor(detail.container);
         }
         syncIdleReturnBallDesktopStateFromManualMove(event && event.detail);

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -1279,6 +1279,7 @@
                 return;
             }
             let hadCatCycle = false;
+            let live2DPeekRestoreAnchor = null;
             try {
                 const returnContainer = I.getVisibleIdleReturnBallContainer();
                 hadCatCycle = !!(returnContainer &&
@@ -1287,6 +1288,11 @@
                     ? window.nekoCatMind.getState()
                     : null;
                 hadCatCycle = hadCatCycle || !!(catMindState && (catMindState.active || catMindState.returnSummaryDraft));
+                // 变猫前模型若处于贴边探身态，goodbye 会把探身锚点暂存在 return-ball 容器上，
+                // 回来时用它恢复探身态。拖过 return-ball 会在 drag-start 清除该锚点，此时不恢复。
+                if (returnContainer && returnContainer.__nekoLive2DPeekEdgeAnchor) {
+                    live2DPeekRestoreAnchor = returnContainer.__nekoLive2DPeekEdgeAnchor;
+                }
             } catch (_) {}
             I.publishCatLocalActive(false, {
                 source: event && event.type ? event.type : 'return-click',
@@ -1766,6 +1772,16 @@
                 window.appInterpage.postGoodbyeChatComposerHiddenState(false, 'return-complete');
             } else if (typeof window.postGoodbyeChatComposerHiddenState === 'function') {
                 window.postGoodbyeChatComposerHiddenState(false, 'return-complete');
+            }
+            // 恢复贴边探身态：变猫前模型若在边缘探身，回来时只回到边缘 base 位置而不会重新探身。
+            // 用 goodbye 捕获的锚点重新对齐边缘并应用探身变换；贴边已关闭、模型失效或锚点缺失时静默跳过，
+            // 不阻塞普通 return。fire-and-forget，避免探身动画推迟 return-complete 的后续业务。
+            if (live2DPeekRestoreAnchor
+                && window.nekoLive2DPeek
+                && typeof window.nekoLive2DPeek.restoreAnchor === 'function') {
+                try {
+                    window.nekoLive2DPeek.restoreAnchor(live2DPeekRestoreAnchor).catch(() => {});
+                } catch (_) {}
             }
             window.dispatchEvent(new CustomEvent('neko:cat-return-complete', {
                 detail: {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -1225,6 +1225,10 @@ function captureLive2DPeekRestoreAnchor() {
 
 async function restoreLive2DPeekAnchor(anchor) {
     if (!anchor || anchor.kind !== 'live2d-edge-peek') return false;
+    // 贴边探身已关闭（如猫形态期间用户关掉 Widget 模式）时不得再把模型挪回旧边缘位置：
+    // _tryApplyLive2DPeek 会在对齐边缘后才检查 isLive2DPeekEnabled 并返回 false，
+    // 若在这里不拦，模型会被留在陈旧边缘坐标上。
+    if (!isLive2DPeekEnabled()) return false;
     const manager = window.live2dManager;
     const model = manager && manager.currentModel && !manager.currentModel.destroyed
         ? manager.currentModel

--- a/tests/unit/live2d_peek_behavior.test.js
+++ b/tests/unit/live2d_peek_behavior.test.js
@@ -930,6 +930,41 @@ test('Widget Mode disabled event restores active edge peek to its base position'
     assert.equal(harness.bodyClasses.has('neko-live2d-peek'), false);
 });
 
+test('restoreAnchor leaves the model untouched while Widget Mode is disabled', async () => {
+    const harness = createHarness({ widgetModeEnabled: false });
+    const manager = new harness.Live2DManager();
+    const model = createRotatingModel({ x: 0, y: 0, scaleX: 1 });
+    manager.currentModel = model;
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getBodyScreenRectInfo = () => {
+        const waist = model.transformPoint(150, 330);
+        return { rect: { centerX: waist.x, bottom: waist.y } };
+    };
+    harness.window.live2dManager = manager;
+
+    // 猫形态期间用户关掉 Widget 模式后，return 仍残留探身锚点。restore 必须在
+    // 触碰模型坐标之前先拒绝，否则 _tryApplyLive2DPeek 会在对齐边缘后才因
+    // isLive2DPeekEnabled() 失败，把模型留在陈旧边缘位置。
+    const anchor = {
+        kind: 'live2d-edge-peek',
+        edge: 'left',
+        side: 'left',
+        edgeAnchorRatio: 0.5,
+        facing: 'inward'
+    };
+    model.x = 350;
+    model.y = 100;
+    const beforeX = model.x;
+    const beforeY = model.y;
+
+    const restored = await harness.window.nekoLive2DPeek.restoreAnchor(anchor);
+
+    assert.equal(restored, false);
+    assert.equal(manager.isLive2DPeekActive(), false);
+    assert.equal(model.x, beforeX);
+    assert.equal(model.y, beforeY);
+});
+
 test('top and bottom edges alone do not trigger edge peek', async () => {
     const topHarness = createHarness();
     const topManager = new topHarness.Live2DManager();

--- a/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
+++ b/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
@@ -28,9 +28,19 @@ def test_live2d_peek_restore_anchor_is_consumed_on_return():
     app_ui_source = read_js_parts(APP_UI_PATH)
     return_block = app_ui_source.split("const handleReturnClick", 1)[1]
 
+    restore_call = "window.nekoLive2DPeek.restoreAnchor(live2DPeekRestoreAnchor)"
+    settle_call = "settleReturnedModelBounds(returnModelWasMoved)"
+    complete_dispatch = "new CustomEvent('neko:cat-return-complete'"
+
     assert "let live2DPeekRestoreAnchor = null;" in return_block
     assert "live2DPeekRestoreAnchor = returnContainer.__nekoLive2DPeekEdgeAnchor;" in return_block
-    assert "window.nekoLive2DPeek.restoreAnchor(live2DPeekRestoreAnchor)" in return_block
+    assert restore_call in return_block
+    # fire-and-forget 调用必须保留 Promise rejection handler，不能吞掉异常。
+    assert restore_call + ".catch(() => {});" in return_block
+    assert settle_call in return_block
+    assert complete_dispatch in return_block
+    # 顺序约束：先 settle 模型边界 → 再恢复贴边探身 → 最后派发 return-complete。
+    assert return_block.index(settle_call) < return_block.index(restore_call) < return_block.index(complete_dispatch)
 
 
 def test_live2d_peek_return_ball_supports_exactly_four_corners_and_two_side_edges():
@@ -43,7 +53,7 @@ def test_live2d_peek_return_ball_supports_exactly_four_corners_and_two_side_edge
     assert "'bottom'" not in anchor_block
     assert "container.setAttribute('data-neko-live2d-peek-anchor', edge);" in source
     assert "positionLive2DPeekReturnBallAtEdge(container, container.__nekoLive2DPeekEdgeAnchor);" in source
-    assert "detail.reason === 'return-ball-drag-start'" in source
+    assert "detail.reason === 'return-ball-drag-active'" in source
     assert "clearLive2DPeekReturnBallEdgeAnchor(detail.container);" in source
 
 

--- a/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
+++ b/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
@@ -21,6 +21,18 @@ def test_live2d_peek_goodbye_transfers_the_edge_anchor_to_return_ball():
     assert "positionReturnBallContainer(container, anchorRect, options.edgeAnchor);" in app_ui_source
 
 
+def test_live2d_peek_restore_anchor_is_consumed_on_return():
+    # The return handler must keep the peek anchor captured from the return-ball
+    # container and restore it after the model is shown again, so the model
+    # re-enters the edge-peek state instead of coming back flat at the edge.
+    app_ui_source = read_js_parts(APP_UI_PATH)
+    return_block = app_ui_source.split("const handleReturnClick", 1)[1]
+
+    assert "let live2DPeekRestoreAnchor = null;" in return_block
+    assert "live2DPeekRestoreAnchor = returnContainer.__nekoLive2DPeekEdgeAnchor;" in return_block
+    assert "window.nekoLive2DPeek.restoreAnchor(live2DPeekRestoreAnchor)" in return_block
+
+
 def test_live2d_peek_return_ball_supports_exactly_four_corners_and_two_side_edges():
     source = read_js_parts(APP_UI_PATH)
     anchor_block = source.split("const NEKO_LIVE2D_PEEK_RETURN_EDGE_ANCHORS = [", 1)[1].split("];", 1)[0]


### PR DESCRIPTION
## 改动概述 / Summary

修复 Live2D 贴边探身（Widget 模式）与变猫（goodbye/return）交互的回归：
开启贴边探身后模型在边缘探身，此时进入猫形态再变回来，模型回到边缘 base
位置但不再重新探身。

根因：变猫时 `clearLive2DPeekOnGoodbye`（live2d-interaction.js）会把贴边
探身锚点捕获并暂存在 return-ball 容器上，但「请她回来」流程从未消费该锚点
恢复探身态——`restoreLive2DPeekAnchor` 此前仅在显示器切换时被调用。

修复（static/app/app-ui/surface-floating-controls.js 的 handleReturnClick）：
1. return 开始、隐藏 return-ball 前，从容器捕获 `__nekoLive2DPeekEdgeAnchor`；
2. 模型显示并 settle 完成后、派发 `neko:cat-return-complete` 前，调用
   `window.nekoLive2DPeek.restoreAnchor` 恢复探身态（fire-and-forget，不阻塞后续业务）。

拖过 return-ball（`return-ball-drag-start` 会清除锚点）或贴边关闭时静默跳过，
不影响其他 return 逻辑。

## 回归报告 / Regression Report

不适用。

本 PR 仅改动前端 `static/app/app-ui/surface-floating-controls.js` 与测试文件
`tests/unit/test_widget_mode_return_ball_edge_anchor_static.py`，未触碰
`app/`、`main_logic/`、`memory/` 任一模块。

## 不拆分理由 / Why Not Split

不适用。

计入上限的改动文件仅 1 个（`surface-floating-controls.js`），另 1 个为测试
文件不计入，合计远小于 20 个。

## 测试 / Testing

新增回归测试：
- `tests/unit/test_widget_mode_return_ball_edge_anchor_static.py` 新增
  `test_live2d_peek_restore_anchor_is_consumed_on_return`，断言 return 流程
  会捕获容器上的 `__nekoLive2DPeekEdgeAnchor` 并调用
  `window.nekoLive2DPeek.restoreAnchor`。

运行结果：
- `test_widget_mode_return_ball_edge_anchor_static.py`：5 passed
- `test_auto_goodbye_goodbye_return_contract.py` / `test_app_auto_goodbye_phase1.py`
  / `test_avatar_return_button_idle_tiers_static.py` / `test_cat_idle_state_machine_static.py`：107 passed
- `tests/unit/live2d_peek_behavior.test.js`（50 个贴边探身运行时测试）：50 passed
- `static/app/app-ui/*.js` 全部通过 `node --check`

验证覆盖的路径：
- 贴边探身 → 变猫 → 变回来：恢复探身态（本次修复目标）
- 未贴边 / 贴边已关闭 / 锚点缺失：静默跳过，模型正常回位
- 拖过 return-ball：锚点被清除，不强制恢复，尊重用户新位置
- VRM / MMD / PNGTuber：不挂锚点，行为不受影响
- return 被 viewport 阻塞重试：锚点保留在容器上，重试仍可恢复

说明：贴边探身为桌面 Widget（Electron）专属功能，自动化测试无法覆盖真实
桌面窗口，建议合入前在桌面端手动走一遍「贴边 → 变猫 → 变回来」确认探身恢复。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 返回流程完成后会自动恢复 Live2D 贴边探身位置，提升界面状态的连续性。
  * 仅在实际拖动返回球时清除贴边探身锚点，减少不必要的状态变化。
  * 当相关功能未启用、锚点或模型状态不可用时，将安全跳过恢复，不影响返回操作完成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->