### PR TITLE
perf: render desktop source names before thumbnails

### DIFF
--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -2048,11 +2048,21 @@
             // 第二阶段在后台获取整批缩略图。N.E.K.O.-PC 对这个显式缓存请求
             // 做 60 秒单快照缓存和 in-flight 去重；旧弹窗的迟到结果不会越过 token。
             Promise.resolve().then(function () {
-                return desktopProvider.getSources({
+                var thumbnailOptions = {
                     types: ['window', 'screen'],
                     thumbnailSize: { width: 160, height: 100 },
                     thumbnailCache: true
-                });
+                };
+                var configuredTimeoutMs = Number(C.SCREEN_SOURCE_THUMBNAIL_TIMEOUT);
+                var thumbnailTimeoutMs = Number.isFinite(configuredTimeoutMs) && configuredTimeoutMs > 0
+                    ? configuredTimeoutMs
+                    : 15000;
+                return window.invokeDesktopCaptureWithTimeout(
+                    desktopProvider,
+                    'getSources',
+                    [thumbnailOptions],
+                    thumbnailTimeoutMs
+                );
             }).then(function (thumbnailSources) {
                 if (!isPopupAvailable()) return;
                 var thumbnailsById = new Map();

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -1958,8 +1958,9 @@
 
                 // 名称阶段先保留与最终图片一致的 90x56 预览区域。
                 var previewHost = document.createElement('div');
-                if (source.thumbnail) renderPreviewImage(previewHost, source);
-                else renderPreviewLoading(previewHost);
+                // 元数据请求明确使用 0x0 跳过缩略图；Electron 仍可能返回
+                // truthy 但为空的 NativeImage，因此这里始终等待第二阶段结果。
+                renderPreviewLoading(previewHost);
                 previewHosts.set(source.id, { host: previewHost, source: source });
                 option.appendChild(previewHost);
 
@@ -2043,6 +2044,15 @@
                     windowGrid.appendChild(createSourceOption(source, null));
                 });
                 screenPopup.appendChild(windowGrid);
+            }
+
+            // Linux portal 的来源枚举可能再次弹出系统选择器。名称阶段已经完成
+            // 一次必要枚举，此类 provider 不再为缩略图重复请求。
+            if (desktopSourceEnumerationMayPrompt(desktopProvider)) {
+                previewHosts.forEach(function (entry) {
+                    renderPreviewFallback(entry.host, entry.source);
+                });
+                return true;
             }
 
             // 第二阶段在后台获取整批缩略图。N.E.K.O.-PC 对这个显式缓存请求

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -1768,10 +1768,13 @@
         }
 
         var popupId = screenPopup.id;
+        var renderToken = (Number(screenPopup._screenSourceRenderToken) || 0) + 1;
+        screenPopup._screenSourceRenderToken = renderToken;
         var requireVisible = renderOptions.requireVisible !== false;
         var isPopupAvailable = function () {
             if (!screenPopup || !screenPopup.isConnected) return false;
             if (popupId && document.getElementById(popupId) !== screenPopup) return false;
+            if (screenPopup._screenSourceRenderToken !== renderToken) return false;
             if (!requireVisible) return true;
             return screenPopup.style.display === 'flex' && screenPopup.style.opacity !== '0';
         };
@@ -1801,10 +1804,11 @@
             loadingItem.style.textAlign = 'center';
             screenPopup.appendChild(loadingItem);
 
-            // 获取屏幕源
+            // 第一阶段只枚举来源元数据。Electron 明确允许用 0x0 跳过每个窗口的
+            // 缩略图捕获，名称返回后立即绘制，完整图片在第二阶段后台补齐。
             var sources = await desktopProvider.getSources({
                 types: ['window', 'screen'],
-                thumbnailSize: { width: 160, height: 100 }
+                thumbnailSize: { width: 0, height: 0 }
             });
 
             if (!isPopupAvailable()) return false;
