### PR TITLE
fix: api key mask after save

### DIFF
--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -81,18 +81,25 @@ def is_core_config_secret_placeholder(value) -> bool:
     if len(stripped) >= 3 and set(stripped) == {'*'}:
         return True
 
-    # Legacy web UI masking kept six characters at each end and replaced the
-    # middle with stars.  Require that exact shape and at least three stars.
-    if len(stripped) < 15:
+    # Display masks keep a visible prefix/suffix and star out the middle.  Both
+    # the current 3+3 shape and the legacy 6+6 shape mean "keep existing".
+    return _is_display_mask_shape(stripped, 3) or _is_display_mask_shape(stripped, 6)
+
+
+def _is_display_mask_shape(stripped: str, edge: int) -> bool:
+    """Whether *stripped* is ``edge`` visible chars + >=3 stars + ``edge`` chars."""
+    if len(stripped) < edge * 2 + 3:
         return False
-    prefix, masked, suffix = stripped[:6], stripped[6:-6], stripped[-6:]
-    if set(masked) != {'*'}:
-        return False
-    # Current masks expose three characters at each end; legacy ones expose six.
+    prefix, masked, suffix = (
+        stripped[:edge],
+        stripped[edge:-edge],
+        stripped[-edge:],
+    )
     return (
         '*' not in prefix
         and '*' not in suffix
         and len(masked) >= 3
+        and set(masked) == {'*'}
     )
 
 

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -103,6 +103,20 @@ def redact_core_config_secret(value, *, preserve_free_access: bool = False) -> s
     return CORE_CONFIG_SECRET_SENTINEL
 
 
+def mask_core_config_secret_for_display(value) -> str:
+    """Return a safe, non-reversible partial display for a stored secret."""
+    if value is None or value == '' or value == 'free-access':
+        return ''
+    value = str(value)
+    # A six-character prefix/suffix would disclose a short credential in full.
+    if len(value) < 15:
+        return '••••••••••••'
+    prefix, suffix = value[:6], value[-6:]
+    if '*' in prefix or '*' in suffix:
+        return '••••••••••••'
+    return f'{prefix}{"*" * (len(value) - 12)}{suffix}'
+
+
 def apply_core_config_secret_update(target: dict, source: dict, field: str) -> bool:
     """Apply a submitted secret unless it is a keep-existing placeholder.
 
@@ -240,6 +254,32 @@ async def get_core_config_api():
             response['api_key'],
             preserve_free_access=True,
         )
+        # Keep the POST contract as a sentinel while offering a separate,
+        # non-reversible value for settings-page display.
+        response['api_key_display'] = mask_core_config_secret_for_display(api_key)
+        # The assist input needs only its currently selected provider's mask.
+        # Resolve through the canonical registry instead of exposing a display
+        # fragment for every Key Book entry.
+        response['assist_api_key_display'] = ''
+        try:
+            from utils.api_config_loader import get_config
+
+            provider_config = await asyncio.to_thread(get_config)
+            api_key_registry = (
+                provider_config.get('api_key_registry', {})
+                if isinstance(provider_config, dict)
+                else {}
+            )
+            assist_key_field = get_core_config_provider_api_key_field(
+                _assist_api_provider,
+                api_key_registry,
+            )
+            if assist_key_field:
+                response['assist_api_key_display'] = mask_core_config_secret_for_display(
+                    response.get(assist_key_field, '')
+                )
+        except Exception:
+            logger.warning('Unable to build assist API key display mask', exc_info=True)
         for field in (
             *CORE_CONFIG_ASSIST_API_KEY_FIELDS,
             'mcpToken',

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -103,6 +103,20 @@ def redact_core_config_secret(value, *, preserve_free_access: bool = False) -> s
     return CORE_CONFIG_SECRET_SENTINEL
 
 
+def mask_core_config_secret_for_display(value) -> str:
+    """Return a safe, non-reversible partial display for a stored secret."""
+    if value is None or value == '' or value == 'free-access':
+        return ''
+    value = str(value)
+    # A six-character prefix/suffix would disclose a short credential in full.
+    if len(value) < 15:
+        return '••••••••••••'
+    prefix, suffix = value[:6], value[-6:]
+    if '*' in prefix or '*' in suffix:
+        return '••••••••••••'
+    return f'{prefix}{"*" * (len(value) - 12)}{suffix}'
+
+
 def apply_core_config_secret_update(target: dict, source: dict, field: str) -> bool:
     """Apply a submitted secret unless it is a keep-existing placeholder.
 
@@ -240,6 +254,9 @@ async def get_core_config_api():
             response['api_key'],
             preserve_free_access=True,
         )
