### PR TITLE
feat(plugin): add shell_runner plugin

### DIFF
--- a/plugin/plugins/shell_runner/README.md
+++ b/plugin/plugins/shell_runner/README.md
@@ -1,0 +1,33 @@
+# Shell 执行器 (shell_runner)
+
+让猫娘直接在用户电脑上执行 **PowerShell / cmd** 命令并返回输出。
+
+## 功能
+
+- **`run_shell`**（LLM 工具）：执行单条命令，支持选择解释器（powershell / cmd）、指定工作目录、超时控制，返回 stdout + 退出码
+- **`shell_test`**（插件面板）：自检（`Write-Output 'shell-ok'`），确认执行器可用
+
+## 设计要点
+
+- **PowerShell 中文乱码**：命令前自动注入 `$OutputEncoding = [Console]::OutputEncoding = [Text.Encoding]::UTF8`，保证 UTF-8 输出
+- **cmd 编码**：输出先按 UTF-8 解码，失败回退 GBK（Windows 默认代码页）
+- **安全**：工具描述中明确要求——破坏性操作（删除、格式化、改注册表、shutdown 等）必须先向用户确认；查询类命令可直接执行
+- **超时**：默认 60s，可调 5-600s，超时自动终止进程
+
+## 使用示例
+
+```text
+猫娘，查一下现在有什么进程在跑
+→ run_shell(shell="powershell", command="Get-Process | Select-Object -First 10 Name, CPU")
+
+猫娘，我的 IP 是多少
+→ run_shell(command="ipconfig")
+```
+
+## 与同类能力的区别
+
+| 能力 | 适用场景 |
+|------|----------|
+| `run_shell`（本插件） | 猫娘自己直接执行单条命令，快、直接 |
+| computer_use | 操作 GUI（截图 + 键鼠模拟），慢 |
+| 编码 agent 插件 | 复杂多步开发任务，交给独立 agent 自主完成 |

