### PR TITLE
fix: LLM SDK 默认 User-Agent 防止 Cloudflare 拦截

### DIFF
--- a/launcher_core/runtime.py
+++ b/launcher_core/runtime.py
@@ -315,6 +315,15 @@ def _install_logging_brace_compat() -> None:
     logging._neko_brace_compat_installed = True
 
 
+def _patch_http_user_agents() -> None:
+    """全局 patch HTTP 客户端的默认 User-Agent，防止 CF 拦截自定义 API。"""
+    try:
+        from utils.http_client import patch_requests_default_user_agent
+        patch_requests_default_user_agent()
+    except Exception as exc:
+        print(f"[Launcher] Warning: failed to patch HTTP User-Agent: {exc}", flush=True)
+
+
 def _initialize_launcher_context() -> None:
     """Populate per-launch ids and env only during explicit launcher startup."""
     global LAUNCH_ID, INSTANCE_ID
@@ -348,6 +357,8 @@ def _bootstrap_launcher_runtime(project_dir: str) -> None:
     _configure_multiprocessing_executable(project_dir)
     _install_logging_brace_compat()
     _initialize_launcher_context()
+    # 全局 patch requests 库的默认 User-Agent，防止 CF 拦截
+    _patch_http_user_agents()
 
 
 def _show_error_dialog(message: str):

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -46,13 +46,11 @@ def ensure_user_agent(headers: dict[str, Any] | None) -> dict[str, Any]:
     """
     merged: dict[str, Any] = dict(headers) if headers else {}
 
-    # 查找是否有任意大小写形式的 User-Agent
-    ua_key_found: str | None = None
+    # 遍历所有大小写变体，选取首个非空的显式值（跳过 None / 空字符串）
     ua_value: Any | None = None
-    for k in merged:
-        if str(k).lower() == "user-agent":
-            ua_key_found = k
-            ua_value = merged[k]
+    for k, value in merged.items():
+        if str(k).lower() == "user-agent" and value not in (None, ""):
+            ua_value = value
             break
 
     # 删除所有大小写变体的 user-agent，避免重复请求头
@@ -62,10 +60,10 @@ def ensure_user_agent(headers: dict[str, Any] | None) -> dict[str, Any]:
 
     # 仅写入一个规范的 User-Agent 键
     if ua_value is not None:
-        # 调用方显式提供了值，保留
+        # 调用方显式提供了非空值，保留
         merged["User-Agent"] = ua_value
     else:
-        # 调用方未提供，注入默认值
+        # 调用方未提供或值为空，注入默认值
         merged["User-Agent"] = get_default_user_agent()
 
     return merged

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -45,10 +45,29 @@ def ensure_user_agent(headers: dict[str, Any] | None) -> dict[str, Any]:
         合并后的新 headers 字典（至少包含 User-Agent）
     """
     merged: dict[str, Any] = dict(headers) if headers else {}
-    # 大小写不敏感地检查调用方是否已设置 UA
-    has_ua = any(str(k).lower() == "user-agent" for k in merged)
-    if not has_ua:
+
+    # 查找是否有任意大小写形式的 User-Agent
+    ua_key_found: str | None = None
+    ua_value: Any | None = None
+    for k in merged:
+        if str(k).lower() == "user-agent":
+            ua_key_found = k
+            ua_value = merged[k]
+            break
+
+    # 删除所有大小写变体的 user-agent，避免重复请求头
+    keys_to_remove = [k for k in merged if str(k).lower() == "user-agent"]
+    for k in keys_to_remove:
+        del merged[k]
+
+    # 仅写入一个规范的 User-Agent 键
+    if ua_value is not None:
+        # 调用方显式提供了值，保留
+        merged["User-Agent"] = ua_value
+    else:
+        # 调用方未提供，注入默认值
         merged["User-Agent"] = get_default_user_agent()
+
     return merged
 
 
@@ -61,8 +80,12 @@ def patch_requests_default_user_agent() -> None:
     import requests.utils
 
     _default_ua = get_default_user_agent()
+    _original_default_user_agent = requests.utils.default_user_agent
 
     def _neko_default_user_agent(name: str = "python-requests") -> str:
