### PR TITLE
fix: release deferred SQLite handles before character deletion

### DIFF
--- a/app/memory_server/outbox_infra.py
+++ b/app/memory_server/outbox_infra.py
@@ -228,7 +228,17 @@ async def _replay_pending_outbox() -> list[asyncio.Task]:
                 if op.get("type") == OP_PERSIST_PROMPT_LOCALE
                 else _replay_semaphore
             )
+            # 按角色登记：改名/删除撞上一次长补跑时，release 才排得空它，
+            # 否则补跑会在 dispose 之后继续给旧身份写文件、把目录重建出来。
+            from . import post_turn
+
             spawned.append(
-                runtime._spawn_background_task(_run_outbox_op(name, op, semaphore))
+                post_turn._track_character_post_turn_task(
+                    name,
+                    runtime._spawn_background_task(
+                        _run_outbox_op(name, op, semaphore),
+                        inherit_character_admission=False,
+                    ),
+                )
             )
     return spawned

--- a/app/memory_server/outbox_infra.py
+++ b/app/memory_server/outbox_infra.py
@@ -237,7 +237,6 @@ async def _replay_pending_outbox() -> list[asyncio.Task]:
                     name,
                     runtime._spawn_background_task(
                         _run_outbox_op(name, op, semaphore),
-                        inherit_character_admission=False,
                     ),
                 )
             )

--- a/app/memory_server/post_turn.py
+++ b/app/memory_server/post_turn.py
@@ -498,10 +498,17 @@ async def _run_post_turn_signals(
             # 强力记忆关 → 整段不跑（这是 evidence-RFC 引入的额外 LLM 路径）
             if user_msgs:
                 from utils.language_utils import get_global_language_full
-                runtime._spawn_background_task(
-                    signal_extraction._amaybe_trigger_negative_keyword_hook(
-                        lanlan_name, user_msgs, get_global_language_full(),
-                    )
+                # 这个子任务由 post-turn 派生，同样按角色登记：
+                # release 只取消父任务的话，它会在 hold 之后继续给旧名字写
+                # disputation / reflection 状态。
+                _track_character_post_turn_task(
+                    lanlan_name,
+                    runtime._spawn_background_task(
+                        signal_extraction._amaybe_trigger_negative_keyword_hook(
+                            lanlan_name, user_msgs, get_global_language_full(),
+                        ),
+                        inherit_character_admission=False,
+                    ),
                 )
         except Exception as e:
             logger.debug(f"[MemoryServer] 负面关键词 hook 派发失败: {e}")

--- a/app/memory_server/post_turn.py
+++ b/app/memory_server/post_turn.py
@@ -232,17 +232,13 @@ async def _spawn_outbox_post_turn_signals(
             )
         return _track_character_post_turn_task(
             lanlan_name,
-            runtime._spawn_background_task(
-                operation,
-                inherit_character_admission=False,
-            ),
+            runtime._spawn_background_task(operation),
         )
     op = {'op_id': op_id, 'type': OP_POST_TURN_SIGNALS, 'payload': payload}
     return _track_character_post_turn_task(
         lanlan_name,
         runtime._spawn_background_task(
             outbox_infra._run_outbox_op(lanlan_name, op),
-            inherit_character_admission=False,
         ),
     )
 
@@ -507,7 +503,6 @@ async def _run_post_turn_signals(
                         signal_extraction._amaybe_trigger_negative_keyword_hook(
                             lanlan_name, user_msgs, get_global_language_full(),
                         ),
-                        inherit_character_admission=False,
                     ),
                 )
         except Exception as e:

--- a/app/memory_server/post_turn.py
+++ b/app/memory_server/post_turn.py
@@ -39,6 +39,47 @@ from ._shared import logger
 from .rows import _extract_ai_response, _extract_user_messages
 
 
+_character_post_turn_tasks: dict[str, set[asyncio.Task]] = {}
+
+
+def _track_character_post_turn_task(
+    lanlan_name: str,
+    task: asyncio.Task,
+) -> asyncio.Task:
+    tasks = _character_post_turn_tasks.setdefault(lanlan_name, set())
+    tasks.add(task)
+
+    def _discard(done_task: asyncio.Task) -> None:
+        tasks.discard(done_task)
+        if not tasks and _character_post_turn_tasks.get(lanlan_name) is tasks:
+            _character_post_turn_tasks.pop(lanlan_name, None)
+
+    task.add_done_callback(_discard)
+    return task
+
+
+async def cancel_character_post_turn_tasks(lanlan_name: str) -> int:
+    tasks = [
+        task
+        for task in _character_post_turn_tasks.get(lanlan_name, ())
+        if not task.done()
+    ]
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                "取消角色 %s 的 post-turn 任务时出现异常: %s",
+                lanlan_name,
+                exc,
+            )
+    return len(tasks)
+
+
 def _with_language_context(func):
     """Run one post-turn operation with its persisted task-local locale."""
 
@@ -189,9 +230,21 @@ async def _spawn_outbox_post_turn_signals(
                 locale_order=locale_order,
                 locale_only=not messages,
             )
-        return runtime._spawn_background_task(operation)
+        return _track_character_post_turn_task(
+            lanlan_name,
+            runtime._spawn_background_task(
+                operation,
+                inherit_character_admission=False,
+            ),
+        )
     op = {'op_id': op_id, 'type': OP_POST_TURN_SIGNALS, 'payload': payload}
