### PR TITLE
fix(web-search): restore resilient Baidu crawling

### DIFF
--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -259,6 +259,10 @@ class WebSearchPlugin(NekoPluginBase):
         self._client_loop: Optional[asyncio.AbstractEventLoop] = None
         self._user_agent = _UA
         self._coordinator = SearchCoordinator()
+        self._coordinators: Dict[str, SearchCoordinator] = {
+            "baidu": self._coordinator,
+            "duckduckgo": SearchCoordinator(),
+        }
 
     def _get_client(self) -> httpx.AsyncClient:
         # 宿主对 startup / 命令循环 / shutdown 分别 asyncio.run()（plugin/core/host.py），
@@ -287,31 +291,30 @@ class WebSearchPlugin(NekoPluginBase):
         )
         self._backend = _select_backend(configured_backend, self._country)
         self._is_cn = self._backend == "baidu"
-        min_interval = (
-            defs["ddg_min_interval"]
-            if self._backend == "duckduckgo"
-            else defs["min_interval"]
-        )
-        cooldown = (
-            defs["ddg_cooldown"]
-            if self._backend == "duckduckgo"
-            else defs["cooldown"]
-        )
-        max_cooldown = (
-            defs["ddg_max_cooldown"]
-            if self._backend == "duckduckgo"
-            # Progressive cooldown is DDG-specific; Baidu keeps a fixed delay.
-            else defs["cooldown"]
-        )
-        self._coordinator = SearchCoordinator(
-            ttl_seconds=defs["cache_ttl"],
-            stale_seconds=defs["stale_ttl"],
-            max_entries=defs["cache_entries"],
-            min_interval_seconds=min_interval,
-            cooldown_seconds=cooldown,
-            max_cooldown_seconds=max_cooldown,
-            queue_wait_seconds=defs["queue_wait"],
-        )
+        common_coordinator_options = {
+            "ttl_seconds": defs["cache_ttl"],
+            "stale_seconds": defs["stale_ttl"],
+            "max_entries": defs["cache_entries"],
+            "queue_wait_seconds": defs["queue_wait"],
+        }
+        self._coordinators = {
+            "baidu": SearchCoordinator(
+                **common_coordinator_options,
+                min_interval_seconds=defs["min_interval"],
+                cooldown_seconds=defs["cooldown"],
+                # Baidu uses a fixed cooldown; DDG retains progressive backoff.
+                max_cooldown_seconds=defs["cooldown"],
+            ),
+            "duckduckgo": SearchCoordinator(
+                **common_coordinator_options,
+                min_interval_seconds=defs["ddg_min_interval"],
+                cooldown_seconds=defs["ddg_cooldown"],
+                max_cooldown_seconds=defs["ddg_max_cooldown"],
+            ),
+        }
+        # Keep the historical attribute for integrations that inspect the
+        # primary backend coordinator directly.
+        self._coordinator = self._coordinators[self._backend]
 
         self.logger.info(
             "WebSearch started: country={}, configured_backend={}, backend={}",
@@ -398,43 +401,79 @@ class WebSearchPlugin(NekoPluginBase):
         timeout: float,
     ) -> List[Dict[str, str]]:
         defs = self._defaults()
-        backend = self._backend
-        key = (backend, " ".join(query.casefold().split()), max_results)
+        primary_backend = self._backend
+        normalized_query = " ".join(query.casefold().split())
+        attempted_backends = [primary_backend]
 
-        async def fetch() -> List[Dict[str, str]]:
-            client = self._get_client()
-            retry_base_delay = (
-                defs["ddg_retry_base_delay"]
-                if backend == "duckduckgo"
-                else defs["retry_base_delay"]
-            )
-            kwargs = {
-                "timeout": timeout,
-                "user_agent": self._user_agent,
-                "retry_attempts": defs["retry_attempts"],
-                "retry_base_delay": retry_base_delay,
-            }
-            if backend == "baidu":
-                return await _search_baidu(client, query, max_results, **kwargs)
+        def coordinator_for(backend: str) -> SearchCoordinator:
+            coordinators = getattr(self, "_coordinators", None)
+            if isinstance(coordinators, dict) and backend in coordinators:
+                return coordinators[backend]
+            return self._coordinator
 
-            try:
-                return await _search_ddg_html(client, query, max_results, **kwargs)
-            except Exception as e:
-                if should_skip_fallback(e):
-                    raise
-                self.logger.warning("DDG html failed, trying lite: {}", e)
-            await asyncio.sleep(
-                max(defs["ddg_fallback_delay"], defs["ddg_min_interval"])
-            )
-            return await _search_ddg_lite(client, query, max_results, **kwargs)
+        async def run_backend(backend: str) -> List[Dict[str, str]]:
+            key = (backend, normalized_query, max_results)
+
+            async def fetch() -> List[Dict[str, str]]:
+                client = self._get_client()
+                retry_base_delay = (
+                    defs["ddg_retry_base_delay"]
+                    if backend == "duckduckgo"
+                    else defs["retry_base_delay"]
+                )
+                kwargs = {
+                    "timeout": timeout,
+                    "user_agent": self._user_agent,
+                    "retry_attempts": defs["retry_attempts"],
+                    "retry_base_delay": retry_base_delay,
+                }
+                if backend == "baidu":
+                    return await _search_baidu(client, query, max_results, **kwargs)
+
+                try:
+                    return await _search_ddg_html(client, query, max_results, **kwargs)
+                except Exception as e:
+                    if should_skip_fallback(e):
+                        raise
+                    self.logger.warning("DDG html failed, trying lite: {}", e)
+                await asyncio.sleep(
+                    max(defs["ddg_fallback_delay"], defs["ddg_min_interval"])
+                )
+                return await _search_ddg_lite(client, query, max_results, **kwargs)
+
+            return await coordinator_for(backend).run(key, fetch)
 
         try:
             async with asyncio.timeout(defs["total_timeout"]):
-                return await self._coordinator.run(key, fetch)
+                try:
+                    return await run_backend(primary_backend)
+                except Exception as primary_error:
+                    if primary_backend != "baidu":
+                        raise
+                    attempted_backends.append("duckduckgo")
+                    self.logger.warning(
+                        "Baidu search failed ({}); trying DuckDuckGo",
+                        type(primary_error).__name__,
+                    )
+                    try:
+                        return await run_backend("duckduckgo")
+                    except Exception:
+                        # Preserve the primary error because it describes the
+                        # selected backend and has already updated its cooldown.
+                        raise primary_error
         except TimeoutError:
-            stale = self._coordinator.stale(key)
-            if stale is not None:
-                return stale
+            # The coordinator cancels an orphaned shared fetch immediately.
+            # At this point asyncio.timeout has restored this task's normal
+            # cancellation state, so a loop turn can safely finish the fetch's
+            # finally blocks before the plugin entry returns.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            for backend in attempted_backends:
+                stale = coordinator_for(backend).stale(
+                    (backend, normalized_query, max_results)
+                )
+                if stale is not None:
+                    return stale
             raise
 
     @staticmethod

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -399,9 +399,12 @@ class WebSearchPlugin(NekoPluginBase):
         query: str,
         max_results: int,
         timeout: float,
+        backend: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         defs = self._defaults()
-        primary_backend = self._backend
+        primary_backend = (
+            backend if backend in {"baidu", "duckduckgo"} else self._backend
+        )
         normalized_query = " ".join(query.casefold().split())
         attempted_backends = [primary_backend]
 
@@ -506,6 +509,12 @@ class WebSearchPlugin(NekoPluginBase):
                     "description": "最大结果数 (默认 8，最少 3)",
                     "default": 8,
                 },
+                "backend": {
+                    "type": "string",
+                    "enum": ["auto", "baidu", "duckduckgo"],
+                    "description": "搜索后端；通常保持 auto",
+                    "default": "auto",
+                },
             },
             "required": ["query"],
         },
@@ -514,6 +523,7 @@ class WebSearchPlugin(NekoPluginBase):
         self,
         query: str,
         max_results: int = 0,
+        backend: str = "auto",
         **_,
     ):
         if not query or not query.strip():
@@ -532,7 +542,7 @@ class WebSearchPlugin(NekoPluginBase):
         )
 
         try:
-            results = await self._do_text_search(query, max_r, timeout)
+            results = await self._do_text_search(query, max_r, timeout, backend=backend)
         except (SearchBlockedError, SearchBusyError, SearchCooldownError) as e:
             return Err(SdkError(str(e)))
         except Exception as e:
@@ -572,11 +582,23 @@ class WebSearchPlugin(NekoPluginBase):
                     "description": "最大结果数（最少 3）",
                     "default": 5,
                 },
+                "backend": {
+                    "type": "string",
+                    "enum": ["auto", "baidu", "duckduckgo"],
+                    "description": "搜索后端；通常保持 auto",
+                    "default": "auto",
+                },
             },
             "required": ["query"],
         },
     )
-    async def search_summary(self, query: str, max_results: int = 5, **_):
+    async def search_summary(
+        self,
+        query: str,
+        max_results: int = 5,
+        backend: str = "auto",
+        **_,
+    ):
         if not query or not query.strip():
             return Err(SdkError("搜索关键词不能为空"))
 
@@ -586,7 +608,7 @@ class WebSearchPlugin(NekoPluginBase):
         timeout = defs["timeout"]
 
         try:
-            results = await self._do_text_search(query, max_r, timeout)
+            results = await self._do_text_search(query, max_r, timeout, backend=backend)
         except (SearchBlockedError, SearchBusyError, SearchCooldownError) as e:
             return Err(SdkError(str(e)))
         except Exception as e:

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -638,6 +638,11 @@ class WebSearchPlugin(NekoPluginBase):
                         if fallback_budget <= 0:
                             raise primary_error
                         return await run_backend("duckduckgo", fallback_budget)
+                    except TimeoutError:
+                        # Let the outer timeout handler inspect retained results
+                        # from both attempted backends. Replacing this with the
+                        # Baidu error would skip DuckDuckGo's stale cache.
+                        raise
                     except Exception:
                         # Preserve the primary error because it describes the
                         # selected backend and has already updated its cooldown.

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -79,6 +79,21 @@ _GEOIP_PROVIDERS = (
 # Countries that cannot reliably access DuckDuckGo
 _CN_COUNTRIES = frozenset({"CN"})
 _BAIDU_COOKIE_STORE_KEY = "baidu_anonymous_cookies"
+_ERROR_CODE_BLOCKED = "WEB_SEARCH_BACKEND_BLOCKED"
+_ERROR_CODE_BUSY = "WEB_SEARCH_BACKEND_BUSY"
+_ERROR_CODE_COOLDOWN = "WEB_SEARCH_BACKEND_COOLDOWN"
+
+
+def _search_sdk_error(error: Exception) -> SdkError:
+    if isinstance(error, SearchBlockedError):
+        code = _ERROR_CODE_BLOCKED
+    elif isinstance(error, SearchBusyError):
+        code = _ERROR_CODE_BUSY
+    elif isinstance(error, SearchCooldownError):
+        code = _ERROR_CODE_COOLDOWN
+    else:
+        code = None
+    return SdkError(str(error), code=code)
 
 
 def _select_backend(configured: object, country: Optional[str]) -> str:
@@ -762,7 +777,7 @@ class WebSearchPlugin(NekoPluginBase):
         try:
             results = await self._do_text_search(query, max_r, timeout, backend=backend)
         except (SearchBlockedError, SearchBusyError, SearchCooldownError) as e:
-            return Err(SdkError(str(e)))
+            return Err(_search_sdk_error(e))
         except Exception as e:
             # 异常文本可能带完整请求 URL（含 wd= 查询词），只回传类型名，
             # 细节留在本地文件日志里
@@ -828,7 +843,7 @@ class WebSearchPlugin(NekoPluginBase):
         try:
             results = await self._do_text_search(query, max_r, timeout, backend=backend)
         except (SearchBlockedError, SearchBusyError, SearchCooldownError) as e:
-            return Err(SdkError(str(e)))
+            return Err(_search_sdk_error(e))
         except Exception as e:
             self.logger.exception("Search failed (query_len={})", len(query))
             return Err(SdkError(f"搜索失败: {type(e).__name__}"))

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -602,10 +602,16 @@ class WebSearchPlugin(NekoPluginBase):
         max_results: int,
         timeout: float,
         backend: Optional[str] = None,
+        preferred_backend: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         defs = self._defaults()
         requested_backend = backend if backend in {"baidu", "duckduckgo"} else None
-        primary_backend = requested_backend or self._backend
+        hinted_backend = (
+            preferred_backend
+            if preferred_backend in {"baidu", "duckduckgo"}
+            else None
+        )
+        primary_backend = requested_backend or hinted_backend or self._backend
         allow_cross_engine_fallback = (
             primary_backend == "baidu" and requested_backend is None
         )
@@ -769,6 +775,7 @@ class WebSearchPlugin(NekoPluginBase):
         query: str,
         max_results: int = 0,
         backend: str = "auto",
+        preferred_backend: str = "",
         **_,
     ):
         if not query or not query.strip():
@@ -787,7 +794,13 @@ class WebSearchPlugin(NekoPluginBase):
         )
 
         try:
-            results = await self._do_text_search(query, max_r, timeout, backend=backend)
+            results = await self._do_text_search(
+                query,
+                max_r,
+                timeout,
+                backend=backend,
+                preferred_backend=preferred_backend,
+            )
         except (SearchBlockedError, SearchBusyError, SearchCooldownError) as e:
             return Err(_search_sdk_error(e))
         except Exception as e:
@@ -842,6 +855,7 @@ class WebSearchPlugin(NekoPluginBase):
         query: str,
         max_results: int = 5,
         backend: str = "auto",
+        preferred_backend: str = "",
         **_,
     ):
         if not query or not query.strip():
@@ -853,7 +867,13 @@ class WebSearchPlugin(NekoPluginBase):
         timeout = defs["timeout"]
 
         try:
-            results = await self._do_text_search(query, max_r, timeout, backend=backend)
+            results = await self._do_text_search(
+                query,
+                max_r,
+                timeout,
+                backend=backend,
+                preferred_backend=preferred_backend,
+            )
         except (SearchBlockedError, SearchBusyError, SearchCooldownError) as e:
             return Err(_search_sdk_error(e))
         except Exception as e:

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -34,6 +34,7 @@ from ._parsing import (
     is_ddg_blocked,
     is_ddg_no_results,
     parse_baidu_html,
+    parse_baidu_mobile_html,
     parse_ddg_html,
     parse_ddg_lite_html,
 )
