### PR TITLE
fix(autostart): defer prompt until tutorial settles

### DIFF
--- a/static/app/app-autostart-prompt.js
+++ b/static/app/app-autostart-prompt.js
@@ -873,7 +873,6 @@
 
     async function showPrompt(promptToken) {
         state.promptOpen = true;
-        state.lastPromptTokenSeen = promptToken;
         let promptVoice = null;
         const buttons = [
             {
@@ -920,6 +919,7 @@
                         }
                         return;
                     }
+                    state.lastPromptTokenSeen = promptToken;
                     promptVoice = startAutostartPromptVoice();
                     return postShownAck(promptToken);
                 },

--- a/static/app/app-autostart-prompt.js
+++ b/static/app/app-autostart-prompt.js
@@ -46,7 +46,6 @@
         requestInFlight: false,
         pendingHeartbeatAfterFlight: false,
         promptOpen: false,
-        activePromptClose: null,
         lastPromptTokenSeen: null,
         pendingForegroundMs: 0,
         foregroundStartedAt: null,
@@ -920,17 +919,11 @@
                         }
                         return;
                     }
-                    state.activePromptClose = modal && typeof modal.close === 'function'
-                        ? modal.close
-                        : null;
                     state.lastPromptTokenSeen = promptToken;
                     promptVoice = startAutostartPromptVoice();
                     return postShownAck(promptToken);
                 },
-                onResolve: function () {
-                    state.activePromptClose = null;
-                    stopPromptVoice();
-                },
+                onResolve: stopPromptVoice,
                 buttons: buttons
             });
 
@@ -947,7 +940,6 @@
             }
         } finally {
             stopPromptVoice();
-            state.activePromptClose = null;
             state.promptOpen = false;
         }
     }
@@ -976,15 +968,6 @@
         document.addEventListener('visibilitychange', syncForegroundWindow);
         window.addEventListener('focus', syncForegroundWindow);
         window.addEventListener('blur', syncForegroundWindow);
-        window.addEventListener('neko:startup-greeting-release', function (event) {
-            const detail = event && event.detail ? event.detail : {};
-            if (detail.released !== false || typeof state.activePromptClose !== 'function') {
-                return;
-            }
-            const closePrompt = state.activePromptClose;
-            state.activePromptClose = null;
-            closePrompt(null);
-        });
         document.addEventListener('pointerdown', function (event) {
             if (state.promptOpen) {
                 return;

--- a/static/app/app-autostart-prompt.js
+++ b/static/app/app-autostart-prompt.js
@@ -671,8 +671,11 @@
         // Register first so a release emitted while another startup gate is
         // pending cannot be missed.
         const tutorialStartupBarrier = waitForTutorialStartupBarrier();
-        await waitForAutostartPromptPrerequisites();
-        await tutorialStartupBarrier;
+        try {
+            await waitForAutostartPromptPrerequisites();
+        } finally {
+            await tutorialStartupBarrier;
+        }
     }
 
     function startForegroundTrackingGate() {
@@ -910,6 +913,9 @@
                 closeOnEscape: false,
                 onShown: function () {
                     stopPromptVoice();
+                    if (isTutorialBusy()) {
+                        return;
+                    }
                     promptVoice = startAutostartPromptVoice();
                     return postShownAck(promptToken);
                 },

--- a/static/app/app-autostart-prompt.js
+++ b/static/app/app-autostart-prompt.js
@@ -46,6 +46,7 @@
         requestInFlight: false,
         pendingHeartbeatAfterFlight: false,
         promptOpen: false,
+        activePromptClose: null,
         lastPromptTokenSeen: null,
         pendingForegroundMs: 0,
         foregroundStartedAt: null,
@@ -919,11 +920,17 @@
                         }
                         return;
                     }
+                    state.activePromptClose = modal && typeof modal.close === 'function'
+                        ? modal.close
+                        : null;
                     state.lastPromptTokenSeen = promptToken;
                     promptVoice = startAutostartPromptVoice();
                     return postShownAck(promptToken);
                 },
-                onResolve: stopPromptVoice,
+                onResolve: function () {
+                    state.activePromptClose = null;
+                    stopPromptVoice();
+                },
                 buttons: buttons
             });
 
@@ -940,6 +947,7 @@
             }
         } finally {
             stopPromptVoice();
+            state.activePromptClose = null;
             state.promptOpen = false;
         }
     }
@@ -968,6 +976,15 @@
         document.addEventListener('visibilitychange', syncForegroundWindow);
         window.addEventListener('focus', syncForegroundWindow);
         window.addEventListener('blur', syncForegroundWindow);