@@ -1825,6 +1829,92 @@
             // 分组：屏幕和窗口
             var screens = sources.filter(function (s) { return s.id.startsWith('screen:'); });
             var windows = sources.filter(function (s) { return s.id.startsWith('window:'); });
+            var previewHosts = new Map();
+
+            function previewFrameStyles() {
+                return {
+                    width: '100%',
+                    maxWidth: '90px',
+                    height: '56px',
+                    borderRadius: '4px',
+                    border: '1px solid var(--neko-popup-separator)',
+                    marginBottom: '4px',
+                    boxSizing: 'border-box',
+                    overflow: 'hidden'
+                };
+            }
+
+            function renderPreviewLoading(host) {
+                host.innerHTML = '';
+                host.className = 'screen-source-thumbnail screen-source-thumbnail-loading';
+                host.textContent = window.t ? window.t('app.screenSource.loading') : 'Loading...';
+                Object.assign(host.style, previewFrameStyles(), {
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: '4px',
+                    background: 'var(--neko-screen-placeholder-bg, #f5f5f5)',
+                    color: 'var(--neko-popup-text-sub)',
+                    fontSize: '10px',
+                    textAlign: 'center'
+                });
+            }
+
+            function renderPreviewFallback(host, source) {
+                host.innerHTML = '';
+                host.className = 'screen-source-thumbnail screen-source-thumbnail-fallback';
+                host.textContent = source.id.startsWith('screen:') ? '\uD83D\uDDA5\uFE0F' : '\uD83E\uDE9F';
+                Object.assign(host.style, previewFrameStyles(), {
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: 'var(--neko-screen-placeholder-bg, #f5f5f5)',
+                    fontSize: '24px'
+                });
+            }
+
+            function sourceThumbnailDataUrl(source) {
+                if (!source || !source.thumbnail) return '';
+                if (typeof source.thumbnail === 'string') return source.thumbnail;
+                if (typeof source.thumbnail.toDataURL === 'function') {
+                    return source.thumbnail.toDataURL();
+                }
+                return '';
+            }
+
+            function renderPreviewImage(host, source) {
+                var thumbnailDataUrl = '';
+                try {
+                    thumbnailDataUrl = sourceThumbnailDataUrl(source);
+                    if (!thumbnailDataUrl || thumbnailDataUrl.trim() === '') {
+                        throw new Error('thumbnail data URL is empty');
+                    }
+                } catch (error) {
+                    console.warn('[屏幕源] 缩略图转换失败，使用占位图:', error);
+                    renderPreviewFallback(host, source);
+                    return false;
+                }
+
+                host.innerHTML = '';
+                host.className = 'screen-source-thumbnail screen-source-thumbnail-ready';
+                Object.assign(host.style, previewFrameStyles(), {
+                    display: 'block',
+                    padding: '0',
+                    background: 'var(--neko-screen-placeholder-bg, #f5f5f5)'
+                });
+                var thumb = document.createElement('img');
+                thumb.alt = '';
+                thumb.src = thumbnailDataUrl;
+                thumb.onerror = function () { renderPreviewFallback(host, source); };
+                Object.assign(thumb.style, {
+                    display: 'block',
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover'
+                });
+                host.appendChild(thumb);
+                return true;
+            }
 
             // 创建网格容器的辅助函数
             function createGridContainer() {
@@ -1866,59 +1956,12 @@
                     option.style.borderColor = '#4f8cff';
                 }
 
