### PR TITLE
鼠标悬停或键盘聚焦表情按钮时暂停浮动动画，避免提示框闪退

### DIFF
--- a/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
@@ -211,4 +211,10 @@ describe('NekoTooltipLayer', () => {
       /\.compact-chat-minimize-ball:focus-visible\s*\{[\s\S]*?outline: 2px solid[\s\S]*?box-shadow: inset 0 0 0 3px/,
     );
   });
+
+  it('pauses floating emoji tools while hovered or keyboard-focused', () => {
+    expect(chatStyles).toMatch(
+      /\.composer-icon-popover \.composer-icon-button:is\(:hover, :focus-visible\)\s*\{\s*animation-play-state: paused;/,
+    );
+  });
 });

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2144,6 +2144,10 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   transition: background 0.16s ease, border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
 }
 
+.composer-icon-popover .composer-icon-button:is(:hover, :focus-visible) {
+  animation-play-state: paused;
+}
+
 .composer-icon-button::before,
 .composer-icon-button::after {
   content: '';


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

鼠标悬停或键盘聚焦表情按钮时暂停浮动动画，避免提示框闪退
相关pr：[让完整聊天窗口的阴影留白区域支持鼠标穿透，同时保持正文区域正常交互](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/455)
相关issues：[完整聊天窗口不太对劲](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2874)

## 测试 / Testing

手动测试可用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **体验优化**
  * 悬停或使用键盘聚焦浮动表情工具时，图标动画会自动暂停，提升操作稳定性。
* **测试**
  * 新增测试，验证悬停和键盘聚焦状态下的动画暂停行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->