### PR TITLE
fix: make survey modal interactive on desktop

### DIFF
--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -1059,6 +1059,7 @@ I.mod = window.appUi;
 
             const overlay = document.createElement('div');
             overlay.id = 'survey-modal-overlay';
+            overlay.className = 'modal-overlay';
             overlay.style.cssText = `
                 position: fixed; inset: 0;
                 background: rgba(0,0,0,0.55);

--- a/tests/unit/test_survey_modal_static.py
+++ b/tests/unit/test_survey_modal_static.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SURVEY_UI_PATH = PROJECT_ROOT / "static/app/app-ui/bootstrap-goodbye-and-toasts.js"
+
+
+def _survey_modal_source() -> str:
+    source = SURVEY_UI_PATH.read_text(encoding="utf-8")
+    return source.split("function showSurveyModal(survey) {", 1)[1].split(
+        "I.mod.showSurveyModal = showSurveyModal;", 1
+    )[0]
+
+
+def test_survey_overlay_uses_shared_full_window_modal_contract():
+    source = _survey_modal_source()
+
+    overlay_id = "overlay.id = 'survey-modal-overlay';"
+    modal_contract = "overlay.className = 'modal-overlay';"
+    overlay_style = "overlay.style.cssText = `"
+    append_overlay = "document.body.appendChild(overlay);"
+
+    assert overlay_id in source
+    assert modal_contract in source
+    assert overlay_style in source
+    assert append_overlay in source
+    assert (
+        source.index(overlay_id)
+        < source.index(modal_contract)
+        < source.index(overlay_style)
+        < source.index(append_overlay)
+    )
+
+    # The shared class is an input-routing contract, not a replacement for the
+    # survey's existing presentation or teardown behavior.
+    for preserved_behavior in (
+        "position: fixed; inset: 0;",
+        "pointer-events: auto;",
+        "overlay.remove();",
+        "if (needRestoreBodyPE) document.body.style.pointerEvents = bodyPE;",
+    ):
+        assert preserved_behavior in source
+
+    # Keep platform policy in the desktop host. The web UI should expose the
+    # same modal semantics to browsers and every packaged desktop platform.
+    for platform_probe in ("process.platform", "navigator.platform", "navigator.userAgent"):
+        assert platform_probe not in source


### PR DESCRIPTION
## 改动概述 / Summary

- 将版本问卷 overlay 标记为项目现有的共享 `.modal-overlay`。
- 使 N.E.K.O.-PC 在 Linux X11 下将问卷识别为整窗交互 surface，避免鼠标事件穿透到桌面应用。
- 增加静态回归测试，锁定共享 modal 契约、既有样式与关闭清理行为，并禁止在 Web UI 中引入平台分支。

根因是问卷使用独立的 `#survey-modal-overlay`，但没有沿用通用对话框的 `.modal-overlay` 契约。N.E.K.O.-PC 的 X11 ShapeInput 已识别通用契约，因此修复不需要修改桌面端或增加操作系统判断。

## 回归报告 / Regression Report

不适用。本 PR 未修改高风险 Python 模块。

## 不拆分理由 / Why Not Split

不适用。本 PR 仅包含一处产品代码修改和一个对应回归测试。

## 测试 / Testing

- `uv run pytest -q tests/unit/test_survey_modal_static.py tests/unit/test_survey_locale_gate.py tests/unit/test_yui_guide_director_static.py`：52 passed
- `node --check static/app/app-ui/bootstrap-goodbye-and-toasts.js`
- `git diff --check`
- KDE / Electron X11 真实运行验证：
  - 打开问卷后 ShapeInput 切换为 `full-window-surface`，原因是 `selector:.modal-overlay`。
  - 鼠标命中探针返回 `inHitRegion:true`。
  - 关闭问卷后恢复精确输入区域，`fullWindowInputReason:null`。
- 核对 N.E.K.O.-PC 当前版本及最初 0.8.3 AppImage 所用的 `8afccfd0`：二者均已识别 `.modal-overlay`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 调查问卷弹窗现支持通用的全窗口模态框样式，同时保留原有兼容性标识。
  - 优化弹窗的显示与清理行为，并确保不受特定桌面平台检测逻辑影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->