### PR TITLE
fix(ci): 同步暂存过滤器镜像，修 main 上的红

### DIFF
--- a/scripts/check_no_nonascii_asset_names.py
+++ b/scripts/check_no_nonascii_asset_names.py
@@ -291,7 +291,16 @@ def _under_bundled_root(rel_posix: str) -> bool:
 # stops us scanning a file that ships (a hole), while missing something it drops
 # only leaves a false positive. Both fail the test; only the first is dangerous.
 _PLUGIN_SKIP_DIR_NAMES = frozenset(
-    {"__pycache__", ".github", ".pytest_cache", ".mypy_cache", ".venv", ".git"}
+    {
+        "__pycache__",
+        ".github",
+        ".vscode",
+        ".idea",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".venv",
+        ".git",
+    }
 )
 _PLUGIN_SKIP_ROOT_DIR_NAMES = frozenset({"dist", "build"})
 _PLUGIN_SKIP_FILE_NAMES = frozenset({".DS_Store"})


### PR DESCRIPTION
## 现状：main 是红的

#2870 与 #2871 在同一个窗口合并，撞上了 #2870 评审时就预告过的交互：

- #2871 往真规则 `_DEFAULT_EXCLUDE_DIR_NAMES` 里加了 `.vscode` / `.idea`；
- #2870 的镜像 `_PLUGIN_SKIP_DIR_NAMES` 当时**刻意不含**这两项——在那个时点真规则里没有它们，镜像多列一项就会从"误报"变成"漏报"（停止扫描一个真会进包的文件）。

两者一合，双向对拍立刻报：

```text
mirror and build rules disagree on .vscode/settings.json:
mirror keeps=True, staging keeps=False
```

方向是**安全**的那一侧（镜像多扫了不进包的文件 → 误报，不漏），但对拍是双向断言，所以 `Unit pytest` 在 main 上现在红着。

## 改动

镜像补上 `.vscode` / `.idea`，与 `plugin/neko_plugin_cli/core/build_rules.py` 对齐。一行集合。

## 说明

这正是当初把对拍从单向改成双向时讲好的代价：改真规则的人会看到测试**指名道姓**地说要同步哪一项，而不是让镜像悄悄漂移。本次它按预期生效了——只是两个 PR 挨着合，红出现在 main 而不是某个 PR 上。

验证：`pytest tests/unit/test_check_no_nonascii_asset_names.py` 32 条全绿；`python scripts/check_no_nonascii_asset_names.py` 退 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 更新插件构建检查规则，正确跳过 `.vscode` 和 `.idea` 目录。
  * 保持其他插件资源过滤逻辑不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->