### PR TITLE
ci(build-desktop): 修复卡死 nightly 的两处构建缺陷

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -706,17 +706,13 @@ jobs:
             # identifier and the whole bundle then fails to seal. The payload is
             # downloaded, so scripts/check_no_nonascii_asset_names.py structurally
             # cannot see it — the only place to look is right here, before the copy.
-            .venv/bin/python -c "
-            import sys
-            from pathlib import Path
             # Files only: a CJK *directory* holding ASCII files seals fine
             # (verified against a real Developer ID cert; see the checker's
             # module docstring), and failing on it would block the build for nothing.
-            bad = [str(p) for p in Path('playwright_browsers').rglob('*')
-                   if p.is_file() and not p.name.isascii()]
-            if bad:
-                sys.exit('non-ASCII name(s) in playwright_browsers, which break macOS signing: ' + repr(bad[:10]))
-            "
+            # One physical line on purpose: `python -c` rejects a first line that
+            # starts with whitespace, and a YAML block scalar cannot carry the
+            # column-0 lines a multi-line form would need.
+            .venv/bin/python -c "import sys; from pathlib import Path; bad = [str(p) for p in Path('playwright_browsers').rglob('*') if p.is_file() and not p.name.isascii()]; sys.exit('non-ASCII name(s) in playwright_browsers, which break macOS signing: ' + repr(bad[:10])) if bad else None"
             cp -R playwright_browsers "$RUNTIME_DIR/playwright_browsers"
             echo "Copied playwright_browsers into $RUNTIME_DIR/"
           fi
@@ -896,7 +892,18 @@ jobs:
 
       - name: Install npm dependencies
         working-directory: electron-app
-        run: npm ci || npm install
+        shell: bash
+        run: |
+          npm ci || npm install
+          # The electron repo's own `dist*` scripts go through `npm run`, so its
+          # scripts/build-electron-distribution.js can spawn a bare
+          # `electron-builder` and let npm's PATH injection find it. We invoke
+          # that script with plain `node`, which gets no such PATH — the spawn
+          # then dies with ENOENT. Put the local bin dir on PATH ourselves so
+          # every call site in this job resolves the same binary npm would.
+          # Not $PWD: on the Windows runner bash reports a /d/a/... MSYS path,
+          # which the runner cannot put on the process PATH.
+          echo "$GITHUB_WORKSPACE/electron-app/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Update version in package.json
         working-directory: electron-app


### PR DESCRIPTION
## 背景

`build-desktop.yml` 的 nightly 从 **2026-08-06 之后一次都没绿过**（最后一次成功是 run `31065418582`）。中间不是同一个原因，是四段接力：

| 日期 | 失败点 | 结论 |
|---|---|---|
| 08-07 ~ 08-12 | `build-electron` 四平台 | 本 PR 修 |
| 08-08 | linux `Prepare embedding model assets` | HuggingFace 429，已知偶发 |
| 08-13 ~ 08-15 | macOS `Re-sign macOS backend` | 已由 #2871 修掉 |
| 08-16 ~ 08-20 | macOS `Rename build output` | 本 PR 修 |

因为 `build-python` 一红，`build-electron` 和 `nightly` 直接 skip，所以 electron 那条从 08-13 起就没再跑过——它不是好了，只是被挡住了。两条都得修，nightly 才会走到发布那一步。

## 缺陷 1：macOS `Rename build output` 的 IndentationError

#2870 加的内联检查用了多行 `python -c "`，脚本正文带着 YAML/shell 的缩进原样喂给解释器：

```
File "<string>", line 2
    import sys
IndentationError: unexpected indent
```

改成单物理行。`python -c` 不接受首行带空白，YAML 块标量又装不下顶格文本，这里只能这么收口，注释里写清楚了原因。检查语义不变，本地验过：干净目录 exit 0，塞一个 `中文.dat` 进去 exit 1 并打印路径。

## 缺陷 2：`build-electron` 全平台 `spawnSync electron-builder ENOENT`

#2439 把构建命令从 `npx electron-builder …` 换成了 `node scripts/build-electron-distribution.js …`。那个脚本（在 N.E.K.O.-PC 仓）里是：

```js
const command = process.platform === 'win32' ? 'electron-builder.cmd' : 'electron-builder';
spawnSync(command, args, { cwd: …, shell: process.platform === 'win32' });
```

electron 仓自己的 `dist` / `dist:mac` / `dist:linux` 都走 `npm run`，靠 npm 注入的 PATH 找到 `node_modules/.bin/electron-builder`；我们用裸 `node` 调同一个脚本就没有那层 PATH，于是四个平台一起 ENOENT。（旁证：`build-desktop-linux.yml` 没跟着改，还是 `npx`，07-30 手动跑还是绿的。）

修法是在装完依赖后把本地 bin 目录写进 `GITHUB_PATH`，四个调用点一次解决，不用改另一个仓，也不用把 matrix 的 platform 值再映射一遍 npm script 名。用 `$GITHUB_WORKSPACE/...` 而不是 `$PWD`：Windows runner 上 bash 的 `$PWD` 是 `/d/a/...` 这种 MSYS 路径，runner 放不进进程 PATH。

## 验证

- 缺陷 1 的单行检查在本地两个方向都验过（见上）。
- 缺陷 2 只能在 CI 上验：`build-electron` 从 08-12 起就没跑过。合并前如果要确认，需要手动 dispatch 一次 `build-desktop.yml`——注意 `nightly` job 在 `workflow_dispatch` 下同样会跑，会删掉并重建 `nightly` release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进 macOS 桌面应用构建流程，继续拦截包含非 ASCII 字符的浏览器文件名。
  * 修复 Electron 依赖安装后的命令解析问题，确保后续构建步骤可正常调用本地工具。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->