--- a/plugin/plugins/shell_runner/__init__.py
+++ b/plugin/plugins/shell_runner/__init__.py
@@ -1,0 +1,189 @@
+"""
+[Shell 执行器] — 让猫娘直接执行 PowerShell / cmd 命令。
+
+定位与 pi_agent 不同：
+- run_shell：猫娘自己直接执行单条命令（快、直接）
+- pi_run：把复杂编码任务交给独立 PiAgent 自主完成（慢、强）
+"""
+
+import asyncio
+import os
+import shutil
+from typing import Any
+
+from plugin.sdk.plugin import (
+    NekoPluginBase,
+    neko_plugin,
+    llm_tool,
+    lifecycle,
+    plugin_entry,
+    Ok,
+)
+
+_MAX_OUTPUT_CHARS = 6000
+_DEFAULT_TIMEOUT = 60.0
+
+
+def _decode_bytes(data: bytes) -> str:
+    """先试 UTF-8（PowerShell 强制 UTF-8 输出），失败回退 GBK（cmd 默认）。"""
+    if not data:
+        return ""
+    for enc in ("utf-8", "gbk"):
+        try:
+            return data.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+def _find_powershell() -> str:
+    """定位 PowerShell（优先 pwsh，回退 powershell）。"""
+    for name in ("pwsh", "powershell"):
+        p = shutil.which(name)
+        if p:
+            return p
+    return "powershell"
+
+
+@neko_plugin
+class ShellRunnerPlugin(NekoPluginBase):
+    """Shell 执行器——执行 PowerShell/cmd 命令并返回输出。"""
+
+    _ps = _find_powershell()
+
+    # ── 生命周期 ───────────────────────────────────────────────────
+
+    @lifecycle(id="startup")
+    async def startup(self, **_):
+        self.logger.info(f"Shell 执行器启动，PowerShell 位于: {self._ps}")
+        return Ok({"status": "ok"})
+
+    # ── 内部执行 ───────────────────────────────────────────────────
+
+    async def _exec(
+        self,
+        shell: str,
+        command: str,
+        cwd: str | None,
+        timeout: float,
+    ) -> dict:
+        workdir = cwd or os.path.expanduser("~")
+        if not os.path.isdir(workdir):
+            workdir = os.path.expanduser("~")
+
+        if shell == "cmd":
+            cmdline = ["cmd", "/c", command]
+        else:
+            # PowerShell：强制 UTF-8 输出，避免中文乱码
+            ps_prefix = "$OutputEncoding = [Console]::OutputEncoding = [Text.Encoding]::UTF8;"
+            cmdline = [self._ps, "-NoProfile", "-NonInteractive", "-Command", ps_prefix + command]
+
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmdline,
+                cwd=workdir,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            if proc is not None:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            return {"ok": False, "error": f"命令执行超时（>{timeout:.0f}s），已终止"}
+        except Exception as exc:
+            return {"ok": False, "error": f"命令启动失败: {exc}"}
+
+        out_text = _decode_bytes(stdout or b"").strip()
+        err_text = _decode_bytes(stderr or b"").strip()
+        exit_code = proc.returncode if proc is not None else -1
+
+        combined = out_text or err_text
+        if len(combined) > _MAX_OUTPUT_CHARS:
+            combined = combined[:_MAX_OUTPUT_CHARS] + (
+                f"\n...[输出过长已截断，完整长度 {len(combined)} 字符]"
+            )
+
+        return {
+            "ok": exit_code == 0,
+            "output": combined,
+            "exit_code": exit_code,
+            "error": None if exit_code == 0 else (err_text or f"退出码 {exit_code}"),
+        }
+
+    # ── LLM 工具 ───────────────────────────────────────────────────
+
+    @llm_tool(
+        name="run_shell",
+        description=(
+            "【Shell·命令执行】在用户电脑上直接执行 PowerShell 或 cmd 命令。\n\n"
+            "适合：运行终端命令、查询系统信息、管理文件、执行脚本、安装软件、查看进程/服务、网络诊断。\n"
+            "shell 参数：powershell（默认，功能强，支持管道/对象/模块）或 cmd（兼容旧命令）。\n"
+            "command 写完整命令文本；需要指定运行目录时用 cwd（绝对路径）。\n"
+            "timeout_seconds 默认 60，长任务可调大；超时会终止命令。\n"
+            "⚠️ 安全：命令会直接在本机执行。破坏性操作（删除文件、格式化、改注册表、下载并运行不明脚本、shutdown）必须先向用户确认，用户明确同意后才能执行。\n"
+            "普通查询类命令（dir、ipconfig、systeminfo、Get-Process 等）可直接执行。"
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "shell": {
+                    "type": "string",
+                    "enum": ["powershell", "cmd"],
+                    "description": "解释器：powershell（默认）或 cmd",
+                },
+                "command": {
+                    "type": "string",
+                    "description": "要执行的完整命令文本",
+                },
+                "cwd": {
+                    "type": "string",
+                    "description": "工作目录（绝对路径），默认用户主目录",
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": "超时秒数，默认 60，范围 5-600",
+                },
+            },
+            "required": ["command"],
+        },
+        timeout=130.0,
+    )
+    async def run_shell(
+        self,
+        *,
+        command: str,
+        shell: str = "powershell",
+        cwd: str = "",
+        timeout_seconds: int = 60,
+        **_,
+    ):
+        if shell not in ("powershell", "cmd"):
+            shell = "powershell"
+        timeout = float(max(5, min(int(timeout_seconds or 60), 600)))
+        result = await self._exec(shell, command, cwd or None, timeout)
+        if result.get("error"):
+            return {
+                "output": (
+                    f"命令失败（退出码 {result['exit_code']}）：{result['error']}\n\n"
+                    f"输出：{result['output']}"
+                ),
+                "is_error": True,
+            }
+        return {"output": result["output"], "is_error": False}
+
+    # ── 面板操作 ───────────────────────────────────────────────────
+
+    @plugin_entry(
+        id="shell_test",
+        name="Shell 执行器自检",
+        description="执行 echo 验证 Shell 执行器可用。",
+    )
+    async def shell_test(self, **_):
+        result = await self._exec("powershell", "Write-Output 'shell-ok'", None, 15.0)
+        if result.get("ok"):
+            return Ok({"status": "ok", "message": f"Shell 执行器可用: {result['output']}"})
+        return Ok({"status": "error", "message": f"Shell 执行器异常: {result.get('error')}"})

--- a/plugin/plugins/shell_runner/i18n/en.json
+++ b/plugin/plugins/shell_runner/i18n/en.json
@@ -1,0 +1,20 @@
+{
+  "plugin": {
+    "name": "Shell Runner",
+    "short_description": "Let Neko run PowerShell / cmd commands directly"
+  },
+  "tool": {
+    "run_shell": {
+      "name": "Shell Command Runner",
+      "params": {
+        "shell": "Interpreter: powershell (default) or cmd",
+        "command": "Full command text to execute",
+        "cwd": "Working directory (absolute path), defaults to the user home directory",
+        "timeout_seconds": "Timeout in seconds, default 60, range 5-600"
+      }
+    }
+  },
+  "entry": {
+    "shell_test": "Shell Runner self-check"
+  }
+}

--- a/plugin/plugins/shell_runner/i18n/zh-CN.json
+++ b/plugin/plugins/shell_runner/i18n/zh-CN.json
@@ -1,0 +1,20 @@
+{
+  "plugin": {
+    "name": "Shell 执行器",
+    "short_description": "让猫娘直接执行 PowerShell / cmd 命令"
+  },
+  "tool": {
+    "run_shell": {
+      "name": "Shell 命令执行",
+      "params": {
+        "shell": "解释器：powershell（默认）或 cmd",
+        "command": "要执行的完整命令文本",
+        "cwd": "工作目录（绝对路径），默认用户主目录",
+        "timeout_seconds": "超时秒数，默认 60，范围 5-600"
+      }
+    }
+  },
+  "entry": {
+    "shell_test": "Shell 执行器自检"
+  }
+}