+        window.addEventListener('neko:startup-greeting-release', function (event) {
+            const detail = event && event.detail ? event.detail : {};
+            if (detail.released !== false || typeof state.activePromptClose !== 'function') {
+                return;
+            }
+            const closePrompt = state.activePromptClose;
+            state.activePromptClose = null;
+            closePrompt(null);
+        });
         document.addEventListener('pointerdown', function (event) {
             if (state.promptOpen) {
                 return;

--- a/static/app/app-autostart-prompt.js
+++ b/static/app/app-autostart-prompt.js
@@ -3,6 +3,8 @@
 
     const HEARTBEAT_INTERVAL_MS = 15000;
     const FAST_HEARTBEAT_DELAY_MS = 1200;
+    const TUTORIAL_GATE_FALLBACK_MS = 15000;
+    const TUTORIAL_GATE_QUIET_MS = 200;
     const AUTOSTART_STATUS_MAX_AGE_MS = HEARTBEAT_INTERVAL_MS;
     const AUTOSTART_PROMPT_COORDINATION_KEY = 'home-autostart-prompt';
     const AUTOSTART_PROMPT_PRIORITY = 100;
@@ -567,30 +569,110 @@
         }
     }
 
-    async function waitForAutostartPromptGate() {
+    function hasActiveTutorialSurface() {
+        return !!document.querySelector([
+            '.yui-guide-overlay',
+            '.yui-guide-stage',
+            '.driver-overlay',
+            '.driver-popover',
+            '#neko-day1-systray-intro-modal',
+        ].join(', '));
+    }
+
+    function isTutorialBusy() {
+        const manager = window.universalTutorialManager || null;
+        return window.isNekoHomeTutorialPending === true
+            || window.isInTutorial === true
+            || !!(manager && (
+                manager.isTutorialRunning
+                || manager.activeAvatarFloatingGuideRound
+                || manager._pendingI18nStart
+                || manager._teardownPromise
+            ))
+            || hasActiveTutorialSurface();
+    }
+
+    function waitForTutorialStartupBarrier() {
+        return new Promise((resolve) => {
+            let moduleUnavailableFallbackExpired = false;
+            let quietSince = 0;
+            let pollTimer = null;
+            let fallbackTimer = null;
+            let done = false;
+
+            const finish = function () {
+                if (done) {
+                    return;
+                }
+                done = true;
+                clearInterval(pollTimer);
+                clearTimeout(fallbackTimer);
+                window.removeEventListener('neko:startup-greeting-release', check);
+                window.removeEventListener('neko:day1-systray-intro-closed', check);
+                resolve();
+            };
+            const check = function () {
+                if (done) {
+                    return;
+                }
+                const startupState = window.__NEKO_TUTORIAL_STARTUP_SETTLED__;
+                const tutorialModuleLoaded = typeof startupState === 'boolean';
+                const tutorialDecisionPending = tutorialModuleLoaded
+                    ? startupState !== true
+                    : !moduleUnavailableFallbackExpired;
+                if (tutorialDecisionPending || isTutorialBusy()) {
+                    quietSince = 0;
+                    return;
+                }
+                const now = Date.now();
+                if (!quietSince) {
+                    quietSince = now;
+                    return;
+                }
+                if (now - quietSince >= TUTORIAL_GATE_QUIET_MS) {
+                    finish();
+                }
+            };
+
+            window.addEventListener('neko:startup-greeting-release', check);
+            window.addEventListener('neko:day1-systray-intro-closed', check);
+            pollTimer = setInterval(check, 50);
+            fallbackTimer = setTimeout(function () {
+                moduleUnavailableFallbackExpired = true;
+                check();
+            }, TUTORIAL_GATE_FALLBACK_MS);
+            check();
+        });
+    }
+
+    async function waitForAutostartPromptPrerequisites() {
         const AUTOSTART_GATE_FALLBACK_MS = 15000;
         if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
             await window.waitForStorageLocationStartupBarrier();
         }
 
         const onboarding = window.CharacterPersonalityOnboarding;
-        if (!onboarding || typeof onboarding.whenSettled !== 'function') {
-            return;
+        if (onboarding && typeof onboarding.whenSettled === 'function') {
+            const settled = await Promise.race([
+                onboarding.whenSettled().then(() => true),
+                new Promise((resolve) => setTimeout(() => resolve(false), AUTOSTART_GATE_FALLBACK_MS)),
+            ]);
+            if (!settled) {
+                const overlayActive = (onboarding.overlay && !onboarding.overlay.hidden)
+                    || onboarding.pendingResumeAfterTutorial;
+                if (overlayActive) {
+                    await onboarding.whenSettled();
+                }
+            }
         }
+    }
 
-        const settled = await Promise.race([
-            onboarding.whenSettled().then(() => true),
-            new Promise((resolve) => setTimeout(() => resolve(false), AUTOSTART_GATE_FALLBACK_MS)),
-        ]);
-        if (settled) {
-            return;
-        }
-
-        const overlayActive = (onboarding.overlay && !onboarding.overlay.hidden)
-            || onboarding.pendingResumeAfterTutorial;
-        if (overlayActive) {
-            await onboarding.whenSettled();
-        }
+    async function waitForAutostartPromptGate() {
+        // Register first so a release emitted while another startup gate is
+        // pending cannot be missed.
+        const tutorialStartupBarrier = waitForTutorialStartupBarrier();
+        await waitForAutostartPromptPrerequisites();
+        await tutorialStartupBarrier;
     }
 
     function startForegroundTrackingGate() {
@@ -598,7 +680,7 @@
             return;
         }
         state.foregroundGateStarted = true;
-        void waitForAutostartPromptGate()
+        void waitForAutostartPromptPrerequisites()
             .catch(function (error) {
                 console.warn('[AutostartPrompt] foreground gate failed, starting timer anyway:', error);
             })
@@ -682,6 +764,9 @@
         if (state.promptOpen) {
             return false;
         }
+        if (isTutorialBusy()) {
+            return false;
+        }
         if (!promptToken) {
             return false;
         }
@@ -696,7 +781,7 @@
         } catch (_) {
             return false;
         }
-        if (!state.autostartSupported || isPromptSuppressedLocally()) {
+        if (!state.autostartSupported || isPromptSuppressedLocally() || isTutorialBusy()) {
             return false;
         }
         return typeof window.showDecisionPrompt === 'function';
@@ -861,6 +946,9 @@
                 return canShowPrompt(promptToken);
             },
             display: function () {
+                if (isTutorialBusy()) {
+                    return null;
+                }
                 return showPrompt(promptToken);
             },
         });

