### PR TITLE
修复 DeepSeek V4 记忆压缩默认启用思考导致的超时问题，仅关闭压缩思考模式，保持记忆整理行为不变，并补充回归测试

### DIFF
--- a/config/providers.py
+++ b/config/providers.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import urlparse
 
 
 # ────────────────────────────────────────────────────────────────
@@ -58,12 +57,6 @@ EXTRA_BODY_OPENAI_NATIVE_MINIMAL_THINKING = {"reasoning_effort": "low"}
 
 EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
 EXTRA_BODY_CLAUDE_THINKING = {"thinking": {"type": "enabled"}}
-
-# DeepSeek V4 官方 OpenAI-compatible 接口使用 thinking.type 方言，且默认开启
-# thinking。不要复用 EXTRA_BODY_CLAUDE：两者当前 wire shape 虽相同，但属于不同
-# provider 契约，后续任一方调整时必须能独立演进。
-EXTRA_BODY_DEEPSEEK = {"thinking": {"type": "disabled"}}
-EXTRA_BODY_DEEPSEEK_THINKING = {"thinking": {"type": "enabled"}}
 
 # Anthropic 原生 claude（经 OpenAI-compat 透传 thinking）跟 GLM/Kimi/Doubao 的
 # thinking.type 方言不一样：Opus 4.7+ 已移除 {type:enabled,budget_tokens}，发它直接
@@ -143,6 +136,12 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "deepseek-ai/DeepSeek-V3.2": EXTRA_BODY_OPENAI,
     "deepseek-ai/DeepSeek-V4-Flash": EXTRA_BODY_OPENAI,
     "Qwen/Qwen3.5-397B-A17B": EXTRA_BODY_OPENAI,
+    # DeepSeek 官方（api.deepseek.com）：V4 默认开思考，且用的是 thinking.type 方言，
+    # 跟 GLM/Kimi/Doubao 同形状，直接复用 EXTRA_BODY_CLAUDE。转售同款的网关是另外的
+    # 键名（SiliconFlow 的 deepseek-ai/…、OpenRouter 的 deepseek/…），各走各的方言，
+    # 不会被这两行波及。
+    "deepseek-v4-flash": EXTRA_BODY_CLAUDE,
+    "deepseek-v4-pro": EXTRA_BODY_CLAUDE,
     # Step
     "step-2-mini": {"tools": [{"type": "web_search", "function": {"description": "这个web_search用来搜索互联网的信息"}}]},
     # 免费版（lanlan.tech / lanlan.app，模型名固定 free-model）：用 thinking.type 风格，
@@ -195,30 +194,6 @@ def get_agent_extra_body(model: str) -> dict | None:
     return get_extra_body(model)
 
 
-_DEEPSEEK_V4_MODELS = frozenset({"deepseek-v4-flash", "deepseek-v4-pro"})
-
-
-def get_memory_compression_extra_body(
-    model: str,
-    base_url: str | None,
-) -> dict | None:
-    """Return provider parameters for the non-thinking memory-compression path.
-
-    DeepSeek V4 defaults to thinking mode.  Its official endpoint uses
-    ``thinking.type`` rather than the ``enable_thinking`` dialect used by
-    SiliconFlow, so model-only lookup cannot safely select the right wire
-    shape.  Keep this override scoped to memory compression: recent-history
-    review deliberately uses the model's native/default thinking behavior.
-    """
-    try:
-        hostname = (urlparse(base_url).hostname or "").lower() if base_url else ""
-    except ValueError:
-        hostname = ""
-    if hostname == "api.deepseek.com" and model in _DEEPSEEK_V4_MODELS:
-        return copy.deepcopy(EXTRA_BODY_DEEPSEEK)
-    return get_extra_body(model)
-
-
 # 凝神（thinking-on）时把各 provider 的「关思考」extra_body 翻成「开思考」形式。
 # 键 = 「关」常量的 id，值 = 对应「开」常量；按各家 API 语义一一对偶，不机械翻 bool。
 # 未收录的「关」常量（如 MiniMax 的 reasoning_split）表示「凝神保持原值不翻」；非
