### PR TITLE
Gal 模式选项模板改为跟随界面语言

### DIFF
--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1030,12 +1030,9 @@
     }
 
     function pickAcceptLanguage() {
-        try {
-            if (typeof window.getConversationLanguagePreference === 'function') {
-                var preferred = window.getConversationLanguagePreference();
-                if (preferred) return String(preferred);
-            }
-        } catch (_) {}
+        // GalGame option copy is part of the visible UI, so its template locale
+        // follows the interface instead of the active character's conversation
+        // language preference.
         try {
             if (typeof window.getCurrentLocale === 'function') {
                 var loc = window.getCurrentLocale();

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1609,6 +1609,24 @@ def test_galgame_history_excludes_tutorial_guide_messages():
     assert history_block.index("if (!m) continue;") < history_block.index("if (isYuiGuideChatMessage(m)) continue;")
 
 
+def test_galgame_option_template_follows_interface_language():
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    language_block = react_host.split("function pickAcceptLanguage()", 1)[1].split(
+        "var GALGAME_FETCH_TIMEOUT_MS",
+        1,
+    )[0]
+    assert "getConversationLanguagePreference" not in language_block
+    assert "window.getCurrentLocale" in language_block
+    assert "window.i18next.language" in language_block
+
+    fetch_block = react_host.split("function fetchGalgameOptionsForLatestTurn()", 1)[1].split(
+        "I.handleGalgameModeToggle",
+        1,
+    )[0]
+    assert "language: pickAcceptLanguage()" in fetch_block
+
+
 def test_icebreaker_reset_clears_prompt_by_source_without_session_match():
     react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1,8 +1,10 @@
 import json
 import re
+import shutil
 
 import pytest
 from pathlib import Path
+from tests.node_harness import run_node_script
 from tests.static_app_parts import read_js_parts
 
 
@@ -1612,19 +1614,66 @@ def test_galgame_history_excludes_tutorial_guide_messages():
 def test_galgame_option_template_follows_interface_language():
     react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
-    language_block = react_host.split("function pickAcceptLanguage()", 1)[1].split(
+    language_tail = react_host.split("function pickAcceptLanguage()", 1)[1].split(
         "var GALGAME_FETCH_TIMEOUT_MS",
         1,
     )[0]
+    language_block = "function pickAcceptLanguage()" + language_tail
     assert "getConversationLanguagePreference" not in language_block
     assert "window.getCurrentLocale" in language_block
     assert "window.i18next.language" in language_block
+    assert "navigator.language" in language_block
+    assert language_block.index("window.getCurrentLocale") < language_block.index(
+        "window.i18next.language"
+    )
+    assert language_block.index("window.i18next.language") < language_block.index(
+        "navigator.language"
+    )
 
     fetch_block = react_host.split("function fetchGalgameOptionsForLatestTurn()", 1)[1].split(
         "I.handleGalgameModeToggle",
         1,
     )[0]
     assert "language: pickAcceptLanguage()" in fetch_block
+
+    node_path = shutil.which("node")
+    assert node_path, "node is required to verify GalGame language selection"
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const functionSource = {json.dumps(language_block)};
+
+function resolve(windowValue, navigatorLanguage) {{
+    const context = {{ window: windowValue }};
+    if (navigatorLanguage !== undefined) {{
+        context.navigator = {{ language: navigatorLanguage }};
+    }}
+    vm.createContext(context);
+    vm.runInContext(functionSource, context);
+    return vm.runInContext('pickAcceptLanguage()', context);
+}}
+
+assert.equal(resolve({{
+    getConversationLanguagePreference: () => 'pt',
+    getCurrentLocale: () => 'ja',
+    i18next: {{ language: 'en' }}
+}}, 'ko'), 'ja');
+assert.equal(resolve({{
+    getCurrentLocale: () => '',
+    i18next: {{ language: 'en' }}
+}}, 'ko'), 'en');
+assert.equal(resolve({{ i18next: {{}} }}, 'ko'), 'ko');
+assert.equal(resolve({{ i18next: {{}} }}, undefined), '');
+"""
+    result = run_node_script(
+        node_path,
+        script,
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_icebreaker_reset_clears_prompt_by_source_without_session_match():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1637,7 +1637,8 @@ def test_galgame_option_template_follows_interface_language():
     assert "language: pickAcceptLanguage()" in fetch_block
 
     node_path = shutil.which("node")
-    assert node_path, "node is required to verify GalGame language selection"
+    if not node_path:
+        pytest.skip("node is required to verify GalGame language selection")
     script = f"""
 const assert = require('node:assert/strict');
 const vm = require('node:vm');


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

Gal 模式选项模板改为跟随界面语言

## 测试 / Testing

手动切换语言测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * Galgame 选项请求现在优先使用当前界面语言，确保生成内容与界面语言保持一致。
  * 优化语言识别顺序：依次参考界面语言、i18next 语言和浏览器语言，并在无法识别时回退为空。

* **测试**
  * 新增测试，验证不同语言来源及回退场景下的请求语言选择。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->