### PR TITLE
修复插件注册表查询超时导致用户插件子开关误关闭的问题，并增加生命周期竞态保护

### DIFF
--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -72,6 +72,10 @@ class Modules:
     _plugin_server_loop: Any = None
     plugin_lifecycle_started: bool = False
     _plugin_lifecycle_lock: Optional[asyncio.Lock] = None
+    # Monotonic user-plugin intent generation.  Enable/disable work runs in
+    # background tasks, so an older readiness check must not overwrite a newer
+    # toggle (or restart the lifecycle after the master switch was turned off).
+    user_plugin_lifecycle_seq: int = 0
     # Task tracking
     task_registry: Dict[str, Dict[str, Any]] = {}
     executor_reset_needed: bool = False

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -535,6 +535,7 @@ async def get_agent_state():
 _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS = 4
 _USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S = 0.75
 _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S = 8.0
+_USER_PLUGIN_REGISTRY_CHECK_MAX_DURATION_S = 12.0
 _USER_PLUGIN_EMPTY_CONFIRMATIONS = 3
 
 
@@ -550,75 +551,89 @@ async def _check_user_plugin_registry_readiness() -> Dict[str, Any]:
     """
     empty_responses = 0
     last_error = "no valid response"
+    timeout = httpx.Timeout(
+        _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S,
+        connect=min(2.0, _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S),
+    )
 
-    for attempt in range(_USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS):
-        await asyncio.sleep(_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S)
-        try:
-            timeout = httpx.Timeout(
-                _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S,
-                connect=min(2.0, _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S),
-            )
-            async with httpx.AsyncClient(timeout=timeout, proxy=None, trust_env=False) as client:
-                response = await client.get(f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}/plugins")
+    try:
+        async with httpx.AsyncClient(timeout=timeout, proxy=None, trust_env=False) as client:
+            async with asyncio.timeout(_USER_PLUGIN_REGISTRY_CHECK_MAX_DURATION_S):
+                for attempt in range(_USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS):
+                    await asyncio.sleep(_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S)
+                    try:
+                        response = await client.get(
+                            f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}/plugins"
+                        )
+                    except Exception as exc:
+                        last_error = f"{type(exc).__name__}: {exc}"
+                        logger.warning(
+                            "[Agent] UserPlugin registry check %d/%d failed: %s",
+                            attempt + 1,
+                            _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                            last_error,
+                        )
+                        continue
 
-            if response.status_code != 200:
-                last_error = f"HTTP {response.status_code}"
-                logger.warning(
-                    "[Agent] UserPlugin registry check %d/%d returned %s",
-                    attempt + 1,
-                    _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
-                    last_error,
-                )
-                continue
+                    if response.status_code != 200:
+                        last_error = f"HTTP {response.status_code}"
+                        logger.warning(
+                            "[Agent] UserPlugin registry check %d/%d returned %s",
+                            attempt + 1,
+                            _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                            last_error,
+                        )
+                        continue
 
-            try:
-                payload = response.json()
-            except Exception as exc:
-                last_error = f"invalid JSON ({type(exc).__name__})"
-                logger.warning(
-                    "[Agent] UserPlugin registry check %d/%d returned %s",
-                    attempt + 1,
-                    _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
-                    last_error,
-                )
-                continue
+                    try:
+                        payload = response.json()
+                    except Exception as exc:
+                        last_error = f"invalid JSON ({type(exc).__name__})"
+                        logger.warning(
+                            "[Agent] UserPlugin registry check %d/%d returned %s",
+                            attempt + 1,
+                            _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                            last_error,
+                        )
+                        continue
 
-            plugins = payload.get("plugins") if isinstance(payload, dict) else None
-            if not isinstance(plugins, list):
-                last_error = "invalid plugins payload"
-                logger.warning(
-                    "[Agent] UserPlugin registry check %d/%d returned %s",
-                    attempt + 1,
-                    _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
-                    last_error,
-                )
-                continue
+                    plugins = payload.get("plugins") if isinstance(payload, dict) else None
+                    if not isinstance(plugins, list):
+                        last_error = "invalid plugins payload"
+                        logger.warning(
+                            "[Agent] UserPlugin registry check %d/%d returned %s",
+                            attempt + 1,
+                            _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                            last_error,
+                        )
+                        continue
 
-            if plugins:
-                return {
-                    "status": "ready",
-                    "plugin_count": len(plugins),
-                    "empty_responses": empty_responses,
-                    "last_error": "",
-                }
+                    if plugins:
+                        return {
+                            "status": "ready",
+                            "plugin_count": len(plugins),
+                            "empty_responses": empty_responses,
+                            "last_error": "",
+                        }
 
-            empty_responses += 1
-            last_error = "empty plugin list"
-            if empty_responses >= _USER_PLUGIN_EMPTY_CONFIRMATIONS:
-                return {
-                    "status": "empty",
-                    "plugin_count": 0,
-                    "empty_responses": empty_responses,
-                    "last_error": last_error,
-                }
-        except Exception as exc:
-            last_error = f"{type(exc).__name__}: {exc}"
-            logger.warning(
-                "[Agent] UserPlugin registry check %d/%d failed: %s",
-                attempt + 1,
-                _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
-                last_error,
-            )
+                    empty_responses += 1
+                    last_error = "empty plugin list"
+                    if empty_responses >= _USER_PLUGIN_EMPTY_CONFIRMATIONS:
+                        return {
+                            "status": "empty",
+                            "plugin_count": 0,
+                            "empty_responses": empty_responses,
+                            "last_error": last_error,
+                        }
+    except TimeoutError:
+        last_error = (
+            "overall timeout "
+            f"({_USER_PLUGIN_REGISTRY_CHECK_MAX_DURATION_S:g}s)"
+        )
+        logger.warning("[Agent] UserPlugin registry check reached %s", last_error)
+    except Exception as exc:
+        last_error = f"{type(exc).__name__}: {exc}"
+        logger.warning("[Agent] UserPlugin registry client failed: %s", last_error)
 
     return {
         "status": "unavailable",
@@ -796,10 +811,10 @@ async def set_agent_flags(payload: Dict[str, Any]):
                         _set_capability("user_plugin", True, "")
                         Modules.notification = json.dumps({"code": "AGENT_PLUGIN_SERVER_ERROR"})
                         logger.warning(
-                            "[Agent] UserPlugin registry unavailable after %d checks; "
+                            "[Agent] UserPlugin registry unavailable within %.1fs; "
                             "keeping user_plugin_enabled ON for recovery "
                             "(empty_responses=%d, last_error=%s)",
-                            _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                            _USER_PLUGIN_REGISTRY_CHECK_MAX_DURATION_S,
                             registry.get("empty_responses", 0),
                             registry.get("last_error", "unknown"),
                         )

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -771,12 +771,32 @@ async def set_agent_flags(payload: Dict[str, Any]):
 
             async def _bg_plugin_enable():
                 _ln = lanlan_name
+
                 def _owns_generation() -> bool:
                     return user_plugin_lifecycle_seq == Modules.user_plugin_lifecycle_seq
 
+                def _may_start_generation() -> bool:
+                    return (
+                        _owns_generation()
+                        and Modules.analyzer_enabled
+                        and Modules.agent_flags.get("user_plugin_enabled", False)
+                    )
+
                 try:
-                    started = await _ensure_plugin_lifecycle_started(should_start=_owns_generation)
+                    if not Modules.analyzer_enabled:
+                        Modules.notification = ""
+                        _set_capability("user_plugin", True, "")
+                        logger.info(
+                            "[Agent] UserPlugin enable deferred until the master switch is ON"
+                        )
+                        return
+
+                    started = await _ensure_plugin_lifecycle_started(
+                        should_start=_may_start_generation
+                    )
                     if not _owns_generation():
+                        return
+                    if not Modules.analyzer_enabled:
                         return
                     if not started:
                         Modules.agent_flags["user_plugin_enabled"] = False
@@ -981,6 +1001,15 @@ async def agent_command(payload: Dict[str, Any]):
                 first_reason = (gate.get("reasons") or ["AGENT_ENDPOINT_NOT_CONFIGURED"])[0]
                 _set_capability("computer_use", False, first_reason)
                 _set_capability("browser_use", False, first_reason)
+            if Modules.agent_flags.get("user_plugin_enabled"):
+                # Master OFF preserves sub-feature intent but stops the plugin
+                # lifecycle. Replaying the existing ON intent schedules a new,
+                # generation-owned startup for the re-enabled master.
+                await set_agent_flags({
+                    "user_plugin_enabled": True,
+                    "lanlan_name": lanlan_name,
+                    "_persist_intent": False,
+                })
         else:
             Modules.analyzer_enabled = False
             Modules.analyzer_profile = {}
@@ -1002,7 +1031,9 @@ async def agent_command(payload: Dict[str, Any]):
             _set_capability("user_plugin", True, "")
             _set_capability("openclaw", False, "")
             await admin_control({"action": "end_all"})
-            await _ensure_plugin_lifecycle_stopped()
+            await _ensure_plugin_lifecycle_stopped(
+                should_stop=lambda: not Modules.analyzer_enabled
+            )
         if persist_intent:
             try:
                 from app.agent_runtime_intent import set_intent

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -532,6 +532,102 @@ async def get_agent_state():
     return {"success": True, "snapshot": snapshot}
 
 
+_USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS = 4
+_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S = 0.75
+_USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S = 8.0
+_USER_PLUGIN_EMPTY_CONFIRMATIONS = 3
+
+
+async def _check_user_plugin_registry_readiness() -> Dict[str, Any]:
+    """Classify the embedded plugin registry without conflating failures with emptiness.
+
+    ``GET /plugins`` is deliberately richer than a health endpoint: it may wait
+    for runtime-state locks and render metadata/i18n for every registered
+    plugin.  A short client timeout therefore means "registry unavailable",
+    not "there are no plugins".  Only repeated, structurally valid HTTP 200
+    responses containing an empty plugin list are authoritative enough to
+    return ``empty``.
+    """
+    empty_responses = 0
+    last_error = "no valid response"
+
+    for attempt in range(_USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS):
+        await asyncio.sleep(_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S)
+        try:
+            timeout = httpx.Timeout(
+                _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S,
+                connect=min(2.0, _USER_PLUGIN_REGISTRY_CHECK_TIMEOUT_S),
+            )
+            async with httpx.AsyncClient(timeout=timeout, proxy=None, trust_env=False) as client:
+                response = await client.get(f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}/plugins")
+
+            if response.status_code != 200:
+                last_error = f"HTTP {response.status_code}"
+                logger.warning(
+                    "[Agent] UserPlugin registry check %d/%d returned %s",
+                    attempt + 1,
+                    _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                    last_error,
+                )
+                continue
+
+            try:
+                payload = response.json()
+            except Exception as exc:
+                last_error = f"invalid JSON ({type(exc).__name__})"
+                logger.warning(
+                    "[Agent] UserPlugin registry check %d/%d returned %s",
+                    attempt + 1,
+                    _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                    last_error,
+                )
+                continue
+
+            plugins = payload.get("plugins") if isinstance(payload, dict) else None
+            if not isinstance(plugins, list):
+                last_error = "invalid plugins payload"
+                logger.warning(
+                    "[Agent] UserPlugin registry check %d/%d returned %s",
+                    attempt + 1,
+                    _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                    last_error,
+                )
+                continue
+
+            if plugins:
+                return {
+                    "status": "ready",
+                    "plugin_count": len(plugins),
+                    "empty_responses": empty_responses,
+                    "last_error": "",
+                }
+
+            empty_responses += 1
+            last_error = "empty plugin list"
+            if empty_responses >= _USER_PLUGIN_EMPTY_CONFIRMATIONS:
+                return {
+                    "status": "empty",
+                    "plugin_count": 0,
+                    "empty_responses": empty_responses,
+                    "last_error": last_error,
+                }
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "[Agent] UserPlugin registry check %d/%d failed: %s",
+                attempt + 1,
+                _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                last_error,
+            )
+
+    return {
+        "status": "unavailable",
+        "plugin_count": 0,
+        "empty_responses": empty_responses,
+        "last_error": last_error,
+    }
+
+
 @app.post("/agent/flags")
 async def set_agent_flags(payload: Dict[str, Any]):
     lanlan_name = (payload or {}).get("lanlan_name")
@@ -554,6 +650,10 @@ async def set_agent_flags(payload: Dict[str, Any]):
     if isinstance(bf, bool):
         Modules.browser_use_lifecycle_seq += 1
         browser_use_lifecycle_seq = Modules.browser_use_lifecycle_seq
+    user_plugin_lifecycle_seq = Modules.user_plugin_lifecycle_seq
+    if isinstance(uf, bool):
+        Modules.user_plugin_lifecycle_seq += 1
+        user_plugin_lifecycle_seq = Modules.user_plugin_lifecycle_seq
     of = (payload or {}).get("openfang_enabled")
     # Agent LLM gate fail (endpoint/key not configured) blocks **only** the
     # four LLM-dependent sub flags. ``user_plugin_enabled`` runs entirely on
@@ -656,45 +756,62 @@ async def set_agent_flags(payload: Dict[str, Any]):
 
             async def _bg_plugin_enable():
                 _ln = lanlan_name
+                def _owns_generation() -> bool:
+                    return user_plugin_lifecycle_seq == Modules.user_plugin_lifecycle_seq
+
                 try:
-                    started = await _ensure_plugin_lifecycle_started()
+                    started = await _ensure_plugin_lifecycle_started(should_start=_owns_generation)
+                    if not _owns_generation():
+                        return
                     if not started:
                         Modules.agent_flags["user_plugin_enabled"] = False
                         Modules.notification = json.dumps({"code": "AGENT_PLUGIN_SERVER_ERROR"})
                         logger.warning("[Agent] Cannot enable UserPlugin: lifecycle startup failed")
-                        _bump_state_revision()
-                        await _emit_agent_status_update(lanlan_name=_ln)
                         return
 
-                    plugins = []
-                    for _attempt in range(8):
-                        await asyncio.sleep(0.5)
-                        try:
-                            async with httpx.AsyncClient(timeout=1.0, proxy=None, trust_env=False) as client:
-                                r = await client.get(f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}/plugins")
-                                if r.status_code == 200:
-                                    data = r.json()
-                                    plugins = data.get("plugins", []) if isinstance(data, dict) else []
-                                    if plugins:
-                                        break
-                        except Exception:
-                            pass
+                    registry = await _check_user_plugin_registry_readiness()
+                    if not _owns_generation():
+                        return
 
-                    if not plugins:
+                    registry_status = registry.get("status")
+                    if registry_status == "empty":
                         Modules.agent_flags["user_plugin_enabled"] = False
                         Modules.notification = json.dumps({"code": "AGENT_NO_PLUGINS_FOUND"})
-                        logger.warning("[Agent] Cannot enable UserPlugin: no plugins found after lifecycle start")
-                        await _ensure_plugin_lifecycle_stopped()
-                    else:
+                        logger.warning(
+                            "[Agent] Cannot enable UserPlugin: registry confirmed empty "
+                            "(%d valid empty responses)",
+                            registry.get("empty_responses", 0),
+                        )
+                        await _ensure_plugin_lifecycle_stopped(should_stop=_owns_generation)
+                    elif registry_status == "ready":
                         _set_capability("user_plugin", True, "")
-                        logger.info("[Agent] UserPlugin lifecycle ready (%d plugins)", len(plugins))
+                        logger.info(
+                            "[Agent] UserPlugin lifecycle ready (%d plugins)",
+                            registry.get("plugin_count", 0),
+                        )
+                    else:
+                        # A slow or temporarily unreachable registry is not an
+                        # authoritative empty registry.  Preserve the user's ON
+                        # intent so the provider can recover on a later request.
+                        _set_capability("user_plugin", True, "")
+                        Modules.notification = json.dumps({"code": "AGENT_PLUGIN_SERVER_ERROR"})
+                        logger.warning(
+                            "[Agent] UserPlugin registry unavailable after %d checks; "
+                            "keeping user_plugin_enabled ON for recovery "
+                            "(empty_responses=%d, last_error=%s)",
+                            _USER_PLUGIN_REGISTRY_CHECK_ATTEMPTS,
+                            registry.get("empty_responses", 0),
+                            registry.get("last_error", "unknown"),
+                        )
                 except Exception as exc:
-                    Modules.agent_flags["user_plugin_enabled"] = False
-                    Modules.notification = json.dumps({"code": "AGENT_PLUGIN_SERVER_ERROR"})
-                    logger.error("[Agent] Background plugin enable failed: %s", exc)
+                    if _owns_generation():
+                        Modules.agent_flags["user_plugin_enabled"] = False
+                        Modules.notification = json.dumps({"code": "AGENT_PLUGIN_SERVER_ERROR"})
+                        logger.error("[Agent] Background plugin enable failed: %s", exc)
                 finally:
-                    _bump_state_revision()
-                    await _emit_agent_status_update(lanlan_name=_ln)
+                    if _owns_generation():
+                        _bump_state_revision()
+                        await _emit_agent_status_update(lanlan_name=_ln)
 
             _bg = asyncio.create_task(_bg_plugin_enable())
             Modules._persistent_tasks.add(_bg)
@@ -704,8 +821,16 @@ async def set_agent_flags(payload: Dict[str, Any]):
             _set_capability("user_plugin", True, "")
 
             async def _bg_plugin_disable():
+                def _owns_disabled_generation() -> bool:
+                    return (
+                        user_plugin_lifecycle_seq == Modules.user_plugin_lifecycle_seq
+                        and not Modules.agent_flags.get("user_plugin_enabled", False)
+                    )
+
+                if not _owns_disabled_generation():
+                    return
                 try:
-                    await _ensure_plugin_lifecycle_stopped()
+                    await _ensure_plugin_lifecycle_stopped(should_stop=_owns_disabled_generation)
                 except Exception as exc:
                     logger.warning("[Agent] Background plugin disable error: %s", exc)
 
@@ -845,6 +970,9 @@ async def agent_command(payload: Dict[str, Any]):
             Modules.analyzer_enabled = False
             Modules.analyzer_profile = {}
             _cancel_openclaw_enable_probe()
+            # Invalidate an in-flight user-plugin enable/readiness task before
+            # stopping its lifecycle.  The sub-flag intent itself remains ON.
+            Modules.user_plugin_lifecycle_seq += 1
             # NOTE: sub flags are NOT reset here. The master switch is a runtime
             # gate, not a clear-all command — sub flags carry the user's intent
             # for each component and must survive a master OFF/ON cycle (so the

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -249,7 +249,12 @@ async def _stop_embedded_user_plugin_server() -> None:
 async def _ensure_plugin_lifecycle_started(
     should_start: Callable[[], bool] | None = None,
 ) -> bool:
-    """Start the plugin lifecycle (load & run plugins). Returns True on success."""
+    """Start the plugin lifecycle (load and run plugins).
+
+    Returns ``False`` both when startup fails and when ``should_start`` says
+    that the caller no longer owns the current lifecycle generation. Callers
+    must re-check ownership before treating ``False`` as a startup failure.
+    """
     if should_start is not None and not should_start():
         return False
     if _shared.Modules.plugin_lifecycle_started:

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -28,7 +28,7 @@ import sys
 import time
 import asyncio
 import threading
-from typing import Dict
+from typing import Callable, Dict
 
 import httpx
 
@@ -246,13 +246,19 @@ async def _stop_embedded_user_plugin_server() -> None:
             server.force_exit = True
 
 
-async def _ensure_plugin_lifecycle_started() -> bool:
+async def _ensure_plugin_lifecycle_started(
+    should_start: Callable[[], bool] | None = None,
+) -> bool:
     """Start the plugin lifecycle (load & run plugins). Returns True on success."""
+    if should_start is not None and not should_start():
+        return False
     if _shared.Modules.plugin_lifecycle_started:
         return True
     if _shared.Modules._plugin_lifecycle_lock is None:
         _shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
     async with _shared.Modules._plugin_lifecycle_lock:
+        if should_start is not None and not should_start():
+            return False
         if _shared.Modules.plugin_lifecycle_started:
             return True
         try:
@@ -266,13 +272,19 @@ async def _ensure_plugin_lifecycle_started() -> bool:
             return False
 
 
-async def _ensure_plugin_lifecycle_stopped() -> None:
+async def _ensure_plugin_lifecycle_stopped(
+    should_stop: Callable[[], bool] | None = None,
+) -> None:
     """Stop the plugin lifecycle (stop plugin processes, cleanup)."""
+    if should_stop is not None and not should_stop():
+        return
     if not _shared.Modules.plugin_lifecycle_started:
         return
     if _shared.Modules._plugin_lifecycle_lock is None:
         _shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
     async with _shared.Modules._plugin_lifecycle_lock:
+        if should_stop is not None and not should_stop():
+            return
         if not _shared.Modules.plugin_lifecycle_started:
             return
         try:

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -257,8 +257,6 @@ async def _ensure_plugin_lifecycle_started(
     """
     if should_start is not None and not should_start():
         return False