@@ -46,12 +47,29 @@ from ._resilience import (
     should_skip_fallback,
 )
 
-_UA = "N.E.K.O-WebSearch/0.1.4 (+https://github.com/Project-N-E-K-O/N.E.K.O)"
+_UA = "N.E.K.O-WebSearch/0.1.5 (+https://github.com/Project-N-E-K-O/N.E.K.O)"
+# Baidu currently answers plain bot-style user agents with a tiny JavaScript
+# redirect shell even after the normal BAIDUID cookie warm-up.  Use a
+# browser-compatible UA for Baidu while retaining the N.E.K.O product token;
+# DuckDuckGo continues to receive the honest crawler UA above.
+_BAIDU_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36 "
+    "N.E.K.O-WebSearch/0.1.5"
+)
 
 _DDG_HTML_URL = "https://html.duckduckgo.com/html/"
 _DDG_LITE_URL = "https://lite.duckduckgo.com/lite/"
 _BAIDU_HOME_URL = "https://www.baidu.com/"
 _BAIDU_SEARCH_URL = "https://www.baidu.com/s"
+_BAIDU_MOBILE_SEARCH_URL = "https://m.baidu.com/s"
+_BAIDU_MOBILE_UA = (
+    "Mozilla/5.0 (Linux; Android 10; K) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Mobile Safari/537.36 "
+    "N.E.K.O-WebSearch/0.1.5"
+)
 _GEOIP_PROVIDERS = (
     ("https://ipwho.is/?fields=success,country_code", "country_code"),
     ("https://ipapi.co/json/", "country_code"),
@@ -59,6 +77,7 @@ _GEOIP_PROVIDERS = (
 
 # Countries that cannot reliably access DuckDuckGo
 _CN_COUNTRIES = frozenset({"CN"})
+_BAIDU_COOKIE_STORE_KEY = "baidu_anonymous_cookies"
 
 
 def _select_backend(configured: object, country: Optional[str]) -> str:
@@ -66,6 +85,54 @@ def _select_backend(configured: object, country: Optional[str]) -> str:
     if backend in {"baidu", "duckduckgo"}:
         return backend
     return "duckduckgo" if country and country not in _CN_COUNTRIES else "baidu"
+
+
+def _snapshot_baidu_cookies(client: httpx.AsyncClient) -> List[Dict[str, str]]:
+    """Copy anonymous Baidu cookies without touching a user's browser profile."""
+    snapshot: List[Dict[str, str]] = []
+    for cookie in client.cookies.jar:
+        domain = str(cookie.domain or "").lower().lstrip(".")
+        if domain != "baidu.com" and not domain.endswith(".baidu.com"):
+            continue
+        name = str(cookie.name or "")[:128]
+        value = str(cookie.value or "")[:4096]
+        if not name or not value:
+            continue
+        snapshot.append(
+            {
+                "name": name,
+                "value": value,
+                "domain": str(cookie.domain or ".baidu.com")[:255],
+                "path": str(cookie.path or "/")[:255],
+            }
+        )
+    return snapshot[:64]
+
+
+def _restore_baidu_cookies(
+    client: httpx.AsyncClient,
+    saved: object,
+) -> None:
+    if not isinstance(saved, list):
+        return
+    for item in saved[:64]:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "")[:128]
+        value = str(item.get("value") or "")[:4096]
+        domain = str(item.get("domain") or ".baidu.com")[:255]
+        path = str(item.get("path") or "/")[:255]
+        normalized_domain = domain.lower().lstrip(".")
+        if (
+            not name
+            or not value
+            or (
+                normalized_domain != "baidu.com"
+                and not normalized_domain.endswith(".baidu.com")
+            )
+        ):
+            continue
+        client.cookies.set(name, value, domain=domain, path=path)
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +268,7 @@ async def _search_baidu(
     query: str,
     max_results: int = 8,
     timeout: float = 15.0,
-    user_agent: str = _UA,
+    user_agent: str = _BAIDU_UA,
     retry_attempts: int = 2,
     retry_base_delay: float = 0.5,
 ) -> List[Dict[str, str]]:
@@ -231,13 +298,41 @@ async def _search_baidu(
     )
 
     html = decode_html(resp.content, resp.headers.get("content-type", ""))
-    # 被拦截时会 302 到 wappass.baidu.com 验证码页
-    if "wappass.baidu.com" in str(resp.url) or is_baidu_blocked(html):
-        raise SearchBlockedError("百度返回安全验证页（反爬拦截），请稍后重试")
+    # 桌面端风控比移动 SSR 入口更敏感。桌面端返回验证码或 JavaScript
+    # 跳转壳时仍留在百度体系内降级，不直接切换搜索引擎。
+    desktop_blocked = "wappass.baidu.com" in str(resp.url) or is_baidu_blocked(html)
     results = parse_baidu_html(html, max_results)
-    if not results and not is_baidu_no_results(html):
-        raise SearchResponseError("百度未返回可解析结果")
-    return results
+    if not desktop_blocked and (results or is_baidu_no_results(html)):
+        return results
+
+    mobile_headers = {
+        "User-Agent": _BAIDU_MOBILE_UA,
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        "Referer": _BAIDU_HOME_URL,
+    }
+    mobile_resp = await request_with_retry(
+        lambda: client.get(
+            _BAIDU_MOBILE_SEARCH_URL,
+            params={"word": query},
+            headers=mobile_headers,
+            timeout=timeout,
+        ),
+        max_attempts=retry_attempts,
+        base_delay=retry_base_delay,
+    )
+    mobile_html = decode_html(
+        mobile_resp.content,
+        mobile_resp.headers.get("content-type", ""),
+    )
+    if "wappass.baidu.com" in str(mobile_resp.url) or is_baidu_blocked(mobile_html):
+        raise SearchBlockedError("百度桌面端和移动端均返回安全验证页，请稍后重试")
+    mobile_results = parse_baidu_mobile_html(mobile_html, max_results)
+    if not mobile_results:
+        if desktop_blocked:
+            raise SearchResponseError("百度移动端未返回可解析结果")
+        raise SearchResponseError("百度桌面端和移动端均未返回可解析结果")
+    return mobile_results
 
 
 # ---------------------------------------------------------------------------
@@ -257,6 +352,7 @@ class WebSearchPlugin(NekoPluginBase):
         self._backend: str = "baidu"
         self._client: Optional[httpx.AsyncClient] = None
         self._client_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._baidu_cookies: List[Dict[str, str]] = []
         self._user_agent = _UA
         self._coordinator = SearchCoordinator()
         self._coordinators: Dict[str, SearchCoordinator] = {
@@ -273,15 +369,52 @@ class WebSearchPlugin(NekoPluginBase):
             or self._client.is_closed
             or self._client_loop is not loop
         ):
+            if self._client is not None:
+                current = _snapshot_baidu_cookies(self._client)
+                if current:
+                    self._baidu_cookies = current
             self._client = httpx.AsyncClient(follow_redirects=True)
+            _restore_baidu_cookies(self._client, self._baidu_cookies)
             self._client_loop = loop
         return self._client
+
+    async def _load_baidu_cookies(self) -> None:
+        self._baidu_cookies = []
+        store = getattr(self, "store", None)
+        if store is None or not getattr(store, "enabled", False):
+            return
+        result = await store.get(_BAIDU_COOKIE_STORE_KEY, [])
+        if hasattr(result, "is_ok") and callable(result.is_ok):
+            if not result.is_ok():
+                self.logger.warning("Failed to restore Baidu anonymous session")
+                return
+            saved = result.value
+        else:
+            saved = getattr(result, "value", result)
+        if isinstance(saved, list):
+            self._baidu_cookies = [dict(item) for item in saved if isinstance(item, dict)][:64]
+
+    async def _persist_baidu_cookies(self, client: httpx.AsyncClient) -> None:
+        current = _snapshot_baidu_cookies(client)
+        if current:
+            self._baidu_cookies = current
+        store = getattr(self, "store", None)
+        if store is None or not getattr(store, "enabled", False):
+            return
+        result = await store.set(_BAIDU_COOKIE_STORE_KEY, self._baidu_cookies)
+        if (
+            hasattr(result, "is_ok")
+            and callable(result.is_ok)
+            and not result.is_ok()
+        ):
+            self.logger.warning("Failed to persist Baidu anonymous session")
 
     @lifecycle(id="startup")
     async def startup(self, **_):
         cfg = await self.config.dump(timeout=5.0)
         cfg = cfg if isinstance(cfg, dict) else {}
         self._cfg = cfg.get("search") if isinstance(cfg.get("search"), dict) else {}
+        await self._load_baidu_cookies()
         defs = self._defaults()
         configured_backend = str(self._cfg.get("backend", "auto")).strip().lower()
         self._country = (
@@ -300,7 +433,7 @@ class WebSearchPlugin(NekoPluginBase):
         self._coordinators = {
             "baidu": SearchCoordinator(
                 **common_coordinator_options,
-                min_interval_seconds=defs["min_interval"],
+                min_interval_seconds=defs["baidu_min_interval"],
                 cooldown_seconds=defs["cooldown"],
                 # Baidu uses a fixed cooldown; DDG retains progressive backoff.
                 max_cooldown_seconds=defs["cooldown"],
@@ -372,6 +505,9 @@ class WebSearchPlugin(NekoPluginBase):
             "stale_ttl": number("stale_ttl_seconds", 600.0, 0.0, 86400.0),
             "cache_entries": max(1, min(cache_entries, 1024)),
             "min_interval": number("min_interval_seconds", 0.75, 0.0, 10.0),
+            "baidu_min_interval": number(
+                "baidu_min_interval_seconds", 15.0, 3.0, 60.0
+            ),
             "ddg_min_interval": number(
                 "duckduckgo_min_interval_seconds", 3.0, 1.0, 15.0
             ),
@@ -426,15 +562,31 @@ class WebSearchPlugin(NekoPluginBase):
                 )
                 kwargs = {
                     "timeout": timeout,
-                    "user_agent": self._user_agent,
                     "retry_attempts": defs["retry_attempts"],
                     "retry_base_delay": retry_base_delay,
                 }
                 if backend == "baidu":
-                    return await _search_baidu(client, query, max_results, **kwargs)
+                    try:
+                        return await _search_baidu(
+                            client,
+                            query,
+                            max_results,
+                            user_agent=_BAIDU_UA,
+                            **kwargs,
+                        )
+                    finally:
+                        persist = getattr(self, "_persist_baidu_cookies", None)
+                        if callable(persist):
+                            await persist(client)
 
                 try:
-                    return await _search_ddg_html(client, query, max_results, **kwargs)
+                    return await _search_ddg_html(
+                        client,
+                        query,
+                        max_results,
+                        user_agent=self._user_agent,
+                        **kwargs,
+                    )
                 except Exception as e:
                     if should_skip_fallback(e):
                         raise
@@ -442,7 +594,13 @@ class WebSearchPlugin(NekoPluginBase):
                 await asyncio.sleep(
                     max(defs["ddg_fallback_delay"], defs["ddg_min_interval"])
                 )
-                return await _search_ddg_lite(client, query, max_results, **kwargs)
+                return await _search_ddg_lite(
+                    client,
+                    query,
+                    max_results,
+                    user_agent=self._user_agent,
+                    **kwargs,
+                )
 
             return await coordinator_for(backend).run(key, fetch)
 

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -419,6 +419,7 @@ class WebSearchPlugin(NekoPluginBase):
         self._client: Optional[httpx.AsyncClient] = None
         self._client_loop: Optional[asyncio.AbstractEventLoop] = None
         self._baidu_cookies: List[Dict[str, Any]] = []
+        self._baidu_persist_tasks: set[asyncio.Task[None]] = set()
         self._user_agent = _UA
         self._coordinator = SearchCoordinator()
         self._coordinators: Dict[str, SearchCoordinator] = {
@@ -459,19 +460,36 @@ class WebSearchPlugin(NekoPluginBase):
         if isinstance(saved, list):
             self._baidu_cookies = [dict(item) for item in saved if isinstance(item, dict)][:64]
 
-    async def _persist_baidu_cookies(self, client: httpx.AsyncClient) -> None:
-        current = _snapshot_baidu_cookies(client)
+    def _schedule_baidu_cookie_persist(self, client: httpx.AsyncClient) -> None:
+        try:
+            current = _snapshot_baidu_cookies(client)
+        except Exception:
+            self.logger.warning("Failed to snapshot Baidu anonymous session")
+            return
         self._baidu_cookies = current
         store = getattr(self, "store", None)
         if store is None or not getattr(store, "enabled", False):
             return
-        result = await store.set(_BAIDU_COOKIE_STORE_KEY, self._baidu_cookies)
-        if (
-            hasattr(result, "is_ok")
-            and callable(result.is_ok)
-            and not result.is_ok()
-        ):
-            self.logger.warning("Failed to persist Baidu anonymous session")
+
+        async def persist() -> None:
+            try:
+                result = await store.set(_BAIDU_COOKIE_STORE_KEY, current)
+                if (
+                    hasattr(result, "is_ok")
+                    and callable(result.is_ok)
+                    and not result.is_ok()
+                ):
+                    self.logger.warning("Failed to persist Baidu anonymous session")
+            except Exception:
+                self.logger.warning("Failed to persist Baidu anonymous session")
+
+        task = asyncio.create_task(persist())
+        tasks = getattr(self, "_baidu_persist_tasks", None)
+        if not isinstance(tasks, set):
+            tasks = set()
+            self._baidu_persist_tasks = tasks
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
 
     @lifecycle(id="startup")
     async def startup(self, **_):
@@ -654,9 +672,13 @@ class WebSearchPlugin(NekoPluginBase):
                             **kwargs,
                         )
                     finally:
-                        persist = getattr(self, "_persist_baidu_cookies", None)
-                        if callable(persist):
-                            await persist(client)
+                        schedule = getattr(
+                            self,
+                            "_schedule_baidu_cookie_persist",
+                            None,
+                        )
+                        if callable(schedule):
+                            schedule(client)
 
                 try:
                     return await _search_ddg_html(

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any, Dict, List, NoReturn, Optional
 
 from plugin.sdk.plugin import (
@@ -87,9 +88,10 @@ def _select_backend(configured: object, country: Optional[str]) -> str:
     return "duckduckgo" if country and country not in _CN_COUNTRIES else "baidu"
 
 
-def _snapshot_baidu_cookies(client: httpx.AsyncClient) -> List[Dict[str, str]]:
+def _snapshot_baidu_cookies(client: httpx.AsyncClient) -> List[Dict[str, Any]]:
     """Copy anonymous Baidu cookies without touching a user's browser profile."""
-    snapshot: List[Dict[str, str]] = []
+    snapshot: List[Dict[str, Any]] = []
+    now = time.time()
     for cookie in client.cookies.jar:
         domain = str(cookie.domain or "").lower().lstrip(".")
         if domain != "baidu.com" and not domain.endswith(".baidu.com"):
@@ -98,14 +100,18 @@ def _snapshot_baidu_cookies(client: httpx.AsyncClient) -> List[Dict[str, str]]:
         value = str(cookie.value or "")[:4096]
         if not name or not value:
             continue
-        snapshot.append(
-            {
-                "name": name,
-                "value": value,
-                "domain": str(cookie.domain or ".baidu.com")[:255],
-                "path": str(cookie.path or "/")[:255],
-            }
-        )
+        expires = int(cookie.expires) if cookie.expires is not None else None
+        if expires is not None and expires <= now:
+            continue
+        item: Dict[str, Any] = {
+            "name": name,
+            "value": value,
+            "domain": str(cookie.domain or ".baidu.com")[:255],
+            "path": str(cookie.path or "/")[:255],
+        }
+        if expires is not None:
+            item["expires"] = expires
+        snapshot.append(item)
     return snapshot[:64]
 
 
@@ -122,6 +128,15 @@ def _restore_baidu_cookies(
         value = str(item.get("value") or "")[:4096]
         domain = str(item.get("domain") or ".baidu.com")[:255]
         path = str(item.get("path") or "/")[:255]
+        expires_value = item.get("expires")
+        expires: Optional[int] = None
+        if expires_value is not None:
+            try:
+                expires = int(float(expires_value))
+            except (TypeError, ValueError):
+                continue
+            if expires <= time.time():
+                continue
         normalized_domain = domain.lower().lstrip(".")
         if (
             not name
@@ -133,6 +148,19 @@ def _restore_baidu_cookies(
         ):
             continue
         client.cookies.set(name, value, domain=domain, path=path)
+        if expires is not None:
+            # httpx.Cookies.set does not expose expiry. Restore it on the
+            # underlying CookieJar so the next persisted snapshot cannot turn
+            # a time-limited Baidu token into an immortal session cookie.
+            for cookie in client.cookies.jar:
+                if (
+                    cookie.name == name
+                    and cookie.domain == domain
+                    and cookie.path == path
+                ):
+                    cookie.expires = expires
+                    cookie.discard = False
+                    break
 
 
 # ---------------------------------------------------------------------------
@@ -311,16 +339,23 @@ async def _search_baidu(
         "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
         "Referer": _BAIDU_HOME_URL,
     }
-    mobile_resp = await request_with_retry(
-        lambda: client.get(
-            _BAIDU_MOBILE_SEARCH_URL,
-            params={"word": query},
-            headers=mobile_headers,
-            timeout=min(timeout, 5.0),
-        ),
-        max_attempts=1,
-        base_delay=retry_base_delay,
-    )
+    try:
+        mobile_resp = await request_with_retry(
+            lambda: client.get(
+                _BAIDU_MOBILE_SEARCH_URL,
+                params={"word": query},
+                headers=mobile_headers,
+                timeout=min(timeout, 5.0),
+            ),
+            max_attempts=1,
+            base_delay=retry_base_delay,
+        )
+    except httpx.HTTPError as error:
+        if desktop_blocked:
+            raise SearchBlockedError(
+                "百度桌面端已触发安全验证，移动端请求失败，请稍后重试"
+            ) from error
+        raise
     mobile_html = decode_html(
         mobile_resp.content,
         mobile_resp.headers.get("content-type", ""),
@@ -354,7 +389,7 @@ class WebSearchPlugin(NekoPluginBase):
         self._backend: str = "baidu"
         self._client: Optional[httpx.AsyncClient] = None
         self._client_loop: Optional[asyncio.AbstractEventLoop] = None
-        self._baidu_cookies: List[Dict[str, str]] = []
+        self._baidu_cookies: List[Dict[str, Any]] = []
         self._user_agent = _UA
         self._coordinator = SearchCoordinator()
         self._coordinators: Dict[str, SearchCoordinator] = {

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -316,9 +316,9 @@ async def _search_baidu(
             _BAIDU_MOBILE_SEARCH_URL,
             params={"word": query},
             headers=mobile_headers,
-            timeout=timeout,
+            timeout=min(timeout, 5.0),
         ),
-        max_attempts=retry_attempts,
+        max_attempts=1,
         base_delay=retry_base_delay,
     )
     mobile_html = decode_html(
@@ -330,7 +330,9 @@ async def _search_baidu(
     mobile_results = parse_baidu_mobile_html(mobile_html, max_results)
     if not mobile_results:
         if desktop_blocked:
-            raise SearchResponseError("百度移动端未返回可解析结果")
+            raise SearchBlockedError(
+                "百度桌面端已触发安全验证，移动端未返回可解析结果，请稍后重试"
+            )
         raise SearchResponseError("百度桌面端和移动端均未返回可解析结果")
     return mobile_results
 
@@ -496,6 +498,8 @@ class WebSearchPlugin(NekoPluginBase):
             cache_entries = int(self._cfg.get("cache_entries", 128))
         except (TypeError, ValueError):
             cache_entries = 128
+        total_timeout = number("total_timeout_seconds", 25.0, 5.0, 25.0)
+        baidu_interval_high = max(3.0, min(20.0, total_timeout - 2.0))
         return {
             "max_results": mr,
             "timeout": to,
@@ -506,7 +510,7 @@ class WebSearchPlugin(NekoPluginBase):
             "cache_entries": max(1, min(cache_entries, 1024)),
             "min_interval": number("min_interval_seconds", 0.75, 0.0, 10.0),
             "baidu_min_interval": number(
-                "baidu_min_interval_seconds", 15.0, 3.0, 60.0
+                "baidu_min_interval_seconds", 15.0, 3.0, baidu_interval_high
             ),
             "ddg_min_interval": number(
                 "duckduckgo_min_interval_seconds", 3.0, 1.0, 15.0
@@ -527,7 +531,7 @@ class WebSearchPlugin(NekoPluginBase):
             ),
             # Keep the complete operation below the host's default 30-second
             # plugin-entry watchdog, including retries and DDG fallback.
-            "total_timeout": number("total_timeout_seconds", 25.0, 1.0, 25.0),
+            "total_timeout": total_timeout,
         }
 
     async def _do_text_search(
@@ -538,11 +542,15 @@ class WebSearchPlugin(NekoPluginBase):
         backend: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         defs = self._defaults()
-        primary_backend = (
-            backend if backend in {"baidu", "duckduckgo"} else self._backend
+        requested_backend = backend if backend in {"baidu", "duckduckgo"} else None
+        primary_backend = requested_backend or self._backend
+        allow_cross_engine_fallback = (
+            primary_backend == "baidu" and requested_backend is None
         )
         normalized_query = " ".join(query.casefold().split())
         attempted_backends = [primary_backend]
+        total_timeout = defs["total_timeout"]
+        deadline = asyncio.get_running_loop().time() + total_timeout
 
         def coordinator_for(backend: str) -> SearchCoordinator:
             coordinators = getattr(self, "_coordinators", None)
@@ -550,7 +558,10 @@ class WebSearchPlugin(NekoPluginBase):
                 return coordinators[backend]
             return self._coordinator
 
-        async def run_backend(backend: str) -> List[Dict[str, str]]:
+        async def run_backend(
+            backend: str,
+            budget: float,
+        ) -> List[Dict[str, str]]:
             key = (backend, normalized_query, max_results)
 
             async def fetch() -> List[Dict[str, str]]:
@@ -602,14 +613,20 @@ class WebSearchPlugin(NekoPluginBase):
                     **kwargs,
                 )
 
-            return await coordinator_for(backend).run(key, fetch)
+            async with asyncio.timeout(max(0.01, budget)):
+                return await coordinator_for(backend).run(key, fetch)
 
         try:
-            async with asyncio.timeout(defs["total_timeout"]):
+            async with asyncio.timeout(total_timeout):
+                primary_budget = (
+                    total_timeout * 0.72
+                    if allow_cross_engine_fallback
+                    else total_timeout
+                )
                 try:
-                    return await run_backend(primary_backend)
+                    return await run_backend(primary_backend, primary_budget)
                 except Exception as primary_error:
-                    if primary_backend != "baidu":
+                    if not allow_cross_engine_fallback:
                         raise
                     attempted_backends.append("duckduckgo")
                     self.logger.warning(
@@ -617,7 +634,10 @@ class WebSearchPlugin(NekoPluginBase):
                         type(primary_error).__name__,
                     )
                     try:
-                        return await run_backend("duckduckgo")
+                        fallback_budget = deadline - asyncio.get_running_loop().time()
+                        if fallback_budget <= 0:
+                            raise primary_error
+                        return await run_backend("duckduckgo", fallback_budget)
                     except Exception:
                         # Preserve the primary error because it describes the
                         # selected backend and has already updated its cooldown.

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -374,7 +374,12 @@ async def _search_baidu(
             base_delay=retry_base_delay,
         )
     except httpx.HTTPError as error:
-        if desktop_blocked:
+        blocked_status = (
+            error.response.status_code
+            if isinstance(error, httpx.HTTPStatusError)
+            else None
+        )
+        if desktop_blocked or blocked_status in {403, 429}:
             declared_delay = (
                 retry_after_seconds(error.response.headers)
                 if isinstance(error, httpx.HTTPStatusError)
@@ -419,7 +424,8 @@ class WebSearchPlugin(NekoPluginBase):
         self._client: Optional[httpx.AsyncClient] = None
         self._client_loop: Optional[asyncio.AbstractEventLoop] = None
         self._baidu_cookies: List[Dict[str, Any]] = []
-        self._baidu_persist_tasks: set[asyncio.Task[None]] = set()
+        self._baidu_pending_cookie_snapshot: Optional[List[Dict[str, Any]]] = None
+        self._baidu_persist_task: Optional[asyncio.Task[None]] = None
         self._user_agent = _UA
         self._coordinator = SearchCoordinator()
         self._coordinators: Dict[str, SearchCoordinator] = {
@@ -428,8 +434,9 @@ class WebSearchPlugin(NekoPluginBase):
         }
 
     def _get_client(self) -> httpx.AsyncClient:
-        # 宿主对 startup / 命令循环 / shutdown 分别 asyncio.run()（plugin/core/host.py），
-        # 连接池绑定在创建它的循环上：只在同一循环内复用，循环切换时丢弃重建
+        # The host uses separate asyncio.run() calls for startup, one persistent
+        # command loop containing every entry, and shutdown. Rebuild the pool
+        # only when crossing those loop boundaries.
         loop = asyncio.get_running_loop()
         if (
             self._client is None
@@ -460,6 +467,24 @@ class WebSearchPlugin(NekoPluginBase):
         if isinstance(saved, list):
             self._baidu_cookies = [dict(item) for item in saved if isinstance(item, dict)][:64]
 
+    async def _persist_baidu_cookie_snapshot(
+        self,
+        snapshot: List[Dict[str, Any]],
+    ) -> None:
+        store = getattr(self, "store", None)
+        if store is None or not getattr(store, "enabled", False):
+            return
+        try:
+            result = await store.set(_BAIDU_COOKIE_STORE_KEY, snapshot)
+            if (
+                hasattr(result, "is_ok")
+                and callable(result.is_ok)
+                and not result.is_ok()
+            ):
+                self.logger.warning("Failed to persist Baidu anonymous session")
+        except Exception:
+            self.logger.warning("Failed to persist Baidu anonymous session")
+
     def _schedule_baidu_cookie_persist(self, client: httpx.AsyncClient) -> None:
         try:
             current = _snapshot_baidu_cookies(client)
@@ -470,26 +495,27 @@ class WebSearchPlugin(NekoPluginBase):
         store = getattr(self, "store", None)
         if store is None or not getattr(store, "enabled", False):
             return
+        self._baidu_pending_cookie_snapshot = current
+        task = getattr(self, "_baidu_persist_task", None)
+        if task is not None and not task.done():
+            return
 
-        async def persist() -> None:
-            try:
-                result = await store.set(_BAIDU_COOKIE_STORE_KEY, current)
-                if (
-                    hasattr(result, "is_ok")
-                    and callable(result.is_ok)
-                    and not result.is_ok()
-                ):
-                    self.logger.warning("Failed to persist Baidu anonymous session")
-            except Exception:
-                self.logger.warning("Failed to persist Baidu anonymous session")
+        async def persist_pending() -> None:
+            while True:
+                snapshot = self._baidu_pending_cookie_snapshot
+                self._baidu_pending_cookie_snapshot = None
+                if snapshot is None:
+                    return
+                await self._persist_baidu_cookie_snapshot(snapshot)
 
-        task = asyncio.create_task(persist())
-        tasks = getattr(self, "_baidu_persist_tasks", None)
-        if not isinstance(tasks, set):
-            tasks = set()
-            self._baidu_persist_tasks = tasks
-        tasks.add(task)
-        task.add_done_callback(tasks.discard)
+        task = asyncio.create_task(persist_pending())
+        self._baidu_persist_task = task
+
+        def finish(done: asyncio.Task[None]) -> None:
+            if self._baidu_persist_task is done:
+                self._baidu_persist_task = None
+
+        task.add_done_callback(finish)
 
     @lifecycle(id="startup")
     async def startup(self, **_):
@@ -539,6 +565,11 @@ class WebSearchPlugin(NekoPluginBase):
 
     @lifecycle(id="shutdown")
     async def shutdown(self, **_):
+        try:
+            async with asyncio.timeout(2.0):
+                await self._persist_baidu_cookie_snapshot(self._baidu_cookies)
+        except TimeoutError:
+            self.logger.warning("Timed out flushing Baidu anonymous session")
         client, self._client = self._client, None
         self._client_loop = None
         if client is not None and not client.is_closed:

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -332,13 +332,21 @@ async def _search_baidu(
             # 安全验证页，由下方 is_baidu_blocked 显式报错，无需在此处理
             pass
 
-    resp = await request_with_retry(
-        lambda: client.get(
-            _BAIDU_SEARCH_URL, params=params, headers=headers, timeout=timeout
-        ),
-        max_attempts=retry_attempts,
-        base_delay=retry_base_delay,
-    )
+    try:
+        resp = await request_with_retry(
+            lambda: client.get(
+                _BAIDU_SEARCH_URL, params=params, headers=headers, timeout=timeout
+            ),
+            max_attempts=retry_attempts,
+            base_delay=retry_base_delay,
+        )
+    except httpx.HTTPStatusError as error:
+        if error.response.status_code in {403, 429}:
+            raise SearchBlockedError(
+                f"百度桌面端请求受限（{error.response.status_code}），请稍后重试",
+                retry_after_seconds=retry_after_seconds(error.response.headers),
+            ) from error
+        raise
 
     html = decode_html(resp.content, resp.headers.get("content-type", ""))
     # 桌面端风控比移动 SSR 入口更敏感。桌面端返回验证码或 JavaScript
@@ -367,8 +375,14 @@ async def _search_baidu(
         )
     except httpx.HTTPError as error:
         if desktop_blocked:
+            declared_delay = (
+                retry_after_seconds(error.response.headers)
+                if isinstance(error, httpx.HTTPStatusError)
+                else None
+            )
             raise SearchBlockedError(
-                "百度桌面端已触发安全验证，移动端请求失败，请稍后重试"
+                "百度桌面端已触发安全验证，移动端请求失败，请稍后重试",
+                retry_after_seconds=declared_delay,
             ) from error
         raise
     mobile_html = decode_html(
@@ -423,8 +437,7 @@ class WebSearchPlugin(NekoPluginBase):
         ):
             if self._client is not None:
                 current = _snapshot_baidu_cookies(self._client)
-                if current:
-                    self._baidu_cookies = current
+                self._baidu_cookies = current
             self._client = httpx.AsyncClient(follow_redirects=True)
             _restore_baidu_cookies(self._client, self._baidu_cookies)
             self._client_loop = loop
@@ -448,8 +461,7 @@ class WebSearchPlugin(NekoPluginBase):
 
     async def _persist_baidu_cookies(self, client: httpx.AsyncClient) -> None:
         current = _snapshot_baidu_cookies(client)
-        if current:
-            self._baidu_cookies = current
+        self._baidu_cookies = current
         store = getattr(self, "store", None)
         if store is None or not getattr(store, "enabled", False):
             return

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -335,6 +335,8 @@ def parse_baidu_mobile_html(
             metadata = json.loads(str(item.get("data-log") or "{}"))
         except (TypeError, ValueError, json.JSONDecodeError):
             continue
+        if not isinstance(metadata, dict):
+            continue
         url = str(metadata.get("mu") or "").strip()
         if not is_http_url(url) or url in seen_urls:
             continue

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -246,7 +246,27 @@ def parse_ddg_lite_html(html: str, max_results: int = 8) -> List[Dict[str, str]]
 
 def is_baidu_blocked(html: str) -> bool:
     head = html[:5000]
-    return "百度安全验证" in head or "wappass.baidu.com" in head
+    if "百度安全验证" in head or "wappass.baidu.com" in head:
+        return True
+
+    # Baidu may answer non-browser clients with a tiny JavaScript redirect
+    # document while still returning HTTP 200.  httpx does not execute the
+    # redirect, so treating it as a normal empty result would bypass the
+    # backend cooldown and encourage an immediate retry burst.
+    if len(html) <= 4096 and not re.search(
+        r"id\s*=\s*['\"]content_left['\"]", head, re.I
+    ):
+        compact = re.sub(r"\s+", "", head).casefold()
+        return any(
+            marker in compact
+            for marker in (
+                "location.replace(",
+                "window.location=",
+                "window.location.href=",
+                "location.href=",
+            )
+        )
+    return False
 
 
 def parse_baidu_html(html: str, max_results: int = 8) -> List[Dict[str, str]]:

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -10,6 +10,7 @@ web_search 插件的解析层：纯函数、不依赖 SDK 和网络，便于单�
 
 from __future__ import annotations
 
+import json
 import math
 import re
 import unicodedata
@@ -308,6 +309,58 @@ def parse_baidu_html(html: str, max_results: int = 8) -> List[Dict[str, str]]:
             "url": href,
             "snippet": _clip(snippet, MAX_SNIPPET_LEN),
         })
+        if len(results) >= max_results:
+            break
+
+    return results
+
+
+def parse_baidu_mobile_html(
+    html: str,
+    max_results: int = 8,
+) -> List[Dict[str, str]]:
+    """Parse Baidu's mobile SSR cards without executing page JavaScript."""
+    soup = BeautifulSoup(html, "html.parser")
+    results: List[Dict[str, str]] = []
+    seen_urls: set[str] = set()
+
+    for item in soup.select("div.c-result.result"):
+        try:
+            metadata = json.loads(str(item.get("data-log") or "{}"))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        url = str(metadata.get("mu") or "").strip()
+        if not is_http_url(url) or url in seen_urls:
+            continue
+
+        # Recommendation/search-suggestion cards use Baidu-owned synthetic
+        # targets and are not ordinary web results.
+        host = (urlparse(url).hostname or "").lower()
+        if host.endswith("recommend_list.baidu.com"):
+            continue
+
+        title_tag = item.select_one("h3.cosc-title, h3")
+        if title_tag is None:
+            continue
+        title = sanitize_text(title_tag.get_text(" ", strip=True))
+        if not title:
+            continue
+
+        snippet = ""
+        snippet_tag = item.select_one(
+            "span[class*='summary-text'], div[class*='summary-gap']"
+        )
+        if snippet_tag is not None:
+            snippet = sanitize_text(snippet_tag.get_text(" ", strip=True))
+
+        seen_urls.add(url)
+        results.append(
+            {
+                "title": _clip(title, MAX_TITLE_LEN),
+                "url": url,
+                "snippet": _clip(snippet, MAX_SNIPPET_LEN),
+            }
+        )
         if len(results) >= max_results:
             break
 

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -257,13 +257,19 @@ def is_baidu_blocked(html: str) -> bool:
     if len(html) <= 4096 and not re.search(
         r"id\s*=\s*['\"]content_left['\"]", head, re.I
     ):
+        if re.search(
+            r"<meta\b[^>]*\bhttp-equiv\s*=\s*['\"]?\s*refresh\b",
+            head,
+            re.I,
+        ):
+            return True
         compact = re.sub(r"\s+", "", head).casefold()
         return any(
             marker in compact
             for marker in (
                 "location.replace(",
+                "location.assign(",
                 "window.location=",
-                "window.location.href=",
                 "location.href=",
             )
         )

--- a/plugin/plugins/web_search/_resilience.py
+++ b/plugin/plugins/web_search/_resilience.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -197,7 +196,16 @@ class SearchCoordinator:
     ) -> SearchResults:
         state = self._backends.setdefault(backend, _BackendState(asyncio.Lock()))
         try:
-            async with asyncio.timeout(self.queue_wait_seconds):
+            if state.lock.locked():
+                await asyncio.wait_for(
+                    state.lock.acquire(),
+                    timeout=self.queue_wait_seconds,
+                )
+            else:
+                # Avoid spawning an internal wait_for task on the uncontended
+                # path. Besides reducing latency, this lets short caller-level
+                # timeouts cancel the actual fetch rather than a pending lock
+                # acquisition helper.
                 await state.lock.acquire()
         except TimeoutError as error:
             raise SearchBusyError("search backend is busy; retry shortly") from error
@@ -317,12 +325,3 @@ class SearchCoordinator:
                     if self._inflight.get(key) is task:
                         self._inflight.pop(key, None)
                     task.cancel()
-                    # On Python 3.11 a cancellation can race with an immediately
-                    # completing ``wait_for(lock.acquire())`` and be consumed by
-                    # that awaitable. Give the task one turn, then repeat the
-                    # cancellation so caller-level timeouts remain a hard bound.
-                    await asyncio.sleep(0)
-                    if not task.done():
-                        task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await task

--- a/plugin/plugins/web_search/_resilience.py
+++ b/plugin/plugins/web_search/_resilience.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -23,6 +24,7 @@ SearchResults = List[Dict[str, str]]
 
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 _NO_RETRY_STATUS = frozenset({429})
+_MAX_THROTTLE_WAIT_SECONDS = 3.0
 
 
 def _copy_results(results: SearchResults) -> SearchResults:
@@ -196,16 +198,7 @@ class SearchCoordinator:
     ) -> SearchResults:
         state = self._backends.setdefault(backend, _BackendState(asyncio.Lock()))
         try:
-            if state.lock.locked():
-                await asyncio.wait_for(
-                    state.lock.acquire(),
-                    timeout=self.queue_wait_seconds,
-                )
-            else:
-                # Avoid spawning an internal wait_for task on the uncontended
-                # path. Besides reducing latency, this lets short caller-level
-                # timeouts cancel the actual fetch rather than a pending lock
-                # acquisition helper.
+            async with asyncio.timeout(self.queue_wait_seconds):
                 await state.lock.acquire()
         except TimeoutError as error:
             raise SearchBusyError("search backend is busy; retry shortly") from error
@@ -218,6 +211,10 @@ class SearchCoordinator:
                 )
             wait_seconds = state.next_allowed - now
             if wait_seconds > 0:
+                if wait_seconds > _MAX_THROTTLE_WAIT_SECONDS:
+                    raise SearchBusyError(
+                        "search backend rate-limited; retry shortly"
+                    )
                 await asyncio.sleep(wait_seconds)
             try:
                 results = await fetch()
@@ -325,3 +322,11 @@ class SearchCoordinator:
                     if self._inflight.get(key) is task:
                         self._inflight.pop(key, None)
                     task.cancel()
+                    # Python 3.11 can race cancellation with the internal lock
+                    # waiter. Give it a turn and repeat cancellation so a caller
+                    # timeout remains a hard bound without leaking the fetch.
+                    await asyncio.sleep(0)
+                    if not task.done():
+                        task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await task

--- a/plugin/plugins/web_search/plugin.toml
+++ b/plugin/plugins/web_search/plugin.toml
@@ -3,7 +3,7 @@ name = "网络搜索"
 description = "联网搜索。自动根据用户 IP 选择搜索引擎（国内百度/海外DuckDuckGo），无需 API Key。"
 short_description = "Web search via Baidu (CN) or DuckDuckGo (intl). Returns search results or AI-summarized answers."
 keywords = ["搜索", "search", "百度", "duckduckgo", "搜一", "查[一找]", "google", "검색", "찾아", "検索", "調べ", "探し", "поиск", "искать", "найти"]
-version = "0.1.4"
+version = "0.1.5"
 id = "web_search"
 entry = "plugin.plugins.web_search:WebSearchPlugin"
 
@@ -23,7 +23,7 @@ enabled = true
 auto_start = true
 
 [plugin.store]
-enabled = false
+enabled = true
 
 [search]
 # auto: CN -> Baidu, known non-CN -> DuckDuckGo, detection failure -> Baidu.
@@ -39,6 +39,9 @@ stale_ttl_seconds = 600
 cache_entries = 128
 # Serialize requests per engine and pause after rate limits/challenge pages.
 min_interval_seconds = 0.75
+# Baidu ties challenges to IP/session bursts. Keep its anonymous cookie jar
+# across commands/restarts and leave a wider gap between distinct queries.
+baidu_min_interval_seconds = 15
 # DuckDuckGo is more sensitive to automated bursts than Baidu.
 duckduckgo_min_interval_seconds = 3
 cooldown_seconds = 60

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -27,12 +27,15 @@ _MIN_RUN_INTERVAL_SECONDS = 5.0
 _MAX_CACHE_ENTRIES = 64
 _RUN_TIMEOUT_SECONDS = 30.0
 _POLL_INTERVAL_SECONDS = 0.25
+_MAX_POLL_INTERVAL_SECONDS = 2.0
+_MAX_QUEUE_WAIT_SECONDS = 2.0
+_MAX_THROTTLE_WAIT_SECONDS = 2.0
 
 _cache: OrderedDict[tuple[str, str, int], tuple[float, Dict[str, Any]]] = OrderedDict()
 _lock: Optional[asyncio.Lock] = None
 _lock_loop: Optional[asyncio.AbstractEventLoop] = None
-_next_run_at = 0.0
-_failure_cooldown_until = 0.0
+_next_run_at: Dict[str, float] = {}
+_failure_cooldown_until: Dict[str, float] = {}
 
 
 def _copy_result(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -90,12 +93,36 @@ def _extract_export(payload: object) -> Dict[str, Any]:
             raw = item.get("json_data")
         if not isinstance(raw, dict):
             continue
-        if raw.get("error"):
-            raise RuntimeError(_error_message(raw.get("error"), "搜索插件执行失败"))
-        data = raw.get("data")
-        if isinstance(data, dict):
-            return data
+        current = raw
+        # Run exports contain the server envelope and the child-host response
+        # envelope before the plugin's own result payload.
+        for _ in range(4):
+            if current.get("success") is False or current.get("error"):
+                raise RuntimeError(
+                    _error_message(current.get("error"), "搜索插件执行失败")
+                )
+            nested = current.get("data")
+            if not isinstance(nested, dict):
+                break
+            current = nested
+        if isinstance(current.get("results"), list):
+            return current
     raise RuntimeError("搜索插件没有返回结构化结果")
+
+
+async def _cancel_run(
+    client: httpx.AsyncClient,
+    base: str,
+    run_id: str,
+) -> None:
+    try:
+        await client.post(
+            f"{base}/runs/{run_id}/cancel",
+            json={"reason": "search gateway stopped waiting"},
+            timeout=1.0,
+        )
+    except Exception:
+        logger.debug("取消遗留联网搜索任务失败 (run_id=%s)", run_id)
 
 
 async def _invoke_plugin(
@@ -129,28 +156,50 @@ async def _invoke_plugin(
 
         deadline = asyncio.get_running_loop().time() + _RUN_TIMEOUT_SECONDS
         terminal = {"succeeded", "failed", "canceled", "timeout"}
-        while True:
-            remaining = deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                raise TimeoutError("等待联网搜索插件超时")
-            response = await client.get(f"{base}/runs/{run_id}")
-            if response.status_code != 200:
-                raise RuntimeError(f"读取联网搜索任务失败（HTTP {response.status_code}）")
-            candidate = response.json()
-            run_data = candidate if isinstance(candidate, dict) else {}
-            status = str(run_data.get("status") or "")
-            if status in terminal:
-                if status != "succeeded":
+        poll_interval = _POLL_INTERVAL_SECONDS
+        terminal_seen = False
+        try:
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError("等待联网搜索插件超时")
+                response = await client.get(f"{base}/runs/{run_id}")
+                if response.status_code != 200:
                     raise RuntimeError(
-                        _error_message(run_data.get("error"), f"联网搜索任务状态：{status}")
+                        f"读取联网搜索任务失败（HTTP {response.status_code}）"
                     )
-                break
-            await asyncio.sleep(min(_POLL_INTERVAL_SECONDS, remaining))
+                candidate = response.json()
+                run_data = candidate if isinstance(candidate, dict) else {}
+                status = str(run_data.get("status") or "")
+                if status in terminal:
+                    terminal_seen = True
+                    if status != "succeeded":
+                        raise RuntimeError(
+                            _error_message(
+                                run_data.get("error"),
+                                f"联网搜索任务状态：{status}",
+                            )
+                        )
+                    break
+                await asyncio.sleep(min(poll_interval, remaining))
+                poll_interval = min(
+                    poll_interval * 1.5,
+                    _MAX_POLL_INTERVAL_SECONDS,
+                )
 
-        response = await client.get(f"{base}/runs/{run_id}/export", params={"limit": 20})
-        if response.status_code != 200:
-            raise RuntimeError(f"导出联网搜索结果失败（HTTP {response.status_code}）")
-        data = _extract_export(response.json())
+            response = await client.get(
+                f"{base}/runs/{run_id}/export",
+                params={"limit": 20},
+            )
+            if response.status_code != 200:
+                raise RuntimeError(
+                    f"导出联网搜索结果失败（HTTP {response.status_code}）"
+                )
+            data = _extract_export(response.json())
+        except BaseException:
+            if not terminal_seen:
+                await _cancel_run(client, base, run_id)
+            raise
 
     normalized_results = []
     for item in data.get("results") or []:
@@ -182,36 +231,60 @@ async def search_via_plugin(
     backend: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run a cached, rate-limited search through the web_search plugin."""
-    global _next_run_at, _failure_cooldown_until
-
     normalized_query = " ".join(str(query or "").split())
     if len(normalized_query) < 2:
         return {"success": False, "error": "搜索关键词太短", "results": []}
-    bounded_limit = max(3, min(int(limit), 10))
+    try:
+        requested_limit = max(1, min(int(limit), 10))
+    except (TypeError, ValueError):
+        requested_limit = 5
+    plugin_limit = max(3, requested_limit)
     selected_backend = backend if backend in {"baidu", "duckduckgo"} else "auto"
-    key = (selected_backend, normalized_query.casefold(), bounded_limit)
+    key = (selected_backend, normalized_query.casefold(), requested_limit)
     cached = _cached(key)
     if cached is not None:
         return cached
 
-    async with _gateway_lock():
+    lock = _gateway_lock()
+    try:
+        await asyncio.wait_for(
+            lock.acquire(),
+            timeout=_MAX_QUEUE_WAIT_SECONDS,
+        )
+    except TimeoutError:
+        return {
+            "success": False,
+            "error": "联网搜索网关繁忙，请稍后重试",
+            "results": [],
+        }
+    try:
         cached = _cached(key)
         if cached is not None:
             return cached
         now = time.monotonic()
-        if now < _failure_cooldown_until:
+        cooldown_until = _failure_cooldown_until.get(selected_backend, 0.0)
+        if now < cooldown_until:
             return {
                 "success": False,
                 "error": "联网搜索暂处于失败冷却期",
                 "results": [],
             }
-        if now < _next_run_at:
-            await asyncio.sleep(_next_run_at - now)
+        throttle_wait = _next_run_at.get(selected_backend, 0.0) - now
+        if throttle_wait > _MAX_THROTTLE_WAIT_SECONDS:
+            return {
+                "success": False,
+                "error": "联网搜索请求过于频繁，请稍后重试",
+                "results": [],
+            }
+        if throttle_wait > 0:
+            await asyncio.sleep(throttle_wait)
 
         try:
-            result = await _invoke_plugin(normalized_query, bounded_limit, backend)
+            result = await _invoke_plugin(normalized_query, plugin_limit, backend)
         except Exception as error:
-            _failure_cooldown_until = time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+            _failure_cooldown_until[selected_backend] = (
+                time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+            )
             logger.warning(
                 "受控联网搜索失败 (query_len=%s, error_type=%s)",
                 len(normalized_query),
@@ -223,9 +296,22 @@ async def search_via_plugin(
                 "results": [],
             }
         finally:
-            _next_run_at = time.monotonic() + _MIN_RUN_INTERVAL_SECONDS
+            _next_run_at[selected_backend] = (
+                time.monotonic() + _MIN_RUN_INTERVAL_SECONDS
+            )
+
+        result["results"] = [
+            dict(item)
+            for item in result.get("results", [])[:requested_limit]
+            if isinstance(item, dict)
+        ]
+        result["success"] = bool(result["results"])
+        if result["success"]:
+            result["error"] = ""
 
         # A valid empty result is cacheable too; otherwise a stable obscure
         # window title would still trigger one upstream search every refresh.
         _store(key, result)
         return _copy_result(result)
+    finally:
+        lock.release()

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -28,6 +28,7 @@ _FAILURE_COOLDOWN_SECONDS = 300.0
 _MIN_RUN_INTERVAL_SECONDS = 5.0
 _MAX_CACHE_ENTRIES = 64
 _RUN_TIMEOUT_SECONDS = 30.0
+_PRIMARY_BACKEND_BUDGET_RATIO = 0.72
 _POLL_INTERVAL_SECONDS = 0.25
 _MAX_POLL_INTERVAL_SECONDS = 2.0
 _FLOW_CONTROL_ERROR_CODES = frozenset(
@@ -418,13 +419,19 @@ async def search_via_plugin(
 
         async def execute() -> Dict[str, Any]:
             deadline = loop.time() + _RUN_TIMEOUT_SECONDS
+            primary_deadline = (
+                loop.time()
+                + (_RUN_TIMEOUT_SECONDS * _PRIMARY_BACKEND_BUDGET_RATIO)
+                if allow_cross_engine_fallback
+                else deadline
+            )
             try:
                 try:
                     result = await _invoke_in_backend_slot(
                         normalized_query,
                         plugin_limit,
                         selected_backend,
-                        deadline,
+                        primary_deadline,
                     )
                 except Exception as primary_error:
                     if not allow_cross_engine_fallback:

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from contextlib import suppress
 import time
 from typing import Any, Dict, Optional
 import uuid
@@ -22,20 +23,28 @@ from ._shared import logger
 
 
 _CACHE_TTL_SECONDS = 600.0
+_CACHE_STALE_SECONDS = 1800.0
 _FAILURE_COOLDOWN_SECONDS = 300.0
 _MIN_RUN_INTERVAL_SECONDS = 5.0
 _MAX_CACHE_ENTRIES = 64
 _RUN_TIMEOUT_SECONDS = 30.0
 _POLL_INTERVAL_SECONDS = 0.25
 _MAX_POLL_INTERVAL_SECONDS = 2.0
-_MAX_QUEUE_WAIT_SECONDS = 2.0
 _MAX_THROTTLE_WAIT_SECONDS = 2.0
 
-_cache: OrderedDict[tuple[str, str, int], tuple[float, Dict[str, Any]]] = OrderedDict()
-_lock: Optional[asyncio.Lock] = None
-_lock_loop: Optional[asyncio.AbstractEventLoop] = None
+_cache: OrderedDict[
+    tuple[str, str, int],
+    tuple[float, float, Dict[str, Any]],
+] = OrderedDict()
 _next_run_at: Dict[str, float] = {}
 _failure_cooldown_until: Dict[str, float] = {}
+_inflight: Dict[tuple[str, str, int], asyncio.Task[Dict[str, Any]]] = {}
+_waiters: Dict[tuple[str, str, int], int] = {}
+_runtime_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+class _PluginThrottleError(RuntimeError):
+    """The plugin is healthy but intentionally refused work for now."""
 
 
 def _copy_result(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -46,29 +55,47 @@ def _copy_result(result: Dict[str, Any]) -> Dict[str, Any]:
     return copied
 
 
-def _gateway_lock() -> asyncio.Lock:
-    global _lock, _lock_loop
+def _prepare_runtime_loop() -> asyncio.AbstractEventLoop:
+    global _runtime_loop
     loop = asyncio.get_running_loop()
-    if _lock is None or _lock_loop is not loop:
-        _lock = asyncio.Lock()
-        _lock_loop = loop
-    return _lock
+    if _runtime_loop is not loop:
+        # Tasks cannot cross event loops. The durable cache and cooldown clocks
+        # remain valid across host lifecycle restarts, but in-flight ownership
+        # belongs to one loop only.
+        _runtime_loop = loop
+        _inflight.clear()
+        _waiters.clear()
+    return loop
 
 
-def _cached(key: tuple[str, str, int]) -> Optional[Dict[str, Any]]:
+def _cached(
+    key: tuple[str, str, int],
+    *,
+    fresh: bool = True,
+) -> Optional[Dict[str, Any]]:
     cached = _cache.get(key)
     if cached is None:
         return None
-    expires_at, result = cached
-    if time.monotonic() >= expires_at:
+    fresh_until, stale_until, result = cached
+    now = time.monotonic()
+    if now >= stale_until:
         _cache.pop(key, None)
+        return None
+    if fresh and now >= fresh_until:
+        return None
+    if not fresh and (not result.get("success") or not result.get("results")):
         return None
     _cache.move_to_end(key)
     return _copy_result(result)
 
 
 def _store(key: tuple[str, str, int], result: Dict[str, Any]) -> None:
-    _cache[key] = (time.monotonic() + _CACHE_TTL_SECONDS, _copy_result(result))
+    now = time.monotonic()
+    _cache[key] = (
+        now + _CACHE_TTL_SECONDS,
+        now + _CACHE_TTL_SECONDS + _CACHE_STALE_SECONDS,
+        _copy_result(result),
+    )
     _cache.move_to_end(key)
     while len(_cache) > _MAX_CACHE_ENTRIES:
         _cache.popitem(last=False)
@@ -80,6 +107,21 @@ def _error_message(value: object, default: str) -> str:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return default
+
+
+def _plugin_error(value: object, default: str) -> RuntimeError:
+    message = _error_message(value, default)
+    normalized = message.casefold()
+    if any(
+        marker in normalized
+        for marker in (
+            "search backend is busy",
+            "search backend rate-limited",
+            "search backend cooling down",
+        )
+    ):
+        return _PluginThrottleError(message)
+    return RuntimeError(message)
 
 
 def _extract_export(payload: object) -> Dict[str, Any]:
@@ -98,8 +140,8 @@ def _extract_export(payload: object) -> Dict[str, Any]:
         # envelope before the plugin's own result payload.
         for _ in range(4):
             if current.get("success") is False or current.get("error"):
-                raise RuntimeError(
-                    _error_message(current.get("error"), "搜索插件执行失败")
+                raise _plugin_error(
+                    current.get("error"), "搜索插件执行失败"
                 )
             nested = current.get("data")
             if not isinstance(nested, dict):
@@ -174,11 +216,9 @@ async def _invoke_plugin(
                 if status in terminal:
                     terminal_seen = True
                     if status != "succeeded":
-                        raise RuntimeError(
-                            _error_message(
-                                run_data.get("error"),
-                                f"联网搜索任务状态：{status}",
-                            )
+                        raise _plugin_error(
+                            run_data.get("error"),
+                            f"联网搜索任务状态：{status}",
                         )
                     break
                 await asyncio.sleep(min(poll_interval, remaining))
@@ -245,73 +285,98 @@ async def search_via_plugin(
     if cached is not None:
         return cached
 
-    lock = _gateway_lock()
-    try:
-        await asyncio.wait_for(
-            lock.acquire(),
-            timeout=_MAX_QUEUE_WAIT_SECONDS,
-        )
-    except TimeoutError:
-        return {
-            "success": False,
-            "error": "联网搜索网关繁忙，请稍后重试",
-            "results": [],
-        }
-    try:
-        cached = _cached(key)
-        if cached is not None:
-            return cached
+    loop = _prepare_runtime_loop()
+    task = _inflight.get(key)
+    if task is None:
+        # Reserve a per-backend start slot synchronously before yielding. This
+        # prevents bursts without holding one global lock for a complete plugin
+        # run; other backends remain independent and identical keys share work.
         now = time.monotonic()
+        stale = _cached(key, fresh=False)
         cooldown_until = _failure_cooldown_until.get(selected_backend, 0.0)
         if now < cooldown_until:
-            return {
+            return stale or {
                 "success": False,
                 "error": "联网搜索暂处于失败冷却期",
                 "results": [],
             }
-        throttle_wait = _next_run_at.get(selected_backend, 0.0) - now
+        start_at = max(now, _next_run_at.get(selected_backend, 0.0))
+        throttle_wait = start_at - now
         if throttle_wait > _MAX_THROTTLE_WAIT_SECONDS:
-            return {
+            return stale or {
                 "success": False,
                 "error": "联网搜索请求过于频繁，请稍后重试",
                 "results": [],
             }
-        if throttle_wait > 0:
-            await asyncio.sleep(throttle_wait)
+        _next_run_at[selected_backend] = start_at + _MIN_RUN_INTERVAL_SECONDS
 
-        try:
-            result = await _invoke_plugin(normalized_query, plugin_limit, backend)
-        except Exception as error:
-            _failure_cooldown_until[selected_backend] = (
-                time.monotonic() + _FAILURE_COOLDOWN_SECONDS
-            )
-            logger.warning(
-                "受控联网搜索失败 (query_len=%s, error_type=%s)",
-                len(normalized_query),
-                type(error).__name__,
-            )
-            return {
-                "success": False,
-                "error": str(error),
-                "results": [],
-            }
-        finally:
-            _next_run_at[selected_backend] = (
-                time.monotonic() + _MIN_RUN_INTERVAL_SECONDS
-            )
+        async def execute() -> Dict[str, Any]:
+            if throttle_wait > 0:
+                await asyncio.sleep(throttle_wait)
+            try:
+                result = await _invoke_plugin(
+                    normalized_query,
+                    plugin_limit,
+                    backend,
+                )
+            except _PluginThrottleError as error:
+                # Busy/cooldown responses are normal flow control from a
+                # healthy plugin, not grounds for a five-minute outage.
+                return stale or {
+                    "success": False,
+                    "error": str(error),
+                    "results": [],
+                }
+            except Exception as error:
+                _failure_cooldown_until[selected_backend] = (
+                    time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+                )
+                logger.warning(
+                    "受控联网搜索失败 (query_len=%s, error_type=%s)",
+                    len(normalized_query),
+                    type(error).__name__,
+                )
+                return stale or {
+                    "success": False,
+                    "error": str(error),
+                    "results": [],
+                }
 
-        result["results"] = [
-            dict(item)
-            for item in result.get("results", [])[:requested_limit]
-            if isinstance(item, dict)
-        ]
-        result["success"] = bool(result["results"])
-        if result["success"]:
-            result["error"] = ""
+            result["results"] = [
+                dict(item)
+                for item in result.get("results", [])[:requested_limit]
+                if isinstance(item, dict)
+            ]
+            result["success"] = bool(result["results"])
+            if result["success"]:
+                result["error"] = ""
 
-        # A valid empty result is cacheable too; otherwise a stable obscure
-        # window title would still trigger one upstream search every refresh.
-        _store(key, result)
-        return _copy_result(result)
+            # A valid empty result is cacheable too; otherwise a stable obscure
+            # window title would still trigger one upstream search every refresh.
+            _store(key, result)
+            return _copy_result(result)
+
+        task = loop.create_task(execute())
+        _inflight[key] = task
+
+        def finish(done: asyncio.Task[Dict[str, Any]]) -> None:
+            if _inflight.get(key) is done:
+                _inflight.pop(key, None)
+
+        task.add_done_callback(finish)
+
+    _waiters[key] = _waiters.get(key, 0) + 1
+    try:
+        return _copy_result(await asyncio.shield(task))
     finally:
-        lock.release()
+        remaining = _waiters.get(key, 1) - 1
+        if remaining > 0:
+            _waiters[key] = remaining
+        else:
+            _waiters.pop(key, None)
+            if not task.done():
+                if _inflight.get(key) is task:
+                    _inflight.pop(key, None)
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -306,7 +306,19 @@ async def search_via_plugin(
                 "error": "联网搜索暂处于失败冷却期",
                 "results": [],
             }
-        start_at = max(now, _next_run_at.get(selected_backend, 0.0))
+        # The gateway cannot know which backend the plugin will choose for
+        # auto until after the run. Reserve both possible short start slots so
+        # auto cannot race an explicit request into the same coordinator.
+        # Explicit Baidu and DuckDuckGo requests still use independent slots.
+        coordination_slots = (
+            ("baidu", "duckduckgo")
+            if selected_backend == "auto"
+            else (selected_backend,)
+        )
+        start_at = max(
+            now,
+            *(_next_run_at.get(slot, 0.0) for slot in coordination_slots),
+        )
         throttle_wait = start_at - now
         if throttle_wait > _MAX_THROTTLE_WAIT_SECONDS:
             return stale or {
@@ -314,7 +326,9 @@ async def search_via_plugin(
                 "error": "联网搜索请求过于频繁，请稍后重试",
                 "results": [],
             }
-        _next_run_at[selected_backend] = start_at + _MIN_RUN_INTERVAL_SECONDS
+        next_start = start_at + _MIN_RUN_INTERVAL_SECONDS
+        for slot in coordination_slots:
+            _next_run_at[slot] = next_start
 
         async def execute() -> Dict[str, Any]:
             if throttle_wait > 0:

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -177,6 +177,7 @@ async def _invoke_plugin(
     query: str,
     limit: int,
     backend: Optional[str],
+    preferred_backend: Optional[str],
 ) -> Dict[str, Any]:
     base = f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}"
     args: Dict[str, Any] = {
@@ -186,6 +187,10 @@ async def _invoke_plugin(
     }
     if backend in {"baidu", "duckduckgo"}:
         args["backend"] = backend
+    elif preferred_backend in {"baidu", "duckduckgo"}:
+        # Keep plugin auto semantics (including Baidu -> DDG fallback), while
+        # making its primary coordinator match the gateway's reserved slot.
+        args["preferred_backend"] = preferred_backend
     body = {
         "task_id": f"proactive-search-{uuid.uuid4().hex}",
         "plugin_id": "web_search",
@@ -275,6 +280,7 @@ async def search_via_plugin(
     limit: int = 5,
     *,
     backend: Optional[str] = None,
+    preferred_backend: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run a cached, rate-limited search through the web_search plugin."""
     normalized_query = " ".join(str(query or "").split())
@@ -285,7 +291,13 @@ async def search_via_plugin(
     except (TypeError, ValueError):
         requested_limit = 5
     plugin_limit = max(3, requested_limit)
-    selected_backend = backend if backend in {"baidu", "duckduckgo"} else "auto"
+    requested_backend = backend if backend in {"baidu", "duckduckgo"} else None
+    hinted_backend = (
+        preferred_backend
+        if preferred_backend in {"baidu", "duckduckgo"}
+        else None
+    )
+    selected_backend = requested_backend or hinted_backend or "auto"
     key = (selected_backend, normalized_query.casefold(), requested_limit)
     cached = _cached(key)
     if cached is not None:
@@ -306,19 +318,7 @@ async def search_via_plugin(
                 "error": "联网搜索暂处于失败冷却期",
                 "results": [],
             }
-        # The gateway cannot know which backend the plugin will choose for
-        # auto until after the run. Reserve both possible short start slots so
-        # auto cannot race an explicit request into the same coordinator.
-        # Explicit Baidu and DuckDuckGo requests still use independent slots.
-        coordination_slots = (
-            ("baidu", "duckduckgo")
-            if selected_backend == "auto"
-            else (selected_backend,)
-        )
-        start_at = max(
-            now,
-            *(_next_run_at.get(slot, 0.0) for slot in coordination_slots),
-        )
+        start_at = max(now, _next_run_at.get(selected_backend, 0.0))
         throttle_wait = start_at - now
         if throttle_wait > _MAX_THROTTLE_WAIT_SECONDS:
             return stale or {
@@ -327,8 +327,7 @@ async def search_via_plugin(
                 "results": [],
             }
         next_start = start_at + _MIN_RUN_INTERVAL_SECONDS
-        for slot in coordination_slots:
-            _next_run_at[slot] = next_start
+        _next_run_at[selected_backend] = next_start
 
         async def execute() -> Dict[str, Any]:
             if throttle_wait > 0:
@@ -338,6 +337,7 @@ async def search_via_plugin(
                     normalized_query,
                     plugin_limit,
                     backend,
+                    hinted_backend,
                 )
             except _PluginThrottleError as error:
                 # Busy/cooldown responses are normal flow control from a

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 from collections import OrderedDict
 from contextlib import suppress
+import os
 import time
 from typing import Any, Dict, Optional
 import uuid
@@ -47,6 +48,7 @@ _next_run_at: Dict[str, float] = {}
 _failure_cooldown_until: Dict[str, float] = {}
 _inflight: Dict[tuple[str, str, int], asyncio.Task[Dict[str, Any]]] = {}
 _waiters: Dict[tuple[str, str, int], int] = {}
+_cleanup_tasks: set[asyncio.Task[None]] = set()
 _runtime_loop: Optional[asyncio.AbstractEventLoop] = None
 
 
@@ -158,19 +160,37 @@ def _extract_export(payload: object) -> Dict[str, Any]:
     raise RuntimeError("搜索插件没有返回结构化结果")
 
 
-async def _cancel_run(
-    client: httpx.AsyncClient,
-    base: str,
-    run_id: str,
-) -> None:
+def _plugin_server_base() -> str:
+    raw_port = os.getenv("NEKO_USER_PLUGIN_SERVER_PORT", "").strip()
     try:
-        await client.post(
-            f"{base}/runs/{run_id}/cancel",
-            json={"reason": "search gateway stopped waiting"},
-            timeout=1.0,
-        )
+        port = int(raw_port) if raw_port else int(USER_PLUGIN_SERVER_PORT)
+    except (TypeError, ValueError):
+        port = int(USER_PLUGIN_SERVER_PORT)
+    if not 1 <= port <= 65535:
+        port = int(USER_PLUGIN_SERVER_PORT)
+    return f"http://127.0.0.1:{port}"
+
+
+async def _cancel_run(base: str, run_id: str) -> None:
+    try:
+        timeout = httpx.Timeout(0.5, connect=0.2)
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            proxy=None,
+            trust_env=False,
+        ) as client:
+            await client.post(
+                f"{base}/runs/{run_id}/cancel",
+                json={"reason": "search gateway stopped waiting"},
+            )
     except Exception:
         logger.debug("取消遗留联网搜索任务失败 (run_id=%s)", run_id)
+
+
+def _schedule_cancel(base: str, run_id: str) -> None:
+    task = asyncio.create_task(_cancel_run(base, run_id))
+    _cleanup_tasks.add(task)
+    task.add_done_callback(_cleanup_tasks.discard)
 
 
 async def _invoke_plugin(
@@ -179,7 +199,16 @@ async def _invoke_plugin(
     backend: Optional[str],
     preferred_backend: Optional[str],
 ) -> Dict[str, Any]:
-    base = f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}"
+    base = _plugin_server_base()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _RUN_TIMEOUT_SECONDS
+
+    def remaining_timeout() -> float:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError("等待联网搜索插件超时")
+        return min(5.0, remaining)
+
     args: Dict[str, Any] = {
         "query": query,
         "max_results": limit,
@@ -199,7 +228,13 @@ async def _invoke_plugin(
     }
     timeout = httpx.Timeout(5.0, connect=1.0)
     async with httpx.AsyncClient(timeout=timeout, proxy=None, trust_env=False) as client:
-        response = await client.post(f"{base}/runs", json=body)
+        request_timeout = remaining_timeout()
+        async with asyncio.timeout(request_timeout):
+            response = await client.post(
+                f"{base}/runs",
+                json=body,
+                timeout=request_timeout,
+            )
         if not 200 <= response.status_code < 300:
             raise RuntimeError(f"联网搜索插件不可用（HTTP {response.status_code}）")
         accepted = response.json()
@@ -207,16 +242,17 @@ async def _invoke_plugin(
         if not isinstance(run_id, str) or not run_id:
             raise RuntimeError("联网搜索插件未返回有效任务编号")
 
-        deadline = asyncio.get_running_loop().time() + _RUN_TIMEOUT_SECONDS
         terminal = {"succeeded", "failed", "canceled", "timeout"}
         poll_interval = _POLL_INTERVAL_SECONDS
         terminal_seen = False
         try:
             while True:
-                remaining = deadline - asyncio.get_running_loop().time()
-                if remaining <= 0:
-                    raise TimeoutError("等待联网搜索插件超时")
-                response = await client.get(f"{base}/runs/{run_id}")
+                request_timeout = remaining_timeout()
+                async with asyncio.timeout(request_timeout):
+                    response = await client.get(
+                        f"{base}/runs/{run_id}",
+                        timeout=request_timeout,
+                    )
                 if response.status_code != 200:
                     raise RuntimeError(
                         f"读取联网搜索任务失败（HTTP {response.status_code}）"
@@ -232,16 +268,21 @@ async def _invoke_plugin(
                             f"联网搜索任务状态：{status}",
                         )
                     break
-                await asyncio.sleep(min(poll_interval, remaining))
+                await asyncio.sleep(
+                    min(poll_interval, max(0.0, deadline - loop.time()))
+                )
                 poll_interval = min(
                     poll_interval * 1.5,
                     _MAX_POLL_INTERVAL_SECONDS,
                 )
 
-            response = await client.get(
-                f"{base}/runs/{run_id}/export",
-                params={"limit": 20},
-            )
+            request_timeout = remaining_timeout()
+            async with asyncio.timeout(request_timeout):
+                response = await client.get(
+                    f"{base}/runs/{run_id}/export",
+                    params={"limit": 20},
+                    timeout=request_timeout,
+                )
             if response.status_code != 200:
                 raise RuntimeError(
                     f"导出联网搜索结果失败（HTTP {response.status_code}）"
@@ -249,7 +290,7 @@ async def _invoke_plugin(
             data = _extract_export(response.json())
         except BaseException:
             if not terminal_seen:
-                await _cancel_run(client, base, run_id)
+                _schedule_cancel(base, run_id)
             raise
 
     normalized_results = []

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -19,7 +19,7 @@ import httpx
 
 from config import USER_PLUGIN_SERVER_PORT
 
-from ._shared import logger
+from ._shared import is_china_region, logger
 
 
 _CACHE_TTL_SECONDS = 600.0
@@ -74,6 +74,7 @@ def _prepare_runtime_loop() -> asyncio.AbstractEventLoop:
         _inflight.clear()
         _waiters.clear()
         _backend_locks.clear()
+        _cleanup_tasks.clear()
     return loop
 
 
@@ -394,8 +395,18 @@ async def search_via_plugin(
         if preferred_backend in {"baidu", "duckduckgo"}
         else None
     )
-    selected_backend = requested_backend or hinted_backend or "auto"
-    key = (selected_backend, normalized_query.casefold(), requested_limit)
+    selected_backend = requested_backend or hinted_backend
+    if selected_backend is None:
+        selected_backend = "baidu" if is_china_region() else "duckduckgo"
+    allow_cross_engine_fallback = (
+        requested_backend is None and selected_backend == "baidu"
+    )
+    cache_scope = (
+        f"{selected_backend}:fallback"
+        if allow_cross_engine_fallback
+        else selected_backend
+    )
+    key = (cache_scope, normalized_query.casefold(), requested_limit)
     cached = _cached(key)
     if cached is not None:
         return cached
@@ -408,39 +419,30 @@ async def search_via_plugin(
         async def execute() -> Dict[str, Any]:
             deadline = loop.time() + _RUN_TIMEOUT_SECONDS
             try:
-                if selected_backend in {"baidu", "duckduckgo"}:
+                try:
+                    result = await _invoke_in_backend_slot(
+                        normalized_query,
+                        plugin_limit,
+                        selected_backend,
+                        deadline,
+                    )
+                except Exception as primary_error:
+                    if not allow_cross_engine_fallback:
+                        raise
+                    logger.info(
+                        "受控百度搜索失败，协调 DuckDuckGo 后端后重试 "
+                        "(error_type=%s)",
+                        type(primary_error).__name__,
+                    )
                     try:
                         result = await _invoke_in_backend_slot(
                             normalized_query,
                             plugin_limit,
-                            selected_backend,
+                            "duckduckgo",
                             deadline,
                         )
-                    except Exception as primary_error:
-                        if requested_backend is not None or selected_backend != "baidu":
-                            raise
-                        logger.info(
-                            "受控百度搜索失败，协调 DuckDuckGo 后端后重试 "
-                            "(error_type=%s)",
-                            type(primary_error).__name__,
-                        )
-                        try:
-                            result = await _invoke_in_backend_slot(
-                                normalized_query,
-                                plugin_limit,
-                                "duckduckgo",
-                                deadline,
-                            )
-                        except Exception:
-                            raise primary_error
-                else:
-                    result = await _invoke_plugin(
-                        normalized_query,
-                        plugin_limit,
-                        None,
-                        None,
-                        run_timeout=max(0.01, deadline - loop.time()),
-                    )
+                    except Exception:
+                        raise primary_error
             except _PluginThrottleError as error:
                 # Busy/cooldown responses are normal flow control from a
                 # healthy plugin, not grounds for a five-minute outage.
@@ -450,10 +452,6 @@ async def search_via_plugin(
                     "results": [],
                 }
             except Exception as error:
-                if selected_backend == "auto":
-                    _failure_cooldown_until[selected_backend] = (
-                        time.monotonic() + _FAILURE_COOLDOWN_SECONDS
-                    )
                 logger.warning(
                     "受控联网搜索失败 (query_len=%s, error_type=%s)",
                     len(normalized_query),

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -1,9 +1,8 @@
 """Controlled main-process access to the web-search plugin.
 
-All proactive search traffic goes through the plugin run protocol so the
-plugin owns upstream caching, rate limits, cooldowns, and backend fallback.
-This module adds a longer-lived proactive cache and failure cooldown to avoid
-turning frequent context refreshes into frequent plugin runs.
+All proactive search traffic goes through the plugin run protocol. This module
+coordinates proactive backend transitions and adds a longer-lived cache and
+failure cooldown, while the plugin remains the final upstream resilience layer.
 """
 
 from __future__ import annotations
@@ -31,7 +30,6 @@ _MAX_CACHE_ENTRIES = 64
 _RUN_TIMEOUT_SECONDS = 30.0
 _POLL_INTERVAL_SECONDS = 0.25
 _MAX_POLL_INTERVAL_SECONDS = 2.0
-_MAX_THROTTLE_WAIT_SECONDS = 2.0
 _FLOW_CONTROL_ERROR_CODES = frozenset(
     {
         "web_search_backend_blocked",
@@ -48,6 +46,7 @@ _next_run_at: Dict[str, float] = {}
 _failure_cooldown_until: Dict[str, float] = {}
 _inflight: Dict[tuple[str, str, int], asyncio.Task[Dict[str, Any]]] = {}
 _waiters: Dict[tuple[str, str, int], int] = {}
+_backend_locks: Dict[str, asyncio.Lock] = {}
 _cleanup_tasks: set[asyncio.Task[None]] = set()
 _runtime_loop: Optional[asyncio.AbstractEventLoop] = None
 
@@ -74,6 +73,7 @@ def _prepare_runtime_loop() -> asyncio.AbstractEventLoop:
         _runtime_loop = loop
         _inflight.clear()
         _waiters.clear()
+        _backend_locks.clear()
     return loop
 
 
@@ -198,10 +198,12 @@ async def _invoke_plugin(
     limit: int,
     backend: Optional[str],
     preferred_backend: Optional[str],
+    run_timeout: float = _RUN_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
     base = _plugin_server_base()
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + _RUN_TIMEOUT_SECONDS
+    run_timeout = max(0.01, min(float(run_timeout), _RUN_TIMEOUT_SECONDS))
+    deadline = loop.time() + run_timeout
 
     def remaining_timeout() -> float:
         remaining = deadline - loop.time()
@@ -212,7 +214,7 @@ async def _invoke_plugin(
     args: Dict[str, Any] = {
         "query": query,
         "max_results": limit,
-        "_ctx": {"entry_timeout": _RUN_TIMEOUT_SECONDS},
+        "_ctx": {"entry_timeout": run_timeout},
     }
     if backend in {"baidu", "duckduckgo"}:
         args["backend"] = backend
@@ -316,6 +318,60 @@ async def _invoke_plugin(
     }
 
 
+async def _invoke_in_backend_slot(
+    query: str,
+    limit: int,
+    backend: str,
+    deadline: float,
+) -> Dict[str, Any]:
+    """Serialize one upstream backend while leaving other engines independent."""
+    loop = asyncio.get_running_loop()
+    lock = _backend_locks.setdefault(backend, asyncio.Lock())
+    remaining = deadline - loop.time()
+    if remaining <= 0:
+        raise TimeoutError("等待联网搜索插件超时")
+    try:
+        async with asyncio.timeout(remaining):
+            await lock.acquire()
+    except TimeoutError as error:
+        raise _PluginThrottleError("联网搜索后端繁忙，请稍后重试") from error
+
+    try:
+        now = time.monotonic()
+        cooldown_until = _failure_cooldown_until.get(backend, 0.0)
+        if now < cooldown_until:
+            raise _PluginThrottleError("联网搜索暂处于失败冷却期")
+        throttle_wait = max(0.0, _next_run_at.get(backend, 0.0) - now)
+        if throttle_wait:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError("等待联网搜索插件超时")
+            async with asyncio.timeout(remaining):
+                await asyncio.sleep(throttle_wait)
+
+        _next_run_at[backend] = time.monotonic() + _MIN_RUN_INTERVAL_SECONDS
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError("等待联网搜索插件超时")
+        try:
+            return await _invoke_plugin(
+                query,
+                limit,
+                backend,
+                None,
+                run_timeout=remaining,
+            )
+        except _PluginThrottleError:
+            raise
+        except Exception:
+            _failure_cooldown_until[backend] = (
+                time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+            )
+            raise
+    finally:
+        lock.release()
+
+
 async def search_via_plugin(
     query: str,
     limit: int = 5,
@@ -347,39 +403,44 @@ async def search_via_plugin(
     loop = _prepare_runtime_loop()
     task = _inflight.get(key)
     if task is None:
-        # Reserve a per-backend start slot synchronously before yielding. This
-        # prevents bursts without holding one global lock for a complete plugin
-        # run; other backends remain independent and identical keys share work.
-        now = time.monotonic()
         stale = _cached(key, fresh=False)
-        cooldown_until = _failure_cooldown_until.get(selected_backend, 0.0)
-        if now < cooldown_until:
-            return stale or {
-                "success": False,
-                "error": "联网搜索暂处于失败冷却期",
-                "results": [],
-            }
-        start_at = max(now, _next_run_at.get(selected_backend, 0.0))
-        throttle_wait = start_at - now
-        if throttle_wait > _MAX_THROTTLE_WAIT_SECONDS:
-            return stale or {
-                "success": False,
-                "error": "联网搜索请求过于频繁，请稍后重试",
-                "results": [],
-            }
-        next_start = start_at + _MIN_RUN_INTERVAL_SECONDS
-        _next_run_at[selected_backend] = next_start
 
         async def execute() -> Dict[str, Any]:
-            if throttle_wait > 0:
-                await asyncio.sleep(throttle_wait)
+            deadline = loop.time() + _RUN_TIMEOUT_SECONDS
             try:
-                result = await _invoke_plugin(
-                    normalized_query,
-                    plugin_limit,
-                    backend,
-                    hinted_backend,
-                )
+                if selected_backend in {"baidu", "duckduckgo"}:
+                    try:
+                        result = await _invoke_in_backend_slot(
+                            normalized_query,
+                            plugin_limit,
+                            selected_backend,
+                            deadline,
+                        )
+                    except Exception as primary_error:
+                        if requested_backend is not None or selected_backend != "baidu":
+                            raise
+                        logger.info(
+                            "受控百度搜索失败，协调 DuckDuckGo 后端后重试 "
+                            "(error_type=%s)",
+                            type(primary_error).__name__,
+                        )
+                        try:
+                            result = await _invoke_in_backend_slot(
+                                normalized_query,
+                                plugin_limit,
+                                "duckduckgo",
+                                deadline,
+                            )
+                        except Exception:
+                            raise primary_error
+                else:
+                    result = await _invoke_plugin(
+                        normalized_query,
+                        plugin_limit,
+                        None,
+                        None,
+                        run_timeout=max(0.01, deadline - loop.time()),
+                    )
             except _PluginThrottleError as error:
                 # Busy/cooldown responses are normal flow control from a
                 # healthy plugin, not grounds for a five-minute outage.
@@ -389,9 +450,10 @@ async def search_via_plugin(
                     "results": [],
                 }
             except Exception as error:
-                _failure_cooldown_until[selected_backend] = (
-                    time.monotonic() + _FAILURE_COOLDOWN_SECONDS
-                )
+                if selected_backend == "auto":
+                    _failure_cooldown_until[selected_backend] = (
+                        time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+                    )
                 logger.warning(
                     "受控联网搜索失败 (query_len=%s, error_type=%s)",
                     len(normalized_query),

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -1,0 +1,231 @@
+"""Controlled main-process access to the web-search plugin.
+
+All proactive search traffic goes through the plugin run protocol so the
+plugin owns upstream caching, rate limits, cooldowns, and backend fallback.
+This module adds a longer-lived proactive cache and failure cooldown to avoid
+turning frequent context refreshes into frequent plugin runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+import time
+from typing import Any, Dict, Optional
+import uuid
+
+import httpx
+
+from config import USER_PLUGIN_SERVER_PORT
+
+from ._shared import logger
+
+
+_CACHE_TTL_SECONDS = 600.0
+_FAILURE_COOLDOWN_SECONDS = 300.0
+_MIN_RUN_INTERVAL_SECONDS = 5.0
+_MAX_CACHE_ENTRIES = 64
+_RUN_TIMEOUT_SECONDS = 30.0
+_POLL_INTERVAL_SECONDS = 0.25
+
+_cache: OrderedDict[tuple[str, str, int], tuple[float, Dict[str, Any]]] = OrderedDict()
+_lock: Optional[asyncio.Lock] = None
+_lock_loop: Optional[asyncio.AbstractEventLoop] = None
+_next_run_at = 0.0
+_failure_cooldown_until = 0.0
+
+
+def _copy_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    copied = dict(result)
+    copied["results"] = [
+        dict(item) for item in result.get("results", []) if isinstance(item, dict)
+    ]
+    return copied
+
+
+def _gateway_lock() -> asyncio.Lock:
+    global _lock, _lock_loop
+    loop = asyncio.get_running_loop()
+    if _lock is None or _lock_loop is not loop:
+        _lock = asyncio.Lock()
+        _lock_loop = loop
+    return _lock
+
+
+def _cached(key: tuple[str, str, int]) -> Optional[Dict[str, Any]]:
+    cached = _cache.get(key)
+    if cached is None:
+        return None
+    expires_at, result = cached
+    if time.monotonic() >= expires_at:
+        _cache.pop(key, None)
+        return None
+    _cache.move_to_end(key)
+    return _copy_result(result)
+
+
+def _store(key: tuple[str, str, int], result: Dict[str, Any]) -> None:
+    _cache[key] = (time.monotonic() + _CACHE_TTL_SECONDS, _copy_result(result))
+    _cache.move_to_end(key)
+    while len(_cache) > _MAX_CACHE_ENTRIES:
+        _cache.popitem(last=False)
+
+
+def _error_message(value: object, default: str) -> str:
+    if isinstance(value, dict):
+        return str(value.get("message") or value.get("code") or default)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return default
+
+
+def _extract_export(payload: object) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("搜索插件返回了无效导出数据")
+    for item in payload.get("items") or []:
+        if not isinstance(item, dict) or item.get("type") != "json":
+            continue
+        raw = item.get("json")
+        if raw is None:
+            raw = item.get("json_data")
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("error"):
+            raise RuntimeError(_error_message(raw.get("error"), "搜索插件执行失败"))
+        data = raw.get("data")
+        if isinstance(data, dict):
+            return data
+    raise RuntimeError("搜索插件没有返回结构化结果")
+
+
+async def _invoke_plugin(
+    query: str,
+    limit: int,
+    backend: Optional[str],
+) -> Dict[str, Any]:
+    base = f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}"
+    args: Dict[str, Any] = {
+        "query": query,
+        "max_results": limit,
+        "_ctx": {"entry_timeout": _RUN_TIMEOUT_SECONDS},
+    }
+    if backend in {"baidu", "duckduckgo"}:
+        args["backend"] = backend
+    body = {
+        "task_id": f"proactive-search-{uuid.uuid4().hex}",
+        "plugin_id": "web_search",
+        "entry_id": "search",
+        "args": args,
+    }
+    timeout = httpx.Timeout(5.0, connect=1.0)
+    async with httpx.AsyncClient(timeout=timeout, proxy=None, trust_env=False) as client:
+        response = await client.post(f"{base}/runs", json=body)
+        if not 200 <= response.status_code < 300:
+            raise RuntimeError(f"联网搜索插件不可用（HTTP {response.status_code}）")
+        accepted = response.json()
+        run_id = accepted.get("run_id") if isinstance(accepted, dict) else None
+        if not isinstance(run_id, str) or not run_id:
+            raise RuntimeError("联网搜索插件未返回有效任务编号")
+
+        deadline = asyncio.get_running_loop().time() + _RUN_TIMEOUT_SECONDS
+        terminal = {"succeeded", "failed", "canceled", "timeout"}
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError("等待联网搜索插件超时")
+            response = await client.get(f"{base}/runs/{run_id}")
+            if response.status_code != 200:
+                raise RuntimeError(f"读取联网搜索任务失败（HTTP {response.status_code}）")
+            candidate = response.json()
+            run_data = candidate if isinstance(candidate, dict) else {}
+            status = str(run_data.get("status") or "")
+            if status in terminal:
+                if status != "succeeded":
+                    raise RuntimeError(
+                        _error_message(run_data.get("error"), f"联网搜索任务状态：{status}")
+                    )
+                break
+            await asyncio.sleep(min(_POLL_INTERVAL_SECONDS, remaining))
+
+        response = await client.get(f"{base}/runs/{run_id}/export", params={"limit": 20})
+        if response.status_code != 200:
+            raise RuntimeError(f"导出联网搜索结果失败（HTTP {response.status_code}）")
+        data = _extract_export(response.json())
+
+    normalized_results = []
+    for item in data.get("results") or []:
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or "").strip()
+        url = str(item.get("url") or "").strip()
+        if not title or not url:
+            continue
+        normalized_results.append(
+            {
+                "title": title,
+                "abstract": str(item.get("snippet") or item.get("abstract") or "").strip(),
+                "url": url,
+            }
+        )
+    return {
+        "success": bool(normalized_results),
+        "query": query,
+        "results": normalized_results,
+        "error": "" if normalized_results else "未获得搜索结果",
+    }
+
+
+async def search_via_plugin(
+    query: str,
+    limit: int = 5,
+    *,
+    backend: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run a cached, rate-limited search through the web_search plugin."""
+    global _next_run_at, _failure_cooldown_until
+
+    normalized_query = " ".join(str(query or "").split())
+    if len(normalized_query) < 2:
+        return {"success": False, "error": "搜索关键词太短", "results": []}
+    bounded_limit = max(3, min(int(limit), 10))
+    selected_backend = backend if backend in {"baidu", "duckduckgo"} else "auto"
+    key = (selected_backend, normalized_query.casefold(), bounded_limit)
+    cached = _cached(key)
+    if cached is not None:
+        return cached
+
+    async with _gateway_lock():
+        cached = _cached(key)
+        if cached is not None:
+            return cached
+        now = time.monotonic()
+        if now < _failure_cooldown_until:
+            return {
+                "success": False,
+                "error": "联网搜索暂处于失败冷却期",
+                "results": [],
+            }
+        if now < _next_run_at:
+            await asyncio.sleep(_next_run_at - now)
+
+        try:
+            result = await _invoke_plugin(normalized_query, bounded_limit, backend)
+        except Exception as error:
+            _failure_cooldown_until = time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+            logger.warning(
+                "受控联网搜索失败 (query_len=%s, error_type=%s)",
+                len(normalized_query),
+                type(error).__name__,
+            )
+            return {
+                "success": False,
+                "error": str(error),
+                "results": [],
+            }
+        finally:
+            _next_run_at = time.monotonic() + _MIN_RUN_INTERVAL_SECONDS
+
+        # A valid empty result is cacheable too; otherwise a stable obscure
+        # window title would still trigger one upstream search every refresh.
+        _store(key, result)
+        return _copy_result(result)

--- a/utils/web_scraper/search_gateway.py
+++ b/utils/web_scraper/search_gateway.py
@@ -31,6 +31,13 @@ _RUN_TIMEOUT_SECONDS = 30.0
 _POLL_INTERVAL_SECONDS = 0.25
 _MAX_POLL_INTERVAL_SECONDS = 2.0
 _MAX_THROTTLE_WAIT_SECONDS = 2.0
+_FLOW_CONTROL_ERROR_CODES = frozenset(
+    {
+        "web_search_backend_blocked",
+        "web_search_backend_busy",
+        "web_search_backend_cooldown",
+    }
+)
 
 _cache: OrderedDict[
     tuple[str, str, int],
@@ -103,7 +110,9 @@ def _store(key: tuple[str, str, int], result: Dict[str, Any]) -> None:
 
 def _error_message(value: object, default: str) -> str:
     if isinstance(value, dict):
-        return str(value.get("message") or value.get("code") or default)
+        nested = value.get("error")
+        source = nested if isinstance(nested, dict) else value
+        return str(source.get("message") or source.get("code") or default)
     if isinstance(value, str) and value.strip():
         return value.strip()
     return default
@@ -111,15 +120,12 @@ def _error_message(value: object, default: str) -> str:
 
 def _plugin_error(value: object, default: str) -> RuntimeError:
     message = _error_message(value, default)
-    normalized = message.casefold()
-    if any(
-        marker in normalized
-        for marker in (
-            "search backend is busy",
-            "search backend rate-limited",
-            "search backend cooling down",
-        )
-    ):
+    code = ""
+    if isinstance(value, dict):
+        nested = value.get("error")
+        source = nested if isinstance(nested, dict) else value
+        code = str(source.get("code") or "").strip().casefold()
+    if code in _FLOW_CONTROL_ERROR_CODES:
         return _PluginThrottleError(message)
     return RuntimeError(message)
 

--- a/utils/web_scraper/window_context.py
+++ b/utils/web_scraper/window_context.py
@@ -392,13 +392,7 @@ def parse_google_results(html_content: str, limit: int = 5) -> List[Dict[str, st
 
 async def search_duckduckgo(query: str, limit: int = 10) -> Dict[str, Any]:
     """
-    Search keywords on DuckDuckGo and fetch results (for non-Chinese regions).
-
-    Replaces Google: Google's anti-bot measures are nearly guaranteed to trip for
-    headless/scripted requests (302 → /sorry/index → 429), so the proactive-chat
-    window-context search got basically no results. DuckDuckGo's HTML endpoint
-    (html.duckduckgo.com) is far more tolerant of scripted access, and results are
-    embedded directly in the HTML, easy to parse.
+    Search DuckDuckGo through the controlled web-search plugin gateway.
 
     Args:
         query: search keywords
@@ -515,7 +509,7 @@ def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str
 
 async def search_baidu(query: str, limit: int = 5) -> Dict[str, Any]:
     """
-    Search keywords on Baidu and fetch results
+    Search Baidu through the controlled web-search plugin gateway.
     
     Args:
         query: search keywords

--- a/utils/web_scraper/window_context.py
+++ b/utils/web_scraper/window_context.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     pass
 
 from ._shared import _extract_llm_text_content, get_random_user_agent, is_china_region, logger
+from .search_gateway import search_via_plugin
 
 def get_active_window_title(include_raw: bool = False) -> Optional[Union[str, Dict[str, str]]]:
     """
@@ -406,66 +407,7 @@ async def search_duckduckgo(query: str, limit: int = 10) -> Dict[str, Any]:
     Returns:
         Dict with search results
     """
-    try:
-        if not query or len(query.strip()) < 2:
-            return {
-                'success': False,
-                'error': '搜索关键词太短'
-            }
-
-        # 清理查询词
-        query = query.strip()
-        encoded_query = quote(query)
-
-        # DuckDuckGo 无 JS 的 HTML 端点（kl=us-en 对齐非中文区域口径）
-        url = f"https://html.duckduckgo.com/html/?q={encoded_query}&kl=us-en"
-
-        headers = {
-            'User-Agent': get_random_user_agent(),
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Referer': 'https://duckduckgo.com/',
-            'Connection': 'keep-alive',
-            'DNT': '1',
-            'Cache-Control': 'no-cache',
-        }
-
-        # 添加随机延迟
-        await asyncio.sleep(random.uniform(0.2, 0.5))
-
-        client = get_external_http_client()
-        response = await client.get(url, headers=headers, timeout=5.0)
-        response.raise_for_status()
-        html_content = response.text
-
-        # 解析搜索结果（BS4 大 HTML 同步解析放线程池，避免阻塞 event loop）
-        results = await asyncio.to_thread(parse_duckduckgo_results, html_content, limit)
-
-        if results:
-            return {
-                'success': True,
-                'query': query,
-                'results': results
-            }
-        else:
-            return {
-                'success': False,
-                'error': '未能解析到搜索结果',
-                'query': query
-            }
-
-    except httpx.TimeoutException:
-        logger.exception("DuckDuckGo搜索超时")
-        return {
-            'success': False,
-            'error': '搜索超时'
-        }
-    except Exception as e:
-        logger.exception(f"DuckDuckGo搜索失败: {e}")
-        return {
-            'success': False,
-            'error': str(e)
-        }
+    return await search_via_plugin(query, limit, backend="duckduckgo")
 
 _SEARCH_TEXT_WS_RE = re.compile(r"\s+")
 
@@ -582,66 +524,7 @@ async def search_baidu(query: str, limit: int = 5) -> Dict[str, Any]:
     Returns:
         Dict with search results
     """
-    try:
-        if not query or len(query.strip()) < 2:
-            return {
-                'success': False,
-                'error': '搜索关键词太短'
-            }
-        
-        # 清理查询词
-        query = query.strip()
-        encoded_query = quote(query)
-        
-        # 百度搜索URL
-        url = f"https://www.baidu.com/s?wd={encoded_query}"
-        
-        headers = {
-            'User-Agent': get_random_user_agent(),
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-            'Connection': 'keep-alive',
-            'Referer': 'https://www.baidu.com/',
-            'DNT': '1',
-            'Cache-Control': 'no-cache',
-        }
-        
-        # 添加随机延迟
-        await asyncio.sleep(random.uniform(0.2, 0.5))
-        
-        client = get_external_http_client()
-        response = await client.get(url, headers=headers, timeout=5.0)
-        response.raise_for_status()
-        html_content = response.text
-
-        # 解析搜索结果
-        results = await asyncio.to_thread(parse_baidu_results, html_content, limit)
-
-        if results:
-            return {
-                'success': True,
-                'query': query,
-                'results': results
-            }
-        else:
-            return {
-                'success': False,
-                'error': '未能解析到搜索结果',
-                'query': query
-            }
-
-    except httpx.TimeoutException:
-        logger.exception("百度搜索超时")
-        return {
-            'success': False,
-            'error': '搜索超时'
-        }
-    except Exception as e:
-        logger.exception(f"百度搜索失败: {e}")
-        return {
-            'success': False,
-            'error': str(e)
-        }
+    return await search_via_plugin(query, limit, backend="baidu")
 
 def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str]]:
     """
@@ -820,9 +703,7 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
     """
     Get the active window title and run a search on it
     
-    Region detection decides the search engine:
-    - Chinese region: Baidu
-    - non-Chinese region: DuckDuckGo (replacing Google to dodge its anti-bot 429)
+    The web_search plugin selects the backend and owns all upstream resilience.
     
     Args:
         limit: max number of search results
@@ -856,8 +737,9 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
         # 清理窗口标题以移除敏感信息，避免发送给LLM
         cleaned_title = clean_window_title(raw_title)
         
-        # 使用清理后的标题生成多样化搜索查询（保护隐私）
-        search_queries = await generate_diverse_queries(cleaned_title)
+        # 只提交一个稳定、清理后的查询。搜索插件负责缓存、限流、冷却和
+        # 后端回退，避免每轮主动上下文刷新放大成三次公网请求。
+        search_queries = [cleaned_title] if cleaned_title else []
         
         if not search_queries or all(not q or len(q) < 2 for q in search_queries):
             if china_region:
@@ -874,33 +756,18 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
                 }
         
         # 窗口标题 + 查询都不写 logger
-        logger.info(f"从窗口标题生成多样化查询完成 (queries_count={len(search_queries or [])})")
-        print(f"从窗口标题「{sanitized_title}」生成多样化查询: {search_queries}")
+        logger.info("窗口标题已生成受控查询 (queries_count=1)")
         
         # 执行搜索并合并结果
         all_results = []
         successful_queries = []
         
-        # 根据区域选择搜索函数
-        if china_region:
-            search_func = search_baidu
-        else:
-            # 非中文区域改用 DuckDuckGo：Google 对脚本请求几乎必触发 429/sorry 反爬
-            search_func = search_duckduckgo
-        
-        for query in search_queries:
-            if not query or len(query) < 2:
-                continue
-            
-            # query 是从用户窗口标题派生的搜索词，不写 logger
-            logger.info(f"使用查询关键词 (len={len(query)})")
-            print(f"使用查询关键词: {query}")
-            
-            search_result = await search_func(query, limit)
-            
-            if search_result.get('success') and search_result.get('results'):
-                all_results.extend(search_result['results'])
-                successful_queries.append(query)
+        query = search_queries[0]
+        logger.info(f"使用受控窗口查询 (len={len(query)})")
+        search_result = await search_via_plugin(query, limit)
+        if search_result.get('success') and search_result.get('results'):
+            all_results.extend(search_result['results'])
+            successful_queries.append(query)
         
         # 去重结果（优先使用URL，如果URL缺失则使用title）
         seen_keys = set()

--- a/utils/web_scraper/window_context.py
+++ b/utils/web_scraper/window_context.py
@@ -758,7 +758,11 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
         
         query = search_queries[0]
         logger.info(f"使用受控窗口查询 (len={len(query)})")
-        search_result = await search_via_plugin(query, limit)
+        search_result = await search_via_plugin(
+            query,
+            limit,
+            preferred_backend="baidu" if china_region else "duckduckgo",
+        )
         if search_result.get('success') and search_result.get('results'):
             all_results.extend(search_result['results'])
             successful_queries.append(query)


### PR DESCRIPTION
## 改动概述 / Summary

修复国内网络搜索在百度返回 JavaScript 跳转壳或安全验证页时不可用、并被后台窗口抓取放大请求频率的问题。

- 识别百度小型 JavaScript 重定向壳，避免把反爬响应当成空结果。
- 为百度和 DuckDuckGo 使用独立协调器；百度失败时才跨引擎回退。
- 百度使用保留 N.E.K.O 产品标识的浏览器兼容 UA，并持久化匿名百度 Cookie。
- 百度桌面结果受验证时，先降级到百度移动 SSR 结果；两个百度入口均失败后才回退 DuckDuckGo。
- 百度不同查询最小间隔为 15 秒，并保留缓存、合并请求、冷却和过期结果兜底。
- 后台窗口/话题搜索统一走 web_search 插件协议，共享插件限流与缓存；主进程额外提供 10 分钟缓存和失败冷却。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/ 或 memory/。

## 不拆分理由 / Why Not Split

不适用。计入上限的文件数不超过 20。

## 测试 / Testing

- `uv run ruff check plugin/plugins/web_search/__init__.py plugin/plugins/web_search/_parsing.py plugin/plugins/web_search/_resilience.py utils/web_scraper/search_gateway.py utils/web_scraper/window_context.py`
- `uv run pytest plugin/tests/unit/plugins/test_web_search_parsing.py plugin/tests/unit/plugins/test_web_search_resilience.py -p no:cacheprovider -q`：80 passed
- `uv run pytest tests/unit/test_topic_materials.py tests/unit/test_web_scraper.py tests/unit/test_proactive_service_boundary.py -p no:cacheprovider -q`：115 passed
- 真实联网回归：同一会话以 16 秒间隔执行 3 个不同百度查询，均由 `www.baidu.com/s` 返回 HTTP 200，每次解析 3 条结果，耗时 1.39–1.72 秒，无验证码、超时、移动端降级或 DDG 回退。
- 相同查询立即重试命中缓存，耗时约 0 秒且没有新增网络请求。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持指定首选搜索后端；未指定时可自动选择并回退。
  - 百度移动端结果解析更完善，可过滤重复、无标题及推荐内容。
  - 保存百度匿名会话，跨重启保留搜索状态。

- **改进**
  - 优化百度受限、限流及失败时的等待提示。
  - 搜索流程统一支持缓存、限流、冷却与超时控制。
  - 窗口搜索基于窗口标题执行一次搜索，提升效率。
  - 明确指定后端时不再自动切换其他后端。
  - 改进后台保存体验，减少搜索完成后的等待。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->