### PR TITLE
Refresh the Pet forge-credit badge after the social button mounts

### DIFF
--- a/static/app-social-ui.js
+++ b/static/app-social-ui.js
@@ -9,6 +9,7 @@
  * - 红点显示 = max(未读, 可领?1:0)；挂在圆形 social 按钮上（非 wrapper，避免错位）
  * - NOTIFY_INCOMING         → 简短 toast 提示（"📩 新消息"）
  * - QUOTA_CHANGED           → 不直接画 UI（snapshot 数据留给后续 quota panel 用）
+ * - FORGE_CREDIT_CHANGED    → 转发给 forge-drop-overlay 的蓝色券数角标
  * - CONN_STATE              → 不画 UI（log 一行调试）
  *
  * DROP_ANIMATION（🪙 / emoji 飘落）已退役：掉券 UX 统一走 CREDIT_DROP →
@@ -117,6 +118,22 @@
       paintBadge();
     });
   }
+
+  if (typeof window.nekoSocial.onForgeCreditChanged === 'function') {
+    window.nekoSocial.onForgeCreditChanged((data) => {
+      try {
+        window.dispatchEvent(new window.CustomEvent('neko-forge-credit-state', {
+          detail: data || {},
+        }));
+      } catch (_) {}
+    });
+  }
+
+  window.addEventListener('neko-forge-credit-state-refresh', () => {
+    if (typeof window.nekoSocial.replaySnapshots === 'function') {
+      try { window.nekoSocial.replaySnapshots(); } catch (_) {}
+    }
+  });
 
   // social 按钮的 id 在插入 DOM 前就已设好，新挂载时用缓存补画
   const buttonObserver = new MutationObserver((mutations) => {

--- a/static/app-social-ui.js
+++ b/static/app-social-ui.js
@@ -129,12 +129,6 @@
     });
   }
 
-  window.addEventListener('neko-forge-credit-state-refresh', () => {
-    if (typeof window.nekoSocial.replaySnapshots === 'function') {
-      try { window.nekoSocial.replaySnapshots(); } catch (_) {}
-    }
-  });
-
   // social 按钮的 id 在插入 DOM 前就已设好，新挂载时用缓存补画
   const buttonObserver = new MutationObserver((mutations) => {
     for (const m of mutations) {

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -247,6 +247,8 @@
     try {
       var cs = window.getComputedStyle(btn);
       if (cs && cs.position === 'static') btn.style.position = 'relative';
+      btn.style.overflow = 'visible';
+      if (btn.parentElement) btn.parentElement.style.overflow = 'visible';
     } catch (_) {}
     var badge = btn.querySelector('.neko-social-forge-badge');
     if (!badge) {
@@ -656,10 +658,8 @@
       expiryRefreshTimer = null;
       creditStateRevision += 1;
       // 到期只说明最早的一张券失效，不能据此推断全部券都已清空。
-      // 请求 Electron 主进程重新读取云端权威状态；本体不访问本地券账本。
-      try {
-        window.dispatchEvent(new window.CustomEvent('neko-forge-credit-state-refresh'));
-      } catch (_) {}
+      // 请求 Electron 主进程回放 / 重读云端权威状态；本体不访问本地券账本。
+      requestCreditStateRefresh();
     }, delay);
   }
 
@@ -675,6 +675,18 @@
     }
     // 关闭效果时仍经 playOne 的 disabled 分支，以便立即派发动画完成 ACK。
     play(queuedDetail);
+  }
+
+  function requestCreditStateRefresh() {
+    try {
+      if (window.nekoSocial && typeof window.nekoSocial.replaySnapshots === 'function') {
+        window.nekoSocial.replaySnapshots();
+        return;
+      }
+    } catch (_) {}
+    try {
+      window.dispatchEvent(new window.CustomEvent('neko-forge-credit-state-refresh'));
+    } catch (_) {}
   }
 
   function onCreditStateEvent(event) {
@@ -717,6 +729,7 @@
     window.addEventListener('neko-forge-credit-drop', onCreditDropEvent);
     window.addEventListener('neko-forge-credit-state', onCreditStateEvent);
     window.addEventListener('neko-forge-drop-effects-changed', onDropEffectsChanged);
+    requestCreditStateRefresh();
     // 按钮可见时持续刷新缓存位置，隐藏后飞出仍能对准
     try {
       setInterval(function () { readVisibleSocialCenter(); }, 1000);
@@ -726,6 +739,7 @@
       window.addEventListener('live2d-floating-buttons-ready', function () {
         setTimeout(readVisibleSocialCenter, 50);
         setTimeout(readVisibleSocialCenter, 500);
+        setTimeout(requestCreditStateRefresh, 80);
       });
     } catch (_) {}
     setTimeout(readVisibleSocialCenter, 300);

--- a/static/forge-drop-overlay.js
+++ b/static/forge-drop-overlay.js
@@ -658,7 +658,7 @@
       expiryRefreshTimer = null;
       creditStateRevision += 1;
       // 到期只说明最早的一张券失效，不能据此推断全部券都已清空。
-      // 请求 Electron 主进程回放 / 重读云端权威状态；本体不访问本地券账本。
+      // 请求 Electron 主进程重新读取云端权威状态；本体不访问本地券账本。
       requestCreditStateRefresh();
     }, delay);
   }