-    if _shared.Modules.plugin_lifecycle_started:
-        return True
     if _shared.Modules._plugin_lifecycle_lock is None:
         _shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
     async with _shared.Modules._plugin_lifecycle_lock:
@@ -282,8 +280,6 @@ async def _ensure_plugin_lifecycle_stopped(
 ) -> None:
     """Stop the plugin lifecycle (stop plugin processes, cleanup)."""
     if should_stop is not None and not should_stop():
-        return
-    if not _shared.Modules.plugin_lifecycle_started:
         return
     if _shared.Modules._plugin_lifecycle_lock is None:
         _shared.Modules._plugin_lifecycle_lock = asyncio.Lock()

--- a/plugin/server/application/plugins/query_service.py
+++ b/plugin/server/application/plugins/query_service.py
@@ -474,7 +474,7 @@ def _build_plugin_list_sync(locale: str | None = None) -> list[dict[str, object]
             type(exc).__name__,
             str(exc),
         )
-        return result
+        raise _PluginRegistryUnavailableError from exc
 
     running_plugin_ids = set()
     for plugin_id, host_obj in hosts_snapshot.items():

--- a/plugin/server/application/plugins/query_service.py
+++ b/plugin/server/application/plugins/query_service.py
@@ -25,6 +25,10 @@ logger = get_logger("server.application.plugins.query")
 _PLUGIN_CARD_I18N_KEYS = {"plugin.name", "plugin.description", "plugin.short_description"}
 
 