@@ -229,7 +204,6 @@ _THINKING_ENABLE_FORM: dict[int, dict] = {
     id(EXTRA_BODY_OPENAI_NATIVE): EXTRA_BODY_OPENAI_NATIVE_THINKING,
     id(EXTRA_BODY_OPENAI_NATIVE_MINIMAL): EXTRA_BODY_OPENAI_NATIVE_MINIMAL_THINKING,
     id(EXTRA_BODY_CLAUDE): EXTRA_BODY_CLAUDE_THINKING,
-    id(EXTRA_BODY_DEEPSEEK): EXTRA_BODY_DEEPSEEK_THINKING,
     id(EXTRA_BODY_GEMINI): EXTRA_BODY_GEMINI_THINKING,
     id(EXTRA_BODY_GEMINI_3): EXTRA_BODY_GEMINI_3_THINKING,
     id(EXTRA_BODY_OPENROUTER): EXTRA_BODY_OPENROUTER_THINKING,

--- a/config/providers.py
+++ b/config/providers.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 
 # ────────────────────────────────────────────────────────────────
@@ -57,6 +58,12 @@ EXTRA_BODY_OPENAI_NATIVE_MINIMAL_THINKING = {"reasoning_effort": "low"}
 
 EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
 EXTRA_BODY_CLAUDE_THINKING = {"thinking": {"type": "enabled"}}
+
+# DeepSeek V4 官方 OpenAI-compatible 接口使用 thinking.type 方言，且默认开启
+# thinking。不要复用 EXTRA_BODY_CLAUDE：两者当前 wire shape 虽相同，但属于不同
+# provider 契约，后续任一方调整时必须能独立演进。
+EXTRA_BODY_DEEPSEEK = {"thinking": {"type": "disabled"}}
+EXTRA_BODY_DEEPSEEK_THINKING = {"thinking": {"type": "enabled"}}
 
 # Anthropic 原生 claude（经 OpenAI-compat 透传 thinking）跟 GLM/Kimi/Doubao 的
 # thinking.type 方言不一样：Opus 4.7+ 已移除 {type:enabled,budget_tokens}，发它直接
@@ -188,6 +195,30 @@ def get_agent_extra_body(model: str) -> dict | None:
     return get_extra_body(model)
 
 
+_DEEPSEEK_V4_MODELS = frozenset({"deepseek-v4-flash", "deepseek-v4-pro"})
+
+
+def get_memory_compression_extra_body(
+    model: str,
+    base_url: str | None,
+) -> dict | None:
+    """Return provider parameters for the non-thinking memory-compression path.
+
+    DeepSeek V4 defaults to thinking mode.  Its official endpoint uses
+    ``thinking.type`` rather than the ``enable_thinking`` dialect used by
+    SiliconFlow, so model-only lookup cannot safely select the right wire
+    shape.  Keep this override scoped to memory compression: recent-history
+    review deliberately uses the model's native/default thinking behavior.
+    """
+    try:
+        hostname = (urlparse(base_url).hostname or "").lower() if base_url else ""
+    except ValueError:
+        hostname = ""
+    if hostname == "api.deepseek.com" and model in _DEEPSEEK_V4_MODELS:
+        return copy.deepcopy(EXTRA_BODY_DEEPSEEK)
+    return get_extra_body(model)
+
+
 # 凝神（thinking-on）时把各 provider 的「关思考」extra_body 翻成「开思考」形式。
 # 键 = 「关」常量的 id，值 = 对应「开」常量；按各家 API 语义一一对偶，不机械翻 bool。
 # 未收录的「关」常量（如 MiniMax 的 reasoning_split）表示「凝神保持原值不翻」；非
@@ -198,6 +229,7 @@ _THINKING_ENABLE_FORM: dict[int, dict] = {
     id(EXTRA_BODY_OPENAI_NATIVE): EXTRA_BODY_OPENAI_NATIVE_THINKING,
     id(EXTRA_BODY_OPENAI_NATIVE_MINIMAL): EXTRA_BODY_OPENAI_NATIVE_MINIMAL_THINKING,
     id(EXTRA_BODY_CLAUDE): EXTRA_BODY_CLAUDE_THINKING,
+    id(EXTRA_BODY_DEEPSEEK): EXTRA_BODY_DEEPSEEK_THINKING,
     id(EXTRA_BODY_GEMINI): EXTRA_BODY_GEMINI_THINKING,
     id(EXTRA_BODY_GEMINI_3): EXTRA_BODY_GEMINI_3_THINKING,
     id(EXTRA_BODY_OPENROUTER): EXTRA_BODY_OPENROUTER_THINKING,

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -604,14 +604,20 @@ class CompressedRecentHistoryManager:
         upstream's 30s timeout.
         max_retries=0 disables the OpenAI SDK's default 2 automatic retries,
         avoiding a 3× blow-up stacked on the business-level retry.
+        Memory compression is non-judgmental summarization, so provider-specific
+        thinking is disabled here; review keeps its separate native-thinking path.
         """
         api_config = self._config_manager.get_model_api_config('summary')
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
+        from config.providers import get_memory_compression_extra_body
         return create_chat_llm(
             api_config['model'], api_config['base_url'],
             api_config['api_key'] or None,
             timeout=30, max_retries=0,
             max_completion_tokens=LLM_OUTPUT_GUARD_MAX_TOKENS,  # runaway guard; generous so variable-length summary/JSON isn't truncated
+            extra_body=get_memory_compression_extra_body(
+                api_config['model'], api_config['base_url'],
+            ),
             provider_type=api_config.get('provider_type'),
         )
 

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -604,20 +604,14 @@ class CompressedRecentHistoryManager:
         upstream's 30s timeout.
         max_retries=0 disables the OpenAI SDK's default 2 automatic retries,
         avoiding a 3× blow-up stacked on the business-level retry.
-        Memory compression is non-judgmental summarization, so provider-specific
-        thinking is disabled here; review keeps its separate native-thinking path.
         """
         api_config = self._config_manager.get_model_api_config('summary')
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        from config.providers import get_memory_compression_extra_body
         return create_chat_llm(
             api_config['model'], api_config['base_url'],
             api_config['api_key'] or None,
             timeout=30, max_retries=0,
             max_completion_tokens=LLM_OUTPUT_GUARD_MAX_TOKENS,  # runaway guard; generous so variable-length summary/JSON isn't truncated
-            extra_body=get_memory_compression_extra_body(
-                api_config['model'], api_config['base_url'],
-            ),
             provider_type=api_config.get('provider_type'),
         )
 

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -547,6 +547,26 @@ def test_focus_extra_body_provider_dialects():
     assert focus_extra_body("glm-5.2") == {"thinking": {"type": "enabled"}}
 
 
+def test_memory_compression_uses_official_deepseek_thinking_dialect():
+    from config.providers import get_memory_compression_extra_body
+
+    expected = {"thinking": {"type": "disabled"}}
+    assert get_memory_compression_extra_body(
+        "deepseek-v4-flash", "https://api.deepseek.com/v1",
+    ) == expected
+    assert get_memory_compression_extra_body(
+        "deepseek-v4-pro", "https://api.deepseek.com",
+    ) == expected
+    # 同名模型挂在非官方兼容网关时不能擅自发送 DeepSeek 官方方言。
+    assert get_memory_compression_extra_body(
+        "deepseek-v4-pro", "https://example.com/v1",
+    ) == {}
+    # SiliconFlow 保持现有 enable_thinking 方言，不被官方接口特例覆盖。
+    assert get_memory_compression_extra_body(
+        "deepseek-ai/DeepSeek-V4-Flash", "https://api.siliconflow.cn/v1",
+    ) == {"enable_thinking": False}
+
+
 async def test_focus_override_threads_through_visible_stream():
     """The override returned above must reach ``llm.astream`` unchanged through
     the real production path (``_astream_visible_with_tools`` → tool-leak filter

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -547,24 +547,26 @@ def test_focus_extra_body_provider_dialects():
     assert focus_extra_body("glm-5.2") == {"thinking": {"type": "enabled"}}
 
 
-def test_memory_compression_uses_official_deepseek_thinking_dialect():
-    from config.providers import get_memory_compression_extra_body
+def test_official_deepseek_v4_registers_the_thinking_type_dialect():
+    """Official DeepSeek V4 defaults to thinking-on, so it belongs in the map.
 
-    expected = {"thinking": {"type": "disabled"}}
-    assert get_memory_compression_extra_body(
-        "deepseek-v4-flash", "https://api.deepseek.com/v1",
-    ) == expected
-    assert get_memory_compression_extra_body(
-        "deepseek-v4-pro", "https://api.deepseek.com",
-    ) == expected
-    # 同名模型挂在非官方兼容网关时不能擅自发送 DeepSeek 官方方言。
-    assert get_memory_compression_extra_body(
-        "deepseek-v4-pro", "https://example.com/v1",
-    ) == {}
-    # SiliconFlow 保持现有 enable_thinking 方言，不被官方接口特例覆盖。
-    assert get_memory_compression_extra_body(
-        "deepseek-ai/DeepSeek-V4-Flash", "https://api.siliconflow.cn/v1",
-    ) == {"enable_thinking": False}
+    Asserting the VALUE alone would not be enough: swapping in a fresh constant
+    with identical contents (a separate ``EXTRA_BODY_DEEPSEEK``) keeps the value
+    assertions green, yet ``_THINKING_ENABLE_FORM`` pairs by ``id()`` — a new
+    identity silently drops the focus dual. So pin the constant identity too.
+    """
+    from config.providers import (
+        EXTRA_BODY_CLAUDE, MODELS_EXTRA_BODY_MAP, focus_extra_body, get_extra_body,
+    )
+
+    for model in ("deepseek-v4-flash", "deepseek-v4-pro"):
+        assert MODELS_EXTRA_BODY_MAP[model] is EXTRA_BODY_CLAUDE
+        assert get_extra_body(model) == {"thinking": {"type": "disabled"}}
+        # 凝神对偶由派生表自动获得，不需要单独登记。
+        assert focus_extra_body(model) == {"thinking": {"type": "enabled"}}
+
+    # 转售同款的网关是另外的键名，各走各的方言，不被官方那两行波及。
+    assert get_extra_body("deepseek-ai/DeepSeek-V4-Flash") == {"enable_thinking": False}
 
 
 async def test_focus_override_threads_through_visible_stream():

--- a/tests/unit/test_recent_compression_failure.py
+++ b/tests/unit/test_recent_compression_failure.py
@@ -57,6 +57,17 @@ class _FakeConfig:
         )
 
 
+class _FakeModelConfig:
+    def get_model_api_config(self, feature: str) -> dict[str, Any]:
+        assert feature in {"summary", "correction"}
+        return {
+            "model": "deepseek-v4-pro",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "test-key",
+            "provider_type": None,
+        }
+
+
 @pytest.fixture(autouse=True)
 def _patch_cloudsave(monkeypatch):
     monkeypatch.setattr(
@@ -112,6 +123,27 @@ def test_compress_history_returns_none_when_summary_llm_keeps_failing(tmp_path):
 
     assert result is None
     assert fake_llm.calls == 3
+
+
+def test_deepseek_thinking_is_disabled_only_for_memory_compression(monkeypatch):
+    calls = []
+    sentinel = object()
+
+    def _fake_create_chat_llm(*args, **kwargs):
+        calls.append((args, kwargs))
+        return sentinel
+
+    monkeypatch.setattr("memory.recent.create_chat_llm", _fake_create_chat_llm)
+    mgr = object.__new__(CompressedRecentHistoryManager)
+    mgr._config_manager = _FakeModelConfig()
+
+    assert mgr._get_llm() is sentinel
+    assert mgr._get_review_llm() is sentinel
+
+    assert calls[0][1]["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert calls[0][1]["timeout"] == 30
+    assert calls[1][1]["extra_body"] is None
+    assert calls[1][1]["timeout"] == 110
 
 
 def test_update_history_preserves_existing_memo_when_compression_fails(tmp_path):

--- a/tests/unit/test_recent_compression_failure.py
+++ b/tests/unit/test_recent_compression_failure.py
@@ -58,8 +58,13 @@ class _FakeConfig:
 
 
 class _FakeModelConfig:
+    """Serves the official DeepSeek V4 endpoint and records which feature asked."""
+
+    def __init__(self):
+        self.features: list[str] = []
+
     def get_model_api_config(self, feature: str) -> dict[str, Any]:
-        assert feature in {"summary", "correction"}
+        self.features.append(feature)
         return {
             "model": "deepseek-v4-pro",
             "base_url": "https://api.deepseek.com/v1",
@@ -125,25 +130,24 @@ def test_compress_history_returns_none_when_summary_llm_keeps_failing(tmp_path):
     assert fake_llm.calls == 3
 
 
-def test_deepseek_thinking_is_disabled_only_for_memory_compression(monkeypatch):
-    calls = []
-    sentinel = object()
+def test_deepseek_thinking_is_disabled_only_for_memory_compression():
+    """Compression must run thinking-off; review keeps the model's native thinking.
 
-    def _fake_create_chat_llm(*args, **kwargs):
-        calls.append((args, kwargs))
-        return sentinel
-
-    monkeypatch.setattr("memory.recent.create_chat_llm", _fake_create_chat_llm)
+    Deliberately goes through the real ``create_chat_llm`` instead of stubbing it:
+    thinking-off is resolved by the factory from the model name, so a stub would
+    only show what ``_get_llm`` passed (nothing) and prove nothing about what the
+    client ends up sending.
+    """
     mgr = object.__new__(CompressedRecentHistoryManager)
     mgr._config_manager = _FakeModelConfig()
 
-    assert mgr._get_llm() is sentinel
-    assert mgr._get_review_llm() is sentinel
+    compression = mgr._get_llm()
+    review = mgr._get_review_llm()
 
-    assert calls[0][1]["extra_body"] == {"thinking": {"type": "disabled"}}
-    assert calls[0][1]["timeout"] == 30
-    assert calls[1][1]["extra_body"] is None
-    assert calls[1][1]["timeout"] == 110
+    assert mgr._config_manager.features == ["summary", "correction"]
+    assert compression.extra_body == {"thinking": {"type": "disabled"}}
+    # 记忆整理显式 extra_body=None，压过工厂的自动解析，保持模型原生思考行为。
+    assert review.extra_body == {}
 
 
 def test_update_history_preserves_existing_memo_when_compression_fails(tmp_path):


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

<!-- 这个 PR 做了什么。若有对应 Issue 可关联（如 Closes #123），非必须。 -->
修复 DeepSeek V4 记忆压缩默认启用思考模式导致请求超时的问题。
仅对 DeepSeek 官方接口的 deepseek-v4-pro 和 deepseek-v4-flash 压缩请求显式传入 thinking.type=disabled；记忆整理仍保留原生思考行为，第三方兼容网关继续使用各自参数方言。
## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
改动内容：为 memory_compression 增加独立的 provider 参数解析，并在创建摘要模型客户端时传入关闭思考参数。
必要性：DeepSeek V4 默认开启思考，而历史压缩单次超时为 30 秒，容易因思考耗时触发超时和重复请求。
改动前：DeepSeek 官方 V4 压缩请求未显式关闭思考，可能在 30 秒后超时并进入重试及后台兜底链路。
改动后：官方 DeepSeek V4 压缩请求使用非思考模式；记忆整理仍可使用思考模式。
潜在回归点：模型参数方言识别、第三方 DeepSeek 兼容网关及记忆整理模型创建。
验证方式：覆盖 DeepSeek Pro/Flash 官方接口、非官方兼容接口、SiliconFlow 参数方言，以及压缩与记忆整理相互隔离的场景。

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->
uv run pytest tests/unit/test_recent_compression_failure.py tests/unit/test_focus_mode.py -q73 passed

uv run pytest tests/unit/test_config_manager_follow_urls.py tests/unit/test_providers.py tests/unit/test_llm_client_response_safety.py -q38 passed, 6 skipped

uv run ruff check config/providers.py memory/recent.py tests/unit/test_focus_mode.py tests/unit/test_recent_compression_failure.py通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能调整**
  * 官方 DeepSeek V4 模型现采用统一的思考模式配置，并支持启用或禁用思考。
  * 保留 SiliconFlow 同名模型的独立思考参数行为。

* **测试**
  * 更新相关验证，覆盖官方 DeepSeek V4 的模型注册、思考配置及请求流程。
  * 增强压缩模型与评审模型默认配置的回归测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->