### PR TITLE
chore(tests): 把 #2859 新增测试里的中文注释改回英文

### DIFF
--- a/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
+++ b/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
@@ -35,11 +35,13 @@ def test_live2d_peek_restore_anchor_is_consumed_on_return():
     assert "let live2DPeekRestoreAnchor = null;" in return_block
     assert "live2DPeekRestoreAnchor = returnContainer.__nekoLive2DPeekEdgeAnchor;" in return_block
     assert restore_call in return_block
-    # fire-and-forget 调用必须保留 Promise rejection handler，不能吞掉异常。
+    # The fire-and-forget call must keep its Promise rejection handler so a
+    # failed restore never surfaces as an unhandled rejection.
     assert restore_call + ".catch(() => {});" in return_block
     assert settle_call in return_block
     assert complete_dispatch in return_block
-    # 顺序约束：先 settle 模型边界 → 再恢复贴边探身 → 最后派发 return-complete。
+    # Order constraint: settle the model bounds first, then restore the edge
+    # peek, and only then dispatch return-complete.
     assert return_block.index(settle_call) < return_block.index(restore_call) < return_block.index(complete_dispatch)
 
 


### PR DESCRIPTION
#2859 在 `tests/unit/test_widget_mode_return_ball_edge_anchor_static.py` 里新加了两行中文行内注释，而该文件（包括同一 PR 在同一个测试函数上方加的注释块）其余全部是英文。按「Python 文档一律英文」的约定统一回来。

先说清楚一点：**`scripts/check_docstring_no_cjk.py` 并没有红**——#2859 那次改动没有引入任何 docstring，门只管 docstring、明确不管注释，`--base origin/main` 跑出来是 exit 0（本分支上仍然是 0）。这个 PR 修的是同一约定下门抓不到的那部分：同一文件里中英混排。

改动只有注释文字，断言一行没动。

验证：
- `uv run pytest tests/unit/test_widget_mode_return_ball_edge_anchor_static.py -q` → 5 passed
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 将相关测试注释由中文改为英文。
  * 保持异步恢复调用、边界结算、边缘探身恢复及完成事件顺序的测试行为和断言不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->