@@ -678,12 +678,8 @@
   }
 
   function requestCreditStateRefresh() {
-    try {
-      if (window.nekoSocial && typeof window.nekoSocial.replaySnapshots === 'function') {
-        window.nekoSocial.replaySnapshots();
-        return;
-      }
-    } catch (_) {}
+    // 到期 / 晚挂载必须走 PC 的云端权威刷新（CREDIT_STATE_REFRESH）。
+    // 不要回放 SSE 缓存快照：那只会重播过期的 lastForgeCredit。
     try {
       window.dispatchEvent(new window.CustomEvent('neko-forge-credit-state-refresh'));
     } catch (_) {}

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -13,6 +13,7 @@ APP_UI_PATH = PROJECT_ROOT / "static" / "app" / "app-ui"
 APP_SETTINGS_PATH = PROJECT_ROOT / "static" / "app" / "app-settings.js"
 AVATAR_UI_POPUP_PATH = PROJECT_ROOT / "static" / "avatar" / "avatar-ui-popup.js"
 FORGE_DROP_OVERLAY_PATH = PROJECT_ROOT / "static" / "forge-drop-overlay.js"
+APP_SOCIAL_UI_PATH = PROJECT_ROOT / "static" / "app-social-ui.js"
 FORGE_AVATAR_REACTION_PATH = PROJECT_ROOT / "static" / "forge-avatar-reaction.js"
 FORGE_DROP_TOKENS_PATH = PROJECT_ROOT / "static" / "forge-drop-tokens.js"
 FORGE_SOUND_DIR = PROJECT_ROOT / "static" / "sounds" / "forge"
@@ -470,10 +471,24 @@ def test_credit_badge_uses_only_pc_pushed_cloud_state():
     assert "scheduleExpiryClear(detail.next_expires_at);" in source
     assert "neko-forge-credit-state-refresh" in source
     assert "function requestCreditStateRefresh()" in source
-    assert "window.nekoSocial.replaySnapshots" in source
+    refresh = _extract_js_function(source, "function requestCreditStateRefresh()")
+    assert "neko-forge-credit-state-refresh" in refresh
+    assert "replaySnapshots" not in refresh
     assert "renderForgeBadge(0, false);" not in source
     assert "neko-forge-credit-animation-complete" in source
     assert "earliest - now + 1000" in source
+
+
+@pytest.mark.unit
+def test_credit_badge_social_bridge_forwards_pc_credit_state():
+    source = APP_SOCIAL_UI_PATH.read_text(encoding="utf-8")
+
+    assert "window.nekoSocial.onForgeCreditChanged" in source
+    assert "new window.CustomEvent('neko-forge-credit-state'" in source
+    # Refresh is owned by PC CREDIT_STATE_REFRESH. Replaying cached snapshots
+    # here would hide expiry and keep the old next_expires_at timer.
+    assert "replaySnapshots" not in source
+    assert "neko-forge-credit-state-refresh" not in source
 
 
 @pytest.mark.unit

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -485,6 +485,7 @@ def test_credit_badge_social_bridge_forwards_pc_credit_state():
 
     assert "window.nekoSocial.onForgeCreditChanged" in source
     assert "new window.CustomEvent('neko-forge-credit-state'" in source
+    assert "detail: data || {}" in source
     # Refresh is owned by PC CREDIT_STATE_REFRESH. Replaying cached snapshots
     # here would hide expiry and keep the old next_expires_at timer.
     assert "replaySnapshots" not in source

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -469,6 +469,8 @@ def test_credit_badge_uses_only_pc_pushed_cloud_state():
     assert "window.addEventListener('neko-forge-credit-state'" in source
     assert "scheduleExpiryClear(detail.next_expires_at);" in source
     assert "neko-forge-credit-state-refresh" in source
+    assert "function requestCreditStateRefresh()" in source
+    assert "window.nekoSocial.replaySnapshots" in source
     assert "renderForgeBadge(0, false);" not in source
     assert "neko-forge-credit-animation-complete" in source
     assert "earliest - now + 1000" in source


### PR DESCRIPTION
## Summary
- Forward `onForgeCreditChanged` to the overlay, and request a credit-state refresh on boot / when the floating 喵宇宙 button becomes ready, so a handshake that landed first still paints the count.
- Force `overflow: visible` on the circular social button so the blue count badge is not clipped.

Depends on N.E.K.O.-PC #447 for `forge_credit_changed` → `CREDIT_STATE` / `neko-forge-credit-state-refresh`. This PR only fixes the Pet-side late-mount and clipping gaps.

## Test plan
- [ ] Log into 喵宇宙 with an account that holds forge credits: the blue count appears on the social button after the floating bar mounts.
- [ ] Restart Pet / rebuild the floating buttons: badge comes back without waiting for another SSE event.
- [ ] Badge sits on the lower-right of the circular button and is not clipped.
- [ ] `tests/unit/test_social_button_static_contracts.py` still passes.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 Forge 券额度状态同步，支持实时更新角标显示。
  - 启动、到期及浮动按钮就绪时，可主动请求最新额度状态。
- **问题修复**
  - 扩大券角标及容器的可见范围，避免内容被裁剪。
  - 优化异常及接口不可用时的静默处理，提升显示稳定性。
- **测试**
  - 增加额度状态同步与刷新机制的静态契约检查，确保不处理过期快照。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->