### PR TITLE
fix(docs): make description length advisory

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,8 @@
     "test:indexnow": "node --test scripts/submit-indexnow.test.mjs",
     "test:analytics": "node --test scripts/analytics-consent.test.mjs",
     "test:steam-cta": "node --test scripts/steam-cta.test.mjs",
-    "test": "npm run test:indexnow && npm run test:analytics && npm run test:steam-cta && npm run test:dataforseo && npm run test:seo-monitoring"
+    "test:seo-output": "node --test scripts/seo-description-policy.test.mjs",
+    "test": "npm run test:indexnow && npm run test:analytics && npm run test:steam-cta && npm run test:seo-output && npm run test:dataforseo && npm run test:seo-monitoring"
   },
   "devDependencies": {
     "vitepress": "^1.6.3",

--- a/docs/scripts/check-seo-output.mjs
+++ b/docs/scripts/check-seo-output.mjs
@@ -4,10 +4,12 @@ import {
   LOCALE_HOME_PATHS,
   SITE_ORIGIN,
 } from '../.vitepress/seo-shared.mjs'
+import { descriptionLengthWarning } from './seo-description-policy.mjs'
 
 const DIST_DIR = resolve('.vitepress/dist')
 const PUBLIC_DIR = resolve('public')
 const errors = []
+const warnings = []
 
 function filesRecursively(directory, extension) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -62,6 +64,10 @@ function decodeHtml(value) {
 
 function fail(file, message) {
   errors.push(`${file}: ${message}`)
+}
+
+function warn(file, message) {
+  warnings.push(`${file}: ${message}`)
 }
 
 function jsonLdNodes(data) {
@@ -155,13 +161,11 @@ for (const htmlPath of filesRecursively(DIST_DIR, '.html')) {
   if (titleMatches.length !== 1 || !titleMatches[0][1].trim()) {
     fail(file, 'must contain exactly one non-empty title')
   }
-  if (!description.trim()) fail(file, 'meta description is missing or empty')
-  const descriptionLength = Array.from(description).length
-  if (descriptionLength < 40 || descriptionLength > 180) {
-    fail(
-      file,
-      `meta description length must be 40-180 characters, found ${descriptionLength}`,
-    )
+  if (!description.trim()) {
+    fail(file, 'meta description is missing or empty')
+  } else {
+    const warning = descriptionLengthWarning(description)
+    if (warning) warn(file, warning)
   }
   if (!htmlLang) fail(file, 'html lang is missing')
   if ((html.match(/<h1\b/gi) ?? []).length !== 1) {
@@ -375,6 +379,14 @@ for (const page of pages.values()) {
         `hreflang target does not link back: ${alternate.href}`,
       )
     }
+  }
+}
+
+if (warnings.length) {
+  console.warn(`SEO validation completed with ${warnings.length} warning(s):`)
+  for (const warning of warnings.slice(0, 200)) console.warn(`- ${warning}`)
+  if (warnings.length > 200) {
+    console.warn(`- ...and ${warnings.length - 200} more`)
   }
 }
 

--- a/docs/scripts/seo-description-policy.mjs
+++ b/docs/scripts/seo-description-policy.mjs
@@ -1,0 +1,15 @@
+const RECOMMENDED_MIN_LENGTH = 40
+const RECOMMENDED_MAX_LENGTH = 180
+
+export function descriptionLengthWarning(description) {
+  const length = Array.from(description).length
+  if (length >= RECOMMENDED_MIN_LENGTH && length <= RECOMMENDED_MAX_LENGTH) {
+    return null
+  }
+
+  return (
+    `meta description length is outside the recommended ` +
+    `${RECOMMENDED_MIN_LENGTH}-${RECOMMENDED_MAX_LENGTH} character range, ` +
+    `found ${length}`
+  )
+}

--- a/docs/scripts/seo-description-policy.test.mjs
+++ b/docs/scripts/seo-description-policy.test.mjs
@@ -14,6 +14,14 @@ test('short CJK descriptions produce an advisory warning', () => {
   )
 })
 
+test('description length counts Unicode code points', () => {
+  const description = `${'a'.repeat(38)}😀`
+
+  assert.equal(Array.from(description).length, 39)
+  assert.equal(description.length, 40)
+  assert.match(descriptionLengthWarning(description), /found 39$/)
+})
+
 test('descriptions within the recommended range produce no warning', () => {
   assert.equal(descriptionLengthWarning('a'.repeat(40)), null)
   assert.equal(descriptionLengthWarning('a'.repeat(180)), null)

--- a/docs/scripts/seo-description-policy.test.mjs
+++ b/docs/scripts/seo-description-policy.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { descriptionLengthWarning } from './seo-description-policy.mjs'
+
+test('short CJK descriptions produce an advisory warning', () => {
+  const description =
+    '在不依赖标签触发云端构建的情况下，构建、签名、验证并发布稳定桌面资产。'
+
+  assert.equal(Array.from(description).length, 35)
+  assert.equal(
+    descriptionLengthWarning(description),
+    'meta description length is outside the recommended 40-180 character range, found 35',
+  )
+})
+
+test('descriptions within the recommended range produce no warning', () => {
+  assert.equal(descriptionLengthWarning('a'.repeat(40)), null)
+  assert.equal(descriptionLengthWarning('a'.repeat(180)), null)
+})
+
+test('long descriptions produce an advisory warning', () => {
+  assert.equal(
+    descriptionLengthWarning('a'.repeat(181)),
+    'meta description length is outside the recommended 40-180 character range, found 181',
+  )
+})


### PR DESCRIPTION
## Summary
- keep missing or empty meta descriptions as deployment-blocking SEO errors
- downgrade the generic 40–180 character recommendation to a non-blocking warning
- add focused policy tests for short CJK, recommended-range, and long descriptions
- wire the new regression test into the docs test suite

## Why
Search engines do not impose a universal 40-character minimum, and a concise Chinese description can communicate complete information in fewer characters than an English description. The previous language-agnostic lower bound blocked the entire Pages deployment for an otherwise valid 35-character Chinese description.

Structural SEO problems such as missing descriptions, duplicate descriptions, invalid canonical links, robots conflicts, sitemap mismatches, and hreflang errors remain hard failures.

## Testing
- `npm run test:seo-output`
- `npm test`
- `npm run build:check`
  - VitePress build passed
  - SEO validation passed: 305 indexable pages, 46 noindex pages, 1,158 hreflang links
  - the 35-character Chinese description emitted one warning with exit code 0
- `git diff --check`

## Scope
Docs-only validation change. No application runtime, analytics, consent, sitemap contents, or page copy changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加 SEO 描述长度检查，推荐范围为 40–180 个字符。
  * 描述缺失继续报告错误；长度不符合建议时显示警告，并提供实际长度信息。

* **测试**
  * 新增 SEO 描述长度测试，覆盖中日韩字符、Unicode 计数、边界值及超长描述。
  * SEO 测试已纳入统一测试流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->