-                // 缩略图（带异常处理和占位图回退）
-                if (source.thumbnail) {
-                    var thumb = document.createElement('img');
-                    var thumbnailDataUrl = '';
-                    try {
-                        // NativeImage 对象需要转换为 dataURL 字符串
-                        if (typeof source.thumbnail === 'string') {
-                            thumbnailDataUrl = source.thumbnail;
-                        } else if (source.thumbnail && typeof source.thumbnail.toDataURL === 'function') {
-                            thumbnailDataUrl = source.thumbnail.toDataURL();
-                        }
-                        // 检查是否为空字符串或无效值
-                        if (!thumbnailDataUrl || thumbnailDataUrl.trim() === '') {
-                            throw new Error('thumbnail.toDataURL() 返回空值');
-                        }
-                    } catch (e) {
-                        console.warn('[屏幕源] 缩略图转换失败，使用占位图:', e);
-                        // 使用占位图（1x1 透明像素的 dataURL）
-                        thumbnailDataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-                    }
-                    thumb.src = thumbnailDataUrl;
-                    // 添加错误处理，如果图片加载失败也使用占位图
-                    thumb.onerror = function () {
-                        thumb.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-                    };
-                    Object.assign(thumb.style, {
-                        width: '100%',
-                        maxWidth: '90px',
-                        height: '56px',
-                        objectFit: 'cover',
-                        borderRadius: '4px',
-                        border: '1px solid var(--neko-popup-separator)',
-                        marginBottom: '4px'
-                    });
-                    option.appendChild(thumb);
-                } else {
-                    // 无缩略图时显示图标
-                    var iconPlaceholder = document.createElement('div');
-                    iconPlaceholder.textContent = source.id.startsWith('screen:') ? '\uD83D\uDDA5\uFE0F' : '\uD83E\uDE9F';
-                    Object.assign(iconPlaceholder.style, {
-                        width: '100%',
-                        maxWidth: '90px',
-                        height: '56px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '24px',
-                        background: 'var(--neko-screen-placeholder-bg, #f5f5f5)',
-                        borderRadius: '4px',
-                        marginBottom: '4px'
-                    });
-                    option.appendChild(iconPlaceholder);
-                }
+                // 名称阶段先保留与最终图片一致的 90x56 预览区域。
+                var previewHost = document.createElement('div');
+                if (source.thumbnail) renderPreviewImage(previewHost, source);
+                else renderPreviewLoading(previewHost);
+                previewHosts.set(source.id, { host: previewHost, source: source });
+                option.appendChild(previewHost);
 
                 // 名称（在缩略图下方，允许多行）
                 var label = document.createElement('span');
@@ -2001,6 +2044,36 @@
                 });
                 screenPopup.appendChild(windowGrid);
             }