-        return _default_ua
+        # name 为默认值时返回 neko UA，否则调用原始函数保留调用方名称
+        if name == "python-requests":
+            return _default_ua
+        return _original_default_user_agent(name)
 
     requests.utils.default_user_agent = _neko_default_user_agent

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -1,0 +1,68 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""统一 User-Agent 管理，防止自定义 API 端点的 Cloudflare Bot Management 拦截。
+
+背景：OpenAI / Anthropic 官方 SDK 会自带形如 ``AsyncOpenAI/Python 2.8.1`` 的
+User-Agent。Cloudflare 的 "Manage AI bots" 规则会精准识别这些已知 AI SDK 的 UA
+并直接 block，导致部分自建 / 反代的自定义 API 端点返回拦截页而非正常响应。
+
+解决办法：给 SDK 客户端注入 ``User-Agent: neko/<版本号>`` 覆盖内置 UA。SDK 的
+``default_headers`` 在请求头合并顺序里优先级最高，可以稳定覆盖内置 User-Agent。
+"""
+
+from __future__ import annotations
+from typing import Any
+
+from config.application import APP_VERSION
+
+
+def get_default_user_agent() -> str:
+    """返回统一 User-Agent，格式 ``neko/<版本号>``（例如 ``neko/0.9.0``）。"""
+    return f"neko/{APP_VERSION}"
+
+
+def ensure_user_agent(headers: dict[str, Any] | None) -> dict[str, Any]:
+    """确保 headers 字典里带有默认 User-Agent，返回新字典。
+
+    若调用方已显式提供了 User-Agent（任意大小写），则尊重调用方的值不覆盖；
+    否则注入 ``neko/<版本号>``。用于 OpenAI / Anthropic SDK 的 ``default_headers``。
+
+    Args:
+        headers: 原始请求头（可为 None）
+
+    Returns:
+        合并后的新 headers 字典（至少包含 User-Agent）
+    """
+    merged: dict[str, Any] = dict(headers) if headers else {}
+    # 大小写不敏感地检查调用方是否已设置 UA
+    has_ua = any(str(k).lower() == "user-agent" for k in merged)
+    if not has_ua:
+        merged["User-Agent"] = get_default_user_agent()
+    return merged
+
+
+def patch_requests_default_user_agent() -> None:
+    """全局覆盖 requests 库的默认 User-Agent（防止插件用 requests 时被 CF 拦截）。
+
+    仅覆盖 requests 的默认 UA（原本是 ``python-requests/x.y.z``）。显式传入
+    ``headers={"User-Agent": ...}`` 的调用方不受影响。启动时调用一次即可。
+    """
+    import requests.utils
+
+    _default_ua = get_default_user_agent()
+
+    def _neko_default_user_agent(name: str = "python-requests") -> str:
+        return _default_ua
+
+    requests.utils.default_user_agent = _neko_default_user_agent

--- a/utils/llm_client/anthropic_client.py
+++ b/utils/llm_client/anthropic_client.py
@@ -642,8 +642,11 @@ class ChatAnthropic:
             client_kw["base_url"] = self.base_url
         if _timeout is not None:
             client_kw["timeout"] = _timeout
-        if default_headers:
-            client_kw["default_headers"] = default_headers
+        # 注入 neko/<版本号> User-Agent 覆盖 SDK 自带 UA（AsyncAnthropic/Python x.y.z），
+        # 防止自定义 API 端点的 Cloudflare "Manage AI bots" 规则拦截。调用方若已在
+        # default_headers 里显式指定 UA（如 Kimi Code 的 claude-code/0.1.0）则不覆盖。
+        from utils.http_client import ensure_user_agent
+        client_kw["default_headers"] = ensure_user_agent(default_headers)
 
         self._client = anthropic_cls(**client_kw)
         self._aclient = async_anthropic_cls(**client_kw)

--- a/utils/llm_client/embeddings.py
+++ b/utils/llm_client/embeddings.py
@@ -36,11 +36,13 @@ class OpenAIEmbeddings:
         # 注入 neko/<版本号> User-Agent 覆盖 SDK 自带 UA，防止自定义 embedding
         # 端点的 Cloudflare "Manage AI bots" 规则拦截。
         # 显式提取 _kwargs 中的 default_headers，合并后再传给客户端，避免丢失调用方自定义 headers。
+        # 仅提取 default_headers 合并，不转发其他 _kwargs：sync/async 客户端对
+        # http_client 等参数有不同的类型校验，一律转发会导致初始化失败。
         from utils.http_client import ensure_user_agent
-        _caller_headers = _kwargs.pop("default_headers", None)
+        _caller_headers = _kwargs.get("default_headers")
         _headers = ensure_user_agent(_caller_headers)
-        self._client = OpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers, **_kwargs)
-        self._aclient = AsyncOpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers, **_kwargs)
+        self._client = OpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers)
+        self._aclient = AsyncOpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers)
 
     def embed_query(self, text: str) -> list[float]:
         resp = self._client.embeddings.create(model=self.model, input=text)

--- a/utils/llm_client/embeddings.py
+++ b/utils/llm_client/embeddings.py
@@ -33,8 +33,12 @@ class OpenAIEmbeddings:
 
         self.model = model
         _api_key = api_key or "sk-placeholder"
-        self._client = OpenAI(base_url=base_url, api_key=_api_key)
-        self._aclient = AsyncOpenAI(base_url=base_url, api_key=_api_key)
+        # 注入 neko/<版本号> User-Agent 覆盖 SDK 自带 UA，防止自定义 embedding
+        # 端点的 Cloudflare "Manage AI bots" 规则拦截。
+        from utils.http_client import ensure_user_agent
+        _headers = ensure_user_agent(None)
+        self._client = OpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers)
+        self._aclient = AsyncOpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers)
 
     def embed_query(self, text: str) -> list[float]:
         resp = self._client.embeddings.create(model=self.model, input=text)

--- a/utils/llm_client/embeddings.py
+++ b/utils/llm_client/embeddings.py
@@ -35,10 +35,12 @@ class OpenAIEmbeddings:
         _api_key = api_key or "sk-placeholder"
         # 注入 neko/<版本号> User-Agent 覆盖 SDK 自带 UA，防止自定义 embedding
         # 端点的 Cloudflare "Manage AI bots" 规则拦截。
+        # 显式提取 _kwargs 中的 default_headers，合并后再传给客户端，避免丢失调用方自定义 headers。
         from utils.http_client import ensure_user_agent
-        _headers = ensure_user_agent(None)
-        self._client = OpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers)
-        self._aclient = AsyncOpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers)
+        _caller_headers = _kwargs.pop("default_headers", None)
+        _headers = ensure_user_agent(_caller_headers)
+        self._client = OpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers, **_kwargs)
+        self._aclient = AsyncOpenAI(base_url=base_url, api_key=_api_key, default_headers=_headers, **_kwargs)
 
     def embed_query(self, text: str) -> list[float]:
         resp = self._client.embeddings.create(model=self.model, input=text)

--- a/utils/llm_client/openai_client.py
+++ b/utils/llm_client/openai_client.py
@@ -123,8 +123,10 @@ class ChatOpenAI:
         client_kw: dict[str, Any] = dict(base_url=base_url, api_key=_api_key, max_retries=max_retries)
         if _timeout is not None:
             client_kw["timeout"] = _timeout
-        if default_headers:
-            client_kw["default_headers"] = default_headers
+        # 注入 neko/<版本号> User-Agent 覆盖 SDK 自带 UA（AsyncOpenAI/Python x.y.z），
+        # 防止自定义 API 端点的 Cloudflare "Manage AI bots" 规则拦截。
+        from utils.http_client import ensure_user_agent
+        client_kw["default_headers"] = ensure_user_agent(default_headers)
         from openai import AsyncOpenAI, DefaultAsyncHttpxClient, DefaultHttpxClient, OpenAI
 
         ssl_context = _get_default_ssl_context()


### PR DESCRIPTION
# fix: LLM SDK 默认 User-Agent 防止 Cloudflare 拦截

## 问题

第三方API 会被 CF「Manage AI bots」规则拦截

OpenAI / Anthropic SDK 默认 UA（如 `AsyncOpenAI/Python 2.8.1`）命中 Cloudflare AI bots 特征库

## 方案

LLM 客户端时注入 `User-Agent: neko/<APP_VERSION>`，通过 `default_headers` 覆盖 SDK 内置 UA。版本号取`config.application.APP_VERSION 内配置`

## 改动

- **新增** `utils/http_client.py` — UA 工具（`get_default_user_agent`、`ensure_user_agent`、`patch_requests_default_user_agent`）
- **修改** `openai_client.py`、`anthropic_client.py`、`embeddings.py` — 注入默认 UA
- **修改** `launcher_core/runtime.py` — 启动时 patch `requests` 默认 UA



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 统一网络请求的默认 User-Agent，便于识别应用版本。
  * OpenAI、Anthropic 及嵌入服务请求会自动携带应用版本信息。
  * 保留调用方显式设置的 User-Agent，不影响自定义请求配置。
  * 应用启动时自动启用默认请求标识；即使设置失败，也不会阻止正常启动。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->