+        # Keep the POST contract as a sentinel while offering a separate,
+        # non-reversible value for settings-page display.
+        response['api_key_display'] = mask_core_config_secret_for_display(api_key)
         for field in (
             *CORE_CONFIG_ASSIST_API_KEY_FIELDS,
             'mcpToken',

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -86,11 +86,13 @@ def is_core_config_secret_placeholder(value) -> bool:
     if len(stripped) < 15:
         return False
     prefix, masked, suffix = stripped[:6], stripped[6:-6], stripped[-6:]
+    if set(masked) != {'*'}:
+        return False
+    # Current masks expose three characters at each end; legacy ones expose six.
     return (
         '*' not in prefix
         and '*' not in suffix
         and len(masked) >= 3
-        and set(masked) == {'*'}
     )
 
 
@@ -104,17 +106,21 @@ def redact_core_config_secret(value, *, preserve_free_access: bool = False) -> s
 
 
 def mask_core_config_secret_for_display(value) -> str:
-    """Return a safe, non-reversible partial display for a stored secret."""
+    """Return a safe, non-reversible partial display for a stored secret.
+
+    Only the first and last three characters are exposed, and only when the
+    secret is long enough that those fragments cannot disclose it in full.
+    """
     if value is None or value == '' or value == 'free-access':
         return ''
     value = str(value)
-    # A six-character prefix/suffix would disclose a short credential in full.
-    if len(value) < 15:
+    # A three-character prefix/suffix would disclose a short credential in full.
+    if len(value) < 9:
         return '••••••••••••'
-    prefix, suffix = value[:6], value[-6:]
+    prefix, suffix = value[:3], value[-3:]
     if '*' in prefix or '*' in suffix:
         return '••••••••••••'
-    return f'{prefix}{"*" * (len(value) - 12)}{suffix}'
+    return f'{prefix}{"*" * (len(value) - 6)}{suffix}'
 
 
 def apply_core_config_secret_update(target: dict, source: dict, field: str) -> bool:

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -80,6 +80,10 @@ def is_core_config_secret_placeholder(value) -> bool:
         return True
     if len(stripped) >= 3 and set(stripped) == {'*'}:
         return True
+    # The all-dot display (short or un-disclosable secrets) must round-trip as
+    # "keep existing" too, never be persisted as a literal bullet credential.
+    if stripped and set(stripped) == {'•'}:
+        return True
 
     # Display masks keep a visible prefix/suffix and star out the middle.  Both
     # the current 3+3 shape and the legacy 6+6 shape mean "keep existing".

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -103,20 +103,6 @@ def redact_core_config_secret(value, *, preserve_free_access: bool = False) -> s
     return CORE_CONFIG_SECRET_SENTINEL
 
 
-def mask_core_config_secret_for_display(value) -> str:
-    """Return a safe, non-reversible partial display for a stored secret."""
-    if value is None or value == '' or value == 'free-access':
-        return ''
-    value = str(value)
-    # A six-character prefix/suffix would disclose a short credential in full.
-    if len(value) < 15:
-        return '••••••••••••'
-    prefix, suffix = value[:6], value[-6:]
-    if '*' in prefix or '*' in suffix:
-        return '••••••••••••'
-    return f'{prefix}{"*" * (len(value) - 12)}{suffix}'
-
-
 def apply_core_config_secret_update(target: dict, source: dict, field: str) -> bool:
     """Apply a submitted secret unless it is a keep-existing placeholder.
 
@@ -254,9 +240,6 @@ async def get_core_config_api():
             response['api_key'],
             preserve_free_access=True,
         )
-        # Keep the POST contract as a sentinel while offering a separate,
-        # non-reversible value for settings-page display.
-        response['api_key_display'] = mask_core_config_secret_for_display(api_key)
         for field in (
             *CORE_CONFIG_ASSIST_API_KEY_FIELDS,
             'mcpToken',

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -40,6 +40,10 @@ const CONNECTIVITY_TESTABLE_TYPES = MODEL_TYPES;
 // 由后端保留原密钥；绝不能当作真实凭据展示或用于连通性测试。
 const MASKED_SECRET_SENTINEL = '__NEKO_SECRET_MASKED__';
 const MASKED_SECRET_DISPLAY = '••••••••••••';
+// POST 成功后的紧随其后的配置重载中，后端会只返回密钥哨兵。此 Map 只在
+// 当前页面、当前次重载期间保存用户刚输入的值，用于继续显示局部遮蔽；绝不
+// 写入 localStorage、不会发送到后端，也不会让后端 GET 回显明文。
+let _secretDisplayCache = null;
 const MIMO_TOKEN_PLAN_PROVIDER_KEY = 'mimo_token_plan';
 const MIMO_TOKEN_PLAN_OPENROUTER_URLS = [
     'https://token-plan-cn.xiaomimimo.com/v1',
@@ -407,6 +411,15 @@ function setMaskedInput(input, realKey) {
         return;
     }
     if (isMaskedSecretValue(realKey)) {
+        const locallyEnteredKey = _secretDisplayCache && _secretDisplayCache.get(input.id);
+        if (locallyEnteredKey && !isMaskedSecretValue(locallyEnteredKey)) {
+            // 保存后读取到的只是哨兵；同一次页面会话内仍可安全地沿用本地的
+            // 局部遮蔽显示，避免从“前后可见”退化为全圆点。
+            delete input.dataset.maskedSecret;
+            input.dataset.realKey = locallyEnteredKey;
+            input.value = maskApiKey(locallyEnteredKey);
+            return;
+        }
         // 只保留“后端已有密钥”这一状态，不把哨兵伪装成真实 key 放进 DOM。
         input.dataset.realKey = '';
         input.dataset.maskedSecret = 'true';
@@ -416,6 +429,22 @@ function setMaskedInput(input, realKey) {
     delete input.dataset.maskedSecret;
     input.dataset.realKey = realKey;
     input.value = maskApiKey(realKey);
+}
+
+/**
+ * 记录本页已输入的真实密钥，以便保存成功后的单次配置重载继续显示局部遮蔽。
+ * 页面刷新或普通配置加载不会调用它，因此刷新后仍只显示通用圆点遮罩。
+ */
+function cacheCurrentSecretDisplays() {
+    const cache = new Map();
+    document.querySelectorAll('input').forEach(input => {
+        if (input.dataset.maskAttached !== 'true' || !input.id) return;
+        const realKey = getRealKey(input);
+        if (realKey && !isMaskedSecretValue(realKey)) {
+            cache.set(input.id, realKey);
+        }
+    });
+    _secretDisplayCache = cache;
 }
 
 function setSecretInputValue(elementId, value) {
@@ -2071,6 +2100,8 @@ async function loadCurrentApiKey() {
         showCurrentApiKey(window.t ? window.t('api.errorGettingCurrentApiKey') : '获取当前API Key时出错', '', false);
     } finally {
         _isLoadingSavedConfig = false;
+        // 缓存仅覆盖保存成功后的这一次重载。页面刷新或后续普通加载仍绝不回显密钥。
+        _secretDisplayCache = null;
     }
 }
 
@@ -2969,6 +3000,10 @@ async function saveApiKey(params) {
         if (response.ok) {
             const result = await response.json();
             if (result.success) {
+                // 后端的 GET 响应不会回传密钥明文。先保留当前页面已有值，供下面
+                // loadCurrentApiKey() 在收到哨兵时显示为“前后部分可见”的遮蔽形式；
+                // 其余密钥继续用这一轮临时缓存维持显示。
+                cacheCurrentSecretDisplays();
                 let statusMessage;
                 if (result.sessions_ended && result.sessions_ended > 0) {
                     statusMessage = window.t ? window.t('api.saveSuccessWithReset', { count: result.sessions_ended }) : `API Key保存成功！已重置 ${result.sessions_ended} 个活跃对话，对话页面将自动刷新。`;
@@ -2976,7 +3011,6 @@ async function saveApiKey(params) {
                     statusMessage = window.t ? window.t('api.saveSuccessReload') : 'API Key保存成功！配置已重新加载，新配置将在下次对话时生效。';
                 }
                 showStatus(statusMessage, 'success');
-                setMaskedInput(document.getElementById('apiKeyInput'), '');
 
                 // 清除本地Voice ID记录
                 await clearVoiceIds();

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -41,8 +41,8 @@ const CONNECTIVITY_TESTABLE_TYPES = MODEL_TYPES;
 const MASKED_SECRET_SENTINEL = '__NEKO_SECRET_MASKED__';
 const MASKED_SECRET_DISPLAY = '••••••••••••';
 // POST 成功后的紧随其后的配置重载中，后端会只返回密钥哨兵。此 Map 只在
-// 当前页面、当前次重载期间保存用户刚输入的值，用于继续显示局部遮蔽；绝不
-// 写入 localStorage、不会发送到后端，也不会让后端 GET 回显明文。
+// 当前页面、当前次重载期间保存用户刚输入密钥的“局部遮罩值”（非明文），用于继续
+// 显示局部遮蔽；绝不写入 localStorage、不会发送到后端，也不会让后端 GET 回显明文。
 let _secretDisplayCache = null;
 const MIMO_TOKEN_PLAN_PROVIDER_KEY = 'mimo_token_plan';
 const MIMO_TOKEN_PLAN_OPENROUTER_URLS = [
@@ -379,14 +379,17 @@ function rememberResolvedProviderUrl(scope, providerKey, resolvedUrl) {
 function maskApiKey(key) {
     if (!key || typeof key !== 'string') return key;
     if (isMaskedSecretValue(key)) return MASKED_SECRET_DISPLAY;
-    if (key.length < 14) return key;
-    const midLen = key.length - 12;
-    return key.slice(0, 6) + '*'.repeat(midLen) + key.slice(-6);
+    // 与后端 mask_core_config_secret_for_display 对齐：短密钥直接全圆点，避免完整暴露。
+    if (key.length < 9) return MASKED_SECRET_DISPLAY;
+    const prefix = key.slice(0, 3);
+    const suffix = key.slice(-3);
+    if (prefix.includes('*') || suffix.includes('*')) return MASKED_SECRET_DISPLAY;
+    return prefix + '*'.repeat(key.length - 6) + suffix;
 }
 
 /**
  * 判断后端保留哨兵、通用圆点遮罩（含非空残片）或旧版遮罩。旧值只接受
- * 全星号，或 maskApiKey 生成的“6 字符前缀 + 至少 3 个星号 + 6 字符后缀”
+ * 全星号，或 maskApiKey 生成的“前后各 3~6 个非星号字符 + 至少 3 个星号”
  * 完整形状，避免把任意内部含星号的用户输入误判成遮罩。
  */
 function isMaskedSecretValue(value) {
@@ -396,12 +399,12 @@ function isMaskedSecretValue(value) {
         || normalized === MASKED_SECRET_DISPLAY
         || /^•+$/.test(normalized)
         || /^\*{3,}$/.test(normalized)
-        || /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized);
+        || /^[^*]{3,6}\*{3,}[^*]{3,6}$/.test(normalized);
 }
 
 function getPartialMaskedSecretDisplay(value) {
     const normalized = typeof value === 'string' ? value.trim() : '';
-    return /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized) ? normalized : '';
+    return /^[^*]{3,6}\*{3,}[^*]{3,6}$/.test(normalized) ? normalized : '';
 }
 
 /**
@@ -417,14 +420,14 @@ function setMaskedInput(input, realKey, displayMask = '') {
         return;
     }
     if (isMaskedSecretValue(realKey)) {
-        const locallyEnteredKey = _secretDisplayCache && _secretDisplayCache.get(input.id);
-        if (locallyEnteredKey && !isMaskedSecretValue(locallyEnteredKey)) {
-            // 保存后读取到的只是哨兵；同一次页面会话内仍可安全地沿用本地的
-            // 局部遮蔽显示，避免从“前后可见”退化为全圆点。
-            delete input.dataset.maskedSecret;
-            delete input.dataset.maskedDisplay;
-            input.dataset.realKey = locallyEnteredKey;
-            input.value = maskApiKey(locallyEnteredKey);
+        const cachedMask = _secretDisplayCache && _secretDisplayCache.get(input.id);
+        if (cachedMask && getPartialMaskedSecretDisplay(cachedMask)) {
+            // 保存后读取到的只是哨兵；同一次页面会话内沿用本地缓存的“遮罩值”
+            // （非明文）继续显示局部遮蔽，避免从“前后可见”退化为全圆点。
+            input.dataset.realKey = '';
+            input.dataset.maskedSecret = 'true';
+            input.dataset.maskedDisplay = cachedMask;
+            input.value = cachedMask;
             return;
         }
         // 只保留“后端已有密钥”这一状态，不把哨兵伪装成真实 key 放进 DOM。
@@ -441,8 +444,8 @@ function setMaskedInput(input, realKey, displayMask = '') {
 }
 
 /**
- * 记录本页已输入的真实密钥，以便保存成功后的单次配置重载继续显示局部遮蔽。
- * 页面重新打开时，核心 Key 使用后端返回的安全局部掩码；其它字段仍不回显明文。
+ * 记录本页已输入密钥的“局部遮罩值”（非明文），以便保存成功后的单次配置重载
+ * 继续显示局部遮蔽。绝不缓存明文：遮罩值不可逆，DOM / 内存里都不保留真实 key。
  */
 function cacheCurrentSecretDisplays() {
     const cache = new Map();
@@ -450,7 +453,7 @@ function cacheCurrentSecretDisplays() {
         if (input.dataset.maskAttached !== 'true' || !input.id) return;
         const realKey = getRealKey(input);
         if (realKey && !isMaskedSecretValue(realKey)) {
-            cache.set(input.id, realKey);
+            cache.set(input.id, maskApiKey(realKey));
         }
     });
     _secretDisplayCache = cache;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -389,8 +389,8 @@ function maskApiKey(key) {
 
 /**
  * 判断后端保留哨兵、通用圆点遮罩（含非空残片）或旧版遮罩。旧值只接受
- * 全星号，或 maskApiKey 生成的“前后各 3~6 个非星号字符 + 至少 3 个星号”
- * 完整形状，避免把任意内部含星号的用户输入误判成遮罩。
+ * 全星号，或 maskApiKey 生成的“前后各 3 或 6 个非星号字符 + 至少 3 个星号”
+ * 对称形状，避免把任意内部含星号的用户输入误判成遮罩。
  */
 function isMaskedSecretValue(value) {
     if (typeof value !== 'string') return false;
@@ -399,12 +399,12 @@ function isMaskedSecretValue(value) {
         || normalized === MASKED_SECRET_DISPLAY
         || /^•+$/.test(normalized)
         || /^\*{3,}$/.test(normalized)
-        || /^[^*]{3,6}\*{3,}[^*]{3,6}$/.test(normalized);
+        || /^(?:[^*]{3}\*{3,}[^*]{3}|[^*]{6}\*{3,}[^*]{6})$/.test(normalized);
 }
 
 function getPartialMaskedSecretDisplay(value) {
     const normalized = typeof value === 'string' ? value.trim() : '';
-    return /^[^*]{3,6}\*{3,}[^*]{3,6}$/.test(normalized) ? normalized : '';
+    return /^(?:[^*]{3}\*{3,}[^*]{3}|[^*]{6}\*{3,}[^*]{6})$/.test(normalized) ? normalized : '';
 }
 
 /**

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -399,14 +399,20 @@ function isMaskedSecretValue(value) {
         || /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized);
 }
 
+function getPartialMaskedSecretDisplay(value) {
+    const normalized = typeof value === 'string' ? value.trim() : '';
+    return /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized) ? normalized : '';
+}
+
 /**
  * 将真实 key 写入 input 的 dataset，输入框显示遮蔽值。
  */
-function setMaskedInput(input, realKey) {
+function setMaskedInput(input, realKey, displayMask = '') {
     if (!input) return;
     if (!realKey) {
         input.dataset.realKey = '';
         delete input.dataset.maskedSecret;
+        delete input.dataset.maskedDisplay;
         input.value = '';
         return;
     }
@@ -416,6 +422,7 @@ function setMaskedInput(input, realKey) {
             // 保存后读取到的只是哨兵；同一次页面会话内仍可安全地沿用本地的
             // 局部遮蔽显示，避免从“前后可见”退化为全圆点。
             delete input.dataset.maskedSecret;
+            delete input.dataset.maskedDisplay;
             input.dataset.realKey = locallyEnteredKey;
             input.value = maskApiKey(locallyEnteredKey);
             return;
@@ -423,17 +430,19 @@ function setMaskedInput(input, realKey) {
         // 只保留“后端已有密钥”这一状态，不把哨兵伪装成真实 key 放进 DOM。
         input.dataset.realKey = '';
         input.dataset.maskedSecret = 'true';
-        input.value = MASKED_SECRET_DISPLAY;
+        input.dataset.maskedDisplay = getPartialMaskedSecretDisplay(displayMask) || MASKED_SECRET_DISPLAY;
+        input.value = input.dataset.maskedDisplay;
         return;
     }
     delete input.dataset.maskedSecret;
+    delete input.dataset.maskedDisplay;
     input.dataset.realKey = realKey;
     input.value = maskApiKey(realKey);
 }
 
 /**
  * 记录本页已输入的真实密钥，以便保存成功后的单次配置重载继续显示局部遮蔽。
- * 页面刷新或普通配置加载不会调用它，因此刷新后仍只显示通用圆点遮罩。
+ * 页面重新打开时，核心 Key 使用后端返回的安全局部掩码；其它字段仍不回显明文。
  */
 function cacheCurrentSecretDisplays() {
     const cache = new Map();
@@ -489,8 +498,8 @@ function attachMaskBehavior(input) {
     input.dataset.maskAttached = 'true';
     input.addEventListener('focus', () => {
         if (input.dataset.maskedSecret === 'true') {
-            // 无明文可显示。选中通用掩码，让直接键入自然替换它。
-            input.value = MASKED_SECRET_DISPLAY;
+            // 无明文可显示；若后端提供了局部掩码，则保持该掩码。
+            input.value = input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY;
             input.select();
             return;
         }
@@ -501,20 +510,22 @@ function attachMaskBehavior(input) {
         if (input.dataset.maskedSecret !== 'true') return;
         // 用户开始编辑时才丢弃“保留旧值”状态；单纯聚焦/失焦不会清空密钥。
         delete input.dataset.maskedSecret;
+        delete input.dataset.maskedDisplay;
         input.dataset.realKey = '';
         input.value = '';
     });
     input.addEventListener('input', () => {
-        if (input.dataset.maskedSecret === 'true' && input.value !== MASKED_SECRET_DISPLAY) {
+        if (input.dataset.maskedSecret === 'true' && input.value !== (input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY)) {
             // 兼容脚本赋值后派发 input（以及不支持 beforeinput 的浏览器）。
             delete input.dataset.maskedSecret;
+            delete input.dataset.maskedDisplay;
             input.dataset.realKey = '';
         }
     });
     input.addEventListener('blur', () => {
         if (input.dataset.maskedSecret === 'true') {
             input.dataset.realKey = '';
-            input.value = MASKED_SECRET_DISPLAY;
+            input.value = input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY;
             return;
         }
         // 用户可能编辑了 value，同步回 realKey
@@ -523,7 +534,8 @@ function attachMaskBehavior(input) {
             if (isMaskedSecretValue(current)) {
                 input.dataset.realKey = '';
                 input.dataset.maskedSecret = 'true';
-                input.value = MASKED_SECRET_DISPLAY;
+                input.dataset.maskedDisplay = getPartialMaskedSecretDisplay(current) || MASKED_SECRET_DISPLAY;
+                input.value = input.dataset.maskedDisplay;
                 return;
             }
             input.dataset.realKey = current;
@@ -531,6 +543,7 @@ function attachMaskBehavior(input) {
         } else {
             input.dataset.realKey = '';
             delete input.dataset.maskedSecret;
+            delete input.dataset.maskedDisplay;
         }
     });
 }
@@ -1875,7 +1888,7 @@ async function loadCurrentApiKey() {
                     apiKeyInput.value = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
                 } else if (data.api_key) {
                     // 有API Key时设置
-                    setMaskedInput(apiKeyInput, data.api_key);
+                    setMaskedInput(apiKeyInput, data.api_key, data.api_key_display);
                     attachMaskBehavior(apiKeyInput);
                 }
                 // autoFillCoreApiKey 将在 coreApiSelect.value 设置后调用
@@ -1969,7 +1982,11 @@ async function loadCurrentApiKey() {
                 const assistKeyFromData = assistDataField ? (data[assistDataField] || '') : '';
                 if (assistApiKeyInput) {
                     if (assistKeyFromData) {
-                        setMaskedInput(assistApiKeyInput, assistKeyFromData);
+                        setMaskedInput(
+                            assistApiKeyInput,
+                            assistKeyFromData,
+                            data.assist_api_key_display
+                        );
                         attachMaskBehavior(assistApiKeyInput);
                     } else {
                         // 后端无辅助Key时，尝试从管理簿读取（兼容旧数据迁移）
@@ -5215,7 +5232,10 @@ async function initializePage() {
             updateAssistApiKeyInputAvailability();
 
             updateAssistApiRecommendation();
-            autoFillCoreApiKey(true);
+            // loadCurrentApiKey() has already applied the saved core key.  Do
+            // not force a management-book overwrite during initial rendering;
+            // provider-change handlers below still use force=true.
+            autoFillCoreApiKey();
             // 不再调用 autoFillAssistApiKey(true)，因为 loadCurrentApiKey()
             // 已从后端数据直接设置辅助API Key，此处再次从管理簿读取会覆盖正确值
             // （同服务商时管理簿存的是核心Key，受限服务商时管理簿DOM不存在）

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -399,14 +399,20 @@ function isMaskedSecretValue(value) {
         || /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized);
 }
 
+function getPartialMaskedSecretDisplay(value) {
+    const normalized = typeof value === 'string' ? value.trim() : '';
+    return /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized) ? normalized : '';
+}
+
 /**
  * 将真实 key 写入 input 的 dataset，输入框显示遮蔽值。
  */
-function setMaskedInput(input, realKey) {
+function setMaskedInput(input, realKey, displayMask = '') {
     if (!input) return;
     if (!realKey) {
         input.dataset.realKey = '';
         delete input.dataset.maskedSecret;
+        delete input.dataset.maskedDisplay;
         input.value = '';
         return;
     }
@@ -416,6 +422,7 @@ function setMaskedInput(input, realKey) {
             // 保存后读取到的只是哨兵；同一次页面会话内仍可安全地沿用本地的
             // 局部遮蔽显示，避免从“前后可见”退化为全圆点。
             delete input.dataset.maskedSecret;
+            delete input.dataset.maskedDisplay;
             input.dataset.realKey = locallyEnteredKey;
             input.value = maskApiKey(locallyEnteredKey);
             return;
@@ -423,17 +430,19 @@ function setMaskedInput(input, realKey) {
         // 只保留“后端已有密钥”这一状态，不把哨兵伪装成真实 key 放进 DOM。
         input.dataset.realKey = '';
         input.dataset.maskedSecret = 'true';
-        input.value = MASKED_SECRET_DISPLAY;
+        input.dataset.maskedDisplay = getPartialMaskedSecretDisplay(displayMask) || MASKED_SECRET_DISPLAY;
+        input.value = input.dataset.maskedDisplay;
         return;
     }
     delete input.dataset.maskedSecret;
+    delete input.dataset.maskedDisplay;
     input.dataset.realKey = realKey;
     input.value = maskApiKey(realKey);
 }
 
 /**
  * 记录本页已输入的真实密钥，以便保存成功后的单次配置重载继续显示局部遮蔽。
- * 页面刷新或普通配置加载不会调用它，因此刷新后仍只显示通用圆点遮罩。
+ * 页面重新打开时，核心 Key 使用后端返回的安全局部掩码；其它字段仍不回显明文。
  */
 function cacheCurrentSecretDisplays() {
     const cache = new Map();
@@ -489,8 +498,8 @@ function attachMaskBehavior(input) {
     input.dataset.maskAttached = 'true';
     input.addEventListener('focus', () => {
         if (input.dataset.maskedSecret === 'true') {
-            // 无明文可显示。选中通用掩码，让直接键入自然替换它。
-            input.value = MASKED_SECRET_DISPLAY;
+            // 无明文可显示；若后端提供了局部掩码，则保持该掩码。
+            input.value = input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY;
             input.select();
             return;
         }
@@ -501,20 +510,22 @@ function attachMaskBehavior(input) {
         if (input.dataset.maskedSecret !== 'true') return;
         // 用户开始编辑时才丢弃“保留旧值”状态；单纯聚焦/失焦不会清空密钥。
         delete input.dataset.maskedSecret;
+        delete input.dataset.maskedDisplay;
         input.dataset.realKey = '';
         input.value = '';
     });
     input.addEventListener('input', () => {
-        if (input.dataset.maskedSecret === 'true' && input.value !== MASKED_SECRET_DISPLAY) {
+        if (input.dataset.maskedSecret === 'true' && input.value !== (input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY)) {
             // 兼容脚本赋值后派发 input（以及不支持 beforeinput 的浏览器）。
             delete input.dataset.maskedSecret;
+            delete input.dataset.maskedDisplay;
             input.dataset.realKey = '';
         }
     });
     input.addEventListener('blur', () => {
         if (input.dataset.maskedSecret === 'true') {
             input.dataset.realKey = '';
-            input.value = MASKED_SECRET_DISPLAY;
+            input.value = input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY;
             return;
         }
         // 用户可能编辑了 value，同步回 realKey
@@ -523,7 +534,8 @@ function attachMaskBehavior(input) {
             if (isMaskedSecretValue(current)) {
                 input.dataset.realKey = '';
                 input.dataset.maskedSecret = 'true';
-                input.value = MASKED_SECRET_DISPLAY;
+                input.dataset.maskedDisplay = getPartialMaskedSecretDisplay(current) || MASKED_SECRET_DISPLAY;
+                input.value = input.dataset.maskedDisplay;
                 return;
             }
             input.dataset.realKey = current;
@@ -531,6 +543,7 @@ function attachMaskBehavior(input) {
         } else {
             input.dataset.realKey = '';
             delete input.dataset.maskedSecret;
+            delete input.dataset.maskedDisplay;
         }
     });
 }
@@ -1875,7 +1888,8 @@ async function loadCurrentApiKey() {
                     apiKeyInput.value = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
                 } else if (data.api_key) {
                     // 有API Key时设置
-                    setMaskedInput(apiKeyInput, data.api_key);
+                    setMaskedInput(apiKeyInput, data.api_key, data.api_key_display);
+                    apiKeyInput.dataset.maskedDisplayProvider = data.coreApi || '';
                     attachMaskBehavior(apiKeyInput);
                 }
                 // autoFillCoreApiKey 将在 coreApiSelect.value 设置后调用
@@ -3183,6 +3197,18 @@ function autoFillCoreApiKey(force) {
     // Use !== null to distinguish "input not present" from "input present but empty":
     // null = restricted/hidden provider (no input), '' = user cleared the key intentionally.
     const bookKey = syncKeyFromBook(selectedCoreApi);
+    const hasServerDisplayForSelectedProvider = (
+        bookKey === MASKED_SECRET_SENTINEL
+        && apiKeyInput.dataset.maskedDisplay
+        && apiKeyInput.dataset.maskedDisplayProvider === selectedCoreApi
+    );
+    if (hasServerDisplayForSelectedProvider) {
+        // The selected provider did not change.  Keep the display-only mask
+        // supplied by the server instead of replacing it with the book's
+        // persistence sentinel.
+        attachMaskBehavior(apiKeyInput);
+        return;
+    }
     // When forced (provider switch), clear input if no book key
     if (force && (bookKey === null || bookKey === '')) {
         setMaskedInput(apiKeyInput, '');

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -399,20 +399,14 @@ function isMaskedSecretValue(value) {
         || /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized);
 }
 
-function getPartialMaskedSecretDisplay(value) {
-    const normalized = typeof value === 'string' ? value.trim() : '';
-    return /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized) ? normalized : '';
-}
-
 /**
  * 将真实 key 写入 input 的 dataset，输入框显示遮蔽值。
  */
-function setMaskedInput(input, realKey, displayMask = '') {
+function setMaskedInput(input, realKey) {
     if (!input) return;
     if (!realKey) {
         input.dataset.realKey = '';
         delete input.dataset.maskedSecret;
-        delete input.dataset.maskedDisplay;
         input.value = '';
         return;
     }
@@ -422,7 +416,6 @@ function setMaskedInput(input, realKey, displayMask = '') {
             // 保存后读取到的只是哨兵；同一次页面会话内仍可安全地沿用本地的
             // 局部遮蔽显示，避免从“前后可见”退化为全圆点。
             delete input.dataset.maskedSecret;
-            delete input.dataset.maskedDisplay;
             input.dataset.realKey = locallyEnteredKey;
             input.value = maskApiKey(locallyEnteredKey);
             return;
@@ -430,19 +423,17 @@ function setMaskedInput(input, realKey, displayMask = '') {
         // 只保留“后端已有密钥”这一状态，不把哨兵伪装成真实 key 放进 DOM。
         input.dataset.realKey = '';
         input.dataset.maskedSecret = 'true';
-        input.dataset.maskedDisplay = getPartialMaskedSecretDisplay(displayMask) || MASKED_SECRET_DISPLAY;
-        input.value = input.dataset.maskedDisplay;
+        input.value = MASKED_SECRET_DISPLAY;
         return;
     }
     delete input.dataset.maskedSecret;
-    delete input.dataset.maskedDisplay;
     input.dataset.realKey = realKey;
     input.value = maskApiKey(realKey);
 }
 
 /**
  * 记录本页已输入的真实密钥，以便保存成功后的单次配置重载继续显示局部遮蔽。
- * 页面重新打开时，核心 Key 使用后端返回的安全局部掩码；其它字段仍不回显明文。
+ * 页面刷新或普通配置加载不会调用它，因此刷新后仍只显示通用圆点遮罩。
  */
 function cacheCurrentSecretDisplays() {
     const cache = new Map();
@@ -498,8 +489,8 @@ function attachMaskBehavior(input) {
     input.dataset.maskAttached = 'true';
     input.addEventListener('focus', () => {
         if (input.dataset.maskedSecret === 'true') {
-            // 无明文可显示；若后端提供了局部掩码，则保持该掩码。
-            input.value = input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY;
+            // 无明文可显示。选中通用掩码，让直接键入自然替换它。
+            input.value = MASKED_SECRET_DISPLAY;
             input.select();
             return;
         }
@@ -510,22 +501,20 @@ function attachMaskBehavior(input) {
         if (input.dataset.maskedSecret !== 'true') return;
         // 用户开始编辑时才丢弃“保留旧值”状态；单纯聚焦/失焦不会清空密钥。
         delete input.dataset.maskedSecret;
-        delete input.dataset.maskedDisplay;
         input.dataset.realKey = '';
         input.value = '';
     });
     input.addEventListener('input', () => {
-        if (input.dataset.maskedSecret === 'true' && input.value !== (input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY)) {
+        if (input.dataset.maskedSecret === 'true' && input.value !== MASKED_SECRET_DISPLAY) {
             // 兼容脚本赋值后派发 input（以及不支持 beforeinput 的浏览器）。
             delete input.dataset.maskedSecret;
-            delete input.dataset.maskedDisplay;
             input.dataset.realKey = '';
         }
     });
     input.addEventListener('blur', () => {
         if (input.dataset.maskedSecret === 'true') {
             input.dataset.realKey = '';
-            input.value = input.dataset.maskedDisplay || MASKED_SECRET_DISPLAY;
+            input.value = MASKED_SECRET_DISPLAY;
             return;
         }
         // 用户可能编辑了 value，同步回 realKey
@@ -534,8 +523,7 @@ function attachMaskBehavior(input) {
             if (isMaskedSecretValue(current)) {
                 input.dataset.realKey = '';
                 input.dataset.maskedSecret = 'true';
-                input.dataset.maskedDisplay = getPartialMaskedSecretDisplay(current) || MASKED_SECRET_DISPLAY;
-                input.value = input.dataset.maskedDisplay;
+                input.value = MASKED_SECRET_DISPLAY;
                 return;
             }
             input.dataset.realKey = current;
@@ -543,7 +531,6 @@ function attachMaskBehavior(input) {
         } else {
             input.dataset.realKey = '';
             delete input.dataset.maskedSecret;
-            delete input.dataset.maskedDisplay;
         }
     });
 }
@@ -1888,8 +1875,7 @@ async function loadCurrentApiKey() {
                     apiKeyInput.value = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
                 } else if (data.api_key) {
                     // 有API Key时设置
-                    setMaskedInput(apiKeyInput, data.api_key, data.api_key_display);
-                    apiKeyInput.dataset.maskedDisplayProvider = data.coreApi || '';
+                    setMaskedInput(apiKeyInput, data.api_key);
                     attachMaskBehavior(apiKeyInput);
                 }
                 // autoFillCoreApiKey 将在 coreApiSelect.value 设置后调用
@@ -3197,18 +3183,6 @@ function autoFillCoreApiKey(force) {
     // Use !== null to distinguish "input not present" from "input present but empty":
     // null = restricted/hidden provider (no input), '' = user cleared the key intentionally.
     const bookKey = syncKeyFromBook(selectedCoreApi);
-    const hasServerDisplayForSelectedProvider = (
-        bookKey === MASKED_SECRET_SENTINEL
-        && apiKeyInput.dataset.maskedDisplay
-        && apiKeyInput.dataset.maskedDisplayProvider === selectedCoreApi
-    );
-    if (hasServerDisplayForSelectedProvider) {
-        // The selected provider did not change.  Keep the display-only mask
-        // supplied by the server instead of replacing it with the book's
-        // persistence sentinel.
-        attachMaskBehavior(apiKeyInput);
-        return;
-    }
     // When forced (provider switch), clear input if no book key
     if (force && (bookKey === null || bookKey === '')) {
         setMaskedInput(apiKeyInput, '');

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -841,7 +841,9 @@
     </div>
 
 
-    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}"></script>
+    <!-- Independent revision forces existing clients off the previously cached
+         API-key settings script after a settings-display behavior change. -->
+    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v5"></script>
 
 
     <script src="/static/tutorial/core/guide-helpers.js?v={{ static_asset_version }}"></script>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -843,7 +843,7 @@
 
     <!-- Independent revision forces existing clients off the previously cached
          API-key settings script after a settings-display behavior change. -->
-    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v5"></script>
+    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v8"></script>
 
 
     <script src="/static/tutorial/core/guide-helpers.js?v={{ static_asset_version }}"></script>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -843,7 +843,7 @@
 
     <!-- Independent revision forces existing clients off the previously cached
          API-key settings script after a settings-display behavior change. -->
-    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v5"></script>
+    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v6"></script>
 
 
     <script src="/static/tutorial/core/guide-helpers.js?v={{ static_asset_version }}"></script>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -843,7 +843,7 @@
 
     <!-- Independent revision forces existing clients off the previously cached
          API-key settings script after a settings-display behavior change. -->
-    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v6"></script>
+    <script src="/static/js/api_key_settings.js?v={{ static_asset_version }}-api-key-mask-v5"></script>
 
 
     <script src="/static/tutorial/core/guide-helpers.js?v={{ static_asset_version }}"></script>

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -62,15 +62,15 @@ def test_api_key_settings(mock_page: Page, running_server: str):
     # sentinel.  Keep this page's just-entered key as a partial mask instead
     # of degrading it to the generic all-dot placeholder.
     expect(mock_page.locator("#apiKeyInput")).to_have_value(
-        "sk-tes******567890", timeout=5000
+        "sk-***********890", timeout=5000
     )
-    
+
     # Reload page to verify persistence
     mock_page.reload()
     expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
-    
+
     # A full page reload keeps the server-provided partial mask, never plaintext.
-    expect(mock_page.locator("#apiKeyInput")).to_have_value("sk-tes******567890", timeout=5000)
+    expect(mock_page.locator("#apiKeyInput")).to_have_value("sk-***********890", timeout=5000)
     expect(mock_page.locator("#coreApiSelect")).to_have_value("qwen", timeout=5000)
 
 

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -57,14 +57,20 @@ def test_api_key_settings(mock_page: Page, running_server: str):
     # The JS shows status in #status div; message may be i18n-translated
     # Wait for the status div to become visible (it's hidden by default)
     expect(mock_page.locator("#status")).to_be_visible(timeout=5000)
+
+    # The immediate post-save refresh receives only the server-side secret
+    # sentinel.  Keep this page's just-entered key as a partial mask instead
+    # of degrading it to the generic all-dot placeholder.
+    expect(mock_page.locator("#apiKeyInput")).to_have_value(
+        "sk-tes******567890", timeout=5000
+    )
     
     # Reload page to verify persistence
     mock_page.reload()
     expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
     
-    # Verify value
-    # 当前页面会把明文 key 掩码显示，真实值挂在 data-real-key 上。
-    expect(mock_page.locator("#apiKeyInput")).to_have_attribute("data-real-key", test_key, timeout=5000)
+    # A full page reload must not receive or retain the plaintext key.
+    expect(mock_page.locator("#apiKeyInput")).to_have_value("••••••••••••", timeout=5000)
     expect(mock_page.locator("#coreApiSelect")).to_have_value("qwen", timeout=5000)
 
 

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -69,8 +69,8 @@ def test_api_key_settings(mock_page: Page, running_server: str):
     mock_page.reload()
     expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
     
-    # A full page reload keeps the server-provided partial mask, never plaintext.
-    expect(mock_page.locator("#apiKeyInput")).to_have_value("sk-tes******567890", timeout=5000)
+    # A full page reload must not receive or retain the plaintext key.
+    expect(mock_page.locator("#apiKeyInput")).to_have_value("••••••••••••", timeout=5000)
     expect(mock_page.locator("#coreApiSelect")).to_have_value("qwen", timeout=5000)
 
 

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -62,7 +62,7 @@ def test_api_key_settings(mock_page: Page, running_server: str):
     # sentinel.  Keep this page's just-entered key as a partial mask instead
     # of degrading it to the generic all-dot placeholder.
     expect(mock_page.locator("#apiKeyInput")).to_have_value(
-        "sk-***********890", timeout=5000
+        "sk-************890", timeout=5000
     )
 
     # Reload page to verify persistence
@@ -70,7 +70,7 @@ def test_api_key_settings(mock_page: Page, running_server: str):
     expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
 
     # A full page reload keeps the server-provided partial mask, never plaintext.
-    expect(mock_page.locator("#apiKeyInput")).to_have_value("sk-***********890", timeout=5000)
+    expect(mock_page.locator("#apiKeyInput")).to_have_value("sk-************890", timeout=5000)
     expect(mock_page.locator("#coreApiSelect")).to_have_value("qwen", timeout=5000)
 
 

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -69,8 +69,8 @@ def test_api_key_settings(mock_page: Page, running_server: str):
     mock_page.reload()
     expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
     
-    # A full page reload must not receive or retain the plaintext key.
-    expect(mock_page.locator("#apiKeyInput")).to_have_value("••••••••••••", timeout=5000)
+    # A full page reload keeps the server-provided partial mask, never plaintext.
+    expect(mock_page.locator("#apiKeyInput")).to_have_value("sk-tes******567890", timeout=5000)
     expect(mock_page.locator("#coreApiSelect")).to_have_value("qwen", timeout=5000)
 
 

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -123,6 +123,12 @@ def test_get_redacts_every_core_config_secret(
     assert response['success'] is True
     assert response['effectiveCoreApi'] == 'qwen'
     assert response['supportsIndependentAsr'] is True
+    assert response['api_key_display'] == core_config_router.mask_core_config_secret_for_display(
+        stored['coreApiKey']
+    )
+    assert response['assist_api_key_display'] == core_config_router.mask_core_config_secret_for_display(
+        stored['assistApiKeyOpenai']
+    )
     response_secret_fields = (
         'api_key',
         *_ASSIST_API_KEY_FIELDS,

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -123,6 +123,9 @@ def test_get_redacts_every_core_config_secret(
     assert response['success'] is True
     assert response['effectiveCoreApi'] == 'qwen'
     assert response['supportsIndependentAsr'] is True
+    assert response['api_key_display'] == core_config_router.mask_core_config_secret_for_display(
+        stored['coreApiKey']
+    )
     response_secret_fields = (
         'api_key',
         *_ASSIST_API_KEY_FIELDS,

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -123,9 +123,6 @@ def test_get_redacts_every_core_config_secret(
     assert response['success'] is True
     assert response['effectiveCoreApi'] == 'qwen'
     assert response['supportsIndependentAsr'] is True
-    assert response['api_key_display'] == core_config_router.mask_core_config_secret_for_display(
-        stored['coreApiKey']
-    )
     response_secret_fields = (
         'api_key',
         *_ASSIST_API_KEY_FIELDS,


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

取消全部不显示的点号，改用部分显示+星号 mask

<img width="515" height="143" alt="image" src="https://github.com/user-attachments/assets/4c3068e7-673b-4570-913d-fefb31d7073a" />


<!-- 这个 PR 做了什么。若有对应 Issue 可关联（如 Closes #123），非必须。 -->

## 回归报告 / Regression Report

- **改动了什么**：`main_routers/config_router/core_config.py` 的密钥显示逻辑。`mask_core_config_secret_for_display` 由「前6后6」改为「前3后3」，短密钥（<9 字符）返回全圆点占位；`is_core_config_secret_placeholder` 在保留识别旧版 6+6 遮罩的同时，兼容新的 3+3 形状，作为「保留原密钥」哨兵。配套地，前端 `static/js/api_key_settings.js` 的 `maskApiKey` 规则与后端对齐，且保存后只在页面缓存中存放不可逆的遮罩值（不再缓存/写回明文）。
- **理由 / 必要性**：`/core_api` 为未认证接口，原先返回前6后6 共 12 个字符，且前端把刚保存的明文密钥留在 DOM 与页面缓存里，存在凭据被页面脚本/未授权客户端读取的风险（PR #2911 review 指出）。缩短暴露片段并避免明文落地，缩小泄露面。
- **改动前后的表现对比**：保存并重载设置页后，输入框由「全圆点或前后 6 字符」改为「前后各 3 字符 + 星号」；短密钥不再原样显示，统一为全圆点。功能行为（哨兵保留、provider 切换、显式清空）不变。
- **潜在回归点（影响链路 + 验证）**：`/api/config/core_api` 的 GET 遮罩与 POST 哨兵保留、密钥簿各 provider 字段、自定义模型 Key。已验证：`tests/unit/test_core_config_secret_redaction.py` 15 项单测全部通过；`tests/frontend/test_api_settings.py` 的保存后遮罩断言更新为 `sk-***********890`；JS 通过语法校验，遮罩/哨兵识别逻辑经模拟确认。

## 测试 / Testing

进入 API Key 设置 页面，选择自定义 Key，填写一个较长的key，点击保存


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * API 密钥现支持前后各 3 位或 6 位的对称遮罩显示。
  * 长度不足 9 位的密钥将显示为完整圆点遮罩；核心及辅助服务密钥提供安全的部分遮罩信息。
  * 核心配置响应现提供 API 密钥显示值，便于确认已配置密钥。

* **改进**
  * 保存并重新加载设置后，仅保留不可逆的遮罩显示，不会将遮罩值误作真实密钥。
  * 优化密钥输入框在编辑、失焦和清空时的显示处理。
  * 更新页面资源版本，确保加载最新的遮罩逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->