### PR TITLE
fix: use Qwen credentials after custom TTS fallback

### DIFF
--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -253,6 +253,10 @@ class TtsRuntimeMixin:
     def resolve_tts_api_key(provider_key: str | None, api_key_override: str | None, tts_config: dict) -> str:
         if provider_key == 'vllm_omni':
             return api_key_override or ''
+        if provider_key == 'qwen' and api_key_override is not None:
+            # Qwen fallback owns its credential explicitly. An empty override
+            # must stay empty instead of leaking the failed custom provider key.
+            return api_key_override
         return api_key_override or tts_config.get('api_key', '')
 
     @staticmethod

--- a/main_logic/tts_client/__init__.py
+++ b/main_logic/tts_client/__init__.py
@@ -395,7 +395,17 @@ def get_tts_worker(
 
     # 没有自定义音色时，使用与 core_api 匹配的默认 TTS
     if core_api_type in ('qwen', 'qwen_intl'):
-        return qwen_realtime_tts_worker, None, 'qwen'
+        qwen_api_key_override = None
+        if excluded_provider_keys:
+            qwen_key_field = (
+                'ASSIST_API_KEY_QWEN_INTL'
+                if core_api_type == 'qwen_intl'
+                else 'ASSIST_API_KEY_QWEN'
+            )
+            # A supervised fallback must not inherit the failed configured
+            # endpoint's TTS_MODEL_API_KEY through the tts_default slot.
+            qwen_api_key_override = str(core_cfg.get(qwen_key_field) or '').strip()
+        return qwen_realtime_tts_worker, qwen_api_key_override, 'qwen'
     if core_api_type == 'free':
         # 免费服务拥有独立 worker；底层仍复用它与 StepFun 当前共有的流式
         # wire transport，但 provider 路由、端点和音色选择不再伪装成 StepFun。

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -18,6 +18,7 @@ from main_logic.tts_client.workers import openai as openai_worker_module
 from main_logic.tts_client.workers import vllm_omni as vllm_worker_module
 from main_routers.characters_router import voice_preview as voice_preview_module
 from main_routers.config_router.connectivity import _test_connectivity_candidates
+from utils.config_manager import ConfigManager
 from utils.openai_tts import (
     OPENAI_TTS_PCM_SAMPLE_RATE,
     OpenAITtsConfigError,
@@ -540,15 +541,43 @@ def test_failed_configured_preset_redispatch_uses_default_voice_route(monkeypatc
     assert provider_key == "qwen"
 
 
-def test_supervised_fallback_uses_default_voice_and_default_credentials(monkeypatch):
+@pytest.mark.parametrize(
+    ("core_api_type", "custom_key", "qwen_key", "qwen_intl_key", "expected_key"),
+    [
+        ("qwen", "", "sk-qwen", "", "sk-qwen"),
+        ("qwen", "sk-custom", "sk-qwen", "", "sk-qwen"),
+        ("qwen", "sk-custom", "", "", ""),
+        ("qwen_intl", "sk-custom", "", "sk-qwen-intl", "sk-qwen-intl"),
+    ],
+)
+def test_supervised_fallback_uses_qwen_credentials_from_real_config(
+    monkeypatch,
+    core_api_type,
+    custom_key,
+    qwen_key,
+    qwen_intl_key,
+    expected_key,
+):
     mgr = LLMSessionManager.__new__(LLMSessionManager)
+    cm = _CustomTtsConfigManager()
+    cm.snapshot.update({
+        "CORE_API_TYPE": core_api_type,
+        "PROVIDER_TYPE": "openai_compatible",
+        "TTS_MODEL": "vendor-tts",
+        "TTS_MODEL_URL": "https://speech.example.com/v1",
+        "TTS_MODEL_API_KEY": custom_key,
+        "ASSIST_API_KEY_QWEN": qwen_key,
+        "ASSIST_API_KEY_QWEN_INTL": qwen_intl_key,
+    })
     config_slots = []
     dispatch_calls = []
+    thread_targets = []
     thread_args = []
 
     class _FakeThread:
         def __init__(self, *, target, args, daemon):
-            _ = target, daemon
+            _ = daemon
+            thread_targets.append(target)
             thread_args.append(args)
 
         def start(self):
@@ -556,33 +585,54 @@ def test_supervised_fallback_uses_default_voice_and_default_credentials(monkeypa
 
     def get_model_api_config(slot):
         config_slots.append(slot)
-        return {"api_key": "sk-default" if slot == "tts_default" else "sk-custom"}
+        return ConfigManager.get_model_api_config(
+            cm,
+            slot,
+            _core_config=cm.get_core_config(),
+        )
 
     def get_worker(**kwargs):
         dispatch_calls.append(kwargs)
-        return (lambda *_args: None), None, "qwen"
+        return tts_client.get_tts_worker(**kwargs)
 
-    mgr._config_manager = SimpleNamespace(
-        get_core_config=lambda: {},
-        get_model_api_config=get_model_api_config,
-    )
-    mgr.core_api_type = "qwen"
+    cm.get_model_api_config = get_model_api_config
+    mgr._config_manager = cm
+    mgr.core_api_type = core_api_type
     mgr.voice_id = "vendor-voice"
     mgr._is_free_preset_voice = False
-    mgr._tts_fallback_uses_default_voice = True
-    mgr._tts_excluded_provider_keys = frozenset({"custom"})
+    mgr._tts_active_provider_key = "custom"
+    mgr._tts_fallback_uses_default_voice = False
+    mgr._tts_excluded_provider_keys = frozenset()
+    old_request_queue = queue.Queue()
+    mgr.tts_request_queue = old_request_queue
+    mgr.current_speech_id = "speech-1"
+    mgr.tts_pending_chunks = []
+    mgr._tts_replay_speech_id = "speech-1"
+    mgr._tts_replay_chunks = []
+    mgr._tts_replay_done = False
+    mgr._tts_replay_audio_emitted = False
+    mgr._tts_done_queued_for_turn = False
+    mgr._tts_done_pending_until_ready = False
+    mgr._last_tts_error_code = "TTS_CONNECTION_FAILED"
+    mgr._tts_retry_notify_count = 2
+    mgr._reset_tts_stream_normalizer = lambda: None
     mgr._build_tts_runtime_key = lambda: ("fallback",)
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
     monkeypatch.setattr(tts_runtime_module, "Thread", _FakeThread)
     monkeypatch.setattr(tts_runtime_module._core_facade, "get_tts_worker", get_worker)
 
-    LLMSessionManager._start_tts_thread(mgr, preserve_provider_exclusions=True)
+    assert LLMSessionManager._activate_configured_tts_fallback(mgr, "test") is True
 
     # The replacement sees neither the failed Voice ID nor the custom credential.
     # 替代 worker 只能收到默认路由的空音色和默认凭证，不能复用失败配置。
+    assert old_request_queue.get_nowait() == ("__shutdown__", None)
+    assert mgr._tts_excluded_provider_keys == frozenset({"custom"})
+    assert mgr._tts_fallback_uses_default_voice is True
     assert dispatch_calls[0]["voice_id"] == ""
     assert dispatch_calls[0]["has_custom_voice"] is False
-    assert config_slots == ["tts_default"]
-    assert thread_args[0][2:] == ("sk-default", "")
+    assert config_slots[-1:] == ["tts_default"]
+    assert thread_targets == [tts_client.qwen_realtime_tts_worker]
+    assert thread_args[0][2:] == (expected_key, "")
 
 
 def test_vllm_config_read_failure_stays_owned_until_supervised_fallback(monkeypatch):


### PR DESCRIPTION
## 改动概要 / Summary

- Custom TTS 失败并由运行时回退到 Qwen 时，改为显式使用所选 Qwen provider 的凭证。
- 增加覆盖国内 Qwen、国际 Qwen、空 Qwen key 和已填写第三方 custom key 的回归测试。

## 回归报告 / Regression Report

- **改动与必要性**：`main_logic` 的 custom TTS 回退链会排除失败 provider 后重新选择 Qwen；此前 Qwen dispatcher 没有提供 key override，运行时会从 `tts_default` 读取凭证。在开启 custom API 时，该槽位可能仍解析为失败的第三方 `ttsModelApiKey`，或在自定义 key 为空时让 Qwen 收到空 key。
- **行为对比**：修复前，Qwen fallback 可能使用第三方 custom TTS key，或忽略有效的 `ASSIST_API_KEY_QWEN` / `ASSIST_API_KEY_QWEN_INTL`。修复后，仅在受监管的 fallback 路径中显式传递匹配 Qwen provider 的 key；正常 Qwen 路由保持原有配置解析行为。
- **潜在回归与验证**：变更只影响已排除 provider 后的 Qwen / Qwen Intl fallback。测试通过真实 `ConfigManager` 走完整回退链，验证四种凭证组合，并运行完整 TTS 单元测试集合。

## 不拆分理由 / Why Not Split

本 PR 只改动两个紧密耦合的运行时凭证选择点及其同一条回退链测试，拆分会造成中间提交无法验证完整行为。

## 测试 / Testing

- `uv run pytest tests/unit/test_openai_compatible_tts.py -q`
- `uv run pytest (Get-ChildItem tests/unit -Filter 'test_*tts*.py' | ForEach-Object { $_.FullName }) -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复 Qwen TTS 在运行时故障回退时的凭证选择问题。
  - 现在会正确保留明确提供的 API 密钥覆盖值，包括空值。
  - 当存在被排除的服务提供商时，系统会使用对应的 Qwen 助手密钥进行回退；无此情况时保持原有凭证行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->