-    return runtime._spawn_background_task(outbox_infra._run_outbox_op(lanlan_name, op))
+    return _track_character_post_turn_task(
+        lanlan_name,
+        runtime._spawn_background_task(
+            outbox_infra._run_outbox_op(lanlan_name, op),
+            inherit_character_admission=False,
+        ),
+    )
 
 
 async def _wait_for_character_prompt_locale_order(

--- a/app/memory_server/review.py
+++ b/app/memory_server/review.py
@@ -71,6 +71,14 @@ def is_character_publication_held(lanlan_name: str) -> bool:
     return lanlan_name in _publication_held_derived_task_names
 
 
+def is_character_derived_task_claim_active(
+    lanlan_name: str, claim_token: str,
+) -> bool:
+    """Return whether one lifecycle operation still owns its admission claim."""
+    claims = _derived_task_admission_claims.get(lanlan_name)
+    return bool(claims and claim_token in claims)
+
+
 def _capture_character_admission_generation(lanlan_name: str) -> int | None:
     """Return the main-process identity generation for one character path."""
     config_manager = getattr(runtime, "_config_manager", None)

--- a/app/memory_server/review.py
+++ b/app/memory_server/review.py
@@ -66,6 +66,11 @@ _released_derived_task_claim_tokens: OrderedDict[tuple[str, str], None] = (
 _RELEASED_DERIVED_TASK_CLAIM_TOKEN_LIMIT = 4096
 
 
+def is_character_publication_held(lanlan_name: str) -> bool:
+    """Return whether a lifecycle transaction has fenced the old identity."""
+    return lanlan_name in _publication_held_derived_task_names
+
+
 def _capture_character_admission_generation(lanlan_name: str) -> int | None:
     """Return the main-process identity generation for one character path."""
     config_manager = getattr(runtime, "_config_manager", None)

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -770,8 +770,6 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
             logger.info(f"[MemoryServer] cache: {lanlan_name} +{len(input_history)} 条消息")
             uid = str(uuid4())
             async with runtime._get_settle_lock(lanlan_name):
-                if not runtime._is_character_publication_admitted(lanlan_name):
-                    return {"status": "cancelled", "message": "character release in progress"}
                 await runtime.recent_history_manager.update_history(input_history, lanlan_name, compress=False)
                 # store_conversation 必须在 lock 内、与 update_history 串行：和
                 # /process / /renew 路径对偶，确保单角色 db 写顺序一致。
@@ -825,18 +823,15 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
             if _has_human_messages(input_history):
                 await gates._aclear_review_clean(lanlan_name)
             logger.info(f"[MemoryServer] 收到 {lanlan_name} 的对话历史处理请求，消息数: {len(input_history)}")
-            async with runtime._get_settle_lock(lanlan_name):
-                if not runtime._is_character_publication_admitted(lanlan_name):
-                    return {"status": "cancelled", "message": "character release in progress"}
-                await runtime.recent_history_manager.update_history(
-                    input_history,
-                    lanlan_name,
-                    on_compress_done=review._on_compress_done,
-                )
-                # 旧模块已禁用（性能不足）：
-                # await settings_manager.extract_and_update_settings(input_history, lanlan_name)
-                # await semantic_manager.store_conversation(uid, input_history, lanlan_name)
-                await runtime.time_manager.astore_conversation(uid, input_history, lanlan_name)
+            await runtime.recent_history_manager.update_history(
+                input_history,
+                lanlan_name,
+                on_compress_done=review._on_compress_done,
+            )
+            # 旧模块已禁用（性能不足）：
+            # await settings_manager.extract_and_update_settings(input_history, lanlan_name)
+            # await semantic_manager.store_conversation(uid, input_history, lanlan_name)
+            await runtime.time_manager.astore_conversation(uid, input_history, lanlan_name)
 
             # 异步事实提取（不阻塞返回，失败静默跳过）
             await post_turn._spawn_outbox_post_turn_signals(
@@ -891,8 +886,6 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
             logger.info(f"[MemoryServer] renew: 收到 {lanlan_name} 的对话历史处理请求，消息数: {len(input_history)}")
             # 首轮摘要带锁：阻塞 /new_dialog 直到摘要+时间戳写入完成
             async with runtime._get_settle_lock(lanlan_name):
-                if not runtime._is_character_publication_admitted(lanlan_name):
-                    return {"status": "cancelled", "message": "character release in progress"}
                 await runtime.recent_history_manager.update_history(
                     input_history,
                     lanlan_name,
@@ -947,8 +940,6 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
             logger.info(f"[MemoryServer] settle: 收到 {lanlan_name} 的结算请求，消息数: {len(input_history)}")
 
             async with runtime._get_settle_lock(lanlan_name):
-                if not runtime._is_character_publication_admitted(lanlan_name):
-                    return {"status": "cancelled", "message": "character release in progress"}
                 if input_history:
                     await runtime.time_manager.astore_conversation(uid, input_history, lanlan_name)
                 await runtime.recent_history_manager.update_history(

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -3645,7 +3645,13 @@ async def _new_dialog(
                     locale_admission_order=locale_admission_order,
                     op_id=op_id,
                 )
-                runtime._spawn_background_task(operation)
+                # 这个重试活得比 /new_dialog 请求久：不登记的话中间件一放行
+                # 就算排空了，改名/删除之后它还能把 prompt_locale.json 写回去，
+                # 把旧身份的目录重建出来。
+                post_turn._track_character_post_turn_task(
+                    lanlan_name,
+                    runtime._spawn_background_task(operation),
+                )
         else:
             _promote_new_dialog_locale_generation(
                 lanlan_name,

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -770,6 +770,8 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
             logger.info(f"[MemoryServer] cache: {lanlan_name} +{len(input_history)} 条消息")
             uid = str(uuid4())
             async with runtime._get_settle_lock(lanlan_name):
+                if not runtime._is_character_publication_admitted(lanlan_name):
+                    return {"status": "cancelled", "message": "character release in progress"}
                 await runtime.recent_history_manager.update_history(input_history, lanlan_name, compress=False)
                 # store_conversation 必须在 lock 内、与 update_history 串行：和
                 # /process / /renew 路径对偶，确保单角色 db 写顺序一致。
@@ -823,15 +825,18 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
             if _has_human_messages(input_history):
                 await gates._aclear_review_clean(lanlan_name)
             logger.info(f"[MemoryServer] 收到 {lanlan_name} 的对话历史处理请求，消息数: {len(input_history)}")
-            await runtime.recent_history_manager.update_history(
-                input_history,
-                lanlan_name,
-                on_compress_done=review._on_compress_done,
-            )
-            # 旧模块已禁用（性能不足）：
-            # await settings_manager.extract_and_update_settings(input_history, lanlan_name)
-            # await semantic_manager.store_conversation(uid, input_history, lanlan_name)
-            await runtime.time_manager.astore_conversation(uid, input_history, lanlan_name)
+            async with runtime._get_settle_lock(lanlan_name):
+                if not runtime._is_character_publication_admitted(lanlan_name):
+                    return {"status": "cancelled", "message": "character release in progress"}
+                await runtime.recent_history_manager.update_history(
+                    input_history,
+                    lanlan_name,
+                    on_compress_done=review._on_compress_done,
+                )
+                # 旧模块已禁用（性能不足）：
+                # await settings_manager.extract_and_update_settings(input_history, lanlan_name)
+                # await semantic_manager.store_conversation(uid, input_history, lanlan_name)
+                await runtime.time_manager.astore_conversation(uid, input_history, lanlan_name)
 
             # 异步事实提取（不阻塞返回，失败静默跳过）
             await post_turn._spawn_outbox_post_turn_signals(
@@ -886,6 +891,8 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
             logger.info(f"[MemoryServer] renew: 收到 {lanlan_name} 的对话历史处理请求，消息数: {len(input_history)}")
             # 首轮摘要带锁：阻塞 /new_dialog 直到摘要+时间戳写入完成
             async with runtime._get_settle_lock(lanlan_name):
+                if not runtime._is_character_publication_admitted(lanlan_name):
+                    return {"status": "cancelled", "message": "character release in progress"}
                 await runtime.recent_history_manager.update_history(
                     input_history,
                     lanlan_name,
@@ -940,6 +947,8 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
             logger.info(f"[MemoryServer] settle: 收到 {lanlan_name} 的结算请求，消息数: {len(input_history)}")
 
             async with runtime._get_settle_lock(lanlan_name):
+                if not runtime._is_character_publication_admitted(lanlan_name):
+                    return {"status": "cancelled", "message": "character release in progress"}
                 if input_history:
                     await runtime.time_manager.astore_conversation(uid, input_history, lanlan_name)
                 await runtime.recent_history_manager.update_history(

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -647,7 +647,12 @@ async def api_reflect(lanlan_name: str):
     # timeout。periodic auto_promote loop 每 180s 跑一次会兜底，本端点不
     # 等也安全。caller (system_router) 仅用 auto_transitions 打 log，丢失
     # 计数无功能影响。
-    runtime._spawn_background_task(_safe_auto_promote(lanlan_name))
+    # 这个 30-90s 的 task 活得比请求久，改名/删除必须能排空它，否则它会在
+    # dispose 之后继续给旧身份写 reflection / persona 状态。
+    post_turn._track_character_post_turn_task(
+        lanlan_name,
+        runtime._spawn_background_task(_safe_auto_promote(lanlan_name)),
+    )
     try:
         reflection_result = await locale_state.run_with_character_prompt_locale(
             lanlan_name,

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -245,6 +245,28 @@ class ExternalMemoryImportRequest(BaseModel):
 
 @app.post("/internal/memory/import_external_markdown")
 async def import_external_markdown(request: ExternalMemoryImportRequest):
+    """Join the per-character admission ledger, then run the import.
+
+    This endpoint is body-addressed, so the publication guard middleware cannot
+    see which character it writes to. Its facts path reaches
+    ``fact_store`` → ``aindex_fact`` → that character's SQLite index, and one
+    persona fusion can run for minutes, so it has to register here explicitly —
+    otherwise release sees no active request and can dispose underneath it.
+    """
+    name = validate_lanlan_name(request.character_name)
+    context_token = runtime._begin_character_request(name)
+    if context_token is None:
+        return JSONResponse(
+            {"status": "cancelled", "message": "character release in progress"},
+            status_code=409,
+        )
+    try:
+        return await _import_external_markdown(request)
+    finally:
+        runtime._end_character_request(name, context_token)
+
+
+async def _import_external_markdown(request: ExternalMemoryImportRequest):
     """Persist already-previewed OpenClaw/Hermes entries via live managers.
 
     The persona and facts persistence paths are **asymmetric**, because their

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -75,7 +75,16 @@ class ContinueStorageStartupRequest(BaseModel):
 
 
 app = FastAPI()
-_CHARACTER_WRITE_PATH_PREFIXES = ("/cache/", "/process/", "/renew/", "/settle/")
+_CHARACTER_WRITE_PATH_PREFIXES = (
+    "/cache/",
+    "/process/",
+    "/renew/",
+    "/settle/",
+    # 反思合成与 surfaced 冷却登记同样往角色目录写 reflections.json /
+    # surfaced.json，删除后落盘会把旧身份的目录重建出来。
+    "/reflect/",
+    "/record_surfaced/",
+)
 # 群记忆写端点走 /internal/memory/{lanlan_name}/<op>，最终同样落到该角色的
 # FactStore / TimeIndexedMemory。围栏漏掉它们的话，删除窗口里这些请求既不会被
 # 拒绝也不会被排空，仍能带着已 checkout 的 SQLite 连接跨过 dispose。

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -75,15 +75,20 @@ class ContinueStorageStartupRequest(BaseModel):
 
 
 app = FastAPI()
-_CHARACTER_WRITE_PATH_PREFIXES = (
-    "/cache/",
-    "/process/",
-    "/renew/",
-    "/settle/",
+# 角色写端点 → 允许的方法。围栏和排空按这张表走；方法维度是必要的，
+# /prompt-locale/{name} 的 GET 只读、PUT 才写。
+_CHARACTER_WRITE_ROUTES: tuple[tuple[str, frozenset[str]], ...] = (
+    ("/cache/", frozenset({"POST"})),
+    ("/process/", frozenset({"POST"})),
+    ("/renew/", frozenset({"POST"})),
+    ("/settle/", frozenset({"POST"})),
     # 反思合成与 surfaced 冷却登记同样往角色目录写 reflections.json /
     # surfaced.json，删除后落盘会把旧身份的目录重建出来。
-    "/reflect/",
-    "/record_surfaced/",
+    ("/reflect/", frozenset({"POST"})),
+    ("/record_surfaced/", frozenset({"POST"})),
+    # GET，但显式带语言的请求会落盘 prompt_locale.json。
+    ("/new_dialog/", frozenset({"GET"})),
+    ("/prompt-locale/", frozenset({"PUT"})),
 )
 # 群记忆写端点走 /internal/memory/{lanlan_name}/<op>，最终同样落到该角色的
 # FactStore / TimeIndexedMemory。围栏漏掉它们的话，删除窗口里这些请求既不会被
@@ -115,15 +120,20 @@ _STORAGE_LIMITED_MODE_ALLOWED_PATHS = {
 }
 
 
-def _character_write_name_from_path(path: str) -> str | None:
+def _character_write_name_from_path(path: str, method: str) -> str | None:
     raw_name = None
-    for prefix in _CHARACTER_WRITE_PATH_PREFIXES:
+    method = (method or "").upper()
+    for prefix, methods in _CHARACTER_WRITE_ROUTES:
         if path.startswith(prefix):
             candidate = path[len(prefix):]
-            if candidate and "/" not in candidate:
+            if method in methods and candidate and "/" not in candidate:
                 raw_name = candidate
             break
-    if raw_name is None and path.startswith(_CHARACTER_SCOPED_WRITE_PATH_PREFIX):
+    if (
+        raw_name is None
+        and method == "POST"
+        and path.startswith(_CHARACTER_SCOPED_WRITE_PATH_PREFIX)
+    ):
         segments = path[len(_CHARACTER_SCOPED_WRITE_PATH_PREFIX):].split("/")
         if len(segments) == 2 and segments[1] in _CHARACTER_SCOPED_WRITE_OPS:
             raw_name = segments[0]
@@ -202,7 +212,9 @@ async def _wait_for_character_requests(
 
 @app.middleware("http")
 async def character_publication_guard(request: Request, call_next):
-    lanlan_name = _character_write_name_from_path(request.url.path)
+    lanlan_name = _character_write_name_from_path(
+        request.url.path, request.method,
+    )
     if lanlan_name is None:
         return await call_next(request)
     context_token = _begin_character_request(lanlan_name)
@@ -784,20 +796,19 @@ def _get_settle_lock(lanlan_name: str) -> asyncio.Lock:
     return _settle_locks[lanlan_name]
 
 
-def _spawn_background_task(
-    coro,
-    *,
-    inherit_character_admission: bool = True,
-) -> asyncio.Task:
-    """Create a background task with strong reference + exception logging."""
-    context_token = None
-    if not inherit_character_admission:
-        context_token = _admitted_character_context.set(frozenset())
+def _spawn_background_task(coro) -> asyncio.Task:
+    """Create a background task with strong reference + exception logging.
+
+    Detached work never inherits the caller's admission lease. That lease means
+    "an admitted request is still running and release will wait for it"; a
+    fire-and-forget task outlives the request and is not waited for, so keeping
+    the lease would let it reopen the engine after disposal.
+    """
+    context_token = _admitted_character_context.set(frozenset())
     try:
         task = asyncio.create_task(coro)
     finally:
-        if context_token is not None:
-            _admitted_character_context.reset(context_token)
+        _admitted_character_context.reset(context_token)
     _BACKGROUND_TASKS.add(task)
 
     def _on_done(t: asyncio.Task):

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -244,6 +244,49 @@ def _defer_time_manager_cleanup(manager: TimeIndexedMemory | None) -> None:
     _deferred_time_managers.append(manager)
     logger.info("[MemoryServer] 旧的 TimeIndexedMemory 已加入延迟清理队列")
 
+
+def _dispose_character_engines_across_generations(
+    lanlan_name: str,
+) -> tuple[int, int]:
+    """Release one character from the current and every deferred manager.
+
+    Hot reload deliberately keeps old managers alive for requests that already
+    captured them.  A character rename/delete must nevertheless close that
+    character's idle SQLite pools in every retained generation before touching
+    its files.  Other characters and the deferred-manager lifecycle are left
+    unchanged.
+    """
+    managers: list[TimeIndexedMemory] = []
+    seen: set[int] = set()
+    for manager in (time_manager, *_deferred_time_managers):
+        if manager is None or id(manager) in seen:
+            continue
+        seen.add(id(manager))
+        managers.append(manager)
+
+    released_count = 0
+    errors: list[tuple[int, Exception]] = []
+    for index, manager in enumerate(managers):
+        try:
+            if manager.dispose_engine(lanlan_name):
+                released_count += 1
+        except Exception as exc:
+            # Continue so one broken generation cannot hide the manager that
+            # actually owns the Windows file handle.
+            errors.append((index, exc))
+
+    if errors:
+        summary = ", ".join(
+            f"manager[{index}]={type(exc).__name__}"
+            for index, exc in errors
+        )
+        raise RuntimeError(
+            f"failed to dispose character engines: {summary}"
+        ) from errors[0][1]
+
+    return len(managers), released_count
+
+
 async def reload_memory_components(
     *,
     resume_derived_task_names: set[str] | None = None,
@@ -446,10 +489,15 @@ async def release_character_resources(
         )
     async with _reload_lock:
         try:
-            time_manager.dispose_engine(lanlan_name)
+            scanned_managers, released_managers = (
+                _dispose_character_engines_across_generations(lanlan_name)
+            )
             logger.info(
-                "[MemoryServer] 已主动释放角色 %s 的 SQLite 引擎并排空 %d 个派生任务",
+                "[MemoryServer] 已扫描角色 %s 的 %d 个 TimeIndexedMemory 实例，"
+                "实际释放 %d 个 SQLite 引擎并排空 %d 个派生任务",
                 lanlan_name,
+                scanned_managers,
+                released_managers,
                 cancelled_tasks,
             )
             return {

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -177,9 +177,27 @@ def _end_character_request(
         event.set()
 
 
+async def _acquire_within_deadline(lock: asyncio.Lock, deadline: float) -> bool:
+    """Take one lock without outliving the release budget.
+
+    ``/new_dialog`` and the background review hold the per-character settle lock
+    across whole prompt assemblies, and they are deliberately not fenced. An
+    unbounded acquire here would keep this handler running long after the caller
+    gave up, so a lock that cannot be taken in time fails the release instead.
+    """
+    remaining = deadline - asyncio.get_running_loop().time()
+    if remaining <= 0:
+        return False
+    try:
+        await asyncio.wait_for(lock.acquire(), timeout=remaining)
+    except asyncio.TimeoutError:
+        return False
+    return True
+
+
 async def _wait_for_character_requests(
     lanlan_name: str,
-    timeout: float | None = None,
+    deadline: float | None = None,
 ) -> bool:
     """Drain admitted foreground writes; report whether they all finished.
 
@@ -188,10 +206,9 @@ async def _wait_for_character_requests(
     handler running past that point and dispose engines behind the caller's
     back, so the drain stays strictly inside the caller's window.
     """
-    if timeout is None:
-        timeout = _CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
+    if deadline is None:
+        deadline = loop.time() + _CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS
     while _active_character_requests.get(lanlan_name, 0):
         remaining = deadline - loop.time()
         if remaining <= 0:
@@ -430,7 +447,7 @@ def _dispose_character_engines_across_generations(
     errors: list[tuple[int, Exception]] = []
     for index, manager in enumerate(managers):
         try:
-            if manager.dispose_engine(lanlan_name):
+            if manager.dispose_engine(lanlan_name, retain_on_failure=True):
                 released_count += 1
         except Exception as exc:
             # Continue so one broken generation cannot hide the manager that
@@ -657,41 +674,56 @@ async def release_character_resources(
     # drain them and their spawned post-turn tasks before disposing any manager.
     from . import post_turn
 
-    # post-turn task 不持有前台准入 lease，等前台排空期间它仍会给旧名字写
-    # fact / mention / reflection。先取消当前已登记的，再排空前台请求，
-    # 最后补一次——排空窗口里已准入的请求还会派新的 post-turn task。
-    cancelled_post_turn_tasks = await post_turn.cancel_character_post_turn_tasks(
-        lanlan_name
+    # 整个释放流程共用一个预算：排空 + 两把锁的等待加起来都不能超出调用方的
+    # 超时窗口，否则调用方已经放弃并补偿了，这个 handler 还在背后 dispose。
+    deadline = (
+        asyncio.get_running_loop().time()
+        + _CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS
     )
-    # 排空的前提是 publication hold 已经挡住新准入，计数才会单调降到 0。
-    # 不取 hold 的调用方（云存档下载、取消订阅）随时还会有新请求进来，等下去
-    # 只会等到超时——那等于把这两条路径从「立刻释放句柄」变成「永远释放不掉」。
-    # 它们的保护仍是原来那套（清理侧的 PermissionError 重试）。
+    # 排空和取消 post-turn 的前提都是 publication hold 已经挡住新准入。
+    # 不取 hold 的调用方（云存档下载、取消订阅）角色事后还活着：排空等不到
+    # 计数归零（新请求随时进来），取消也留不住（下一毫秒就能派新的），
+    # 净效果只是白白打断在途的 outbox op。这两条路径保持本 PR 之前的语义。
+    holding_publication = review.is_character_publication_held(lanlan_name)
+    cancelled_post_turn_tasks = 0
     drained = True
-    if review.is_character_publication_held(lanlan_name):
-        drained = await _wait_for_character_requests(lanlan_name)
-    cancelled_post_turn_tasks += await post_turn.cancel_character_post_turn_tasks(
-        lanlan_name
-    )
-    if not drained:
+    if holding_publication:
+        # post-turn task 不持有前台准入 lease，等前台排空期间它仍会给旧名字写
+        # fact / mention / reflection。先取消当前已登记的，再排空前台请求，
+        # 最后补一次——排空窗口里已准入的请求还会派新的 post-turn task。
+        cancelled_post_turn_tasks = await post_turn.cancel_character_post_turn_tasks(
+            lanlan_name
+        )
+        drained = await _wait_for_character_requests(lanlan_name, deadline)
+        cancelled_post_turn_tasks += (
+            await post_turn.cancel_character_post_turn_tasks(lanlan_name)
+        )
+
+    async def _fail_release(message: str, status_code: int):
         await review.release_character_derived_task_admission_claim(
             lanlan_name,
             derived_task_claim_token,
         )
-        logger.warning(
-            "[MemoryServer] 等待角色 %s 的在途写入超时，未释放 SQLite 引擎",
-            lanlan_name,
-        )
+        logger.warning("[MemoryServer] 释放角色 %s 中止：%s", lanlan_name, message)
         return JSONResponse(
             {
                 "status": "error",
                 "character_name": lanlan_name,
-                "message": "timed out draining admitted character writes",
+                "message": message,
             },
-            status_code=503,
+            status_code=status_code,
         )
-    async with _get_settle_lock(lanlan_name):
-        async with _reload_lock:
+
+    if not drained:
+        return await _fail_release(
+            "timed out draining admitted character writes", 503,
+        )
+    if not await _acquire_within_deadline(_get_settle_lock(lanlan_name), deadline):
+        return await _fail_release("timed out acquiring the settle lock", 503)
+    try:
+        if not await _acquire_within_deadline(_reload_lock, deadline):
+            return await _fail_release("timed out acquiring the reload lock", 503)
+        try:
             # 排空和拿锁都可能久到调用方超时；那时主进程已经补偿性地释放了
             # 本次 claim 并重新开放准入，这里不能再背着它 dispose。
             if not review.is_character_derived_task_claim_active(
@@ -738,6 +770,10 @@ async def release_character_resources(
                     {"status": "error", "character_name": lanlan_name, "message": str(exc)},
                     status_code=500,
                 )
+        finally:
+            _reload_lock.release()
+    finally:
+        _get_settle_lock(lanlan_name).release()
 
 
 # 全局变量用于控制服务器关闭

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -642,7 +642,13 @@ async def release_character_resources(
     cancelled_post_turn_tasks = await post_turn.cancel_character_post_turn_tasks(
         lanlan_name
     )
-    drained = await _wait_for_character_requests(lanlan_name)
+    # 排空的前提是 publication hold 已经挡住新准入，计数才会单调降到 0。
+    # 不取 hold 的调用方（云存档下载、取消订阅）随时还会有新请求进来，等下去
+    # 只会等到超时——那等于把这两条路径从「立刻释放句柄」变成「永远释放不掉」。
+    # 它们的保护仍是原来那套（清理侧的 PermissionError 重试）。
+    drained = True
+    if review.is_character_publication_held(lanlan_name):
+        drained = await _wait_for_character_requests(lanlan_name)
     cancelled_post_turn_tasks += await post_turn.cancel_character_post_turn_tasks(
         lanlan_name
     )

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -245,6 +245,13 @@ def _defer_time_manager_cleanup(manager: TimeIndexedMemory | None) -> None:
     logger.info("[MemoryServer] 旧的 TimeIndexedMemory 已加入延迟清理队列")
 
 
+def _is_character_publication_admitted(lanlan_name: str) -> bool:
+    """Keep a released identity from reopening storage before publication."""
+    from . import review
+
+    return not review.is_character_publication_held(lanlan_name)
+
+
 def _dispose_character_engines_across_generations(
     lanlan_name: str,
 ) -> tuple[int, int]:
@@ -323,7 +330,10 @@ async def reload_memory_components(
             # 先创建所有新实例
             new_recent = CompressedRecentHistoryManager()
             new_settings = ImportantSettingsManager()
-            new_time = TimeIndexedMemory(new_recent)
+            new_time = TimeIndexedMemory(
+                new_recent,
+                engine_admission_check=_is_character_publication_admitted,
+            )
             new_facts = FactStore(time_indexed_memory=new_time)
             # EventLog 复用（per-character lock dict 没有必要跨 reload 丢弃），
             # 但每次 reload 重建 Reconciler 以便 handlers 指向新 manager 实例。
@@ -487,36 +497,41 @@ async def release_character_resources(
             },
             status_code=409,
         )
-    async with _reload_lock:
-        try:
-            scanned_managers, released_managers = (
-                _dispose_character_engines_across_generations(lanlan_name)
-            )
-            logger.info(
-                "[MemoryServer] 已扫描角色 %s 的 %d 个 TimeIndexedMemory 实例，"
-                "实际释放 %d 个 SQLite 引擎并排空 %d 个派生任务",
-                lanlan_name,
-                scanned_managers,
-                released_managers,
-                cancelled_tasks,
-            )
-            return {
-                "status": "success",
-                "character_name": lanlan_name,
-                "cancelled_derived_tasks": cancelled_tasks,
-                "derived_task_claim_token": derived_task_claim_token,
-            }
-        except Exception as exc:
-            if derived_task_claim_token:
-                await review.release_character_derived_task_admission_claim(
-                    lanlan_name,
-                    derived_task_claim_token,
+    # The publication hold above prevents queued/new work from reopening the
+    # engine.  Taking the same per-character lock as the foreground write paths
+    # drains work that entered before the hold, then the reload lock gives us a
+    # stable current/deferred manager set for the disposal sweep.
+    async with _get_settle_lock(lanlan_name):
+        async with _reload_lock:
+            try:
+                scanned_managers, released_managers = (
+                    _dispose_character_engines_across_generations(lanlan_name)
                 )
-            logger.warning("[MemoryServer] 释放角色 %s 的 SQLite 引擎失败: %s", lanlan_name, exc)
-            return JSONResponse(
-                {"status": "error", "character_name": lanlan_name, "message": str(exc)},
-                status_code=500,
-            )
+                logger.info(
+                    "[MemoryServer] 已扫描角色 %s 的 %d 个 TimeIndexedMemory 实例，"
+                    "实际释放 %d 个 SQLite 引擎并排空 %d 个派生任务",
+                    lanlan_name,
+                    scanned_managers,
+                    released_managers,
+                    cancelled_tasks,
+                )
+                return {
+                    "status": "success",
+                    "character_name": lanlan_name,
+                    "cancelled_derived_tasks": cancelled_tasks,
+                    "derived_task_claim_token": derived_task_claim_token,
+                }
+            except Exception as exc:
+                if derived_task_claim_token:
+                    await review.release_character_derived_task_admission_claim(
+                        lanlan_name,
+                        derived_task_claim_token,
+                    )
+                logger.warning("[MemoryServer] 释放角色 %s 的 SQLite 引擎失败: %s", lanlan_name, exc)
+                return JSONResponse(
+                    {"status": "error", "character_name": lanlan_name, "message": str(exc)},
+                    status_code=500,
+                )
 
 
 # 全局变量用于控制服务器关闭
@@ -699,7 +714,10 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
 
         recent_history_manager = CompressedRecentHistoryManager()
         settings_manager = ImportantSettingsManager()
-        time_manager = TimeIndexedMemory(recent_history_manager)
+        time_manager = TimeIndexedMemory(
+            recent_history_manager,
+            engine_admission_check=_is_character_publication_admitted,
+        )
         fact_store = FactStore(time_indexed_memory=time_manager)
         # Queue erasure is part of the privacy runtime, not the optional
         # vector worker. Construct the lightweight resolver before ready so

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -82,6 +82,9 @@ _admitted_character_context: ContextVar[frozenset[str]] = ContextVar(
 )
 _active_character_requests: dict[str, int] = {}
 _active_character_request_events: dict[str, asyncio.Event] = {}
+# 调用方 release_memory_server_character() 的 HTTP 超时是 5s；排空留在它里面，
+# 剩下的时间给 dispose 和响应。
+_CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS = 3.0
 _STORAGE_LIMITED_MODE_ALLOWED_PATHS = {
     "/health",
     "/shutdown",
@@ -128,15 +131,37 @@ def _end_character_request(
         event.set()
 
 
-async def _wait_for_character_requests(lanlan_name: str) -> None:
+async def _wait_for_character_requests(
+    lanlan_name: str,
+    timeout: float | None = None,
+) -> bool:
+    """Drain admitted foreground writes; report whether they all finished.
+
+    The caller (``release_memory_server_character``) gives up after 5s and
+    compensates by reopening admission. An unbounded wait here would keep this
+    handler running past that point and dispose engines behind the caller's
+    back, so the drain stays strictly inside the caller's window.
+    """
+    if timeout is None:
+        timeout = _CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
     while _active_character_requests.get(lanlan_name, 0):
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
         event = _active_character_request_events.setdefault(
             lanlan_name,
             asyncio.Event(),
         )
         event.clear()
-        if _active_character_requests.get(lanlan_name, 0):
-            await event.wait()
+        if not _active_character_requests.get(lanlan_name, 0):
+            break
+        try:
+            await asyncio.wait_for(event.wait(), timeout=remaining)
+        except asyncio.TimeoutError:
+            return False
+    return True
 
 
 @app.middleware("http")
@@ -584,12 +609,52 @@ async def release_character_resources(
     # drain them and their spawned post-turn tasks before disposing any manager.
     from . import post_turn
 
-    await _wait_for_character_requests(lanlan_name)
+    # post-turn task 不持有前台准入 lease，等前台排空期间它仍会给旧名字写
+    # fact / mention / reflection。先取消当前已登记的，再排空前台请求，
+    # 最后补一次——排空窗口里已准入的请求还会派新的 post-turn task。
     cancelled_post_turn_tasks = await post_turn.cancel_character_post_turn_tasks(
         lanlan_name
     )
+    drained = await _wait_for_character_requests(lanlan_name)
+    cancelled_post_turn_tasks += await post_turn.cancel_character_post_turn_tasks(
+        lanlan_name
+    )
+    if not drained:
+        await review.release_character_derived_task_admission_claim(
+            lanlan_name,
+            derived_task_claim_token,
+        )
+        logger.warning(
+            "[MemoryServer] 等待角色 %s 的在途写入超时，未释放 SQLite 引擎",
+            lanlan_name,
+        )
+        return JSONResponse(
+            {
+                "status": "error",
+                "character_name": lanlan_name,
+                "message": "timed out draining admitted character writes",
+            },
+            status_code=503,
+        )
     async with _get_settle_lock(lanlan_name):
         async with _reload_lock:
+            # 排空和拿锁都可能久到调用方超时；那时主进程已经补偿性地释放了
+            # 本次 claim 并重新开放准入，这里不能再背着它 dispose。
+            if not review.is_character_derived_task_claim_active(
+                lanlan_name, derived_task_claim_token,
+            ):
+                logger.warning(
+                    "[MemoryServer] 角色 %s 的释放声明已被撤回，跳过 dispose",
+                    lanlan_name,
+                )
+                return JSONResponse(
+                    {
+                        "status": "cancelled",
+                        "character_name": lanlan_name,
+                        "message": "release claim was withdrawn while draining",
+                    },
+                    status_code=409,
+                )
             try:
                 scanned_managers, released_managers = (
                     _dispose_character_engines_across_generations(lanlan_name)

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -76,15 +76,28 @@ class ContinueStorageStartupRequest(BaseModel):
 
 app = FastAPI()
 _CHARACTER_WRITE_PATH_PREFIXES = ("/cache/", "/process/", "/renew/", "/settle/")
+# 群记忆写端点走 /internal/memory/{lanlan_name}/<op>，最终同样落到该角色的
+# FactStore / TimeIndexedMemory。围栏漏掉它们的话，删除窗口里这些请求既不会被
+# 拒绝也不会被排空，仍能带着已 checkout 的 SQLite 连接跨过 dispose。
+# scoped_context 是只读的，不进这里——读路径由引擎准入检查兜底。
+_CHARACTER_SCOPED_WRITE_PATH_PREFIX = "/internal/memory/"
+_CHARACTER_SCOPED_WRITE_OPS = frozenset({
+    "scoped_facts",
+    "scoped_history",
+    "scoped_forget",
+    "scoped_mentions",
+})
 _admitted_character_context: ContextVar[frozenset[str]] = ContextVar(
     "admitted_character_context",
     default=frozenset(),
 )
 _active_character_requests: dict[str, int] = {}
 _active_character_request_events: dict[str, asyncio.Event] = {}
-# 调用方 release_memory_server_character() 的 HTTP 超时是 5s；排空留在它里面，
-# 剩下的时间给 dispose 和响应。
-_CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS = 3.0
+# 排空预算必须小于**最紧**的调用方超时，否则调用方会先放弃、然后照样往下删文件，
+# 而这个 handler 还在排空/dispose——正好撞出这个 PR 要修的 Windows 占用失败。
+# 最紧的是取消订阅：_release_workshop_character_handles 的 per_call_timeout=2.5s
+# （改名/删除走 release_memory_server_character()，5s）。
+_CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS = 2.0
 _STORAGE_LIMITED_MODE_ALLOWED_PATHS = {
     "/health",
     "/shutdown",
@@ -94,12 +107,26 @@ _STORAGE_LIMITED_MODE_ALLOWED_PATHS = {
 
 
 def _character_write_name_from_path(path: str) -> str | None:
+    raw_name = None
     for prefix in _CHARACTER_WRITE_PATH_PREFIXES:
         if path.startswith(prefix):
-            lanlan_name = path[len(prefix):]
-            if lanlan_name and "/" not in lanlan_name:
-                return lanlan_name
-    return None
+            candidate = path[len(prefix):]
+            if candidate and "/" not in candidate:
+                raw_name = candidate
+            break
+    if raw_name is None and path.startswith(_CHARACTER_SCOPED_WRITE_PATH_PREFIX):
+        segments = path[len(_CHARACTER_SCOPED_WRITE_PATH_PREFIX):].split("/")
+        if len(segments) == 2 and segments[1] in _CHARACTER_SCOPED_WRITE_OPS:
+            raw_name = segments[0]
+    if not raw_name:
+        return None
+    # 端点自己会 validate_lanlan_name 归一化后才读写角色目录；准入登记必须用
+    # 同一个键，否则 "/process/ Alice " 既躲开 " Alice " 之外的所有围栏，
+    # 请求租约也对不上引擎实际用的 "Alice"。
+    try:
+        return validate_lanlan_name(raw_name)
+    except HTTPException:
+        return None
 
 
 def _begin_character_request(

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -86,8 +86,8 @@ _CHARACTER_WRITE_ROUTES: tuple[tuple[str, frozenset[str]], ...] = (
     # surfaced.json，删除后落盘会把旧身份的目录重建出来。
     ("/reflect/", frozenset({"POST"})),
     ("/record_surfaced/", frozenset({"POST"})),
-    # GET，但显式带语言的请求会落盘 prompt_locale.json。
-    ("/new_dialog/", frozenset({"GET"})),
+    # 只有 PUT 是写；GET 只读 sidecar，不进围栏。
+    # 409 对它的调用方是既有的可重试失败（云存档维护围栏也会给 409）。
     ("/prompt-locale/", frozenset({"PUT"})),
 )
 # 群记忆写端点走 /internal/memory/{lanlan_name}/<op>，最终同样落到该角色的

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -718,7 +718,10 @@ async def release_character_resources(
         return await _fail_release(
             "timed out draining admitted character writes", 503,
         )
-    if not await _acquire_within_deadline(_get_settle_lock(lanlan_name), deadline):
+    # 绑定同一个对象：`_get_settle_lock` 是函数，acquire / release 各调一次会有
+    # 拿到不同实例的风险（测试里就有把它 patch 成每次返回新锁的写法）。
+    settle_lock = _get_settle_lock(lanlan_name)
+    if not await _acquire_within_deadline(settle_lock, deadline):
         return await _fail_release("timed out acquiring the settle lock", 503)
     try:
         if not await _acquire_within_deadline(_reload_lock, deadline):
@@ -773,7 +776,7 @@ async def release_character_resources(
         finally:
             _reload_lock.release()
     finally:
-        _get_settle_lock(lanlan_name).release()
+        settle_lock.release()
 
 
 # 全局变量用于控制服务器关闭

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -32,6 +32,7 @@ the same reason.
 """
 
 import asyncio
+from contextvars import ContextVar, Token
 from datetime import datetime, timezone
 
 from fastapi import FastAPI, HTTPException, Request
@@ -74,12 +75,85 @@ class ContinueStorageStartupRequest(BaseModel):
 
 
 app = FastAPI()
+_CHARACTER_WRITE_PATH_PREFIXES = ("/cache/", "/process/", "/renew/", "/settle/")
+_admitted_character_context: ContextVar[frozenset[str]] = ContextVar(
+    "admitted_character_context",
+    default=frozenset(),
+)
+_active_character_requests: dict[str, int] = {}
+_active_character_request_events: dict[str, asyncio.Event] = {}
 _STORAGE_LIMITED_MODE_ALLOWED_PATHS = {
     "/health",
     "/shutdown",
     "/internal/storage/startup/continue",
     "/internal/storage/startup/block",
 }
+
+
+def _character_write_name_from_path(path: str) -> str | None:
+    for prefix in _CHARACTER_WRITE_PATH_PREFIXES:
+        if path.startswith(prefix):
+            lanlan_name = path[len(prefix):]
+            if lanlan_name and "/" not in lanlan_name:
+                return lanlan_name
+    return None
+
+
+def _begin_character_request(
+    lanlan_name: str,
+) -> Token[frozenset[str]] | None:
+    """Atomically admit one foreground request before its first await."""
+    if not _is_character_publication_admitted(lanlan_name):
+        return None
+    _active_character_requests[lanlan_name] = (
+        _active_character_requests.get(lanlan_name, 0) + 1
+    )
+    return _admitted_character_context.set(
+        _admitted_character_context.get() | {lanlan_name}
+    )
+
+
+def _end_character_request(
+    lanlan_name: str,
+    context_token: Token[frozenset[str]],
+) -> None:
+    _admitted_character_context.reset(context_token)
+    remaining = _active_character_requests.get(lanlan_name, 0) - 1
+    if remaining > 0:
+        _active_character_requests[lanlan_name] = remaining
+        return
+    _active_character_requests.pop(lanlan_name, None)
+    event = _active_character_request_events.pop(lanlan_name, None)
+    if event is not None:
+        event.set()
+
+
+async def _wait_for_character_requests(lanlan_name: str) -> None:
+    while _active_character_requests.get(lanlan_name, 0):
+        event = _active_character_request_events.setdefault(
+            lanlan_name,
+            asyncio.Event(),
+        )
+        event.clear()
+        if _active_character_requests.get(lanlan_name, 0):
+            await event.wait()
+
+
+@app.middleware("http")
+async def character_publication_guard(request: Request, call_next):
+    lanlan_name = _character_write_name_from_path(request.url.path)
+    if lanlan_name is None:
+        return await call_next(request)
+    context_token = _begin_character_request(lanlan_name)
+    if context_token is None:
+        return JSONResponse(
+            {"status": "cancelled", "message": "character release in progress"},
+            status_code=409,
+        )
+    try:
+        return await call_next(request)
+    finally:
+        _end_character_request(lanlan_name, context_token)
 
 
 @app.middleware("http")
@@ -252,6 +326,14 @@ def _is_character_publication_admitted(lanlan_name: str) -> bool:
     return not review.is_character_publication_held(lanlan_name)
 
 
+def _is_character_engine_admitted(lanlan_name: str) -> bool:
+    """Allow a request admitted before the publication hold to finish."""
+    return (
+        lanlan_name in _admitted_character_context.get()
+        or _is_character_publication_admitted(lanlan_name)
+    )
+
+
 def _dispose_character_engines_across_generations(
     lanlan_name: str,
 ) -> tuple[int, int]:
@@ -284,7 +366,7 @@ def _dispose_character_engines_across_generations(
 
     if errors:
         summary = ", ".join(
-            f"manager[{index}]={type(exc).__name__}"
+            f"manager[{index}]={type(exc).__name__}: {exc}"
             for index, exc in errors
         )
         raise RuntimeError(
@@ -332,7 +414,7 @@ async def reload_memory_components(
             new_settings = ImportantSettingsManager()
             new_time = TimeIndexedMemory(
                 new_recent,
-                engine_admission_check=_is_character_publication_admitted,
+                engine_admission_check=_is_character_engine_admitted,
             )
             new_facts = FactStore(time_indexed_memory=new_time)
             # EventLog 复用（per-character lock dict 没有必要跨 reload 丢弃），
@@ -498,9 +580,14 @@ async def release_character_resources(
             status_code=409,
         )
     # The publication hold above prevents queued/new work from reopening the
-    # engine.  Taking the same per-character lock as the foreground write paths
-    # drains work that entered before the hold, then the reload lock gives us a
-    # stable current/deferred manager set for the disposal sweep.
+    # engine. Requests admitted before the hold keep their request-local lease;
+    # drain them and their spawned post-turn tasks before disposing any manager.
+    from . import post_turn
+
+    await _wait_for_character_requests(lanlan_name)
+    cancelled_post_turn_tasks = await post_turn.cancel_character_post_turn_tasks(
+        lanlan_name
+    )
     async with _get_settle_lock(lanlan_name):
         async with _reload_lock:
             try:
@@ -513,7 +600,7 @@ async def release_character_resources(
                     lanlan_name,
                     scanned_managers,
                     released_managers,
-                    cancelled_tasks,
+                    cancelled_tasks + cancelled_post_turn_tasks,
                 )
                 return {
                     "status": "success",
@@ -590,9 +677,20 @@ def _get_settle_lock(lanlan_name: str) -> asyncio.Lock:
     return _settle_locks[lanlan_name]
 
 
-def _spawn_background_task(coro) -> asyncio.Task:
+def _spawn_background_task(
+    coro,
+    *,
+    inherit_character_admission: bool = True,
+) -> asyncio.Task:
     """Create a background task with strong reference + exception logging."""
-    task = asyncio.create_task(coro)
+    context_token = None
+    if not inherit_character_admission:
+        context_token = _admitted_character_context.set(frozenset())
+    try:
+        task = asyncio.create_task(coro)
+    finally:
+        if context_token is not None:
+            _admitted_character_context.reset(context_token)
     _BACKGROUND_TASKS.add(task)
 
     def _on_done(t: asyncio.Task):
@@ -716,7 +814,7 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
         settings_manager = ImportantSettingsManager()
         time_manager = TimeIndexedMemory(
             recent_history_manager,
-            engine_admission_check=_is_character_publication_admitted,
+            engine_admission_check=_is_character_engine_admitted,
         )
         fact_store = FactStore(time_indexed_memory=time_manager)
         # Queue erasure is part of the privacy runtime, not the optional

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -42,6 +42,10 @@ FACT_NEAR_DUP_ARBITRATE_OVERLAP = 0.25
 FACT_NEAR_DUP_ENQUEUE_TIMEOUT_SECONDS = 5.0
 
 
+class CharacterEngineAdmissionError(RuntimeError):
+    """The character identity is fenced for delete/rename publication."""
+
+
 def _next_readonly_batch(
     stream: Generator[list[tuple[object, object, object]], None, None],
 ) -> tuple[bool, list[tuple[object, object, object]] | None]:
@@ -270,11 +274,13 @@ class TimeIndexedMemory:
             self._engine_admission_check is not None
             and not self._engine_admission_check(lanlan_name)
         ):
-            logger.info(
-                "[TimeIndexedMemory] 角色 %s 正在删除或改名，跳过数据库引擎初始化",
+            logger.debug(
+                "[TimeIndexedMemory] 角色 %s 正在删除或改名，拒绝数据库引擎初始化",
                 lanlan_name,
             )
-            return False
+            raise CharacterEngineAdmissionError(
+                f"character engine admission is fenced: {lanlan_name}"
+            )
         if not readonly:
             self._assert_timeindex_writable(lanlan_name)
         if lanlan_name in self.engines and lanlan_name in self.db_paths:

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -19,7 +19,7 @@ from memory.stop_names import collect_stop_names, strip_stop_names
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
-from collections.abc import AsyncIterator, Generator, Iterator
+from collections.abc import AsyncIterator, Callable, Generator, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import asyncio
@@ -195,12 +195,18 @@ def token_overlap(left: list[str], right: list[str]) -> float:
 
 
 class TimeIndexedMemory:
-    def __init__(self, recent_history_manager):
+    def __init__(
+        self,
+        recent_history_manager,
+        *,
+        engine_admission_check: Callable[[str], bool] | None = None,
+    ):
         self.engines = {}  # 存储 {lanlan_name: engine}
         self.db_paths = {} # 存储 {lanlan_name: db_path}
         self._engine_readonly_flags = {}  # 存储 {lanlan_name: bool}
         self._writable_bootstrapped = set()  # 存储已完成可写初始化的角色
         self.recent_history_manager = recent_history_manager
+        self._engine_admission_check = engine_admission_check
         # 懒加载：不在构造器里同步初始化每角色 engine，首次访问时按需创建
         # （MaintenanceModeError 在 _ensure_engine_exists 内部按需处理）
 
@@ -260,6 +266,15 @@ class TimeIndexedMemory:
         readonly: bool = False,
     ) -> bool:
         """Ensure the given character's database engine is initialized, meow~"""
+        if (
+            self._engine_admission_check is not None
+            and not self._engine_admission_check(lanlan_name)
+        ):
+            logger.info(
+                "[TimeIndexedMemory] 角色 %s 正在删除或改名，跳过数据库引擎初始化",
+                lanlan_name,
+            )
+            return False
         if not readonly:
             self._assert_timeindex_writable(lanlan_name)
         if lanlan_name in self.engines and lanlan_name in self.db_paths:

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -411,13 +411,20 @@ class TimeIndexedMemory:
         """
         return await asyncio.to_thread(self._ensure_engine_exists, lanlan_name, db_path)
 
-    def dispose_engine(self, lanlan_name: str) -> bool:
+    def dispose_engine(
+        self, lanlan_name: str, *, retain_on_failure: bool = False,
+    ) -> bool:
         """Dispose one character's cached engines and report whether any were known.
 
-        Bookkeeping is only cleared once every disposal succeeded: a caller that
-        retries after a failure must still find this generation, otherwise the
-        pool that caused the failure keeps the database file locked until the
-        process exits.
+        ``retain_on_failure`` keeps the bookkeeping when a disposal raised, so a
+        caller that retries can still reach this generation instead of losing the
+        pool that holds the file. It is for the character-release path only.
+
+        The default clears the bookkeeping either way, which is what the in-place
+        repair branches of ``_ensure_engine_exists`` (db_path drift, readonly →
+        writable switch) rely on: they dispose and then fall through to the
+        rebuild branch, so a transient disposal failure must not pin this
+        character to the same failing branch forever.
         """
         db_path = self.db_paths.get(lanlan_name)
         engine = self.engines.get(lanlan_name)
@@ -457,12 +464,13 @@ class TimeIndexedMemory:
                         errors.append(exc)
                         continue
                 SQLChatMessageHistory._engine_cache.pop(connection_string, None)
+        if not (errors and retain_on_failure):
+            self.db_paths.pop(lanlan_name, None)
+            self.engines.pop(lanlan_name, None)
+            self._engine_readonly_flags.pop(lanlan_name, None)
+            self._writable_bootstrapped.discard(lanlan_name)
         if errors:
             raise errors[0]
-        self.db_paths.pop(lanlan_name, None)
-        self.engines.pop(lanlan_name, None)
-        self._engine_readonly_flags.pop(lanlan_name, None)
-        self._writable_bootstrapped.discard(lanlan_name)
         return released
 
     def cleanup(self):

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -423,9 +423,11 @@ class TimeIndexedMemory:
         engine = self.engines.get(lanlan_name)
         released = engine is not None
         errors: list[Exception] = []
+        engine_disposed = engine is None
         if engine:
             try:
                 engine.dispose()
+                engine_disposed = True
                 logger.info(f"[TimeIndexedMemory] 已释放角色 {lanlan_name} 的数据库引擎")
             except Exception as exc:
                 # 继续走下面的 _engine_cache 清理：真正扣着文件句柄的往往是
@@ -439,14 +441,22 @@ class TimeIndexedMemory:
             uri_path = normalized_db_path.replace("\\", "/")
             writable_connection_string = f"sqlite:///{uri_path}"
             for connection_string in {readonly_connection_string, writable_connection_string}:
-                cached_engine = SQLChatMessageHistory._engine_cache.pop(connection_string, None)
-                if cached_engine is not None:
-                    released = True
-                    if cached_engine is not engine:
-                        try:
-                            cached_engine.dispose()
-                        except Exception as exc:
-                            errors.append(exc)
+                # 只在确认释放成功之后才摘缓存条目：先摘后放的话，dispose 一抛
+                # 这个 pool 就再也找不回来，重试摸不到它，句柄会一直扣到进程退出。
+                cached_engine = SQLChatMessageHistory._engine_cache.get(connection_string)
+                if cached_engine is None:
+                    continue
+                released = True
+                if cached_engine is engine:
+                    if not engine_disposed:
+                        continue
+                else:
+                    try:
+                        cached_engine.dispose()
+                    except Exception as exc:
+                        errors.append(exc)
+                        continue
+                SQLChatMessageHistory._engine_cache.pop(connection_string, None)
         if errors:
             raise errors[0]
         self.db_paths.pop(lanlan_name, None)

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -209,6 +209,10 @@ class TimeIndexedMemory:
         self.db_paths = {} # 存储 {lanlan_name: db_path}
         self._engine_readonly_flags = {}  # 存储 {lanlan_name: bool}
         self._writable_bootstrapped = set()  # 存储已完成可写初始化的角色
+        # {lanlan_name: {connection_string}}：dispose 失败、仍扣着文件句柄的 pool。
+        # 按连接串记账而不是靠 db_path 现推——路径漂移重建会覆盖 db_path，
+        # 那之后就再也推不出失败 pool 的键了。
+        self._undisposed_pools: dict[str, set[str]] = {}
         self.recent_history_manager = recent_history_manager
         self._engine_admission_check = engine_admission_check
         # 懒加载：不在构造器里同步初始化每角色 engine，首次访问时按需创建
@@ -431,6 +435,23 @@ class TimeIndexedMemory:
         released = engine is not None
         errors: list[Exception] = []
         engine_disposed = engine is None
+        # 本次要处理的连接串 = 当前 db_path 推出来的两个 + 以前失败留账的那些。
+        connection_strings: set[str] = set(
+            self._undisposed_pools.get(lanlan_name, ())
+        )
+        if db_path:
+            normalized_db_path, readonly_connection_string = self._build_sqlite_connection_string(
+                str(db_path),
+                readonly=True,
+            )
+            uri_path = normalized_db_path.replace("\\", "/")
+            connection_strings.add(readonly_connection_string)
+            connection_strings.add(f"sqlite:///{uri_path}")
+
+        def _remember_undisposed(keys: set[str]) -> None:
+            if keys:
+                self._undisposed_pools.setdefault(lanlan_name, set()).update(keys)
+
         if engine:
             try:
                 engine.dispose()
@@ -440,40 +461,34 @@ class TimeIndexedMemory:
                 # 继续走下面的 _engine_cache 清理：真正扣着文件句柄的往往是
                 # 缓存里的那个 pool，不能因为这一步失败就整段跳过。
                 errors.append(exc)
-        if db_path:
-            normalized_db_path, readonly_connection_string = self._build_sqlite_connection_string(
-                str(db_path),
-                readonly=True,
-            )
-            uri_path = normalized_db_path.replace("\\", "/")
-            writable_connection_string = f"sqlite:///{uri_path}"
-            for connection_string in {readonly_connection_string, writable_connection_string}:
-                # 只在确认释放成功之后才摘缓存条目：先摘后放的话，dispose 一抛
-                # 这个 pool 就再也找不回来，重试摸不到它，句柄会一直扣到进程退出。
-                cached_engine = SQLChatMessageHistory._engine_cache.get(connection_string)
-                if cached_engine is None:
+                _remember_undisposed(connection_strings)
+        for connection_string in sorted(connection_strings):
+            # 只在确认释放成功之后才摘缓存条目：先摘后放的话，dispose 一抛
+            # 这个 pool 就再也找不回来，重试摸不到它，句柄会一直扣到进程退出。
+            cached_engine = SQLChatMessageHistory._engine_cache.get(connection_string)
+            if cached_engine is None:
+                self._undisposed_pools.get(lanlan_name, set()).discard(connection_string)
+                continue
+            released = True
+            if cached_engine is engine:
+                if not engine_disposed:
                     continue
-                released = True
-                if cached_engine is engine:
-                    if not engine_disposed:
-                        continue
-                else:
-                    try:
-                        cached_engine.dispose()
-                    except Exception as exc:
-                        errors.append(exc)
-                        continue
-                SQLChatMessageHistory._engine_cache.pop(connection_string, None)
+            else:
+                try:
+                    cached_engine.dispose()
+                except Exception as exc:
+                    errors.append(exc)
+                    _remember_undisposed({connection_string})
+                    continue
+            SQLChatMessageHistory._engine_cache.pop(connection_string, None)
+            self._undisposed_pools.get(lanlan_name, set()).discard(connection_string)
+        if not self._undisposed_pools.get(lanlan_name):
+            self._undisposed_pools.pop(lanlan_name, None)
         if not (errors and retain_on_failure):
+            self.db_paths.pop(lanlan_name, None)
             self.engines.pop(lanlan_name, None)
             self._engine_readonly_flags.pop(lanlan_name, None)
             self._writable_bootstrapped.discard(lanlan_name)
-            if not errors:
-                self.db_paths.pop(lanlan_name, None)
-            # 失败时保留 db_path：没释放掉的那个 pool 还挂在
-            # ``SQLChatMessageHistory._engine_cache`` 里，而它的 connection string
-            # 只能从 db_path 推出来——丢了它，之后的 /release_character 就再也够
-            # 不到那个 pool。清掉 engines 已足够让就地修复分支落到重建。
         if errors:
             raise errors[0]
         return released

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -390,10 +390,11 @@ class TimeIndexedMemory:
         """
         return await asyncio.to_thread(self._ensure_engine_exists, lanlan_name, db_path)
 
-    def dispose_engine(self, lanlan_name: str):
-        """Dispose the given character's database engine resources, meow~"""
+    def dispose_engine(self, lanlan_name: str) -> bool:
+        """Dispose one character's cached engines and report whether any were known."""
         db_path = self.db_paths.pop(lanlan_name, None)
         engine = self.engines.pop(lanlan_name, None)
+        released = engine is not None
         self._engine_readonly_flags.pop(lanlan_name, None)
         self._writable_bootstrapped.discard(lanlan_name)
         if engine:
@@ -408,8 +409,11 @@ class TimeIndexedMemory:
             writable_connection_string = f"sqlite:///{uri_path}"
             for connection_string in {readonly_connection_string, writable_connection_string}:
                 cached_engine = SQLChatMessageHistory._engine_cache.pop(connection_string, None)
-                if cached_engine and cached_engine is not engine:
-                    cached_engine.dispose()
+                if cached_engine is not None:
+                    released = True
+                    if cached_engine is not engine:
+                        cached_engine.dispose()
+        return released
 
     def cleanup(self):
         """Clean up all engine resources, meow~"""

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -465,10 +465,15 @@ class TimeIndexedMemory:
                         continue
                 SQLChatMessageHistory._engine_cache.pop(connection_string, None)
         if not (errors and retain_on_failure):
-            self.db_paths.pop(lanlan_name, None)
             self.engines.pop(lanlan_name, None)
             self._engine_readonly_flags.pop(lanlan_name, None)
             self._writable_bootstrapped.discard(lanlan_name)
+            if not errors:
+                self.db_paths.pop(lanlan_name, None)
+            # 失败时保留 db_path：没释放掉的那个 pool 还挂在
+            # ``SQLChatMessageHistory._engine_cache`` 里，而它的 connection string
+            # 只能从 db_path 推出来——丢了它，之后的 /release_character 就再也够
+            # 不到那个 pool。清掉 engines 已足够让就地修复分支落到重建。
         if errors:
             raise errors[0]
         return released

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -412,15 +412,25 @@ class TimeIndexedMemory:
         return await asyncio.to_thread(self._ensure_engine_exists, lanlan_name, db_path)
 
     def dispose_engine(self, lanlan_name: str) -> bool:
-        """Dispose one character's cached engines and report whether any were known."""
-        db_path = self.db_paths.pop(lanlan_name, None)
-        engine = self.engines.pop(lanlan_name, None)
+        """Dispose one character's cached engines and report whether any were known.
+
+        Bookkeeping is only cleared once every disposal succeeded: a caller that
+        retries after a failure must still find this generation, otherwise the
+        pool that caused the failure keeps the database file locked until the
+        process exits.
+        """
+        db_path = self.db_paths.get(lanlan_name)
+        engine = self.engines.get(lanlan_name)
         released = engine is not None
-        self._engine_readonly_flags.pop(lanlan_name, None)
-        self._writable_bootstrapped.discard(lanlan_name)
+        errors: list[Exception] = []
         if engine:
-            engine.dispose()
-            logger.info(f"[TimeIndexedMemory] 已释放角色 {lanlan_name} 的数据库引擎")
+            try:
+                engine.dispose()
+                logger.info(f"[TimeIndexedMemory] 已释放角色 {lanlan_name} 的数据库引擎")
+            except Exception as exc:
+                # 继续走下面的 _engine_cache 清理：真正扣着文件句柄的往往是
+                # 缓存里的那个 pool，不能因为这一步失败就整段跳过。
+                errors.append(exc)
         if db_path:
             normalized_db_path, readonly_connection_string = self._build_sqlite_connection_string(
                 str(db_path),
@@ -433,7 +443,16 @@ class TimeIndexedMemory:
                 if cached_engine is not None:
                     released = True
                     if cached_engine is not engine:
-                        cached_engine.dispose()
+                        try:
+                            cached_engine.dispose()
+                        except Exception as exc:
+                            errors.append(exc)
+        if errors:
+            raise errors[0]
+        self.db_paths.pop(lanlan_name, None)
+        self.engines.pop(lanlan_name, None)
+        self._engine_readonly_flags.pop(lanlan_name, None)
+        self._writable_bootstrapped.discard(lanlan_name)
         return released
 
     def cleanup(self):

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -4593,6 +4593,25 @@ def test_timeindexed_dispose_engine_also_clears_sql_chat_engine_cache(monkeypatc
 
 
 @pytest.mark.unit
+def test_timeindexed_engine_admission_fence_prevents_lazy_recreation(monkeypatch):
+    from memory.timeindex import TimeIndexedMemory
+
+    manager = TimeIndexedMemory(
+        recent_history_manager=None,
+        engine_admission_check=lambda _name: False,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_resolve_expected_db_path",
+        lambda *_args, **_kwargs: pytest.fail(
+            "fenced identity must not resolve or create storage"
+        ),
+    )
+
+    assert manager._ensure_engine_exists("正在删除角色") is False
+
+
+@pytest.mark.unit
 def test_timeindexed_engine_init_failure_disposes_engine_and_clears_temp_cache(monkeypatch, tmp_path):
     from memory.timeindex import TimeIndexedMemory
     from utils.llm_client import SQLChatMessageHistory

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -4594,7 +4594,7 @@ def test_timeindexed_dispose_engine_also_clears_sql_chat_engine_cache(monkeypatc
 
 @pytest.mark.unit
 def test_timeindexed_engine_admission_fence_prevents_lazy_recreation(monkeypatch):
-    from memory.timeindex import TimeIndexedMemory
+    from memory.timeindex import CharacterEngineAdmissionError, TimeIndexedMemory
 
     manager = TimeIndexedMemory(
         recent_history_manager=None,
@@ -4608,7 +4608,12 @@ def test_timeindexed_engine_admission_fence_prevents_lazy_recreation(monkeypatch
         ),
     )
 
-    assert manager._ensure_engine_exists("正在删除角色") is False
+    with pytest.raises(CharacterEngineAdmissionError):
+        manager._ensure_engine_exists("正在删除角色")
+    with pytest.raises(CharacterEngineAdmissionError):
+        manager._ensure_engine_exists("正在删除角色", readonly=True)
+    with pytest.raises(CharacterEngineAdmissionError):
+        manager.retrieve_original_by_timeframe("正在删除角色", None, None)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -4578,13 +4578,15 @@ def test_timeindexed_dispose_engine_also_clears_sql_chat_engine_cache(monkeypatc
         manager.engines = {"测试角色": primary_engine}
         manager.db_paths = {"测试角色": "D:/tmp/test-time-indexed.db"}
 
-        manager.dispose_engine("测试角色")
+        released = manager.dispose_engine("测试角色")
 
+        assert released is True
         assert primary_engine.dispose_calls == 1
         assert cached_engine.dispose_calls == 1
         assert "测试角色" not in manager.engines
         assert "测试角色" not in manager.db_paths
         assert connection_string not in SQLChatMessageHistory._engine_cache
+        assert manager.dispose_engine("不存在角色") is False
     finally:
         SQLChatMessageHistory._engine_cache.clear()
         SQLChatMessageHistory._engine_cache.update(original_cache)

--- a/tests/unit/test_memory_zh_tw.py
+++ b/tests/unit/test_memory_zh_tw.py
@@ -4286,11 +4286,16 @@ async def test_reflect_endpoint_uses_durable_character_locale(monkeypatch, tmp_p
     monkeypatch.setattr(locale_state, "_locale_path", lambda _name: str(locale_path))
     monkeypatch.setattr(runtime, "reflection_engine", ReflectionEngine())
     monkeypatch.setattr(gates, "_ais_powerful_memory_enabled", powerful_enabled)
-    monkeypatch.setattr(
-        runtime,
-        "_spawn_background_task",
-        lambda coroutine: coroutine.close(),
-    )
+    def _spawn_stub(coroutine):
+        # 不真起 task（下面手动 await _safe_auto_promote），但仍要返回一个
+        # 已完成的 awaitable：调用点会把它登记进 per-character registry，
+        # 已完成的 future 会立刻触发登记表的自清理回调。
+        coroutine.close()
+        finished = asyncio.get_running_loop().create_future()
+        finished.set_result(None)
+        return finished
+
+    monkeypatch.setattr(runtime, "_spawn_background_task", _spawn_stub)
     locale_state._locale_cache.clear()
     locale_state.record_character_prompt_locale("Neko", "zh-TW")
     locale_state._locale_cache.clear()

--- a/tests/unit/test_memory_zh_tw.py
+++ b/tests/unit/test_memory_zh_tw.py
@@ -221,6 +221,23 @@ def test_summary_prompt_uses_request_scoped_traditional_locale():
     assert "負面回饋" in prompt
 
 
+def _collect_spawned_operation(sink):
+    """Stub for ``runtime._spawn_background_task``.
+
+    Collects the coroutine instead of running it, but still returns a finished
+    awaitable: the call sites register the returned task in the per-character
+    post-turn registry, and a finished future clears itself from it immediately.
+    """
+
+    def _spawn(operation):
+        sink.append(operation)
+        finished = asyncio.get_running_loop().create_future()
+        finished.set_result(None)
+        return finished
+
+    return _spawn
+
+
 @pytest.mark.asyncio
 async def test_compressed_memo_wrapper_keeps_traditional_locale():
     from memory.recent import CompressedRecentHistoryManager
@@ -949,7 +966,7 @@ async def test_new_dialog_defers_locale_write_while_cloudsave_is_fenced(monkeypa
     monkeypatch.setattr(
         runtime,
         "_spawn_background_task",
-        lambda operation: deferred.append(operation),
+        _collect_spawned_operation(deferred),
     )
 
     with pytest.raises(ReachedContextRead):
@@ -1356,7 +1373,7 @@ async def test_new_dialog_generation_follows_admission_not_validation_order(
     monkeypatch.setattr(
         runtime,
         "_spawn_background_task",
-        lambda operation: spawned.append(operation),
+        _collect_spawned_operation(spawned),
     )
     monkeypatch.setattr(runtime, "_get_settle_lock", lambda _name: StopLock())
     routes._new_dialog_locale_generations.pop(name, None)

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -103,6 +103,91 @@ async def test_release_character_disposes_current_and_deferred_time_managers_onc
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_drains_inflight_process_and_fences_engine_recreation():
+    """A pre-release write must finish, while queued writes cannot reopen SQLite."""
+    from app import memory_server
+
+    name = "发布窗口竞态角色"
+    claim_token = "foreground-drain-claim"
+    write_started = asyncio.Event()
+    finish_write = asyncio.Event()
+    order: list[str] = []
+
+    async def _astore(*_args, **_kwargs):
+        order.append("write_started")
+        write_started.set()
+        await finish_write.wait()
+        order.append("write_finished")
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.astore_conversation = AsyncMock(side_effect=_astore)
+    fake_time_manager.dispose_engine.side_effect = lambda _name: order.append("disposed") or True
+    fake_recent = MagicMock()
+    fake_recent.update_history = AsyncMock(return_value=None)
+    fake_config = MagicMock()
+    fake_config.aload_characters = AsyncMock(return_value={"猫娘": {name: {}}})
+    request = memory_server.HistoryRequest(input_history="[]")
+
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+        memory_server.runtime, "_deferred_time_managers", [],
+    ), patch.object(
+        memory_server.runtime, "recent_history_manager", fake_recent,
+    ), patch.object(
+        memory_server.runtime, "_config_manager", fake_config,
+    ), patch.object(
+        memory_server.runtime, "embedding_warmup_worker", None,
+    ), patch.object(
+        memory_server.post_turn, "_spawn_outbox_post_turn_signals", AsyncMock(),
+    ), patch.object(
+        memory_server.review, "maybe_spawn_review", AsyncMock(),
+    ):
+        process_task = asyncio.create_task(
+            memory_server.process_conversation(request, name)
+        )
+        await asyncio.wait_for(write_started.wait(), timeout=1)
+
+        release_task = asyncio.create_task(
+            memory_server.runtime.release_character_resources(
+                name,
+                hold_derived_task_admission=True,
+                derived_task_claim_token=claim_token,
+                derived_task_claim_generation=0,
+            )
+        )
+        for _ in range(20):
+            if memory_server.review.is_character_publication_held(name):
+                break
+            await asyncio.sleep(0)
+
+        assert memory_server.review.is_character_publication_held(name)
+        assert "disposed" not in order
+        finish_write.set()
+        process_result, release_result = await asyncio.gather(
+            process_task,
+            release_task,
+        )
+
+        assert process_result == {"status": "processed"}
+        assert release_result["status"] == "success"
+        assert order == ["write_started", "write_finished", "disposed"]
+
+        queued_result = await memory_server.process_conversation(request, name)
+        assert queued_result == {
+            "status": "cancelled",
+            "message": "character release in progress",
+        }
+        assert fake_time_manager.astore_conversation.await_count == 1
+
+    await memory_server.review.release_character_derived_task_admission_claim(
+        name,
+        claim_token,
+    )
+
+
+@pytest.mark.unit
 def test_cross_generation_release_closes_real_sqlite_pool(tmp_path):
     """The deferred generation must stop holding the database file on Windows."""
     from sqlalchemy import create_engine, text

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -46,8 +46,11 @@ async def test_release_character_drains_old_identity_review_and_backup_tasks():
     memory_server.review.compress_backup_tasks[name] = backup_task
     memory_server.review.compress_backup_task_generations[name] = ("old", 0)
     fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = False
 
-    with patch.object(memory_server.runtime, "time_manager", fake_time_manager):
+    with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+        memory_server.runtime, "_deferred_time_managers", [],
+    ):
         result = await memory_server.runtime.release_character_resources(
             name,
             derived_task_claim_token="drain-claim",
@@ -68,6 +71,76 @@ async def test_release_character_drains_old_identity_review_and_backup_tasks():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_release_character_disposes_current_and_deferred_time_managers_once():
+    """A hot-reload generation must not retain the character's SQLite handle."""
+    from app import memory_server
+
+    name = "热重载后删除角色"
+    current_manager = MagicMock()
+    current_manager.dispose_engine.return_value = False
+    old_manager = MagicMock()
+    old_manager.dispose_engine.return_value = True
+    other_old_manager = MagicMock()
+    other_old_manager.dispose_engine.return_value = False
+    deferred = [old_manager, current_manager, old_manager, other_old_manager]
+
+    with patch.object(memory_server.runtime, "time_manager", current_manager), patch.object(
+        memory_server.runtime, "_deferred_time_managers", deferred,
+    ):
+        result = await memory_server.runtime.release_character_resources(
+            name,
+            derived_task_claim_token="cross-generation-claim",
+            derived_task_claim_generation=0,
+        )
+
+        assert memory_server.runtime._deferred_time_managers == deferred
+
+    assert result["status"] == "success"
+    current_manager.dispose_engine.assert_called_once_with(name)
+    old_manager.dispose_engine.assert_called_once_with(name)
+    other_old_manager.dispose_engine.assert_called_once_with(name)
+    memory_server.review._retired_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+def test_cross_generation_release_closes_real_sqlite_pool(tmp_path):
+    """The deferred generation must stop holding the database file on Windows."""
+    from sqlalchemy import create_engine, text
+
+    from app import memory_server
+    from memory.timeindex import TimeIndexedMemory
+
+    name = "真实连接池角色"
+    db_path = tmp_path / "time_indexed.db"
+    engine = create_engine(f"sqlite:///{db_path.as_posix()}")
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE probe (id INTEGER PRIMARY KEY)"))
+
+    current_manager = TimeIndexedMemory(recent_history_manager=None)
+    old_manager = TimeIndexedMemory(recent_history_manager=None)
+    old_manager.engines[name] = engine
+    old_manager.db_paths[name] = str(db_path)
+    deferred = [old_manager]
+
+    with patch.object(memory_server.runtime, "time_manager", current_manager), patch.object(
+        memory_server.runtime, "_deferred_time_managers", deferred,
+    ):
+        scanned_count, released_count = (
+            memory_server.runtime._dispose_character_engines_across_generations(name)
+        )
+
+        assert memory_server.runtime._deferred_time_managers == deferred
+
+    assert scanned_count == 2
+    assert released_count == 1
+    assert name not in old_manager.engines
+    assert name not in old_manager.db_paths
+    db_path.unlink()
+    assert not db_path.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_release_failure_restores_derived_task_admission():
     """A failed resource release must not permanently retire an active name."""
     from app import memory_server
@@ -77,8 +150,12 @@ async def test_release_failure_restores_derived_task_admission():
     memory_server.review._publication_held_derived_task_names.discard(name)
     fake_time_manager = MagicMock()
     fake_time_manager.dispose_engine.side_effect = OSError("busy")
+    deferred_manager = MagicMock()
+    deferred_manager.dispose_engine.return_value = True
 
-    with patch.object(memory_server.runtime, "time_manager", fake_time_manager):
+    with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+        memory_server.runtime, "_deferred_time_managers", [deferred_manager],
+    ):
         result = await memory_server.runtime.release_character_resources(
             name,
             hold_derived_task_admission=True,
@@ -87,6 +164,7 @@ async def test_release_failure_restores_derived_task_admission():
         )
 
     assert result.status_code == 500
+    deferred_manager.dispose_engine.assert_called_once_with(name)
     assert name not in memory_server.review._retired_derived_task_names
     assert name not in memory_server.review._publication_held_derived_task_names
 

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -374,6 +374,119 @@ async def test_admission_lease_survives_a_hold_flip_through_the_real_middleware(
 
 
 @pytest.mark.unit
+def test_every_character_scoped_post_route_is_classified_for_the_fence():
+    """A new character-scoped writer must not silently miss the fence.
+
+    Anything added under ``{lanlan_name}`` either enters the publication guard
+    or gets listed here as a deliberate read/control route.
+    """
+    from app import memory_server
+
+    runtime = memory_server.runtime
+    unfenced_by_design = {
+        # 只读召回：读路径由引擎准入检查兜底，围栏住只会白白打断读取。
+        "/query_memory/{lanlan_name}",
+        "/internal/memory/{lanlan_name}/scoped_context",
+        # 只取消任务，不写角色文件——删除期间恰恰需要它还能用。
+        "/cancel_correction/{lanlan_name}",
+        # 围栏本身就是它设的，自己不能被自己拦。
+        "/release_character/{lanlan_name}",
+    }
+    probe_name = "围栏探针角色"
+    fenced: set[str] = set()
+    unfenced: set[str] = set()
+    for route in runtime.app.routes:
+        path = getattr(route, "path", "")
+        methods = getattr(route, "methods", None) or set()
+        if "{lanlan_name}" not in path or "POST" not in methods:
+            continue
+        probe_path = path.replace("{lanlan_name}", probe_name)
+        if runtime._character_write_name_from_path(probe_path) == probe_name:
+            fenced.add(path)
+        else:
+            unfenced.add(path)
+
+    assert unfenced == unfenced_by_design
+    assert "/cache/{lanlan_name}" in fenced
+    assert "/record_surfaced/{lanlan_name}" in fenced
+
+
+@pytest.mark.unit
+def test_dispose_engine_keeps_bookkeeping_when_disposal_fails(tmp_path):
+    """A failed disposal must stay retryable, not vanish from this generation."""
+    from memory.timeindex import TimeIndexedMemory
+
+    name = "释放失败可重试角色"
+    db_path = tmp_path / "time_indexed.db"
+    engine = MagicMock()
+    engine.dispose.side_effect = OSError("busy")
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    manager.engines[name] = engine
+    manager.db_paths[name] = str(db_path)
+    manager._engine_readonly_flags[name] = False
+    manager._writable_bootstrapped.add(name)
+
+    with pytest.raises(OSError):
+        manager.dispose_engine(name)
+
+    assert manager.engines[name] is engine
+    assert manager.db_paths[name] == str(db_path)
+
+    engine.dispose.side_effect = None
+    assert manager.dispose_engine(name) is True
+    assert name not in manager.engines
+    assert name not in manager.db_paths
+    assert name not in manager._writable_bootstrapped
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_startup_replay_tasks_join_the_per_character_registry(tmp_path):
+    """A long outbox replay must be drainable by a rename/delete that lands on it."""
+    from app import memory_server
+    from app.memory_server import outbox_infra
+
+    name = "补跑登记角色"
+    memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+    started = asyncio.Event()
+
+    async def _fake_run_outbox_op(_name, _op, _semaphore=None):
+        started.set()
+        await asyncio.sleep(30)
+
+    fake_config = MagicMock()
+    fake_config.aload_characters = AsyncMock(return_value={"猫娘": {name: {}}})
+    fake_config.memory_dir = str(tmp_path)
+    fake_outbox = MagicMock()
+    fake_outbox.apending_ops = AsyncMock(
+        return_value=[{"op_id": "op-1", "type": "extract_facts"}]
+    )
+
+    spawned = []
+    try:
+        with patch.object(memory_server.runtime, "_config_manager", fake_config), patch.object(
+            memory_server.runtime, "outbox", fake_outbox,
+        ), patch.object(
+            outbox_infra, "_run_outbox_op", _fake_run_outbox_op,
+        ):
+            spawned = await outbox_infra._replay_pending_outbox()
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            assert len(spawned) == 1
+            assert len(
+                memory_server.post_turn._character_post_turn_tasks.get(name, ())
+            ) == 1
+            cancelled = await memory_server.post_turn.cancel_character_post_turn_tasks(
+                name
+            )
+            assert cancelled == 1
+    finally:
+        for task in spawned:
+            await _cleanup_task(task)
+        memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+
+
+@pytest.mark.unit
 def test_release_drain_budget_stays_under_the_tightest_caller_timeout():
     """A caller that gives up first starts deleting files while the drain runs."""
     import inspect

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -460,6 +460,131 @@ async def test_reflect_auto_promote_task_joins_the_per_character_registry():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_deferred_new_dialog_locale_retry_joins_the_registry():
+    """The deferred locale retry outlives the request; release must drain it."""
+    import contextlib
+
+    from app import memory_server
+    from app.memory_server import routes as routes_module
+
+    name = "延迟locale重试角色"
+    memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+    started = asyncio.Event()
+
+    async def _slow_retry(*_args, **_kwargs):
+        started.set()
+        await asyncio.sleep(30)
+
+    async def _defer_locale_write(*_args, **_kwargs):
+        raise routes_module.MaintenanceModeError("cloud snapshot in progress")
+
+    fake_outbox = MagicMock()
+    fake_outbox.aappend_pending = AsyncMock(return_value="op-1")
+    fake_config = MagicMock()
+    fake_config.aload_characters = AsyncMock(return_value={"猫娘": {name: {}}})
+
+    cancelled = 0
+    try:
+        with patch.object(
+            routes_module, "_write_new_dialog_locale", _defer_locale_write,
+        ), patch.object(
+            routes_module, "_run_durable_new_dialog_locale_retry", _slow_retry,
+        ), patch.object(
+            routes_module, "_promote_new_dialog_locale_generation", MagicMock(),
+        ), patch.object(
+            routes_module.locale_state,
+            "rebase_character_prompt_locale_order",
+            MagicMock(return_value=1),
+        ), patch.object(
+            memory_server.runtime, "outbox", fake_outbox,
+        ), patch.object(
+            memory_server.runtime, "_config_manager", fake_config,
+        ):
+            # 端点后半段要整套 memory 组件；这里只关心「延迟重试有没有被登记」，
+            # 而登记只发生在这条异常分支里，所以断言 registry 有 1 条不会空过。
+            with contextlib.suppress(Exception):
+                await routes_module._new_dialog(name, "zh-TW", None)
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            assert len(
+                memory_server.post_turn._character_post_turn_tasks.get(name, ())
+            ) == 1
+            cancelled = await memory_server.post_turn.cancel_character_post_turn_tasks(
+                name
+            )
+    finally:
+        memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+
+    assert cancelled == 1
+
+
+@pytest.mark.unit
+def test_every_memory_server_background_spawn_is_drainable():
+    """Per-character background work must be drainable by a character release.
+
+    Every ``_spawn_background_task(...)`` call either goes through the
+    per-character post-turn registry, or is listed here together with the
+    registry (or the reason) that already covers it. Adding a new spawn forces
+    that decision instead of silently escaping the release drain.
+    """
+    import ast
+    from pathlib import Path
+
+    import app.memory_server as memory_server_package
+
+    covered_elsewhere = {
+        # 进程级常驻循环 + embedding bootstrap：不属于任何角色，
+        # release 不该、也不能取消它们。
+        ("runtime.py", "ensure_memory_server_runtime_initialized"),
+        # 按角色登记进 compress_backup_tasks，由 cancel_character_derived_tasks 排空。
+        ("review.py", "_on_compress_done"),
+    }
+
+    def _callee_name(node):
+        func = getattr(node, "func", None)
+        return getattr(func, "attr", None) or getattr(func, "id", None)
+
+    tracked: set[tuple[str, str]] = set()
+    untracked: set[tuple[str, str]] = set()
+    for source_path in sorted(Path(memory_server_package.__file__).parent.glob("*.py")):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        parents: dict[ast.AST, ast.AST] = {}
+        enclosing: dict[ast.AST, str] = {}
+
+        def _walk(node, function_name):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+                enclosing[child] = function_name
+                _walk(
+                    child,
+                    child.name
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    else function_name,
+                )
+
+        _walk(tree, "<module>")
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if _callee_name(node) != "_spawn_background_task":
+                continue
+            key = (source_path.name, enclosing.get(node, "<module>"))
+            parent = parents.get(node)
+            if isinstance(parent, ast.Call) and _callee_name(parent) == (
+                "_track_character_post_turn_task"
+            ):
+                tracked.add(key)
+            else:
+                untracked.add(key)
+
+    assert untracked == covered_elsewhere
+    assert ("routes.py", "_new_dialog") in tracked
+    assert ("routes.py", "api_reflect") in tracked
+    assert ("outbox_infra.py", "_replay_pending_outbox") in tracked
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_background_tasks_never_inherit_the_admission_lease():
     """A detached task outlives the request, so release cannot drain it."""
     from app import memory_server

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -517,6 +517,15 @@ def test_dispose_engine_keeps_bookkeeping_when_disposal_fails(tmp_path):
     assert name not in manager._writable_bootstrapped
 
 
+def _sqlite_cache_keys(manager, db_path):
+    """The two connection strings ``dispose_engine`` cleans up for one character."""
+    normalized, readonly_connection_string = manager._build_sqlite_connection_string(
+        str(db_path), readonly=True,
+    )
+    writable_connection_string = f"sqlite:///{normalized.replace(chr(92), '/')}"
+    return readonly_connection_string, writable_connection_string
+
+
 @pytest.mark.unit
 def test_dispose_engine_keeps_the_cached_pool_when_its_disposal_fails(tmp_path):
     """The cache entry is the only handle on that pool — never drop it unreleased."""
@@ -527,32 +536,69 @@ def test_dispose_engine_keeps_the_cached_pool_when_its_disposal_fails(tmp_path):
     manager = TimeIndexedMemory(recent_history_manager=None)
     manager.db_paths[name] = str(db_path)
 
-    normalized, readonly_connection_string = manager._build_sqlite_connection_string(
-        str(db_path), readonly=True,
-    )
-    writable_connection_string = f"sqlite:///{normalized.replace(chr(92), '/')}"
+    readonly_key, writable_key = _sqlite_cache_keys(manager, db_path)
     cached_engine = MagicMock()
     cached_engine.dispose.side_effect = OSError("cached pool busy")
     cache = SQLChatMessageHistory._engine_cache
-    touched = {readonly_connection_string, writable_connection_string}
-    saved = {key: cache.get(key) for key in touched if key in cache}
+    saved = {key: cache[key] for key in (readonly_key, writable_key) if key in cache}
     try:
-        for key in touched:
-            cache[key] = cached_engine
+        # 只挂 writable 这一个键：一次调用对同一个池只该释放一次。
+        cache[writable_key] = cached_engine
 
         with pytest.raises(OSError):
             manager.dispose_engine(name)
 
+        assert cached_engine.dispose.call_count == 1
         # 缓存条目必须还在，否则重试再也够不到这个 pool。
-        assert all(cache.get(key) is cached_engine for key in touched)
+        assert cache.get(writable_key) is cached_engine
         assert manager.db_paths[name] == str(db_path)
 
         cached_engine.dispose.side_effect = None
         assert manager.dispose_engine(name) is True
-        assert all(key not in cache for key in touched)
+        assert cached_engine.dispose.call_count == 2
+        assert writable_key not in cache
         assert name not in manager.db_paths
     finally:
-        for key in touched:
+        for key in (readonly_key, writable_key):
+            cache.pop(key, None)
+        cache.update(saved)
+
+
+@pytest.mark.unit
+def test_dispose_engine_keeps_the_cache_entry_when_the_primary_engine_fails(tmp_path):
+    """The cached entry can BE the manager's engine; a failed one must not be dropped."""
+    from memory.timeindex import SQLChatMessageHistory, TimeIndexedMemory
+
+    name = "主引擎释放失败角色"
+    db_path = tmp_path / "time_indexed.db"
+    engine = MagicMock()
+    engine.dispose.side_effect = OSError("primary pool busy")
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    manager.engines[name] = engine
+    manager.db_paths[name] = str(db_path)
+
+    readonly_key, writable_key = _sqlite_cache_keys(manager, db_path)
+    cache = SQLChatMessageHistory._engine_cache
+    saved = {key: cache[key] for key in (readonly_key, writable_key) if key in cache}
+    try:
+        cache[readonly_key] = engine
+
+        with pytest.raises(OSError):
+            manager.dispose_engine(name)
+
+        # 同一个对象在一次调用里只 dispose 一次，且失败后缓存条目要留住。
+        assert engine.dispose.call_count == 1
+        assert cache.get(readonly_key) is engine
+        assert manager.engines[name] is engine
+
+        engine.dispose.side_effect = None
+        assert manager.dispose_engine(name) is True
+        assert engine.dispose.call_count == 2
+        assert readonly_key not in cache
+        assert name not in manager.engines
+        assert name not in manager.db_paths
+    finally:
+        for key in (readonly_key, writable_key):
             cache.pop(key, None)
         cache.update(saved)
 

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -131,60 +132,115 @@ async def test_release_drains_inflight_process_and_fences_engine_recreation():
 
     memory_server.review._retired_derived_task_names.discard(name)
     memory_server.review._publication_held_derived_task_names.discard(name)
-    with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
-        memory_server.runtime, "_deferred_time_managers", [],
-    ), patch.object(
-        memory_server.runtime, "recent_history_manager", fake_recent,
-    ), patch.object(
-        memory_server.runtime, "_config_manager", fake_config,
-    ), patch.object(
-        memory_server.runtime, "embedding_warmup_worker", None,
-    ), patch.object(
-        memory_server.post_turn, "_spawn_outbox_post_turn_signals", AsyncMock(),
-    ), patch.object(
-        memory_server.review, "maybe_spawn_review", AsyncMock(),
-    ):
-        process_task = asyncio.create_task(
-            memory_server.process_conversation(request, name)
-        )
-        await asyncio.wait_for(write_started.wait(), timeout=1)
-
-        release_task = asyncio.create_task(
-            memory_server.runtime.release_character_resources(
-                name,
-                hold_derived_task_admission=True,
-                derived_task_claim_token=claim_token,
-                derived_task_claim_generation=0,
+    context_token = memory_server.runtime._begin_character_request(name)
+    assert context_token is not None
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ), patch.object(
+            memory_server.runtime, "recent_history_manager", fake_recent,
+        ), patch.object(
+            memory_server.runtime, "_config_manager", fake_config,
+        ), patch.object(
+            memory_server.runtime, "embedding_warmup_worker", None,
+        ), patch.object(
+            memory_server.post_turn, "_spawn_outbox_post_turn_signals", AsyncMock(),
+        ), patch.object(
+            memory_server.review, "maybe_spawn_review", AsyncMock(),
+        ):
+            process_task = asyncio.create_task(
+                memory_server.process_conversation(request, name)
             )
+            await asyncio.wait_for(write_started.wait(), timeout=1)
+
+            release_task = asyncio.create_task(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=True,
+                    derived_task_claim_token=claim_token,
+                    derived_task_claim_generation=0,
+                )
+            )
+
+            async def _wait_for_hold():
+                while not memory_server.review.is_character_publication_held(name):
+                    await asyncio.sleep(0)
+
+            await asyncio.wait_for(_wait_for_hold(), timeout=1)
+            assert memory_server.runtime._is_character_engine_admitted(name)
+            assert "disposed" not in order
+            finish_write.set()
+            process_result = await process_task
+            memory_server.runtime._end_character_request(name, context_token)
+            context_token = None
+            release_result = await release_task
+
+            assert process_result == {"status": "processed"}
+            assert release_result["status"] == "success"
+            assert order == ["write_started", "write_finished", "disposed"]
+
+            assert memory_server.runtime._begin_character_request(name) is None
+            assert fake_time_manager.astore_conversation.await_count == 1
+    finally:
+        if context_token is not None:
+            memory_server.runtime._end_character_request(name, context_token)
+        await memory_server.review.release_character_derived_task_admission_claim(
+            name,
+            claim_token,
         )
-        for _ in range(20):
-            if memory_server.review.is_character_publication_held(name):
-                break
-            await asyncio.sleep(0)
+        memory_server.review._retired_derived_task_names.discard(name)
+        memory_server.review._publication_held_derived_task_names.discard(name)
 
-        assert memory_server.review.is_character_publication_held(name)
-        assert "disposed" not in order
-        finish_write.set()
-        process_result, release_result = await asyncio.gather(
-            process_task,
-            release_task,
-        )
 
-        assert process_result == {"status": "processed"}
-        assert release_result["status"] == "success"
-        assert order == ["write_started", "write_finished", "disposed"]
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_publication_guard_rejects_new_write_with_non_success_status():
+    from starlette.requests import Request
 
-        queued_result = await memory_server.process_conversation(request, name)
-        assert queued_result == {
-            "status": "cancelled",
-            "message": "character release in progress",
+    from app import memory_server
+
+    name = "已关闭准入角色"
+    memory_server.review._publication_held_derived_task_names.add(name)
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "http",
+            "path": f"/cache/{name}",
+            "raw_path": f"/cache/{name}".encode(),
+            "query_string": b"",
+            "headers": [],
+            "server": ("127.0.0.1", 48912),
+            "client": ("127.0.0.1", 1),
         }
-        assert fake_time_manager.astore_conversation.await_count == 1
-
-    await memory_server.review.release_character_derived_task_admission_claim(
-        name,
-        claim_token,
     )
+    call_next = AsyncMock(side_effect=AssertionError("fenced request reached endpoint"))
+    try:
+        response = await memory_server.runtime.character_publication_guard(
+            request,
+            call_next,
+        )
+        assert response.status_code == 409
+        assert json.loads(response.body)["status"] == "cancelled"
+        call_next.assert_not_awaited()
+    finally:
+        memory_server.review._publication_held_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_cancels_tracked_post_turn_task():
+    from app import memory_server
+
+    name = "待取消后台角色"
+    task = asyncio.create_task(asyncio.sleep(30))
+    memory_server.post_turn._track_character_post_turn_task(name, task)
+
+    cancelled = await memory_server.post_turn.cancel_character_post_turn_tasks(name)
+
+    assert cancelled == 1
+    assert task.cancelled()
+    assert name not in memory_server.post_turn._character_post_turn_tasks
 
 
 @pytest.mark.unit

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -518,6 +518,46 @@ def test_dispose_engine_keeps_bookkeeping_when_disposal_fails(tmp_path):
 
 
 @pytest.mark.unit
+def test_dispose_engine_keeps_the_cached_pool_when_its_disposal_fails(tmp_path):
+    """The cache entry is the only handle on that pool — never drop it unreleased."""
+    from memory.timeindex import SQLChatMessageHistory, TimeIndexedMemory
+
+    name = "缓存池释放失败角色"
+    db_path = tmp_path / "time_indexed.db"
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    manager.db_paths[name] = str(db_path)
+
+    normalized, readonly_connection_string = manager._build_sqlite_connection_string(
+        str(db_path), readonly=True,
+    )
+    writable_connection_string = f"sqlite:///{normalized.replace(chr(92), '/')}"
+    cached_engine = MagicMock()
+    cached_engine.dispose.side_effect = OSError("cached pool busy")
+    cache = SQLChatMessageHistory._engine_cache
+    touched = {readonly_connection_string, writable_connection_string}
+    saved = {key: cache.get(key) for key in touched if key in cache}
+    try:
+        for key in touched:
+            cache[key] = cached_engine
+
+        with pytest.raises(OSError):
+            manager.dispose_engine(name)
+
+        # 缓存条目必须还在，否则重试再也够不到这个 pool。
+        assert all(cache.get(key) is cached_engine for key in touched)
+        assert manager.db_paths[name] == str(db_path)
+
+        cached_engine.dispose.side_effect = None
+        assert manager.dispose_engine(name) is True
+        assert all(key not in cache for key in touched)
+        assert name not in manager.db_paths
+    finally:
+        for key in touched:
+            cache.pop(key, None)
+        cache.update(saved)
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_startup_replay_tasks_join_the_per_character_registry(tmp_path):
     """A long outbox replay must be drainable by a rename/delete that lands on it."""

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -914,11 +914,13 @@ def test_engine_repair_branch_self_heals_after_a_failed_disposal(tmp_path):
         with pytest.raises(OSError):
             manager._ensure_engine_exists(name)
 
-        # engines 必须清掉：下一次调用要能走到重建分支，而不是又撞同一个 dispose。
+        # 簿记必须全清：下一次调用要能走到重建分支，而不是又撞同一个 dispose。
         assert name not in manager.engines
-        # 但 db_path 要留着：没释放掉的 pool 还在 _engine_cache 里，它的
-        # connection string 只能从 db_path 推出来，丢了 release 就够不到它。
-        assert manager.db_paths[name] == str(tmp_path / "stale" / "time_indexed.db")
+        assert name not in manager.db_paths
+        # 这一场景里失败的是 manager 自己那个 engine、缓存里没有对应条目，
+        # 所以不留账（留了也够不到）。缓存里真有失败 pool 的情形见
+        # test_release_reaches_a_failed_pool_after_a_path_drift_rebuild。
+        assert name not in manager._undisposed_pools
 
         created = MagicMock()
         with patch.object(
@@ -935,43 +937,47 @@ def test_engine_repair_branch_self_heals_after_a_failed_disposal(tmp_path):
 
 
 @pytest.mark.unit
-def test_release_can_still_reach_a_pool_a_failed_repair_left_behind(tmp_path):
-    """A repair-mode failure must not orphan the pool it could not dispose.
+def test_release_reaches_a_failed_pool_after_a_path_drift_rebuild(tmp_path):
+    """A rebuild overwrites db_path, so reachability cannot depend on it.
 
-    The failed pool stays in ``SQLChatMessageHistory._engine_cache``, whose key
-    is derived from ``db_paths``. Dropping that entry would leave the handle
-    unreachable and release would report success while the file stays locked.
+    Sequence: repair-mode disposal fails on the old path's pool → the drift
+    rebuild replaces ``db_paths`` with the new path → a later release must still
+    dispose the old pool, or it keeps the file locked until the process exits.
     """
     from memory.timeindex import SQLChatMessageHistory, TimeIndexedMemory
 
-    name = "修复失败遗留池角色"
-    db_path = tmp_path / "time_indexed.db"
+    name = "漂移后仍可达角色"
+    old_db_path = tmp_path / "old" / "time_indexed.db"
+    new_db_path = tmp_path / "new" / "time_indexed.db"
     manager = TimeIndexedMemory(recent_history_manager=None)
     manager.engines[name] = MagicMock()
-    manager.db_paths[name] = str(db_path)
+    manager.db_paths[name] = str(old_db_path)
 
-    readonly_key, writable_key = _sqlite_cache_keys(manager, db_path)
+    old_readonly, old_writable = _sqlite_cache_keys(manager, old_db_path)
+    new_readonly, new_writable = _sqlite_cache_keys(manager, new_db_path)
     stuck_pool = MagicMock()
-    stuck_pool.dispose.side_effect = OSError("pool busy")
+    stuck_pool.dispose.side_effect = OSError("old pool busy")
     cache = SQLChatMessageHistory._engine_cache
-    saved = {key: cache[key] for key in (readonly_key, writable_key) if key in cache}
+    touched = {old_readonly, old_writable, new_readonly, new_writable}
+    saved = {key: cache[key] for key in touched if key in cache}
     try:
-        cache[writable_key] = stuck_pool
+        cache[old_writable] = stuck_pool
 
-        # 就地修复语义（默认模式）：清 engines 让重建分支能走，但别丢 db_path。
         with pytest.raises(OSError):
             manager.dispose_engine(name)
-        assert name not in manager.engines
-        assert manager.db_paths[name] == str(db_path)
-        assert cache.get(writable_key) is stuck_pool
+        assert old_writable in manager._undisposed_pools[name]
 
-        # 之后的 release 仍然够得到这个 pool 并重试。
+        # 路径漂移重建：db_path 被换成新路径，旧路径再也推不出来。
+        manager.db_paths[name] = str(new_db_path)
+        manager.engines[name] = MagicMock()
         stuck_pool.dispose.side_effect = None
+
         assert manager.dispose_engine(name, retain_on_failure=True) is True
-        assert writable_key not in cache
-        assert name not in manager.db_paths
+        assert stuck_pool.dispose.call_count == 2
+        assert old_writable not in cache
+        assert name not in manager._undisposed_pools
     finally:
-        for key in (readonly_key, writable_key):
+        for key in touched:
             cache.pop(key, None)
         cache.update(saved)
 

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -374,41 +374,119 @@ async def test_admission_lease_survives_a_hold_flip_through_the_real_middleware(
 
 
 @pytest.mark.unit
-def test_every_character_scoped_post_route_is_classified_for_the_fence():
+def test_every_character_scoped_route_is_classified_for_the_fence():
     """A new character-scoped writer must not silently miss the fence.
 
-    Anything added under ``{lanlan_name}`` either enters the publication guard
-    or gets listed here as a deliberate read/control route.
+    Every ``{lanlan_name}`` route/method pair either enters the publication
+    guard or is listed here as a deliberate read/control route. The list is the
+    written-down boundary — adding an endpoint forces a decision about it.
     """
     from app import memory_server
 
     runtime = memory_server.runtime
     unfenced_by_design = {
-        # 只读召回：读路径由引擎准入检查兜底，围栏住只会白白打断读取。
-        "/query_memory/{lanlan_name}",
-        "/internal/memory/{lanlan_name}/scoped_context",
+        # 只读：读路径由引擎准入检查兜底，围栏住只会白白打断读取。
+        ("/query_memory/{lanlan_name}", "POST"),
+        ("/internal/memory/{lanlan_name}/scoped_context", "POST"),
+        ("/followup_topics/{lanlan_name}", "GET"),
+        ("/get_recent_history/{lanlan_name}", "GET"),
+        ("/search_for_memory/{lanlan_name}/{query}", "GET"),
+        ("/get_persona/{lanlan_name}", "GET"),
+        ("/api/memory/funnel/{lanlan_name}", "GET"),
+        ("/prompt-locale/{lanlan_name}", "GET"),
+        ("/last_conversation_gap/{lanlan_name}", "GET"),
+        # 渲染型读取；顺带刷新 suppress 冷却是 best-effort，而且它本身对
+        # 「角色已不在配置中」有短路分支，不值得为它换来发布窗口里的 409。
+        ("/get_settings/{lanlan_name}", "GET"),
         # 只取消任务，不写角色文件——删除期间恰恰需要它还能用。
-        "/cancel_correction/{lanlan_name}",
+        ("/cancel_correction/{lanlan_name}", "POST"),
         # 围栏本身就是它设的，自己不能被自己拦。
-        "/release_character/{lanlan_name}",
+        ("/release_character/{lanlan_name}", "POST"),
     }
     probe_name = "围栏探针角色"
-    fenced: set[str] = set()
-    unfenced: set[str] = set()
+    fenced: set[tuple[str, str]] = set()
+    unfenced: set[tuple[str, str]] = set()
     for route in runtime.app.routes:
         path = getattr(route, "path", "")
-        methods = getattr(route, "methods", None) or set()
-        if "{lanlan_name}" not in path or "POST" not in methods:
+        if "{lanlan_name}" not in path:
             continue
         probe_path = path.replace("{lanlan_name}", probe_name)
-        if runtime._character_write_name_from_path(probe_path) == probe_name:
-            fenced.add(path)
-        else:
-            unfenced.add(path)
+        for method in getattr(route, "methods", None) or set():
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            name = runtime._character_write_name_from_path(probe_path, method)
+            (fenced if name == probe_name else unfenced).add((path, method))
 
     assert unfenced == unfenced_by_design
-    assert "/cache/{lanlan_name}" in fenced
-    assert "/record_surfaced/{lanlan_name}" in fenced
+    assert ("/cache/{lanlan_name}", "POST") in fenced
+    assert ("/record_surfaced/{lanlan_name}", "POST") in fenced
+    assert ("/new_dialog/{lanlan_name}", "GET") in fenced
+    assert ("/prompt-locale/{lanlan_name}", "PUT") in fenced
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reflect_auto_promote_task_joins_the_per_character_registry():
+    """auto_promote runs 30-90s past the request, so release must drain it."""
+    from app import memory_server
+    from app.memory_server import routes as routes_module
+
+    name = "反思提升登记角色"
+    memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+    started = asyncio.Event()
+
+    async def _slow_auto_promote(_name):
+        started.set()
+        await asyncio.sleep(30)
+
+    with patch.object(routes_module, "_safe_auto_promote", _slow_auto_promote), patch.object(
+        routes_module.locale_state,
+        "run_with_character_prompt_locale",
+        AsyncMock(return_value=None),
+    ):
+        await routes_module.api_reflect(name)
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        assert len(
+            memory_server.post_turn._character_post_turn_tasks.get(name, ())
+        ) == 1
+        cancelled = await memory_server.post_turn.cancel_character_post_turn_tasks(
+            name
+        )
+
+    assert cancelled == 1
+    memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_background_tasks_never_inherit_the_admission_lease():
+    """A detached task outlives the request, so release cannot drain it."""
+    from app import memory_server
+
+    name = "后台不继承租约角色"
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    observed: dict[str, object] = {}
+    done = asyncio.Event()
+
+    async def _detached():
+        observed["lease"] = name in (
+            memory_server.runtime._admitted_character_context.get()
+        )
+        done.set()
+
+    context_token = memory_server.runtime._begin_character_request(name)
+    assert context_token is not None
+    task = None
+    try:
+        assert name in memory_server.runtime._admitted_character_context.get()
+        task = memory_server.runtime._spawn_background_task(_detached())
+        await asyncio.wait_for(done.wait(), timeout=1)
+    finally:
+        memory_server.runtime._end_character_request(name, context_token)
+        await _cleanup_task(task)
+
+    assert observed["lease"] is False
 
 
 @pytest.mark.unit

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -66,7 +66,7 @@ async def test_release_character_drains_old_identity_review_and_backup_tasks():
     assert name not in memory_server.review.correction_tasks
     assert name not in memory_server.review.compress_backup_tasks
     assert name not in memory_server.review.compress_backup_task_generations
-    fake_time_manager.dispose_engine.assert_called_once_with(name)
+    fake_time_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
     memory_server.review._retired_derived_task_names.discard(name)
 
 
@@ -97,9 +97,9 @@ async def test_release_character_disposes_current_and_deferred_time_managers_onc
         assert memory_server.runtime._deferred_time_managers == deferred
 
     assert result["status"] == "success"
-    current_manager.dispose_engine.assert_called_once_with(name)
-    old_manager.dispose_engine.assert_called_once_with(name)
-    other_old_manager.dispose_engine.assert_called_once_with(name)
+    current_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
+    old_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
+    other_old_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
     memory_server.review._retired_derived_task_names.discard(name)
 
 
@@ -123,7 +123,7 @@ async def test_release_drains_inflight_process_and_fences_engine_recreation():
 
     fake_time_manager = MagicMock()
     fake_time_manager.astore_conversation = AsyncMock(side_effect=_astore)
-    fake_time_manager.dispose_engine.side_effect = lambda _name: order.append("disposed") or True
+    fake_time_manager.dispose_engine.side_effect = lambda _name, **_kw: order.append("disposed") or True
     fake_recent = MagicMock()
     fake_recent.update_history = AsyncMock(return_value=None)
     fake_config = MagicMock()
@@ -634,13 +634,13 @@ def test_dispose_engine_keeps_bookkeeping_when_disposal_fails(tmp_path):
     manager._writable_bootstrapped.add(name)
 
     with pytest.raises(OSError):
-        manager.dispose_engine(name)
+        manager.dispose_engine(name, retain_on_failure=True)
 
     assert manager.engines[name] is engine
     assert manager.db_paths[name] == str(db_path)
 
     engine.dispose.side_effect = None
-    assert manager.dispose_engine(name) is True
+    assert manager.dispose_engine(name, retain_on_failure=True) is True
     assert name not in manager.engines
     assert name not in manager.db_paths
     assert name not in manager._writable_bootstrapped
@@ -675,7 +675,7 @@ def test_dispose_engine_keeps_the_cached_pool_when_its_disposal_fails(tmp_path):
         cache[writable_key] = cached_engine
 
         with pytest.raises(OSError):
-            manager.dispose_engine(name)
+            manager.dispose_engine(name, retain_on_failure=True)
 
         assert cached_engine.dispose.call_count == 1
         # 缓存条目必须还在，否则重试再也够不到这个 pool。
@@ -683,7 +683,7 @@ def test_dispose_engine_keeps_the_cached_pool_when_its_disposal_fails(tmp_path):
         assert manager.db_paths[name] == str(db_path)
 
         cached_engine.dispose.side_effect = None
-        assert manager.dispose_engine(name) is True
+        assert manager.dispose_engine(name, retain_on_failure=True) is True
         assert cached_engine.dispose.call_count == 2
         assert writable_key not in cache
         assert name not in manager.db_paths
@@ -713,7 +713,7 @@ def test_dispose_engine_keeps_the_cache_entry_when_the_primary_engine_fails(tmp_
         cache[readonly_key] = engine
 
         with pytest.raises(OSError):
-            manager.dispose_engine(name)
+            manager.dispose_engine(name, retain_on_failure=True)
 
         # 同一个对象在一次调用里只 dispose 一次，且失败后缓存条目要留住。
         assert engine.dispose.call_count == 1
@@ -721,7 +721,7 @@ def test_dispose_engine_keeps_the_cache_entry_when_the_primary_engine_fails(tmp_
         assert manager.engines[name] is engine
 
         engine.dispose.side_effect = None
-        assert manager.dispose_engine(name) is True
+        assert manager.dispose_engine(name, retain_on_failure=True) is True
         assert engine.dispose.call_count == 2
         assert readonly_key not in cache
         assert name not in manager.engines
@@ -802,6 +802,137 @@ async def test_publication_guard_releases_the_slot_when_the_endpoint_raises():
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_gives_up_when_the_settle_lock_is_held_too_long():
+    """/new_dialog holds the settle lock and is deliberately unfenced.
+
+    Blocking on it without a bound would keep this handler running past the
+    caller's timeout, and the caller reports the delete as refused.
+    """
+    from app import memory_server
+
+    name = "结算锁被占角色"
+    claim_token = "settle-lock-timeout-claim"
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = True
+
+    settle_lock = memory_server.runtime._get_settle_lock(name)
+    await settle_lock.acquire()
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ), patch.object(
+            memory_server.runtime, "_CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS", 0.05,
+        ):
+            result = await asyncio.wait_for(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=True,
+                    derived_task_claim_token=claim_token,
+                    derived_task_claim_generation=0,
+                ),
+                timeout=2,
+            )
+    finally:
+        settle_lock.release()
+
+    assert result.status_code == 503
+    fake_time_manager.dispose_engine.assert_not_called()
+    # 声明已归还，主进程补偿后新写入能重新准入。
+    assert memory_server.runtime._is_character_publication_admitted(name)
+    memory_server.review._retired_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_without_a_hold_keeps_post_turn_work_alive():
+    """Cloudsave / unsubscribe leave the character alive and take no hold.
+
+    Cancelling its background work there buys nothing (nothing stops the next
+    one from spawning) and can cut an outbox op short before its done marker.
+    """
+    from app import memory_server
+
+    name = "无围栏保留后台角色"
+    claim_token = "no-hold-keeps-tasks-claim"
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+    post_turn_task = asyncio.create_task(asyncio.sleep(30))
+    memory_server.post_turn._track_character_post_turn_task(name, post_turn_task)
+    fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = True
+
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ):
+            result = await asyncio.wait_for(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=False,
+                    derived_task_claim_token=claim_token,
+                    derived_task_claim_generation=0,
+                ),
+                timeout=2,
+            )
+
+        assert result["status"] == "success"
+        assert not post_turn_task.done()
+    finally:
+        await _cleanup_task(post_turn_task)
+        memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+        await memory_server.review.release_character_derived_task_admission_claim(
+            name, claim_token,
+        )
+        memory_server.review._retired_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+def test_engine_repair_branch_self_heals_after_a_failed_disposal(tmp_path):
+    """The db_path-drift branch disposes and falls through to the rebuild.
+
+    Pinning the bookkeeping there would trap the character on the same failing
+    branch forever, so only the release path may retain it.
+    """
+    from memory.timeindex import TimeIndexedMemory
+
+    name = "漂移自愈角色"
+    stale_engine = MagicMock()
+    stale_engine.dispose.side_effect = OSError("busy")
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    manager.engines[name] = stale_engine
+    manager.db_paths[name] = str(tmp_path / "stale" / "time_indexed.db")
+    manager._engine_readonly_flags[name] = False
+    expected = str(tmp_path / "fresh" / "time_indexed.db")
+
+    with patch.object(
+        manager, "_resolve_expected_db_path", return_value=expected,
+    ), patch.object(manager, "_assert_timeindex_writable", MagicMock()):
+        with pytest.raises(OSError):
+            manager._ensure_engine_exists(name)
+
+        # 簿记必须已经清掉：下一次调用要能走到重建分支，而不是又撞同一个 dispose。
+        assert name not in manager.engines
+        assert name not in manager.db_paths
+
+        created = MagicMock()
+        with patch.object(
+            manager, "_create_engine_for", create=True, return_value=created,
+        ):
+            # 重建分支的细节各版本不同，这里只断言「不再重复抛同一个 dispose 错误」。
+            try:
+                manager._ensure_engine_exists(name, expected)
+            except OSError as exc:  # pragma: no cover - 只在回归时触发
+                pytest.fail(f"repair branch did not self-heal: {exc}")
+            except Exception:
+                pass
+    assert stale_engine.dispose.call_count == 1
+
+
+@pytest.mark.unit
 def test_release_drain_budget_stays_under_the_tightest_caller_timeout():
     """A caller that gives up first starts deleting files while the drain runs."""
     import inspect
@@ -879,7 +1010,7 @@ async def test_release_cancels_post_turn_tasks_before_draining_requests():
             release_task = None
 
         assert result["status"] == "success"
-        fake_time_manager.dispose_engine.assert_called_once_with(name)
+        fake_time_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
     finally:
         if context_token is not None:
             memory_server.runtime._end_character_request(name, context_token)
@@ -973,7 +1104,7 @@ async def test_release_without_a_publication_hold_never_waits_for_new_writes():
         memory_server.runtime._end_character_request(name, context_token)
 
     assert result["status"] == "success"
-    fake_time_manager.dispose_engine.assert_called_once_with(name)
+    fake_time_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
     memory_server.review._retired_derived_task_names.discard(name)
     await memory_server.review.release_character_derived_task_admission_claim(
         name, "no-hold-claim",
@@ -1144,7 +1275,7 @@ async def test_release_failure_restores_derived_task_admission():
         )
 
     assert result.status_code == 500
-    deferred_manager.dispose_engine.assert_called_once_with(name)
+    deferred_manager.dispose_engine.assert_called_once_with(name, retain_on_failure=True)
     assert name not in memory_server.review._retired_derived_task_names
     assert name not in memory_server.review._publication_held_derived_task_names
 

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -914,9 +914,11 @@ def test_engine_repair_branch_self_heals_after_a_failed_disposal(tmp_path):
         with pytest.raises(OSError):
             manager._ensure_engine_exists(name)
 
-        # 簿记必须已经清掉：下一次调用要能走到重建分支，而不是又撞同一个 dispose。
+        # engines 必须清掉：下一次调用要能走到重建分支，而不是又撞同一个 dispose。
         assert name not in manager.engines
-        assert name not in manager.db_paths
+        # 但 db_path 要留着：没释放掉的 pool 还在 _engine_cache 里，它的
+        # connection string 只能从 db_path 推出来，丢了 release 就够不到它。
+        assert manager.db_paths[name] == str(tmp_path / "stale" / "time_indexed.db")
 
         created = MagicMock()
         with patch.object(
@@ -930,6 +932,48 @@ def test_engine_repair_branch_self_heals_after_a_failed_disposal(tmp_path):
             except Exception:
                 pass
     assert stale_engine.dispose.call_count == 1
+
+
+@pytest.mark.unit
+def test_release_can_still_reach_a_pool_a_failed_repair_left_behind(tmp_path):
+    """A repair-mode failure must not orphan the pool it could not dispose.
+
+    The failed pool stays in ``SQLChatMessageHistory._engine_cache``, whose key
+    is derived from ``db_paths``. Dropping that entry would leave the handle
+    unreachable and release would report success while the file stays locked.
+    """
+    from memory.timeindex import SQLChatMessageHistory, TimeIndexedMemory
+
+    name = "修复失败遗留池角色"
+    db_path = tmp_path / "time_indexed.db"
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    manager.engines[name] = MagicMock()
+    manager.db_paths[name] = str(db_path)
+
+    readonly_key, writable_key = _sqlite_cache_keys(manager, db_path)
+    stuck_pool = MagicMock()
+    stuck_pool.dispose.side_effect = OSError("pool busy")
+    cache = SQLChatMessageHistory._engine_cache
+    saved = {key: cache[key] for key in (readonly_key, writable_key) if key in cache}
+    try:
+        cache[writable_key] = stuck_pool
+
+        # 就地修复语义（默认模式）：清 engines 让重建分支能走，但别丢 db_path。
+        with pytest.raises(OSError):
+            manager.dispose_engine(name)
+        assert name not in manager.engines
+        assert manager.db_paths[name] == str(db_path)
+        assert cache.get(writable_key) is stuck_pool
+
+        # 之后的 release 仍然够得到这个 pool 并重试。
+        stuck_pool.dispose.side_effect = None
+        assert manager.dispose_engine(name, retain_on_failure=True) is True
+        assert writable_key not in cache
+        assert name not in manager.db_paths
+    finally:
+        for key in (readonly_key, writable_key):
+            cache.pop(key, None)
+        cache.update(saved)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -244,6 +244,210 @@ async def test_release_cancels_tracked_post_turn_task():
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_cancels_post_turn_tasks_before_draining_requests():
+    """Post-turn work holds no admission lease, so it must die before the drain."""
+    from app import memory_server
+
+    name = "排空前取消后台角色"
+    claim_token = "cancel-before-drain-claim"
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    post_turn_task = asyncio.create_task(asyncio.sleep(30))
+    memory_server.post_turn._track_character_post_turn_task(name, post_turn_task)
+    fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = True
+
+    context_token = memory_server.runtime._begin_character_request(name)
+    assert context_token is not None
+    release_task = None
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ):
+            release_task = asyncio.create_task(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=True,
+                    derived_task_claim_token=claim_token,
+                    derived_task_claim_generation=0,
+                )
+            )
+
+            async def _wait_for_post_turn_cancel():
+                while not post_turn_task.cancelled():
+                    await asyncio.sleep(0)
+
+            await asyncio.wait_for(_wait_for_post_turn_cancel(), timeout=1)
+            # 后台任务已经死了，但前台写入还在跑、引擎也还没释放。
+            assert memory_server.runtime._active_character_requests.get(name) == 1
+            fake_time_manager.dispose_engine.assert_not_called()
+
+            memory_server.runtime._end_character_request(name, context_token)
+            context_token = None
+            result = await asyncio.wait_for(release_task, timeout=2)
+            release_task = None
+
+        assert result["status"] == "success"
+        fake_time_manager.dispose_engine.assert_called_once_with(name)
+    finally:
+        if context_token is not None:
+            memory_server.runtime._end_character_request(name, context_token)
+        await _cleanup_task(release_task)
+        await _cleanup_task(post_turn_task)
+        await memory_server.review.release_character_derived_task_admission_claim(
+            name, claim_token,
+        )
+        memory_server.review._retired_derived_task_names.discard(name)
+        memory_server.review._publication_held_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_gives_up_instead_of_disposing_after_the_caller_timeout():
+    """An undrainable write must fail the release, not dispose behind the caller."""
+    from app import memory_server
+
+    name = "排空超时角色"
+    claim_token = "drain-timeout-claim"
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = True
+
+    context_token = memory_server.runtime._begin_character_request(name)
+    assert context_token is not None
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ), patch.object(
+            memory_server.runtime, "_CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS", 0.05,
+        ):
+            result = await asyncio.wait_for(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=True,
+                    derived_task_claim_token=claim_token,
+                    derived_task_claim_generation=0,
+                ),
+                timeout=2,
+            )
+    finally:
+        memory_server.runtime._end_character_request(name, context_token)
+
+    assert result.status_code == 503
+    fake_time_manager.dispose_engine.assert_not_called()
+    # 声明已归还：主进程补偿后新写入必须能重新准入。
+    assert not memory_server.review.is_character_derived_task_claim_active(
+        name, claim_token,
+    )
+    assert memory_server.runtime._is_character_publication_admitted(name)
+    memory_server.review._retired_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_skips_dispose_when_claim_withdrawn_while_draining():
+    """The caller's timeout compensation wins; a late dispose must not race it."""
+    from app import memory_server
+
+    name = "补偿撤回角色"
+    claim_token = "withdrawn-while-draining-claim"
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = True
+
+    context_token = memory_server.runtime._begin_character_request(name)
+    assert context_token is not None
+    release_task = None
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ):
+            release_task = asyncio.create_task(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=True,
+                    derived_task_claim_token=claim_token,
+                    derived_task_claim_generation=0,
+                )
+            )
+
+            async def _wait_for_hold():
+                while not memory_server.review.is_character_publication_held(name):
+                    await asyncio.sleep(0)
+
+            await asyncio.wait_for(_wait_for_hold(), timeout=1)
+            # 主进程 5s 超时后的补偿：撤回声明并重新开放准入。
+            await memory_server.review.release_character_derived_task_admission_claim(
+                name, claim_token,
+            )
+            memory_server.runtime._end_character_request(name, context_token)
+            context_token = None
+            result = await asyncio.wait_for(release_task, timeout=2)
+            release_task = None
+
+        assert result.status_code == 409
+        assert json.loads(result.body)["status"] == "cancelled"
+        fake_time_manager.dispose_engine.assert_not_called()
+    finally:
+        if context_token is not None:
+            memory_server.runtime._end_character_request(name, context_token)
+        await _cleanup_task(release_task)
+        memory_server.review._retired_derived_task_names.discard(name)
+        memory_server.review._publication_held_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_negative_keyword_hook_task_is_tracked_as_post_turn_work():
+    """The nested hook task must be cancellable through the per-character registry."""
+    from app import memory_server
+    from app.memory_server import post_turn as post_turn_module
+
+    name = "负面关键词后台角色"
+    memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+    hook_started = asyncio.Event()
+
+    async def _hook(*_args, **_kwargs):
+        hook_started.set()
+        await asyncio.sleep(30)
+
+    fake_reflection = MagicMock()
+    fake_reflection.arecord_mentions = AsyncMock(return_value=None)
+    fake_reflection.aload_surfaced = AsyncMock(return_value=[])
+    fake_persona = MagicMock()
+    fake_persona.arecord_mentions = AsyncMock(return_value=None)
+
+    with patch.object(
+        post_turn_module.gates, "_ais_powerful_memory_enabled", AsyncMock(return_value=True),
+    ), patch.object(
+        post_turn_module.signal_extraction, "_signal_check_record_turn", MagicMock(),
+    ), patch.object(
+        post_turn_module.signal_extraction,
+        "_amaybe_trigger_negative_keyword_hook",
+        MagicMock(side_effect=_hook),
+    ), patch.object(
+        post_turn_module.runtime, "reflection_engine", fake_reflection,
+    ), patch.object(
+        post_turn_module.runtime, "persona_manager", fake_persona,
+    ), patch.object(
+        post_turn_module, "_resolve_corrections_with_subject_locale", AsyncMock(return_value=0),
+    ):
+        await post_turn_module._run_post_turn_signals(
+            [HumanMessage(content="你好喵")], name,
+        )
+        await asyncio.wait_for(hook_started.wait(), timeout=1)
+
+        assert len(memory_server.post_turn._character_post_turn_tasks.get(name, ())) == 1
+        cancelled = await memory_server.post_turn.cancel_character_post_turn_tasks(name)
+
+    assert cancelled == 1
+    assert name not in memory_server.post_turn._character_post_turn_tasks
+
+
+@pytest.mark.unit
 def test_cross_generation_release_closes_real_sqlite_pool(tmp_path):
     """The deferred generation must stop holding the database file on Windows."""
     from sqlalchemy import create_engine, text

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -316,6 +316,64 @@ async def test_publication_guard_covers_group_memory_scoped_writes():
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_admission_lease_survives_a_hold_flip_through_the_real_middleware():
+    """The lease is a ContextVar set in middleware — prove it reaches the endpoint.
+
+    Calling the guard directly (as the other tests do) runs it in the caller's
+    own task, so it cannot show whether Starlette's middleware task spawn
+    carries the lease downstream. Drive a real ASGI stack instead.
+    """
+    import httpx
+    from fastapi import FastAPI
+
+    from app import memory_server
+
+    name = "租约穿透角色"
+    observed: dict[str, object] = {}
+
+    probe = FastAPI()
+    probe.middleware("http")(memory_server.runtime.character_publication_guard)
+
+    @probe.post("/process/{lanlan_name}")
+    async def _probe_endpoint(lanlan_name: str):
+        observed["active"] = memory_server.runtime._active_character_requests.get(
+            lanlan_name, 0
+        )
+        observed["admitted"] = memory_server.runtime._is_character_engine_admitted(
+            lanlan_name
+        )
+        # release 在这个请求准入之后才设 hold：已准入的写入必须能写完。
+        memory_server.review._publication_held_derived_task_names.add(lanlan_name)
+        observed["admitted_after_hold"] = (
+            memory_server.runtime._is_character_engine_admitted(lanlan_name)
+        )
+        return {"status": "processed"}
+
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    try:
+        transport = httpx.ASGITransport(app=probe)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://memory-server-probe",
+        ) as client:
+            response = await client.post(f"/process/{name}")
+            assert response.status_code == 200
+
+            # hold 已生效：下一个请求必须被拒。
+            blocked = await client.post(f"/process/{name}")
+            assert blocked.status_code == 409
+            assert blocked.json()["status"] == "cancelled"
+    finally:
+        memory_server.review._publication_held_derived_task_names.discard(name)
+
+    assert observed["active"] == 1
+    assert observed["admitted"] is True
+    assert observed["admitted_after_hold"] is True
+    # 请求结束后账本必须归零，否则 release 会永远排空不掉。
+    assert memory_server.runtime._active_character_requests.get(name, 0) == 0
+
+
+@pytest.mark.unit
 def test_release_drain_budget_stays_under_the_tightest_caller_timeout():
     """A caller that gives up first starts deleting files while the drain runs."""
     import inspect
@@ -447,6 +505,51 @@ async def test_release_gives_up_instead_of_disposing_after_the_caller_timeout():
     )
     assert memory_server.runtime._is_character_publication_admitted(name)
     memory_server.review._retired_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_release_without_a_publication_hold_never_waits_for_new_writes():
+    """Cloudsave / unsubscribe take no hold, so nothing stops new admissions.
+
+    Draining there would just burn the whole budget and report failure while the
+    caller goes on deleting storage — worse than releasing the handles at once.
+    """
+    from app import memory_server
+
+    name = "无围栏释放角色"
+    memory_server.review._retired_derived_task_names.discard(name)
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    fake_time_manager = MagicMock()
+    fake_time_manager.dispose_engine.return_value = True
+
+    # 一个永不结束的在途写入：真去排空就一定超时。
+    context_token = memory_server.runtime._begin_character_request(name)
+    assert context_token is not None
+    try:
+        with patch.object(memory_server.runtime, "time_manager", fake_time_manager), patch.object(
+            memory_server.runtime, "_deferred_time_managers", [],
+        ), patch.object(
+            memory_server.runtime, "_CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS", 0.05,
+        ):
+            result = await asyncio.wait_for(
+                memory_server.runtime.release_character_resources(
+                    name,
+                    hold_derived_task_admission=False,
+                    derived_task_claim_token="no-hold-claim",
+                    derived_task_claim_generation=0,
+                ),
+                timeout=2,
+            )
+    finally:
+        memory_server.runtime._end_character_request(name, context_token)
+
+    assert result["status"] == "success"
+    fake_time_manager.dispose_engine.assert_called_once_with(name)
+    memory_server.review._retired_derived_task_names.discard(name)
+    await memory_server.review.release_character_derived_task_admission_claim(
+        name, "no-hold-claim",
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -227,6 +227,110 @@ async def test_publication_guard_rejects_new_write_with_non_success_status():
         memory_server.review._publication_held_derived_task_names.discard(name)
 
 
+def _memory_server_request(path: str):
+    """Build the minimal ASGI scope the publication guard reads."""
+    from starlette.requests import Request
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "server": ("127.0.0.1", 48912),
+            "client": ("127.0.0.1", 1),
+        }
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_publication_guard_normalizes_the_path_name_like_the_endpoint():
+    """The endpoint strips the name; admission must key on the same value."""
+    from app import memory_server
+
+    name = "两端归一角色"
+    memory_server.review._publication_held_derived_task_names.add(name)
+    call_next = AsyncMock(side_effect=AssertionError("fenced request reached endpoint"))
+    try:
+        response = await memory_server.runtime.character_publication_guard(
+            _memory_server_request(f"/process/  {name} "),
+            call_next,
+        )
+        assert response.status_code == 409
+        call_next.assert_not_awaited()
+    finally:
+        memory_server.review._publication_held_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_publication_guard_covers_group_memory_scoped_writes():
+    """Scoped writes reach the same SQLite index, so they must be fenced+drained."""
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+
+    from app import memory_server
+
+    name = "群记忆写入角色"
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    observed_active: list[int] = []
+
+    async def _call_next(_request):
+        observed_active.append(
+            memory_server.runtime._active_character_requests.get(name, 0)
+        )
+        return StarletteJSONResponse({"status": "ok"})
+
+    admitted = await memory_server.runtime.character_publication_guard(
+        _memory_server_request(f"/internal/memory/{name}/scoped_facts"),
+        _call_next,
+    )
+    assert admitted.status_code == 200
+    # 排空账本必须看得见它，否则 release 会在它写到一半时 dispose。
+    assert observed_active == [1]
+    assert memory_server.runtime._active_character_requests.get(name, 0) == 0
+
+    memory_server.review._publication_held_derived_task_names.add(name)
+    blocked = AsyncMock(side_effect=AssertionError("fenced request reached endpoint"))
+    try:
+        response = await memory_server.runtime.character_publication_guard(
+            _memory_server_request(f"/internal/memory/{name}/scoped_history"),
+            blocked,
+        )
+        assert response.status_code == 409
+        blocked.assert_not_awaited()
+
+        # 只读的 scoped_context 不进围栏（读路径由引擎准入检查兜底）。
+        read_next = AsyncMock(return_value=StarletteJSONResponse({"status": "ok"}))
+        read_response = await memory_server.runtime.character_publication_guard(
+            _memory_server_request(f"/internal/memory/{name}/scoped_context"),
+            read_next,
+        )
+        assert read_response.status_code == 200
+        read_next.assert_awaited_once()
+    finally:
+        memory_server.review._publication_held_derived_task_names.discard(name)
+
+
+@pytest.mark.unit
+def test_release_drain_budget_stays_under_the_tightest_caller_timeout():
+    """A caller that gives up first starts deleting files while the drain runs."""
+    import inspect
+
+    from app import memory_server
+    from main_routers.workshop_router import unsubscribe
+
+    parameters = inspect.signature(
+        unsubscribe._release_workshop_character_handles
+    ).parameters
+    drain_budget = memory_server.runtime._CHARACTER_REQUEST_DRAIN_TIMEOUT_SECONDS
+    assert drain_budget < parameters["per_call_timeout"].default
+    assert drain_budget < parameters["overall_timeout"].default
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_release_cancels_tracked_post_turn_task():

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -398,6 +398,11 @@ def test_every_character_scoped_route_is_classified_for_the_fence():
         # 渲染型读取；顺带刷新 suppress 冷却是 best-effort，而且它本身对
         # 「角色已不在配置中」有短路分支，不值得为它换来发布窗口里的 409。
         ("/get_settings/{lanlan_name}", "GET"),
+        # 会话开场读取。三个调用方（lifecycle 起会话、lifecycle 热切换、
+        # 主动搭话）都把非 2xx 直接变成 ConnectionError 让会话启动失败，
+        # 而它那点 locale 落盘本来就有 outbox durable 重试兜底——为可延迟的
+        # 写去换用户可见的启动硬失败不划算。归入 JSON 侧写入那条 follow-up。
+        ("/new_dialog/{lanlan_name}", "GET"),
         # 只取消任务，不写角色文件——删除期间恰恰需要它还能用。
         ("/cancel_correction/{lanlan_name}", "POST"),
         # 围栏本身就是它设的，自己不能被自己拦。
@@ -420,7 +425,6 @@ def test_every_character_scoped_route_is_classified_for_the_fence():
     assert unfenced == unfenced_by_design
     assert ("/cache/{lanlan_name}", "POST") in fenced
     assert ("/record_surfaced/{lanlan_name}", "POST") in fenced
-    assert ("/new_dialog/{lanlan_name}", "GET") in fenced
     assert ("/prompt-locale/{lanlan_name}", "PUT") in fenced
 
 
@@ -773,6 +777,28 @@ async def test_startup_replay_tasks_join_the_per_character_registry(tmp_path):
         for task in spawned:
             await _cleanup_task(task)
         memory_server.post_turn._character_post_turn_tasks.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_publication_guard_releases_the_slot_when_the_endpoint_raises():
+    """A leaked slot would make every later release for this character time out."""
+    from app import memory_server
+
+    name = "端点抛错角色"
+    memory_server.review._publication_held_derived_task_names.discard(name)
+    boom = AsyncMock(side_effect=RuntimeError("endpoint exploded"))
+
+    with pytest.raises(RuntimeError):
+        await memory_server.runtime.character_publication_guard(
+            _memory_server_request(f"/cache/{name}"),
+            boom,
+        )
+
+    assert memory_server.runtime._active_character_requests.get(name, 0) == 0
+    assert name not in memory_server.runtime._admitted_character_context.get()
+    # 账本干净 → 后续 release 能立刻排空。
+    assert await memory_server.runtime._wait_for_character_requests(name, 0.05) is True
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 改动概述 / Summary

修复 Windows 下记忆服务热重载后，删除角色卡可能因旧代 `TimeIndexedMemory` 仍持有 `time_indexed.db` 而触发 `[WinError 32]` 的问题。

释放流程会关闭新进入的 `/cache`、`/process`、`/renew`、`/settle` 请求，等待已准入请求完整结束，取消并排空这些请求生成的 post-turn task，再按对象身份去重释放当前及延迟代际管理器中的目标角色引擎。后台路径在发布 hold 期间收到明确的准入异常，不会把围栏误判成空数据。

## 回归报告 / Regression Report

- 改动了什么
  - `app/memory_server/runtime.py`：仅对四个角色写端点登记在途请求；release 关闭新准入、排空已准入请求，然后在现有 reload/settle 边界内执行跨代释放。
  - `app/memory_server/post_turn.py`：按角色登记由上述请求生成的 post-turn task，release 在 dispose 前取消并排空。
  - `app/memory_server/review.py`：只读暴露既有 publication hold 状态，不新增发布状态所有权。
  - `memory/timeindex.py`：publication hold 阻止非已准入上下文创建或复用引擎；拒绝使用明确异常，不再复用“空结果/初始化失败”返回值；`dispose_engine()` 返回实际释放状态。
  - `app/memory_server/routes.py`：撤回 `/process` 的外层 settle 锁，恢复原有 LLM 压缩并发行为；准入统一由四端点专用 middleware 处理。
- 理由 / 必要性
  - 热重载保留旧管理器服务在途请求，原实现只释放当前管理器。
  - 单纯跨代扫描仍存在释放后重建、已准入写入被中途截断、post-turn 晚生成及只读 cursor 误推进等竞态。
- 改动前后的表现对比
  - 改动前：旧代或晚到任务可继续持有/重建 SQLite 引擎，Windows 删除失败。
  - 改动后：已准入请求完整完成，新请求收到 HTTP 409；相关 post-turn task 排空后统一释放全部代际，后台只读不会把围栏当成空窗口。
- 潜在回归点
  - 准入登记仅匹配四个现有端点；不同角色及其他 API 不受影响。
  - 不拆分 `update_history`，不修改 recent 压缩流程，不修改 `cross_server` 的既有失败清理策略。
  - 已覆盖跨代、去重、真实 SQLite 解锁、部分释放失败、在途请求排空、新请求非成功响应、post-turn 取消，以及读写围栏异常。

- 本轮 review 后补充（6498155ab）
  - `app/memory_server/runtime.py`：release 改为「先取消 post-turn task → 排空前台请求 → 再补一次取消」；`_wait_for_character_requests` 加 3s 上限（调用方 HTTP 超时是 5s），超时归还 claim 并返回 503 而不是继续 dispose；拿到 settle/reload 锁后、dispose 前复查本次 claim 是否仍然有效，已被主进程补偿撤回时返回 409 不碰任何 manager。
  - `app/memory_server/post_turn.py`：`_amaybe_trigger_negative_keyword_hook` 这个嵌套后台任务也按角色登记进 post-turn registry。
  - `app/memory_server/review.py`：只读暴露 `is_character_derived_task_claim_active()`。
  - 新增 4 条回归测试，逐条做过变异验证（撤掉对应修复即变红）。

- 第二轮 review 后补充（2b5b03f52）
  - `app/memory_server/runtime.py`：排空预算 3s → 2s，卡在最紧的调用方超时之内（取消订阅 `_release_workshop_character_handles` per_call 2.5s / overall 3s，超时后仍会往下删记忆文件）；准入登记改用端点同一个 `validate_lanlan_name()` 归一化，`/process/  A ` 不再绕开围栏；围栏覆盖群记忆写端点 `/internal/memory/{name}/scoped_{facts,history,forget,mentions}`（只读的 `scoped_context` 不进围栏，读路径仍由引擎准入检查兜底）。
  - 再加 3 条回归测试（含一条盯住「排空预算 < 最紧调用方超时」的跨模块不变量），同样逐条变异验证。

- 第三、四轮 review 后补充（cf96269a4 / 22b3a9289）
  - `app/memory_server/runtime.py`：**只在 publication hold 生效时才排空**。只有改名/删除带 `hold_derived_task_admission=True`，云存档下载与取消订阅不取 hold；没有 hold 就没有东西挡住新准入，计数不单调下降，排空必然走到超时，等于把这两条路径从「立刻释放句柄」变成「永远释放不掉」。围栏另补 `/reflect/`、`/record_surfaced/` 两个角色写端点。
  - `app/memory_server/outbox_infra.py`：`_replay_pending_outbox()` 起的 op 也按角色登记，改名/删除撞上长补跑时能被排空。
  - `memory/timeindex.py`：`dispose_engine()` 失败时保留簿记并照跑 `_engine_cache` 清理，全部成功才清，使失败可重试。
  - 再加 5 条回归测试：真实 ASGI 栈验证准入租约能穿过中间件到达端点、无 hold 不排空、路由清单守卫（新增角色写端点漏掉围栏即红）、补跑登记、dispose 失败可重试。全部逐条变异验证。
  - 未在本 PR 处理、已拆成 follow-up issue 的两项：#2935（被围栏的身份仍会被 JSON 侧写入——周期循环不查 hold、读路径顺带的冷却刷新、`asyncio.to_thread` 里的 locale sidecar；含 `TimeIndexedMemory` per-engine 活跃操作租约那条窄缝的同类判据）、#2936（outbox pending op 缺 per-character 重放入口，中止/改名后延后到下次启动）。

- 第五轮 review 后补充（cf916b8a4）
  - `app/memory_server/runtime.py`：`_spawn_background_task()` 去掉 `inherit_character_admission` 参数，**所有**后台任务一律不继承前台准入租约（租约的含义是「已准入的请求还在跑、release 会等它」，fire-and-forget 的 task 不在排空范围内，继承等于给它 dispose 之后重开引擎的通行证）。围栏加方法维度：`GET /new_dialog/{name}`、`PUT /prompt-locale/{name}` 进围栏，`GET /prompt-locale/{name}` 与 `GET /get_settings/{name}` 不进。
  - `app/memory_server/routes.py`：`/reflect/` 派的 `_safe_auto_promote()`（30-90s）按角色登记进 registry。
  - 清单守卫测试扩到所有方法：每个 `{lanlan_name}` 路由 × 方法要么进围栏、要么写进「不进围栏」表并附理由——那张表就是本 PR 的边界声明。

- 回归复查后补充（f5cfa24ee / f183d2c21 / 581851d15）
  - 撤回把 `GET /new_dialog/{name}` 收进围栏：它的三个调用方（lifecycle 起会话、lifecycle 热切换、主动搭话）都把非 2xx 直接变成 `ConnectionError` 让会话启动硬失败，而它那点 locale 落盘本来就有 outbox durable 重试兜底。`PUT /prompt-locale/` 保留在围栏内（纯写端点，调用方本来就把非 superseded 的 409 当可重试失败）。
  - `app/memory_server/runtime.py`：整个释放流程共用一个 deadline——排空 + settle 锁 + reload 锁的等待都算在同一预算里，拿不到就归还声明返回 503。此前 settle 锁是无界等待，而 `/new_dialog` 持同一把锁跑整段 prompt 组装、且三个插件随时会打它，撞上删除会卡过调用方 5s 超时 → 主进程报「已阻止删除」。
  - `memory/timeindex.py`：`dispose_engine()` 的「失败保留簿记」改成显式 `retain_on_failure` 参数，只有跨代释放传 True。默认恢复自愈语义——`_ensure_engine_exists` 的两个就地修复分支（db_path 漂移、只读→可写切换）是「dispose 后落到重建分支」，保留簿记会让一次 dispose 失败把该角色永久钉死在同一分支。
  - `app/memory_server/runtime.py`：取消 post-turn 任务也按 publication hold 上闸，和排空对齐。云存档覆盖不取 hold、角色事后还活着，取消留不住（下一毫秒就能派新的）还可能把一条 outbox op 截在 `handler()` 成功与 `aappend_done` 之间。
  - 中间件在途计数补了槽位泄漏守卫（端点抛异常时必须归还，否则该角色此后每次 release 都排空超时）。
  - 复查同时核过、未改动的：锁序无死锁（全仓无 `_reload_lock → settle_lock` 反向嵌套）；`except Exception` 不吞 `CancelledError`；生产里两处 `TimeIndexedMemory` 构造都带准入检查；turn-end `/cache` 失败不推进 `last_synced_index`（不丢消息）。

## 不拆分理由 / Why Not Split

不适用：源码改动与回归测试属于同一个角色释放时序修复。

## 测试 / Testing

- `uv run --frozen pytest tests/unit/test_recent_compress_backup.py tests/unit/test_memory_server_cache_settle.py tests/unit/test_memory_request_language_context.py -q`：49 passed
- `uv run --frozen pytest tests/unit/test_character_memory_regression.py -q`：90 passed
- `uv run --frozen ruff check app/memory_server/runtime.py app/memory_server/routes.py app/memory_server/post_turn.py app/memory_server/review.py memory/timeindex.py tests/unit/test_recent_compress_backup.py tests/unit/test_character_memory_regression.py`：通过
- `git diff --check`：通过
- Windows 源码运行环境手动验证：打开记忆面板后删除角色卡成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加角色生命周期访问控制，覆盖创建、删除、改名及外部内容导入。
  * 支持查询角色状态，并自动跟踪、取消及等待未完成的后台任务。
  * 增强启动时待处理操作的恢复与角色级任务管理。

* **错误修复**
  * 角色释放期间的请求将返回明确错误，释放超时返回 503。
  * 优化资源释放失败后的清理与重试，避免遗留状态影响后续操作。

* **测试**
  * 补充访问拦截、任务排空、超时恢复及资源释放测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





