### PR TITLE
fix(build): 插件里的 .vscode 目录打死了 macOS 后端构建

### DIFF
--- a/plugin/neko_plugin_cli/core/build_rules.py
+++ b/plugin/neko_plugin_cli/core/build_rules.py
@@ -7,9 +7,19 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Built-in excludes are hard safety defaults. User rules extend them, but do
 # not replace them, so common cache/build artifacts never leak into packages.
+#
+# On macOS an editor directory is not merely noise. The desktop build stages
+# this payload under projectneko_server.app/Contents/MacOS/, and codesign's
+# default rules treat every directory there whose name contains a dot as a
+# nested bundle. It then fails to read one — there is no Contents/ inside — and
+# aborts the whole seal with "bundle format unrecognized, invalid, or
+# unsuitable", naming only the subcomponent. One stray .vscode/ in one plugin
+# therefore breaks the entire mac backend build.
 _DEFAULT_EXCLUDE_DIR_NAMES = {
     "__pycache__",
     ".github",
+    ".vscode",
+    ".idea",
     ".pytest_cache",
     ".mypy_cache",
     ".venv",

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -8,6 +8,7 @@ import sys
 
 import pytest
 
+from plugin.neko_plugin_cli.core.build_rules import _DEFAULT_EXCLUDE_DIR_NAMES
 from scripts.check_nuitka_dist import _check_plugin_stage, _check_plugin_tomls
 from scripts.prepare_nuitka_plugins import install_plugins, prepare_plugins
 
@@ -208,3 +209,78 @@ def test_prepare_helper_is_directly_executable_without_pythonpath(tmp_path: Path
 
     assert completed.returncode == 0, completed.stderr
     assert "stage plugins and generate launcher" in completed.stdout
+
+
+def test_prepare_drops_editor_directories_that_break_macos_codesign(tmp_path: Path) -> None:
+    """codesign reads any dotted directory under MacOS/ as a nested bundle.
+
+    A plugin that ships .vscode/ or .idea/ used to reach the staged payload
+    verbatim, and `codesign --deep` then aborted the whole backend seal with
+    "bundle format unrecognized, invalid, or unsuitable" — see the exclusion
+    list in plugin/neko_plugin_cli/core/build_rules.py.
+    """
+
+    project_root = tmp_path / "repo"
+    plugin_dir = project_root / "plugin" / "plugins" / "demo_plugin"
+    _write(project_root / "launcher.py", "print('launcher')\n")
+    _write(plugin_dir / "plugin.toml", '[plugin]\nid = "demo_plugin"\n')
+    _write(plugin_dir / "__init__.py")
+    _write(plugin_dir / "runtime.py")
+    _write(plugin_dir / ".vscode" / "settings.json", "{}\n")
+    _write(plugin_dir / ".vscode" / "tasks.json", "{}\n")
+    _write(plugin_dir / ".idea" / "workspace.xml", "<project/>\n")
+
+    result = prepare_plugins(
+        project_root=project_root,
+        plugins_root=Path("plugin/plugins"),
+        stage_dir=Path("build/nuitka-plugins"),
+        source_launcher=Path("launcher.py"),
+        generated_launcher=Path("build_nuitka_launcher.py"),
+    )
+
+    stage_plugin = result.stage_dir / "demo_plugin"
+    assert (stage_plugin / "runtime.py").is_file()
+    assert not (stage_plugin / ".vscode").exists()
+    assert not (stage_plugin / ".idea").exists()
+
+    # Nothing dotted may survive anywhere in the staged tree, whatever its depth.
+    assert not [
+        path
+        for path in result.stage_dir.rglob("*")
+        if path.is_dir() and "." in path.name
+    ]
+
+
+def test_no_bundled_plugin_ships_a_dotted_directory_besides_github() -> None:
+    """Guard the real tree, not just the staging helper.
+
+    build_rules only skips names it knows. A plugin adding some other dotted
+    directory would sail past it and kill the mac build again, so pin the set
+    of dotted directories that actually exist under plugin/plugins/.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    plugins_root = repo_root / "plugin" / "plugins"
+    listed = subprocess.run(
+        ["git", "ls-files", "-z", "--", str(plugins_root)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    offenders = sorted(
+        {
+            part
+            for entry in listed.stdout.split("\0")
+            if entry
+            for part in Path(entry).parts[:-1]
+            if "." in part
+        }
+        - set(_DEFAULT_EXCLUDE_DIR_NAMES)
+    )
+
+    assert not offenders, (
+        "dotted directories under plugin/plugins/ break `codesign --deep` on the "
+        f"macOS backend bundle; add them to _DEFAULT_EXCLUDE_DIR_NAMES: {offenders}"
+    )


### PR DESCRIPTION
## 现象

nightly 的 mac x64 / arm64 后端构建自 8-13 起**连续全红**，卡在重签名一步（[最近一次](https://github.com/Project-N-E-K-O/N.E.K.O/actions/workflows/build-desktop.yml)）：

```
dist/Xiao8/projectneko_server.app: replacing existing signature
dist/Xiao8/projectneko_server.app: bundle format unrecognized, invalid, or unsuitable
In subcomponent: .../Contents/MacOS/plugin/plugins/lifekit/.vscode
```

因此 8-06 之后就没有产出过新的 mac 产物。

## 原因

Nuitka `--mode=app` 把插件 payload 摆在 `Contents/MacOS/` 下，而 codesign 的默认规则把这个目录里**名字带点的目录一律当成嵌套 bundle**。`.vscode/` 里没有 `Contents/`，读不出来，于是整个封印失败——报错只给出 subcomponent，别的线索一概没有。一个插件里的一个编辑器目录，就足以让整台 mac 构建停摆。

`.vscode/` 是 #2811 随 lifekit 一起带进来的（`.vscode/settings.json`、`.vscode/tasks.json` 都是 tracked 文件）。`plugin/neko_plugin_cli/core/build_rules.py` 的内建排除清单里有 `.github` 却没有 `.vscode` / `.idea`，于是它原样落进了暂存 payload。

## 改动

把 `.vscode`、`.idea` 补进 `_DEFAULT_EXCLUDE_DIR_NAMES`，并把上面这段因果写进注释——否则下一个人只会觉得这就是「顺手清理编辑器垃圾」，看不出它是构建红线。

**没有**做通用的「删掉所有点目录」：numpy / Pillow 这类 wheel 用 `.dylibs` 存放随包动态库，一刀切会把运行时打断。

## 测试

两条回归测试，覆盖两个不同的失效面：

1. `test_prepare_drops_editor_directories_that_break_macos_codesign` —— 用临时插件树验证 `.vscode` / `.idea` 不进 payload，且暂存树里不留任何点目录；
2. `test_no_bundled_plugin_ships_a_dotted_directory_besides_github` —— 直接扫 `plugin/plugins/` 的真实文件，钉住允许出现的点目录集合。排除清单只认识它列过的名字，换个新名字照样能再把 mac 构建打死，所以护栏必须落在真实树上，而不只落在 staging 逻辑上。

## 验证

- 去掉修复：两条新测试都红；打上修复：该文件 9 条全绿。
- 对真实插件树跑 `prepare_nuitka_plugins.py prepare`：修复前暂存产物里确实有 `lifekit/.vscode`，修复后点目录为零，lifekit 其余内容照常落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 构建过程现在默认排除 `.vscode` 和 `.idea` 目录，避免这些开发工具配置文件被包含在构建路径中。
  - 优化点号目录的过滤规则，同时保留已明确配置的例外目录。

- **测试**
  - 增加了对默认排除目录及插件目录过滤行为的验证，提升构建结果的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->