### PR TITLE
fix(plugin-cli): 隔离 init 测试读到的 GitHub Actions 环境变量（修 main CI 红）

### DIFF
--- a/plugin/tests/unit/test_neko_plugin_cli_init.py
+++ b/plugin/tests/unit/test_neko_plugin_cli_init.py
@@ -16,6 +16,19 @@ from plugin.neko_plugin_cli.paths import CliDefaults
 pytestmark = pytest.mark.plugin_unit
 
 
+@pytest.fixture(autouse=True)
+def _isolate_github_actions_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the release checks from reading the CI job's own repo and ref.
+
+    On a pull-request run ``GITHUB_REF_NAME`` is ``<pr>/merge`` and
+    ``GITHUB_REPOSITORY`` is this repository, so a market-release check that
+    falls back to the environment reports a tag/version mismatch against the
+    fixture plugin. Tests that exercise those variables set them explicitly.
+    """
+    for name in ("GITHUB_REPOSITORY", "GITHUB_REF_NAME", "GITHUB_REF"):
+        monkeypatch.delenv(name, raising=False)
+
+
 def _git(repo: Path, *args: str) -> str:
     completed = subprocess.run(
         ["git", *args],


### PR DESCRIPTION
## 改动概述 / Summary

main 的 `Plugin pytest (Windows)` 从 #2853 合并起一直红，两条用例：

- `test_init_and_market_check_accept_case_equivalent_github_remote`
- `test_market_release_check_uses_origin_instead_of_local_directory_name`

根因是 market-release 检查在参数缺省时会回落读环境变量
（`release_cmd.py:182` 读 `GITHUB_REPOSITORY`，`:235` 读 `GITHUB_REF_NAME`）。
PR 运行里 `GITHUB_REF_NAME` 是 `<pr>/merge`、`GITHUB_REPOSITORY` 是本仓库，
检查于是拿 CI 自己的 ref/repo 去跟夹具插件的 `plugin.toml` 比对，报出：

- `release tag 2896/merge does not match plugin.toml version 0.1.0`
- `market repository name must be n.e.k.o_plugin_identity_demo, got N.E.K.O`

本地跑没有这些变量，所以一直是绿的 —— 只在 CI 红。

修法是给该测试模块加 autouse fixture，清掉 `GITHUB_REPOSITORY` /
`GITHUB_REF_NAME` / `GITHUB_REF`。需要验证这些变量的用例自己 `setenv`，
在 fixture 之后生效，不受影响。

## 回归报告 / Regression Report

不适用（未修改 app/、main_logic/ 或 memory/）。

## 不拆分理由 / Why Not Split

不适用。

## 测试 / Testing

- 模拟 CI 环境
  `GITHUB_REF_NAME=2896/merge GITHUB_REPOSITORY=Project-N-E-K-O/N.E.K.O`：
  修前 2 failed / 33 passed，修后 37 passed。
- 不带环境变量：37 passed（没有把原本的覆盖改掉）。
- 同批次引入的 `test_neko_plugin_cli_publish.py`、`test_neko_plugin_cli_cli.py`、
  `test_neko_plugin_cli_deps.py`、`test_neko_plugin_cli_workflow.py`
  在同样的环境变量下 115 passed，确认没有同类泄漏。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 改进初始化命令相关测试的环境隔离。
  * 测试运行前会清理可能影响结果的 CI 仓库与引用环境变量，提升测试结果的稳定性与可重复性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->