+
+            // 第二阶段在后台获取整批缩略图。N.E.K.O.-PC 对这个显式缓存请求
+            // 做 60 秒单快照缓存和 in-flight 去重；旧弹窗的迟到结果不会越过 token。
+            Promise.resolve().then(function () {
+                return desktopProvider.getSources({
+                    types: ['window', 'screen'],
+                    thumbnailSize: { width: 160, height: 100 },
+                    thumbnailCache: true
+                });
+            }).then(function (thumbnailSources) {
+                if (!isPopupAvailable()) return;
+                var thumbnailsById = new Map();
+                (thumbnailSources || []).forEach(function (source) {
+                    thumbnailsById.set(source.id, source);
+                });
+                previewHosts.forEach(function (entry, sourceId) {
+                    var thumbnailSource = thumbnailsById.get(sourceId);
+                    if (thumbnailSource && thumbnailSource.thumbnail) {
+                        renderPreviewImage(entry.host, thumbnailSource);
+                    } else {
+                        renderPreviewFallback(entry.host, entry.source);
+                    }
+                });
+            }).catch(function (error) {
+                console.error('[屏幕源] 获取缩略图失败:', error);
+                if (!isPopupAvailable()) return;
+                previewHosts.forEach(function (entry) {
+                    renderPreviewFallback(entry.host, entry.source);
+                });
+            });
 
             return true;
         } catch (error) {

--- a/static/app/desktop-capture-provider.js
+++ b/static/app/desktop-capture-provider.js
@@ -21,20 +21,21 @@
      * Invoke a desktop capture bridge method with one shared timeout contract.
      *
      * Calling through the provider preserves Electron preload methods that rely
-     * on `this`, while resolving the provider separately keeps the late-injected
-     * Tauri bridge behavior unchanged. The underlying native request cannot be
-     * cancelled, but its late result is detached after the bounded wait.
+     * on `this`, while the explicit argument array preserves each bridge method's
+     * public call shape. The underlying native request cannot be cancelled, but
+     * its late result is detached after the bounded wait.
      */
-    window.captureDesktopSourceWithTimeout = async function (
+    window.invokeDesktopCaptureWithTimeout = async function (
         provider,
         methodName,
-        sourceId,
-        options,
+        methodArgs,
         timeoutMs
     ) {
         if (!provider || typeof provider[methodName] !== 'function') {
             throw new Error('Desktop capture method unavailable: ' + methodName);
         }
+
+        var args = Array.isArray(methodArgs) ? methodArgs : [];
 
         var effectiveTimeoutMs = Number(timeoutMs);
         if (!Number.isFinite(effectiveTimeoutMs) || effectiveTimeoutMs <= 0) {
@@ -45,7 +46,7 @@
         try {
             return await Promise.race([
                 Promise.resolve().then(function () {
-                    return provider[methodName](sourceId, options);
+                    return provider[methodName].apply(provider, args);
                 }),
                 new Promise(function (_, reject) {
                     timeoutId = setTimeout(function () {
@@ -58,5 +59,20 @@
         } finally {
             if (timeoutId !== null) clearTimeout(timeoutId);
         }
+    };
+
+    window.captureDesktopSourceWithTimeout = function (
+        provider,
+        methodName,
+        sourceId,
+        options,
+        timeoutMs
+    ) {
+        return window.invokeDesktopCaptureWithTimeout(
+            provider,
+            methodName,
+            [sourceId, options],
+            timeoutMs
+        );
     };
 })();

--- a/tests/frontend/test_screen_source_progressive_loading.py
+++ b/tests/frontend/test_screen_source_progressive_loading.py
@@ -13,16 +13,17 @@ def _install_screen_source_harness(
     page: Page,
     *,
     thumbnail_timeout_ms: int = 15_000,
+    source_enumeration_may_prompt: bool = False,
 ) -> None:
     page.set_content(
         '<div id="live2d-popup-screen" '
         'style="display:flex;opacity:1"></div>'
     )
     page.evaluate(
-        """(thumbnailTimeoutMs) => {
+        """(options) => {
             window.appState = { selectedScreenSourceId: null };
             window.appConst = {
-                SCREEN_SOURCE_THUMBNAIL_TIMEOUT: thumbnailTimeoutMs,
+                SCREEN_SOURCE_THUMBNAIL_TIMEOUT: options.thumbnailTimeoutMs,
             };
             window.appUtils = { isMobile: () => false };
             window.safeT = (_key, fallback) => fallback;
@@ -35,15 +36,24 @@ def _install_screen_source_harness(
             };
             window.showStatusToast = () => {};
             window.__captureCalls = [];
+            window.__metadataThumbnailReads = 0;
             window.__thumbnailResolve = null;
             const thumbnailPromise = new Promise((resolve) => {
                 window.__thumbnailResolve = resolve;
             });
+            const emptyMetadataThumbnail = {
+                isEmpty() { return true; },
+                toDataURL() {
+                    window.__metadataThumbnailReads += 1;
+                    return '';
+                },
+            };
             const metadataSources = [
-                { id: 'screen:1', name: 'Entire Screen', display_id: '1', thumbnail: null },
-                { id: 'window:2', name: 'Editor', display_id: '', thumbnail: null },
+                { id: 'screen:1', name: 'Entire Screen', display_id: '1', thumbnail: emptyMetadataThumbnail },
+                { id: 'window:2', name: 'Editor', display_id: '', thumbnail: emptyMetadataThumbnail },
             ];
             window.__desktopProvider = {
+                sourceEnumerationMayPrompt: options.sourceEnumerationMayPrompt,
                 getSources(options) {
                     window.__captureCalls.push(options);
                     if (options.thumbnailSize.width === 0) {
@@ -55,7 +65,10 @@ def _install_screen_source_harness(
             };
             window.electronDesktopCapturer = window.__desktopProvider;
         }""",
-        thumbnail_timeout_ms,
+        {
+            "thumbnailTimeoutMs": thumbnail_timeout_ms,
+            "sourceEnumerationMayPrompt": source_enumeration_may_prompt,
+        },
     )
     page.add_script_tag(path=str(DESKTOP_CAPTURE_PROVIDER))
     page.add_script_tag(path=str(APP_SCREEN))
@@ -83,6 +96,7 @@ def test_screen_source_names_render_before_cached_thumbnails(page: Page) -> None
             imageCount: document.querySelectorAll(
                 '.screen-source-thumbnail-ready img'
             ).length,
+            metadataThumbnailReads: window.__metadataThumbnailReads,
             calls: window.__captureCalls,
         })"""
     )
@@ -90,6 +104,7 @@ def test_screen_source_names_render_before_cached_thumbnails(page: Page) -> None
         "labels": ["Screen 1", "Editor"],
         "loadingCount": 2,
         "imageCount": 0,
+        "metadataThumbnailReads": 0,
         "calls": [
             {
                 "types": ["window", "screen"],
@@ -186,6 +201,44 @@ def test_screen_source_hung_thumbnail_request_falls_back_after_timeout(
                 "thumbnailCache": True,
             },
         ],
+        "loadingCount": 0,
+        "fallbackCount": 2,
+    }
+
+
+@pytest.mark.frontend
+def test_screen_source_prompt_provider_skips_thumbnail_reenumeration(
+    page: Page,
+) -> None:
+    _install_screen_source_harness(page, source_enumeration_may_prompt=True)
+
+    rendered = page.evaluate(
+        """async () => window.renderFloatingScreenSourceList(
+            document.getElementById('live2d-popup-screen')
+        )"""
+    )
+    assert rendered is True
+
+    state = page.evaluate(
+        """() => ({
+            calls: window.__captureCalls,
+            metadataThumbnailReads: window.__metadataThumbnailReads,
+            loadingCount: document.querySelectorAll(
+                '.screen-source-thumbnail-loading'
+            ).length,
+            fallbackCount: document.querySelectorAll(
+                '.screen-source-thumbnail-fallback'
+            ).length,
+        })"""
+    )
+    assert state == {
+        "calls": [
+            {
+                "types": ["window", "screen"],
+                "thumbnailSize": {"width": 0, "height": 0},
+            }
+        ],
+        "metadataThumbnailReads": 0,
         "loadingCount": 0,
         "fallbackCount": 2,
     }

--- a/tests/frontend/test_screen_source_progressive_loading.py
+++ b/tests/frontend/test_screen_source_progressive_loading.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_SCREEN = ROOT / "static" / "app" / "app-screen.js"
+
+
+def _install_screen_source_harness(page: Page) -> None:
+    page.set_content(
+        '<div id="live2d-popup-screen" '
+        'style="display:flex;opacity:1"></div>'
+    )
+    page.evaluate(
+        """() => {
+            window.appState = { selectedScreenSourceId: null };
+            window.appConst = {};
+            window.appUtils = { isMobile: () => false };
+            window.safeT = (_key, fallback) => fallback;
+            window.t = (key, options = {}) => {
+                if (key === 'app.screenSource.loading') return 'Loading...';
+                if (key === 'app.screenSource.screenLabel') {
+                    return `Screen ${options.index}`;
+                }
+                return key;
+            };
+            window.showStatusToast = () => {};
+            window.__captureCalls = [];
+            window.__thumbnailResolve = null;
+            const thumbnailPromise = new Promise((resolve) => {
+                window.__thumbnailResolve = resolve;
+            });
+            const metadataSources = [
+                { id: 'screen:1', name: 'Entire Screen', display_id: '1', thumbnail: null },
+                { id: 'window:2', name: 'Editor', display_id: '', thumbnail: null },
+            ];
+            window.__desktopProvider = {
+                getSources(options) {
+                    window.__captureCalls.push(options);
+                    if (options.thumbnailSize.width === 0) {
+                        return Promise.resolve(metadataSources);
+                    }
+                    return thumbnailPromise;
+                },
+                setSelectedSource() { return Promise.resolve(); },
+            };
+            window.getDesktopCaptureProvider = () => window.__desktopProvider;
+        }"""
+    )
+    page.add_script_tag(path=str(APP_SCREEN))
+
+
+@pytest.mark.frontend
+def test_screen_source_names_render_before_cached_thumbnails(page: Page) -> None:
+    _install_screen_source_harness(page)
+
+    rendered = page.evaluate(
+        """async () => window.renderFloatingScreenSourceList(
+            document.getElementById('live2d-popup-screen')
+        )"""
+    )
+    assert rendered is True
+    page.wait_for_function("window.__captureCalls.length === 2")
+
+    before_thumbnails = page.evaluate(
+        """() => ({
+            labels: Array.from(document.querySelectorAll('.screen-source-option span'))
+                .map((node) => node.textContent),
+            loadingCount: document.querySelectorAll(
+                '.screen-source-thumbnail-loading'
+            ).length,
+            imageCount: document.querySelectorAll(
+                '.screen-source-thumbnail-ready img'
+            ).length,
+            calls: window.__captureCalls,
+        })"""
+    )
+    assert before_thumbnails == {
+        "labels": ["Screen 1", "Editor"],
+        "loadingCount": 2,
+        "imageCount": 0,
+        "calls": [
+            {
+                "types": ["window", "screen"],
+                "thumbnailSize": {"width": 0, "height": 0},
+            },
+            {
+                "types": ["window", "screen"],
+                "thumbnailSize": {"width": 160, "height": 100},
+                "thumbnailCache": True,
+            },
+        ],
+    }
+
+    page.evaluate(
+        """() => window.__thumbnailResolve([
+            {
+                id: 'screen:1',
+                name: 'Entire Screen',
+                display_id: '1',
+                thumbnail: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+            },
+            {
+                id: 'window:2',
+                name: 'Editor',
+                display_id: '',
+                thumbnail: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+            },
+            {
+                id: 'window:stale',
+                name: 'Closed Window',
+                display_id: '',
+                thumbnail: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+            },
+        ])"""
+    )
+    page.wait_for_function(
+        "document.querySelectorAll('.screen-source-thumbnail-ready img').length === 2"
+    )
+
+    after_thumbnails = page.evaluate(
+        """() => ({
+            optionCount: document.querySelectorAll('.screen-source-option').length,
+            loadingCount: document.querySelectorAll(
+                '.screen-source-thumbnail-loading'
+            ).length,
+            imageCount: document.querySelectorAll(
+                '.screen-source-thumbnail-ready img'
+            ).length,
+        })"""
+    )
+    assert after_thumbnails == {
+        "optionCount": 2,
+        "loadingCount": 0,
+        "imageCount": 2,
+    }

--- a/tests/frontend/test_screen_source_progressive_loading.py
+++ b/tests/frontend/test_screen_source_progressive_loading.py
@@ -6,17 +6,24 @@ from playwright.sync_api import Page
 
 ROOT = Path(__file__).resolve().parents[2]
 APP_SCREEN = ROOT / "static" / "app" / "app-screen.js"
+DESKTOP_CAPTURE_PROVIDER = ROOT / "static" / "app" / "desktop-capture-provider.js"
 
 
-def _install_screen_source_harness(page: Page) -> None:
+def _install_screen_source_harness(
+    page: Page,
+    *,
+    thumbnail_timeout_ms: int = 15_000,
+) -> None:
     page.set_content(
         '<div id="live2d-popup-screen" '
         'style="display:flex;opacity:1"></div>'
     )
     page.evaluate(
-        """() => {
+        """(thumbnailTimeoutMs) => {
             window.appState = { selectedScreenSourceId: null };
-            window.appConst = {};
+            window.appConst = {
+                SCREEN_SOURCE_THUMBNAIL_TIMEOUT: thumbnailTimeoutMs,
+            };
             window.appUtils = { isMobile: () => false };
             window.safeT = (_key, fallback) => fallback;
             window.t = (key, options = {}) => {
@@ -46,9 +53,11 @@ def _install_screen_source_harness(page: Page) -> None:
                 },
                 setSelectedSource() { return Promise.resolve(); },
             };
-            window.getDesktopCaptureProvider = () => window.__desktopProvider;
-        }"""
+            window.electronDesktopCapturer = window.__desktopProvider;
+        }""",
+        thumbnail_timeout_ms,
     )
+    page.add_script_tag(path=str(DESKTOP_CAPTURE_PROVIDER))
     page.add_script_tag(path=str(APP_SCREEN))
 
 
@@ -135,4 +144,48 @@ def test_screen_source_names_render_before_cached_thumbnails(page: Page) -> None
         "optionCount": 2,
         "loadingCount": 0,
         "imageCount": 2,
+    }
+
+
+@pytest.mark.frontend
+def test_screen_source_hung_thumbnail_request_falls_back_after_timeout(
+    page: Page,
+) -> None:
+    _install_screen_source_harness(page, thumbnail_timeout_ms=25)
+
+    rendered = page.evaluate(
+        """async () => window.renderFloatingScreenSourceList(
+            document.getElementById('live2d-popup-screen')
+        )"""
+    )
+    assert rendered is True
+    page.wait_for_function(
+        "document.querySelectorAll('.screen-source-thumbnail-fallback').length === 2"
+    )
+
+    state = page.evaluate(
+        """() => ({
+            calls: window.__captureCalls,
+            loadingCount: document.querySelectorAll(
+                '.screen-source-thumbnail-loading'
+            ).length,
+            fallbackCount: document.querySelectorAll(
+                '.screen-source-thumbnail-fallback'
+            ).length,
+        })"""
+    )
+    assert state == {
+        "calls": [
+            {
+                "types": ["window", "screen"],
+                "thumbnailSize": {"width": 0, "height": 0},
+            },
+            {
+                "types": ["window", "screen"],
+                "thumbnailSize": {"width": 160, "height": 100},
+                "thumbnailCache": True,
+            },
+        ],
+        "loadingCount": 0,
+        "fallbackCount": 2,
     }

--- a/tests/unit/test_desktop_capture_provider_static.py
+++ b/tests/unit/test_desktop_capture_provider_static.py
@@ -88,6 +88,28 @@ eval({provider_source});
     throw new Error('Electron capture call contract changed');
   }}
 
+  let getSourcesArgs = null;
+  const sourceOptions = {{
+    types: ['window', 'screen'],
+    thumbnailSize: {{ width: 160, height: 100 }}
+  }};
+  const sources = await window.invokeDesktopCaptureWithTimeout(
+    {{
+      getSources(options) {{
+        getSourcesArgs = Array.from(arguments);
+        return Promise.resolve([{{ id: 'screen:1', options }}]);
+      }}
+    }},
+    'getSources',
+    [sourceOptions],
+    50
+  );
+  if (getSourcesArgs.length !== 1
+      || getSourcesArgs[0] !== sourceOptions
+      || sources[0].options !== sourceOptions) {{
+    throw new Error('Generic timeout changed the getSources(options) contract');
+  }}
+
   const tauriProvider = {{ captureSourceAsDataUrl() {{ return Promise.resolve(null); }} }};
   window.tauriDesktopCapturer = tauriProvider;
   if (window.getDesktopCaptureProvider() !== tauriProvider) {{


### PR DESCRIPTION
## 改动概述 / Summary

- Split desktop source rendering into a metadata stage and a thumbnail stage.
- Render source names immediately with fixed-size `Loading...` placeholders.
- Request complete thumbnails in the background and update only currently listed source IDs.
- Ignore late results from an older popup render and fall back to source icons when a thumbnail is unavailable.
- Bound the background thumbnail wait at 15 seconds so a permanently pending native request cannot leave `Loading...` placeholders indefinitely.
- Keep the metadata stage in `Loading...` even when Electron returns a truthy but empty `NativeImage` for a `0x0` thumbnail request.
- Skip the thumbnail re-enumeration for providers that may reopen a system capture portal, using source-type fallback icons instead.
- Opt in to the N.E.K.O-PC 60-second thumbnail cache for the background image request.

## Before / After

Measured with Electron 41.2.0 on the same Windows environment:

| User-visible stage | Before | After |
| --- | ---: | ---: |
| Source names become visible | After the complete flow: 7038.669 ms average | After metadata: 779.921 ms |
| First thumbnail batch | Names and images appeared together | Images fill the fixed-size placeholders in the background; 6621.905 ms in the updated run |
| Reopen within one minute, paired with the N.E.K.O-PC PR | Repeated the complete capture | Names: 324.992 ms; thumbnail cache hit: 0.076 ms |

The baseline used 47 dynamic sources; the updated run used 43. The first-capture values therefore document user-visible staging and the remaining native cost rather than a strict same-sample speedup.

## Why this matters

Before this change, users received no actionable source information while Electron and Windows captured every thumbnail. The selector looked stalled even though source enumeration was in progress.

The two-stage flow exposes useful source names first, reserves stable thumbnail space to avoid layout shift, and updates only sources that still belong to the current popup render. It improves perceived and functional responsiveness without claiming that the operating system's first thumbnail capture has disappeared.

The N.E.K.O frontend owns this presentation and stale-render protection; N.E.K.O-PC owns native capture caching and request deduplication. Both PRs are required for the complete behavior.

## 回归报告 / Regression Report

不适用。本 PR 未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。改动范围为一个现有前端模块和一个新增前端测试文件。

## 测试 / Testing

- `node --check static/app/app-screen.js`
- `node --check static/app/desktop-capture-provider.js`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/unit/test_desktop_capture_provider_static.py tests/frontend/test_screen_source_progressive_loading.py tests/frontend/test_voice_recognition_popover.py -q` — 28 passed
- Playwright coverage verifies that names and two `Loading...` placeholders render before the deferred thumbnail Promise resolves.
- Playwright coverage verifies the `0x0` metadata request, the cached `160x100` thumbnail request, source-ID matching, and rejection of a stale extra source.
- Playwright coverage verifies that a permanently pending thumbnail request reaches the fallback state after the bounded wait, while the shared helper preserves the one-argument `getSources(options)` contract.
- Playwright coverage verifies that truthy empty metadata thumbnails are not read and that prompt-capable portal providers do not perform a second source enumeration.
- Opened the screen-source subwindow in the updated N.E.K.O-PC development application and confirmed that the current screen/window source list renders.
- Rebased onto N.E.K.O `upstream/main` at `e5894f5ec` and reran the checks above successfully.

## Cross-repository dependency

Related N.E.K.O-PC PR: https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/450

The frontend remains compatible with an older N.E.K.O-PC build: names still render before thumbnails, but the one-minute cache and in-flight deduplication are unavailable. The full behavior requires both PRs. Merging N.E.K.O-PC first is the recommended rollout order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 屏幕源列表会先显示来源名称，再逐步加载缩略图。
  * 缩略图加载期间显示加载状态；缺失、超时或加载失败时显示来源类型占位图。

* **问题修复**
  * 防止旧弹窗的异步结果覆盖当前弹窗内容。
  * 仅显示当前有效来源的缩略图，避免过期内容混入。
  * 桌面捕获请求增加超时处理，减少加载长时间无响应的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->