### PR TITLE
修复 API 服务商下拉菜单及人格选择弹窗滚动条被边框裁切或越界的问题，并补充前端回归测试

### DIFF
--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1286,6 +1286,7 @@ transition: max-height 0.3s ease-in-out, margin-top 0.3s ease-in-out;
     border: 1px solid #d5eaf4;
     border-top: 3px solid #40c5f1;
     border-radius: 24px;
+    overflow: visible;
 }
 
 .nested-model-config-container {

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1286,6 +1286,9 @@ transition: max-height 0.3s ease-in-out, margin-top 0.3s ease-in-out;
     border: 1px solid #d5eaf4;
     border-top: 3px solid #40c5f1;
     border-radius: 24px;
+}
+
+.model-content.expanded:has(.api-provider-dropdown.open) {
     overflow: visible;
 }
 

--- a/static/css/character_personality_onboarding.css
+++ b/static/css/character_personality_onboarding.css
@@ -44,9 +44,11 @@
 }
 
 .character-personality-shell {
+    display: flex;
+    flex-direction: column;
     width: min(780px, 100%);
     max-height: min(780px, calc(100vh - 48px));
-    overflow: auto;
+    overflow: hidden;
     border: 4px solid rgba(255, 255, 255, 0.96);
     border-radius: 32px;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(244, 251, 255, 0.98));
@@ -55,6 +57,7 @@
 }
 
 .shell-deco-bar {
+    flex: 0 0 auto;
     height: 10px;
     width: 100%;
     background: linear-gradient(
@@ -65,7 +68,10 @@
 }
 
 .character-personality-body {
-    min-height: 440px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
 }
 
 .character-personality-stage {

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -71,6 +71,7 @@ def test_api_key_settings(mock_page: Page, running_server: str):
 @pytest.mark.frontend
 def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_server: str):
     """Collapsed custom-model headers must not borrow rounded corners from a wrapper."""
+    mock_page.set_viewport_size({"width": 1280, "height": 1200})
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
     mock_page.goto(f"{running_server}/api_key")
 
@@ -128,6 +129,46 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
         "marginTop": "8px",
         "overflow": "visible",
     }
+
+    mock_page.wait_for_selector(
+        "#conversationModelProvider option",
+        state="attached",
+        timeout=10000,
+    )
+    mock_page.evaluate("""
+        () => {
+            document.getElementById('custom-api-options').style.display = 'block';
+            document.getElementById('custom-api-container').style.display = 'grid';
+            document.getElementById('conversation-model-content')
+                .closest('.model-config-container').style.display = 'block';
+        }
+    """)
+    provider_trigger = mock_page.locator("#conversationModelProvider-dropdown-trigger")
+    provider_menu = mock_page.locator("#conversationModelProvider-menu")
+    provider_trigger.click()
+    expect(provider_menu).to_be_visible()
+
+    dropdown_geometry = mock_page.evaluate("""
+        () => {
+            const content = document.getElementById('conversation-model-content');
+            const menu = document.getElementById('conversationModelProvider-menu');
+            const contentRect = content.getBoundingClientRect();
+            const menuRect = menu.getBoundingClientRect();
+            const probeX = menuRect.left + (menuRect.width / 2);
+            const probeY = Math.min(menuRect.bottom - 2, contentRect.bottom + 4);
+            const hit = document.elementFromPoint(probeX, probeY);
+
+            return {
+                contentBottom: contentRect.bottom,
+                menuBottom: menuRect.bottom,
+                menuExtendsPastContent: menuRect.bottom > contentRect.bottom,
+                exposedMenuPointIsVisible: !!(hit && menu.contains(hit)),
+            };
+        }
+    """)
+
+    assert dropdown_geometry["menuExtendsPastContent"] is True
+    assert dropdown_geometry["exposedMenuPointIsVisible"] is True
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -131,7 +131,8 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
     }
 
     mock_page.wait_for_selector(
-        "#conversationModelProvider option",
+        "#conversationModelProvider-menu "
+        ".api-provider-dropdown-option[data-value='qwen']",
         state="attached",
         timeout=10000,
     )
@@ -155,13 +156,16 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
             const contentRect = content.getBoundingClientRect();
             const menuRect = menu.getBoundingClientRect();
             const probeX = menuRect.left + (menuRect.width / 2);