--- a/plugin/plugins/shell_runner/plugin.toml
+++ b/plugin/plugins/shell_runner/plugin.toml
@@ -1,0 +1,30 @@
+[plugin]
+name = "Shell 执行器"
+description = "让猫娘直接在用户电脑上执行 PowerShell / cmd 命令并返回输出。支持指定工作目录、超时控制、退出码回传。"
+short_description = "Run PowerShell / cmd commands on the user's machine and return their output."
+keywords = [
+    "shell", "powershell", "cmd", "命令", "终端", "命令行", "cli",
+    "执行命令", "run command", "terminal", "コマンド", "명령", "команда",
+]
+version = "0.1.0"
+id = "shell_runner"
+type = "plugin"
+entry = "plugin.plugins.shell_runner:ShellRunnerPlugin"
+
+[plugin.author]
+name = "UmR"
+
+[plugin.sdk]
+recommended = ">=0.1.0,<0.2.0"
+supported = ">=0.1.0,<0.3.0"
+
+[plugin.i18n]
+default_locale = "zh-CN"
+locales_dir = "i18n"
+
+[plugin_runtime]
+enabled = true
+auto_start = true
+
+[plugin.store]
+enabled = false

--- a/plugin/tests/unit/plugins/test_shell_runner.py
+++ b/plugin/tests/unit/plugins/test_shell_runner.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the shell_runner plugin (platform-independent parts).
+
+Execution of PowerShell / cmd is Windows-only and intentionally not
+covered here; only the output-decoding helpers are tested.
+"""
+
+from plugin.plugins.shell_runner import _decode_bytes
+
+
+def test_decode_bytes_utf8():
+    assert _decode_bytes("中文测试".encode("utf-8")) == "中文测试"
+
+
+def test_decode_bytes_gbk():
+    assert _decode_bytes("中文测试".encode("gbk")) == "中文测试"
+
+
+def test_decode_bytes_utf8_with_ascii():
+    assert _decode_bytes(b"ipconfig /all") == "ipconfig /all"
+
+
+def test_decode_bytes_empty():
+    assert _decode_bytes(b"") == ""
+
+
+def test_decode_bytes_unknown_encoding():
+    # 既非 UTF-8 也非 GBK 的字节流 → errors=replace，不抛异常
+    out = _decode_bytes(b"\xff\xfe\x00\x80\x41")
+    assert isinstance(out, str)
+    assert out.endswith("A")


### PR DESCRIPTION
## What

Adds a new **shell_runner** plugin that lets Neko execute shell commands on the user's machine and return their output.

## Features

- **`run_shell`** LLM tool
  - Interpreter selection: `pwsh` (default) / `cmd`
  - Optional working directory (`cwd`)
  - Timeout control (5–600s, default 60), auto-termination on timeout
  - Returns stdout/stderr + exit code
- **`shell_test`** plugin entry — quick self-check (`Write-Output 'shell-ok'`)

## Implementation notes

- **Encoding**: prepends `$OutputEncoding = [Console]::OutputEncoding = [Text.Encoding]::UTF8` for pwsh to avoid CJK mojibake; cmd output is decoded UTF-8-first with GBK fallback (Windows default codepage).
- **Platform-independent decoder** (`_decode_bytes`) with unit tests (`plugin/tests/unit/plugins/test_shell_runner.py`, 5 tests passing).
- **Safety**: the tool description instructs the model to ask the user before destructive operations (delete, format, registry edits, shutdown); read-only queries (dir/ipconfig/Get-Process) run directly.

## Why not computer_use?

`run_shell` is direct and fast for command-line tasks, while computer_use (screenshot + key/mouse simulation) is slow and better suited for GUI interaction. Both coexist.

## Files

- `plugin/plugins/shell_runner/__init__.py`
- `plugin/plugins/shell_runner/plugin.toml`
- `plugin/plugins/shell_runner/README.md`
- `plugin/plugins/shell_runner/i18n/{zh-CN,en}.json`
- `plugin/tests/unit/plugins/test_shell_runner.py`

## Tests

```bash
uv run pytest plugin/tests/unit/plugins/test_shell_runner.py
```

> Note: the plugin targets Windows (pwsh/cmd). Unit tests cover only platform-independent decoding logic so CI on other platforms stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 Shell 执行器插件，支持通过 PowerShell 或 cmd 执行单条命令并返回结果。
  - 提供工作目录、超时控制、错误处理及输出截断能力。
  - 新增执行器自检入口，并支持中英文界面。
- **文档**
  - 补充使用示例、安全确认、编码处理、超时控制及功能边界说明。
- **测试**
  - 增加多种命令输出编码场景的验证，提升跨平台兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->