### PR TITLE
magic 意图分类关思考：10s 用户路径窗口不该给思考型模型

### DIFF
--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -902,7 +902,11 @@ class OpenClawAdapter:
                 temperature=0,
                 max_completion_tokens=OPENCLAW_MAGIC_INTENT_MAX_TOKENS,
                 max_retries=0,
-                extra_body=None,
+                # ⚠️ 不传 extra_body（≠ extra_body=None）：让工厂按模型名解析出各家的
+                # 「关思考」方言。这条腿是用户路径上的 10s 窗口，思考型模型（GLM、Kimi、
+                # Doubao、官方 DeepSeek V4 这些默认开思考的）几乎必然打满 10s 再回落规则
+                # 层，白烧一次派单的等待。分类本身是二选一的判断，也用不上思考。
+                # extra_body=None 会**跳过**工厂解析、保留模型原生行为，正好是反的。
                 timeout=10,  # quick magic-intent classification on the user path
                 provider_type=(cfg or {}).get("provider_type"),
             )

--- a/tests/unit/test_magic_intent_thinking.py
+++ b/tests/unit/test_magic_intent_thinking.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import pytest
 
-from brain.openclaw_adapter import OpenClawAdapter
+import brain.openclaw_adapter as adapter_mod
 
 
 class _FakeConfigManager:
@@ -55,8 +55,6 @@ def test_magic_intent_client_disables_thinking(monkeypatch, model, api_base, exp
     """
     captured: list[Any] = []
 
-    import brain.openclaw_adapter as adapter_mod
-
     monkeypatch.setattr(
         adapter_mod, "get_config_manager", lambda: _FakeConfigManager(model, api_base),
     )
@@ -78,7 +76,7 @@ def test_magic_intent_client_disables_thinking(monkeypatch, model, api_base, exp
 
     monkeypatch.setattr(adapter_mod, "create_chat_llm_async", _capturing_factory)
 
-    adapter = OpenClawAdapter.__new__(OpenClawAdapter)
+    adapter = adapter_mod.OpenClawAdapter.__new__(adapter_mod.OpenClawAdapter)
     result = asyncio.run(adapter._classify_magic_intent_with_llm("帮我停下来"))
 
     assert result == {"is_magic_intent": False, "command": None, "source": "llm"}

--- a/tests/unit/test_magic_intent_thinking.py
+++ b/tests/unit/test_magic_intent_thinking.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Magic-intent classification must run thinking-off.
+
+It sits on the user path behind a 10s timeout (``brain/openclaw_adapter.py``),
+so a thinking-default model — official DeepSeek V4, GLM, Kimi, Doubao — would
+burn the whole window and fall back to the rule layer on every dispatch. The
+regression this guards is a one-word one: ``extra_body=None`` SKIPS the
+factory's provider-aware resolution and keeps the model's native behavior,
+which is the opposite of what this call site wants.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from brain.openclaw_adapter import OpenClawAdapter
+
+
+class _FakeConfigManager:
+    def __init__(self, model: str, base_url: str):
+        self._model = model
+        self._base_url = base_url
+
+    async def aget_model_api_config(self, feature: str) -> dict[str, Any]:
+        assert feature == "summary"
+        return {
+            "model": self._model,
+            "base_url": self._base_url,
+            "api_key": "test-key",
+            "provider_type": None,
+        }
+
+
+@pytest.mark.parametrize(
+    "model, api_base, expected",
+    [
+        # thinking.type 方言（GLM / Kimi / Doubao；官方 DeepSeek V4 登记后同此列）
+        ("glm-5.2", "https://open.bigmodel.cn/api/paas/v4", {"thinking": {"type": "disabled"}}),
+        ("kimi-k3", "https://api.moonshot.cn/v1", {"thinking": {"type": "disabled"}}),
+        # enable_thinking 方言（DashScope / SiliconFlow）
+        ("qwen3.7-flash", "https://dashscope.aliyuncs.com/compatible-mode/v1", {"enable_thinking": False}),
+        # 未登记的模型：没有可下发的方言，保持空（不能瞎猜一个形状发过去）
+        ("some-unregistered-model", "https://example.com/v1", {}),
+    ],
+)
+def test_magic_intent_client_disables_thinking(monkeypatch, model, api_base, expected):
+    """The client built for magic-intent classification carries thinking-off.
+
+    Deliberately goes through the real ``create_chat_llm_async`` rather than
+    stubbing it: the thinking-off dialect is resolved inside the factory from
+    the model name, so a stub would only show that the call site passed nothing
+    and prove nothing about what actually reaches the wire.
+    """
+    captured: list[Any] = []
+
+    import brain.openclaw_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod, "get_config_manager", lambda: _FakeConfigManager(model, api_base),
+    )
+
+    real_factory = adapter_mod.create_chat_llm_async
+
+    async def _capturing_factory(*args: Any, **kwargs: Any):
+        llm = await real_factory(*args, **kwargs)
+        captured.append(llm)
+
+        class _Resp:
+            content = '{"is_magic_intent": false, "command": null}'
+
+        async def _fake_ainvoke(_messages, **_kw):
+            return _Resp()
+
+        llm.ainvoke = _fake_ainvoke
+        return llm
+
+    monkeypatch.setattr(adapter_mod, "create_chat_llm_async", _capturing_factory)
+
+    adapter = OpenClawAdapter.__new__(OpenClawAdapter)
+    result = asyncio.run(adapter._classify_magic_intent_with_llm("帮我停下来"))
+
+    assert result == {"is_magic_intent": False, "command": None, "source": "llm"}
+    assert len(captured) == 1
+    assert captured[0].extra_body == expected


### PR DESCRIPTION
## 改动概述 / Summary

magic 意图分类（「用户这句话是不是 `/stop` `/new` 这类魔法命令」）跑在用户路径上，10s 超时，却把思考开着。改成关思考。

[`brain/openclaw_adapter.py:905`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/brain/openclaw_adapter.py#L905) 的 `_classify_magic_intent_with_llm` 传了 `extra_body=None`。这个值在 `create_chat_llm` 里的语义是**跳过**工厂按模型名的解析、保留模型原生行为（见 `utils/llm_client/factory.py` 的 docstring），对 GLM / Kimi / Doubao / 官方 DeepSeek V4 这些默认开思考的模型，等于把思考开着送进一个 10 秒窗口。

后果不是崩，是白等：超时后异常被 `_classify_magic_intent_with_llm` 自己的 try/except 吞掉、回落到 `_classify_magic_intent_with_rules`，所以功能正常——但 [`brain/task_executor.py:2043`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/brain/task_executor.py#L2043) 是 inline `await` 的，每次派单先白烧 10 秒。分类任务本身是二选一判断，也用不上思考。

改法是删掉 `extra_body=None` 这一行（不传 ≠ 传 None），让工厂解析出各家的关思考方言。回落行为、超时、重试逻辑都没动。

触发条件是 `qwenpaw_available` 且用户消息无附件，不是每轮都走。

## 回归报告 / Regression Report

不适用（`brain/` 不在 `check_pr_report.py` 的 `WATCHED_PREFIXES` 内）。

## 测试 / Testing

新增 `tests/unit/test_magic_intent_thinking.py`：走真实 `create_chat_llm_async`（不打桩工厂——打桩只能看到调用点传了什么，看不到关思考有没有真的落到客户端上），断言构造出来的客户端身上的最终 `extra_body`：

- `thinking.type` 方言：`glm-5.2`、`kimi-k3` → `{"thinking": {"type": "disabled"}}`
- `enable_thinking` 方言：`qwen3.7-flash` → `{"enable_thinking": False}`
- 未登记的模型 → `{}`（没有可下发的方言，不瞎猜一个形状发过去）

变异验证：把 `extra_body=None` 加回去，三条方言用例全红，未登记那条正确保持绿。

```
uv run pytest tests/unit/test_magic_intent_thinking.py tests/unit/test_zh_tw_input_parity.py tests/unit/test_providers.py -q
→ 465 passed, 6 skipped
uv run ruff check brain/openclaw_adapter.py tests/unit/test_magic_intent_thinking.py → All checks passed
uv run python scripts/check_docstring_no_cjk.py --base origin/main → 通过
```

## 相关

同源问题的另一面在 #2888：官方 DeepSeek V4 没登记进 `MODELS_EXTRA_BODY_MAP`，导致包括记忆压缩在内的所有链路思考常开。那个 PR 合了之后，本 PR 的机制会自动把官方 DeepSeek V4 也覆盖进来（不需要再改这里）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 意图分类会根据所选模型和服务商自动应用禁用思考模式的配置，提升分类行为的一致性。
  - 对未登记的模型保持默认配置，不影响现有分类流程。

- **测试**
  - 新增测试，覆盖不同模型配置下的思考模式参数、客户端创建次数及意图分类结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->