--- a/static/app/app-autostart-prompt.js
+++ b/static/app/app-autostart-prompt.js
@@ -586,6 +586,7 @@
             || !!(manager && (
                 manager.isTutorialRunning
                 || manager.activeAvatarFloatingGuideRound
+                || manager.pendingTutorialStartSource
                 || manager._pendingI18nStart
                 || manager._teardownPromise
             ))
@@ -911,9 +912,12 @@
                 dismissValue: null,
                 closeOnClickOutside: false,
                 closeOnEscape: false,
-                onShown: function () {
+                onShown: function (modal) {
                     stopPromptVoice();
                     if (isTutorialBusy()) {
+                        if (modal && typeof modal.close === 'function') {
+                            modal.close(null);
+                        }
                         return;
                     }
                     promptVoice = startAutostartPromptVoice();

--- a/static/common_dialogs.js
+++ b/static/common_dialogs.js
@@ -1329,6 +1329,7 @@
                             return modalConfig.onShown({
                                 overlay: overlay,
                                 dialog: dialog,
+                                close: finish,
                             });
                         })
                         .catch(function (error) {

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -4390,6 +4390,26 @@ function dispatchStartupGreetingReleaseWithoutManager(reason, detail = {}) {
     return releaseDetail;
 }
 
+function rearmStartupGreetingWithoutManager(reason, detail = {}) {
+    window.isNekoHomeTutorialPending = true;
+    const rearmDetail = Object.assign({
+        released: false,
+        page: 'unknown',
+        reason: reason || 'tutorial-manager-initializing',
+        timestamp: Date.now()
+    }, detail || {});
+    try {
+        window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = false;
+        delete window.__NEKO_STARTUP_GREETING_RELEASED__;
+        window.dispatchEvent(new CustomEvent(STARTUP_GREETING_RELEASE_EVENT, {
+            detail: rearmDetail
+        }));
+    } catch (error) {
+        console.warn('[Tutorial] 无管理器启动问候重新上锁失败:', error);
+    }
+    return rearmDetail;
+}
+
 async function destroyUniversalTutorialManagerInstance(reason = 'destroy') {
     const manager = window.universalTutorialManager;
     if (!manager) return;
@@ -4415,6 +4435,9 @@ function bindUniversalTutorialManagerResizeRetry() {
         window.removeEventListener('resize', retryUniversalTutorialManagerInit);
         window.__universalTutorialManagerResizeRetryBound = false;
         if (window.__universalTutorialManagerInitialized) return;
+        rearmStartupGreetingWithoutManager('tutorial-manager-resize-init', {
+            viewportWidth: window.innerWidth
+        });
         initUniversalTutorialManager().then(function (initialized) {
             if (initialized !== false) {
                 window.__universalTutorialManagerInitialized = true;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -4410,6 +4410,32 @@ function rearmStartupGreetingWithoutManager(reason, detail = {}) {
     return rearmDetail;
 }
 
+function waitForActiveAutostartPromptClosed() {
+    const selector = '.modal-overlay-autostart-retention';
+    if (!document.querySelector(selector)) {
+        return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+        let done = false;
+        const finish = function () {
+            if (done) return;
+            done = true;
+            window.removeEventListener('neko:decision-prompt-closed', onPromptClosed);
+            resolve();
+        };
+        const onPromptClosed = function (event) {
+            const detail = event && event.detail ? event.detail : {};
+            if (detail.skin === 'autostart-retention') {
+                finish();
+            }
+        };
+        window.addEventListener('neko:decision-prompt-closed', onPromptClosed);
+        if (!document.querySelector(selector)) {
+            finish();
+        }
+    });
+}
+
 async function destroyUniversalTutorialManagerInstance(reason = 'destroy') {
     const manager = window.universalTutorialManager;
     if (!manager) return;
@@ -4438,7 +4464,9 @@ function bindUniversalTutorialManagerResizeRetry() {
         rearmStartupGreetingWithoutManager('tutorial-manager-resize-init', {
             viewportWidth: window.innerWidth
         });
-        initUniversalTutorialManager().then(function (initialized) {
+        waitForActiveAutostartPromptClosed().then(function () {
+            return initUniversalTutorialManager();
+        }).then(function (initialized) {
             if (initialized !== false) {
                 window.__universalTutorialManagerInitialized = true;
             }

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -195,6 +195,11 @@ def _bootstrap_home_runtime_page(
     script_names.append("app/app-prompt-shared.js")
     script_names.append("tutorial/core/home-tutorial-runtime.js")
     if include_autostart_prompt or include_autostart_provider:
+        setup_js = setup_js + """
+            if (typeof window.__NEKO_TUTORIAL_STARTUP_SETTLED__ !== 'boolean') {
+                window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
+            }
+        """
         script_names.append("app/app-autostart-prompt.js")
     _bootstrap_page(
         mock_page,
@@ -447,6 +452,137 @@ def test_autostart_prompt_offers_never_after_backend_allows_it(
 
     assert autostart_decisions
     assert autostart_decisions[-1]["body"]["decision"] == "never"
+
+
+@pytest.mark.frontend
+def test_autostart_prompt_waits_for_tutorial_release_and_teardown(
+    mock_page: Page,
+):
+    _bootstrap_home_runtime_page(
+        mock_page,
+        include_common_dialogs=True,
+        include_autostart_prompt=True,
+        setup_js="""
+            window.__requestLog = [];
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = false;
+            window.isNekoHomeTutorialPending = true;
+            window.nekoAutostartProvider = {
+                getStatus: async function() {
+                    return {
+                        ok: true,
+                        supported: true,
+                        enabled: false,
+                        authoritative: true,
+                        provider: 'backend',
+                    };
+                },
+                enable: async function() {
+                    throw new Error('enable should not be called');
+                },
+            };
+        """,
+        fetch_js="""
+            window.__requestLog.push({
+                url: requestUrl,
+                method: method,
+                body: body,
+            });
+
+            if (requestUrl === '/api/autostart-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        autostart_enabled: false,
+                        can_never_remind: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/autostart-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: true,
+                    prompt_reason: 'usage_timeout',
+                    prompt_token: 'tutorial-race-token',
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        autostart_enabled: false,
+                        can_never_remind: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/autostart-prompt/shown') {
+                return jsonResponse({
+                    ok: true,
+                    already_acknowledged: false,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        autostart_enabled: false,
+                        can_never_remind: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        """
+        () => window.__requestLog.some(
+            (entry) => entry.url === '/api/autostart-prompt/heartbeat'
+        )
+        """
+    )
+    expect(mock_page.locator(".modal-dialog-autostart-retention")).to_have_count(0)
+    assert not any(
+        entry["url"] == "/api/autostart-prompt/shown"
+        for entry in mock_page.evaluate("() => window.__requestLog")
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.isNekoHomeTutorialPending = false;
+            window.isInTutorial = false;
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.universalTutorialManager.activeAvatarFloatingGuideRound = null;
+            let resolveTeardown;
+            const teardownPromise = new Promise((resolve) => {
+                resolveTeardown = resolve;
+            });
+            window.universalTutorialManager._teardownPromise = teardownPromise;
+            window.__finishTutorialTeardown = function() {
+                resolveTeardown();
+                teardownPromise.finally(() => {
+                    window.universalTutorialManager._teardownPromise = null;
+                });
+            };
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
+            window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
+                detail: { released: true, reason: 'tutorial-completed' },
+            }));
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(350)
+    expect(mock_page.locator(".modal-dialog-autostart-retention")).to_have_count(0)
+    assert not any(
+        entry["url"] == "/api/autostart-prompt/shown"
+        for entry in mock_page.evaluate("() => window.__requestLog")
+    )
+
+    mock_page.evaluate("() => window.__finishTutorialTeardown()")
+    expect(mock_page.locator(".modal-dialog-autostart-retention")).to_have_count(1, timeout=5000)
+    shown_requests = [
+        entry for entry in mock_page.evaluate("() => window.__requestLog")
+        if entry["url"] == "/api/autostart-prompt/shown"
+    ]
+    assert len(shown_requests) == 1
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -731,7 +731,7 @@ def test_autostart_prompt_waits_for_pending_tutorial_start(
 
 
 @pytest.mark.frontend
-def test_autostart_prompt_on_shown_closes_when_tutorial_starts(
+def test_autostart_prompt_on_shown_closes_and_releases_token_when_tutorial_starts(
     mock_page: Page,
 ):
     _bootstrap_home_runtime_page(
@@ -755,8 +755,10 @@ def test_autostart_prompt_on_shown_closes_when_tutorial_starts(
             window.addEventListener('neko:decision-prompt-opened', function(event) {
                 if (event.detail && event.detail.skin === 'autostart-retention') {
                     window.__autostartPromptOpened += 1;
-                    window.isInTutorial = true;
-                    window.universalTutorialManager.isTutorialRunning = true;
+                    if (window.__autostartPromptOpened === 1) {
+                        window.isInTutorial = true;
+                        window.universalTutorialManager.isTutorialRunning = true;
+                    }
                 }
             });
             window.addEventListener('neko:decision-prompt-closed', function(event) {
@@ -779,6 +781,26 @@ def test_autostart_prompt_on_shown_closes_when_tutorial_starts(
         entry["url"] == "/api/autostart-prompt/shown"
         for entry in mock_page.evaluate("() => window.__requestLog")
     )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.isInTutorial = false;
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.dispatchEvent(new CustomEvent('neko:user-content-sent'));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__autostartPromptOpened === 2",
+        timeout=5000,
+    )
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(1)
+    shown_requests = [
+        entry for entry in mock_page.evaluate("() => window.__requestLog")
+        if entry["url"] == "/api/autostart-prompt/shown"
+    ]
+    assert len(shown_requests) == 1
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -156,6 +156,18 @@ _AUTOSTART_ELIGIBLE_FETCH_JS = """
             },
         });
     }
+    if (requestUrl === '/api/autostart-prompt/decision') {
+        return jsonResponse({
+            ok: true,
+            state: {
+                status: 'deferred',
+                never_remind: false,
+                deferred_until: Date.now() + 1000,
+                autostart_enabled: false,
+                can_never_remind: false,
+            },
+        });
+    }
 """
 
 
@@ -593,6 +605,18 @@ def test_autostart_prompt_waits_for_tutorial_release_and_teardown(
                     },
                 });
             }
+            if (requestUrl === '/api/autostart-prompt/decision') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'deferred',
+                        never_remind: false,
+                        deferred_until: Date.now() + 1000,
+                        autostart_enabled: false,
+                        can_never_remind: false,
+                    },
+                });
+            }
         """,
     )
 
@@ -649,13 +673,7 @@ def test_autostart_prompt_waits_for_tutorial_release_and_teardown(
         if entry["url"] == "/api/autostart-prompt/shown"
     ]
     assert len(shown_requests) == 1
-    mock_page.evaluate(
-        """
-        () => window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
-            detail: { released: false, reason: 'test-cleanup' },
-        }))
-        """
-    )
+    mock_page.locator(".modal-dialog-autostart-retention .modal-btn").first.click()
     expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(0, timeout=5000)
 
 
@@ -809,10 +827,12 @@ def test_autostart_prompt_on_shown_closes_and_releases_token_when_tutorial_start
         if entry["url"] == "/api/autostart-prompt/shown"
     ]
     assert len(shown_requests) == 1
+    mock_page.locator(".modal-dialog-autostart-retention .modal-btn").first.click()
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(0, timeout=5000)
 
 
 @pytest.mark.frontend
-def test_autostart_prompt_closes_open_prompt_when_tutorial_rearms(
+def test_autostart_prompt_stays_open_until_user_decides_when_tutorial_rearms(
     mock_page: Page,
 ):
     _bootstrap_home_runtime_page(
@@ -858,6 +878,10 @@ def test_autostart_prompt_closes_open_prompt_when_tutorial_rearms(
         """
     )
 
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(1)
+    assert mock_page.evaluate("() => window.__audioStops") == 0
+
+    mock_page.locator(".modal-dialog-autostart-retention .modal-btn").first.click()
     expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(0, timeout=5000)
     assert mock_page.evaluate("() => window.__audioStops") == 1
 

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -92,6 +92,72 @@ __FETCH_JS__
 }
 """
 
+_AUTOSTART_ELIGIBLE_SETUP_JS = """
+    window.__requestLog = [];
+    window.nekoAutostartProvider = {
+        getStatus: async function() {
+            return {
+                ok: true,
+                supported: true,
+                enabled: false,
+                authoritative: true,
+                provider: 'backend',
+            };
+        },
+        enable: async function() {
+            throw new Error('enable should not be called');
+        },
+    };
+"""
+
+_AUTOSTART_ELIGIBLE_FETCH_JS = """
+    window.__requestLog.push({
+        url: requestUrl,
+        method: method,
+        body: body,
+    });
+
+    if (requestUrl === '/api/autostart-prompt/state') {
+        return jsonResponse({
+            state: {
+                status: 'observing',
+                never_remind: false,
+                deferred_until: 0,
+                autostart_enabled: false,
+                can_never_remind: false,
+            },
+        });
+    }
+    if (requestUrl === '/api/autostart-prompt/heartbeat') {
+        return jsonResponse({
+            ok: true,
+            should_prompt: true,
+            prompt_reason: 'usage_timeout',
+            prompt_token: 'tutorial-race-token',
+            state: {
+                status: 'observing',
+                never_remind: false,
+                deferred_until: 0,
+                autostart_enabled: false,
+                can_never_remind: false,
+            },
+        });
+    }
+    if (requestUrl === '/api/autostart-prompt/shown') {
+        return jsonResponse({
+            ok: true,
+            already_acknowledged: false,
+            state: {
+                status: 'prompted',
+                never_remind: false,
+                deferred_until: 0,
+                autostart_enabled: false,
+                can_never_remind: false,
+            },
+        });
+    }
+"""
+
 
 def _expand_script_dependencies(script_names: tuple[str, ...]) -> tuple[str, ...]:
     expanded = []
@@ -583,6 +649,101 @@ def test_autostart_prompt_waits_for_tutorial_release_and_teardown(
         if entry["url"] == "/api/autostart-prompt/shown"
     ]
     assert len(shown_requests) == 1
+
+
+@pytest.mark.frontend
+def test_autostart_prompt_waits_for_tutorial_when_prerequisite_rejects(
+    mock_page: Page,
+):
+    _bootstrap_home_runtime_page(
+        mock_page,
+        include_autostart_prompt=True,
+        setup_js=_AUTOSTART_ELIGIBLE_SETUP_JS + """
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = false;
+            window.__promptCalls = 0;
+            window.waitForStorageLocationStartupBarrier = async function() {
+                throw new Error('storage gate failed');
+            };
+            window.showDecisionPrompt = async function() {
+                window.__promptCalls += 1;
+                return null;
+            };
+        """,
+        fetch_js=_AUTOSTART_ELIGIBLE_FETCH_JS,
+    )
+
+    mock_page.wait_for_function(
+        """
+        () => window.__requestLog.some(
+            (entry) => entry.url === '/api/autostart-prompt/heartbeat'
+        )
+        """
+    )
+    mock_page.wait_for_timeout(350)
+    assert mock_page.evaluate("() => window.__promptCalls") == 0
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
+            window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
+                detail: { released: true, reason: 'no-avatar-floating-round' },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function("() => window.__promptCalls === 1", timeout=5000)
+
+
+@pytest.mark.frontend
+def test_autostart_prompt_on_shown_skips_effects_when_tutorial_starts(
+    mock_page: Page,
+):
+    _bootstrap_home_runtime_page(
+        mock_page,
+        include_autostart_prompt=True,
+        setup_js=_AUTOSTART_ELIGIBLE_SETUP_JS + """
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
+            window.__audioStarts = 0;
+            window.i18next = { language: 'en' };
+            window.Audio = function() {
+                this.pause = function() {};
+                this.play = function() {
+                    window.__audioStarts += 1;
+                    return Promise.resolve();
+                };
+                this.currentTime = 0;
+            };
+            window.showDecisionPrompt = function(config) {
+                window.__capturedAutostartPrompt = config;
+                return new Promise((resolve) => {
+                    window.__resolveAutostartPrompt = resolve;
+                });
+            };
+        """,
+        fetch_js=_AUTOSTART_ELIGIBLE_FETCH_JS,
+    )
+
+    mock_page.wait_for_function(
+        "() => !!window.__capturedAutostartPrompt",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        async () => {
+            window.isInTutorial = true;
+            window.universalTutorialManager.isTutorialRunning = true;
+            await window.__capturedAutostartPrompt.onShown();
+        }
+        """
+    )
+
+    assert mock_page.evaluate("() => window.__audioStarts") == 0
+    assert not any(
+        entry["url"] == "/api/autostart-prompt/shown"
+        for entry in mock_page.evaluate("() => window.__requestLog")
+    )
+    mock_page.evaluate("() => window.__resolveAutostartPrompt(null)")
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -649,6 +649,14 @@ def test_autostart_prompt_waits_for_tutorial_release_and_teardown(
         if entry["url"] == "/api/autostart-prompt/shown"
     ]
     assert len(shown_requests) == 1
+    mock_page.evaluate(
+        """
+        () => window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
+            detail: { released: false, reason: 'test-cleanup' },
+        }))
+        """
+    )
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(0, timeout=5000)
 
 
 @pytest.mark.frontend
@@ -801,6 +809,57 @@ def test_autostart_prompt_on_shown_closes_and_releases_token_when_tutorial_start
         if entry["url"] == "/api/autostart-prompt/shown"
     ]
     assert len(shown_requests) == 1
+
+
+@pytest.mark.frontend
+def test_autostart_prompt_closes_open_prompt_when_tutorial_rearms(
+    mock_page: Page,
+):
+    _bootstrap_home_runtime_page(
+        mock_page,
+        include_common_dialogs=True,
+        include_autostart_prompt=True,
+        setup_js=_AUTOSTART_ELIGIBLE_SETUP_JS + """
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
+            window.__audioStops = 0;
+            window.i18next = { language: 'en' };
+            window.Audio = function() {
+                this.currentTime = 0;
+                this.play = function() {
+                    return Promise.resolve();
+                };
+                this.pause = function() {
+                    window.__audioStops += 1;
+                };
+            };
+        """,
+        fetch_js=_AUTOSTART_ELIGIBLE_FETCH_JS,
+    )
+
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(1, timeout=5000)
+    mock_page.wait_for_function(
+        """
+        () => window.__requestLog.some(
+            (entry) => entry.url === '/api/autostart-prompt/shown'
+        )
+        """,
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = false;
+            window.isNekoHomeTutorialPending = true;
+            window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
+                detail: { released: false, reason: 'tutorial-manager-resize-init' },
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(0, timeout=5000)
+    assert mock_page.evaluate("() => window.__audioStops") == 1
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -696,7 +696,7 @@ def test_autostart_prompt_waits_for_tutorial_when_prerequisite_rejects(
 
 
 @pytest.mark.frontend
-def test_autostart_prompt_on_shown_skips_effects_when_tutorial_starts(
+def test_autostart_prompt_waits_for_pending_tutorial_start(
     mock_page: Page,
 ):
     _bootstrap_home_runtime_page(
@@ -704,7 +704,45 @@ def test_autostart_prompt_on_shown_skips_effects_when_tutorial_starts(
         include_autostart_prompt=True,
         setup_js=_AUTOSTART_ELIGIBLE_SETUP_JS + """
             window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
+            window.__promptCalls = 0;
+            window.universalTutorialManager.pendingTutorialStartSource = 'manual';
+            window.showDecisionPrompt = async function() {
+                window.__promptCalls += 1;
+                return null;
+            };
+        """,
+        fetch_js=_AUTOSTART_ELIGIBLE_FETCH_JS,
+    )
+
+    mock_page.wait_for_function(
+        """
+        () => window.__requestLog.some(
+            (entry) => entry.url === '/api/autostart-prompt/heartbeat'
+        )
+        """
+    )
+    mock_page.wait_for_timeout(350)
+    assert mock_page.evaluate("() => window.__promptCalls") == 0
+
+    mock_page.evaluate(
+        "() => { window.universalTutorialManager.pendingTutorialStartSource = null; }"
+    )
+    mock_page.wait_for_function("() => window.__promptCalls === 1", timeout=5000)
+
+
+@pytest.mark.frontend
+def test_autostart_prompt_on_shown_closes_when_tutorial_starts(
+    mock_page: Page,
+):
+    _bootstrap_home_runtime_page(
+        mock_page,
+        include_common_dialogs=True,
+        include_autostart_prompt=True,
+        setup_js=_AUTOSTART_ELIGIBLE_SETUP_JS + """
+            window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = true;
             window.__audioStarts = 0;
+            window.__autostartPromptOpened = 0;
+            window.__autostartPromptClosed = 0;
             window.i18next = { language: 'en' };
             window.Audio = function() {
                 this.pause = function() {};
@@ -714,36 +752,33 @@ def test_autostart_prompt_on_shown_skips_effects_when_tutorial_starts(
                 };
                 this.currentTime = 0;
             };
-            window.showDecisionPrompt = function(config) {
-                window.__capturedAutostartPrompt = config;
-                return new Promise((resolve) => {
-                    window.__resolveAutostartPrompt = resolve;
-                });
-            };
+            window.addEventListener('neko:decision-prompt-opened', function(event) {
+                if (event.detail && event.detail.skin === 'autostart-retention') {
+                    window.__autostartPromptOpened += 1;
+                    window.isInTutorial = true;
+                    window.universalTutorialManager.isTutorialRunning = true;
+                }
+            });
+            window.addEventListener('neko:decision-prompt-closed', function(event) {
+                if (event.detail && event.detail.skin === 'autostart-retention') {
+                    window.__autostartPromptClosed += 1;
+                }
+            });
         """,
         fetch_js=_AUTOSTART_ELIGIBLE_FETCH_JS,
     )
 
     mock_page.wait_for_function(
-        "() => !!window.__capturedAutostartPrompt",
+        "() => window.__autostartPromptOpened === 1",
         timeout=5000,
     )
-    mock_page.evaluate(
-        """
-        async () => {
-            window.isInTutorial = true;
-            window.universalTutorialManager.isTutorialRunning = true;
-            await window.__capturedAutostartPrompt.onShown();
-        }
-        """
-    )
-
+    expect(mock_page.locator(".modal-overlay-autostart-retention")).to_have_count(0, timeout=5000)
+    assert mock_page.evaluate("() => window.__autostartPromptClosed") == 1
     assert mock_page.evaluate("() => window.__audioStarts") == 0
     assert not any(
         entry["url"] == "/api/autostart-prompt/shown"
         for entry in mock_page.evaluate("() => window.__requestLog")
     )
-    mock_page.evaluate("() => window.__resolveAutostartPrompt(null)")
 
 
 @pytest.mark.frontend

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -518,6 +518,29 @@ def test_universal_tutorial_manager_releases_startup_greeting_without_manager_or
     assert "this.dispatchStartupGreetingRelease('avatar-floating-auto-round-check-failed');" in auto_round_block
 
 
+def test_universal_tutorial_manager_rearms_startup_greeting_before_resize_init():
+    source = _read_manager()
+
+    assert "function rearmStartupGreetingWithoutManager(reason, detail = {})" in source
+    rearm_block = source.split(
+        "function rearmStartupGreetingWithoutManager(reason, detail = {})",
+        1,
+    )[1].split("\n}", 1)[0]
+    assert "window.isNekoHomeTutorialPending = true;" in rearm_block
+    assert "window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = false;" in rearm_block
+    assert "delete window.__NEKO_STARTUP_GREETING_RELEASED__;" in rearm_block
+
+    resize_block = source.split(
+        "window.addEventListener('resize', function retryUniversalTutorialManagerInit() {",
+        1,
+    )[1].split("\n    });", 1)[0]
+    rearm_call = "rearmStartupGreetingWithoutManager('tutorial-manager-resize-init'"
+    assert rearm_call in resize_block
+    assert resize_block.index(rearm_call) < resize_block.index(
+        "initUniversalTutorialManager().then(function (initialized) {"
+    )
+
+
 def test_universal_tutorial_manager_resets_and_delays_startup_greeting_release():
     source = _read_manager()
 

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -529,6 +529,9 @@ def test_universal_tutorial_manager_rearms_startup_greeting_before_resize_init()
     assert "window.isNekoHomeTutorialPending = true;" in rearm_block
     assert "window.__NEKO_TUTORIAL_STARTUP_SETTLED__ = false;" in rearm_block
     assert "delete window.__NEKO_STARTUP_GREETING_RELEASED__;" in rearm_block
+    assert "released: false," in rearm_block
+    assert "window.dispatchEvent(new CustomEvent(STARTUP_GREETING_RELEASE_EVENT" in rearm_block
+    assert "detail: rearmDetail" in rearm_block
 
     resize_block = source.split(
         "window.addEventListener('resize', function retryUniversalTutorialManagerInit() {",

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -538,10 +538,21 @@ def test_universal_tutorial_manager_rearms_startup_greeting_before_resize_init()
         1,
     )[1].split("\n    });", 1)[0]
     rearm_call = "rearmStartupGreetingWithoutManager('tutorial-manager-resize-init'"
+    wait_call = "waitForActiveAutostartPromptClosed().then(function () {"
     assert rearm_call in resize_block
-    assert resize_block.index(rearm_call) < resize_block.index(
-        "initUniversalTutorialManager().then(function (initialized) {"
+    assert wait_call in resize_block
+    assert resize_block.index(rearm_call) < resize_block.index(wait_call)
+    assert resize_block.index(wait_call) < resize_block.index(
+        "return initUniversalTutorialManager();"
     )
+
+    wait_block = source.split("function waitForActiveAutostartPromptClosed()", 1)[1].split(
+        "\n}",
+        1,
+    )[0]
+    assert "'.modal-overlay-autostart-retention'" in wait_block
+    assert "window.addEventListener('neko:decision-prompt-closed', onPromptClosed);" in wait_block
+    assert "detail.skin === 'autostart-retention'" in wait_block
 
 
 def test_universal_tutorial_manager_resets_and_delays_startup_greeting_release():


### PR DESCRIPTION
## 改动概述 / Summary

修复用户启动 N.E.K.O. 时，每日教程与开机自启动推荐可能同时出现的问题。

- 为自启动推荐增加教程启动屏障，等待教程启动决策完成。
- 教程处于 pending、running 或 teardown 状态时阻止自启动推荐展示。
- 在异步展示检查和真正创建弹窗前分别复查教程状态，关闭竞态窗口。
- 保持原有前台计时和 heartbeat 行为不变。
- 教程占屏期间不发送 shown 确认，教程结束后仍可正常展示。
- 增加浏览器回归测试，覆盖 pending、startup release、teardown 和单次展示。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/、memory/ 下的任何 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 仅修改 1 个计入上限的非测试文件。

## 测试 / Testing

- 自启动提示前端测试：9 passed
- 公共提示队列与教程管理器单元测试：32 passed
- Ruff 检查通过
- JavaScript 语法检查通过
- git diff --check 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 教程运行、启动或退出过程中不再显示自启动提示，避免干扰教程体验。
  * 自启动提示会等待教程完全结束并保持稳定后再显示。
  * 教程启动时若提示已显示，系统会自动关闭提示，并停止相关音效与确认操作。
  * 优化提示显示请求，确保仅在实际显示时发送，并避免重复发送。
  * 窗口初始化或尺寸变化后，教程状态会正确恢复并重新阻止过早显示启动提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->