+class _PluginRegistryUnavailableError(RuntimeError):
+    """The registry snapshot could not be read within its lock timeout."""
+
+
 def _normalize_mapping(
     raw: Mapping[object, object],
     *,
@@ -449,9 +453,21 @@ def _build_plugin_list_sync(locale: str | None = None) -> list[dict[str, object]
     try:
         plugins_snapshot = state.get_plugins_snapshot_cached(timeout=2.0)
         if not plugins_snapshot:
-            return result
+            # The cached API intentionally collapses a lock timeout into an
+            # empty mapping. Confirm emptiness under the public read lock so
+            # callers can distinguish a genuinely empty registry from lock
+            # contention instead of auto-disabling user plugins.
+            try:
+                with state.acquire_plugins_read_lock(timeout=2.0):
+                    plugins_snapshot = dict(state.plugins)
+            except TimeoutError as exc:
+                raise _PluginRegistryUnavailableError from exc
+            if not plugins_snapshot:
+                return result
         hosts_snapshot = state.get_plugin_hosts_snapshot_cached(timeout=2.0)
         handlers_snapshot = state.get_event_handlers_snapshot_cached(timeout=2.0)
+    except _PluginRegistryUnavailableError:
+        raise
     except IO_RUNTIME_ERRORS as exc:
         logger.warning(
             "failed to get state snapshots for plugin list: err_type={}, err={}",
@@ -606,6 +622,12 @@ class PluginQueryService:
                 "plugins": normalized_plugins,
                 "message": "" if normalized_plugins else "no plugins registered",
             }
+        except _PluginRegistryUnavailableError as exc:
+            raise ServerDomainError(
+                code="PLUGIN_REGISTRY_UNAVAILABLE",
+                message="Plugin registry is temporarily unavailable",
+                status_code=503,
+            ) from exc
         except ServerDomainError:
             raise
         except IO_RUNTIME_ERRORS as exc:

--- a/plugin/tests/unit/server/test_plugin_query_status.py
+++ b/plugin/tests/unit/server/test_plugin_query_status.py
@@ -44,6 +44,39 @@ async def test_list_plugins_reports_registry_lock_timeout_as_unavailable(
     assert exc_info.value.status_code == 503
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_snapshot", ["hosts", "handlers"])
+async def test_list_plugins_reports_related_snapshot_failure_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_snapshot: str,
+) -> None:
+    monkeypatch.setattr(
+        query_module.state,
+        "get_plugins_snapshot_cached",
+        lambda timeout=2.0: {"sample": {"id": "sample", "name": "Sample"}},
+    )
+
+    def _snapshot_failure(timeout=2.0):
+        raise RuntimeError(f"{failing_snapshot} snapshot busy")
+
+    monkeypatch.setattr(
+        query_module.state,
+        "get_plugin_hosts_snapshot_cached",
+        _snapshot_failure if failing_snapshot == "hosts" else lambda timeout=2.0: {},
+    )
+    monkeypatch.setattr(
+        query_module.state,
+        "get_event_handlers_snapshot_cached",
+        _snapshot_failure if failing_snapshot == "handlers" else lambda timeout=2.0: {},
+    )
+
+    with pytest.raises(ServerDomainError) as exc_info:
+        await query_module.PluginQueryService().list_plugins()
+
+    assert exc_info.value.code == "PLUGIN_REGISTRY_UNAVAILABLE"
+    assert exc_info.value.status_code == 503
+
+
 def test_build_plugin_list_reports_source_missing_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         query_module.state,

--- a/plugin/tests/unit/server/test_plugin_query_status.py
+++ b/plugin/tests/unit/server/test_plugin_query_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,10 +9,39 @@ import pytest
 
 from plugin.server.application.plugins import query_service as query_module
 from plugin.server.application.plugins import router_query_service as router_module
+from plugin.server.domain.errors import ServerDomainError
 from plugin.sdk.shared.i18n import PluginI18n
 
 
 pytestmark = pytest.mark.plugin_unit
+
+
+@pytest.mark.asyncio
+async def test_list_plugins_reports_registry_lock_timeout_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        query_module.state,
+        "get_plugins_snapshot_cached",
+        lambda timeout=2.0: {},
+    )
+
+    @contextmanager
+    def _registry_lock_timeout(timeout=2.0):
+        raise TimeoutError("plugins registry busy")
+        yield
+
+    monkeypatch.setattr(
+        query_module.state,
+        "acquire_plugins_read_lock",
+        _registry_lock_timeout,
+    )
+
+    with pytest.raises(ServerDomainError) as exc_info:
+        await query_module.PluginQueryService().list_plugins()
+
+    assert exc_info.value.code == "PLUGIN_REGISTRY_UNAVAILABLE"
+    assert exc_info.value.status_code == 503
 
 
 def test_build_plugin_list_reports_source_missing_status(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -1169,6 +1169,100 @@ async def test_user_plugin_enable_is_deferred_while_master_is_off(
     assert starts == []
 
 
+@pytest.mark.asyncio
+async def test_lifecycle_start_waits_for_in_progress_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.agent_server import plugin_host
+    from plugin.server import lifecycle
+
+    shutdown_entered = asyncio.Event()
+    release_shutdown = asyncio.Event()
+    startup_calls: list[bool] = []
+    backup_started = plugin_host._shared.Modules.plugin_lifecycle_started
+    backup_lock = plugin_host._shared.Modules._plugin_lifecycle_lock
+
+    async def _delayed_shutdown():
+        shutdown_entered.set()
+        await release_shutdown.wait()
+
+    async def _record_startup():
+        startup_calls.append(True)
+
+    monkeypatch.setattr(lifecycle, "shutdown", _delayed_shutdown)
+    monkeypatch.setattr(lifecycle, "startup", _record_startup)
+    plugin_host._shared.Modules.plugin_lifecycle_started = True
+    plugin_host._shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
+
+    try:
+        stopping = asyncio.create_task(
+            plugin_host._ensure_plugin_lifecycle_stopped()
+        )
+        await shutdown_entered.wait()
+
+        starting = asyncio.create_task(
+            plugin_host._ensure_plugin_lifecycle_started()
+        )
+        await asyncio.sleep(0)
+        assert startup_calls == []
+
+        release_shutdown.set()
+        await asyncio.gather(stopping, starting)
+
+        assert startup_calls == [True]
+        assert plugin_host._shared.Modules.plugin_lifecycle_started is True
+    finally:
+        plugin_host._shared.Modules.plugin_lifecycle_started = backup_started
+        plugin_host._shared.Modules._plugin_lifecycle_lock = backup_lock
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_stop_waits_for_in_progress_startup(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.agent_server import plugin_host
+    from plugin.server import lifecycle
+
+    startup_entered = asyncio.Event()
+    release_startup = asyncio.Event()
+    shutdown_calls: list[bool] = []
+    backup_started = plugin_host._shared.Modules.plugin_lifecycle_started
+    backup_lock = plugin_host._shared.Modules._plugin_lifecycle_lock
+
+    async def _delayed_startup():
+        startup_entered.set()
+        await release_startup.wait()
+
+    async def _record_shutdown():
+        shutdown_calls.append(True)
+
+    monkeypatch.setattr(lifecycle, "startup", _delayed_startup)
+    monkeypatch.setattr(lifecycle, "shutdown", _record_shutdown)
+    plugin_host._shared.Modules.plugin_lifecycle_started = False
+    plugin_host._shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
+
+    try:
+        starting = asyncio.create_task(
+            plugin_host._ensure_plugin_lifecycle_started()
+        )
+        await startup_entered.wait()
+
+        stopping = asyncio.create_task(
+            plugin_host._ensure_plugin_lifecycle_stopped()
+        )
+        await asyncio.sleep(0)
+        assert shutdown_calls == []
+
+        release_startup.set()
+        await asyncio.gather(starting, stopping)
+
+        assert shutdown_calls == [True]
+        assert plugin_host._shared.Modules.plugin_lifecycle_started is False
+    finally:
+        plugin_host._shared.Modules.plugin_lifecycle_started = backup_started
+        plugin_host._shared.Modules._plugin_lifecycle_lock = backup_lock
+
+
 # ---------------------------------------------------------------------------
 # 4. Intent writes on explicit toggles
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -1193,6 +1193,8 @@ async def test_lifecycle_start_waits_for_in_progress_shutdown(
     monkeypatch.setattr(lifecycle, "startup", _record_startup)
     plugin_host._shared.Modules.plugin_lifecycle_started = True
     plugin_host._shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
+    stopping: asyncio.Task | None = None
+    starting: asyncio.Task | None = None
 
     try:
         stopping = asyncio.create_task(
@@ -1212,6 +1214,13 @@ async def test_lifecycle_start_waits_for_in_progress_shutdown(
         assert startup_calls == [True]
         assert plugin_host._shared.Modules.plugin_lifecycle_started is True
     finally:
+        release_shutdown.set()
+        pending = [
+            task for task in (stopping, starting)
+            if task is not None and not task.done()
+        ]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         plugin_host._shared.Modules.plugin_lifecycle_started = backup_started
         plugin_host._shared.Modules._plugin_lifecycle_lock = backup_lock
 
@@ -1240,6 +1249,8 @@ async def test_lifecycle_stop_waits_for_in_progress_startup(
     monkeypatch.setattr(lifecycle, "shutdown", _record_shutdown)
     plugin_host._shared.Modules.plugin_lifecycle_started = False
     plugin_host._shared.Modules._plugin_lifecycle_lock = asyncio.Lock()
+    starting: asyncio.Task | None = None
+    stopping: asyncio.Task | None = None
 
     try:
         starting = asyncio.create_task(
@@ -1259,6 +1270,13 @@ async def test_lifecycle_stop_waits_for_in_progress_startup(
         assert shutdown_calls == [True]
         assert plugin_host._shared.Modules.plugin_lifecycle_started is False
     finally:
+        release_startup.set()
+        pending = [
+            task for task in (starting, stopping)
+            if task is not None and not task.done()
+        ]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         plugin_host._shared.Modules.plugin_lifecycle_started = backup_started
         plugin_host._shared.Modules._plugin_lifecycle_lock = backup_lock
 

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -14,6 +14,8 @@ Scope:
    ``_persist_intent=False`` (restore replay) does not re-write intent
 6. Restore: ``_maybe_restore_agent_intent`` once-flag + escape hatch +
    permanent error short-circuit
+7. User-plugin readiness: transient registry failures preserve the ON intent;
+   only confirmed empty registries auto-disable the sub-switch
 """
 
 from __future__ import annotations
@@ -530,6 +532,7 @@ def agent_state_isolation(monkeypatch: pytest.MonkeyPatch):
     backup_analyzer_enabled = srv.Modules.analyzer_enabled
     backup_analyzer_profile = dict(srv.Modules.analyzer_profile)
     backup_agent_flags = dict(srv.Modules.agent_flags)
+    backup_user_plugin_lifecycle_seq = srv.Modules.user_plugin_lifecycle_seq
     backup_capability = {
         k: dict(v) for k, v in srv.Modules.capability_cache.items()
     }
@@ -546,9 +549,18 @@ def agent_state_isolation(monkeypatch: pytest.MonkeyPatch):
         # False and create a race against the test's assertions.
         return True
 
+    async def _user_plugin_registry_ready(*args, **kwargs):
+        return {
+            "status": "ready",
+            "plugin_count": 1,
+            "empty_responses": 0,
+            "last_error": "",
+        }
+
     monkeypatch.setattr(srv, "_emit_agent_status_update", _noop_async)
     monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _noop_async)
     monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _plugin_lifecycle_started_ok)
+    monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _user_plugin_registry_ready)
     monkeypatch.setattr(srv, "admin_control", _noop_admin)
     monkeypatch.setattr(srv, "_cancel_openclaw_enable_probe", lambda: None)
     monkeypatch.setattr(srv, "_try_refresh_computer_use_adapter", lambda force=False: False)
@@ -560,6 +572,7 @@ def agent_state_isolation(monkeypatch: pytest.MonkeyPatch):
     srv.Modules.analyzer_enabled = backup_analyzer_enabled
     srv.Modules.analyzer_profile = backup_analyzer_profile
     srv.Modules.agent_flags = backup_agent_flags
+    srv.Modules.user_plugin_lifecycle_seq = backup_user_plugin_lifecycle_seq
     srv.Modules.capability_cache = backup_capability
 
 
@@ -755,6 +768,257 @@ async def test_gate_fail_preserves_user_plugin_enabled(
     # user_plugin was let through (in-memory flag set to True by handler,
     # background _bg_plugin_enable runs but we don't care about its outcome here).
     assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+
+
+class _UserPluginRegistryResponse:
+    def __init__(self, status_code: int, payload: object):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _UserPluginRegistryClient:
+    outcomes: list[object] = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url: str):
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+@pytest.mark.asyncio
+async def test_user_plugin_registry_check_does_not_treat_timeouts_as_empty(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.agent_server import api_routes as srv
+
+    timeout_error = srv.httpx.ReadTimeout("plugin registry busy")
+    _UserPluginRegistryClient.outcomes = [
+        _UserPluginRegistryResponse(200, {"plugins": []}),
+        timeout_error,
+        srv.httpx.ReadTimeout("plugin registry busy"),
+        srv.httpx.ReadTimeout("plugin registry busy"),
+    ]
+    monkeypatch.setattr(srv.httpx, "AsyncClient", _UserPluginRegistryClient)
+    monkeypatch.setattr(srv, "_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S", 0)
+
+    result = await srv._check_user_plugin_registry_readiness()
+
+    assert result["status"] == "unavailable"
+    assert result["empty_responses"] == 1
+
+
+@pytest.mark.asyncio
+async def test_user_plugin_registry_check_requires_repeated_valid_empty_responses(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.agent_server import api_routes as srv
+
+    _UserPluginRegistryClient.outcomes = [
+        _UserPluginRegistryResponse(200, {"plugins": []})
+        for _ in range(srv._USER_PLUGIN_EMPTY_CONFIRMATIONS)
+    ]
+    monkeypatch.setattr(srv.httpx, "AsyncClient", _UserPluginRegistryClient)
+    monkeypatch.setattr(srv, "_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S", 0)
+
+    result = await srv._check_user_plugin_registry_readiness()
+
+    assert result["status"] == "empty"
+    assert result["empty_responses"] == srv._USER_PLUGIN_EMPTY_CONFIRMATIONS
+
+
+async def _await_new_agent_tasks(srv, before: set[asyncio.Task]) -> None:
+    tasks = set(srv.Modules._persistent_tasks) - before
+    assert tasks
+    await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_user_plugin_registry_unavailable_keeps_switch_enabled(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+
+    async def _registry_unavailable():
+        return {
+            "status": "unavailable",
+            "plugin_count": 0,
+            "empty_responses": 0,
+            "last_error": "ReadTimeout",
+        }
+
+    monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _registry_unavailable)
+    srv.Modules.agent_flags["user_plugin_enabled"] = False
+    before = set(srv.Modules._persistent_tasks)
+
+    await srv.set_agent_flags({
+        "user_plugin_enabled": True,
+        "_persist_intent": False,
+    })
+    await _await_new_agent_tasks(srv, before)
+
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert json.loads(srv.Modules.notification)["code"] == "AGENT_PLUGIN_SERVER_ERROR"
+    assert srv.Modules.capability_cache["user_plugin"]["ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_user_plugin_confirmed_empty_registry_disables_switch(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+    stopped: list[bool] = []
+
+    async def _registry_empty():
+        return {
+            "status": "empty",
+            "plugin_count": 0,
+            "empty_responses": srv._USER_PLUGIN_EMPTY_CONFIRMATIONS,
+            "last_error": "empty plugin list",
+        }
+
+    async def _record_stop(*args, **kwargs):
+        stopped.append(True)
+
+    monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _registry_empty)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _record_stop)
+    srv.Modules.agent_flags["user_plugin_enabled"] = False
+    before = set(srv.Modules._persistent_tasks)
+
+    await srv.set_agent_flags({
+        "user_plugin_enabled": True,
+        "_persist_intent": False,
+    })
+    await _await_new_agent_tasks(srv, before)
+
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is False
+    assert json.loads(srv.Modules.notification)["code"] == "AGENT_NO_PLUGINS_FOUND"
+    assert stopped == [True]
+
+
+@pytest.mark.asyncio
+async def test_stale_user_plugin_empty_result_cannot_disable_newer_enable(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+    first_probe_started = asyncio.Event()
+    release_first_probe = asyncio.Event()
+    probe_calls = 0
+    stopped: list[bool] = []
+
+    async def _sequenced_registry_check():
+        nonlocal probe_calls
+        probe_calls += 1
+        if probe_calls == 1:
+            first_probe_started.set()
+            await release_first_probe.wait()
+            return {
+                "status": "empty",
+                "plugin_count": 0,
+                "empty_responses": srv._USER_PLUGIN_EMPTY_CONFIRMATIONS,
+                "last_error": "empty plugin list",
+            }
+        return {
+            "status": "ready",
+            "plugin_count": 19,
+            "empty_responses": 0,
+            "last_error": "",
+        }
+
+    async def _record_stop(*args, **kwargs):
+        stopped.append(True)
+
+    monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _sequenced_registry_check)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _record_stop)
+    srv.Modules.agent_flags["user_plugin_enabled"] = False
+
+    before_first = set(srv.Modules._persistent_tasks)
+    await srv.set_agent_flags({
+        "user_plugin_enabled": True,
+        "_persist_intent": False,
+    })
+    first_tasks = set(srv.Modules._persistent_tasks) - before_first
+    assert first_tasks
+    await first_probe_started.wait()
+
+    before_second = set(srv.Modules._persistent_tasks)
+    await srv.set_agent_flags({
+        "user_plugin_enabled": True,
+        "_persist_intent": False,
+    })
+    second_tasks = set(srv.Modules._persistent_tasks) - before_second
+    assert second_tasks
+    await asyncio.gather(*second_tasks)
+
+    release_first_probe.set()
+    await asyncio.gather(*first_tasks)
+
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert srv.Modules.user_plugin_lifecycle_seq >= 2
+    assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_pending_user_plugin_enable_cannot_restart_after_master_off(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+    start_waiting = asyncio.Event()
+    release_start = asyncio.Event()
+    lifecycle_started: list[bool] = []
+
+    async def _delayed_start(*, should_start=None):
+        start_waiting.set()
+        await release_start.wait()
+        if should_start is not None and not should_start():
+            return False
+        lifecycle_started.append(True)
+        return True
+
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _delayed_start)
+    srv.Modules.agent_flags["user_plugin_enabled"] = False
+    srv.Modules.analyzer_enabled = True
+    before = set(srv.Modules._persistent_tasks)
+
+    await srv.set_agent_flags({
+        "user_plugin_enabled": True,
+        "_persist_intent": False,
+    })
+    enable_tasks = set(srv.Modules._persistent_tasks) - before
+    assert enable_tasks
+    await start_waiting.wait()
+
+    await srv.agent_command({
+        "command": "set_agent_enabled",
+        "enabled": False,
+        "_persist_intent": False,
+    })
+    release_start.set()
+    await asyncio.gather(*enable_tasks)
+
+    assert srv.Modules.analyzer_enabled is False
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert lifecycle_started == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -641,6 +641,98 @@ async def test_set_agent_enabled_on_reprobes_openclaw_when_intent_survives(
 
 
 @pytest.mark.asyncio
+async def test_master_on_restarts_preserved_user_plugin_lifecycle(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+    starts: list[bool] = []
+
+    async def _record_start(*, should_start=None):
+        if should_start is not None and not should_start():
+            return False
+        starts.append(True)
+        return True
+
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _record_start)
+    srv.Modules.analyzer_enabled = False
+    srv.Modules.agent_flags["user_plugin_enabled"] = True
+    before = set(srv.Modules._persistent_tasks)
+
+    with patch.object(
+        srv,
+        "_check_agent_api_gate",
+        return_value={"ready": True, "reasons": [], "is_free_version": False},
+    ):
+        await srv.agent_command({
+            "command": "set_agent_enabled",
+            "enabled": True,
+            "_persist_intent": False,
+        })
+
+    await _await_new_agent_tasks(srv, before)
+
+    assert srv.Modules.analyzer_enabled is True
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert starts == [True]
+
+
+@pytest.mark.asyncio
+async def test_stale_master_off_cannot_stop_reenabled_master_lifecycle(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+    admin_waiting = asyncio.Event()
+    release_admin = asyncio.Event()
+    stops: list[bool] = []
+
+    async def _delayed_admin(*args, **kwargs):
+        admin_waiting.set()
+        await release_admin.wait()
+        return {"success": True}
+
+    async def _conditional_stop(*, should_stop=None):
+        if should_stop is not None and not should_stop():
+            return
+        stops.append(True)
+
+    monkeypatch.setattr(srv, "admin_control", _delayed_admin)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _conditional_stop)
+    srv.Modules.analyzer_enabled = True
+    srv.Modules.agent_flags["user_plugin_enabled"] = True
+
+    master_off = asyncio.create_task(srv.agent_command({
+        "command": "set_agent_enabled",
+        "enabled": False,
+        "_persist_intent": False,
+    }))
+    await admin_waiting.wait()
+
+    before_enable = set(srv.Modules._persistent_tasks)
+    with patch.object(
+        srv,
+        "_check_agent_api_gate",
+        return_value={"ready": True, "reasons": [], "is_free_version": False},
+    ):
+        await srv.agent_command({
+            "command": "set_agent_enabled",
+            "enabled": True,
+            "_persist_intent": False,
+        })
+    await _await_new_agent_tasks(srv, before_enable)
+
+    release_admin.set()
+    await master_off
+
+    assert srv.Modules.analyzer_enabled is True
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert stops == []
+
+
+@pytest.mark.asyncio
 async def test_openclaw_availability_ready_emits_after_canceling_pending_probe(
     agent_state_isolation, monkeypatch: pytest.MonkeyPatch
 ):
@@ -887,6 +979,7 @@ async def test_user_plugin_registry_unavailable_keeps_switch_enabled(
         }
 
     monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _registry_unavailable)
+    srv.Modules.analyzer_enabled = True
     srv.Modules.agent_flags["user_plugin_enabled"] = False
     before = set(srv.Modules._persistent_tasks)
 
@@ -923,6 +1016,7 @@ async def test_user_plugin_confirmed_empty_registry_disables_switch(
 
     monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _registry_empty)
     monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _record_stop)
+    srv.Modules.analyzer_enabled = True
     srv.Modules.agent_flags["user_plugin_enabled"] = False
     before = set(srv.Modules._persistent_tasks)
 
@@ -973,6 +1067,7 @@ async def test_stale_user_plugin_empty_result_cannot_disable_newer_enable(
 
     monkeypatch.setattr(srv, "_check_user_plugin_registry_readiness", _sequenced_registry_check)
     monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _record_stop)
+    srv.Modules.analyzer_enabled = True
     srv.Modules.agent_flags["user_plugin_enabled"] = False
 
     before_first = set(srv.Modules._persistent_tasks)
@@ -1044,6 +1139,34 @@ async def test_pending_user_plugin_enable_cannot_restart_after_master_off(
     assert srv.Modules.analyzer_enabled is False
     assert srv.Modules.agent_flags["user_plugin_enabled"] is True
     assert lifecycle_started == []
+
+
+@pytest.mark.asyncio
+async def test_user_plugin_enable_is_deferred_while_master_is_off(
+    agent_state_isolation,
+    isolated_intent_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    srv = agent_state_isolation
+    starts: list[bool] = []
+
+    async def _record_start(*args, **kwargs):
+        starts.append(True)
+        return True
+
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _record_start)
+    srv.Modules.analyzer_enabled = False
+    srv.Modules.agent_flags["user_plugin_enabled"] = False
+    before = set(srv.Modules._persistent_tasks)
+
+    await srv.set_agent_flags({
+        "user_plugin_enabled": True,
+        "_persist_intent": False,
+    })
+    await _await_new_agent_tasks(srv, before)
+
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert starts == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -781,9 +781,10 @@ class _UserPluginRegistryResponse:
 
 class _UserPluginRegistryClient:
     outcomes: list[object] = []
+    instances = 0
 
     def __init__(self, *args, **kwargs):
-        pass
+        type(self).instances += 1
 
     async def __aenter__(self):
         return self
@@ -811,6 +812,7 @@ async def test_user_plugin_registry_check_does_not_treat_timeouts_as_empty(
         srv.httpx.ReadTimeout("plugin registry busy"),
         srv.httpx.ReadTimeout("plugin registry busy"),
     ]
+    _UserPluginRegistryClient.instances = 0
     monkeypatch.setattr(srv.httpx, "AsyncClient", _UserPluginRegistryClient)
     monkeypatch.setattr(srv, "_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S", 0)
 
@@ -818,6 +820,7 @@ async def test_user_plugin_registry_check_does_not_treat_timeouts_as_empty(
 
     assert result["status"] == "unavailable"
     assert result["empty_responses"] == 1
+    assert _UserPluginRegistryClient.instances == 1
 
 
 @pytest.mark.asyncio
@@ -837,6 +840,28 @@ async def test_user_plugin_registry_check_requires_repeated_valid_empty_response
 
     assert result["status"] == "empty"
     assert result["empty_responses"] == srv._USER_PLUGIN_EMPTY_CONFIRMATIONS
+
+
+@pytest.mark.asyncio
+async def test_user_plugin_registry_check_has_an_overall_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.agent_server import api_routes as srv
+
+    never_responds = asyncio.Event()
+
+    class _HangingUserPluginRegistryClient(_UserPluginRegistryClient):
+        async def get(self, url: str):
+            await never_responds.wait()
+
+    monkeypatch.setattr(srv.httpx, "AsyncClient", _HangingUserPluginRegistryClient)
+    monkeypatch.setattr(srv, "_USER_PLUGIN_REGISTRY_CHECK_INTERVAL_S", 0)
+    monkeypatch.setattr(srv, "_USER_PLUGIN_REGISTRY_CHECK_MAX_DURATION_S", 0.01)
+
+    result = await srv._check_user_plugin_registry_readiness()
+
+    assert result["status"] == "unavailable"
+    assert result["last_error"] == "overall timeout (0.01s)"
 
 
 async def _await_new_agent_tasks(srv, before: set[asyncio.Task]) -> None:


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复用户插件注册表查询超时被误判为“没有插件”，导致用户插件子开关自动关闭的问题；同时增加生命周期代次校验，避免旧后台任务覆盖用户的新操作。

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
改动内容：区分插件注册表“确认为空”和“暂时不可用”。
只有多次收到有效空列表时才自动关闭子开关。
为插件生命周期启动、停止任务增加代次校验。

改动理由：原有 1 秒查询超时会被当作空插件列表，但日志显示实际已有 19 个插件，属于误判。

表现对比：改动前：查询超时、连接异常可能导致用户插件子开关自动关闭。
改动后：临时异常会保留开启状态并报告服务错误；仅确认无插件或生命周期启动失败时关闭。

潜在回归点及验证：影响用户插件启停、总开关关闭及并发切换链路。
已覆盖超时、确认空列表、重复启用、总开关关闭和旧任务结果晚到等场景。
Agent 相关单元测试全部通过。


## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->
uv run pytest tests/unit/test_agent_*.py -q：189 项通过。
uv run ruff check app/agent_server/_shared.py app/agent_server/api_routes.py app/agent_server/plugin_host.py tests/unit/test_agent_runtime_intent.py：通过。
git diff --check：通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 优化用户插件注册表状态识别，区分暂时不可用、确认为空和正常就绪。
  * 支持用户插件独立启用或停用，不再受主 Agent 开关限制。
  * 改进插件启停流程，避免过期操作或并发操作覆盖最新状态。

* **问题修复**
  * 注册表暂时不可用时保留现有启用状态并提示错误。
  * 关闭主 Agent 后，进行中的插件启动操作将安全取消。
  * 注册表无法访问时返回明确的服务暂不可用提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->