### PR TITLE
修复默认猫咪形态完成教程并切换为猫娘后锁定开关丢失的问题，并补充浮动控件自愈回归测试

### DIFF
--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -111,6 +111,70 @@
         return true;
     }
 
+    I.ensureActiveModelOverlayControls = function ensureActiveModelOverlayControls(prefix) {
+        const normalizedPrefix = String(prefix || '').trim().toLowerCase();
+        const managers = {
+            live2d: window.live2dManager,
+            vrm: window.vrmManager,
+            mmd: window.mmdManager,
+            pngtuber: window.pngtuberManager
+        };
+        const manager = managers[normalizedPrefix];
+        const controls = () => ({
+            floatingButtons: document.getElementById(`${normalizedPrefix}-floating-buttons`),
+            lockIcon: document.getElementById(`${normalizedPrefix}-lock-icon`)
+        });
+        if (!manager || !Object.prototype.hasOwnProperty.call(managers, normalizedPrefix)) {
+            return controls();
+        }
+
+        const currentModel = normalizedPrefix === 'live2d'
+            ? (typeof manager.getCurrentModel === 'function' ? manager.getCurrentModel() : manager.currentModel)
+            : (normalizedPrefix === 'pngtuber' ? manager.image : manager.currentModel);
+        let currentControls = controls();
+
+        try {
+            if (
+                !currentControls.floatingButtons
+                && currentModel
+                && currentModel.destroyed !== true
+                && typeof manager.setupFloatingButtons === 'function'
+            ) {
+                if (normalizedPrefix === 'live2d') {
+                    manager.setupFloatingButtons(currentModel);
+                } else {
+                    manager.setupFloatingButtons();
+                }
+                currentControls = controls();
+            }
+
+            if (!currentControls.lockIcon && currentModel && currentModel.destroyed !== true) {
+                if (
+                    (normalizedPrefix === 'live2d' || normalizedPrefix === 'pngtuber')
+                    && typeof manager.setupHTMLLockIcon === 'function'
+                ) {
+                    if (normalizedPrefix === 'live2d') {
+                        manager.setupHTMLLockIcon(currentModel);
+                    } else {
+                        manager.setupHTMLLockIcon();
+                    }
+                } else if (
+                    (normalizedPrefix === 'vrm' || normalizedPrefix === 'mmd')
+                    && typeof manager.setupFloatingButtons === 'function'
+                ) {
+                    // VRM / MMD 在 setupFloatingButtons 内创建锁图标；工具栏尚存但锁图标被
+                    // 教程或模型切换清掉时，也必须重建整组 overlay，不能只检查工具栏。
+                    manager.setupFloatingButtons();
+                }
+                currentControls = controls();
+            }
+        } catch (error) {
+            console.warn(`[App] ${normalizedPrefix} 浮动控件自愈失败:`, error);
+        }
+
+        return currentControls;
+    }
+
     function restoreLive2DDisplaySurface(reason) {
         const preserveAvatarCornerPeekOpacity = window.nekoYuiGuideAvatarCornerPeekActive === true;
         const preserveYuiGuidePreparing = shouldPreserveYuiGuideLive2DPreparing();
@@ -268,24 +332,11 @@
             container.style.display !== 'none' &&
             getComputedStyle(container).display !== 'none';
 
-        // 检查Live2D浮动按钮是否存在，如果不存在则重新创建
-        let floatingButtons = document.getElementById('live2d-floating-buttons');
+        // 教程临时模型与用户模型互换时，工具栏和锁图标可能只残留其中一个；
+        // 按当前模型分别校验并自愈，避免从猫咪形态回来后永久缺少锁开关。
+        const overlayControls = I.ensureActiveModelOverlayControls('live2d');
+        const floatingButtons = overlayControls.floatingButtons;
         console.log('[showLive2d] 检查浮动按钮 - 存在:', !!floatingButtons, 'live2dManager:', !!window.live2dManager);
-
-        if (!floatingButtons && window.live2dManager) {
-            console.log('[showLive2d] Live2D浮动按钮不存在，准备重新创建');
-            const currentModel = window.live2dManager.getCurrentModel();
-            console.log('[showLive2d] currentModel:', !!currentModel, 'setupFloatingButtons:', typeof window.live2dManager.setupFloatingButtons);
-
-            if (currentModel && typeof window.live2dManager.setupFloatingButtons === 'function') {
-                console.log('[showLive2d] 调用 setupFloatingButtons');
-                window.live2dManager.setupFloatingButtons(currentModel);
-                floatingButtons = document.getElementById('live2d-floating-buttons');
-                console.log('[showLive2d] 创建后按钮存在:', !!floatingButtons);
-            } else {
-                console.warn('[showLive2d] 无法重新创建按钮 - currentModel或setupFloatingButtons不可用');
-            }
-        }
 
         // 确保浮动按钮显示
         if (!preserveYuiGuidePreparing && !preserveYuiGuideAvatarMotion && floatingButtons) {
@@ -298,7 +349,7 @@
             floatingButtons.style.setProperty('pointer-events', 'auto');
         }
 
-        const lockIcon = document.getElementById('live2d-lock-icon');
+        const lockIcon = overlayControls.lockIcon || document.getElementById('live2d-lock-icon');
         if (!preserveYuiGuidePreparing && !preserveYuiGuideAvatarMotion && lockIcon) {
             lockIcon.style.removeProperty('display');
             lockIcon.style.removeProperty('visibility');
@@ -826,15 +877,9 @@
                 }
 
                 // 检查VRM浮动按钮是否存在
-                let vrmFloatingButtons = document.getElementById('vrm-floating-buttons');
+                const vrmOverlayControls = I.ensureActiveModelOverlayControls('vrm');
+                const vrmFloatingButtons = vrmOverlayControls.floatingButtons;
                 console.log('[showCurrentModel] VRM浮动按钮存在:', !!vrmFloatingButtons, 'vrmManager存在:', !!window.vrmManager);
-
-                if (!vrmFloatingButtons && window.vrmManager && typeof window.vrmManager.setupFloatingButtons === 'function') {
-                    console.log('[showCurrentModel] VRM浮动按钮不存在，重新创建');
-                    window.vrmManager.setupFloatingButtons();
-                    vrmFloatingButtons = document.getElementById('vrm-floating-buttons');
-                    console.log('[showCurrentModel] 创建后VRM浮动按钮存在:', !!vrmFloatingButtons);
-                }
 
                 if (vrmFloatingButtons) {
                     if (isMobileViewport()) {
@@ -848,7 +893,7 @@
                     }
                 }
 
-                const vrmLockIcon = document.getElementById('vrm-lock-icon');
+                const vrmLockIcon = vrmOverlayControls.lockIcon || document.getElementById('vrm-lock-icon');
                 if (vrmLockIcon) {
                     if (isMobileViewport()) {
                         vrmLockIcon.style.removeProperty('display');
@@ -956,11 +1001,8 @@
                 if (live2dContainerMmd) { live2dContainerMmd.style.display = 'none'; live2dContainerMmd.classList.add('hidden'); }
 
                 // 显示 MMD 浮动按钮
-                let mmdFloatingButtons = document.getElementById('mmd-floating-buttons');
-                if (!mmdFloatingButtons && window.mmdManager && typeof window.mmdManager.setupFloatingButtons === 'function') {
-                    window.mmdManager.setupFloatingButtons();
-                    mmdFloatingButtons = document.getElementById('mmd-floating-buttons');
-                }
+                const mmdOverlayControls = I.ensureActiveModelOverlayControls('mmd');
+                const mmdFloatingButtons = mmdOverlayControls.floatingButtons;
                 if (mmdFloatingButtons) {
                     const isMmdMobile = typeof window.isMobileWidth === 'function'
                         ? window.isMobileWidth()
@@ -1067,6 +1109,7 @@
                 if (window.pngtuberManager && typeof window.pngtuberManager.setupFloatingButtons === 'function') {
                     window.pngtuberManager.setupFloatingButtons();
                 }
+                I.ensureActiveModelOverlayControls('pngtuber');
             } else {
                 // 显示 Live2D 模型
                 I.showLive2d();

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -126,13 +126,15 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
     }
 
     const existingLockIcon = document.getElementById('live2d-lock-icon');
-    if (existingLockIcon) {
-        if (this._lockIconTicker && this.pixi_app?.ticker) {
-            this.pixi_app.ticker.remove(this._lockIconTicker);
-            this._lockIconTicker = null;
+    // 教程可能只移除 DOM、保留 manager 上的 ticker 引用。重建前必须独立摘除旧
+    // ticker，不能把清理条件绑定到旧锁图标仍存在，否则会留下永久的逐帧回调。
+    if (this._lockIconTicker) {
+        if (this.pixi_app?.ticker) {
+            try { this.pixi_app.ticker.remove(this._lockIconTicker); } catch (_) {}
         }
-        existingLockIcon.remove();
+        this._lockIconTicker = null;
     }
+    if (existingLockIcon) existingLockIcon.remove();
 
     const lockIcon = document.createElement('div');
     lockIcon.id = 'live2d-lock-icon';

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -19,6 +19,7 @@ def _read_avatar_ui_buttons_source() -> str:
 
 
 LIVE2D_UI_BUTTONS_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-ui-buttons.js"
+MODEL_DISPLAY_PATH = PROJECT_ROOT / "static" / "app" / "app-ui" / "model-display.js"
 APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app" / "app-interpage"
 INDEX_CSS_PATH = PROJECT_ROOT / "static" / "css" / "index.css"
 
@@ -126,6 +127,80 @@ def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():
     assert "window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockTop, actualLockIconSize)" in lock_icon_block
     assert "right: clampedLeft + actualLockIconSize" in lock_icon_block
     assert "bottom: clampedTop + actualLockIconSize" in lock_icon_block
+
+
+def test_model_display_rebuilds_a_missing_lock_icon_when_the_toolbar_survives():
+    source = MODEL_DISPLAY_PATH.read_text(encoding="utf-8")
+    for prefix in ("live2d", "vrm", "mmd", "pngtuber"):
+        assert f"I.ensureActiveModelOverlayControls('{prefix}')" in source
+
+    script = f"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+const source = fs.readFileSync({json.dumps(str(MODEL_DISPLAY_PATH))}, 'utf8');
+const elements = new Map([
+  ['live2d-floating-buttons', {{ id: 'live2d-floating-buttons' }}],
+  ['vrm-floating-buttons', {{ id: 'vrm-floating-buttons' }}],
+  ['mmd-floating-buttons', {{ id: 'mmd-floating-buttons' }}],
+  ['pngtuber-floating-buttons', {{ id: 'pngtuber-floating-buttons' }}],
+]);
+const calls = {{ live2dToolbar: 0, live2dLock: 0, vrm: 0, mmd: 0, pngToolbar: 0, pngLock: 0 }};
+const document = {{
+  getElementById(id) {{ return elements.get(id) || null; }},
+}};
+const window = {{
+  appUi: {{}},
+  __appUiParts: {{ mod: {{}} }},
+  live2dManager: {{
+    getCurrentModel() {{ return {{ destroyed: false }}; }},
+    setupFloatingButtons() {{ calls.live2dToolbar += 1; }},
+    setupHTMLLockIcon() {{
+      calls.live2dLock += 1;
+      elements.set('live2d-lock-icon', {{ id: 'live2d-lock-icon' }});
+    }},
+  }},
+  vrmManager: {{
+    currentModel: {{ destroyed: false }},
+    setupFloatingButtons() {{
+      calls.vrm += 1;
+      elements.set('vrm-lock-icon', {{ id: 'vrm-lock-icon' }});
+    }},
+  }},
+  mmdManager: {{
+    currentModel: {{ destroyed: false }},
+    setupFloatingButtons() {{
+      calls.mmd += 1;
+      elements.set('mmd-lock-icon', {{ id: 'mmd-lock-icon' }});
+    }},
+  }},
+  pngtuberManager: {{
+    image: {{ destroyed: false }},
+    setupFloatingButtons() {{ calls.pngToolbar += 1; }},
+    setupHTMLLockIcon() {{
+      calls.pngLock += 1;
+      elements.set('pngtuber-lock-icon', {{ id: 'pngtuber-lock-icon' }});
+    }},
+  }},
+}};
+window.window = window;
+window.document = document;
+vm.runInNewContext(source, {{ window, document, console, Object, String }});
+
+for (const prefix of ['live2d', 'vrm', 'mmd', 'pngtuber']) {{
+  const controls = window.__appUiParts.ensureActiveModelOverlayControls(prefix);
+  if (!controls.floatingButtons || !controls.lockIcon) {{
+    throw new Error(prefix + ' overlay controls were not repaired');
+  }}
+}}
+if (calls.live2dToolbar !== 0 || calls.pngToolbar !== 0) {{
+  throw new Error('an intact toolbar should not be rebuilt');
+}}
+if (calls.live2dLock !== 1 || calls.vrm !== 1 || calls.mmd !== 1 || calls.pngLock !== 1) {{
+  throw new Error('missing lock icons were not rebuilt exactly once: ' + JSON.stringify(calls));
+}}
+"""
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_model_lock_icons_ignore_pointer_input_while_avatar_overlays_overlap():

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -129,6 +129,65 @@ def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():
     assert "bottom: clampedTop + actualLockIconSize" in lock_icon_block
 
 
+def test_live2d_lock_icon_repair_detaches_an_orphaned_ticker():
+    script = f"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+const source = fs.readFileSync({json.dumps(str(LIVE2D_UI_BUTTONS_PATH))}, 'utf8');
+const start = source.indexOf('Live2DManager.prototype.setupHTMLLockIcon = function(model) {{');
+const end = source.indexOf('Live2DManager.prototype.setupFloatingButtons = function(model) {{', start);
+const setupSource = source.slice(start, end);
+const elements = new Map();
+const makeElement = (tagName) => ({{
+  tagName,
+  dataset: {{}},
+  style: {{}},
+  appendChild() {{}},
+  addEventListener() {{}},
+  remove() {{ if (this.id) elements.delete(this.id); }},
+}});
+const canvas = makeElement('canvas');
+const document = {{
+  body: {{ appendChild(element) {{ elements.set(element.id, element); }} }},
+  createElement: makeElement,
+  getElementById(id) {{
+    if (id === 'live2d-canvas') return canvas;
+    if (id === 'chat-container') return {{}};
+    return elements.get(id) || null;
+  }},
+  querySelectorAll() {{ return []; }},
+}};
+const removed = [];
+const added = [];
+const oldTicker = () => {{}};
+function Live2DManager() {{}}
+const window = {{ isViewerMode: false }};
+vm.runInNewContext(setupSource, {{ Live2DManager, document, window, console, Date, Object }});
+
+const manager = new Live2DManager();
+manager.isLocked = false;
+manager._lockIconTicker = oldTicker;
+manager.pixi_app = {{ ticker: {{
+  remove(ticker) {{ removed.push(ticker); }},
+  add(ticker) {{ added.push(ticker); }},
+}} }};
+manager.setLocked = () => {{}};
+manager.setupHTMLLockIcon({{ parent: true }});
+
+if (removed.length !== 1 || removed[0] !== oldTicker) {{
+  throw new Error('the orphaned Live2D lock ticker was not removed');
+}}
+if (added.length !== 1 || manager._lockIconTicker !== added[0] || added[0] === oldTicker) {{
+  throw new Error('the replacement Live2D lock ticker was not installed exactly once');
+}}
+if (!document.getElementById('live2d-lock-icon')) {{
+  throw new Error('the Live2D lock icon was not rebuilt');
+}}
+"""
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def test_model_display_rebuilds_a_missing_lock_icon_when_the_toolbar_survives():
     source = MODEL_DISPLAY_PATH.read_text(encoding="utf-8")
     for prefix in ("live2d", "vrm", "mmd", "pngtuber"):

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -192,11 +192,17 @@ for (const prefix of ['live2d', 'vrm', 'mmd', 'pngtuber']) {{
     throw new Error(prefix + ' overlay controls were not repaired');
   }}
 }}
+for (const prefix of ['live2d', 'vrm', 'mmd', 'pngtuber']) {{
+  const controls = window.__appUiParts.ensureActiveModelOverlayControls(prefix);
+  if (!controls.floatingButtons || !controls.lockIcon) {{
+    throw new Error(prefix + ' repaired overlay controls were not retained');
+  }}
+}}
 if (calls.live2dToolbar !== 0 || calls.pngToolbar !== 0) {{
   throw new Error('an intact toolbar should not be rebuilt');
 }}
 if (calls.live2dLock !== 1 || calls.vrm !== 1 || calls.mmd !== 1 || calls.pngLock !== 1) {{
-  throw new Error('missing lock icons were not rebuilt exactly once: ' + JSON.stringify(calls));
+  throw new Error('repeated checks must not accumulate overlay rebuilds: ' + JSON.stringify(calls));
 }}
 """
     result = _run_node_harness(script)


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复默认猫咪形态完成教程并切换为猫娘后锁定开关丢失的问题，并补充浮动控件自愈回归测试

## 测试 / Testing

尝试复现步骤确认已经修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改善 Live2D、VRM、MMD 和 PNGTuber 模型的浮动控件恢复机制。
  * 当锁定图标或相关控件缺失时，系统会自动重新创建，避免模型显示异常。
  * 优化控件重建流程，减少重复创建及残留状态导致的问题。

* **测试**
  * 增加对四类模型控件自动恢复行为的验证。
  * 增加 Live2D 控件异常清理与重建场景的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->