-            const probeY = Math.min(menuRect.bottom - 2, contentRect.bottom + 4);
-            const hit = document.elementFromPoint(probeX, probeY);
+            const exposedHeight = menuRect.bottom - contentRect.bottom;
+            const probeY = contentRect.bottom + (Math.min(4, exposedHeight) / 2);
+            const hit = exposedHeight > 0
+                ? document.elementFromPoint(probeX, probeY)
+                : null;
 
             return {
                 contentBottom: contentRect.bottom,
                 menuBottom: menuRect.bottom,
-                menuExtendsPastContent: menuRect.bottom > contentRect.bottom,
+                menuExtendsPastContent: exposedHeight > 0,
                 exposedMenuPointIsVisible: !!(hit && menu.contains(hit)),
             };
         }

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -117,6 +117,7 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
                 borderWidth: style.borderTopWidth,
                 borderRadius: style.borderTopLeftRadius,
                 marginTop: style.marginTop,
+                overflow: style.overflow,
             };
         }
     """)
@@ -125,6 +126,7 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
         "borderWidth": "3px",
         "borderRadius": "24px",
         "marginTop": "8px",
+        "overflow": "visible",
     }
 
 

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -106,7 +106,15 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
         "headerWidth": styles["headerWidth"],
     }
 
-    mock_page.evaluate("toggleModelConfig('conversation')")
+    transition_overflow = mock_page.evaluate("""
+        () => {
+            toggleModelConfig('conversation');
+            return getComputedStyle(
+                document.getElementById('conversation-model-content')
+            ).overflow;
+        }
+    """)
+    assert transition_overflow == "hidden"
     mock_page.wait_for_timeout(350)
 
     expanded_styles = mock_page.evaluate("""
@@ -127,7 +135,7 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
         "borderWidth": "3px",
         "borderRadius": "24px",
         "marginTop": "8px",
