### PR TITLE
fix(realtime): recognize unannounced responses and recover peer disconnects

### DIFF
--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -125,14 +125,6 @@ logger = get_module_logger("main_logic.core", "Main")
 IDLE_SESSION_RESET_THRESHOLD_SECONDS = 1800
 IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
 
-# 关闭一个已退役 session 的等待上限。热切换步骤 2 与 end_session 都持锁调
-# session.close()，过去完全无界，实际上界由 realtime 侧的 websockets
-# close_timeout 隐式决定——那个值从 0.5s 提到 2s 后，这两处的最坏停顿就跟着变长，
-# 说明它们本就不该依赖传输层的参数来封顶。这里显式封顶：超时只放弃「等」，不放弃
-# 「关」（realtime 的 close 走 shield，取消调用方不会中断关闭本身），退役 socket
-# 由后台收尾。取 3s：比 close_timeout=2s 略宽，让正常的慢握手仍能等到。
-SESSION_CLOSE_TIMEOUT_SECONDS = 3.0
-
 # 前端文本会话 start_session 等 session_started 的硬超时（static/app/app-buttons.js
 # 的 setTimeout(..., 15000)）。start_session 去重路径等 in-flight 启动落定后给
 # 本请求补发 ack 时，等待上限绑到这个值：超过前端这个超时再补发 session_started

--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -125,6 +125,14 @@ logger = get_module_logger("main_logic.core", "Main")
 IDLE_SESSION_RESET_THRESHOLD_SECONDS = 1800
 IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
 
+# 关闭一个已退役 session 的等待上限。热切换步骤 2 与 end_session 都持锁调
+# session.close()，过去完全无界，实际上界由 realtime 侧的 websockets
+# close_timeout 隐式决定——那个值从 0.5s 提到 2s 后，这两处的最坏停顿就跟着变长，
+# 说明它们本就不该依赖传输层的参数来封顶。这里显式封顶：超时只放弃「等」，不放弃
+# 「关」（realtime 的 close 走 shield，取消调用方不会中断关闭本身），退役 socket
+# 由后台收尾。取 3s：比 close_timeout=2s 略宽，让正常的慢握手仍能等到。
+SESSION_CLOSE_TIMEOUT_SECONDS = 3.0
+
 # 前端文本会话 start_session 等 session_started 的硬超时（static/app/app-buttons.js
 # 的 setTimeout(..., 15000)）。start_session 去重路径等 in-flight 启动落定后给
 # 本请求补发 ack 时，等待上限绑到这个值：超过前端这个超时再补发 session_started

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -261,7 +261,10 @@ class LifecycleMixin:
                     and failure_generation != current_generation
                 ):
                     logger.info(
-                        "⏭️ handle_connection_error: connection generation stale, skipping"
+                        "⏭️ handle_connection_error: connection generation stale "
+                        "(failure=%s current=%s), skipping",
+                        failure_generation,
+                        current_generation,
                     )
                     return
             # Only flag the manager-level flag for main session errors (or unguarded calls).

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -27,7 +27,11 @@ from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
 from main_logic.omni_realtime_client import OmniRealtimeClient
