### PR TITLE
fix: keep character voice dropdown within panel

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -6250,6 +6250,10 @@ margin-top: 10px;
     z-index: 6;
 }
 
+.settings-form-layout.panel-tab-settings .field-row-wrapper:has(.voice-custom-select.active) {
+    z-index: 7;
+}
+
 .settings-form-layout.panel-tab-settings .personality-row .field-row {
     grid-column: 2;
 }

--- a/static/js/character_card_manager/card-form-and-actions.js
+++ b/static/js/character_card_manager/card-form-and-actions.js
@@ -1374,6 +1374,8 @@ function _panelCreateVoiceSelectUi(selectEl) {
     container.appendChild(header);
     container.appendChild(options);
 
+    let geometryAnimationFrame = null;
+
     function getItems() {
         return Array.from(options.querySelectorAll('.voice-select-option:not(.disabled)'));
     }
@@ -1449,6 +1451,7 @@ function _panelCreateVoiceSelectUi(selectEl) {
 
     function closeDropdown(restoreFocus = false) {
         const wasActive = container.classList.contains('active');
+        stopTransformGeometryTracking();
         container.classList.remove('active', 'open-up', 'open-down');
         header.setAttribute('aria-expanded', 'false');
         setOptionTabbability(false);
@@ -1473,6 +1476,7 @@ function _panelCreateVoiceSelectUi(selectEl) {
         header.setAttribute('aria-expanded', 'true');
         setOptionTabbability(true);
         applyDropdownDirection();
+        startTransformGeometryTracking();
 
         const selectedItem = options.querySelector('.voice-select-option.selected:not(.disabled)');
         if (selectedItem) selectedItem.scrollIntoView({ block: 'nearest' });
@@ -1631,6 +1635,51 @@ function _panelCreateVoiceSelectUi(selectEl) {
         applyDropdownDirection();
     }
 
+    function hasRunningAncestorTransformAnimation() {
+        for (let ancestor = container.parentElement; ancestor; ancestor = ancestor.parentElement) {
+            if (typeof ancestor.getAnimations !== 'function') continue;
+            const hasRunningTransform = ancestor.getAnimations().some(animation => {
+                if (!['pending', 'running'].includes(animation.playState)) return false;
+                if (animation.transitionProperty === 'transform') return true;
+                const keyframes = animation.effect?.getKeyframes?.() || [];
+                return keyframes.some(
+                    keyframe => Object.prototype.hasOwnProperty.call(keyframe, 'transform')
+                );
+            });
+            if (hasRunningTransform) return true;
+        }
+        return false;
+    }
+
+    function stopTransformGeometryTracking() {
+        if (geometryAnimationFrame === null) return;
+        cancelAnimationFrame(geometryAnimationFrame);
+        geometryAnimationFrame = null;
+    }
+
+    function trackTransformGeometry() {
+        geometryAnimationFrame = null;
+        if (!container.classList.contains('active')) return;
+        applyDropdownDirection();
+        if (hasRunningAncestorTransformAnimation()) {
+            geometryAnimationFrame = requestAnimationFrame(trackTransformGeometry);
+        }
+    }
+
+    function startTransformGeometryTracking() {
+        if (geometryAnimationFrame !== null || !container.classList.contains('active')) return;
+        geometryAnimationFrame = requestAnimationFrame(trackTransformGeometry);
+    }
+
+    function handleAncestorTransformTransition(event) {
+        if (event.propertyName !== 'transform'
+            || !(event.target instanceof Element)
+            || !event.target.contains(container)) {
+            return;
+        }
+        startTransformGeometryTracking();
+    }
+
     header.addEventListener('click', toggleDropdown);
     header.addEventListener('keydown', event => {
         if (event.key === 'Enter' || event.key === ' ') {
@@ -1647,6 +1696,9 @@ function _panelCreateVoiceSelectUi(selectEl) {
     document.addEventListener('click', handleDocumentClick);
     document.addEventListener('keydown', handleDocumentKeydown);
     document.addEventListener('scroll', handleViewportChange, true);
+    document.addEventListener('transitionrun', handleAncestorTransformTransition, true);
+    document.addEventListener('transitionend', handleAncestorTransformTransition, true);
+    document.addEventListener('transitioncancel', handleAncestorTransformTransition, true);
     window.addEventListener('resize', handleViewportChange);
 
     refresh();
@@ -1665,6 +1717,9 @@ function _panelCreateVoiceSelectUi(selectEl) {
             document.removeEventListener('click', handleDocumentClick);
             document.removeEventListener('keydown', handleDocumentKeydown);
             document.removeEventListener('scroll', handleViewportChange, true);
+            document.removeEventListener('transitionrun', handleAncestorTransformTransition, true);
+            document.removeEventListener('transitionend', handleAncestorTransformTransition, true);
+            document.removeEventListener('transitioncancel', handleAncestorTransformTransition, true);
             window.removeEventListener('resize', handleViewportChange);
             container.remove();
         }

--- a/static/js/character_card_manager/card-form-and-actions.js
+++ b/static/js/character_card_manager/card-form-and-actions.js
@@ -1398,9 +1398,35 @@ function _panelCreateVoiceSelectUi(selectEl) {
         const maxHeight = 250;
         const gap = 8;
         const headerRect = header.getBoundingClientRect();
-        const optionHeight = Math.min(options.scrollHeight || maxHeight, maxHeight);
-        const spaceBelow = window.innerHeight - headerRect.bottom - gap;
-        const spaceAbove = headerRect.top - gap;
+        const containerRect = container.getBoundingClientRect();
+        const containerScaleY = container.offsetHeight > 0
+            ? containerRect.height / container.offsetHeight
+            : 1;
+        const safeScaleY = Number.isFinite(containerScaleY) && containerScaleY > 0
+            ? containerScaleY
+            : 1;
+        const optionHeight = Math.min(options.scrollHeight || maxHeight, maxHeight) * safeScaleY;
+        const visualGap = gap * safeScaleY;
+        let visibleTop = 0;
+        let visibleBottom = window.innerHeight;
+
+        for (let ancestor = container.parentElement; ancestor; ancestor = ancestor.parentElement) {
+            const overflowY = window.getComputedStyle(ancestor).overflowY;
+            if (!['auto', 'scroll', 'hidden', 'clip'].includes(overflowY)) continue;
+            const ancestorRect = ancestor.getBoundingClientRect();
+            const ancestorScaleY = ancestor.offsetHeight > 0
+                ? ancestorRect.height / ancestor.offsetHeight
+                : safeScaleY;
+            const clientTop = ancestorRect.top + ancestor.clientTop * ancestorScaleY;
+            visibleTop = Math.max(visibleTop, clientTop);
+            visibleBottom = Math.min(
+                visibleBottom,
+                clientTop + ancestor.clientHeight * ancestorScaleY
+            );
+        }
+
+        const spaceBelow = Math.max(0, visibleBottom - headerRect.bottom - visualGap);
+        const spaceAbove = Math.max(0, headerRect.top - visibleTop - visualGap);
         let placement = 'open-down';
         let computedMaxHeight = maxHeight;
 
@@ -1410,9 +1436,9 @@ function _panelCreateVoiceSelectUi(selectEl) {
             placement = 'open-up';
         } else if (spaceAbove > spaceBelow) {
             placement = 'open-up';
-            computedMaxHeight = Math.max(80, Math.floor(spaceAbove));
+            computedMaxHeight = Math.floor(spaceAbove / safeScaleY);
         } else {
-            computedMaxHeight = Math.max(80, Math.floor(spaceBelow));
+            computedMaxHeight = Math.floor(spaceBelow / safeScaleY);
         }
 
         container.classList.toggle('open-up', placement === 'open-up');
@@ -1600,6 +1626,11 @@ function _panelCreateVoiceSelectUi(selectEl) {
         }
     }
 
+    function handleViewportChange(event) {
+        if (!container.classList.contains('active') || event?.target === options) return;
+        applyDropdownDirection();
+    }
+
     header.addEventListener('click', toggleDropdown);
     header.addEventListener('keydown', event => {
         if (event.key === 'Enter' || event.key === ' ') {
@@ -1615,6 +1646,8 @@ function _panelCreateVoiceSelectUi(selectEl) {
     selectEl.addEventListener('change', syncSelectionState);
     document.addEventListener('click', handleDocumentClick);
     document.addEventListener('keydown', handleDocumentKeydown);
+    document.addEventListener('scroll', handleViewportChange, true);
+    window.addEventListener('resize', handleViewportChange);
 
     refresh();
 
@@ -1631,6 +1664,8 @@ function _panelCreateVoiceSelectUi(selectEl) {
             selectEl.removeEventListener('change', syncSelectionState);
             document.removeEventListener('click', handleDocumentClick);
             document.removeEventListener('keydown', handleDocumentKeydown);
+            document.removeEventListener('scroll', handleViewportChange, true);
+            window.removeEventListener('resize', handleViewportChange);
             container.remove();
         }
     };

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -441,13 +441,13 @@ def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
 
     state = mock_page.evaluate(
         """
-        () => {
+        async () => {
             const wrapper = document.createElement('div');
             wrapper.className = 'catgirl-panel-wrapper phase-expand';
             wrapper.style.cssText = [
                 'position: fixed',
                 'left: 120px',
-                'top: 80px',
+                'top: calc(100vh - 380px)',
                 'width: 720px',
                 'height: 400px',
                 'max-height: none',
@@ -473,7 +473,7 @@ def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
 
             const scrollport = document.createElement('div');
             scrollport.className = 'panel-tab-content active';
-            scrollport.style.cssText = 'height: 320px; overflow-y: auto; padding: 0;';
+            scrollport.style.cssText = 'height: 400px; overflow-y: auto; padding: 0;';
             host.appendChild(scrollport);
 
             const form = document.createElement('form');
@@ -511,11 +511,11 @@ def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
                 return { wrapper, ui };
             }
 
-            const language = appendSelectRow('language-preference-row', ['zh-CN']);
             const voice = appendSelectRow(
                 'voice-row',
                 Array.from({ length: 12 }, (_, index) => `voice-${index}`)
             );
+            const language = appendSelectRow('language-preference-row', ['zh-CN']);
 
             const bottomSpacer = document.createElement('div');
             bottomSpacer.style.height = '320px';
@@ -525,7 +525,7 @@ def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
             const scrollportBefore = scrollport.getBoundingClientRect();
             const headerBefore = header.getBoundingClientRect();
             scrollport.scrollTop += (
-                headerBefore.bottom - (scrollportBefore.bottom - 24 * 0.95)
+                headerBefore.top - (scrollportBefore.top + 140 * 0.95)
             ) / 0.95;
 
             header.click();
@@ -545,32 +545,47 @@ def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
                     (overlapTop + overlapBottom) / 2
                 )
                 : null;
-            const opensUp = voice.ui.container.classList.contains('open-up');
+            const opensDown = voice.ui.container.classList.contains('open-down');
             const optionsOwnsOverlap = Boolean(topmost && options.contains(topmost));
             const optionsStayInsideScrollport = optionsRect.top >= scrollportRect.top - 1
-                && optionsRect.bottom <= scrollportRect.bottom + 1;
+                && optionsRect.bottom <= Math.min(scrollportRect.bottom, window.innerHeight) + 1;
+            const maxHeightBeforeScale = Number.parseFloat(options.style.maxHeight);
 
-            wrapper.style.transform = 'scale(1)';
             wrapper.getBoundingClientRect();
+            wrapper.style.transition = 'transform 80ms linear';
+            wrapper.style.transform = 'scale(1)';
+            const transformTransition = wrapper.getAnimations().find(
+                animation => animation.transitionProperty === 'transform'
+            );
+            if (!transformTransition) throw new Error('Expected wrapper transform transition');
+            await transformTransition.finished;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
             const optionsAfterScale = options.getBoundingClientRect();
             const scrollportAfterScale = scrollport.getBoundingClientRect();
+            const maxHeightAfterScale = Number.parseFloat(options.style.maxHeight);
             const staysInsideAfterScaleEnd = optionsAfterScale.top >= scrollportAfterScale.top - 1
-                && optionsAfterScale.bottom <= scrollportAfterScale.bottom + 1;
+                && optionsAfterScale.bottom
+                    <= Math.min(scrollportAfterScale.bottom, window.innerHeight) + 1;
 
             const headerAfterScale = header.getBoundingClientRect();
-            scrollport.scrollTop += headerAfterScale.top - (scrollportAfterScale.top + 40);
+            scrollport.scrollTop += headerAfterScale.top
+                - (Math.min(scrollportAfterScale.bottom, window.innerHeight) - 60);
             scrollport.dispatchEvent(new Event('scroll'));
             const optionsAfterScroll = options.getBoundingClientRect();
 
             return {
-                opensUp,
+                opensDown,
                 hasOverlap,
                 optionsOwnsOverlap,
                 optionsStayInsideScrollport,
                 staysInsideAfterScaleEnd,
-                repositionsDownAfterScroll: voice.ui.container.classList.contains('open-down'),
+                maxHeightBeforeScale,
+                maxHeightAfterScale,
+                repositionsUpAfterScroll: voice.ui.container.classList.contains('open-up'),
                 staysInsideScrollportAfterScroll: optionsAfterScroll.top >= scrollportRect.top - 1
-                    && optionsAfterScroll.bottom <= scrollportRect.bottom + 1,
+                    && optionsAfterScroll.bottom
+                        <= Math.min(scrollportAfterScale.bottom, window.innerHeight) + 1,
                 activeRowZIndex: Number.parseInt(getComputedStyle(voice.wrapper).zIndex, 10),
                 languageRowZIndex: Number.parseInt(getComputedStyle(language.wrapper).zIndex, 10)
             };
@@ -578,13 +593,14 @@ def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
         """
     )
 
-    assert state["opensUp"] is True, state
+    assert state["opensDown"] is True, state
     assert state["hasOverlap"] is True, state
     assert state["activeRowZIndex"] > state["languageRowZIndex"], state
     assert state["optionsOwnsOverlap"] is True, state
     assert state["optionsStayInsideScrollport"] is True, state
     assert state["staysInsideAfterScaleEnd"] is True, state
-    assert state["repositionsDownAfterScroll"] is True, state
+    assert state["maxHeightAfterScale"] < state["maxHeightBeforeScale"], state
+    assert state["repositionsUpAfterScroll"] is True, state
     assert state["staysInsideScrollportAfterScroll"] is True, state
 
 

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -433,6 +433,162 @@ def test_character_card_manager_voice_dropdown_prefers_clone_prefix(
 
 
 @pytest.mark.frontend
+def test_character_card_manager_open_voice_dropdown_stays_above_adjacent_rows(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        () => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'catgirl-panel-wrapper phase-expand';
+            wrapper.style.cssText = [
+                'position: fixed',
+                'left: 120px',
+                'top: 80px',
+                'width: 720px',
+                'height: 400px',
+                'max-height: none',
+                'z-index: 2147483647',
+                'overflow: hidden',
+                'opacity: 1',
+                'transform: scale(0.95)',
+                'transform-origin: top left',
+                'transition: none'
+            ].join(';');
+
+            const host = document.createElement('div');
+            host.className = 'catgirl-panel-right';
+            host.style.cssText = [
+                'width: 720px',
+                'height: 400px',
+                'max-height: none',
+                'overflow: visible',
+                'opacity: 1',
+                'transform: none'
+            ].join(';');
+            wrapper.appendChild(host);
+
+            const scrollport = document.createElement('div');
+            scrollport.className = 'panel-tab-content active';
+            scrollport.style.cssText = 'height: 320px; overflow-y: auto; padding: 0;';
+            host.appendChild(scrollport);
+
+            const form = document.createElement('form');
+            form.className = 'settings-form-layout panel-tab-settings';
+            scrollport.appendChild(form);
+            document.body.appendChild(wrapper);
+
+            const topSpacer = document.createElement('div');
+            topSpacer.style.height = '320px';
+            form.appendChild(topSpacer);
+
+            function appendSelectRow(wrapperClass, values) {
+                const wrapper = document.createElement('div');
+                wrapper.className = `field-row-wrapper ${wrapperClass}`;
+
+                const label = document.createElement('label');
+                label.textContent = wrapperClass;
+                wrapper.appendChild(label);
+
+                const row = document.createElement('div');
+                row.className = 'field-row';
+                const select = document.createElement('select');
+                select.className = 'voice-native-select';
+                values.forEach((value, index) => {
+                    const option = document.createElement('option');
+                    option.value = value;
+                    option.textContent = `Option ${index + 1}`;
+                    select.appendChild(option);
+                });
+                row.appendChild(select);
+                const ui = _panelCreateVoiceSelectUi(select);
+                row.appendChild(ui.container);
+                wrapper.appendChild(row);
+                form.appendChild(wrapper);
+                return { wrapper, ui };
+            }
+
+            const language = appendSelectRow('language-preference-row', ['zh-CN']);
+            const voice = appendSelectRow(
+                'voice-row',
+                Array.from({ length: 12 }, (_, index) => `voice-${index}`)
+            );
+
+            const bottomSpacer = document.createElement('div');
+            bottomSpacer.style.height = '320px';
+            form.appendChild(bottomSpacer);
+
+            const header = voice.ui.container.querySelector('.voice-select-header');
+            const scrollportBefore = scrollport.getBoundingClientRect();
+            const headerBefore = header.getBoundingClientRect();
+            scrollport.scrollTop += (
+                headerBefore.bottom - (scrollportBefore.bottom - 24 * 0.95)
+            ) / 0.95;
+
+            header.click();
+
+            const options = voice.ui.container.querySelector('.voice-select-options');
+            const languageRect = language.wrapper.getBoundingClientRect();
+            const optionsRect = options.getBoundingClientRect();
+            const scrollportRect = scrollport.getBoundingClientRect();
+            const overlapTop = Math.max(languageRect.top, optionsRect.top);
+            const overlapBottom = Math.min(languageRect.bottom, optionsRect.bottom);
+            const overlapLeft = Math.max(languageRect.left, optionsRect.left);
+            const overlapRight = Math.min(languageRect.right, optionsRect.right);
+            const hasOverlap = overlapTop < overlapBottom && overlapLeft < overlapRight;
+            const topmost = hasOverlap
+                ? document.elementFromPoint(
+                    (overlapLeft + overlapRight) / 2,
+                    (overlapTop + overlapBottom) / 2
+                )
+                : null;
+            const opensUp = voice.ui.container.classList.contains('open-up');
+            const optionsOwnsOverlap = Boolean(topmost && options.contains(topmost));
+            const optionsStayInsideScrollport = optionsRect.top >= scrollportRect.top - 1
+                && optionsRect.bottom <= scrollportRect.bottom + 1;
+
+            wrapper.style.transform = 'scale(1)';
+            wrapper.getBoundingClientRect();
+            const optionsAfterScale = options.getBoundingClientRect();
+            const scrollportAfterScale = scrollport.getBoundingClientRect();
+            const staysInsideAfterScaleEnd = optionsAfterScale.top >= scrollportAfterScale.top - 1
+                && optionsAfterScale.bottom <= scrollportAfterScale.bottom + 1;
+
+            const headerAfterScale = header.getBoundingClientRect();
+            scrollport.scrollTop += headerAfterScale.top - (scrollportAfterScale.top + 40);
+            scrollport.dispatchEvent(new Event('scroll'));
+            const optionsAfterScroll = options.getBoundingClientRect();
+
+            return {
+                opensUp,
+                hasOverlap,
+                optionsOwnsOverlap,
+                optionsStayInsideScrollport,
+                staysInsideAfterScaleEnd,
+                repositionsDownAfterScroll: voice.ui.container.classList.contains('open-down'),
+                staysInsideScrollportAfterScroll: optionsAfterScroll.top >= scrollportRect.top - 1
+                    && optionsAfterScroll.bottom <= scrollportRect.bottom + 1,
+                activeRowZIndex: Number.parseInt(getComputedStyle(voice.wrapper).zIndex, 10),
+                languageRowZIndex: Number.parseInt(getComputedStyle(language.wrapper).zIndex, 10)
+            };
+        }
+        """
+    )
+
+    assert state["opensUp"] is True, state
+    assert state["hasOverlap"] is True, state
+    assert state["activeRowZIndex"] > state["languageRowZIndex"], state
+    assert state["optionsOwnsOverlap"] is True, state
+    assert state["optionsStayInsideScrollport"] is True, state
+    assert state["staysInsideAfterScaleEnd"] is True, state
+    assert state["repositionsDownAfterScroll"] is True, state
+    assert state["staysInsideScrollportAfterScroll"] is True, state
+
+
+@pytest.mark.frontend
 def test_character_language_fallback_can_be_pinned_by_reselecting_it(
     mock_page: Page,
     running_server: str,


### PR DESCRIPTION
## 改动概述 / Summary

- Raise the active character voice row above adjacent settings rows so its option list remains interactive.
- Choose the dropdown direction and maximum height against every clipping ancestor, using transformed visual coordinates consistently.
- Recalculate an open dropdown on ancestor scrolling and viewport resizing.

The previous implementation only considered the viewport and left the voice row below the language row. It could therefore be covered by adjacent fields or clipped by the character panel. During the panel's `scale(0.9)` to `scale(1)` entrance transition, it also mixed transformed rectangle coordinates with unscaled client dimensions, which could leave the menu clipped after the animation finished.

The change keeps the voice menu visible and clickable without altering voice selection or persistence behavior.

## 回归报告 / Regression Report

不适用：本 PR 未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本 PR 仅修改 3 个文件，CSS 层级、下拉定位逻辑与对应回归测试共同构成一个可独立验证的修复。

## 测试 / Testing

- `uv run python -m pytest tests/frontend/test_character_card_manager_regressions.py -q` (`28 passed`)
- `uv run ruff check tests/frontend/test_character_card_manager_regressions.py`
- `node --check static/js/character_card_manager/card-form-and-actions.js`
- `git diff --check`

The browser regression uses the real `.catgirl-panel-wrapper` clipping structure and verifies the menu at `scale(0.95)`, after changing to `scale(1)` without a scroll/resize event, and after deterministic scroll repositioning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化角色卡设置中的语音下拉菜单，使其在滚动容器、缩放面板及空间不足时保持正确定位和尺寸。
  - 菜单可根据可用空间自动调整展开方向，避免被相邻内容遮挡。
  - 滚动、窗口调整或面板动画期间，菜单位置和高度会动态更新。

- **Bug 修复**
  - 修复语音选项列表超出可视区域、层级不足及展开位置异常的问题。
  - 确保下拉菜单始终可见且可交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->