-        "overflow": "visible",
+        "overflow": "hidden",
     }
 
     mock_page.wait_for_selector(
@@ -155,24 +163,37 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
             const menu = document.getElementById('conversationModelProvider-menu');
             const contentRect = content.getBoundingClientRect();
             const menuRect = menu.getBoundingClientRect();
-            const probeX = menuRect.left + (menuRect.width / 2);
+            const probeXs = [
+                menuRect.left + (menuRect.width / 2),
+                menuRect.right - 4,
+            ];
             const exposedHeight = menuRect.bottom - contentRect.bottom;
             const probeY = contentRect.bottom + (Math.min(4, exposedHeight) / 2);
-            const hit = exposedHeight > 0
-                ? document.elementFromPoint(probeX, probeY)
-                : null;
+            const hits = exposedHeight > 0
+                ? probeXs.map((probeX) => document.elementFromPoint(probeX, probeY))
+                : [];
 
             return {
                 contentBottom: contentRect.bottom,
                 menuBottom: menuRect.bottom,
+                contentOverflow: getComputedStyle(content).overflow,
                 menuExtendsPastContent: exposedHeight > 0,
-                exposedMenuPointIsVisible: !!(hit && menu.contains(hit)),
+                exposedMenuCenterIsVisible: !!(hits[0] && menu.contains(hits[0])),
+                exposedMenuRightEdgeIsVisible: !!(hits[1] && menu.contains(hits[1])),
             };
         }
     """)
 
+    assert dropdown_geometry["contentOverflow"] == "visible"
     assert dropdown_geometry["menuExtendsPastContent"] is True
-    assert dropdown_geometry["exposedMenuPointIsVisible"] is True
+    assert dropdown_geometry["exposedMenuCenterIsVisible"] is True
+    assert dropdown_geometry["exposedMenuRightEdgeIsVisible"] is True
+
+    provider_trigger.click()
+    expect(provider_menu).to_be_hidden()
+    expect(mock_page.locator("#conversation-model-content")).to_have_css(
+        "overflow", "hidden"
+    )
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -2028,6 +2028,50 @@ def test_onboarding_persona_grid_is_two_columns_on_desktop_and_one_on_mobile(moc
     assert desktop_fit["shellOverflow"] == "hidden"
     assert desktop_fit["bodyOverflowY"] == "auto"
 
+    def assert_scroll_stays_inside_shell() -> None:
+        scroll_metrics = mock_page.evaluate(
+            """
+            () => {
+                const shell = document.querySelector('.character-personality-shell');
+                const body = document.querySelector('.character-personality-body');
+                const shellRect = shell.getBoundingClientRect();
+                const bodyRect = body.getBoundingClientRect();
+                body.scrollTop = body.scrollHeight;
+
+                return {
+                    viewportHeight: window.innerHeight,
+                    shellTop: shellRect.top,
+                    shellBottom: shellRect.bottom,
+                    bodyTop: bodyRect.top,
+                    bodyBottom: bodyRect.bottom,
+                    shellClientHeight: shell.clientHeight,
+                    shellScrollHeight: shell.scrollHeight,
+                    bodyClientHeight: body.clientHeight,
+                    bodyScrollHeight: body.scrollHeight,
+                    bodyScrollTop: body.scrollTop,
+                };
+            }
+            """
+        )
+        assert scroll_metrics["bodyScrollHeight"] > scroll_metrics["bodyClientHeight"]
+        assert scroll_metrics["bodyScrollTop"] > 0
+        assert scroll_metrics["shellScrollHeight"] <= (
+            scroll_metrics["shellClientHeight"] + layout_tolerance_px
+        )
+        assert scroll_metrics["shellTop"] >= -layout_tolerance_px
+        assert scroll_metrics["shellBottom"] <= (
+            scroll_metrics["viewportHeight"] + layout_tolerance_px
+        )
+        assert scroll_metrics["bodyTop"] >= (
+            scroll_metrics["shellTop"] - layout_tolerance_px
+        )
+        assert scroll_metrics["bodyBottom"] <= (
+            scroll_metrics["shellBottom"] + layout_tolerance_px
+        )
+
+    mock_page.set_viewport_size({"width": 1280, "height": 520})
+    assert_scroll_stays_inside_shell()
+
     mock_page.set_viewport_size({"width": 820, "height": 900})
     tablet_columns = mock_page.locator(".character-personality-grid").evaluate(
         "element => getComputedStyle(element).gridTemplateColumns.split(' ').length"
@@ -2039,6 +2083,7 @@ def test_onboarding_persona_grid_is_two_columns_on_desktop_and_one_on_mobile(moc
         "element => getComputedStyle(element).gridTemplateColumns.split(' ').length"
     )
     assert mobile_columns == 1
+    assert_scroll_stays_inside_shell()
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -2009,12 +2009,15 @@ def test_onboarding_persona_grid_is_two_columns_on_desktop_and_one_on_mobile(moc
         """
         () => {
             const shell = document.querySelector('.character-personality-shell');
+            const body = document.querySelector('.character-personality-body');
             const actions = document.querySelector('.character-personality-actions');
             return {
                 actionsBottom: actions.getBoundingClientRect().bottom,
                 viewportHeight: window.innerHeight,
                 shellClientHeight: shell.clientHeight,
                 shellScrollHeight: shell.scrollHeight,
+                shellOverflow: getComputedStyle(shell).overflow,
+                bodyOverflowY: getComputedStyle(body).overflowY,
             };
         }
         """
@@ -2022,6 +2025,8 @@ def test_onboarding_persona_grid_is_two_columns_on_desktop_and_one_on_mobile(moc
     layout_tolerance_px = 4
     assert desktop_fit["actionsBottom"] <= desktop_fit["viewportHeight"] + layout_tolerance_px
     assert desktop_fit["shellScrollHeight"] <= desktop_fit["shellClientHeight"] + layout_tolerance_px
+    assert desktop_fit["shellOverflow"] == "hidden"
+    assert desktop_fit["bodyOverflowY"] == "auto"
 
     mock_page.set_viewport_size({"width": 820, "height": 900})
     tablet_columns = mock_page.locator(".character-personality-grid").evaluate(


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 API 服务商下拉菜单及人格选择弹窗滚动条被边框裁切或越界的问题

## 测试 / Testing

手动查看UI是否正常

## 对比
之前：
<img width="642" height="511" alt="image" src="https://github.com/user-attachments/assets/24711527-b28b-4880-8cf0-b7819466ab3c" />
<img width="833" height="831" alt="image" src="https://github.com/user-attachments/assets/1c6bd699-4cb0-4a3b-b91a-ef06db35732a" />
之后：
<img width="654" height="516" alt="image" src="https://github.com/user-attachments/assets/9186edca-1138-4b40-9826-b11cb59bd582" />
<img width="792" height="785" alt="image" src="https://github.com/user-attachments/assets/d9419dd3-f2b7-4025-aeff-2e00da1f804d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化自定义模型展开区域，确保 API 提供商下拉菜单可完整显示并操作。
  * 改进性格引导弹窗布局，支持主体区域独立垂直滚动，避免内容超出视口。
* **测试**
  * 增加界面验证，确保下拉菜单在不同状态下正常显示和交互。
  * 验证不同视口尺寸下弹窗内容可滚动且不会超出边界。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->