-from main_logic.omni_offline_client import OmniOfflineClient, _is_safety_violation_signal
+from main_logic.omni_offline_client import OmniOfflineClient
+from main_logic.provider_failure_signals import (
+    CODES_REQUIRING_MSG_DETAIL,
+    classify_provider_failure_text,
+)
 from main_logic.proactive_delivery import (
     DELIVERY_RETRACTED_KEY,
     SWAP_PRIME_DELIVERY_CLAIM_KEY,
@@ -44,6 +48,7 @@ from ._shared import (
     logger,
     IDLE_SESSION_RESET_THRESHOLD_SECONDS,
     IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS,
+    SESSION_CLOSE_TIMEOUT_SECONDS,
     FRONTEND_START_SESSION_TIMEOUT_SECONDS,
     _HANDSHAKE_OVERRIDE_UNSET,
     _START_LLM_CONCURRENT_ABORTED,
@@ -278,8 +283,6 @@ class LifecycleMixin:
             return
         
         if message:
-            message_text_lower = message_text.lower()
-
             # Pre-classified structured errors from omni_realtime_client (JSON with "code")
             # Forward them directly so the frontend sees the original code.
             if _parsed and isinstance(_parsed, dict) and _parsed.get('code'):
@@ -288,24 +291,21 @@ class LifecycleMixin:
                 # Forwarding this marker here would show the same toast twice.
                 if _parsed.get('code') != 'CHARACTER_DISCONNECTED':
                     await self.send_status(message_text)
-            elif '欠费' in message_text_lower or 'standing' in message_text_lower:
-                await self.send_status(json.dumps({"code": "API_ARREARS"}))
-            elif 'quota' in message_text_lower or 'time limit' in message_text_lower:
-                await self.send_status(json.dumps({"code": "API_QUOTA_TIME"}))
-            elif '429' in message_text_lower or 'too many' in message_text_lower:
-                await self.send_status(json.dumps({"code": "API_RATE_LIMIT"}))
-            elif ('401' in message_text_lower or 'unauthorized' in message_text_lower
-                    or 'authentication' in message_text_lower
-                    or 'incorrect api key' in message_text_lower
-                    or 'invalid_api_key' in message_text_lower
-                    or ('invalid' in message_text_lower and 'key' in message_text_lower)):
-                await self.send_status(json.dumps({"code": "API_KEY_REJECTED"}))
-            elif _is_safety_violation_signal(message_text_lower):
-                await self.send_status(json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": message_text}}))
-            elif '1008' in message_text_lower:
-                await self.send_status(json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": message_text}}))
             else:
-                await self.send_status(json.dumps({"code": "API_UNKNOWN_ERROR", "details": {"msg": message_text}}))
+                # Same criteria, and the same ordering, the realtime close
+                # path reads — from one place, so a keyword added for one
+                # provider never goes missing on the other side. The details
+                # payload stays this side's own: here we are holding a real
+                # upstream diagnostic and echo it, where a peer-controlled
+                # close reason is deliberately withheld.
+                status_code = (
+                    classify_provider_failure_text(message_text)
+                    or "API_UNKNOWN_ERROR"
+                )
+                status_payload = {"code": status_code}
+                if status_code in CODES_REQUIRING_MSG_DETAIL:
+                    status_payload["details"] = {"msg": message_text}
+                await self.send_status(json.dumps(status_payload))
         logger.info("💥 Realtime connection recovery requested.")
         await self.disconnected_by_server(expected_session=expected_session)
     
@@ -2542,10 +2542,9 @@ class LifecycleMixin:
                 )
                 # ── 步骤 2：旧 task 已停，安全关闭旧 session ─────────────────────
                 if old_main_session:
-                    try:
-                        await old_main_session.close()
-                    except Exception as e:
-                        logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
+                    await self._close_session_within_budget(
+                        old_main_session, "Final Swap Sequence"
+                    )
 
                 _abort_if_passive_claim_retracted("before promote")
 
@@ -2762,6 +2761,44 @@ class LifecycleMixin:
             self.is_hot_swap_imminent = False  # Always reset this flag
             if self.final_swap_task and self.final_swap_task.done():
                 self.final_swap_task = None
+
+    async def _close_session_within_budget(self, session, label: str) -> None:
+        """Close a retired session without letting a slow peer stall the caller.
+
+        Both callers sit on a teardown path other work is blocked behind, so
+        the wait needs a ceiling of its own. It deliberately does not borrow
+        the transport's: the realtime client bounds its close handshake with
+        the websockets ``close_timeout``, but an offline client, a wedged SDK
+        teardown, or a close that never reaches a socket at all is bounded by
+        nothing. The ceiling sits above ``close_timeout`` on purpose — on the
+        realtime path that bound still fires first, and this one only catches
+        the case where the close is stuck somewhere else entirely.
+
+        Giving up on the wait is not giving up on the close: the realtime
+        ``close()`` seizes its socket synchronously and awaits the teardown
+        through a shield, so a caller that stops waiting leaves the closing
+        running rather than orphaning a live socket.
+
+        ``asyncio.timeout``, NOT ``asyncio.wait_for``: wait_for runs the
+        coroutine in a CHILD task, so ``asyncio.current_task()`` inside
+        ``close()`` would stop being the caller's task. The hot-swap sequence
+        reads exactly that to survive Python 3.11 swallowing an external
+        cancel — its pre-promote ``cancelling() > 0`` checkpoint is what stops
+        a zombie swap from overwriting ``self.session``, and moving close()
+        off the swap task's own stack silently disarms it.
+        """
+
+        try:
+            async with asyncio.timeout(SESSION_CLOSE_TIMEOUT_SECONDS):
+                await session.close()
+        except asyncio.TimeoutError:
+            logger.warning(
+                "⏱️ %s: close exceeded %.1fs; it finishes detached",
+                label,
+                SESSION_CLOSE_TIMEOUT_SECONDS,
+            )
+        except Exception as e:
+            logger.error(f"💥 {label}: Error closing session: {e}")
 
     async def disconnected_by_server(self, *, expected_session=None):
         if expected_session is not None and expected_session is not self.session:
@@ -3008,10 +3045,10 @@ class LifecycleMixin:
         if main_session_ref:
             try:
                 logger.info("End Session: Closing connection...")
-                await main_session_ref.close()
+                await self._close_session_within_budget(
+                    main_session_ref, "End Session"
+                )
                 logger.info("End Session: Qwen connection closed.")
-            except Exception as e:
-                logger.error(f"💥 End Session: Error during cleanup: {e}")
             finally:
                 if self.session is main_session_ref:
                     self.session = None

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -48,7 +48,6 @@ from ._shared import (
     logger,
     IDLE_SESSION_RESET_THRESHOLD_SECONDS,
     IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS,
-    SESSION_CLOSE_TIMEOUT_SECONDS,
     FRONTEND_START_SESSION_TIMEOUT_SECONDS,
     _HANDSHAKE_OVERRIDE_UNSET,
     _START_LLM_CONCURRENT_ABORTED,
@@ -2542,9 +2541,10 @@ class LifecycleMixin:
                 )
                 # ── 步骤 2：旧 task 已停，安全关闭旧 session ─────────────────────
                 if old_main_session:
-                    await self._close_session_within_budget(
-                        old_main_session, "Final Swap Sequence"
-                    )
+                    try:
+                        await old_main_session.close()
+                    except Exception as e:
+                        logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
 
                 _abort_if_passive_claim_retracted("before promote")
 
@@ -2761,45 +2761,6 @@ class LifecycleMixin:
             self.is_hot_swap_imminent = False  # Always reset this flag
             if self.final_swap_task and self.final_swap_task.done():
                 self.final_swap_task = None
-
-    async def _close_session_within_budget(self, session, label: str) -> None:
-        """Close a retired session without letting a slow peer stall the caller.
-
-        Both callers sit on a teardown path other work is blocked behind, so
-        the wait wants a ceiling. Only some closes can safely be given one:
-        abandoning the WAIT is only harmless when the close itself keeps
-        running, and that is a property of the implementation, not of ours to
-        assume. ``close_finishes_detached`` is where an implementation says so
-        — the realtime client seizes its socket synchronously and awaits the
-        teardown behind a shield, so a cancelled waiter leaves the closing
-        intact. An offline client's close is a plain coroutine: cancelling it
-        skips ``self.llm = None`` and the threaded genai client close, leaking
-        the very connection pools it exists to release. Those stay unbounded,
-        exactly as they were before this ceiling existed.
-
-        ``asyncio.timeout``, NOT ``asyncio.wait_for``: wait_for runs the
-        coroutine in a CHILD task, so ``asyncio.current_task()`` inside
-        ``close()`` would stop being the caller's task. The hot-swap sequence
-        reads exactly that to survive Python 3.11 swallowing an external
-        cancel — its pre-promote ``cancelling() > 0`` checkpoint is what stops
-        a zombie swap from overwriting ``self.session``, and moving close()
-        off the swap task's own stack silently disarms it.
-        """
-
-        try:
-            if not getattr(session, "close_finishes_detached", False):
-                await session.close()
-                return
-            async with asyncio.timeout(SESSION_CLOSE_TIMEOUT_SECONDS):
-                await session.close()
-        except asyncio.TimeoutError:
-            logger.warning(
-                "⏱️ %s: close exceeded %.1fs; it finishes detached",
-                label,
-                SESSION_CLOSE_TIMEOUT_SECONDS,
-            )
-        except Exception as e:
-            logger.error(f"💥 {label}: Error closing session: {e}")
 
     async def disconnected_by_server(self, *, expected_session=None):
         if expected_session is not None and expected_session is not self.session:
@@ -3046,10 +3007,10 @@ class LifecycleMixin:
         if main_session_ref:
             try:
                 logger.info("End Session: Closing connection...")
-                await self._close_session_within_budget(
-                    main_session_ref, "End Session"
-                )
+                await main_session_ref.close()
                 logger.info("End Session: Qwen connection closed.")
+            except Exception as e:
+                logger.error(f"💥 End Session: Error during cleanup: {e}")
             finally:
                 if self.session is main_session_ref:
                     self.session = None

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -232,6 +232,12 @@ class LifecycleMixin:
             logger.error(f"处理静默超时时出错: {e}")
     
     async def handle_connection_error(self, message=None, *, expected_session=None):
+        message_text = str(message) if message is not None else ""
+        try:
+            _parsed = json.loads(message_text) if message_text.startswith('{') else None
+        except (json.JSONDecodeError, TypeError):
+            _parsed = None
+
         async with self.lock:
             is_pending = False
             if expected_session is not None:
@@ -239,6 +245,24 @@ class LifecycleMixin:
                     is_pending = True
                 elif expected_session is not self.session:
                     logger.info("⏭️ handle_connection_error: expected_session stale (not current session), skipping")
+                    return
+                details = _parsed.get('details') if isinstance(_parsed, dict) else None
+                failure_generation = (
+                    details.get('connection_generation')
+                    if isinstance(details, dict)
+                    else None
+                )
+                current_generation = getattr(
+                    expected_session, '_connection_generation', None
+                )
+                if (
+                    isinstance(failure_generation, int)
+                    and isinstance(current_generation, int)
+                    and failure_generation != current_generation
+                ):
+                    logger.info(
+                        "⏭️ handle_connection_error: connection generation stale, skipping"
+                    )
                     return
             # Only flag the manager-level flag for main session errors (or unguarded calls).
             # A pending_session failure must not misclassify the main session as closed.
@@ -251,17 +275,16 @@ class LifecycleMixin:
             return
         
         if message:
-            message_text = str(message)
             message_text_lower = message_text.lower()
 
             # Pre-classified structured errors from omni_realtime_client (JSON with "code")
             # Forward them directly so the frontend sees the original code.
-            try:
-                _parsed = json.loads(message_text) if message_text.startswith('{') else None
-            except (json.JSONDecodeError, TypeError):
-                _parsed = None
             if _parsed and isinstance(_parsed, dict) and _parsed.get('code'):
-                await self.send_status(message_text)
+                # Peer disconnects use the existing recovery below, which
+                # supplies CHARACTER_DISCONNECTED with the configured name.
+                # Forwarding this marker here would show the same toast twice.
+                if _parsed.get('code') != 'CHARACTER_DISCONNECTED':
+                    await self.send_status(message_text)
             elif '欠费' in message_text_lower or 'standing' in message_text_lower:
                 await self.send_status(json.dumps({"code": "API_ARREARS"}))
             elif 'quota' in message_text_lower or 'time limit' in message_text_lower:
@@ -280,7 +303,7 @@ class LifecycleMixin:
                 await self.send_status(json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": message_text}}))
             else:
                 await self.send_status(json.dumps({"code": "API_UNKNOWN_ERROR", "details": {"msg": message_text}}))
-        logger.info("💥 Session closed by API Server.")
+        logger.info("💥 Realtime connection recovery requested.")
         await self.disconnected_by_server(expected_session=expected_session)
     
     async def handle_repetition_detected(self):

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -2766,18 +2766,16 @@ class LifecycleMixin:
         """Close a retired session without letting a slow peer stall the caller.
 
         Both callers sit on a teardown path other work is blocked behind, so
-        the wait needs a ceiling of its own. It deliberately does not borrow
-        the transport's: the realtime client bounds its close handshake with
-        the websockets ``close_timeout``, but an offline client, a wedged SDK
-        teardown, or a close that never reaches a socket at all is bounded by
-        nothing. The ceiling sits above ``close_timeout`` on purpose — on the
-        realtime path that bound still fires first, and this one only catches
-        the case where the close is stuck somewhere else entirely.
-
-        Giving up on the wait is not giving up on the close: the realtime
-        ``close()`` seizes its socket synchronously and awaits the teardown
-        through a shield, so a caller that stops waiting leaves the closing
-        running rather than orphaning a live socket.
+        the wait wants a ceiling. Only some closes can safely be given one:
+        abandoning the WAIT is only harmless when the close itself keeps
+        running, and that is a property of the implementation, not of ours to
+        assume. ``close_finishes_detached`` is where an implementation says so
+        — the realtime client seizes its socket synchronously and awaits the
+        teardown behind a shield, so a cancelled waiter leaves the closing
+        intact. An offline client's close is a plain coroutine: cancelling it
+        skips ``self.llm = None`` and the threaded genai client close, leaking
+        the very connection pools it exists to release. Those stay unbounded,
+        exactly as they were before this ceiling existed.
 
         ``asyncio.timeout``, NOT ``asyncio.wait_for``: wait_for runs the
         coroutine in a CHILD task, so ``asyncio.current_task()`` inside
@@ -2789,6 +2787,9 @@ class LifecycleMixin:
         """
 
         try:
+            if not getattr(session, "close_finishes_detached", False):
+                await session.close()
+                return
             async with asyncio.timeout(SESSION_CLOSE_TIMEOUT_SECONDS):
                 await session.close()
         except asyncio.TimeoutError:

--- a/main_logic/omni_offline_client/_shared.py
+++ b/main_logic/omni_offline_client/_shared.py
@@ -87,32 +87,14 @@ _SUMMARY_HARD_TOKEN_CAP = 50
 
 _SUMMARY_API_BUDGET_FLOOR = 3000
 
-_API_KEY_REJECTED_KEYWORDS = (
-    "incorrect api key",
-    "incorect api key",
-    "invalid_api_key",
-    "invalid api key",
-    "invalid key",
-    "api key is invalid",
-)
-
-_SAFETY_VIOLATION_KEYWORDS = (
-    "safety",
-    "content_filter",
-    "content filter",
-    "policy violation",
-    "policy_violation",
-    "blocklist",
-    "prohibited",
-    "prohibited_content",
-    "recitation",
-    "spii",
-    "language",
-    "image_safety",
-    "image_prohibited_content",
-    "image_recitation",
-    "responsibleaipolicyviolation",
-    "responsible ai policy",
+# Re-exported, not redefined. The realtime transport and the session manager
+# classify the same provider vocabulary, and three private copies of these
+# tables is how a keyword added in one place stops being honoured in another.
+# Existing importers of these two names keep working unchanged.
+from main_logic.provider_failure_signals import (  # noqa: E402
+    _API_KEY_REJECTED_KEYWORDS,
+    _SAFETY_VIOLATION_KEYWORDS,
+    _is_safety_violation_signal,
 )
 
 def _is_api_key_rejected_error(error: BaseException | str) -> bool:
@@ -136,13 +118,6 @@ def _is_api_key_rejected_error(error: BaseException | str) -> bool:
         ("authenticationerror" in text or "authentication" in text or "unauthorized" in text)
         and "api key" in text
     )
-
-def _is_safety_violation_signal(*values: object) -> bool:
-    """Return True when provider diagnostics point to safety/policy blocking."""
-    text = " ".join(str(value) for value in values if value).lower()
-    if not text:
-        return False
-    return any(keyword in text for keyword in _SAFETY_VIOLATION_KEYWORDS)
 
 def _truncate_to_last_sentence_end(text: str) -> str:
     """Return the prefix of ``text`` up to and including the last

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -92,15 +92,6 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
             hooks behave exactly as they did before it existed.
     """
 
-    # ``close()`` seizes the socket synchronously and then awaits the teardown
-    # through ``asyncio.shield`` (see ``_own_teardown``), so a caller that
-    # stops waiting leaves the closing running to completion instead of
-    # abandoning a half-released connection. Callers use this to decide
-    # whether bounding their wait is safe; an implementation whose close is
-    # a plain coroutine must NOT set it, or a cancelled wait truncates its
-    # cleanup.
-    close_finishes_detached = True
-
     def __init__(
         self,
         base_url,

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -170,6 +170,12 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # scalars, the shared audio processor, the Gemini session) belongs to
         # whoever attached last.
         self._connection_generation = 0
+        # ``(generation, reason)`` armed when a local component aborts the
+        # attached transport out from under the receive loop, so the loop can
+        # still request manager recovery for a socket it no longer owns.
+        # Cleared by an ordinary close() (the manager already knows) and by a
+        # replacement attach (a successor never inherits this).
+        self._local_failure_recovery: tuple[int, str] | None = None
 
         # Track current response state
         self._current_response_id = None

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -123,6 +123,19 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self.api_key = api_key
         self.model = model
         self._model_lower = model.lower() if model else ''
+        _base_url_lower = (base_url or '').lower()
+        _known_lanlan_free_route = (
+            'lanlan.tech' in _base_url_lower
+            or 'lanlan.app' in _base_url_lower
+            or bool(livestream_mode)
+        )
+        _effective_api_type = api_type or ""
+        if (
+            not _effective_api_type
+            and 'free' in self._model_lower
+            and _known_lanlan_free_route
+        ):
+            _effective_api_type = "free"
         self.voice = voice
         self.ws = None
         self.instructions = None
@@ -185,7 +198,11 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # on those the epoch is unchanged and only the speech id moves. #2612.
         self._current_turn_host_id: str | None = None
         self._realtime_protocol_capabilities = (
-            resolve_realtime_protocol_capabilities(api_type, base_url)
+            resolve_realtime_protocol_capabilities(
+                _effective_api_type,
+                base_url,
+                livestream_mode=bool(livestream_mode),
+            )
         )
         self._response_arbiter = RealtimeResponseArbiter(
             self.send_event,
@@ -369,25 +386,12 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
 
         # Gemini Live API specific attributes
         self._is_gemini = self._api_type.lower() == 'gemini'
-        _base_url_lower = (base_url or '').lower()
-        _known_lanlan_free_route = (
-            'lanlan.tech' in _base_url_lower
-            or 'lanlan.app' in _base_url_lower
-            or bool(livestream_mode)
-        )
         # ``api_type`` is the provider-ownership signal. The model name is
         # user-configurable, so an arbitrary local model such as
         # ``freeform-realtime`` must not inherit Lanlan's image wire protocol.
         # Keep a narrow compatibility fallback only for old callers that omit
         # api_type while targeting a known Lanlan/livestream route.
-        self._is_free_provider = (
-            self._api_type.lower() == 'free'
-            or (
-                not self._api_type
-                and 'free' in self._model_lower
-                and _known_lanlan_free_route
-            )
-        )
+        self._is_free_provider = _effective_api_type.lower() == 'free'
 
         # Only the international/livestream free routes proxy Gemini. This flag
         # remains about VAD/lifecycle behaviour, not image capability: every

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -92,6 +92,15 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
             hooks behave exactly as they did before it existed.
     """
 
+    # ``close()`` seizes the socket synchronously and then awaits the teardown
+    # through ``asyncio.shield`` (see ``_own_teardown``), so a caller that
+    # stops waiting leaves the closing running to completion instead of
+    # abandoning a half-released connection. Callers use this to decide
+    # whether bounding their wait is safe; an implementation whose close is
+    # a plain coroutine must NOT set it, or a cancelled wait truncates its
+    # cleanup.
+    close_finishes_detached = True
+
     def __init__(
         self,
         base_url,

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -38,6 +38,7 @@ from ._audio import _AudioMixin
 from ._transport import _TransportMixin
 from ._responses import _ResponseMixin
 from ._response_arbiter import RealtimeResponseArbiter
+from ._protocol_capabilities import resolve_realtime_protocol_capabilities
 from ._gemini_support import _GeminiMixin
 
 
@@ -183,11 +184,15 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # here (``handle_new_message`` off a text input or independent ASR), so
         # on those the epoch is unchanged and only the speech id moves. #2612.
         self._current_turn_host_id: str | None = None
+        self._realtime_protocol_capabilities = (
+            resolve_realtime_protocol_capabilities(api_type, base_url)
+        )
         self._response_arbiter = RealtimeResponseArbiter(
             self.send_event,
             abort_transport=self._abort_failed_transport,
             fail_open=response_arbiter_fail_open_enabled(),
             on_stuck_release=self._on_arbiter_stuck_release,
+            protocol_capabilities=self._realtime_protocol_capabilities,
         )
         # Track printing state for input and output transcripts
         self._is_first_text_chunk = False

--- a/main_logic/omni_realtime_client/_protocol_capabilities.py
+++ b/main_logic/omni_realtime_client/_protocol_capabilities.py
@@ -1,0 +1,89 @@
+# -- coding: utf-8 --
+"""Resolve provider-specific Realtime lifecycle capabilities.
+
+Routes select a protocol profile; they don't directly change arbiter policy.
+Unknown routes stay on the strict OpenAI-compatible lifecycle so a provider
+must be explicitly verified before content events can stand in for a missing
+``response.created`` announcement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from utils.tts.native_voice_registry import (
+    is_free_lanlan_app_route,
+    is_free_lanlan_tech_route,
+)
+
+
+# Only events that prove actual model output may replace a missing
+# response.created on a capability-approved route. Boundary-only events such
+# as output_item.added are intentionally excluded: allocating an item is not
+# proof that the response itself has started producing content.
+ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES = frozenset(
+    {
+        "response.text.delta",
+        "response.output_text.delta",
+        "response.audio.delta",
+        "response.output_audio.delta",
+        "response.audio_transcript.delta",
+        "response.output_audio_transcript.delta",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+    }
+)
+
+
+class ResponseStartEvidence(str, Enum):
+    """Evidence the arbiter may accept as proof an owned response started."""
+
+    ANNOUNCEMENT_ONLY = "response_created_only"
+    ANNOUNCEMENT_OR_ID_BEARING_CONTENT = "response_created_or_id_bearing_content"
+
+
+@dataclass(frozen=True, slots=True)
+class RealtimeProtocolCapabilities:
+    """Immutable capabilities for one resolved Realtime route."""
+
+    route_key: str
+    response_start_evidence: ResponseStartEvidence
+
+    @property
+    def accepts_id_bearing_content_start(self) -> bool:
+        return (
+            self.response_start_evidence
+            is ResponseStartEvidence.ANNOUNCEMENT_OR_ID_BEARING_CONTENT
+        )
+
+
+STRICT_REALTIME_PROTOCOL_CAPABILITIES = RealtimeProtocolCapabilities(
+    route_key="strict_default",
+    response_start_evidence=ResponseStartEvidence.ANNOUNCEMENT_ONLY,
+)
+
+LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES = RealtimeProtocolCapabilities(
+    route_key="lanlan_app_gemini",
+    response_start_evidence=(
+        ResponseStartEvidence.ANNOUNCEMENT_OR_ID_BEARING_CONTENT
+    ),
+)
+
+LANLAN_TECH_REALTIME_PROTOCOL_CAPABILITIES = RealtimeProtocolCapabilities(
+    route_key="lanlan_tech_stepfun",
+    response_start_evidence=ResponseStartEvidence.ANNOUNCEMENT_ONLY,
+)
+
+
+def resolve_realtime_protocol_capabilities(
+    api_type: str | None,
+    realtime_base_url: str | None,
+) -> RealtimeProtocolCapabilities:
+    """Return the verified lifecycle profile for a concrete route."""
+
+    if is_free_lanlan_app_route(api_type, realtime_base_url):
+        return LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES
+    if is_free_lanlan_tech_route(api_type, realtime_base_url):
+        return LANLAN_TECH_REALTIME_PROTOCOL_CAPABILITIES
+    return STRICT_REALTIME_PROTOCOL_CAPABILITIES

--- a/main_logic/omni_realtime_client/_protocol_capabilities.py
+++ b/main_logic/omni_realtime_client/_protocol_capabilities.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 from utils.tts.native_voice_registry import (
     is_free_lanlan_app_route,
@@ -34,6 +35,21 @@ ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES = frozenset(
         "response.function_call_arguments.done",
     }
 )
+
+
+def _response_id_text(value: Any) -> str | None:
+    """Return one canonical reading of whether a value names a response.
+
+    ``None`` and the empty string name nothing. Numeric zero remains a valid
+    identity, because a provider may number its first response from zero. All
+    response lifecycle paths share this normalization so ownership, stale
+    filtering, and terminal matching cannot disagree about the same frame.
+    """
+
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
 
 
 class ResponseStartEvidence(str, Enum):
@@ -79,9 +95,13 @@ LANLAN_TECH_REALTIME_PROTOCOL_CAPABILITIES = RealtimeProtocolCapabilities(
 def resolve_realtime_protocol_capabilities(
     api_type: str | None,
     realtime_base_url: str | None,
+    *,
+    livestream_mode: bool = False,
 ) -> RealtimeProtocolCapabilities:
     """Return the verified lifecycle profile for a concrete route."""
 
+    if str(api_type or "").lower() == "free" and livestream_mode:
+        return LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES
     if is_free_lanlan_app_route(api_type, realtime_base_url):
         return LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES
     if is_free_lanlan_tech_route(api_type, realtime_base_url):

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -17,6 +17,12 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Iterator
 
+from ._protocol_capabilities import (
+    ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES,
+    RealtimeProtocolCapabilities,
+    STRICT_REALTIME_PROTOCOL_CAPABILITIES,
+)
+
 
 SendEvent = Callable[[dict[str, Any]], Awaitable[None]]
 AbortTransport = Callable[[str], Awaitable[None]]
@@ -199,6 +205,7 @@ class RealtimeResponseArbiter:
         abort_transport: AbortTransport | None = None,
         fail_open: bool = False,
         on_stuck_release: OnStuckRelease | None = None,
+        protocol_capabilities: RealtimeProtocolCapabilities | None = None,
     ) -> None:
         self._send_event = send_event
         self._abort_transport = abort_transport
@@ -209,6 +216,9 @@ class RealtimeResponseArbiter:
         # Notified that a turn ended, so the host can run the same end-of-turn
         # work its terminal event drives. Dual to ``abort_transport``.
         self._on_stuck_release = on_stuck_release
+        self._protocol_capabilities = (
+            protocol_capabilities or STRICT_REALTIME_PROTOCOL_CAPABILITIES
+        )
         # True while the queue consumer is suspended inside a transport
         # write; only the worker's own sends set it.
         self._worker_send_in_flight = False
@@ -547,6 +557,14 @@ class RealtimeResponseArbiter:
         # An empty string still normalizes to None on purpose: it names
         # nothing, and admitting it would collapse every unidentified response
         # onto one shared identity.
+        if response_id is None:
+            return None
+        text = str(response_id)
+        return text or None
+
+    @staticmethod
+    def _content_event_response_id(event: dict[str, Any] | None) -> str | None:
+        response_id = (event or {}).get("response_id")
         if response_id is None:
             return None
         text = str(response_id)
@@ -927,6 +945,53 @@ class RealtimeResponseArbiter:
         # here decides that; ``_adoptable_id_for`` does, against evidence the
         # dispatching request captured for itself.
         self._note_unowned_announcement(response_id)
+        return True
+
+    def notify_response_content(self, event: dict[str, Any]) -> bool:
+        """Use verified, id-bearing content as an owned response's start.
+
+        This is deliberately narrower than merely observing output. Only a
+        route whose protocol profile explicitly permits the fallback can use
+        it, and the id must still be new on this connection and attributable
+        to the single owner currently sending or awaiting its response.
+        """
+
+        if (
+            not self._protocol_capabilities.accepts_id_bearing_content_start
+            or str(event.get("type") or "")
+            not in ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES
+        ):
+            return False
+        owner = self._response_owner
+        if (
+            owner is None
+            or self._current is not owner
+            or owner.ticket.started.done()
+            or not owner.response_send_started
+            or owner.interrupted
+            or owner.server_vad_won_during_response_send
+            or self._server_vad_response_pending
+            or self._retired_created_window_live()
+            or self._idless_server_response_live()
+        ):
+            return False
+        response_id = self._content_event_response_id(event)
+        if (
+            response_id is None
+            or response_id in self._seen_response_ids
+            or response_id in self._server_response_ids
+        ):
+            return False
+
+        owner.response_id = response_id
+        self._remember_seen_response_id(response_id)
+        owner.ticket.started.set_result(None)
+        logger.info(
+            "id-bearing response content confirmed owned response start "
+            "(route=%s source=%s)",
+            self._protocol_capabilities.route_key,
+            owner.source,
+        )
         return True
 
     def notify_server_vad_started(self) -> None:

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -21,6 +21,7 @@ from ._protocol_capabilities import (
     ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES,
     RealtimeProtocolCapabilities,
     STRICT_REALTIME_PROTOCOL_CAPABILITIES,
+    _response_id_text,
 )
 
 
@@ -545,30 +546,11 @@ class RealtimeResponseArbiter:
         response = (event or {}).get("response")
         if not isinstance(response, dict):
             return None
-        response_id = response.get("id")
-        # Presence, not truthiness. A provider numbering its responses from
-        # zero would have had its FIRST response read as unidentified, which
-        # among other things makes ``_cannot_keep_the_connection`` report "no
-        # id to attribute later events by" and tear the transport down in
-        # spite of the escape hatch. No configured provider numbers this way —
-        # this is a trap, not a live failure — but "0 is not an id" is the
-        # kind of thing that is free to get right and expensive to discover.
-        #
-        # An empty string still normalizes to None on purpose: it names
-        # nothing, and admitting it would collapse every unidentified response
-        # onto one shared identity.
-        if response_id is None:
-            return None
-        text = str(response_id)
-        return text or None
+        return _response_id_text(response.get("id"))
 
     @staticmethod
     def _content_event_response_id(event: dict[str, Any] | None) -> str | None:
-        response_id = (event or {}).get("response_id")
-        if response_id is None:
-            return None
-        text = str(response_id)
-        return text or None
+        return _response_id_text((event or {}).get("response_id"))
 
     def _remember_server_response_id(self, response_id: str) -> None:
         self._server_response_ids.pop(response_id, None)
@@ -880,6 +862,8 @@ class RealtimeResponseArbiter:
     def notify_response_created(self, event: dict[str, Any]) -> bool:
         """Attribute an announcement and report whether transport may expose it."""
 
+        owner = self._response_owner
+        response_id = self._event_response_id(event)
         self._server_response_active = True
         self._idle.clear()
         retired_created_live = self._retired_created_window_live()
@@ -895,7 +879,6 @@ class RealtimeResponseArbiter:
             # second retirement window here would swallow a legitimate id-less
             # successor, recreating the ownership failure in the other direction.
             self._retired_created_deadline = None
-            response_id = self._event_response_id(event)
             self._remember_seen_response_id(response_id)
             logger.info(
                 "ignored late response.created %s from a retired owner",
@@ -906,7 +889,6 @@ class RealtimeResponseArbiter:
         if self._server_vad_response_pending:
             self._cancel_server_vad_pending_timer()
             self._server_vad_response_pending = False
-            response_id = self._event_response_id(event)
             self._remember_seen_response_id(response_id)
             if response_id is not None:
                 self._remember_server_response_id(response_id)
@@ -917,13 +899,24 @@ class RealtimeResponseArbiter:
             # automatic response, so it is the last thing a queued request
             # should be allowed to claim.
             return True
-        owner = self._response_owner
+        if self.response_created_confirms_started_owner(event):
+            # A capability-approved route may deliver real content before its
+            # announcement. The content already started this exact owner; the
+            # later created frame confirms it rather than naming a second,
+            # server-initiated response that would hold the lane after the
+            # owner's terminal arrives.
+            self._remember_seen_response_id(response_id)
+            logger.info(
+                "late response.created confirmed content-started owner (%s)",
+                owner.source,
+            )
+            return False
         if owner is not None and not owner.ticket.started.done():
             # The first response.created after the owner's response.create is
             # credited to the owner. Remember its response id (when the
             # provider supplies one) so only that response's terminal event
             # can release the lane.
-            owner.response_id = self._event_response_id(event)
+            owner.response_id = response_id
             self._remember_seen_response_id(owner.response_id)
             owner.ticket.started.set_result(None)
             return True
@@ -932,7 +925,6 @@ class RealtimeResponseArbiter:
         # server-initiated response. Remember its id so its terminal event is
         # recognized as an orphan even when the owner's own response.created
         # carried no id.
-        response_id = self._event_response_id(event)
         self._remember_seen_response_id(response_id)
         if response_id is not None:
             self._remember_server_response_id(response_id)
@@ -946,6 +938,23 @@ class RealtimeResponseArbiter:
         # dispatching request captured for itself.
         self._note_unowned_announcement(response_id)
         return True
+
+    def response_created_confirms_started_owner(
+        self,
+        event: dict[str, Any],
+    ) -> bool:
+        """Whether a delayed announcement only confirms the current owner."""
+
+        if self._retired_created_window_live() or self._server_vad_response_pending:
+            return False
+        owner = self._response_owner
+        response_id = self._event_response_id(event)
+        return bool(
+            owner is not None
+            and owner.ticket.started.done()
+            and owner.response_id is not None
+            and response_id == owner.response_id
+        )
 
     def notify_response_content(self, event: dict[str, Any]) -> bool:
         """Use verified, id-bearing content as an owned response's start.

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -34,6 +34,7 @@ from config.prompts.prompts_proactive import (
 from config.prompts.prompts_sys import _loc
 
 from ._response_arbiter import RealtimeResponseArbiter, ResponseTicket
+from ._protocol_capabilities import STRICT_REALTIME_PROTOCOL_CAPABILITIES
 
 
 # A missing response.done must fail conservatively instead of acknowledging a
@@ -64,6 +65,11 @@ class _ResponseMixin:
                 abort_transport=getattr(self, "_abort_failed_transport", None),
                 fail_open=response_arbiter_fail_open_enabled(),
                 on_stuck_release=getattr(self, "_on_arbiter_stuck_release", None),
+                protocol_capabilities=getattr(
+                    self,
+                    "_realtime_protocol_capabilities",
+                    STRICT_REALTIME_PROTOCOL_CAPABILITIES,
+                ),
             )
             self._response_arbiter = arbiter
         return arbiter

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -39,29 +39,10 @@ from ._shared import (
     uuid,
     websockets,
 )
-from ._protocol_capabilities import ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES
-
-
-def _response_id_text(value: Any) -> str | None:
-    """One reading of "does this name a response", used by both id sources.
-
-    Absent is ``None`` or the empty string — neither names anything, and
-    admitting the empty one would collapse every unidentified response onto a
-    shared identity. Zero is PRESENT: a provider numbering from zero names its
-    first response perfectly well.
-
-    Both halves matter and I got each wrong once. The original truthiness test
-    dropped `0`; replacing it with a bare ``is None`` check then stopped an
-    empty top-level ``response_id`` from falling back to the nested
-    ``response.id``, so a late terminal of that shape skipped the stale filter
-    and finalized whatever turn was current. Reading it in one place is what
-    keeps the two sources from disagreeing again.
-    """
-
-    if value is None:
-        return None
-    text = str(value)
-    return text or None
+from ._protocol_capabilities import (
+    ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES,
+    _response_id_text,
+)
 
 
 _ATTACHED_TRANSPORT = object()
@@ -1964,14 +1945,28 @@ class _TransportMixin:
                     self._reset_per_turn_output_state()
                     await self._notify_turn_finished()
                 elif event_type == "response.created":
+                    confirms_started_owner = (
+                        self._response_arbiter.response_created_confirms_started_owner(
+                            event
+                        )
+                    )
                     expose_response = self._response_arbiter.notify_response_created(event)
                     self._response_created_total += 1
                     self._last_response_created_time = time.time()
                     if not expose_response:
+                        # A delayed announcement for a content-started owner is
+                        # consumed without beginning host lifecycle twice, but
+                        # still proves that this connection announces.
+                        if confirms_started_owner:
+                            self._announces_responses = True
                         continue
                     self._announces_responses = True
                     self._begin_response_lifecycle(
-                        event.get("response", {}).get("id")
+                        _response_id_text(
+                            (event.get("response") or {}).get("id")
+                            if isinstance(event.get("response"), dict)
+                            else None
+                        )
                     )
                 elif event_type == "response.output_item.added":
                     self._current_item_id = event.get("item", {}).get("id")
@@ -2136,11 +2131,22 @@ class _TransportMixin:
         except websockets.exceptions.ConnectionClosedError as e:
             received_code = getattr(getattr(e, "rcvd", None), "code", None)
             sent_code = getattr(getattr(e, "sent", None), "code", None)
+            status_code = (
+                "API_1008_FALLBACK"
+                if received_code == 1008
+                else "CHARACTER_DISCONNECTED"
+            )
+            status_details = (
+                {"msg": "WebSocket close code 1008"}
+                if received_code == 1008
+                else None
+            )
             recovered = await self._recover_receive_loop_disconnect(
                 message_ws,
                 message_generation,
                 "realtime connection closed unexpectedly",
-                status_code="CHARACTER_DISCONNECTED",
+                status_code=status_code,
+                status_details=status_details,
             )
             if recovered:
                 logger.warning(
@@ -2219,6 +2225,7 @@ class _TransportMixin:
         reason: str,
         *,
         status_code: str,
+        status_details: dict[str, Any] | None = None,
     ) -> bool:
         """Retire a peer-failed connection and request the existing recovery.
 
@@ -2239,10 +2246,20 @@ class _TransportMixin:
         await self._close_failed_transport(reason)
         if not self._still_owns_connection(generation):
             return False
-        self._schedule_connection_error(status_code, generation)
+        self._schedule_connection_error(
+            status_code,
+            generation,
+            status_details=status_details,
+        )
         return True
 
-    def _schedule_connection_error(self, status_code: str, generation) -> None:
+    def _schedule_connection_error(
+        self,
+        status_code: str,
+        generation,
+        *,
+        status_details: dict[str, Any] | None = None,
+    ) -> None:
         """Run manager recovery outside the receive loop that it must cancel."""
 
         callback = self.on_connection_error
@@ -2253,11 +2270,13 @@ class _TransportMixin:
             if not self._still_owns_connection(generation):
                 return
             try:
+                details = dict(status_details or {})
+                details["connection_generation"] = generation
                 await callback(
                     json.dumps(
                         {
                             "code": status_code,
-                            "details": {"connection_generation": generation},
+                            "details": details,
                         }
                     )
                 )

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -39,6 +39,7 @@ from ._shared import (
     uuid,
     websockets,
 )
+from ._protocol_capabilities import ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES
 
 
 def _response_id_text(value: Any) -> str | None:
@@ -80,7 +81,6 @@ _STUCK_RELEASE_STEP_TIMEOUT = 0.5
 # arrives right behind its original, so this only has to outlive the events
 # interleaved between them; it is a leak guard, not a history.
 _USAGE_RECORDED_ID_LIMIT = 32
-
 
 # `error` 事件的致命性判定是一串子串匹配（'429' / '1008' / '503' / 'quota' ...）。它
 # 过去匹配在 `str(event['error'])` 上，也就是整个 dict 的 repr —— 里面回显着我们自己
@@ -190,6 +190,13 @@ class _TransportMixin:
         # connection (flag may be leftover from a previous failed session
         # when the same OmniRealtimeClient instance is reused).
         self._fatal_error_occurred = False
+        capabilities = self._realtime_protocol_capabilities
+        logger.info(
+            "Realtime protocol profile resolved "
+            "(route=%s response_start_evidence=%s)",
+            capabilities.route_key,
+            capabilities.response_start_evidence.value,
+        )
 
         # 启动静默检测任务（只在启用时）
         self._last_speech_time = time.time()
@@ -1207,6 +1214,23 @@ class _TransportMixin:
         # 确保中断标志在响应结束时清除，防止阻塞下一轮 text.delta
         self._interrupted = False
 
+    def _begin_response_lifecycle(self, response_id: Any) -> None:
+        """Apply the host-side state shared by all accepted start evidence."""
+
+        self._current_response_id = response_id
+        self._is_responding = True
+        self._turn_epoch += 1
+        self._current_turn_epoch = self._turn_epoch
+        self._current_turn_host_id = self._read_host_turn_id()
+        self._interrupted = False
+        # A stable successor id also closes the id-less quarantine opened by
+        # a fail-open release; ordered socket delivery puts this evidence
+        # before any later id-less event from the successor.
+        self._idless_quarantine = False
+        self._is_first_text_chunk = self._is_first_transcript_chunk = True
+        self._output_transcript_buffer = ""
+        self._current_response_transcript = ""
+
     def _read_host_turn_id(self) -> str | None:
         """Sample the host's live speech id, or None for "no answer".
 
@@ -1720,6 +1744,15 @@ class _TransportMixin:
                         await self.close()
                     continue
 
+                if event_type in ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES:
+                    content_started = self._response_arbiter.notify_response_content(
+                        event
+                    )
+                    if content_started:
+                        self._begin_response_lifecycle(
+                            _response_id_text(event.get("response_id"))
+                        )
+
                 # A cancelled response can still emit buffered events after a
                 # replacement response has become current.  Providers that
                 # include response identity let us reject those late events
@@ -1935,23 +1968,9 @@ class _TransportMixin:
                     if not expose_response:
                         continue
                     self._announces_responses = True
-                    self._current_response_id = event.get("response", {}).get("id")
-                    self._is_responding = True
-                    self._turn_epoch += 1
-                    self._current_turn_epoch = self._turn_epoch
-                    self._current_turn_host_id = self._read_host_turn_id()
-                    self._interrupted = False  # Clear interruption flag on new response
-                    # Closes the id-less quarantine a fail-open release opened.
-                    # Safe as the sole exit: a release only happens when the
-                    # abandoned response HAD an id, ids are written only here,
-                    # and this socket is consumed by one ordered ``async for`` —
-                    # so a successor's announcement always precedes its own
-                    # id-less events and none of them are ever suppressed.
-                    self._idless_quarantine = False
-                    self._is_first_text_chunk = self._is_first_transcript_chunk = True
-                    # 清空转录 buffer，防止累积旧内容
-                    self._output_transcript_buffer = ""
-                    self._current_response_transcript = ""  # 重置当前回复转录
+                    self._begin_response_lifecycle(
+                        event.get("response", {}).get("id")
+                    )
                 elif event_type == "response.output_item.added":
                     self._current_item_id = event.get("item", {}).get("id")
                 elif event_type == "input_audio_buffer.committed":

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -89,6 +89,53 @@ def _error_classification_text(error: Any) -> str:
     return str(error or "")
 
 
+_PEER_CLOSE_SAFETY_KEYWORDS = (
+    "safety",
+    "content_filter",
+    "content filter",
+    "policy violation",
+    "policy_violation",
+    "blocklist",
+    "prohibited",
+    "prohibited_content",
+    "recitation",
+    "spii",
+    "language",
+    "image_safety",
+    "image_prohibited_content",
+    "image_recitation",
+    "responsibleaipolicyviolation",
+    "responsible ai policy",
+)
+
+
+def _classify_peer_close(received_code, received_reason) -> tuple[str, dict[str, str] | None]:
+    """Map a peer close to existing stable UI codes without exposing its reason."""
+
+    reason_text = str(received_reason or "")
+    reason_lower = reason_text.lower()
+    if "欠费" in reason_text or "standing" in reason_lower:
+        return "API_ARREARS", None
+    if "quota" in reason_lower or "time limit" in reason_lower:
+        return "API_QUOTA_TIME", None
+    if "429" in reason_lower or "too many" in reason_lower:
+        return "API_RATE_LIMIT", None
+    if (
+        "401" in reason_lower
+        or "unauthorized" in reason_lower
+        or "authentication" in reason_lower
+        or "incorrect api key" in reason_lower
+        or "invalid_api_key" in reason_lower
+        or ("invalid" in reason_lower and "key" in reason_lower)
+    ):
+        return "API_KEY_REJECTED", None
+    if any(keyword in reason_lower for keyword in _PEER_CLOSE_SAFETY_KEYWORDS):
+        return "API_POLICY_VIOLATION", None
+    if received_code == 1008:
+        return "API_1008_FALLBACK", {"msg": "WebSocket close code 1008"}
+    return "CHARACTER_DISCONNECTED", None
+
+
 class RealtimeImagePayloadTooLargeError(RuntimeError):
     """A callback image cannot fit the provider's WebSocket frame limit."""
 
@@ -1670,6 +1717,14 @@ class _TransportMixin:
                 return
 
             async for message in message_ws:
+                if (
+                    not self._still_owns_connection(message_generation)
+                    or self.ws is not message_ws
+                ):
+                    logger.info(
+                        "Ignoring a frame from a retired realtime connection"
+                    )
+                    return
                 event = json.loads(message)
                 event_type = event.get("type")
 
@@ -2130,16 +2185,11 @@ class _TransportMixin:
                 logger.info("Realtime connection was closed by the peer")
         except websockets.exceptions.ConnectionClosedError as e:
             received_code = getattr(getattr(e, "rcvd", None), "code", None)
+            received_reason = getattr(getattr(e, "rcvd", None), "reason", None)
             sent_code = getattr(getattr(e, "sent", None), "code", None)
-            status_code = (
-                "API_1008_FALLBACK"
-                if received_code == 1008
-                else "CHARACTER_DISCONNECTED"
-            )
-            status_details = (
-                {"msg": "WebSocket close code 1008"}
-                if received_code == 1008
-                else None
+            status_code, status_details = _classify_peer_close(
+                received_code,
+                received_reason,
             )
             recovered = await self._recover_receive_loop_disconnect(
                 message_ws,
@@ -2163,6 +2213,15 @@ class _TransportMixin:
                 status_code="CONNECTION_TIMEOUT",
             )
         except Exception as e:
+            if (
+                not self._still_owns_connection(message_generation)
+                or self.ws is not message_ws
+            ):
+                logger.info(
+                    "Retired realtime receive loop failed after replacement; "
+                    "ignoring its handler exception"
+                )
+                return
             await self._close_failed_transport(
                 f"realtime message handling failed: {type(e).__name__}"
             )

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -178,10 +178,10 @@ class _TransportMixin:
         headers = {
             "Authorization": f"Bearer {self.api_key}"
         }
-        # close_timeout=0.5 缩短 close handshake 的等待上限：默认 10s 会把
-        # end_session 协程挂住数百毫秒~数秒（Qwen 回 CLOSE 帧偶尔很慢），
-        # 超时后 websockets 内部会 transport.abort() 强制关闭。
-        self.ws = await websockets.connect(url, additional_headers=headers, close_timeout=0.5)
+        # Give proxies and cross-region free routes enough time to complete the
+        # close handshake without restoring websockets' 10s default. A peer
+        # that never answers is still force-aborted after this bounded wait.
+        self.ws = await websockets.connect(url, additional_headers=headers, close_timeout=2.0)
         self._on_connection_attached()
         # Do not reopen the arbiter until the replacement transport exists.
         # A failed reconnect must leave the prior shutdown state intact.
@@ -1682,11 +1682,13 @@ class _TransportMixin:
             return
 
         try:
-            if not self.ws:
+            message_ws = self.ws
+            message_generation = self._connection_generation
+            if not message_ws:
                 logger.error("WebSocket connection is not established")
                 return
 
-            async for message in self.ws:
+            async for message in message_ws:
                 event = json.loads(message)
                 event_type = event.get("type")
 
@@ -2122,26 +2124,51 @@ class _TransportMixin:
                                 self._skip_until_next_response, self._interrupted, self._current_response_id
                             )
 
-            await self._close_failed_transport("realtime message stream ended")
         except websockets.exceptions.ConnectionClosedOK:
-            await self._close_failed_transport("realtime connection closed")
-            logger.info("Connection closed as expected")
+            recovered = await self._recover_receive_loop_disconnect(
+                message_ws,
+                message_generation,
+                "realtime connection closed",
+                status_code="CHARACTER_DISCONNECTED",
+            )
+            if recovered:
+                logger.info("Realtime connection was closed by the peer")
         except websockets.exceptions.ConnectionClosedError as e:
-            error_msg = str(e)
-            await self._close_failed_transport(error_msg)
-            logger.error(f"Connection closed with error: {error_msg}")
-            if self.on_connection_error:
-                await self.on_connection_error(error_msg)
+            received_code = getattr(getattr(e, "rcvd", None), "code", None)
+            sent_code = getattr(getattr(e, "sent", None), "code", None)
+            recovered = await self._recover_receive_loop_disconnect(
+                message_ws,
+                message_generation,
+                "realtime connection closed unexpectedly",
+                status_code="CHARACTER_DISCONNECTED",
+            )
+            if recovered:
+                logger.warning(
+                    "Realtime connection closed unexpectedly "
+                    "(received_code=%s sent_code=%s)",
+                    received_code,
+                    sent_code,
+                )
         except asyncio.TimeoutError:
-            await self._close_failed_transport("realtime connection timeout")
-            if self.on_connection_error:
-                await self.on_connection_error(json.dumps({"code": "CONNECTION_TIMEOUT"}))
+            await self._recover_receive_loop_disconnect(
+                message_ws,
+                message_generation,
+                "realtime connection timeout",
+                status_code="CONNECTION_TIMEOUT",
+            )
         except Exception as e:
             await self._close_failed_transport(
                 f"realtime message handling failed: {type(e).__name__}"
             )
             logger.error(f"Error in message handling: {str(e)}")
             raise
+        else:
+            await self._recover_receive_loop_disconnect(
+                message_ws,
+                message_generation,
+                "realtime message stream ended",
+                status_code="CHARACTER_DISCONNECTED",
+            )
 
     def _on_connection_attached(self) -> None:
         """Mark a replacement connection as live and hand it the teardown latches.
@@ -2184,6 +2211,65 @@ class _TransportMixin:
         """
 
         return self._connection_generation == generation
+
+    async def _recover_receive_loop_disconnect(
+        self,
+        message_ws,
+        generation,
+        reason: str,
+        *,
+        status_code: str,
+    ) -> bool:
+        """Retire a peer-failed connection and request the existing recovery.
+
+        ``close()`` detaches its socket synchronously before awaiting the close
+        handshake. Therefore an ending receive loop still owns ``self.ws`` only
+        when the peer (or the network) ended the live connection first. An old
+        loop ending after a manager close or replacement attach must be silent:
+        reporting it as a fresh provider failure would tear down the successor.
+        """
+
+        if not self._still_owns_connection(generation) or self.ws is not message_ws:
+            logger.info(
+                "Realtime receive loop ended after its transport was already "
+                "closed or replaced; no connection error will be reported"
+            )
+            return False
+
+        await self._close_failed_transport(reason)
+        if not self._still_owns_connection(generation):
+            return False
+        self._schedule_connection_error(status_code, generation)
+        return True
+
+    def _schedule_connection_error(self, status_code: str, generation) -> None:
+        """Run manager recovery outside the receive loop that it must cancel."""
+
+        callback = self.on_connection_error
+        if callback is None:
+            return
+
+        async def _notify() -> None:
+            if not self._still_owns_connection(generation):
+                return
+            try:
+                await callback(
+                    json.dumps(
+                        {
+                            "code": status_code,
+                            "details": {"connection_generation": generation},
+                        }
+                    )
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error(
+                    "Realtime connection recovery callback failed: %s",
+                    type(exc).__name__,
+                )
+
+        self._fire_task(_notify())
 
     async def _own_teardown(self, slot: str, detach):
         """Await a teardown that this client owns, not the caller.
@@ -2397,9 +2483,9 @@ class _TransportMixin:
             return
         if ws:
             try:
-                # 连接时已设 close_timeout=0.5s：远端超时未回 CLOSE 帧时，
+                # 连接时已设 close_timeout=2s：远端超时未回 CLOSE 帧时，
                 # websockets 内部会自行 abort transport 强制关闭，
-                # 保证 end_session 快速返回、主事件循环心跳不受影响。
+                # 在兼容慢代理的同时保持清理等待有界。
                 await ws.close()
             except Exception as e:
                 logger.error(f"Error closing websocket: {e}")

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -39,6 +39,10 @@ from ._shared import (
     uuid,
     websockets,
 )
+from main_logic.provider_failure_signals import (
+    CODES_REQUIRING_MSG_DETAIL,
+    classify_provider_failure_text,
+)
 from ._protocol_capabilities import (
     ID_BEARING_RESPONSE_CONTENT_EVENT_TYPES,
     _response_id_text,
@@ -89,51 +93,31 @@ def _error_classification_text(error: Any) -> str:
     return str(error or "")
 
 
-_PEER_CLOSE_SAFETY_KEYWORDS = (
-    "safety",
-    "content_filter",
-    "content filter",
-    "policy violation",
-    "policy_violation",
-    "blocklist",
-    "prohibited",
-    "prohibited_content",
-    "recitation",
-    "spii",
-    "language",
-    "image_safety",
-    "image_prohibited_content",
-    "image_recitation",
-    "responsibleaipolicyviolation",
-    "responsible ai policy",
-)
+def _peer_close_descriptor(received_code) -> str:
+    """Name a peer close by its code alone, never by its reason text."""
+
+    if received_code is None:
+        return "WebSocket closed without a close code"
+    return f"WebSocket close code {received_code}"
 
 
 def _classify_peer_close(received_code, received_reason) -> tuple[str, dict[str, str] | None]:
     """Map a peer close to existing stable UI codes without exposing its reason."""
 
-    reason_text = str(received_reason or "")
-    reason_lower = reason_text.lower()
-    if "欠费" in reason_text or "standing" in reason_lower:
-        return "API_ARREARS", None
-    if "quota" in reason_lower or "time limit" in reason_lower:
-        return "API_QUOTA_TIME", None
-    if "429" in reason_lower or "too many" in reason_lower:
-        return "API_RATE_LIMIT", None
-    if (
-        "401" in reason_lower
-        or "unauthorized" in reason_lower
-        or "authentication" in reason_lower
-        or "incorrect api key" in reason_lower
-        or "invalid_api_key" in reason_lower
-        or ("invalid" in reason_lower and "key" in reason_lower)
-    ):
-        return "API_KEY_REJECTED", None
-    if any(keyword in reason_lower for keyword in _PEER_CLOSE_SAFETY_KEYWORDS):
-        return "API_POLICY_VIOLATION", None
-    if received_code == 1008:
-        return "API_1008_FALLBACK", {"msg": "WebSocket close code 1008"}
-    return "CHARACTER_DISCONNECTED", None
+    code = classify_provider_failure_text(received_reason)
+    if code is None and received_code == 1008:
+        # The reason said nothing, but the close code alone is a policy
+        # signal on every provider that sends it.
+        code = "API_1008_FALLBACK"
+    if code is None:
+        return "CHARACTER_DISCONNECTED", None
+    if code in CODES_REQUIRING_MSG_DETAIL:
+        # The reason string is peer-controlled and deliberately withheld, but
+        # these codes' i18n strings interpolate {{msg}} — emitting them with
+        # no msg renders the raw placeholder to the user. Substitute the close
+        # code, which is ours to disclose and is what a bug report needs.
+        return code, {"msg": _peer_close_descriptor(received_code)}
+    return code, None
 
 
 class RealtimeImagePayloadTooLargeError(RuntimeError):
@@ -2261,6 +2245,10 @@ class _TransportMixin:
         self._close_task = None
         self._failed_transport_close_task = None
         self._gemini_close_task = None
+        # A predecessor's unclaimed abort is not the replacement's to report.
+        # The generation stamp already refuses it; dropping it here keeps the
+        # latch from outliving the connection it describes.
+        self._local_failure_recovery = None
 
     def _still_owns_connection(self, generation) -> bool:
         """Whether the connection a teardown seized is still the client's.
@@ -2296,11 +2284,33 @@ class _TransportMixin:
         """
 
         if not self._still_owns_connection(generation) or self.ws is not message_ws:
-            logger.info(
-                "Realtime receive loop ended after its transport was already "
-                "closed or replaced; no connection error will be reported"
+            local_failure = self._consume_local_failure_recovery(generation)
+            if local_failure is None:
+                logger.info(
+                    "Realtime receive loop ended after its transport was already "
+                    "closed or replaced; no connection error will be reported"
+                )
+                return False
+            # A local component (the arbiter's fail-close, a fatal send) tore
+            # this transport down and nobody told the manager. Finish the host
+            # cleanup the aborting caller could not do from its own stack, and
+            # route it through the ordinary disconnect recovery. Deliberately
+            # NOT reclassified from the local close result: the primary cause
+            # is the reason the aborting caller already logged, and the CLOSE
+            # 1000 handshake outcome must not be shown as a provider API error.
+            logger.warning(
+                "Realtime transport was aborted locally (%s); requesting "
+                "session recovery",
+                local_failure,
             )
-            return False
+            await self._close_failed_transport(local_failure)
+            if not self._still_owns_connection(generation):
+                return False
+            self._schedule_connection_error(
+                "CHARACTER_DISCONNECTED",
+                generation,
+            )
+            return True
 
         await self._close_failed_transport(reason)
         if not self._still_owns_connection(generation):
@@ -2311,6 +2321,23 @@ class _TransportMixin:
             status_details=status_details,
         )
         return True
+
+    def _consume_local_failure_recovery(self, generation) -> str | None:
+        """Take the pending local-abort reason, if it belongs to ``generation``.
+
+        One-shot on purpose: the receive loop that owned the aborted socket is
+        the only party that may act on it, and a retired loop or a replacement
+        connection must not inherit a predecessor's failure.
+        """
+
+        pending = getattr(self, "_local_failure_recovery", None)
+        if pending is None:
+            return None
+        pending_generation, reason = pending
+        if pending_generation != generation:
+            return None
+        self._local_failure_recovery = None
+        return reason
 
     def _schedule_connection_error(
         self,
@@ -2420,11 +2447,27 @@ class _TransportMixin:
         ws=_ATTACHED_TRANSPORT,
         generation=None,
     ) -> None:
-        """Detach, when needed, and physically close a failed raw WebSocket."""
+        """Detach, when needed, and physically close a failed raw WebSocket.
+
+        The sentinel ``ws`` marks the arbiter's own entry point: it seizes the
+        attached socket itself, where ``_close_failed_transport_impl`` hands
+        over a socket it already seized. Only the former leaves nobody holding
+        the failure — the receive loop is about to wake up on a socket it no
+        longer owns and, without the latch armed here, would exit silently and
+        strand the manager on a live session over a dead transport.
+        """
 
         if generation is None or self._still_owns_connection(generation):
             self._fatal_error_occurred = True
         if ws is _ATTACHED_TRANSPORT:
+            # getattr, because this path is reachable on a client shell built
+            # without __init__ (abort is deliberately the one teardown that
+            # needs nothing but a socket) — and a shell has no receive loop to
+            # claim the latch anyway.
+            self._local_failure_recovery = (
+                getattr(self, "_connection_generation", 0),
+                reason,
+            )
             ws, self.ws = self.ws, None
         if ws is not None:
             try:
@@ -2455,6 +2498,9 @@ class _TransportMixin:
 
         generation = self._connection_generation
         ws, self.ws = self.ws, None
+        # The manager is the one closing, so it already knows this session is
+        # over: an abort latched just before this must not also fire recovery.
+        self._local_failure_recovery = None
         silence_check_task, self._silence_check_task = self._silence_check_task, None
         gemini_context = self._gemini_context_manager
         gemini_close_task = self._gemini_close_task

--- a/main_logic/provider_failure_signals.py
+++ b/main_logic/provider_failure_signals.py
@@ -39,6 +39,17 @@ _API_KEY_REJECTED_KEYWORDS = (
     "api key is invalid",
 )
 
+# Mostly Gemini's ``finishReason`` / ``blockReason`` enum, lowercased, plus the
+# OpenAI and Azure spellings. The primary caller (_streaming's
+# ``_is_safety_violation_signal(finish_reason, block_reason)``) matches against
+# those enum VALUES, not against free-form prose — which is why entries like
+# "language" and "recitation" are single common words and must stay: they are
+# Gemini's LANGUAGE and RECITATION finish reasons verbatim, and dropping one
+# sends that block into the unknown-error fallback instead of the policy toast.
+# The free-text callers (a provider error message, a WebSocket close reason)
+# inherit the same table and therefore the same substring behaviour they have
+# always had; tightening THAT is a matching-strategy change for all callers at
+# once, not a keyword edit.
 _SAFETY_VIOLATION_KEYWORDS = (
     "safety",
     "content_filter",

--- a/main_logic/provider_failure_signals.py
+++ b/main_logic/provider_failure_signals.py
@@ -1,0 +1,136 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One reading of "what did the provider just tell us", shared by every caller.
+
+Three call sites classify the same provider vocabulary: the offline client's
+safety check, the session manager's ``handle_connection_error`` chain, and the
+realtime transport's WebSocket close-frame classifier. They used to carry
+private copies of the keyword tables and of the ordering between them, which
+is exactly the shape that drifts: adding a safety keyword in one place left
+another silently reporting a policy block as an ordinary disconnect.
+
+Only the CRITERIA live here. Each caller still builds its own ``details``
+payload, because the payloads mean different things: the manager echoes the
+upstream diagnostic text, while the realtime close path deliberately withholds
+a peer-controlled reason string and substitutes a stable descriptor.
+"""
+
+from __future__ import annotations
+
+
+_API_KEY_REJECTED_KEYWORDS = (
+    "incorrect api key",
+    "incorect api key",
+    "invalid_api_key",
+    "invalid api key",
+    "invalid key",
+    "api key is invalid",
+)
+
+_SAFETY_VIOLATION_KEYWORDS = (
+    "safety",
+    "content_filter",
+    "content filter",
+    "policy violation",
+    "policy_violation",
+    "blocklist",
+    "prohibited",
+    "prohibited_content",
+    "recitation",
+    "spii",
+    "language",
+    "image_safety",
+    "image_prohibited_content",
+    "image_recitation",
+    "responsibleaipolicyviolation",
+    "responsible ai policy",
+)
+
+_ARREARS_KEYWORDS = ("欠费", "standing")
+
+_QUOTA_KEYWORDS = ("quota", "time limit")
+
+_RATE_LIMIT_KEYWORDS = ("429", "too many")
+
+_KEY_REJECTED_KEYWORDS = (
+    "401",
+    "unauthorized",
+    "authentication",
+    "incorrect api key",
+    "invalid_api_key",
+)
+
+
+def _is_safety_violation_signal(*values: object) -> bool:
+    """Return True when provider diagnostics point to safety/policy blocking."""
+    text = " ".join(str(value) for value in values if value).lower()
+    if not text:
+        return False
+    return any(keyword in text for keyword in _SAFETY_VIOLATION_KEYWORDS)
+
+
+def _is_key_rejected_signal(text_lower: str) -> bool:
+    """Return True when the text reads as a rejected API key."""
+    if any(keyword in text_lower for keyword in _KEY_REJECTED_KEYWORDS):
+        return True
+    return "invalid" in text_lower and "key" in text_lower
+
+
+def classify_provider_failure_text(text: object) -> str | None:
+    """Map provider diagnostic text to a stable frontend status code.
+
+    Returns ``None`` when nothing in the text identifies a known failure
+    class, leaving the caller to pick its own fallback: the manager reports
+    ``API_UNKNOWN_ERROR`` because it is holding a real upstream error, while
+    the realtime close path reports ``CHARACTER_DISCONNECTED`` because a close
+    frame it cannot classify is an ordinary disconnect, not an API error.
+
+    The ordering is load-bearing and predates this module: arrears before
+    quota (an unpaid account also reports a quota), rate limit before key
+    rejection (a 429 body often echoes auth headers), and safety last of the
+    keyword classes because its vocabulary is the broadest.
+    """
+
+    raw = str(text or "")
+    if not raw:
+        return None
+    lowered = raw.lower()
+    if any(keyword in lowered for keyword in _ARREARS_KEYWORDS):
+        return "API_ARREARS"
+    if any(keyword in lowered for keyword in _QUOTA_KEYWORDS):
+        return "API_QUOTA_TIME"
+    if any(keyword in lowered for keyword in _RATE_LIMIT_KEYWORDS):
+        return "API_RATE_LIMIT"
+    if _is_key_rejected_signal(lowered):
+        return "API_KEY_REJECTED"
+    if _is_safety_violation_signal(lowered):
+        return "API_POLICY_VIOLATION"
+    if "1008" in lowered:
+        return "API_1008_FALLBACK"
+    return None
+
+
+# Codes whose frontend i18n string interpolates ``{{msg}}``. A caller emitting
+# one of these without a ``msg`` detail ships a toast that renders the raw
+# placeholder, so every producer must supply one — either the upstream text it
+# already holds, or a stable descriptor when the upstream text must not be
+# shown.
+CODES_REQUIRING_MSG_DETAIL = frozenset(
+    {
+        "API_POLICY_VIOLATION",
+        "API_1008_FALLBACK",
+        "API_UNKNOWN_ERROR",
+    }
+)

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -8,6 +8,12 @@ import pytest
 
 from main_logic.omni_realtime_client import OmniRealtimeClient
 import main_logic.omni_realtime_client._response_arbiter as arbiter_module
+from main_logic.omni_realtime_client._protocol_capabilities import (
+    LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES,
+    STRICT_REALTIME_PROTOCOL_CAPABILITIES,
+    ResponseStartEvidence,
+    resolve_realtime_protocol_capabilities,
+)
 from main_logic.tool_calling import ToolResult
 
 _DEFAULT_RESPONSE_DONE_TIMEOUT = arbiter_module._DEFAULT_RESPONSE_DONE_TIMEOUT
@@ -882,6 +888,222 @@ async def test_a_terminal_for_a_never_announced_id_belongs_to_the_owner():
     assert "response.cancel" not in [event["type"] for event in sent]
     assert arbiter.is_busy is False, "the lane must reopen for the next turn"
     await arbiter.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("api_type", "route_url", "expected_route", "allows_content_start"),
+    [
+        ("free", "wss://lanlan.app/realtime", "lanlan_app_gemini", True),
+        ("free", "wss://edge.lanlan.app/realtime", "lanlan_app_gemini", True),
+        ("free", "wss://lanlan.tech/realtime", "lanlan_tech_stepfun", False),
+        ("free", "wss://edge.lanlan.tech/realtime", "lanlan_tech_stepfun", False),
+        ("free", "wss://notlanlan.tech/realtime", "strict_default", False),
+        ("free", "wss://other.example/realtime", "strict_default", False),
+        ("gpt", "wss://lanlan.app/realtime", "strict_default", False),
+    ],
+)
+def test_realtime_protocol_capabilities_are_resolved_by_concrete_route(
+    api_type,
+    route_url,
+    expected_route,
+    allows_content_start,
+):
+    capabilities = resolve_realtime_protocol_capabilities(api_type, route_url)
+
+    assert capabilities.route_key == expected_route
+    assert (
+        capabilities.accepts_id_bearing_content_start is allows_content_start
+    )
+    if allows_content_start:
+        assert capabilities.response_start_evidence is (
+            ResponseStartEvidence.ANNOUNCEMENT_OR_ID_BEARING_CONTENT
+        )
+
+
+@pytest.mark.asyncio
+async def test_lanlan_app_id_bearing_content_starts_a_long_owned_response():
+    sent = []
+    aborted = []
+
+    async def send(event):
+        sent.append(dict(event))
+
+    async def abort(reason):
+        aborted.append(reason)
+
+    arbiter = RealtimeResponseArbiter(
+        send,
+        abort_transport=abort,
+        protocol_capabilities=LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES,
+    )
+    ticket = await arbiter.enqueue(
+        source="tool_result",
+        response_started_timeout=0.02,
+        cancel_timeout=0.01,
+    )
+    await asyncio.wait_for(ticket.sent, 0.2)
+
+    assert arbiter.notify_response_content(
+        {
+            "type": "response.audio.delta",
+            "response_id": "resp-owner",
+            "item_id": "item-owner",
+        }
+    )
+    await asyncio.wait_for(ticket.started, 0.2)
+
+    # This response deliberately outlives the old five-second phase (scaled
+    # down here). Content-start evidence must prevent cancel/fail-close while
+    # the matching response is still healthy and streaming.
+    await asyncio.sleep(0.04)
+    assert "response.cancel" not in [event["type"] for event in sent]
+    assert aborted == []
+
+    assert arbiter.notify_response_terminal(
+        {
+            "type": "response.done",
+            "response": {"id": "resp-owner", "status": "completed"},
+        }
+    )
+    await asyncio.wait_for(ticket.done, 0.2)
+    assert arbiter.is_busy is False
+    await arbiter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_strict_route_does_not_accept_content_in_place_of_announcement():
+    sent = []
+    aborted = asyncio.Event()
+
+    async def send(event):
+        sent.append(dict(event))
+
+    async def abort(_reason):
+        aborted.set()
+
+    arbiter = RealtimeResponseArbiter(
+        send,
+        abort_transport=abort,
+        protocol_capabilities=STRICT_REALTIME_PROTOCOL_CAPABILITIES,
+    )
+    ticket = await arbiter.enqueue(
+        source="tool_result",
+        response_started_timeout=0.02,
+        cancel_timeout=0.01,
+    )
+    await asyncio.wait_for(ticket.sent, 0.2)
+
+    assert not arbiter.notify_response_content(
+        {"type": "response.audio.delta", "response_id": "resp-unannounced"}
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(ticket.done, 0.5)
+    assert aborted.is_set()
+    assert [event["type"] for event in sent] == [
+        "response.create",
+        "response.cancel",
+    ]
+    await arbiter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_content_start_requires_a_new_id_and_matching_terminal():
+    async def send(_event):
+        return None
+
+    arbiter = RealtimeResponseArbiter(
+        send,
+        protocol_capabilities=LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES,
+    )
+    first = await arbiter.enqueue(source="first")
+    await asyncio.wait_for(first.sent, 0.2)
+    assert not arbiter.notify_response_content(
+        {"type": "response.output_item.added", "response_id": "resp-first"}
+    )
+    assert not arbiter.notify_response_content(
+        {"type": "response.audio.delta", "response_id": ""}
+    )
+    assert arbiter.notify_response_content(
+        {"type": "response.audio.delta", "response_id": "resp-first"}
+    )
+    assert not arbiter.notify_response_terminal(
+        {
+            "type": "response.done",
+            "response": {"id": "resp-other", "status": "completed"},
+        }
+    )
+    assert first.done.done() is False
+    assert arbiter.notify_response_terminal(
+        {
+            "type": "response.done",
+            "response": {"id": "resp-first", "status": "completed"},
+        }
+    )
+    await asyncio.wait_for(first.done, 0.2)
+
+    second = await arbiter.enqueue(source="second")
+    await asyncio.wait_for(second.sent, 0.2)
+    assert not arbiter.notify_response_content(
+        {"type": "response.audio.delta", "response_id": "resp-first"}
+    )
+    assert arbiter.notify_response_content(
+        {"type": "response.audio.delta", "response_id": "resp-second"}
+    )
+    arbiter.notify_response_terminal(
+        {
+            "type": "response.done",
+            "response": {"id": "resp-second", "status": "completed"},
+        }
+    )
+    await asyncio.wait_for(second.done, 0.2)
+    await arbiter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lanlan_app_transport_forwards_content_start_to_arbiter():
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+    )
+    socket = AsyncMock()
+    client.ws = socket
+    ticket = await client._response_arbiter.enqueue(
+        source="tool_result",
+        response_started_timeout=0.1,
+        cancel_timeout=0.02,
+    )
+    await asyncio.wait_for(ticket.sent, 0.2)
+
+    async def response_events():
+        yield json.dumps(
+            {
+                "type": "response.audio.delta",
+                "response_id": "resp-app",
+                "item_id": "item-app",
+                "delta": "AAA=",
+            }
+        )
+        yield json.dumps(
+            {
+                "type": "response.done",
+                "response": {"id": "resp-app", "status": "completed"},
+            }
+        )
+        # Let the arbiter worker consume its terminal future before ending the
+        # synthetic socket; a real WebSocket stays open after response.done.
+        await asyncio.wait_for(ticket.done, 0.2)
+
+    socket.__aiter__.side_effect = response_events
+
+    await client.handle_messages()
+
+    await asyncio.wait_for(ticket.done, 0.2)
+    sent_types = [json.loads(call.args[0])["type"] for call in socket.send.call_args_list]
+    assert sent_types == ["response.create"]
+    assert client._response_created_total == 0
+    await client._response_arbiter.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -891,24 +891,37 @@ async def test_a_terminal_for_a_never_announced_id_belongs_to_the_owner():
 
 
 @pytest.mark.parametrize(
-    ("api_type", "route_url", "expected_route", "allows_content_start"),
+    (
+        "api_type",
+        "route_url",
+        "livestream_mode",
+        "expected_route",
+        "allows_content_start",
+    ),
     [
-        ("free", "wss://lanlan.app/realtime", "lanlan_app_gemini", True),
-        ("free", "wss://edge.lanlan.app/realtime", "lanlan_app_gemini", True),
-        ("free", "wss://lanlan.tech/realtime", "lanlan_tech_stepfun", False),
-        ("free", "wss://edge.lanlan.tech/realtime", "lanlan_tech_stepfun", False),
-        ("free", "wss://notlanlan.tech/realtime", "strict_default", False),
-        ("free", "wss://other.example/realtime", "strict_default", False),
-        ("gpt", "wss://lanlan.app/realtime", "strict_default", False),
+        ("free", "wss://lanlan.app/realtime", False, "lanlan_app_gemini", True),
+        ("free", "wss://edge.lanlan.app/realtime", False, "lanlan_app_gemini", True),
+        ("free", "wss://lanlan.tech/realtime", False, "lanlan_tech_stepfun", False),
+        ("free", "wss://edge.lanlan.tech/realtime", False, "lanlan_tech_stepfun", False),
+        ("free", "wss://notlanlan.tech/realtime", False, "strict_default", False),
+        ("free", "wss://other.example/realtime", False, "strict_default", False),
+        ("gpt", "wss://lanlan.app/realtime", False, "strict_default", False),
+        ("free", "wss://192.168.1.9:8000/core", True, "lanlan_app_gemini", True),
+        ("gpt", "wss://192.168.1.9:8000/core", True, "strict_default", False),
     ],
 )
 def test_realtime_protocol_capabilities_are_resolved_by_concrete_route(
     api_type,
     route_url,
+    livestream_mode,
     expected_route,
     allows_content_start,
 ):
-    capabilities = resolve_realtime_protocol_capabilities(api_type, route_url)
+    capabilities = resolve_realtime_protocol_capabilities(
+        api_type,
+        route_url,
+        livestream_mode=livestream_mode,
+    )
 
     assert capabilities.route_key == expected_route
     assert (
@@ -918,6 +931,37 @@ def test_realtime_protocol_capabilities_are_resolved_by_concrete_route(
         assert capabilities.response_start_evidence is (
             ResponseStartEvidence.ANNOUNCEMENT_OR_ID_BEARING_CONTENT
         )
+    else:
+        assert capabilities.response_start_evidence is (
+            ResponseStartEvidence.ANNOUNCEMENT_ONLY
+        )
+
+
+@pytest.mark.parametrize(
+    ("api_type", "model", "route_url", "livestream_mode", "expected_route"),
+    [
+        (None, "free-model", "wss://lanlan.app/realtime", False, "lanlan_app_gemini"),
+        (None, "free-model", "wss://other.example/realtime", False, "strict_default"),
+        ("gpt", "free-model", "wss://lanlan.app/realtime", False, "strict_default"),
+        (None, "free-model", "wss://192.168.1.9:8000/core", True, "lanlan_app_gemini"),
+    ],
+)
+def test_client_capabilities_follow_the_existing_effective_free_provider(
+    api_type,
+    model,
+    route_url,
+    livestream_mode,
+    expected_route,
+):
+    client = OmniRealtimeClient(
+        route_url,
+        "test-key",
+        model=model,
+        api_type=api_type,
+        livestream_mode=livestream_mode,
+    )
+
+    assert client._realtime_protocol_capabilities.route_key == expected_route
 
 
 @pytest.mark.asyncio
@@ -938,7 +982,7 @@ async def test_lanlan_app_id_bearing_content_starts_a_long_owned_response():
     )
     ticket = await arbiter.enqueue(
         source="tool_result",
-        response_started_timeout=0.02,
+        response_started_timeout=0.2,
         cancel_timeout=0.01,
     )
     await asyncio.wait_for(ticket.sent, 0.2)
@@ -968,6 +1012,123 @@ async def test_lanlan_app_id_bearing_content_starts_a_long_owned_response():
     await asyncio.wait_for(ticket.done, 0.2)
     assert arbiter.is_busy is False
     await arbiter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_late_created_confirms_content_started_owner_without_duplication():
+    sent = []
+
+    async def send(event):
+        sent.append(dict(event))
+
+    arbiter = RealtimeResponseArbiter(
+        send,
+        protocol_capabilities=LANLAN_APP_REALTIME_PROTOCOL_CAPABILITIES,
+    )
+    ticket = await arbiter.enqueue(source="tool_result")
+    await asyncio.wait_for(ticket.sent, 0.2)
+
+    assert arbiter.notify_response_content(
+        {"type": "response.text.delta", "response_id": "resp-owner"}
+    )
+    assert not arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-owner"}}
+    )
+    assert arbiter._server_response_ids == {}
+
+    assert arbiter.notify_response_terminal(
+        {
+            "type": "response.done",
+            "response": {"id": "resp-owner", "status": "completed"},
+        }
+    )
+    await asyncio.wait_for(ticket.done, 0.2)
+    assert arbiter.is_busy is False
+    await arbiter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_transport_begins_content_started_lifecycle_only_once():
+    class _Socket:
+        def __init__(self, frames):
+            self._frames = frames
+
+        async def __aiter__(self):
+            for frame in self._frames:
+                yield json.dumps(frame)
+                await asyncio.sleep(0)
+            await asyncio.Event().wait()
+
+        async def send(self, *_args, **_kwargs):
+            return None
+
+        async def close(self, *_args, **_kwargs):
+            return None
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+    )
+    client.ws = _Socket(
+        [
+            {
+                "type": "response.text.delta",
+                "response_id": "resp-owner",
+                "delta": "hello",
+            },
+            {"type": "response.created", "response": {"id": "resp-owner"}},
+            {
+                "type": "response.done",
+                "response": {"id": "resp-owner", "status": "completed"},
+            },
+        ]
+    )
+    ticket = await client._response_arbiter.enqueue(source="tool_result")
+    await asyncio.wait_for(ticket.sent, 0.2)
+    receiver = asyncio.create_task(client.handle_messages())
+
+    await asyncio.wait_for(ticket.done, 0.2)
+    assert client._turn_epoch == 1
+    assert client._announces_responses is True
+    assert client._response_arbiter._server_response_ids == {}
+    receiver.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await receiver
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_null_created_response_is_normalized_without_crashing_transport():
+    class _Socket:
+        async def __aiter__(self):
+            yield json.dumps({"type": "response.created", "response": None})
+            await asyncio.Event().wait()
+
+        async def close(self, *_args, **_kwargs):
+            return None
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="qwen-omni-turbo-realtime",
+        api_type="qwen",
+    )
+    client.ws = _Socket()
+    receiver = asyncio.create_task(client.handle_messages())
+    for _ in range(100):
+        if client._response_created_total == 1:
+            break
+        await asyncio.sleep(0)
+
+    assert client._response_created_total == 1
+    assert client._current_response_id is None
+    assert not receiver.done()
+    receiver.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await receiver
+    await client.close()
 
 
 @pytest.mark.asyncio
@@ -3527,7 +3688,7 @@ async def test_a_zero_id_is_still_an_identity_to_the_stale_filter():
     assert fired == [], (
         "response 0's terminal must not finalize the turn response 1 owns"
     )
-    assert client._current_response_id == 1
+    assert client._current_response_id == "1"
 
 
 @pytest.mark.unit
@@ -3658,6 +3819,11 @@ def test_a_response_id_is_absent_only_when_it_names_nothing():
     assert _response_id_text("resp-1") == "resp-1"
     assert _response_id_text("") is None, "an empty id names nothing"
     assert _response_id_text(None) is None
+
+    read_content = RealtimeResponseArbiter._content_event_response_id
+    assert read_content({"response_id": 0}) == "0"
+    assert read_content({"response_id": ""}) is None
+    assert read_content({}) is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -1149,10 +1149,22 @@ async def test_strict_route_does_not_accept_content_in_place_of_announcement():
     )
     ticket = await arbiter.enqueue(
         source="tool_result",
-        response_started_timeout=0.02,
+        response_started_timeout=0.2,
         cancel_timeout=0.01,
     )
     await asyncio.wait_for(ticket.sent, 0.2)
+
+    # The refusal has to be observed while the owner is still legitimately
+    # waiting. With a 20ms allowance a slow CI tick (GC pause, loaded runner)
+    # could let the started timeout fire first, and notify_response_content
+    # would then return False because the owner is GONE rather than because
+    # the route is strict — every assertion below still passes, so the test
+    # would go on succeeding while testing nothing.
+    owner = arbiter._response_owner
+    assert owner is not None and not owner.ticket.started.done(), (
+        "the owner must still be awaiting its announcement for this refusal "
+        "to mean what the test claims"
+    )
 
     assert not arbiter.notify_response_content(
         {"type": "response.audio.delta", "response_id": "resp-unannounced"}

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import re
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,6 +12,8 @@ from websockets.frames import Close
 
 from main_logic.core import LLMSessionManager
 from main_logic.omni_realtime_client import OmniRealtimeClient, TurnDetectionMode
+from main_logic.omni_realtime_client._transport import _classify_peer_close
+from main_logic.provider_failure_signals import CODES_REQUIRING_MSG_DETAIL
 
 
 pytestmark = pytest.mark.unit
@@ -231,20 +235,28 @@ async def test_peer_policy_close_preserves_existing_1008_classification():
 
 
 @pytest.mark.parametrize(
-    ("reason", "expected_code"),
+    ("reason", "expected_code", "expected_details"),
     (
-        ("insufficient standing", "API_ARREARS"),
-        ("quota exceeded", "API_QUOTA_TIME"),
-        ("too many requests", "API_RATE_LIMIT"),
-        ("unauthorized", "API_KEY_REJECTED"),
-        ("safety policy violation", "API_POLICY_VIOLATION"),
-        ("unclassified provider close", "CHARACTER_DISCONNECTED"),
+        ("insufficient standing", "API_ARREARS", {}),
+        ("quota exceeded", "API_QUOTA_TIME", {}),
+        ("too many requests", "API_RATE_LIMIT", {}),
+        ("unauthorized", "API_KEY_REJECTED", {}),
+        # Every code whose i18n string interpolates {{msg}} must carry one, or
+        # the toast renders the raw placeholder. The substitute names the close
+        # by its code, never by the peer-controlled reason text.
+        (
+            "safety policy violation",
+            "API_POLICY_VIOLATION",
+            {"msg": "WebSocket close code 4000"},
+        ),
+        ("unclassified provider close", "CHARACTER_DISCONNECTED", {}),
     ),
 )
 @pytest.mark.asyncio
 async def test_application_close_reason_preserves_existing_classification(
     reason: str,
     expected_code: str,
+    expected_details: dict,
 ):
     failures = AsyncMock()
     client = _make_client(on_connection_error=failures)
@@ -262,9 +274,36 @@ async def test_application_close_reason_preserves_existing_classification(
 
     assert json.loads(failures.await_args.args[0]) == {
         "code": expected_code,
-        "details": {"connection_generation": 0},
+        "details": {"connection_generation": 0, **expected_details},
     }
     assert reason not in failures.await_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "code",
+    sorted(CODES_REQUIRING_MSG_DETAIL),
+)
+def test_every_msg_interpolating_code_is_given_a_msg_by_the_close_classifier(code):
+    # The frontend renders these through i18next with skipOnVariables on, so a
+    # missing `msg` ships a literal "{{msg}}" to the user. Any close reason
+    # that maps to one of them must therefore arrive with the detail attached.
+    reasons = {
+        "API_POLICY_VIOLATION": (1000, "blocked for safety"),
+        "API_1008_FALLBACK": (1008, "unclassifiable"),
+        "API_UNKNOWN_ERROR": None,
+    }
+    probe = reasons[code]
+    if probe is None:
+        # Not produced by the close classifier; the manager owns this one and
+        # supplies the upstream text it is already holding.
+        return
+    received_code, reason = probe
+    classified, details = _classify_peer_close(received_code, reason)
+    assert classified == code
+    assert details and details.get("msg"), (
+        f"{code} interpolates {{{{msg}}}} and must not be emitted without one"
+    )
+    assert reason not in details["msg"]
 
 
 @pytest.mark.asyncio
@@ -285,6 +324,78 @@ async def test_arbiter_fail_close_preserves_first_cause_without_user_status(capl
     assert client._fatal_error_occurred is True
     assert f"response arbiter failing closed: {reason}" in caplog.text
     assert "sent 1000" not in caplog.text
+    # The fail-close itself never reports to the user: no receive loop is
+    # running here, so nothing consumes the latch it armed. The companion
+    # test below covers the live case, where the loop that owned the aborted
+    # socket is the one that requests recovery.
+    failures.assert_not_awaited()
+    assert client._local_failure_recovery == (0, reason)
+
+
+@pytest.mark.asyncio
+async def test_arbiter_fail_close_still_reaches_the_manager_via_receive_loop():
+    # An arbiter fail-close detaches the socket out from under the receive
+    # loop, so the loop wakes up on a transport it no longer owns. Without the
+    # local-abort latch it would exit silently, leaving the manager on a live
+    # session over a dead socket: send_event drops every later frame at its
+    # `_fatal_error_occurred` guard, so the microphone goes nowhere with no
+    # toast and no rebuild.
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    reason = "response lifecycle could not reach a terminal state"
+    await client._response_arbiter._tear_down_transport(reason)
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert client.ws is None
+    assert client._fatal_error_occurred is True
+    # Routed through the ordinary disconnect recovery, NOT reclassified from
+    # the local CLOSE 1000 handshake result.
+    failures.assert_awaited_once_with(_failure_status("CHARACTER_DISCONNECTED"))
+    assert "1000" not in failures.await_args.args[0]
+    assert client._local_failure_recovery is None
+
+
+@pytest.mark.asyncio
+async def test_a_retired_loop_cannot_claim_a_successors_local_abort():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    retired = _ControlledWs()
+    receiver = await _start_receiver(client, retired)
+
+    replacement = _ControlledWs()
+    client.ws = replacement
+    client._on_connection_attached()
+    # The SUCCESSOR's transport is aborted locally. Only the loop that owned
+    # that socket may report it; this retired one must stay silent and leave
+    # the latch for its rightful claimant.
+    await client._abort_failed_transport("successor abort")
+    retired.finish_from_peer()
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    failures.assert_not_awaited()
+    assert client._local_failure_recovery == (1, "successor abort")
+
+
+@pytest.mark.asyncio
+async def test_manager_initiated_close_disarms_the_local_abort_latch():
+    # close() means the manager already knows the session is over. An abort
+    # latched just before it must not also fire a recovery request.
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    client._local_failure_recovery = (0, "aborted just before the close")
+    await client.close()
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert client._local_failure_recovery is None
     failures.assert_not_awaited()
 
 
@@ -343,6 +454,61 @@ async def test_preclassified_timeout_is_forwarded_before_existing_recovery():
     manager.send_status.assert_awaited_once_with(status)
     manager.disconnected_by_server.assert_awaited_once_with(
         expected_session=manager.session
+    )
+
+
+@pytest.mark.parametrize(
+    ("diagnostic", "expected_code"),
+    (
+        ("account is not in good standing", "API_ARREARS"),
+        ("欠费了", "API_ARREARS"),
+        ("quota exceeded for this project", "API_QUOTA_TIME"),
+        ("HTTP 429 Too Many Requests", "API_RATE_LIMIT"),
+        ("unauthorized: incorrect api key", "API_KEY_REJECTED"),
+        ("blocked by content filter", "API_POLICY_VIOLATION"),
+        ("recitation", "API_POLICY_VIOLATION"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_both_failure_paths_classify_the_same_text_identically(
+    diagnostic: str,
+    expected_code: str,
+):
+    # The manager's error chain and the realtime close classifier read the
+    # same provider vocabulary. They used to hold private copies of the
+    # keywords AND of the ordering between them, so a keyword added for one
+    # silently went missing on the other. Assert the two agree on real text,
+    # not merely that a shared helper exists — a call site that stops using
+    # it is exactly the regression this is here to catch.
+    manager = _make_manager()
+    await manager.handle_connection_error(
+        diagnostic, expected_session=manager.session
+    )
+    manager_code = json.loads(manager.send_status.await_args.args[0])["code"]
+
+    close_code, _ = _classify_peer_close(4000, diagnostic)
+
+    assert manager_code == expected_code
+    assert close_code == expected_code
+
+
+def test_provider_failure_keywords_are_defined_in_exactly_one_place():
+    # The drift this guards against is additive: someone needing the table in
+    # a third module copies it rather than importing it, and from then on a
+    # keyword added to one copy is honoured by one caller only.
+    import main_logic
+
+    root = Path(main_logic.__file__).resolve().parent
+    pattern = re.compile(r"^_SAFETY_VIOLATION_KEYWORDS\s*=\s*\(", re.MULTILINE)
+    definitions = sorted(
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*.py")
+        if pattern.search(path.read_text(encoding="utf-8"))
+    )
+
+    assert definitions == ["provider_failure_signals.py"], (
+        "the safety keyword table must have exactly one definition; "
+        f"found {definitions}"
     )
 
 

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import websockets
+from websockets.frames import Close
 
 from main_logic.core import LLMSessionManager
 from main_logic.omni_realtime_client import OmniRealtimeClient, TurnDetectionMode
@@ -69,10 +70,25 @@ async def _start_receiver(client: OmniRealtimeClient, ws: _ControlledWs):
 
 
 async def _settle_background_tasks(client: OmniRealtimeClient) -> None:
-    for _ in range(10):
-        if not client._bg_tasks:
-            return
-        await asyncio.sleep(0)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 2.0
+    while client._bg_tasks:
+        pending = set(client._bg_tasks)
+        await asyncio.wait_for(
+            asyncio.gather(*pending),
+            timeout=max(0.0, deadline - loop.time()),
+        )
+
+
+def _make_manager(session=None) -> LLMSessionManager:
+    manager = object.__new__(LLMSessionManager)
+    manager.lock = asyncio.Lock()
+    manager.session = session if session is not None else object()
+    manager.pending_session = None
+    manager.session_closed_by_server = False
+    manager.send_status = AsyncMock()
+    manager.disconnected_by_server = AsyncMock()
+    return manager
 
 
 @pytest.mark.asyncio
@@ -132,10 +148,38 @@ async def test_retired_receive_loop_cannot_condemn_or_report_the_replacement():
     client._on_connection_attached()
     retired.finish_from_peer()
     await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
 
     assert client.ws is replacement
     assert client._fatal_error_occurred is False
     failures.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_peer_policy_close_preserves_existing_1008_classification():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    ws.fail_from_peer(
+        websockets.exceptions.ConnectionClosedError(
+            Close(1008, "provider-controlled reason"),
+            None,
+        )
+    )
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    payload = json.loads(failures.await_args.args[0])
+    assert payload == {
+        "code": "API_1008_FALLBACK",
+        "details": {
+            "msg": "WebSocket close code 1008",
+            "connection_generation": 0,
+        },
+    }
+    assert "provider-controlled reason" not in failures.await_args.args[0]
 
 
 @pytest.mark.asyncio
@@ -193,13 +237,7 @@ async def test_connect_uses_two_second_close_handshake_timeout():
 
 @pytest.mark.asyncio
 async def test_peer_disconnect_marker_is_not_shown_twice_before_recovery():
-    manager = object.__new__(LLMSessionManager)
-    manager.lock = asyncio.Lock()
-    manager.session = object()
-    manager.pending_session = None
-    manager.session_closed_by_server = False
-    manager.send_status = AsyncMock()
-    manager.disconnected_by_server = AsyncMock()
+    manager = _make_manager()
 
     marker = json.dumps({"code": "CHARACTER_DISCONNECTED"})
     await manager.handle_connection_error(marker, expected_session=manager.session)
@@ -212,13 +250,7 @@ async def test_peer_disconnect_marker_is_not_shown_twice_before_recovery():
 
 @pytest.mark.asyncio
 async def test_preclassified_timeout_is_forwarded_before_existing_recovery():
-    manager = object.__new__(LLMSessionManager)
-    manager.lock = asyncio.Lock()
-    manager.session = object()
-    manager.pending_session = None
-    manager.session_closed_by_server = False
-    manager.send_status = AsyncMock()
-    manager.disconnected_by_server = AsyncMock()
+    manager = _make_manager()
 
     status = json.dumps({"code": "CONNECTION_TIMEOUT"})
     await manager.handle_connection_error(status, expected_session=manager.session)
@@ -231,13 +263,9 @@ async def test_preclassified_timeout_is_forwarded_before_existing_recovery():
 
 @pytest.mark.asyncio
 async def test_late_failure_from_a_retired_generation_cannot_recover_the_successor():
-    manager = object.__new__(LLMSessionManager)
-    manager.lock = asyncio.Lock()
-    manager.session = type("Session", (), {"_connection_generation": 2})()
-    manager.pending_session = None
-    manager.session_closed_by_server = False
-    manager.send_status = AsyncMock()
-    manager.disconnected_by_server = AsyncMock()
+    manager = _make_manager(
+        type("Session", (), {"_connection_generation": 2})()
+    )
 
     await manager.handle_connection_error(
         _failure_status("CHARACTER_DISCONNECTED", generation=1),

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -522,10 +522,13 @@ async def test_a_close_that_cannot_finish_detached_is_never_cut_short(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_a_shielded_close_is_bounded_by_the_budget(monkeypatch):
-    # The dual: the realtime client declares close_finishes_detached, so
-    # giving up on the wait leaves its teardown running and the caller is
-    # released instead of parking on a wedged peer.
+async def test_a_shielded_close_is_bounded_but_still_runs_to_completion(monkeypatch):
+    # The dual, and the whole point of the contract: giving up on the WAIT
+    # must not give up on the CLOSE. The fake mirrors OmniRealtimeClient's
+    # `_own_teardown` — the teardown is an independent task awaited through
+    # asyncio.shield — because asserting only "the caller was released" would
+    # pass just as happily against a close that the timeout simply cancelled,
+    # which is the exact bug `close_finishes_detached` exists to prevent.
     monkeypatch.setattr(lifecycle_module, "SESSION_CLOSE_TIMEOUT_SECONDS", 0.01)
 
     class _ShieldedSession:
@@ -533,8 +536,14 @@ async def test_a_shielded_close_is_bounded_by_the_budget(monkeypatch):
 
         def __init__(self):
             self.fully_closed = False
+            self._teardown = None
 
         async def close(self):
+            if self._teardown is None:
+                self._teardown = asyncio.create_task(self._finish())
+            await asyncio.shield(self._teardown)
+
+        async def _finish(self):
             await asyncio.sleep(0.05)
             self.fully_closed = True
 
@@ -545,6 +554,12 @@ async def test_a_shielded_close_is_bounded_by_the_budget(monkeypatch):
     )
 
     assert session.fully_closed is False, "the budget must release the caller"
+
+    await asyncio.wait_for(session._teardown, timeout=1)
+    assert session.fully_closed is True, (
+        "the teardown must survive the caller giving up on it — that is what "
+        "close_finishes_detached promises"
+    )
 
 
 def test_the_realtime_client_declares_a_detachable_close():

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -10,6 +10,7 @@ import pytest
 import websockets
 from websockets.frames import Close
 
+import main_logic.core.lifecycle as lifecycle_module
 from main_logic.core import LLMSessionManager
 from main_logic.omni_realtime_client import OmniRealtimeClient, TurnDetectionMode
 from main_logic.omni_realtime_client._transport import _classify_peer_close
@@ -490,6 +491,66 @@ async def test_both_failure_paths_classify_the_same_text_identically(
 
     assert manager_code == expected_code
     assert close_code == expected_code
+
+
+@pytest.mark.asyncio
+async def test_a_close_that_cannot_finish_detached_is_never_cut_short(monkeypatch):
+    # Bounding the WAIT is only safe when the close keeps running without a
+    # waiter. An offline client's close is a plain coroutine: cancelling it
+    # skips `self.llm = None` and the threaded genai close, leaking the
+    # connection pools it exists to release. Such a session must be awaited
+    # to completion however long it takes.
+    monkeypatch.setattr(lifecycle_module, "SESSION_CLOSE_TIMEOUT_SECONDS", 0.01)
+
+    class _UnshieldedSession:
+        def __init__(self):
+            self.fully_closed = False
+
+        async def close(self):
+            await asyncio.sleep(0.05)
+            self.fully_closed = True
+
+    manager = _make_manager()
+    session = _UnshieldedSession()
+    await LLMSessionManager._close_session_within_budget(
+        manager, session, "Unshielded"
+    )
+
+    assert session.fully_closed is True, (
+        "a close that cannot finish detached must not be cancelled by the budget"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_shielded_close_is_bounded_by_the_budget(monkeypatch):
+    # The dual: the realtime client declares close_finishes_detached, so
+    # giving up on the wait leaves its teardown running and the caller is
+    # released instead of parking on a wedged peer.
+    monkeypatch.setattr(lifecycle_module, "SESSION_CLOSE_TIMEOUT_SECONDS", 0.01)
+
+    class _ShieldedSession:
+        close_finishes_detached = True
+
+        def __init__(self):
+            self.fully_closed = False
+
+        async def close(self):
+            await asyncio.sleep(0.05)
+            self.fully_closed = True
+
+    manager = _make_manager()
+    session = _ShieldedSession()
+    await LLMSessionManager._close_session_within_budget(
+        manager, session, "Shielded"
+    )
+
+    assert session.fully_closed is False, "the budget must release the caller"
+
+
+def test_the_realtime_client_declares_a_detachable_close():
+    # The contract the bounded wait reads. Asserted on the class, because it
+    # is what makes the timeout above safe on this implementation.
+    assert OmniRealtimeClient.close_finishes_detached is True
 
 
 def test_provider_failure_keywords_are_defined_in_exactly_one_place():

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -156,6 +156,54 @@ async def test_retired_receive_loop_cannot_condemn_or_report_the_replacement():
 
 
 @pytest.mark.asyncio
+async def test_retired_receive_loop_drops_buffered_frame_before_dispatch():
+    failures = AsyncMock()
+    event_handler = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    client.extra_event_handlers["test.buffered"] = event_handler
+    retired = _ControlledWs()
+    receiver = await _start_receiver(client, retired)
+
+    replacement = _ControlledWs()
+    client.ws = replacement
+    client._on_connection_attached()
+    retired._events.put_nowait(json.dumps({"type": "test.buffered"}))
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert client.ws is replacement
+    assert client._fatal_error_occurred is False
+    event_handler.assert_not_awaited()
+    failures.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retired_handler_exception_cannot_close_the_replacement():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    retired = _ControlledWs()
+    replacement = _ControlledWs()
+
+    async def attach_replacement_then_fail(_event) -> None:
+        client.ws = replacement
+        client._on_connection_attached()
+        raise RuntimeError("retired handler failed")
+
+    client.extra_event_handlers["test.replace_then_fail"] = (
+        attach_replacement_then_fail
+    )
+    receiver = await _start_receiver(client, retired)
+    retired._events.put_nowait(json.dumps({"type": "test.replace_then_fail"}))
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert client.ws is replacement
+    assert replacement.close_calls == 0
+    assert client._fatal_error_occurred is False
+    failures.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_peer_policy_close_preserves_existing_1008_classification():
     failures = AsyncMock()
     client = _make_client(on_connection_error=failures)
@@ -180,6 +228,43 @@ async def test_peer_policy_close_preserves_existing_1008_classification():
         },
     }
     assert "provider-controlled reason" not in failures.await_args.args[0]
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected_code"),
+    (
+        ("insufficient standing", "API_ARREARS"),
+        ("quota exceeded", "API_QUOTA_TIME"),
+        ("too many requests", "API_RATE_LIMIT"),
+        ("unauthorized", "API_KEY_REJECTED"),
+        ("safety policy violation", "API_POLICY_VIOLATION"),
+        ("unclassified provider close", "CHARACTER_DISCONNECTED"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_application_close_reason_preserves_existing_classification(
+    reason: str,
+    expected_code: str,
+):
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    ws.fail_from_peer(
+        websockets.exceptions.ConnectionClosedError(
+            Close(4000, reason),
+            None,
+        )
+    )
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert json.loads(failures.await_args.args[0]) == {
+        "code": expected_code,
+        "details": {"connection_generation": 0},
+    }
+    assert reason not in failures.await_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -10,7 +10,6 @@ import pytest
 import websockets
 from websockets.frames import Close
 
-import main_logic.core.lifecycle as lifecycle_module
 from main_logic.core import LLMSessionManager
 from main_logic.omni_realtime_client import OmniRealtimeClient, TurnDetectionMode
 from main_logic.omni_realtime_client._transport import _classify_peer_close
@@ -491,81 +490,6 @@ async def test_both_failure_paths_classify_the_same_text_identically(
 
     assert manager_code == expected_code
     assert close_code == expected_code
-
-
-@pytest.mark.asyncio
-async def test_a_close_that_cannot_finish_detached_is_never_cut_short(monkeypatch):
-    # Bounding the WAIT is only safe when the close keeps running without a
-    # waiter. An offline client's close is a plain coroutine: cancelling it
-    # skips `self.llm = None` and the threaded genai close, leaking the
-    # connection pools it exists to release. Such a session must be awaited
-    # to completion however long it takes.
-    monkeypatch.setattr(lifecycle_module, "SESSION_CLOSE_TIMEOUT_SECONDS", 0.01)
-
-    class _UnshieldedSession:
-        def __init__(self):
-            self.fully_closed = False
-
-        async def close(self):
-            await asyncio.sleep(0.05)
-            self.fully_closed = True
-
-    manager = _make_manager()
-    session = _UnshieldedSession()
-    await LLMSessionManager._close_session_within_budget(
-        manager, session, "Unshielded"
-    )
-
-    assert session.fully_closed is True, (
-        "a close that cannot finish detached must not be cancelled by the budget"
-    )
-
-
-@pytest.mark.asyncio
-async def test_a_shielded_close_is_bounded_but_still_runs_to_completion(monkeypatch):
-    # The dual, and the whole point of the contract: giving up on the WAIT
-    # must not give up on the CLOSE. The fake mirrors OmniRealtimeClient's
-    # `_own_teardown` — the teardown is an independent task awaited through
-    # asyncio.shield — because asserting only "the caller was released" would
-    # pass just as happily against a close that the timeout simply cancelled,
-    # which is the exact bug `close_finishes_detached` exists to prevent.
-    monkeypatch.setattr(lifecycle_module, "SESSION_CLOSE_TIMEOUT_SECONDS", 0.01)
-
-    class _ShieldedSession:
-        close_finishes_detached = True
-
-        def __init__(self):
-            self.fully_closed = False
-            self._teardown = None
-
-        async def close(self):
-            if self._teardown is None:
-                self._teardown = asyncio.create_task(self._finish())
-            await asyncio.shield(self._teardown)
-
-        async def _finish(self):
-            await asyncio.sleep(0.05)
-            self.fully_closed = True
-
-    manager = _make_manager()
-    session = _ShieldedSession()
-    await LLMSessionManager._close_session_within_budget(
-        manager, session, "Shielded"
-    )
-
-    assert session.fully_closed is False, "the budget must release the caller"
-
-    await asyncio.wait_for(session._teardown, timeout=1)
-    assert session.fully_closed is True, (
-        "the teardown must survive the caller giving up on it — that is what "
-        "close_finishes_detached promises"
-    )
-
-
-def test_the_realtime_client_declares_a_detachable_close():
-    # The contract the bounded wait reads. Asserted on the class, because it
-    # is what makes the timeout above safe on this implementation.
-    assert OmniRealtimeClient.close_finishes_detached is True
 
 
 def test_provider_failure_keywords_are_defined_in_exactly_one_place():

--- a/tests/unit/test_realtime_connection_recovery.py
+++ b/tests/unit/test_realtime_connection_recovery.py
@@ -1,0 +1,249 @@
+"""Regression coverage for realtime peer/local close classification."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import websockets
+
+from main_logic.core import LLMSessionManager
+from main_logic.omni_realtime_client import OmniRealtimeClient, TurnDetectionMode
+
+
+pytestmark = pytest.mark.unit
+
+
+_END = object()
+
+
+def _failure_status(code: str, generation: int = 0) -> str:
+    return json.dumps(
+        {"code": code, "details": {"connection_generation": generation}}
+    )
+
+
+class _ControlledWs:
+    def __init__(self) -> None:
+        self._events: asyncio.Queue[object] = asyncio.Queue()
+        self.close_calls = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        event = await self._events.get()
+        if event is _END:
+            raise StopAsyncIteration
+        if isinstance(event, BaseException):
+            raise event
+        return event
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self._events.put_nowait(_END)
+
+    def finish_from_peer(self) -> None:
+        self._events.put_nowait(_END)
+
+    def fail_from_peer(self, exc: BaseException) -> None:
+        self._events.put_nowait(exc)
+
+
+def _make_client(*, on_connection_error=None) -> OmniRealtimeClient:
+    return OmniRealtimeClient(
+        base_url="wss://example.test/realtime",
+        api_key="sk-test",
+        model="qwen-omni-turbo-realtime",
+        turn_detection_mode=TurnDetectionMode.MANUAL,
+        api_type="qwen",
+        on_connection_error=on_connection_error,
+    )
+
+
+async def _start_receiver(client: OmniRealtimeClient, ws: _ControlledWs):
+    client.ws = ws
+    task = asyncio.create_task(client.handle_messages())
+    await asyncio.sleep(0)
+    return task
+
+
+async def _settle_background_tasks(client: OmniRealtimeClient) -> None:
+    for _ in range(10):
+        if not client._bg_tasks:
+            return
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_expected_local_close_does_not_become_a_connection_failure():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    await client.close()
+    await asyncio.wait_for(receiver, timeout=2)
+
+    assert ws.close_calls == 1
+    assert client._fatal_error_occurred is False
+    failures.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_peer_stream_end_uses_existing_disconnect_recovery_marker():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    ws.finish_from_peer()
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert client._fatal_error_occurred is True
+    failures.assert_awaited_once_with(_failure_status("CHARACTER_DISCONNECTED"))
+
+
+@pytest.mark.asyncio
+async def test_unclean_peer_loss_never_exposes_the_websocket_exception_text():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    ws.fail_from_peer(websockets.exceptions.ConnectionClosedError(None, None))
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    failures.assert_awaited_once_with(_failure_status("CHARACTER_DISCONNECTED"))
+    assert "close frame" not in failures.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_retired_receive_loop_cannot_condemn_or_report_the_replacement():
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    retired = _ControlledWs()
+    receiver = await _start_receiver(client, retired)
+
+    replacement = _ControlledWs()
+    client.ws = replacement
+    client._on_connection_attached()
+    retired.finish_from_peer()
+    await asyncio.wait_for(receiver, timeout=2)
+
+    assert client.ws is replacement
+    assert client._fatal_error_occurred is False
+    failures.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_arbiter_fail_close_preserves_first_cause_without_user_status(caplog):
+    failures = AsyncMock()
+    client = _make_client(on_connection_error=failures)
+    ws = _ControlledWs()
+    client.ws = ws
+    reason = "response lifecycle could not reach a terminal state"
+
+    with caplog.at_level(
+        "WARNING",
+        logger="main_logic.omni_realtime_client._response_arbiter",
+    ):
+        await client._response_arbiter._tear_down_transport(reason)
+
+    assert client.ws is None
+    assert client._fatal_error_occurred is True
+    assert f"response arbiter failing closed: {reason}" in caplog.text
+    assert "sent 1000" not in caplog.text
+    failures.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_peer_recovery_callback_runs_outside_the_receive_loop_task():
+    callback_task = None
+
+    async def on_failure(_message):
+        nonlocal callback_task
+        callback_task = asyncio.current_task()
+
+    client = _make_client(on_connection_error=on_failure)
+    ws = _ControlledWs()
+    receiver = await _start_receiver(client, ws)
+
+    ws.finish_from_peer()
+    await asyncio.wait_for(receiver, timeout=2)
+    await _settle_background_tasks(client)
+
+    assert callback_task is not None
+    assert callback_task is not receiver
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_two_second_close_handshake_timeout():
+    client = _make_client()
+    ws = AsyncMock()
+
+    with patch("websockets.connect", new_callable=AsyncMock, return_value=ws) as connect:
+        await client.connect(instructions="hi", native_audio=True)
+
+    assert connect.await_args.kwargs["close_timeout"] == 2.0
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_peer_disconnect_marker_is_not_shown_twice_before_recovery():
+    manager = object.__new__(LLMSessionManager)
+    manager.lock = asyncio.Lock()
+    manager.session = object()
+    manager.pending_session = None
+    manager.session_closed_by_server = False
+    manager.send_status = AsyncMock()
+    manager.disconnected_by_server = AsyncMock()
+
+    marker = json.dumps({"code": "CHARACTER_DISCONNECTED"})
+    await manager.handle_connection_error(marker, expected_session=manager.session)
+
+    manager.send_status.assert_not_awaited()
+    manager.disconnected_by_server.assert_awaited_once_with(
+        expected_session=manager.session
+    )
+
+
+@pytest.mark.asyncio
+async def test_preclassified_timeout_is_forwarded_before_existing_recovery():
+    manager = object.__new__(LLMSessionManager)
+    manager.lock = asyncio.Lock()
+    manager.session = object()
+    manager.pending_session = None
+    manager.session_closed_by_server = False
+    manager.send_status = AsyncMock()
+    manager.disconnected_by_server = AsyncMock()
+
+    status = json.dumps({"code": "CONNECTION_TIMEOUT"})
+    await manager.handle_connection_error(status, expected_session=manager.session)
+
+    manager.send_status.assert_awaited_once_with(status)
+    manager.disconnected_by_server.assert_awaited_once_with(
+        expected_session=manager.session
+    )
+
+
+@pytest.mark.asyncio
+async def test_late_failure_from_a_retired_generation_cannot_recover_the_successor():
+    manager = object.__new__(LLMSessionManager)
+    manager.lock = asyncio.Lock()
+    manager.session = type("Session", (), {"_connection_generation": 2})()
+    manager.pending_session = None
+    manager.session_closed_by_server = False
+    manager.send_status = AsyncMock()
+    manager.disconnected_by_server = AsyncMock()
+
+    await manager.handle_connection_error(
+        _failure_status("CHARACTER_DISCONNECTED", generation=1),
+        expected_session=manager.session,
+    )
+
+    assert manager.session_closed_by_server is False
+    manager.send_status.assert_not_awaited()
+    manager.disconnected_by_server.assert_not_awaited()

--- a/utils/tts/native_voice_registry.py
+++ b/utils/tts/native_voice_registry.py
@@ -253,11 +253,25 @@ def get_native_voice_catalog_for_ui(
     return provider.voice_catalog_for_ui()
 
 
+def _is_free_lanlan_domain_route(
+    core_api_type: str | None,
+    realtime_base_url: str | None,
+    domain: str,
+) -> bool:
+    raw_url = str(realtime_base_url or "").strip()
+    parsed = urlparse(raw_url if "://" in raw_url else f"//{raw_url}")
+    hostname = (parsed.hostname or "").lower()
+    return bool(
+        str(core_api_type or "").lower() == "free"
+        and (hostname == domain or hostname.endswith(f".{domain}"))
+    )
+
+
 def is_free_lanlan_app_route(
     core_api_type: str | None,
     realtime_base_url: str | None,
 ) -> bool:
-    """Whether this is the overseas free route (core_api_type='free' with host in the lanlan.app domain).
+    """Whether this is the overseas free route hosted on lanlan.app.
 
     The overseas free upstream is lanlan.app's Gemini proxy; available voices are the
     full Gemini set + the branded yui, so the "effective native voice provider" of
@@ -265,12 +279,24 @@ def is_free_lanlan_app_route(
     _effective_native_provider_key). Host checks are centralized here instead of
     leaking into cross-cutting files.
     """
-    raw_url = str(realtime_base_url or "").strip()
-    parsed = urlparse(raw_url if "://" in raw_url else f"//{raw_url}")
-    hostname = (parsed.hostname or "").lower()
-    return bool(
-        str(core_api_type or "").lower() == "free"
-        and (hostname == "lanlan.app" or hostname.endswith(".lanlan.app"))
+
+    return _is_free_lanlan_domain_route(
+        core_api_type,
+        realtime_base_url,
+        "lanlan.app",
+    )
+
+
+def is_free_lanlan_tech_route(
+    core_api_type: str | None,
+    realtime_base_url: str | None,
+) -> bool:
+    """Whether this is the domestic StepFun-compatible free route."""
+
+    return _is_free_lanlan_domain_route(
+        core_api_type,
+        realtime_base_url,
+        "lanlan.tech",
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary

- Accept ID-bearing response content as start evidence only for explicitly non-announcing Realtime routes, while preserving response ownership and terminal correlation safeguards.
- Distinguish expected local teardown from current peer-first disconnects by socket identity and connection generation, then route peer disconnects through the existing session recovery flow.
- Keep response-arbiter failure reasons as the primary cause instead of replacing them with a later local CLOSE 1000 handshake result, and retain a bounded 2-second close timeout.

Closes #2900

## 回归报告 / Regression Report

### What changed

- Added explicit lifecycle capability profiles for `lanlan.app`, `lanlan.tech`, and unknown Realtime routes. Only the known non-announcing route may use owned, ID-bearing response content as start evidence.
- Bound fallback response IDs to the currently waiting arbiter owner without relaxing strict announcement or matching-terminal behavior for announcing routes.
- Captured receive-loop socket identity and connection generation so retired listeners cannot report expected local teardown as a new provider failure.
- Routed current peer-first stream termination through the existing `CHARACTER_DISCONNECTED` session-recovery path and increased the bounded close handshake timeout from 0.5 to 2 seconds.
- Prevented a later CLOSE 1000 handshake result from replacing the response arbiter's existing primary fail-close reason.

### Why this is necessary

The `lanlan.app` Gemini compatibility route can return valid audio or transcript content with a stable `response_id` without emitting OpenAI's `response.created` event. The previous arbiter ignored that content, timed out after five seconds, sent `response.cancel`, and could close the entire Realtime connection three seconds later. The local `websockets` teardown result could then be forwarded as `API_UNKNOWN_ERROR`, even though it was not a provider API error event.

Separately, a peer-first normal CLOSE 1000 could end the receive stream and latch the current session as fatal instead of entering the application's existing automatic disconnection recovery.

### Before and after

- Before: valid response audio could already be playing while the arbiter still considered the response unstarted; after 5+3 seconds the whole voice connection could be closed and shown as `API error: sent 1000 (OK); no close frame received`.
- After: verified ID-bearing content starts only its owned ticket on the non-announcing route, so the reply can finish normally and the voice connection remains available.
- Before: expected manager/hot-swap teardown and old receive loops could be confused with a current provider failure.
- After: only the receive loop that still owns the current socket generation can request peer-disconnect recovery; expected local teardown and retired generations exit silently.
- Before: a peer-first stream end could leave a fatal session that ignored later microphone input.
- After: the existing `CHARACTER_DISCONNECTED` flow closes and rebuilds the voice session.

### Potential regressions and controls

- Response mis-association: fallback adoption requires the non-announcing capability, a unique waiting owner, a sent create request, a valid unseen `response_id`, and no VAD/interruption/ownership conflict. Stale and mismatched IDs are covered by ownership tests.
- Announcing-provider behavior: `lanlan.tech` and unknown routes retain strict `response.created` evidence; route-selection tests cover the capability boundary.
- Replacement-session corruption: recovery is guarded by socket identity and connection generation before scheduling and again under the lifecycle manager lock.
- Receive-loop self-cancellation and retained tasks: recovery runs in the existing bounded background-task set, is removed by the existing completion callback, and has tests for callback execution outside the receive loop and stale-generation rejection.
- Close latency: the timeout remains explicitly bounded at 2 seconds and is covered by a connection-parameter test.

### Review follow-up round (commits `02ff072c3`..`6f1711569`)

Four review findings were addressed on top of the two original commits; one of them was subsequently reverted (see the last bullet of each section).

**What changed**

- `_classify_peer_close` now supplies a `msg` detail for every status code whose i18n string interpolates `{{msg}}`. The substitute names the close by its code (`WebSocket close code <n>`), so the peer-controlled reason string stays withheld.
- New `main_logic/provider_failure_signals.py` holds the provider-failure keyword tables and the ordering between them. `main_logic/omni_offline_client/_shared.py` re-exports the two existing names unchanged; the session manager's classification chain and the realtime close classifier both read the shared criteria and keep building their own `details` payloads.
- `_abort_failed_transport` arms a generation-stamped, one-shot latch when it seizes the attached socket itself. The receive loop that owned that socket claims it on exit, runs the `_close_failed_transport` host cleanup, and requests the ordinary `CHARACTER_DISCONNECTED` recovery. `close()` and a replacement attach both disarm it.
- ~~The session close in the hot-swap sequence and in `end_session` is bounded by `SESSION_CLOSE_TIMEOUT_SECONDS` (3s).~~ **Reverted in `6f1711569`** — both call sites are back to their original unbounded `await session.close()`.

**Why this is necessary**

- `API_POLICY_VIOLATION` was emitted with no `msg`. The bundled i18next runs with `skipOnVariables`, so the toast rendered a literal `{{msg}}` to the user. The previous manager-side branch had attached `details.msg`; routing the classification through the transport dropped it.
- The same provider vocabulary was duplicated across three modules, so a keyword added for one caller silently went missing for another — precisely the divergence that produced the finding above.
- An arbiter fail-close detaches the socket out from under the receive loop, so the loop exits owning nothing and, under the new ownership guard, exited silently. Nothing then shut the arbiter down or told the manager, leaving `is_active` true over a dead socket: `send_event` drops every later frame at its `_fatal_error_occurred` guard, with no toast and no rebuild.
- ~~Both close call sites were relying on the transport's `close_timeout` for their ceiling.~~ The ceiling was dropped: `close_timeout=2s` already fires first on the realtime path, so it only ever covered a close wedged somewhere no one has reported, and it cost three separate regressions to carry (see below).

**Before and after**

- Before: a safety-flagged peer close produced a toast reading `💥 ... : {{msg}}`. After: it names the close code, and the peer reason is still never shown.
- Before: an arbiter fail-close left a silently dead session. After: it routes through the existing disconnect recovery, without reclassifying the local CLOSE 1000 handshake result as a provider API error.

**Potential regressions and controls**

- Bounded close, reverted in `6f1711569` after three regressions, recorded here because the area is a trap: (1) `asyncio.wait_for` runs the coroutine in a child task, moving `asyncio.current_task()` off the swap task and silently disarming the pre-promote `cancelling() > 0` checkpoint that stops a zombie swap from overwriting `self.session`; (2) switching to `asyncio.timeout` fixed that but the 3s ceiling then cancelled `OmniOfflineClient.close()` mid-cleanup, skipping `self.llm = None` and the threaded genai close and leaking their httpx pools; (3) routing the call through a helper broke `test_hot_swap_lifecycle_guards_close_and_promote_with_voice_barrier`, which does `source.index("await old_main_session.close()")` on `_perform_final_swap_sequence` to pin `barrier < close < promote`. Anyone re-attempting this must keep that literal call site intact and must not bound a close that is not shielded.
- Latch misattribution: the latch is generation-stamped and one-shot, so a retired loop cannot claim a successor's abort and a successor cannot inherit a predecessor's. Covered by dedicated tests.
- Duplicate recovery: `close()` disarms the latch, because the manager initiating the close already knows the session is over.
- Classification drift: a test asserts the two paths classify identical diagnostic text identically, and a second asserts the keyword table has exactly one definition under `main_logic/`.
- Half-constructed clients: `_abort_failed_transport` remains the one teardown that needs nothing but a socket, so the latch reads the generation via `getattr`.

## 不拆分理由 / Why Not Split

Not applicable. The PR changes fewer than 20 counted production files. The commits remain separate: one handles response-start compatibility, one handles close-cause ownership and peer recovery, and one addresses the review findings on both.

## 测试 / Testing

- Ran 496 related unit and static-contract tests covering connection recovery and ownership, arbiter native/fail-open/escalation paths, response ownership, proactive and host turns, SID rotation, external text turns, Gemini route selection, ASR smoke, voice sessions, and frontend WebSocket behavior: 496 passed, 4 skipped.
- Ran Ruff, `py_compile`, and `git diff --check upstream/main...HEAD`: all passed.
- Field-tested the same two fixes on the `lanlan.app` route: 19/19 tool-result responses were recognized as started without an announcement timeout, and 8/8 peer-first disconnects recovered to a new `session_started` state.
- Confirmed the field window contained no `response.cancel`, announcement timeout, arbiter fail-close, terminal timeout, `sent 1000 (OK); no close frame received`, `API_UNKNOWN_ERROR`, latched session fatal warning, or keepalive timeout.

- Follow-up round: 619 related tests passed (4 skipped) across realtime connection recovery, close ownership, arbiter native/fail-open/escalation, response ownership, external text turns, voice sessions and teardown paths, hot-swap cancellation, passive swap prime, tool calling, SID rotation, host turn identity, proactive text, and ASR smoke.
- Follow-up round mutation check: reverting each fix individually turns the new tests red — 8/8 mutants killed (msg detail dropped, latch never armed, latch generation isolation removed, `close()` no longer disarming, keyword table re-copied, and each of the two call sites abandoning the shared criteria).
- Follow-up round gates: Ruff, `py_compile`, `scripts/check_docstring_no_cjk.py --base origin/main`, and `git diff --check origin/main...HEAD` all passed.

- Revert round (`6f1711569`): 457 related tests passed, now including `tests/unit/test_core_independent_asr.py` — the structural hot-swap guard that the bounded close had broken and that the earlier rounds had not run locally.

Out of scope: the local 90-second silence policy, keepalive CLOSE 1011 handling, Live2D/N.E.K.O-PC behavior, search triggering, and new user-facing classifications for every arbiter failure reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 根据实时服务路由和直播模式自动适配协议能力，提升响应兼容性。
  * 支持通过带响应标识的内容事件确认响应开始。
  * 支持识别欠费、配额、限流、密钥拒绝及策略违规等连接错误。
  * 支持识别新的免费实时服务路由。

* **问题修复**
  * 改善实时连接恢复，避免旧连接或过期错误影响当前会话。
  * 减少重复断开通知、响应误判及重复用量统计。
  * 优化会话关闭流程，超时后可继续完成清理，降低阻塞风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

