### PR TITLE
feat(plugin-manager): show plugin author

### DIFF
--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -87,6 +87,9 @@
             <el-descriptions :column="2" border>
               <el-descriptions-item :label="$t('plugins.id')">{{ plugin.id }}</el-descriptions-item>
               <el-descriptions-item :label="$t('plugins.version')">{{ plugin.version }}</el-descriptions-item>
+              <el-descriptions-item :label="$t('market.filterLabels.author')" :span="2">
+                {{ authorDisplay || $t('common.noData') }}
+              </el-descriptions-item>
               <el-descriptions-item :label="$t('plugins.description')" :span="2">{{ pluginDisplayText.description || $t('common.noData') }}</el-descriptions-item>
               <el-descriptions-item :label="$t('plugins.pluginType')">
                 <el-tag size="small" :type="pluginTypeTagType">
@@ -188,6 +191,13 @@ const emptyPluginDisplayText: PluginDisplayText = {
 
 const pluginDisplayText = computed(() => {
   return plugin.value ? resolvePluginDisplayText(plugin.value, locale.value) : emptyPluginDisplayText
+})
+
+const authorDisplay = computed(() => {
+  const author = plugin.value?.author
+  if (!author) return ''
+  if (author.name && author.email) return `${author.name} <${author.email}>`
+  return author.name || author.email || ''
 })
 
 const panelSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'panel'))


### PR DESCRIPTION
## Summary
- Display plugin author name and email in the basic information section.
- Place the author row between version and description.

## Testing
- npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 插件详情页的基础信息区域新增作者信息展示。
  * 显示作者姓名和邮箱；信息缺失时显示“无数据”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->