### PR TITLE
feat(config): add OrcaRouter as an assist API provider

### DIFF
--- a/config/api_profiles.py
+++ b/config/api_profiles.py
@@ -210,8 +210,6 @@ DEFAULT_ASSIST_API_PROFILES = {
         'AGENT_MODEL': "openai/gpt-4.1",
     },
     'orcarouter': {
-        # OrcaRouter：Anthropic 兼容网关的 OpenAI 兼容端点（/v1/chat/completions），
-        # 模型 id 带 anthropic/ 前缀。纯 OpenAI 兼容通道，无需 provider_type 特判。
         'OPENROUTER_URL': "https://api.orcarouter.ai/v1",
         'CONVERSATION_MODEL': "anthropic/claude-sonnet-5",
         'SUMMARY_MODEL': "anthropic/claude-haiku-4.5",

--- a/config/api_profiles.py
+++ b/config/api_profiles.py
@@ -212,8 +212,8 @@ DEFAULT_ASSIST_API_PROFILES = {
     'orcarouter': {
         'OPENROUTER_URL': "https://api.orcarouter.ai/v1",
         'CONVERSATION_MODEL': "anthropic/claude-sonnet-5",
-        'SUMMARY_MODEL': "anthropic/claude-haiku-4.5",
-        'CORRECTION_MODEL': "anthropic/claude-haiku-4.5",
+        'SUMMARY_MODEL': "anthropic/claude-sonnet-5",
+        'CORRECTION_MODEL': "anthropic/claude-sonnet-5",
         'EMOTION_MODEL': "anthropic/claude-haiku-4.5",
         'VISION_MODEL': "anthropic/claude-sonnet-5",
         'AGENT_MODEL': "anthropic/claude-sonnet-5",

--- a/config/api_profiles.py
+++ b/config/api_profiles.py
@@ -36,6 +36,7 @@ DEFAULT_CORE_CONFIG = {
     "assistApiKeyMimoTokenPlan": "",
     "assistApiKeyElevenlabs": "",
     "assistApiKeyClaude": "",
+    "assistApiKeyOrcarouter": "",
     "assistApiKeyGrok": "",
     "assistApiKeyDoubao": "",
     "assistApiKeyDoubaoTts": "",
@@ -208,6 +209,17 @@ DEFAULT_ASSIST_API_PROFILES = {
         'VISION_MODEL': "openai/gpt-4.1",
         'AGENT_MODEL': "openai/gpt-4.1",
     },
+    'orcarouter': {
+        # OrcaRouter：Anthropic 兼容网关的 OpenAI 兼容端点（/v1/chat/completions），
+        # 模型 id 带 anthropic/ 前缀。纯 OpenAI 兼容通道，无需 provider_type 特判。
+        'OPENROUTER_URL': "https://api.orcarouter.ai/v1",
+        'CONVERSATION_MODEL': "anthropic/claude-sonnet-5",
+        'SUMMARY_MODEL': "anthropic/claude-haiku-4.5",
+        'CORRECTION_MODEL': "anthropic/claude-haiku-4.5",
+        'EMOTION_MODEL': "anthropic/claude-haiku-4.5",
+        'VISION_MODEL': "anthropic/claude-sonnet-5",
+        'AGENT_MODEL': "anthropic/claude-sonnet-5",
+    },
     'grok': {
         'OPENROUTER_URL': "https://api.x.ai/v1",
         'CONVERSATION_MODEL': "grok-4-1-fast-non-reasoning",
@@ -258,6 +270,7 @@ DEFAULT_ASSIST_API_KEY_FIELDS = {
     'elevenlabs': 'ASSIST_API_KEY_ELEVENLABS',
     'claude': 'ASSIST_API_KEY_CLAUDE',
     'openrouter': 'ASSIST_API_KEY_OPENROUTER',
+    'orcarouter': 'ASSIST_API_KEY_ORCAROUTER',
     'grok': 'ASSIST_API_KEY_GROK',
     'doubao': 'ASSIST_API_KEY_DOUBAO',
 }

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -294,7 +294,7 @@
     "orcarouter": {
       "key": "orcarouter",
       "name": "OrcaRouter",
-      "description": "Anthropic 兼容网关：OpenAI 兼容端点直通 Claude 全系模型",
+      "description": "第三方 Claude 中转网关，国内版不支持",
       "openrouter_url": "https://api.orcarouter.ai/v1",
       "conversation_model": "anthropic/claude-sonnet-5",
       "summary_model": "anthropic/claude-haiku-4.5",
@@ -445,7 +445,7 @@
     },
     "orcarouter": {
       "config_field": "assistApiKeyOrcarouter",
-      "restricted": false
+      "restricted": true
     },
     "vllm_omni": {
       "config_field": "ttsModelApiKey",

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -297,8 +297,8 @@
       "description": "第三方 Claude 中转网关，国内版不支持",
       "openrouter_url": "https://api.orcarouter.ai/v1",
       "conversation_model": "anthropic/claude-sonnet-5",
-      "summary_model": "anthropic/claude-haiku-4.5",
-      "correction_model": "anthropic/claude-haiku-4.5",
+      "summary_model": "anthropic/claude-sonnet-5",
+      "correction_model": "anthropic/claude-sonnet-5",
       "emotion_model": "anthropic/claude-haiku-4.5",
       "vision_model": "anthropic/claude-sonnet-5",
       "agent_model": "anthropic/claude-sonnet-5"

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -291,6 +291,18 @@
       "vision_model": "google/gemini-2.5-flash",
       "agent_model": "google/gemini-3-flash-preview"
     },
+    "orcarouter": {
+      "key": "orcarouter",
+      "name": "OrcaRouter",
+      "description": "Anthropic 兼容网关：OpenAI 兼容端点直通 Claude 全系模型",
+      "openrouter_url": "https://api.orcarouter.ai/v1",
+      "conversation_model": "anthropic/claude-sonnet-5",
+      "summary_model": "anthropic/claude-haiku-4.5",
+      "correction_model": "anthropic/claude-haiku-4.5",
+      "emotion_model": "anthropic/claude-haiku-4.5",
+      "vision_model": "anthropic/claude-sonnet-5",
+      "agent_model": "anthropic/claude-sonnet-5"
+    },
     "vllm_omni": {
       "key": "vllm_omni",
       "name": "vLLM-Omni (TTS)",
@@ -355,7 +367,8 @@
     "elevenlabs": "ASSIST_API_KEY_ELEVENLABS",
     "claude": "ASSIST_API_KEY_CLAUDE",
     "grok": "ASSIST_API_KEY_GROK",
-    "openrouter": "ASSIST_API_KEY_OPENROUTER"
+    "openrouter": "ASSIST_API_KEY_OPENROUTER",
+    "orcarouter": "ASSIST_API_KEY_ORCAROUTER"
   },
   "api_key_registry": {
     "qwen": {
@@ -429,6 +442,10 @@
     "openrouter": {
       "config_field": "assistApiKeyOpenrouter",
       "restricted": true
+    },
+    "orcarouter": {
+      "config_field": "assistApiKeyOrcarouter",
+      "restricted": false
     },
     "vllm_omni": {
       "config_field": "ttsModelApiKey",

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -45,6 +45,7 @@ CORE_CONFIG_ASSIST_API_KEY_FIELDS = (
     'assistApiKeyMinimaxIntl', 'assistApiKeyMimo',
     'assistApiKeyMimoTokenPlan', 'assistApiKeyElevenlabs', 'assistApiKeyGrok',
     'assistApiKeyClaude', 'assistApiKeyKimiCode', 'assistApiKeyOpenrouter',
+    'assistApiKeyOrcarouter',
 )
 
 CORE_CONFIG_MODEL_API_KEY_FIELDS = tuple(
@@ -218,6 +219,7 @@ async def get_core_config_api():
             "assistApiKeyGrok": core_cfg.get('assistApiKeyGrok', '') or _fb('grok'),
             "assistApiKeyClaude": core_cfg.get('assistApiKeyClaude', '') or _fb('claude'),
             "assistApiKeyOpenrouter": core_cfg.get('assistApiKeyOpenrouter', '') or _fb('openrouter'),
+            "assistApiKeyOrcarouter": core_cfg.get('assistApiKeyOrcarouter', '') or _fb('orcarouter'),
             "mcpToken": core_cfg.get('mcpToken', ''),
             "openclawUrl": core_cfg.get('openclawUrl'),
             "openclawTimeout": core_cfg.get('openclawTimeout'),

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (Model Aggregator)",
+            "orcarouter": "OrcaRouter (Claude Gateway)",
             "vllm_omni": "vLLM-Omni (TTS)",
             "gptsovits": "GPT-SoVITS (self-hosted)"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "Free version does not require API Key",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude (antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (agregador de modelos)",
+            "orcarouter": "OrcaRouter (pasarela de Claude)",
             "vllm_omni": "vLLM-Omni (TTS)",
             "gptsovits": "GPT-SoVITS (autoalojado)"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude (antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (agregador de modelos)",
+            "orcarouter": "OrcaRouter (pasarela de Claude)",
             "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "La versión gratuita no requiere clave API",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（モデルアグリゲーター）",
+            "orcarouter": "OrcaRouter（Claude ゲートウェイ）",
             "vllm_omni": "vLLM-Omni（TTS）",
             "gptsovits": "GPT-SoVITS（セルフホスト）"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni（TTS）"
         },
         "freeVersionNoApiKey": "無料版はAPIキー不要です",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude(Anthropic)",
             "grok": "Grok(xAI)",
             "openrouter": "OpenRouter(모델 통합 플랫폼)",
+            "orcarouter": "OrcaRouter(Claude 게이트웨이)",
             "vllm_omni": "vLLM-Omni (TTS)",
             "gptsovits": "GPT-SoVITS (자체 호스팅)"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude(Anthropic)",
             "grok": "Grok(xAI)",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni(TTS)"
         },
         "freeVersionNoApiKey": "무료 버전에는 API 키가 필요하지 않습니다.",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude (Antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (agregador de modelo)",
+            "orcarouter": "OrcaRouter (gateway do Claude)",
             "vllm_omni": "vLLM-Omni (TTS)",
             "gptsovits": "GPT-SoVITS (auto-hospedado)"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude (Antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "A versão gratuita não requer chave API",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (агрегатор моделей)",
+            "orcarouter": "OrcaRouter (шлюз Claude)",
             "vllm_omni": "vLLM-Omni (TTS)",
             "gptsovits": "GPT-SoVITS (свой сервер)"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "Бесплатная версия не требует API Key",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude（Anthropic，国内无法使用）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（模型聚合，国内无法使用）",
+            "orcarouter": "OrcaRouter（Claude 网关，国内无法使用）",
             "vllm_omni": "vLLM-Omni（TTS）",
             "gptsovits": "GPT-SoVITS（自部署）"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni（TTS）"
         },
         "freeVersionNoApiKey": "免费版无需API Key",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1084,6 +1084,7 @@
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（模型聚合，國內無法使用）",
+            "orcarouter": "OrcaRouter（Claude 閘道，國內無法使用）",
             "vllm_omni": "vLLM-Omni（TTS）",
             "gptsovits": "GPT-SoVITS（自部署）"
         },
@@ -1134,6 +1135,7 @@
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter",
+            "orcarouter": "OrcaRouter",
             "vllm_omni": "vLLM-Omni（TTS）"
         },
         "freeVersionNoApiKey": "免費版無需API Key",

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -103,6 +103,7 @@ class TestKeybookSaveLoad:
                        'ASSIST_API_KEY_DEEPSEEK',
                        'ASSIST_API_KEY_DOUBAO', 'ASSIST_API_KEY_DOUBAO_TTS', 'ASSIST_API_KEY_GROK',
                        'ASSIST_API_KEY_CLAUDE', 'ASSIST_API_KEY_OPENROUTER',
+                       'ASSIST_API_KEY_ORCAROUTER',
                        'ASSIST_API_KEY_QWEN_INTL',
                        'ASSIST_API_KEY_MINIMAX', 'ASSIST_API_KEY_MINIMAX_INTL',
                        'ASSIST_API_KEY_MIMO']:

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -799,6 +799,7 @@ class TestProviderExclusion:
             'grok',
             'claude',
             'openrouter',
+            'orcarouter',
             'elevenlabs',
             'qwen_intl',
             'minimax_intl',

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -14,6 +14,7 @@ _ASSIST_API_KEY_FIELDS = (
     'assistApiKeyMinimaxIntl', 'assistApiKeyMimo',
     'assistApiKeyMimoTokenPlan', 'assistApiKeyElevenlabs', 'assistApiKeyGrok',
     'assistApiKeyClaude', 'assistApiKeyKimiCode', 'assistApiKeyOpenrouter',
+    'assistApiKeyOrcarouter',
 )
 
 _MODEL_TYPES = (

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1064,6 +1064,7 @@ class CoreConfigMixin:
         config['ASSIST_API_KEY_GROK'] = core_cfg.get('assistApiKeyGrok', '') or _fb('grok')
         config['ASSIST_API_KEY_CLAUDE'] = core_cfg.get('assistApiKeyClaude', '') or _fb('claude')
         config['ASSIST_API_KEY_OPENROUTER'] = core_cfg.get('assistApiKeyOpenrouter', '') or _fb('openrouter')
+        config['ASSIST_API_KEY_ORCAROUTER'] = core_cfg.get('assistApiKeyOrcarouter', '') or _fb('orcarouter')
 
         if core_cfg.get('mcpToken'):
             config['MCP_ROUTER_API_KEY'] = core_cfg['mcpToken']


### PR DESCRIPTION
## 改动概述 / Summary

Adds **OrcaRouter** as a named assist API provider. OrcaRouter is an Anthropic-compatible gateway whose OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1/chat/completions`) passes through to Claude models, so it drops into the existing OpenAI-compatible channel with no protocol special-casing.

- **`config/api_profiles.py`**: `orcarouter` entry in `DEFAULT_ASSIST_API_PROFILES` (base url `https://api.orcarouter.ai/v1`, `anthropic/*` model ids), `DEFAULT_ASSIST_API_KEY_FIELDS` mapping, and `assistApiKeyOrcarouter` in `DEFAULT_CORE_CONFIG`
- **`config/api_providers.json`**: `orcarouter` card in `assist_api_providers`, `assist_api_key_fields` mapping, and `api_key_registry` entry
- **`utils/config_manager/core_config.py`** / **`main_routers/config_router/core_config.py`**: `ASSIST_API_KEY_ORCAROUTER` resolution with the same gated core-key fallback as other providers, plus secret redaction coverage
- **`static/locales/*.json`** (8 files): `api.assistProviderNames.orcarouter` and `api.keyBook.orcarouter`
- **tests**: redaction, non-fallback field lists, and the `test_restricted_providers` closed list updated

### Why

OpenRouter is a first-class provider in the assist API list; OrcaRouter offers the same universal-gateway convenience with a fully Anthropic-compatible surface. Users who want to reach Claude through [OrcaRouter](https://www.orcarouter.ai) can now pick it from the provider list instead of hand-rolling a custom endpoint.

> Disclosure from the original author: *"I'm an engineer on the OrcaRouter team."*

## 回归报告 / Regression Report

**改动了什么。** `main_routers/config_router/core_config.py` 只多了两行，都是纯登记：`CORE_CONFIG_PROVIDER_API_KEY_FIELDS` 元组里加 `'assistApiKeyOrcarouter'`，以及 GET `/api/core_config` 回填时多返回一个 `assistApiKeyOrcarouter` 字段（沿用 `_fb()` 门控回退）。没有新增分支、没有改任何既有 provider 的解析路径。`utils/config_manager/core_config.py` 是对偶的一行。

**理由 / 必要性。** 新 provider 要有自己的 Key 槽位，否则它的 Key 会与 `coreApiKey` 混用；而这两个文件分别是「运行时解析」和「设置页 payload + 脱敏」两条链，缺任何一条都会让这个 Key 要么读不到、要么明文出现在设置页响应里。

**改动前后的表现对比。**
- 之前：`assistApi` 选不到 orcarouter；即使手工写进 `core_config.json`，`ASSIST_API_KEY_ORCAROUTER` 也不会被解析。
- 之后：provider 出现在辅助 API 下拉与 Key 管理簿中；Key 走独立槽位，只在 orcarouter 被选中时才回退到 `coreApiKey`；GET `/api/core_config` 对该字段做与其它 Key 相同的脱敏。

**潜在回归点与验证方式。**
1. *Key 广播* —— 最大的风险是新槽位破坏「未选中的 provider 不得回退到主 Key」这条不变量。已被 `test_missing_keys_gated_fallback_to_core_key` 覆盖（该用例的清单里已加入 `ASSIST_API_KEY_ORCAROUTER`）。
2. *脱敏遗漏* —— 由 `test_core_config_secret_redaction.py` 的全量字段清单覆盖。
3. *registry 一致性* —— `test_api_key_registry_covers_all_assist_providers` 与 `test_restricted_providers` 两条结构化守卫都会遍历到新条目。
4. *thinking 参数* —— `anthropic/*` 这两个 id **有意不登记进** `MODELS_EXTRA_BODY_MAP`，理由见下方 Maintainer follow-up 第 4 条。实测 `get_extra_body('anthropic/claude-sonnet-5')` 返回 `{}`，与 step / kimi_code / deepseek / mimo / grok 同形态。
5. *前端渲染* —— `api.keyBook.*` 缺翻译时 `updatePageTexts()` 会把查找键本身写进 `textContent`（该分支没有 `text !== key` 兜底），Key 管理簿会显示一行字面量 `api.keyBook.orcarouter`。已补齐 8 个 locale。

跑过：`tests/unit/test_api_config_manager.py`、`test_core_config_secret_redaction.py`、`test_providers.py` → 133 passed, 6 skipped；`scripts/check_i18n_sync.py --base origin/main`、`check_core_contracts.py`、`check_module_layering.py`、`check_prompt_hygiene.py`、`check_docstring_no_cjk.py --base origin/main`、`ruff check` 全部通过。

## 不拆分理由 / Why Not Split

不适用（改动文件数远低于 20）。

## 测试 / Testing

见上「潜在回归点与验证方式」。补充说明两条本地观察：

- `scripts/check_i18n.py` 在本仓库当前 `main` 上本来就是红的（缺 `Jukebox.settingsShort` 等三个键），与本 PR 无关；CI 的 Analyze 只跑 `check_i18n_sync.py`，该门通过。
- `tests/frontend/test_api_settings.py::test_doubao_tts_keybook_saves_independent_speech_key` 在 `origin/main` 上同样失败，属既有问题；`tests/frontend/` 不在 CI 范围内。

## Maintainer follow-up

在原作者的提交之上追加了一个 commit，把这个条目对齐到既有 provider 的写法：

1. **8 个 locale 补齐**（见上，这是唯一会被用户直接看到的缺陷）。
2. **`restricted: false` → `true`**。`api_key_registry` 里这一位的既有判据是「端点域名是否境内」，21 条零例外：境外端点（openrouter / claude / grok / gemini / openai / qwen_intl / minimax_intl / elevenlabs）一律 `true`，境内与 localhost 一律 `false`；决定性对照是同厂商两档 qwen/qwen_intl 与 minimax/minimax_intl。`api.orcarouter.ai` 按此归入前者。同步更新了 `test_restricted_providers` 的闭集名单。
3. **description 改写**为「第三方 Claude 中转网关，国内版不支持」，与 openrouter/claude/grok 一样点明品类和区域可用性。
4. **`MODELS_EXTRA_BODY_MAP` 有意不登记 `anthropic/*`**。曾一度登记（复用 `EXTRA_BODY_ANTHROPIC`）以回应 Greptile 的 P1，但 Codex 随后的 P2 指出了这样做的问题，复核后成立，故撤回：该表只按模型名查，`create_chat_llm()` 全程不看 `base_url`；而 `anthropic/claude-sonnet-5` 在 OpenRouter 上是同样合法的 id，那条链路要的是统一的 `reasoning` 方言——`config/providers.py` 自己的注释就记着方言错配会被 400。留空与 step / kimi_code / deepseek / mimo / grok 一致，且实际代价为零：Anthropic 的 extended thinking 本来就要显式开启才生效。要真正修好这一类问题，得让 extra_body 查表变成 endpoint-aware，那是独立的架构改动，不属于本 PR。
5. **删掉 profile 里的说明性注释** —— `DEFAULT_ASSIST_API_PROFILES` 中没有任何其它条目带注释。

### 合并前仍待作者澄清

原描述的 Notes 里有这么一句：

> "It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes."

这与随 diff 落地的 description（「直通」）指向的行为不是一回事，需要作者说明：

1. 上述筛查 / tool-call 默认拒绝，对走这个 endpoint 的流量是否**默认开启**？
2. 若开启：选中该 provider 后，对话历史、屏幕截图、长期记忆原文、agent 工具调用都会流经该网关并被逐条检查——这一点必须在 provider 描述里对用户明示。
3. 若 tool call 可能被网关策略拒绝：本项目目前无法把「网关拒绝」与「模型异常 / 网络错误」区分开，用户只会看到无法解释的 agent 失败。

另外 `anthropic/claude-sonnet-5` / `anthropic/claude-haiku-4.5` 这两个模型 id 无法从仓库内验证，依赖作者声明的 live probe 结果。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 OrcaRouter（Claude 网关）作为助手 API 提供商，支持对话、摘要、纠错、视觉及代理等功能。
  * 新增 OrcaRouter API 密钥配置，并支持核心密钥回退与安全脱敏。
  * 在多种语言界面中新增 OrcaRouter 提供商名称和密钥簿显示。
* **配置**
  * 标记 OrcaRouter 为受地区限制的提供商，并完善相关配置展示与管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->