### PR TITLE
fix(api): 让显式配置的自定义 API 真正生效 (#2886)

### DIFF
--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -42,9 +42,13 @@ logger = logging.getLogger("openfang_adapter")
 # OpenFang 原生支持多种 provider: anthropic, openai, groq, gemini, deepseek, ollama 等
 # 根据用户配置的 agent API base_url 推断最合适的 provider 和是否需要 proxy
 
-def _detect_provider_info(base_url: str, model: str) -> dict:
+def _detect_provider_info(base_url: str, model: str, provider_type: str | None = None) -> dict:
     """
     Infer the OpenFang provider and whether an LLM proxy is needed from the user-configured agent API.
+
+    ``provider_type`` is the dialect the config layer already resolved for this
+    slot; pass it when available so an Anthropic-Messages endpoint is routed as
+    Anthropic even when its hostname is not a known one.
 
     Returns:
         {
@@ -79,8 +83,17 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": "OPENAI_API_KEY",
         }
 
-    # Anthropic 原生 API -- OpenFang 直接支持, 无需 proxy
-    if _host_matches("anthropic.com", "api.anthropic.com"):
+    # Anthropic Messages 协议端点 -- OpenFang 直接支持, 无需 proxy
+    #
+    # 判据复用 utils.llm_client 的 _is_anthropic_endpoint（聊天链路的同一套真相），
+    # 而不是在这里再抄一份域名白名单。原来只认 anthropic.com，于是 #1948 加进来的
+    # kimi_code（api.kimi.com/coding，provider_type=anthropic）落到了末尾的
+    # provider=openai + needs_proxy 兜底，被当成 OpenAI 端点塞进 LLM proxy。
+    from utils.llm_client import _is_anthropic_endpoint
+
+    if _host_matches("anthropic.com", "api.anthropic.com") or _is_anthropic_endpoint(
+        base_url, provider_type
+    ):
         return {
             "provider": "anthropic",
             "needs_proxy": False,
@@ -595,7 +608,9 @@ class OpenFangAdapter:
 
         # 先检测 provider，再决定是否需要 api_key
         # Ollama 等本地 provider 不需要 api_key（api_key_env 为空串）
-        pinfo = _detect_provider_info(base_url, model)
+        pinfo = _detect_provider_info(
+            base_url, model, provider_type=agent_cfg.get("provider_type")
+        )
         if not api_key and pinfo.get("api_key_env"):
             # 云端 provider 缺少 api_key，跳过同步
             logger.warning("[OpenFang] Agent API key 未配置 (provider=%s), 跳过同步",

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -713,7 +713,12 @@ class OpenFangAdapter:
         # (3) Write config.toml（同步文件 IO，offload 到线程）
         file_written = False
         try:
-            await asyncio.to_thread(self._write_openfang_model_config, api_key, base_url, model)
+            # 把本次已解析好的 pinfo 传下去：落盘路径自己重算的话会漏掉配置层的
+            # provider_type，声明式 anthropic 端点被判成 openai，config.toml 与
+            # 运行时推上去的 provider 分叉。
+            await asyncio.to_thread(
+                self._write_openfang_model_config, api_key, base_url, model, pinfo
+            )
             file_written = True
         except Exception as e:
             logger.debug("[OpenFang] config.toml write failed (non-fatal): %s", e)
@@ -763,7 +768,9 @@ class OpenFangAdapter:
         return ok
 
     @staticmethod
-    def _write_openfang_model_config(api_key: str, base_url: str, model: str) -> None:
+    def _write_openfang_model_config(
+        api_key: str, base_url: str, model: str, pinfo: dict | None = None
+    ) -> None:
         """
         Ensure ~/.openfang/config.toml contains the [default_model] and [provider_urls] config.
         Whether to go through the proxy is decided by the provider type.
@@ -784,12 +791,9 @@ class OpenFangAdapter:
             with open(config_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
-        # 根据 base_url 检测 provider
-        #
-        # 优先复用 sync_config 已经算好的那份（它带上了配置层解析出的 provider_type）。
-        # 落盘这条路自己重算的话，声明式 anthropic 端点会被判成 openai —— 运行时推的
-        # provider 和 config.toml 里写的对不上。
-        pinfo = getattr(self, '_provider_info', None) or _detect_provider_info(base_url, model)
+        # 优先用调用方已解析好的那份（它带上了配置层的 provider_type）；
+        # 没传时才自己按 URL/模型名重算，保住其他调用路径。
+        pinfo = pinfo or _detect_provider_info(base_url, model)
         provider = pinfo["provider"]
         effective_url = pinfo["effective_url"]
         api_key_env = pinfo["api_key_env"]

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -83,17 +83,8 @@ def _detect_provider_info(base_url: str, model: str, provider_type: str | None =
             "api_key_env": "OPENAI_API_KEY",
         }
 
-    # Anthropic Messages 协议端点 -- OpenFang 直接支持, 无需 proxy
-    #
-    # 判据复用 utils.llm_client 的 _is_anthropic_endpoint（聊天链路的同一套真相），
-    # 而不是在这里再抄一份域名白名单。原来只认 anthropic.com，于是 #1948 加进来的
-    # kimi_code（api.kimi.com/coding，provider_type=anthropic）落到了末尾的
-    # provider=openai + needs_proxy 兜底，被当成 OpenAI 端点塞进 LLM proxy。
-    from utils.llm_client import _is_anthropic_endpoint
-
-    if _host_matches("anthropic.com", "api.anthropic.com") or _is_anthropic_endpoint(
-        base_url, provider_type
-    ):
+    # Anthropic 原生 API -- OpenFang 直接支持, 无需 proxy
+    if _host_matches("anthropic.com", "api.anthropic.com"):
         return {
             "provider": "anthropic",
             "needs_proxy": False,
@@ -177,6 +168,23 @@ def _detect_provider_info(base_url: str, model: str, provider_type: str | None =
             "needs_proxy": False,
             "effective_url": base_url,
             "api_key_env": "",
+        }
+
+    # 其余 Anthropic Messages 协议端点：kimi_code 的 api.kimi.com/coding，以及
+    # 槽位自己声明了 provider_type=anthropic 的自建端点。判据复用 utils.llm_client
+    # 的 _is_anthropic_endpoint（聊天链路的同一套真相），不在这里另抄一份域名表。
+    #
+    # 位置**故意**排在所有按 URL 认人的分支之后：provider_type 是一个声明，
+    # 而上面那些是证据。声明排前面的话，「槽位残留 anthropic + URL 其实是
+    # lanlan 代理 / deepseek」这种组合会被误判成 Anthropic 直连打死。
+    from utils.llm_client import _is_anthropic_endpoint
+
+    if _is_anthropic_endpoint(base_url, provider_type):
+        return {
+            "provider": "anthropic",
+            "needs_proxy": False,
+            "effective_url": base_url,
+            "api_key_env": "ANTHROPIC_API_KEY",
         }
 
     # OpenRouter / lanlan.app / 其他 OpenAI-compatible 代理

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -101,8 +101,9 @@ def _detect_provider_info(base_url: str, model: str, provider_type: str | None =
             "api_key_env": "OPENAI_API_KEY",
         }
 
-    # Groq
-    if _host_matches("groq.com", "api.groq.com") or "groq" in model_lower:
+    # Groq -- 主机证据这一半留在前面；纯按模型名猜的那一半挪到声明式判据之后
+    # （见下面 "其余 Anthropic Messages 协议端点" 处的次序说明）。
+    if _host_matches("groq.com", "api.groq.com"):
         return {
             "provider": "groq",
             "needs_proxy": False,
@@ -136,8 +137,8 @@ def _detect_provider_info(base_url: str, model: str, provider_type: str | None =
             "api_key_env": "GEMINI_API_KEY",
         }
 
-    # DeepSeek
-    if _host_matches("deepseek.com", "api.deepseek.com") or "deepseek" in model_lower:
+    # DeepSeek -- 同 Groq，主机证据留前，模型名猜测挪后
+    if _host_matches("deepseek.com", "api.deepseek.com"):
         return {
             "provider": "deepseek",
             "needs_proxy": False,
@@ -174,9 +175,13 @@ def _detect_provider_info(base_url: str, model: str, provider_type: str | None =
     # 槽位自己声明了 provider_type=anthropic 的自建端点。判据复用 utils.llm_client
     # 的 _is_anthropic_endpoint（聊天链路的同一套真相），不在这里另抄一份域名表。
     #
-    # 位置**故意**排在所有按 URL 认人的分支之后：provider_type 是一个声明，
-    # 而上面那些是证据。声明排前面的话，「槽位残留 anthropic + URL 其实是
-    # lanlan 代理 / deepseek」这种组合会被误判成 Anthropic 直连打死。
+    # 次序是三档：**主机/端口/路径证据 > 声明 > 纯模型名猜测**。
+    #   - 排在所有 URL 分支之后：provider_type 只是槽位携带的一个声明，而上面那些
+    #     是证据。声明排前面的话，「槽位残留 anthropic + URL 其实是 lanlan 代理 /
+    #     deepseek / 本机 ollama」会被误判成 Anthropic 直连打死。
+    #   - 但排在 groq / deepseek 的**模型名**猜测之前：那两条只是看模型名里有没有
+    #     厂商字样，比一个显式声明弱。否则自建 Anthropic 网关只要服务一个名字里带
+    #     deepseek 的模型，就会被按 DeepSeek 协议和 Key 环境变量发出去。
     from utils.llm_client import _is_anthropic_endpoint
 
     if _is_anthropic_endpoint(base_url, provider_type):
@@ -185,6 +190,22 @@ def _detect_provider_info(base_url: str, model: str, provider_type: str | None =
             "needs_proxy": False,
             "effective_url": base_url,
             "api_key_env": "ANTHROPIC_API_KEY",
+        }
+
+    # 纯模型名启发式：证据用尽、也没有声明时才据此猜厂商。
+    if "groq" in model_lower:
+        return {
+            "provider": "groq",
+            "needs_proxy": False,
+            "effective_url": base_url,
+            "api_key_env": "GROQ_API_KEY",
+        }
+    if "deepseek" in model_lower:
+        return {
+            "provider": "deepseek",
+            "needs_proxy": False,
+            "effective_url": base_url,
+            "api_key_env": "DEEPSEEK_API_KEY",
         }
 
     # OpenRouter / lanlan.app / 其他 OpenAI-compatible 代理

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -266,7 +266,12 @@ class OpenFangAdapter:
         import hashlib
         cm = get_config_manager()
         agent_cfg = cm.get_model_api_config('agent')
-        key_fields = f"{agent_cfg.get('model', '')}|{agent_cfg.get('base_url', '')}|{agent_cfg.get('api_key', '')}"
+        # provider_type 也要进哈希：它现在参与 provider 探测，只改协议不改
+        # model/url/key 的配置变更否则会被判成「没变」，重新探测永远不触发。
+        key_fields = (
+            f"{agent_cfg.get('model', '')}|{agent_cfg.get('base_url', '')}"
+            f"|{agent_cfg.get('api_key', '')}|{agent_cfg.get('provider_type', '')}"
+        )
         return hashlib.md5(key_fields.encode()).hexdigest()
 
     async def _ensure_config_synced(self) -> None:
@@ -780,7 +785,11 @@ class OpenFangAdapter:
                 content = f.read()
 
         # 根据 base_url 检测 provider
-        pinfo = _detect_provider_info(base_url, model)
+        #
+        # 优先复用 sync_config 已经算好的那份（它带上了配置层解析出的 provider_type）。
+        # 落盘这条路自己重算的话，声明式 anthropic 端点会被判成 openai —— 运行时推的
+        # provider 和 config.toml 里写的对不上。
+        pinfo = getattr(self, '_provider_info', None) or _detect_provider_info(base_url, model)
         provider = pinfo["provider"]
         effective_url = pinfo["effective_url"]
         api_key_env = pinfo["api_key_env"]

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -90,8 +90,13 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
         userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
         scheme = (parts.scheme or '').lower()
         host, port = _split_hostinfo(hostinfo.lower())
-        # 显式写出的默认端口要归一化掉：https://h/v1 与 https://h:443/v1 是同一个
-        # 端点，判成不同会把本该继承的凭证掐掉 → 付费端点 401。
+        # 端口按**数值**归一化，不是按字符串：:0443 和 :443 是同一个端口，
+        # :08443 和 :8443 也是。用字符串比会把它们判成不同端点，进而掐掉本该
+        # 继承的凭证 → 付费端点 401。非全数字的（畸形端口）原样留着比。
+        if port.isdigit():
+            port = str(int(port))
+        # 显式写出的默认端口同样要归一化掉：https://h/v1 与 https://h:443/v1
+        # 是同一个端点。
         if port and port == _DEFAULT_PORTS.get(scheme):
             port = ''
         return (

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -73,7 +73,13 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
             return None
         if '://' not in text:
             text = f'//{text}'
-        parts = urlsplit(text)
+        try:
+            parts = urlsplit(text)
+        except ValueError:
+            # 畸形 IPv6（如 http://[::1）会让 urlsplit 自己抛。这段跑在 __init__
+            # 里，抛出去等于客户端构造失败。退回按原串比：判据保持 total，
+            # 两个写法相同的坏 URL 仍算同源，不同的仍算不同源。
+            return ('<unparsed>', text)
         # netloc 整体转小写是错的：它还装着 userinfo（user:pass@），而用户名和
         # 口令是大小写敏感的。拆开 userinfo 与 host:port，只折叠后者的大小写
         # （主机名与数字端口都是大小写无关的）。

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -57,6 +57,16 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
     """
     from urllib.parse import urlsplit
 
+    # 该 scheme 下可以省略的默认端口：写与不写是同一个端点。
+    _DEFAULT_PORTS = {'http': '80', 'https': '443', 'ws': '80', 'wss': '443'}
+
+    def _split_hostinfo(hostinfo: str) -> tuple[str, str]:
+        """Split ``host[:port]`` without tripping over IPv6 brackets."""
+        idx = hostinfo.rfind(':')
+        if idx == -1 or hostinfo.rfind(']') > idx:
+            return hostinfo, ''
+        return hostinfo[:idx], hostinfo[idx + 1:]
+
     def _key(raw: str | None):
         text = (raw or '').strip()
         if not text:
@@ -70,12 +80,19 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
         #
         # 刻意不碰 parts.port：它对非法端口（非数字/越界）会抛 ValueError，而这
         # 段代码跑在 __init__ 里 —— 一个写坏的 URL 会让整个客户端构造失败，
-        # 连一次请求都发不出去。按 host:port 原串比较既不会抛，也够用。
+        # 连一次请求都发不出去。自己按文本拆既不会抛，也够用。
         userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
+        scheme = (parts.scheme or '').lower()
+        host, port = _split_hostinfo(hostinfo.lower())
+        # 显式写出的默认端口要归一化掉：https://h/v1 与 https://h:443/v1 是同一个
+        # 端点，判成不同会把本该继承的凭证掐掉 → 付费端点 401。
+        if port and port == _DEFAULT_PORTS.get(scheme):
+            port = ''
         return (
-            (parts.scheme or '').lower(),
+            scheme,
             userinfo,
-            hostinfo.lower(),
+            host,
+            port,
             (parts.path or '').rstrip('/'),
             parts.query,
         )
@@ -169,10 +186,12 @@ class OmniOfflineClient(_ToolingMixin, _GenaiMixin, _StreamingMixin, _MediaMixin
         # 大小写差异不该被当成「换了一家」而把继承掐掉（那会让原本能用的配置开始 401）。
         _vision_url = vision_base_url or base_url
         self.vision_base_url = _vision_url
+        # 「无凭证」统一表示成 None，与上面 self.api_key 的归一化对齐——
+        # 否则视觉侧会出现 '' 而主侧是 None，同一个状态两种写法。
         if _same_endpoint(_vision_url, base_url):
-            self.vision_api_key = vision_api_key if vision_api_key else api_key
+            self.vision_api_key = (vision_api_key or None) or self.api_key
         else:
-            self.vision_api_key = vision_api_key if vision_api_key else None
+            self.vision_api_key = vision_api_key or None
         self.provider_type = provider_type
         self.vision_provider_type = vision_provider_type or provider_type
         self._model_switch_lock = asyncio.Lock()

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -65,13 +65,17 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
             text = f'//{text}'
         parts = urlsplit(text)
         # netloc 整体转小写是错的：它还装着 userinfo（user:pass@），而用户名和
-        # 口令是大小写敏感的。只折叠真正大小写无关的 host，userinfo 与端口原样比。
+        # 口令是大小写敏感的。拆开 userinfo 与 host:port，只折叠后者的大小写
+        # （主机名与数字端口都是大小写无关的）。
+        #
+        # 刻意不碰 parts.port：它对非法端口（非数字/越界）会抛 ValueError，而这
+        # 段代码跑在 __init__ 里 —— 一个写坏的 URL 会让整个客户端构造失败，
+        # 连一次请求都发不出去。按 host:port 原串比较既不会抛，也够用。
+        userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
         return (
             (parts.scheme or '').lower(),
-            parts.username,
-            parts.password,
-            (parts.hostname or '').lower(),
-            parts.port,
+            userinfo,
+            hostinfo.lower(),
             (parts.path or '').rstrip('/'),
             parts.query,
         )

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -40,84 +40,14 @@ from ._streaming import _StreamingMixin
 from ._media import _MediaMixin
 from ._lifecycle import _LifecycleMixin
 
+from utils.http.url import same_endpoint
 
-def _same_endpoint(a: str | None, b: str | None) -> bool:
-    """Whether two configured base URLs address the same endpoint.
 
-    Used to decide whether the vision slot may inherit the chat credential, so
-    it has to be wrong in the safe direction: only the parts of a URL that are
-    genuinely case-insensitive get folded.
-
-    Scheme and host are case-insensitive per RFC 3986, and a trailing slash on
-    the path is cosmetic — those differences accumulate in saved configs and
-    must not read as "a different provider" (that would drop a key that used to
-    work). Path and query are case-SENSITIVE: two routes or tenants can differ
-    by case alone, and treating those as the same endpoint would hand one
-    provider's credential to another.
-    """
-    from urllib.parse import urlsplit
-
-    # 该 scheme 下可以省略的默认端口：写与不写是同一个端点。
-    _DEFAULT_PORTS = {'http': '80', 'https': '443', 'ws': '80', 'wss': '443'}
-
-    def _split_hostinfo(hostinfo: str) -> tuple[str, str]:
-        """Split ``host[:port]`` without tripping over IPv6 brackets."""
-        idx = hostinfo.rfind(':')
-        if idx == -1 or hostinfo.rfind(']') > idx:
-            return hostinfo, ''
-        return hostinfo[:idx], hostinfo[idx + 1:]
-
-    def _key(raw: str | None):
-        text = (raw or '').strip()
-        if not text:
-            return None
-        if '://' not in text:
-            text = f'//{text}'
-        try:
-            parts = urlsplit(text)
-        except ValueError:
-            # 畸形 IPv6（如 http://[::1）会让 urlsplit 自己抛。这段跑在 __init__
-            # 里，抛出去等于客户端构造失败。退回按原串比：判据保持 total，
-            # 两个写法相同的坏 URL 仍算同源，不同的仍算不同源。
-            #
-            # 两个分支返回**同样长度**的元组，首位是「解析成功与否」：长度不同
-            # 的元组比起来虽然也恒不相等，但那是靠巧合而不是靠判据，静态分析
-            # 也会（合理地）报出来。
-            return (False, text, '', '', '', '', '')
-        # netloc 整体转小写是错的：它还装着 userinfo（user:pass@），而用户名和
-        # 口令是大小写敏感的。拆开 userinfo 与 host:port，只折叠后者的大小写
-        # （主机名与数字端口都是大小写无关的）。
-        #
-        # 刻意不碰 parts.port：它对非法端口（非数字/越界）会抛 ValueError，而这
-        # 段代码跑在 __init__ 里 —— 一个写坏的 URL 会让整个客户端构造失败，
-        # 连一次请求都发不出去。自己按文本拆既不会抛，也够用。
-        userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
-        scheme = (parts.scheme or '').lower()
-        host, port = _split_hostinfo(hostinfo.lower())
-        # 端口按**数值**归一化，不是按字符串：:0443 和 :443 是同一个端口，
-        # :08443 和 :8443 也是。用字符串比会把它们判成不同端点，进而掐掉本该
-        # 继承的凭证 → 付费端点 401。非全数字的（畸形端口）原样留着比。
-        if port.isdigit():
-            port = str(int(port))
-        # 显式写出的默认端口同样要归一化掉：https://h/v1 与 https://h:443/v1
-        # 是同一个端点。
-        if port and port == _DEFAULT_PORTS.get(scheme):
-            port = ''
-        return (
-            True,
-            scheme,
-            userinfo,
-            host,
-            port,
-            # 只去掉**一个**尾斜杠：那是配置里会自然攒出来的写法差异。
-            # rstrip('/') 会把 /v1/ 和 /v1// 一起折平，而它们是两条不同的
-            # HTTP 路径 —— 折平就又把凭证送过了边界。
-            (parts.path or '').removesuffix('/'),
-            parts.query,
-        )
-
-    key_a, key_b = _key(a), _key(b)
-    return key_a is not None and key_a == key_b
+# 端点同源判据收口到 utils.http.url：视觉槽的凭证继承与配置层「管理簿 Key 只能
+# 配该服务商自己的端点」问的是同一个问题。这里曾经手搓过一份，前后被评审挑出
+# 尾斜杠 / path 大小写 / userinfo / 畸形端口 / 默认端口 / 畸形 IPv6 六类边界；
+# 配置层后来又独立搓了第二份、把同样的坑重踩一遍。共用一份才是解法。
+_same_endpoint = same_endpoint
 
 
 class OmniOfflineClient(_ToolingMixin, _GenaiMixin, _StreamingMixin, _MediaMixin, _LifecycleMixin):

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -44,12 +44,35 @@ from ._lifecycle import _LifecycleMixin
 def _same_endpoint(a: str | None, b: str | None) -> bool:
     """Whether two configured base URLs address the same endpoint.
 
-    Used to decide whether the vision slot may inherit the chat credential.
-    Compared after trimming and dropping a trailing slash so the cosmetic
-    differences that accumulate in saved configs do not read as a different
-    provider — a false "different" would drop a key that used to work.
+    Used to decide whether the vision slot may inherit the chat credential, so
+    it has to be wrong in the safe direction: only the parts of a URL that are
+    genuinely case-insensitive get folded.
+
+    Scheme and host are case-insensitive per RFC 3986, and a trailing slash on
+    the path is cosmetic — those differences accumulate in saved configs and
+    must not read as "a different provider" (that would drop a key that used to
+    work). Path and query are case-SENSITIVE: two routes or tenants can differ
+    by case alone, and treating those as the same endpoint would hand one
+    provider's credential to another.
     """
-    return (a or '').strip().rstrip('/').lower() == (b or '').strip().rstrip('/').lower()
+    from urllib.parse import urlsplit
+
+    def _key(raw: str | None):
+        text = (raw or '').strip()
+        if not text:
+            return None
+        if '://' not in text:
+            text = f'//{text}'
+        parts = urlsplit(text)
+        return (
+            (parts.scheme or '').lower(),
+            (parts.netloc or '').lower(),
+            (parts.path or '').rstrip('/'),
+            parts.query,
+        )
+
+    key_a, key_b = _key(a), _key(b)
+    return key_a is not None and key_a == key_b
 
 
 class OmniOfflineClient(_ToolingMixin, _GenaiMixin, _StreamingMixin, _MediaMixin, _LifecycleMixin):

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -41,6 +41,17 @@ from ._media import _MediaMixin
 from ._lifecycle import _LifecycleMixin
 
 
+def _same_endpoint(a: str | None, b: str | None) -> bool:
+    """Whether two configured base URLs address the same endpoint.
+
+    Used to decide whether the vision slot may inherit the chat credential.
+    Compared after trimming and dropping a trailing slash so the cosmetic
+    differences that accumulate in saved configs do not read as a different
+    provider — a false "different" would drop a key that used to work.
+    """
+    return (a or '').strip().rstrip('/').lower() == (b or '').strip().rstrip('/').lower()
+
+
 class OmniOfflineClient(_ToolingMixin, _GenaiMixin, _StreamingMixin, _MediaMixin, _LifecycleMixin):
     """
     A client for text-based chat that mimics the interface of OmniRealtimeClient.
@@ -122,12 +133,14 @@ class OmniOfflineClient(_ToolingMixin, _GenaiMixin, _StreamingMixin, _MediaMixin
         # 的付费 Key 发给了另一个厂商，既是路由错误也是凭证越界。留空 Key 让请求
         # 不带 Authorization：本地无鉴权端点本就该如此，付费端点则会直接 401
         # 报错，比静默把凭证送出去可诊断得多。
+        # 同源判定按归一化后的 URL 比：两个槽都指向同一家时，配置里常见的尾斜杠 /
+        # 大小写差异不该被当成「换了一家」而把继承掐掉（那会让原本能用的配置开始 401）。
         _vision_url = vision_base_url or base_url
         self.vision_base_url = _vision_url
-        if _vision_url != base_url:
-            self.vision_api_key = vision_api_key if vision_api_key else None
-        else:
+        if _same_endpoint(_vision_url, base_url):
             self.vision_api_key = vision_api_key if vision_api_key else api_key
+        else:
+            self.vision_api_key = vision_api_key if vision_api_key else None
         self.provider_type = provider_type
         self.vision_provider_type = vision_provider_type or provider_type
         self._model_switch_lock = asyncio.Lock()

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -115,9 +115,19 @@ class OmniOfflineClient(_ToolingMixin, _GenaiMixin, _StreamingMixin, _MediaMixin
         self.api_key = api_key if api_key and api_key != '' else None
         self.model = model
         self.vision_model = vision_model  # Store vision model for temporary switching
-        # 视觉模型独立配置（如果未指定则回退到主配置）
-        self.vision_base_url = vision_base_url if vision_base_url else base_url
-        self.vision_api_key = vision_api_key if vision_api_key else api_key
+        # 视觉模型独立配置：URL 与 Key 必须**成对**回退。
+        #
+        # 这两行原本各自独立判空，于是「视觉槽填了自己的 URL、Key 留空」时
+        # URL 停在视觉那一家的域名、Key 却继承了对话 provider 的凭证 —— 把用户
+        # 的付费 Key 发给了另一个厂商，既是路由错误也是凭证越界。留空 Key 让请求
+        # 不带 Authorization：本地无鉴权端点本就该如此，付费端点则会直接 401
+        # 报错，比静默把凭证送出去可诊断得多。
+        _vision_url = vision_base_url or base_url
+        self.vision_base_url = _vision_url
+        if _vision_url != base_url:
+            self.vision_api_key = vision_api_key if vision_api_key else None
+        else:
+            self.vision_api_key = vision_api_key if vision_api_key else api_key
         self.provider_type = provider_type
         self.vision_provider_type = vision_provider_type or provider_type
         self._model_switch_lock = asyncio.Lock()

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -64,9 +64,14 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
         if '://' not in text:
             text = f'//{text}'
         parts = urlsplit(text)
+        # netloc 整体转小写是错的：它还装着 userinfo（user:pass@），而用户名和
+        # 口令是大小写敏感的。只折叠真正大小写无关的 host，userinfo 与端口原样比。
         return (
             (parts.scheme or '').lower(),
-            (parts.netloc or '').lower(),
+            parts.username,
+            parts.password,
+            (parts.hostname or '').lower(),
+            parts.port,
             (parts.path or '').rstrip('/'),
             parts.query,
         )

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -79,7 +79,11 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
             # 畸形 IPv6（如 http://[::1）会让 urlsplit 自己抛。这段跑在 __init__
             # 里，抛出去等于客户端构造失败。退回按原串比：判据保持 total，
             # 两个写法相同的坏 URL 仍算同源，不同的仍算不同源。
-            return ('<unparsed>', text)
+            #
+            # 两个分支返回**同样长度**的元组，首位是「解析成功与否」：长度不同
+            # 的元组比起来虽然也恒不相等，但那是靠巧合而不是靠判据，静态分析
+            # 也会（合理地）报出来。
+            return (False, text, '', '', '', '', '')
         # netloc 整体转小写是错的：它还装着 userinfo（user:pass@），而用户名和
         # 口令是大小写敏感的。拆开 userinfo 与 host:port，只折叠后者的大小写
         # （主机名与数字端口都是大小写无关的）。
@@ -100,6 +104,7 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
         if port and port == _DEFAULT_PORTS.get(scheme):
             port = ''
         return (
+            True,
             scheme,
             userinfo,
             host,

--- a/main_logic/omni_offline_client/_client.py
+++ b/main_logic/omni_offline_client/_client.py
@@ -104,7 +104,10 @@ def _same_endpoint(a: str | None, b: str | None) -> bool:
             userinfo,
             host,
             port,
-            (parts.path or '').rstrip('/'),
+            # 只去掉**一个**尾斜杠：那是配置里会自然攒出来的写法差异。
+            # rstrip('/') 会把 /v1/ 和 /v1// 一起折平，而它们是两条不同的
+            # HTTP 路径 —— 折平就又把凭证送过了边界。
+            (parts.path or '').removesuffix('/'),
             parts.query,
         )
 

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -33,6 +33,7 @@ from ._shared import (
 
 
 
+from ._shared import canonical_realtime_dialect
 from ._tools import _ToolingMixin
 from ._audio import _AudioMixin
 from ._transport import _TransportMixin
@@ -451,7 +452,12 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         #   qwen  → no custom tool calling per Aliyun docs (only enable_search)
         #   gemini → genai SDK config.tools, response.tool_call.function_calls
         # The provider-side flags below let event handlers cheaply route.
-        self._supports_tools_wire = self._api_type.lower() in ('gpt', 'glm', 'qwen', 'step', 'free', 'gemini', 'grok')
+        # 与 apply_tools_to_session 共用同一套方言词表：这里原来直接比 api_type，
+        # 而 'gpt' 从来不是 api_type 的合法取值（真实值是 'openai'），'qwen_intl'
+        # 也进不了 'qwen'。该字段当前没有读者，但错的判据留着迟早被人接上。
+        self._supports_tools_wire = canonical_realtime_dialect(self._api_type) in (
+            'gpt', 'glm', 'qwen', 'step', 'free', 'gemini', 'grok'
+        )
         # Per-call accumulator for OpenAI-Realtime / StepFun delta arguments
         # keyed by call_id. cleared on response.done.
         self._inflight_tool_args: Dict[str, Dict[str, Any]] = {}

--- a/main_logic/omni_realtime_client/_shared.py
+++ b/main_logic/omni_realtime_client/_shared.py
@@ -108,3 +108,26 @@ def response_arbiter_fail_open_enabled() -> bool:
 
     raw = os.getenv(_ARBITER_FAIL_OPEN_ENV_VAR, "").strip().lower()
     return raw in ("1", "true", "yes", "on")
+
+
+# ``api_type`` carries the provider key that ``CORE_API_TYPE`` resolves to
+# ('openai', 'qwen_intl', ...), never a model-name fragment. Several wire
+# branches were written against 'gpt' — a value the config layer has never
+# produced — so an OpenAI session silently missed every mid-session tool
+# update while its connect-time tools still went out (that path matches on
+# the model name, where 'gpt' really does appear). 'qwen_intl' missed the
+# 'qwen' branch the same way. Normalising here keeps the dialect branches
+# keyed on one vocabulary; 'gpt' stays accepted so existing callers and
+# fixtures that pass it keep working.
+_REALTIME_DIALECT_ALIASES = {
+    "openai": "gpt",
+    "gpt": "gpt",
+    "qwen_intl": "qwen",
+}
+
+
+def canonical_realtime_dialect(api_type: object) -> str:
+    """Map a provider key to the wire dialect its session speaks."""
+
+    raw = str(api_type or "").strip().lower()
+    return _REALTIME_DIALECT_ALIASES.get(raw, raw)

--- a/main_logic/omni_realtime_client/_tools.py
+++ b/main_logic/omni_realtime_client/_tools.py
@@ -22,6 +22,7 @@ from ._shared import (
     ToolCall,
     ToolDefinition,
     ToolResult,
+    canonical_realtime_dialect,
     logger,
     time,
 )
@@ -70,7 +71,7 @@ class _ToolingMixin:
             # tool list is fixed at connect time. Log + ignore.
             logger.info("apply_tools_to_session: Gemini Live does not support mid-session tools update — ignoring")
             return
-        api = self._api_type.lower()
+        api = canonical_realtime_dialect(self._api_type)
         if api == 'step' or api == 'free':
             # stepaudio-2.5-realtime 不再支持内置 web_search，与
             # update_session 初始化路径保持一致：只发 caller 注册的

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1207,17 +1207,15 @@ function isProviderCapableForModelType(providerKey, modelType) {
     if (!pk || pk === 'custom' || pk.startsWith('follow_')) return true;
 
     if (modelType === 'omni') {
-        if (!_coreApiProviders || Object.keys(_coreApiProviders).length === 0) return true;
-        const profile = _coreApiProviders[pk];
-        if (!profile) return false;
-        // 判据是「有没有可直连的 realtime 端点」，不只是「在不在核心表里」：
-        // Gemini 在核心表里但没有 core_url（作为核心 API 走 SDK，不经这个槽），
-        // 选中后 URL 会填成空、自定义三元组凑不齐 → 静默回落。与后端
-        // _normalize_realtime_provider 的判据对偶。
-        // 字段名与 getProviderCoreUrl() 保持**完全一致**（都只认 core_url）：
-        // 这里多认一个别名的话，会出现「判定为有能力、但自动填充填不出 URL」
-        // 的不一致 —— 下拉里又多一个选了没用的选项。
-        return !!String(profile.core_url || '').trim();
+        // 实时全模态槽不提供任何具名服务商，只留「跟随」与「自定义」。
+        //
+        // 这个槽的取值最终会变成进程级的 core api type，而那个身份**同时**决定
+        // TTS worker、原生音色目录和音频凭证——它们都跟着核心 API 走。选一个与
+        // 核心不同的厂商会把音频链路撕成两半（实测过：核心 OpenAI + 本槽选 Qwen
+        // → 启动 Qwen TTS worker 却拿着 OpenAI 的 key，既无声又把一家的凭证发给
+        // 另一家）。整条音频链路只有一个 provider 身份，这个槽表达不了第二个，
+        // 所以干脆不摆出来。与后端 _normalize_realtime_provider 对偶。
+        return false;
     }
 
     if (modelType === 'tts') {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1208,7 +1208,13 @@ function isProviderCapableForModelType(providerKey, modelType) {
 
     if (modelType === 'omni') {
         if (!_coreApiProviders || Object.keys(_coreApiProviders).length === 0) return true;
-        return Object.prototype.hasOwnProperty.call(_coreApiProviders, pk);
+        const profile = _coreApiProviders[pk];
+        if (!profile) return false;
+        // 判据是「有没有可直连的 realtime 端点」，不只是「在不在核心表里」：
+        // Gemini 在核心表里但没有 core_url（作为核心 API 走 SDK，不经这个槽），
+        // 选中后 URL 会填成空、自定义三元组凑不齐 → 静默回落。与后端
+        // _normalize_realtime_provider 的判据对偶。
+        return !!String(profile.core_url || profile.CORE_URL || '').trim();
     }
 
     if (modelType === 'tts') {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1214,7 +1214,10 @@ function isProviderCapableForModelType(providerKey, modelType) {
         // Gemini 在核心表里但没有 core_url（作为核心 API 走 SDK，不经这个槽），
         // 选中后 URL 会填成空、自定义三元组凑不齐 → 静默回落。与后端
         // _normalize_realtime_provider 的判据对偶。
-        return !!String(profile.core_url || profile.CORE_URL || '').trim();
+        // 字段名与 getProviderCoreUrl() 保持**完全一致**（都只认 core_url）：
+        // 这里多认一个别名的话，会出现「判定为有能力、但自动填充填不出 URL」
+        // 的不一致 —— 下拉里又多一个选了没用的选项。
+        return !!String(profile.core_url || '').trim();
     }
 
     if (modelType === 'tts') {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1191,6 +1191,41 @@ function getTtsProviderMeta(pk) {
 }
 
 /**
+ * 该 provider 是否真的具备某个槽位所需的能力。
+ *
+ * TTS 与「实时全模态」两个下拉原本把辅助 LLM 全表无差别铺开，于是列出了一堆后端
+ * 根本没有对应实现的服务商：选中后 TTS 仍由核心 API 决定 worker、实时全模态则落进
+ * 未实现的 api_type='local' 或被静默忽略，而下拉自动填进去的 URL/Key 还会污染该槽
+ * 的凭证。能力真相各有单一来源——实时全模态是 core_api_providers（后端按它分流），
+ * TTS 是后端 tts_provider_registry——这里据此过滤，前端不硬编码任何 provider key。
+ *
+ * 两处都 fail-open：元数据没取到（/api_providers 失败）时不过滤，宁可多列几项，
+ * 也不要把用户正在用的服务商从下拉里藏掉。
+ */
+function isProviderCapableForModelType(providerKey, modelType) {
+    const pk = String(providerKey || '').trim();
+    if (!pk || pk === 'custom' || pk.startsWith('follow_')) return true;
+
+    if (modelType === 'omni') {
+        if (!_coreApiProviders || Object.keys(_coreApiProviders).length === 0) return true;
+        return Object.prototype.hasOwnProperty.call(_coreApiProviders, pk);
+    }
+
+    if (modelType === 'tts') {
+        if (!_ttsProviders || Object.keys(_ttsProviders).length === 0) return true;
+        if (getTtsProviderMeta(pk)) return true;
+        // 注册表用 aliases 表达同一家的多地域入口（如 minimax_intl → minimax），
+        // 只按 key 查会把这些别名误判成无能力。
+        return Object.keys(_ttsProviders).some(k => {
+            const aliases = _ttsProviders[k] && _ttsProviders[k].aliases;
+            return Array.isArray(aliases) && aliases.includes(pk);
+        });
+    }
+
+    return true;
+}
+
+/**
  * 填充所有自定义模型的服务商下拉框
  */
 function getProviderInfo(providerKey) {
@@ -1340,6 +1375,8 @@ function populateModelProviderDropdowns() {
             const _spFilter = getTtsProviderMeta(pk);
             if (mt === 'tts' && !isTtsProviderVisibleInModelConfig(pk, _spFilter)) return;
             if (_spFilter && _spFilter.tts_dropdown_only && mt !== 'tts') return;
+            // 该槽位没有这家的实现就不要摆出来（伪选项 → 静默 fallback）。
+            if (!isProviderCapableForModelType(pk, mt)) return;
             const pInfo = _assistApiProviders[pk];
             const opt = document.createElement('option');
             opt.value = pk;
@@ -2072,6 +2109,19 @@ async function loadCurrentApiKey() {
                 // 覆盖「有 URL 但无 provider → custom」的旧回退，保证存量配置正确回填。
                 if (mt === 'tts' && _loadedGptSovitsState === 'enabled') {
                     sel.value = 'gptsovits';
+                    onCustomModelProviderChange(mt);
+                    return;
+                }
+                if (data[providerField] && !isProviderCapableForModelType(data[providerField], mt)) {
+                    // 存量配置里选中了一个该槽根本没有实现的服务商（TTS / 实时全模态
+                    // 下拉曾把辅助 LLM 全表铺开）。这个选择在后端从来没有生效过，但它
+                    // 自动填进去的 URL/Key 会污染该槽凭证，是「界面绿灯、实际无声」的来源。
+                    //
+                    // 必须落回该槽默认值，**不能**走下面那条 'custom' 兜底：那会把一个
+                    // LLM 端点坐实成用户自配的 TTS/实时端点，反而让原本只是空转的配置
+                    // 真的被拿去请求。落回 follow_* 后 onCustomModelProviderChange 会用
+                    // 被跟随方的值重写 URL/Key，残留污染一并清掉。
+                    sel.value = getDefaultProviderForModelType(mt);
                     onCustomModelProviderChange(mt);
                     return;
                 }

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -1776,18 +1776,19 @@ def test_capability_dropdowns_hide_providers_with_no_implementation(
     for pk in ('deepseek', 'kimi', 'kimi_code', 'claude', 'openrouter', 'silicon'):
         assert pk not in options['tts'], f"TTS 下拉仍暴露无 TTS 能力的 {pk}"
 
-    # 没有 realtime 端点的厂商不该出现在实时全模态下拉里。
-    # gemini 在核心表里但没有 core_url —— 它作为核心 API 走 SDK，这个槽表达不了它，
-    # 选中只会静默回落，所以同样属于伪选项。
-    for pk in ('deepseek', 'kimi', 'claude', 'minimax', 'elevenlabs', 'openrouter', 'gemini'):
-        assert pk not in options['omni'], f"实时全模态下拉仍暴露无 realtime 能力的 {pk}"
+    # 实时全模态下拉不提供**任何**具名服务商。这个槽的取值会变成进程级的
+    # core api type，而那个身份同时决定 TTS worker / 原生音色 / 音频凭证——
+    # 它们都跟着核心 API 走。选一个与核心不同的厂商会把音频链路撕成两半
+    # （Qwen TTS worker 拿着 OpenAI 的 key），所以连真正有 realtime 端点的
+    # qwen / glm 也不摆出来。
+    for pk in ('deepseek', 'kimi', 'claude', 'minimax', 'elevenlabs', 'openrouter',
+               'gemini', 'qwen', 'glm', 'step', 'grok', 'openai'):
+        assert pk not in options['omni'], f"实时全模态下拉不该暴露具名服务商 {pk}"
 
     # 反向断言：真正有能力的项必须还在，避免"全都过滤掉"也能让上面的断言通过
     assert 'gptsovits' in options['tts'], "GPT-SoVITS 被误过滤"
     assert 'vllm_omni' in options['tts'], "vLLM-Omni 被误过滤"
     assert 'custom' in options['tts'], "自定义 TTS 被误过滤"
-    assert 'qwen' in options['omni'], "Qwen 实时被误过滤"
-    assert 'glm' in options['omni'], "GLM 实时被误过滤"
     assert 'custom' in options['omni'], "自定义实时端点被误过滤"
     for sel in ('tts', 'omni'):
         assert 'follow_core' in options[sel] and 'follow_assist' in options[sel], (

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -1745,3 +1745,49 @@ def test_switching_tts_provider_away_from_vllm_clears_fallback_voice(mock_page: 
     """)
 
     assert values == {"vllmVoice": "default", "followVoice": ""}
+
+
+@pytest.mark.frontend
+def test_capability_dropdowns_hide_providers_with_no_implementation(
+    mock_page: Page, running_server: str
+):
+    """TTS / realtime dropdowns must only offer providers the backend implements.
+
+    Both dropdowns used to be filled from the assist (text-LLM) table, so they
+    listed providers that own no TTS worker / no realtime endpoint at all.
+    Picking one was silently ignored downstream while its auto-filled URL and
+    key polluted that slot's credentials.
+    """
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#ttsModelProvider option[value='vllm_omni']", state="attached", timeout=10000)
+
+    options = mock_page.evaluate("""
+        () => {
+            const read = id => Array.from(
+                document.getElementById(id).options
+            ).map(o => o.value);
+            return { tts: read('ttsModelProvider'), omni: read('omniModelProvider') };
+        }
+    """)
+
+    # 纯文本 LLM 厂商没有任何 TTS worker，不该出现在 TTS 下拉里
+    for pk in ('deepseek', 'kimi', 'kimi_code', 'claude', 'openrouter', 'silicon'):
+        assert pk not in options['tts'], f"TTS 下拉仍暴露无 TTS 能力的 {pk}"
+
+    # 没有 realtime 端点的厂商不该出现在实时全模态下拉里
+    for pk in ('deepseek', 'kimi', 'claude', 'minimax', 'elevenlabs', 'openrouter'):
+        assert pk not in options['omni'], f"实时全模态下拉仍暴露无 realtime 能力的 {pk}"
+
+    # 反向断言：真正有能力的项必须还在，避免"全都过滤掉"也能让上面的断言通过
+    assert 'gptsovits' in options['tts'], "GPT-SoVITS 被误过滤"
+    assert 'vllm_omni' in options['tts'], "vLLM-Omni 被误过滤"
+    assert 'custom' in options['tts'], "自定义 TTS 被误过滤"
+    assert 'qwen' in options['omni'], "Qwen 实时被误过滤"
+    assert 'glm' in options['omni'], "GLM 实时被误过滤"
+    assert 'custom' in options['omni'], "自定义实时端点被误过滤"
+    for sel in ('tts', 'omni'):
+        assert 'follow_core' in options[sel] and 'follow_assist' in options[sel], (
+            f"{sel} 下拉丢了跟随项"
+        )

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -1820,6 +1820,7 @@ def test_saved_incapable_provider_falls_back_and_clears_stale_credentials(
         data['ttsModelApiKey'] = 'sk-stale-deepseek'
         data['omniModelProvider'] = 'claude'
         data['omniModelUrl'] = 'https://api.anthropic.com/v1'
+        data['omniModelApiKey'] = 'sk-stale-claude'
         route.fulfill(response=response, json=data)
 
     mock_page.route("**/api/config/core_api", _seed)
@@ -1839,6 +1840,7 @@ def test_saved_incapable_provider_falls_back_and_clears_stale_credentials(
                 ttsUrl: read('ttsModelUrl'),
                 ttsKey: read('ttsModelApiKey'),
                 omniUrl: read('omniModelUrl'),
+                omniKey: read('omniModelApiKey'),
             };
         }
     """)
@@ -1859,4 +1861,7 @@ def test_saved_incapable_provider_falls_back_and_clears_stale_credentials(
     )
     assert 'anthropic' not in (state['omniUrl'] or ''), (
         f"残留的 Anthropic 端点应被覆盖，实际 omniUrl={state['omniUrl']!r}"
+    )
+    assert 'sk-stale-claude' not in (state['omniKey'] or ''), (
+        f"残留凭证应被覆盖，实际 omniKey={state['omniKey']!r}"
     )

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -1793,3 +1793,70 @@ def test_capability_dropdowns_hide_providers_with_no_implementation(
         assert 'follow_core' in options[sel] and 'follow_assist' in options[sel], (
             f"{sel} 下拉丢了跟随项"
         )
+
+
+@pytest.mark.frontend
+def test_saved_incapable_provider_falls_back_and_clears_stale_credentials(
+    mock_page: Page, running_server: str
+):
+    """A saved pick the backend never honoured must not survive as 'custom'.
+
+    The dropdowns used to offer providers with no TTS / realtime implementation.
+    Those picks did nothing downstream, but the URL and key the page auto-filled
+    for them polluted the slot. On load they now fall back to the slot default —
+    NOT to 'custom', which would promote an LLM chat endpoint into a real
+    self-hosted TTS endpoint and start actually calling it.
+    """
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+
+    def _seed(route):
+        response = route.fetch()
+        data = response.json()
+        data['enableCustomApi'] = True
+        # 存量：TTS / omni 槽各选了一个后端根本没有实现的服务商，
+        # 连带被自动填进去的是该厂商的 LLM 端点与凭证
+        data['ttsModelProvider'] = 'deepseek'
+        data['ttsModelUrl'] = 'https://api.deepseek.com/v1'
+        data['ttsModelApiKey'] = 'sk-stale-deepseek'
+        data['omniModelProvider'] = 'claude'
+        data['omniModelUrl'] = 'https://api.anthropic.com/v1'
+        route.fulfill(response=response, json=data)
+
+    mock_page.route("**/api/config/core_api", _seed)
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#ttsModelProvider option[value='vllm_omni']", state="attached", timeout=10000)
+
+    state = mock_page.evaluate("""
+        () => {
+            const read = id => {
+                const el = document.getElementById(id);
+                return el ? (el.dataset.realKey ?? el.value) : null;
+            };
+            return {
+                ttsProvider: document.getElementById('ttsModelProvider').value,
+                omniProvider: document.getElementById('omniModelProvider').value,
+                ttsUrl: read('ttsModelUrl'),
+                ttsKey: read('ttsModelApiKey'),
+                omniUrl: read('omniModelUrl'),
+            };
+        }
+    """)
+
+    assert state['ttsProvider'] == 'follow_assist', (
+        f"无能力的 TTS 选择应回落该槽默认值，实际={state['ttsProvider']!r}"
+    )
+    assert state['omniProvider'] == 'follow_core', (
+        f"无能力的 omni 选择应回落该槽默认值，实际={state['omniProvider']!r}"
+    )
+    # 关键：绝不能落到 'custom' —— 那会把一个 LLM 端点坐实成自配 TTS/实时端点
+    assert state['ttsProvider'] != 'custom' and state['omniProvider'] != 'custom'
+    assert 'deepseek' not in (state['ttsUrl'] or ''), (
+        f"残留的 LLM 端点应被跟随方的值覆盖，实际 ttsUrl={state['ttsUrl']!r}"
+    )
+    assert 'sk-stale-deepseek' not in (state['ttsKey'] or ''), (
+        f"残留凭证应被覆盖，实际 ttsKey={state['ttsKey']!r}"
+    )
+    assert 'anthropic' not in (state['omniUrl'] or ''), (
+        f"残留的 Anthropic 端点应被覆盖，实际 omniUrl={state['omniUrl']!r}"
+    )

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -1776,8 +1776,10 @@ def test_capability_dropdowns_hide_providers_with_no_implementation(
     for pk in ('deepseek', 'kimi', 'kimi_code', 'claude', 'openrouter', 'silicon'):
         assert pk not in options['tts'], f"TTS 下拉仍暴露无 TTS 能力的 {pk}"
 
-    # 没有 realtime 端点的厂商不该出现在实时全模态下拉里
-    for pk in ('deepseek', 'kimi', 'claude', 'minimax', 'elevenlabs', 'openrouter'):
+    # 没有 realtime 端点的厂商不该出现在实时全模态下拉里。
+    # gemini 在核心表里但没有 core_url —— 它作为核心 API 走 SDK，这个槽表达不了它，
+    # 选中只会静默回落，所以同样属于伪选项。
+    for pk in ('deepseek', 'kimi', 'claude', 'minimax', 'elevenlabs', 'openrouter', 'gemini'):
         assert pk not in options['omni'], f"实时全模态下拉仍暴露无 realtime 能力的 {pk}"
 
     # 反向断言：真正有能力的项必须还在，避免"全都过滤掉"也能让上面的断言通过

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -171,6 +171,49 @@ class TestNamedProviderSlotKey:
         )
 
     @pytest.mark.unit
+    def test_non_string_slot_key_is_normalised(self, config_manager):
+        """A hand-edited non-string slot key must not reach `.strip()` callers.
+
+        brain/openfang_adapter.py strips the agent key straight from
+        get_model_api_config(), so a raw non-string here is an AttributeError
+        during OpenFang sync.
+        """
+        _write_core_config(config_manager, _base_config(
+            agentModelProvider='custom',
+            agentModelId='my-agent',
+            agentModelUrl='https://llm.example.com/v1',
+            agentModelApiKey=98765,
+        ))
+        cfg = config_manager.get_core_config()
+        assert isinstance(cfg['AGENT_MODEL_API_KEY'], str), (
+            "槽位 Key 必须归一化成字符串，实际类型="
+            f"{type(cfg['AGENT_MODEL_API_KEY']).__name__}"
+        )
+        assert cfg['AGENT_MODEL_API_KEY'] == '98765'
+
+    @pytest.mark.unit
+    def test_doubao_tts_keeps_the_slot_as_its_credential_truth(self, config_manager):
+        """Doubao speech reads its key from the slot, not from the key book.
+
+        voice_storage.get_tts_api_key('doubao_tts') is slot-first with the book
+        as fallback, and the save path deliberately preserves a legacy key that
+        only exists on the slot. Redirecting this provider to the book would
+        give one credential two opposite resolution orders.
+        """
+        _write_core_config(config_manager, _base_config(
+            ttsModelProvider='doubao_tts',
+            ttsModelId='doubao-tts',
+            ttsModelUrl='https://openspeech.bytedance.com/api/v3/tts',
+            ttsModelApiKey='ark-slot-key',
+            assistApiKeyDoubaoTts='ark-book-key',
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['TTS_MODEL_API_KEY'] == 'ark-slot-key', (
+            "豆包语音的凭证真相是槽位字段，改道管理簿会与 get_tts_api_key 反向，"
+            f"实际={cfg['TTS_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
     def test_custom_provider_keeps_slot_key(self, config_manager):
         """'custom' is user-typed and must never be redirected to the book."""
         _write_core_config(config_manager, _base_config(
@@ -511,6 +554,39 @@ class TestVisionCredentialBoundary:
         )
         assert client.vision_api_key == 'sk-conversation', (
             "尾斜杠差异不该被当成换了一家而掐掉继承，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
+    def test_path_case_is_not_folded_away(self):
+        """Host case is insignificant; path case is not.
+
+        Two tenants or routes can differ by path case alone. Folding the whole
+        URL would call them the same endpoint and hand one provider's
+        credential to the other.
+        """
+        # 两个 path **只**差大小写：这才是「折叠整条 URL」与「只折叠 scheme/host」
+        # 的分界。差别更大的话两种写法都会判成不同，测不出东西。
+        client = _make_offline_client(
+            base_url='https://api.example.com/v1/TenantA',
+            vision_base_url='https://api.example.com/v1/tenanta',
+            vision_api_key='',
+        )
+        assert client.vision_api_key is None, (
+            "path 大小写不同就是不同路由，不得继承凭证，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
+    def test_host_case_is_still_folded(self):
+        """Scheme and host are case-insensitive per RFC 3986."""
+        client = _make_offline_client(
+            base_url='https://API.Example.com/v1',
+            vision_base_url='https://api.example.com/v1',
+            vision_api_key='',
+        )
+        assert client.vision_api_key == 'sk-conversation', (
+            "host 大小写差异不该被当成换了一家，实际="
             f"{client.vision_api_key!r}"
         )
 

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -308,11 +308,25 @@ class TestRealtimeApiType:
         ))
         rt = config_manager.get_model_api_config('realtime')
         tts = config_manager.get_model_api_config('tts_default')
+        cfg = config_manager.get_core_config()
         assert rt['api_type'] == 'openai', (
             "跨厂商的实时槽覆盖必须被忽略并回落核心 API，"
             f"实际={rt['api_type']!r}"
         )
         assert rt['api_type'] != 'local', "也不能落进未实现的 'local'"
+        # 方言回落还不够：端点和凭证必须**一起**回落。只改方言的话会得到
+        # 「用核心的方言去说另一家的端点」——同样是分裂，只是换了个方向。
+        assert rt['base_url'] == cfg['CORE_URL'], (
+            "实时端点必须跟着方言一起回落核心，"
+            f"实际={rt['base_url']!r}"
+        )
+        assert 'dashscope' not in (rt['base_url'] or ''), (
+            f"被忽略的选择不得把自己的端点留下，实际={rt['base_url']!r}"
+        )
+        assert rt['api_key'] == cfg['CORE_API_KEY'], (
+            "实时凭证同样必须是核心那家的，"
+            f"实际={rt['api_key']!r}"
+        )
         # 派发身份与凭证必须同源：worker 按 api_type 选、凭证走 tts_default
         assert 'dashscope' not in (tts['base_url'] or ''), (
             f"TTS 端点不该被实时槽的选择带偏，实际={tts['base_url']!r}"

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -641,6 +641,23 @@ class TestVisionCredentialBoundary:
         )
 
     @pytest.mark.unit
+    def test_zero_padded_ports_compare_by_value(self):
+        """:0443 is port 443, and :08443 is port 8443 — compare numerically."""
+        from main_logic.omni_offline_client._client import _same_endpoint
+        assert _same_endpoint(
+            'https://api.example.com/v1', 'https://api.example.com:0443/v1'
+        ) is True, "补零的默认端口仍是默认端口"
+        assert _same_endpoint(
+            'http://api.example.com/v1', 'http://api.example.com:00080/v1'
+        ) is True, "补零的 http 默认端口同理"
+        assert _same_endpoint(
+            'https://api.example.com:8443/v1', 'https://api.example.com:08443/v1'
+        ) is True, "非默认端口的前导零也不该造成分歧"
+        assert _same_endpoint(
+            'https://api.example.com:8443/v1', 'https://api.example.com:9443/v1'
+        ) is False, "真正不同的端口仍是不同端点"
+
+    @pytest.mark.unit
     def test_non_default_port_is_a_different_endpoint(self):
         """A real port difference still separates the credentials."""
         client = _make_offline_client(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -325,6 +325,42 @@ class TestFallbackProtocolIsSameOrigin:
         )
 
     @pytest.mark.unit
+    def test_agent_slot_drops_residual_dialect_when_custom_api_off(self, config_manager):
+        """The agent slot bypasses the custom-API gate and needs the same rule.
+
+        `if treat_as_custom or model_type == 'agent'` lets agent into the
+        custom branch even with custom API disabled, so the generic fallback
+        fix does not cover it: URL and key come from assist while the residual
+        dropdown still claimed anthropic.
+        """
+        _write_core_config(config_manager, _base_config(
+            enableCustomApi=False,
+            agentModelProvider='claude',
+            agentModelId='claude-sonnet-4',
+            agentModelUrl='https://api.anthropic.com/v1',
+        ))
+        agent = config_manager.get_model_api_config('agent')
+        assert agent['provider_type'] == 'openai_compatible', (
+            "关掉自定义 API 后 agent 槽的地址已回落 assist，协议不能停在 anthropic，"
+            f"实际={agent['provider_type']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_agent_slot_keeps_dialect_when_custom_api_on(self, config_manager):
+        """With custom API on, an explicit agent dialect is still honoured."""
+        _write_core_config(config_manager, _base_config(
+            agentModelProvider='claude',
+            agentModelId='claude-sonnet-4',
+            agentModelUrl='https://api.anthropic.com/v1',
+            assistApiKeyClaude='sk-ant-book',
+        ))
+        agent = config_manager.get_model_api_config('agent')
+        assert agent['provider_type'] == 'anthropic', (
+            "自定义 API 开着时显式选择必须生效，"
+            f"实际={agent['provider_type']!r}"
+        )
+
+    @pytest.mark.unit
     def test_complete_anthropic_slot_still_speaks_anthropic(self, config_manager):
         """A genuinely complete anthropic slot keeps its protocol."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -129,6 +129,44 @@ class TestNamedProviderSlotKey:
         )
 
     @pytest.mark.unit
+    def test_path_case_makes_the_url_foreign(self, config_manager):
+        """`/V1` is not `/v1` — HTTP paths are case-sensitive.
+
+        The first version of this guard lowercased the whole URL, which let a
+        case-swapped path pass as one of the provider's candidates.
+        """
+        _write_core_config(config_manager, _base_config(
+            conversationModelProvider='deepseek',
+            conversationModelId='deepseek-v4-flash',
+            conversationModelUrl='https://api.deepseek.com/V1',
+            assistApiKeyDeepseek='DEEPSEEK-REAL-KEY',
+        ))
+        conv = config_manager.get_model_api_config('conversation')
+        assert conv['api_key'] != 'DEEPSEEK-REAL-KEY', (
+            "path 大小写不同就是另一条路由，不该被当成该服务商的候选端点，"
+            f"实际={conv['api_key']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_explicit_default_port_still_matches_the_provider(self, config_manager):
+        """`:443` on https is the default port — still the provider's own URL.
+
+        The first version compared raw strings, so writing the default port out
+        rejected a legitimate endpoint and dropped the key.
+        """
+        _write_core_config(config_manager, _base_config(
+            conversationModelProvider='deepseek',
+            conversationModelId='deepseek-v4-flash',
+            conversationModelUrl='https://api.deepseek.com:443/v1',
+            assistApiKeyDeepseek='DEEPSEEK-REAL-KEY',
+        ))
+        conv = config_manager.get_model_api_config('conversation')
+        assert conv['api_key'] == 'DEEPSEEK-REAL-KEY', (
+            "写出默认端口仍是同一个端点，不该因此拒发管理簿 Key，"
+            f"实际={conv['api_key']!r}"
+        )
+
+    @pytest.mark.unit
     def test_legacy_slot_key_survives_when_key_book_empty(self, config_manager):
         """Key-book-less legacy configs keep using the stored slot key."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -290,17 +290,36 @@ class TestRealtimeApiType:
         )
 
     @pytest.mark.unit
-    def test_named_realtime_provider_keeps_its_identity(self, config_manager):
-        """An explicitly picked realtime provider is not flattened to 'local'."""
+    def test_named_realtime_provider_never_diverges_from_core(self, config_manager):
+        """A per-slot realtime provider must not split the audio stack.
+
+        api_type becomes the process-wide core api type, which also selects the
+        TTS worker and the audio credential. Honouring a divergent pick gave a
+        Qwen TTS worker holding the OpenAI core key: silent, and one vendor's
+        credential sent to another. One identity only.
+        """
         _write_core_config(config_manager, _base_config(
-            omniModelProvider='glm',
-            omniModelId='glm-realtime-air',
-            omniModelUrl='wss://open.bigmodel.cn/api/paas/v4/realtime',
+            coreApi='openai',
+            assistApi='openai',
+            assistApiKeyQwen='sk-qwen-book',
+            omniModelProvider='qwen',
+            omniModelId='qwen3.5-omni-flash-realtime',
+            omniModelUrl='wss://dashscope.aliyuncs.com/api-ws/v1/realtime',
         ))
         rt = config_manager.get_model_api_config('realtime')
-        assert rt['api_type'] == 'glm', (
-            "显式选中的实时服务商必须保住身份，不能变成未实现的 'local'，"
+        tts = config_manager.get_model_api_config('tts_default')
+        assert rt['api_type'] == 'openai', (
+            "跨厂商的实时槽覆盖必须被忽略并回落核心 API，"
             f"实际={rt['api_type']!r}"
+        )
+        assert rt['api_type'] != 'local', "也不能落进未实现的 'local'"
+        # 派发身份与凭证必须同源：worker 按 api_type 选、凭证走 tts_default
+        assert 'dashscope' not in (tts['base_url'] or ''), (
+            f"TTS 端点不该被实时槽的选择带偏，实际={tts['base_url']!r}"
+        )
+        assert tts['api_key'] == rt['api_key'], (
+            "实时与 TTS 的凭证必须来自同一家，"
+            f"realtime={rt['api_key']!r} tts={tts['api_key']!r}"
         )
 
     @pytest.mark.unit
@@ -323,17 +342,12 @@ class TestRealtimeApiType:
         )
 
     @pytest.mark.unit
-    def test_core_provider_without_a_realtime_endpoint_is_ignored(self, config_manager):
-        """Being in the core table is not the same as having a realtime endpoint.
+    def test_core_provider_pick_is_ignored_too(self, config_manager):
+        """Even a real core provider is ignored in this slot.
 
-        Gemini is a core provider but owns no CORE_URL — as a core API it goes
-        through the SDK, never through this slot. Honouring it here would give
-        a slot that can never assemble a complete custom triple.
+        Being a valid core API says nothing about whether this slot can express
+        it: the whole audio stack carries one provider identity.
         """
-        from utils.api_config_loader import get_core_api_profiles
-        assert not (get_core_api_profiles().get('gemini') or {}).get('CORE_URL'), (
-            "本用例的前提是 gemini 没有 CORE_URL；前提变了就要重写判据"
-        )
         # 带上一条残留 URL（换 provider 时留下的）。没有它，URL 本来就是空的、
         # 自定义分支根本走不到，改动与否结果都一样 —— 这条残留正是唯一的分界。
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -649,6 +649,48 @@ class TestFallbackProtocolIsSameOrigin:
         )
 
     @pytest.mark.unit
+    def test_incomplete_named_slot_drops_the_dialect_even_with_custom_api_on(self, config_manager):
+        """A back-filled URL must not keep the dropdown's protocol.
+
+        Gating on ENABLE_CUSTOM_API is not enough: with it on but the slot left
+        incomplete, upstream fills AGENT_MODEL_URL from the assist endpoint
+        (it has a VISION → OPENROUTER fallback chain), the custom branch then
+        accepts the triple as complete, and the residual dropdown value still
+        claimed anthropic — an assist address wearing another vendor's protocol.
+        """
+        _write_core_config(config_manager, _base_config(
+            agentModelProvider='claude',
+            agentModelId='claude-sonnet-4',
+            agentModelUrl='',  # 没填完 → 上游回填成 assist 地址
+            assistApiKeyClaude='sk-ant-book',
+        ))
+        cfg = config_manager.get_core_config()
+        agent = config_manager.get_model_api_config('agent')
+        assert agent['base_url'] == cfg['OPENROUTER_URL'], (
+            f"前提：URL 被回填成了 assist 地址，实际={agent['base_url']!r}"
+        )
+        assert agent['provider_type'] == 'openai_compatible', (
+            "地址来自 assist 时协议必须跟着 assist，"
+            f"实际={agent['provider_type']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_complete_named_slot_keeps_its_dialect(self, config_manager):
+        """The guard must not strip the dialect from a genuinely complete slot."""
+        _write_core_config(config_manager, _base_config(
+            agentModelProvider='claude',
+            agentModelId='claude-sonnet-4',
+            agentModelUrl='https://api.anthropic.com/v1',
+            assistApiKeyClaude='sk-ant-book',
+        ))
+        agent = config_manager.get_model_api_config('agent')
+        assert agent['provider_type'] == 'anthropic', (
+            "填了该服务商自己的地址时协议必须生效，"
+            f"实际={agent['provider_type']!r}"
+        )
+        assert agent['api_key'] == 'sk-ant-book'
+
+    @pytest.mark.unit
     def test_complete_anthropic_slot_still_speaks_anthropic(self, config_manager):
         """A genuinely complete anthropic slot keeps its protocol."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -1,0 +1,399 @@
+"""Regression tests for explicitly-configured custom API slots.
+
+Covers four defects that all made an explicit configuration silently not take
+effect (issue #2886):
+
+1. A named-provider slot resolved its key from the slot field, which the
+   settings page can only ever fill with the redaction sentinel, so the key
+   landed as an empty string.
+2. A realtime slot stamped ``api_type='local'`` unconditionally, an
+   unimplemented branch that also leaks into the global core api type.
+3. A slot that falls back to core/assist kept the protocol implied by its
+   residual dropdown value, producing an address/protocol mismatch.
+4. The vision endpoint and the vision key fell back independently, so a
+   vision-only endpoint could be called with the conversation provider's
+   credential.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+
+@pytest.fixture()
+def config_manager(clean_user_data_dir):
+    """Return the patched ConfigManager singleton pointing at a temp dir."""
+    from utils.config_manager import get_config_manager
+    cm = get_config_manager('N.E.K.O')
+    cm.config_dir.mkdir(parents=True, exist_ok=True)
+    yield cm
+
+
+def _write_core_config(cm, data: dict):
+    """Write core_config.json into the temp config dir and clear cache."""
+    path = cm.get_config_path('core_config.json')
+    with open(str(path), 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+    cm._core_config_cache = None
+
+
+def _base_config(**overrides):
+    """A minimal saved config with custom API enabled."""
+    data = {
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'coreApiKey': 'sk-core',
+        'assistApiKeyQwen': 'sk-core',
+        'enableCustomApi': True,
+    }
+    data.update(overrides)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# 1. Named-provider slot keys come from the API key book
+# ---------------------------------------------------------------------------
+class TestNamedProviderSlotKey:
+
+    @pytest.mark.unit
+    def test_named_provider_slot_reads_key_book(self, config_manager):
+        """A slot pinned to deepseek uses the key book entry for deepseek."""
+        _write_core_config(config_manager, _base_config(
+            conversationModelProvider='deepseek',
+            conversationModelId='deepseek-v4-flash',
+            conversationModelUrl='https://api.deepseek.com/v1',
+            assistApiKeyDeepseek='sk-deepseek-book',
+            # 前端只能把脱敏哨兵拷进槽位字段，落盘后是空串
+            conversationModelApiKey='',
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['CONVERSATION_MODEL_API_KEY'] == 'sk-deepseek-book', (
+            "具名 provider 槽必须从管理簿取 Key，实际="
+            f"{cfg['CONVERSATION_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_named_provider_slot_self_heals_existing_broken_config(self, config_manager):
+        """An already-broken saved config resolves without needing a re-save."""
+        _write_core_config(config_manager, _base_config(
+            visionModelProvider='glm',
+            visionModelId='glm-4v',
+            visionModelUrl='https://open.bigmodel.cn/api/paas/v4',
+            assistApiKeyGlm='sk-glm-book',
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['VISION_MODEL_API_KEY'] == 'sk-glm-book', (
+            "槽位字段缺失时也应从管理簿解析，实际="
+            f"{cfg['VISION_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_legacy_slot_key_survives_when_key_book_empty(self, config_manager):
+        """Key-book-less legacy configs keep using the stored slot key."""
+        _write_core_config(config_manager, _base_config(
+            summaryModelProvider='openai',
+            summaryModelId='gpt-5-mini',
+            summaryModelUrl='https://api.openai.com/v1',
+            summaryModelApiKey='sk-legacy-slot',
+            # 管理簿里没有 openai 这一条
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['SUMMARY_MODEL_API_KEY'] == 'sk-legacy-slot', (
+            "管理簿为空时必须保住槽位存量 Key，实际="
+            f"{cfg['SUMMARY_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_custom_provider_keeps_slot_key(self, config_manager):
+        """'custom' is user-typed and must never be redirected to the book."""
+        _write_core_config(config_manager, _base_config(
+            correctionModelProvider='custom',
+            correctionModelId='my-model',
+            correctionModelUrl='http://localhost:11434/v1',
+            correctionModelApiKey='sk-typed-by-user',
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['CORRECTION_MODEL_API_KEY'] == 'sk-typed-by-user', (
+            "custom 槽的 Key 必须用用户手填值，实际="
+            f"{cfg['CORRECTION_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_custom_provider_allows_empty_key(self, config_manager):
+        """A keyless local endpoint stays keyless (no key-book borrowing)."""
+        _write_core_config(config_manager, _base_config(
+            correctionModelProvider='custom',
+            correctionModelId='llama3',
+            correctionModelUrl='http://localhost:11434/v1',
+            correctionModelApiKey='',
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['CORRECTION_MODEL_API_KEY'] == '', (
+            "本地无鉴权端点不应被塞进任何 Key，实际="
+            f"{cfg['CORRECTION_MODEL_API_KEY']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Realtime api_type reflects the provider actually selected
+# ---------------------------------------------------------------------------
+class TestRealtimeApiType:
+
+    @pytest.mark.unit
+    def test_user_typed_endpoint_is_local(self, config_manager):
+        """'custom' keeps the original 'local' meaning: a self-hosted endpoint."""
+        _write_core_config(config_manager, _base_config(
+            omniModelProvider='custom',
+            omniModelId='my-realtime',
+            omniModelUrl='ws://localhost:8000/v1/realtime',
+        ))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'local', f"实际={rt['api_type']!r}"
+        assert rt['base_url'] == 'ws://localhost:8000/v1/realtime'
+
+    @pytest.mark.unit
+    def test_named_realtime_provider_keeps_its_identity(self, config_manager):
+        """An explicitly picked realtime provider is not flattened to 'local'."""
+        _write_core_config(config_manager, _base_config(
+            omniModelProvider='glm',
+            omniModelId='glm-realtime-air',
+            omniModelUrl='wss://open.bigmodel.cn/api/paas/v4/realtime',
+        ))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'glm', (
+            "显式选中的实时服务商必须保住身份，不能变成未实现的 'local'，"
+            f"实际={rt['api_type']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_provider_without_realtime_support_is_ignored(self, config_manager):
+        """A text-only provider picked for omni falls back to the core API."""
+        _write_core_config(config_manager, _base_config(
+            coreApi='qwen',
+            omniModelProvider='deepseek',
+            omniModelId='deepseek-v4-flash',
+            omniModelUrl='https://api.deepseek.com/v1',
+        ))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'qwen', (
+            "没有 realtime 实现的服务商应被忽略并回落核心 API，"
+            f"实际={rt['api_type']!r}"
+        )
+        assert 'deepseek' not in (rt['base_url'] or ''), (
+            "被忽略的选择不得把自己的 URL 留在实时槽里，"
+            f"实际 base_url={rt['base_url']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_follow_core_uses_core_api_type(self, config_manager):
+        """The default follow_core value keeps tracking the core provider."""
+        _write_core_config(config_manager, _base_config(
+            coreApi='step',
+            assistApi='step',
+            omniModelProvider='follow_core',
+        ))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'step', f"实际={rt['api_type']!r}"
+
+    @pytest.mark.unit
+    def test_realtime_api_type_never_local_without_custom(self, config_manager):
+        """No named provider may produce the unimplemented 'local' dialect."""
+        from utils.api_config_loader import get_core_api_profiles
+        for provider in get_core_api_profiles():
+            _write_core_config(config_manager, _base_config(
+                omniModelProvider=provider,
+                omniModelId='some-model',
+                omniModelUrl='wss://example.invalid/realtime',
+            ))
+            rt = config_manager.get_model_api_config('realtime')
+            assert rt['api_type'] != 'local', (
+                f"provider={provider} 不该落进未实现的 'local' 分支"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Fallback slots keep protocol and address same-origin
+# ---------------------------------------------------------------------------
+class TestFallbackProtocolIsSameOrigin:
+
+    @pytest.mark.unit
+    def test_residual_anthropic_provider_does_not_survive_disable(self, config_manager):
+        """Turning custom API off drops the residual anthropic protocol."""
+        _write_core_config(config_manager, _base_config(
+            enableCustomApi=False,
+            summaryModelProvider='claude',
+            summaryModelId='claude-sonnet-4',
+            summaryModelUrl='https://api.anthropic.com/v1',
+        ))
+        cfg = config_manager.get_core_config()
+        summary = config_manager.get_model_api_config('summary')
+        assert summary['provider_type'] == 'openai_compatible', (
+            "关掉自定义 API 后地址已回落 assist，协议必须同源回落，"
+            f"实际={summary['provider_type']!r}"
+        )
+        assert summary['base_url'] == cfg['OPENROUTER_URL'], (
+            "回退分支的地址应当就是 assist 的地址，"
+            f"实际={summary['base_url']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_incomplete_custom_slot_does_not_keep_anthropic(self, config_manager):
+        """An incomplete anthropic slot falls back protocol-and-address together."""
+        _write_core_config(config_manager, _base_config(
+            emotionModelProvider='claude',
+            emotionModelId='claude-sonnet-4',
+            emotionModelUrl='',
+        ))
+        emotion = config_manager.get_model_api_config('emotion')
+        assert emotion['provider_type'] == 'openai_compatible', (
+            "URL 不完整时该槽已回落 assist，协议不能停在 anthropic，"
+            f"实际={emotion['provider_type']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_core_fallback_slot_uses_the_core_protocol(self, config_manager):
+        """The core-fallback branch (tts_default / realtime) is same-origin too.
+
+        The TTS dropdown used to offer every assist provider, so a residual
+        'claude' can sit in a saved config while the slot itself falls back to
+        the core API. Address comes from core, protocol must too.
+        """
+        _write_core_config(config_manager, _base_config(
+            coreApi='qwen',
+            enableCustomApi=False,
+            ttsModelProvider='claude',
+        ))
+        cfg = config_manager.get_core_config()
+        tts = config_manager.get_model_api_config('tts_default')
+        assert tts['provider_type'] == 'openai_compatible', (
+            "回落到核心 API 的槽必须用核心 API 的协议，"
+            f"实际={tts['provider_type']!r}"
+        )
+        assert tts['base_url'] == cfg['CORE_URL'], (
+            f"回退地址应为 CORE_URL，实际={tts['base_url']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_complete_anthropic_slot_still_speaks_anthropic(self, config_manager):
+        """A genuinely complete anthropic slot keeps its protocol."""
+        _write_core_config(config_manager, _base_config(
+            emotionModelProvider='claude',
+            emotionModelId='claude-sonnet-4',
+            emotionModelUrl='https://api.anthropic.com/v1',
+            assistApiKeyClaude='sk-ant-book',
+        ))
+        emotion = config_manager.get_model_api_config('emotion')
+        assert emotion['provider_type'] == 'anthropic', (
+            "配置完整时必须真的走 Anthropic 协议，"
+            f"实际={emotion['provider_type']!r}"
+        )
+        assert emotion['base_url'] == 'https://api.anthropic.com/v1'
+        assert emotion['api_key'] == 'sk-ant-book'
+
+
+# ---------------------------------------------------------------------------
+# 4. Vision endpoint and vision key fall back as a pair
+# ---------------------------------------------------------------------------
+def _make_offline_client(**kwargs):
+    """Build an OmniOfflineClient without touching the network."""
+    from main_logic.omni_offline_client import OmniOfflineClient
+    params = {
+        'base_url': 'https://api.deepseek.com/v1',
+        'api_key': 'sk-conversation',
+        'model': 'deepseek-v4-flash',
+    }
+    params.update(kwargs)
+    return OmniOfflineClient(**params)
+
+
+class TestVisionCredentialBoundary:
+
+    @pytest.mark.unit
+    def test_separate_vision_endpoint_does_not_borrow_conversation_key(self):
+        """A vision-only endpoint with no key must not send the chat credential."""
+        client = _make_offline_client(
+            vision_base_url='https://generativelanguage.googleapis.com/v1beta',
+            vision_api_key='',
+            vision_model='gemini-3.1-flash',
+        )
+        assert client.vision_api_key is None, (
+            "视觉端点与对话端点不同源时不得继承对话凭证，实际="
+            f"{client.vision_api_key!r}"
+        )
+        assert client.vision_base_url == 'https://generativelanguage.googleapis.com/v1beta'
+
+    @pytest.mark.unit
+    def test_same_endpoint_still_inherits_key(self):
+        """Same-origin vision config keeps inheriting, as before."""
+        client = _make_offline_client(
+            vision_base_url='https://api.deepseek.com/v1',
+            vision_api_key='',
+        )
+        assert client.vision_api_key == 'sk-conversation', (
+            "同源时应继续继承对话 Key，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
+    def test_unset_vision_endpoint_inherits_both(self):
+        """No vision override at all keeps the original inheritance."""
+        client = _make_offline_client()
+        assert client.vision_base_url == 'https://api.deepseek.com/v1'
+        assert client.vision_api_key == 'sk-conversation'
+
+    @pytest.mark.unit
+    def test_explicit_vision_key_is_used(self):
+        """An explicitly configured vision key is used on its own endpoint."""
+        client = _make_offline_client(
+            vision_base_url='https://generativelanguage.googleapis.com/v1beta',
+            vision_api_key='sk-vision-own',
+        )
+        assert client.vision_api_key == 'sk-vision-own'
+
+
+# ---------------------------------------------------------------------------
+# 5. Realtime wire dialect is keyed on the real api_type vocabulary
+# ---------------------------------------------------------------------------
+class TestRealtimeDialectNormalisation:
+
+    @pytest.mark.unit
+    def test_openai_maps_to_the_gpt_wire_branch(self):
+        from main_logic.omni_realtime_client._shared import canonical_realtime_dialect
+        assert canonical_realtime_dialect('openai') == 'gpt', (
+            "CORE_API_TYPE 的真实取值是 'openai'，必须命中 gpt 分支"
+        )
+
+    @pytest.mark.unit
+    def test_qwen_intl_maps_to_the_qwen_wire_branch(self):
+        from main_logic.omni_realtime_client._shared import canonical_realtime_dialect
+        assert canonical_realtime_dialect('qwen_intl') == 'qwen'
+
+    @pytest.mark.unit
+    def test_unknown_and_legacy_values_pass_through(self):
+        from main_logic.omni_realtime_client._shared import canonical_realtime_dialect
+        assert canonical_realtime_dialect('gpt') == 'gpt'
+        assert canonical_realtime_dialect('glm') == 'glm'
+        assert canonical_realtime_dialect('') == ''
+        assert canonical_realtime_dialect(None) == ''
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_openai_session_receives_mid_session_tool_updates(self):
+        """The call site, not just the predicate: 'openai' must push tools."""
+        from tests.unit.test_tool_calling import _make_rt_client
+
+        client, sent = _make_rt_client('openai')
+
+        async def fake_update_session(payload, _sent=sent):
+            _sent.append(payload)
+
+        client.update_session = fake_update_session
+        await client.apply_tools_to_session()
+
+        assert sent, "OpenAI 会话的中途工具更新被静默丢弃了"
+        assert 'tools' in sent[0], f"实际推送内容={sent[0]!r}"
+        assert sent[0].get('tool_choice') == 'auto'

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -605,8 +605,18 @@ class TestVisionCredentialBoundary:
             ('http://api.example.com:99999999/v1', 'http://api.example.com:1/v1'),
             ('http://[::1]:abc/v1', 'http://[::1]:abc/v1'),
             ('::::', 'http://api.example.com/v1'),
+            # urlsplit 自己就会对未闭合的 IPv6 抛 ValueError
+            ('http://[::1', 'http://api.example.com/v1'),
+            ('http://[::1/v1', 'http://[::1/v1'),
         ):
             _same_endpoint(a, b)  # 不抛就是通过
+
+        assert _same_endpoint('http://[::1/v1', 'http://[::1/v1') is True, (
+            "解析不了时按原串比，两个相同的坏 URL 仍是同源"
+        )
+        assert _same_endpoint('http://[::1/v1', 'http://[::2/v1') is False, (
+            "解析不了时两个不同的坏 URL 仍是不同源"
+        )
 
         assert _same_endpoint(
             'http://api.example.com:not-a-port/v1',

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -346,6 +346,18 @@ class TestVisionCredentialBoundary:
         assert client.vision_api_key == 'sk-conversation'
 
     @pytest.mark.unit
+    def test_cosmetic_url_difference_is_still_same_origin(self):
+        """A trailing slash must not read as 'a different provider'."""
+        client = _make_offline_client(
+            vision_base_url='https://api.deepseek.com/v1/',
+            vision_api_key='',
+        )
+        assert client.vision_api_key == 'sk-conversation', (
+            "尾斜杠差异不该被当成换了一家而掐掉继承，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
     def test_explicit_vision_key_is_used(self):
         """An explicitly configured vision key is used on its own endpoint."""
         client = _make_offline_client(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -591,6 +591,33 @@ class TestVisionCredentialBoundary:
         )
 
     @pytest.mark.unit
+    def test_same_endpoint_is_total_on_malformed_urls(self):
+        """The predicate must never raise — it runs inside __init__.
+
+        urlsplit defers malformed-port errors to the moment ``.port`` is read,
+        so reading it here would turn a broken URL into a ValueError during
+        construction. (httpx rejects such a URL a moment later anyway, so this
+        is about keeping the predicate total, not about rescuing the config.)
+        """
+        from main_logic.omni_offline_client._client import _same_endpoint
+        for a, b in (
+            ('http://api.example.com:not-a-port/v1', 'http://api.example.com:not-a-port/v1'),
+            ('http://api.example.com:99999999/v1', 'http://api.example.com:1/v1'),
+            ('http://[::1]:abc/v1', 'http://[::1]:abc/v1'),
+            ('::::', 'http://api.example.com/v1'),
+        ):
+            _same_endpoint(a, b)  # 不抛就是通过
+
+        assert _same_endpoint(
+            'http://api.example.com:not-a-port/v1',
+            'http://API.example.com:not-a-port/v1',
+        ) is True, "host 大小写仍应折叠"
+        assert _same_endpoint(
+            'http://api.example.com:99999999/v1',
+            'http://api.example.com:1/v1',
+        ) is False, "端口串不同就是不同端点"
+
+    @pytest.mark.unit
     def test_host_case_is_still_folded(self):
         """Scheme and host are case-insensitive per RFC 3986."""
         client = _make_offline_client(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -108,6 +108,25 @@ class TestNamedProviderSlotKey:
         )
 
     @pytest.mark.unit
+    def test_non_string_key_book_value_does_not_crash_config_read(self, config_manager):
+        """core_config.json is hand-editable; a non-string key must not kill startup.
+
+        get_core_config() runs on every config read, so an AttributeError here
+        is a crash-on-launch, not a degraded slot.
+        """
+        _write_core_config(config_manager, _base_config(
+            conversationModelProvider='deepseek',
+            conversationModelId='deepseek-v4-flash',
+            conversationModelUrl='https://api.deepseek.com/v1',
+            assistApiKeyDeepseek=12345,
+        ))
+        cfg = config_manager.get_core_config()
+        assert cfg['CONVERSATION_MODEL_API_KEY'] == '12345', (
+            "非字符串管理簿值应被安全转成字符串而不是抛异常，实际="
+            f"{cfg['CONVERSATION_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
     def test_custom_provider_keeps_slot_key(self, config_manager):
         """'custom' is user-typed and must never be redirected to the book."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -578,6 +578,19 @@ class TestVisionCredentialBoundary:
         )
 
     @pytest.mark.unit
+    def test_userinfo_case_is_not_folded_away(self):
+        """netloc carries userinfo, and usernames/passwords are case-sensitive."""
+        client = _make_offline_client(
+            base_url='https://User:PASS@api.example.com/v1',
+            vision_base_url='https://user:pass@api.example.com/v1',
+            vision_api_key='',
+        )
+        assert client.vision_api_key is None, (
+            "userinfo 大小写不同就是不同凭据主体，不得继承，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
     def test_host_case_is_still_folded(self):
         """Scheme and host are case-insensitive per RFC 3986."""
         client = _make_offline_client(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -641,6 +641,17 @@ class TestVisionCredentialBoundary:
         )
 
     @pytest.mark.unit
+    def test_only_one_trailing_slash_is_cosmetic(self):
+        """`/v1/` vs `/v1` is a writing difference; `/v1/` vs `/v1//` is not."""
+        from main_logic.omni_offline_client._client import _same_endpoint
+        assert _same_endpoint(
+            'https://api.example.com/v1', 'https://api.example.com/v1/'
+        ) is True, "单个尾斜杠是写法差异"
+        assert _same_endpoint(
+            'https://api.example.com/v1/', 'https://api.example.com/v1//'
+        ) is False, "重复斜杠是两条不同的 HTTP 路径，不得折平"
+
+    @pytest.mark.unit
     def test_zero_padded_ports_compare_by_value(self):
         """:0443 is port 443, and :08443 is port 8443 — compare numerically."""
         from main_logic.omni_offline_client._client import _same_endpoint
@@ -648,8 +659,14 @@ class TestVisionCredentialBoundary:
             'https://api.example.com/v1', 'https://api.example.com:0443/v1'
         ) is True, "补零的默认端口仍是默认端口"
         assert _same_endpoint(
+            'http://api.example.com/v1', 'http://api.example.com:80/v1'
+        ) is True, "http 的默认端口是 80，不是 443"
+        assert _same_endpoint(
             'http://api.example.com/v1', 'http://api.example.com:00080/v1'
         ) is True, "补零的 http 默认端口同理"
+        assert _same_endpoint(
+            'http://api.example.com/v1', 'http://api.example.com:443/v1'
+        ) is False, "443 不是 http 的默认端口，不该被抹掉"
         assert _same_endpoint(
             'https://api.example.com:8443/v1', 'https://api.example.com:08443/v1'
         ) is True, "非默认端口的前导零也不该造成分歧"

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -416,6 +416,39 @@ class TestRealtimeApiType:
         )
 
     @pytest.mark.unit
+    def test_follow_assist_on_omni_resolves_against_core(self, config_manager):
+        """The omni slot follows the core API even when set to follow_assist.
+
+        The realtime session, its TTS worker and its credential all belong to
+        the core provider. Deriving this slot's key from the assist provider
+        left an assist credential paired with the core endpoint in the
+        snapshot — currently unreachable (REALTIME_MODEL_URL stays empty under
+        follow_*, so the custom triple never completes), but one change away
+        from going live.
+        """
+        _write_core_config(config_manager, {
+            'coreApi': 'openai',
+            'assistApi': 'qwen',
+            'coreApiKey': 'sk-openai-core',
+            'assistApiKeyOpenai': 'sk-openai-core',
+            'assistApiKeyQwen': 'sk-qwen-assist',
+            'enableCustomApi': True,
+            'omniModelProvider': 'follow_assist',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['REALTIME_MODEL_API_KEY'] != 'sk-qwen-assist', (
+            "实时槽的 Key 不该来自辅助 API —— 那会与核心端点配成跨厂商组合，"
+            f"实际={cfg['REALTIME_MODEL_API_KEY']!r}"
+        )
+        assert cfg['REALTIME_MODEL_API_KEY'] == cfg['CORE_API_KEY'], (
+            f"应与核心同源，实际={cfg['REALTIME_MODEL_API_KEY']!r}"
+        )
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'openai'
+        assert rt['api_key'] == cfg['CORE_API_KEY']
+        assert rt['base_url'] == cfg['CORE_URL']
+
+    @pytest.mark.unit
     def test_follow_core_uses_core_api_type(self, config_manager):
         """The default follow_core value keeps tracking the core provider."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -127,6 +127,50 @@ class TestNamedProviderSlotKey:
         )
 
     @pytest.mark.unit
+    def test_core_key_fallback_does_not_override_a_stored_slot_key(self, config_manager):
+        """ASSIST_API_KEY_* is derived from CORE_API_KEY for the active provider.
+
+        That derivation is a default, not a key-book entry, so it must not
+        outrank a key a legacy config stored on the slot itself.
+        """
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'coreApiKey': 'sk-core-key',
+            'enableCustomApi': True,
+            'summaryModelProvider': 'qwen',
+            'summaryModelId': 'qwen3.7-plus',
+            'summaryModelUrl': 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+            'summaryModelApiKey': 'sk-slot-specific',
+            # 管理簿里没有 qwen 这一条 —— ASSIST_API_KEY_QWEN 只会是 _fb() 派生值
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['SUMMARY_MODEL_API_KEY'] == 'sk-slot-specific', (
+            "派生的核心 Key 不该压过槽位存量 Key，实际="
+            f"{cfg['SUMMARY_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_explicit_key_book_entry_outranks_the_slot(self, config_manager):
+        """An actually-stored key-book entry is still the truth."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'coreApiKey': 'sk-core-key',
+            'enableCustomApi': True,
+            'summaryModelProvider': 'qwen',
+            'summaryModelId': 'qwen3.7-plus',
+            'summaryModelUrl': 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+            'summaryModelApiKey': 'sk-stale-slot',
+            'assistApiKeyQwen': 'sk-book-current',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['SUMMARY_MODEL_API_KEY'] == 'sk-book-current', (
+            "管理簿里真存的那条必须优先，实际="
+            f"{cfg['SUMMARY_MODEL_API_KEY']!r}"
+        )
+
+    @pytest.mark.unit
     def test_custom_provider_keeps_slot_key(self, config_manager):
         """'custom' is user-typed and must never be redirected to the book."""
         _write_core_config(config_manager, _base_config(
@@ -232,6 +276,36 @@ class TestRealtimeApiType:
         )
         assert 'deepseek' not in (rt['base_url'] or ''), (
             "被忽略的选择不得把自己的 URL 留在实时槽里，"
+            f"实际 base_url={rt['base_url']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_core_provider_without_a_realtime_endpoint_is_ignored(self, config_manager):
+        """Being in the core table is not the same as having a realtime endpoint.
+
+        Gemini is a core provider but owns no CORE_URL — as a core API it goes
+        through the SDK, never through this slot. Honouring it here would give
+        a slot that can never assemble a complete custom triple.
+        """
+        from utils.api_config_loader import get_core_api_profiles
+        assert not (get_core_api_profiles().get('gemini') or {}).get('CORE_URL'), (
+            "本用例的前提是 gemini 没有 CORE_URL；前提变了就要重写判据"
+        )
+        # 带上一条残留 URL（换 provider 时留下的）。没有它，URL 本来就是空的、
+        # 自定义分支根本走不到，改动与否结果都一样 —— 这条残留正是唯一的分界。
+        _write_core_config(config_manager, _base_config(
+            coreApi='qwen',
+            omniModelProvider='gemini',
+            omniModelId='gemini-live',
+            omniModelUrl='wss://open.bigmodel.cn/api/paas/v4/realtime',
+        ))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'qwen', (
+            "没有 realtime 端点的核心服务商应被忽略并回落核心 API，"
+            f"实际={rt['api_type']!r}"
+        )
+        assert 'bigmodel' not in (rt['base_url'] or ''), (
+            "被忽略的选择不得把残留 URL 留在实时槽里，"
             f"实际 base_url={rt['base_url']!r}"
         )
 

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -175,6 +175,34 @@ class TestRealtimeApiType:
         assert rt['base_url'] == 'ws://localhost:8000/v1/realtime'
 
     @pytest.mark.unit
+    def test_legacy_hand_typed_endpoint_stays_local(self, config_manager):
+        """Configs predating omniModelProvider keep their previous behaviour.
+
+        Those users typed a realtime endpoint by hand and there is no provider
+        key to read; narrowing 'local' must not change what they get.
+        """
+        _write_core_config(config_manager, _base_config(
+            omniModelId='my-legacy-realtime',
+            omniModelUrl='ws://192.168.1.50:8000/v1/realtime',
+        ))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'local', (
+            "手填过实时端点的老配置行为必须与改动前一致，"
+            f"实际={rt['api_type']!r}"
+        )
+        assert rt['base_url'] == 'ws://192.168.1.50:8000/v1/realtime'
+
+    @pytest.mark.unit
+    def test_no_saved_omni_url_is_not_treated_as_custom(self, config_manager):
+        """A never-configured omni slot is not a hand-typed endpoint."""
+        _write_core_config(config_manager, _base_config(coreApi='glm', assistApi='glm'))
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'glm', (
+            "没存过 omni URL 的配置不该被当成自配端点，"
+            f"实际={rt['api_type']!r}"
+        )
+
+    @pytest.mark.unit
     def test_named_realtime_provider_keeps_its_identity(self, config_manager):
         """An explicitly picked realtime provider is not flattened to 'local'."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -214,6 +214,41 @@ class TestNamedProviderSlotKey:
         )
 
     @pytest.mark.unit
+    @pytest.mark.parametrize('provider', ['minimax', 'minimax_intl', 'elevenlabs', 'deepseek'])
+    def test_tts_slot_never_resolves_a_key_from_the_key_book(self, config_manager, provider):
+        """The TTS slot must not pull a vendor key out of the API key book.
+
+        Several entries reachable from the TTS dropdown are selected by voice
+        metadata, not by ttsModelProvider, so dispatch keeps using the core
+        provider's worker. Resolving the picked vendor's real key into
+        TTS_MODEL_API_KEY therefore handed one vendor's credential to another's
+        TTS endpoint. TTS credentials live on the slot field and each
+        provider's own resolution path; this pins that boundary.
+        """
+        _write_core_config(config_manager, {
+            'coreApi': 'step',
+            'assistApi': 'step',
+            'coreApiKey': 'sk-step-core',
+            'assistApiKeyStep': 'sk-step-core',
+            'assistApiKeyMinimax': 'MINIMAX-REAL-KEY',
+            'assistApiKeyMinimaxIntl': 'MINIMAX-INTL-REAL-KEY',
+            'assistApiKeyElevenlabs': 'ELEVEN-REAL-KEY',
+            'assistApiKeyDeepseek': 'DEEPSEEK-REAL-KEY',
+            'enableCustomApi': True,
+            'ttsModelProvider': provider,
+            'ttsModelId': 'some-tts-model',
+            'ttsModelUrl': 'https://api.minimaxi.com/v1',
+        })
+        cfg = config_manager.get_core_config()
+        resolved = cfg['TTS_MODEL_API_KEY']
+        for leaked in ('MINIMAX-REAL-KEY', 'MINIMAX-INTL-REAL-KEY',
+                       'ELEVEN-REAL-KEY', 'DEEPSEEK-REAL-KEY'):
+            assert resolved != leaked, (
+                f"TTS 槽把 {provider} 的管理簿 Key 解析了出来，它会被送给核心厂商的 "
+                f"TTS 端点，实际={resolved!r}"
+            )
+
+    @pytest.mark.unit
     def test_custom_provider_keeps_slot_key(self, config_manager):
         """'custom' is user-typed and must never be redirected to the book."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -618,6 +618,42 @@ class TestVisionCredentialBoundary:
         ) is False, "端口串不同就是不同端点"
 
     @pytest.mark.unit
+    def test_explicit_default_port_is_same_endpoint(self):
+        """https://h/v1 and https://h:443/v1 are the same endpoint."""
+        client = _make_offline_client(
+            base_url='https://api.example.com/v1',
+            vision_base_url='https://api.example.com:443/v1',
+            vision_api_key='',
+        )
+        assert client.vision_api_key == 'sk-conversation', (
+            "写出默认端口不该被当成换了一家，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
+    def test_non_default_port_is_a_different_endpoint(self):
+        """A real port difference still separates the credentials."""
+        client = _make_offline_client(
+            base_url='https://api.example.com/v1',
+            vision_base_url='https://api.example.com:8443/v1',
+            vision_api_key='',
+        )
+        assert client.vision_api_key is None, (
+            "非默认端口是不同端点，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
+    def test_missing_credentials_are_normalised_to_none(self):
+        """Absent credentials use one representation, not '' on one side."""
+        client = _make_offline_client(api_key='', vision_api_key='')
+        assert client.api_key is None
+        assert client.vision_api_key is None, (
+            "无凭证应统一表示成 None，实际="
+            f"{client.vision_api_key!r}"
+        )
+
+    @pytest.mark.unit
     def test_host_case_is_still_folded(self):
         """Scheme and host are case-insensitive per RFC 3986."""
         client = _make_offline_client(

--- a/tests/unit/test_custom_api_slot_resolution.py
+++ b/tests/unit/test_custom_api_slot_resolution.py
@@ -92,6 +92,43 @@ class TestNamedProviderSlotKey:
         )
 
     @pytest.mark.unit
+    def test_key_book_secret_is_withheld_from_a_foreign_url(self, config_manager):
+        """A provider's key may only be paired with that provider's endpoint.
+
+        Configs that went through the settings page always agree (picking a
+        provider overwrites the slot URL with its own, read-only). Imported or
+        hand-edited configs can pair a provider with another vendor's URL —
+        resolving the key book there sends one vendor's credential to another.
+        """
+        _write_core_config(config_manager, _base_config(
+            conversationModelProvider='deepseek',
+            conversationModelId='deepseek-v4-flash',
+            # 另一家的端点（存量 / 导入 / 手改）
+            conversationModelUrl='https://api.openai.com/v1',
+            assistApiKeyDeepseek='DEEPSEEK-REAL-KEY',
+        ))
+        conv = config_manager.get_model_api_config('conversation')
+        assert conv['api_key'] != 'DEEPSEEK-REAL-KEY', (
+            "端点不属于该服务商时不得交出它的管理簿 Key，"
+            f"base_url={conv['base_url']!r} api_key={conv['api_key']!r}"
+        )
+
+    @pytest.mark.unit
+    def test_key_book_secret_is_used_for_the_providers_own_url(self, config_manager):
+        """The guard must not withhold the key on a legitimate pairing."""
+        _write_core_config(config_manager, _base_config(
+            conversationModelProvider='deepseek',
+            conversationModelId='deepseek-v4-flash',
+            conversationModelUrl='https://api.deepseek.com/v1/',  # 尾斜杠写法差异
+            assistApiKeyDeepseek='DEEPSEEK-REAL-KEY',
+        ))
+        conv = config_manager.get_model_api_config('conversation')
+        assert conv['api_key'] == 'DEEPSEEK-REAL-KEY', (
+            "同家端点必须照常拿到管理簿 Key（尾斜杠不算换了一家），"
+            f"实际={conv['api_key']!r}"
+        )
+
+    @pytest.mark.unit
     def test_legacy_slot_key_survives_when_key_book_empty(self, config_manager):
         """Key-book-less legacy configs keep using the stored slot key."""
         _write_core_config(config_manager, _base_config(

--- a/tests/unit/test_endpoint_identity.py
+++ b/tests/unit/test_endpoint_identity.py
@@ -34,6 +34,8 @@ SAME = [
     ('非默认端口前导零', 'https://api.example.com:08443/v1', 'https://api.example.com:8443/v1'),
     ('IPv6 压缩与展开', 'http://[2001:0db8:0:0:0:0:0:1]:8080/v1', 'http://[2001:db8::1]:8080/v1'),
     ('IPv6 大小写', 'http://[2001:DB8::1]/v1', 'http://[2001:db8::1]/v1'),
+    ('scoped IPv6 地址大小写', 'https://[FE80::1%eth0]/v1', 'https://[fe80::1%eth0]/v1'),
+    ('scoped IPv6 地址展开', 'https://[fe80:0:0:0:0:0:0:1%eth0]/v1', 'https://[fe80::1%eth0]/v1'),
     ('host 尾点(DNS 根)', 'https://api.example.com./v1', 'https://api.example.com/v1'),
     ('尾点+大小写', 'https://API.Example.COM./v1', 'https://api.example.com/v1'),
     ('同样写坏的 URL', 'http://[::1/v1', 'http://[::1/v1'),
@@ -51,6 +53,8 @@ DIFFERENT = [
     ('不同 scheme', 'https://api.example.com/v1', 'http://api.example.com/v1'),
     ('不同 path', 'https://api.example.com/v1', 'https://api.example.com/v2'),
     ('不同 IPv6', 'http://[2001:db8::1]/v1', 'http://[2001:db8::2]/v1'),
+    ('IPv6 zone id 大小写', 'https://[fe80::1%eth0]/v1', 'https://[fe80::1%ETH0]/v1'),
+    ('IPv6 不同 zone', 'https://[fe80::1%eth0]/v1', 'https://[fe80::1%eth1]/v1'),
     ('host 双尾点', 'https://api.example.com../v1', 'https://api.example.com/v1'),
     ('写坏但不同', 'http://[::1/v1', 'http://[::2/v1'),
 ]

--- a/tests/unit/test_endpoint_identity.py
+++ b/tests/unit/test_endpoint_identity.py
@@ -1,0 +1,99 @@
+"""Table-driven contract for utils.http.url endpoint identity.
+
+Two callers depend on this predicate to decide whether one provider's
+credential may travel with a given URL:
+
+* the vision slot, deciding whether it may inherit the chat credential;
+* the config layer, deciding whether a key-book secret matches a slot URL.
+
+Both need it wrong in the safe direction, so the contract is enumerated by
+CLASS here rather than grown one reported edge case at a time — the earlier
+per-edge approach is exactly what let the same mistakes reappear in a second
+hand-rolled copy.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from utils.http.url import endpoint_identity, same_endpoint  # noqa: E402
+
+
+# (标签, a, b) —— 这些写法差异不改变端点身份
+SAME = [
+    ('scheme 大小写', 'HTTPS://api.example.com/v1', 'https://api.example.com/v1'),
+    ('host 大小写', 'https://API.Example.COM/v1', 'https://api.example.com/v1'),
+    ('单个尾斜杠', 'https://api.example.com/v1/', 'https://api.example.com/v1'),
+    ('https 默认端口', 'https://api.example.com:443/v1', 'https://api.example.com/v1'),
+    ('http 默认端口', 'http://api.example.com:80/v1', 'http://api.example.com/v1'),
+    ('wss 默认端口', 'wss://api.example.com:443/rt', 'wss://api.example.com/rt'),
+    ('端口前导零', 'https://api.example.com:0443/v1', 'https://api.example.com/v1'),
+    ('非默认端口前导零', 'https://api.example.com:08443/v1', 'https://api.example.com:8443/v1'),
+    ('IPv6 压缩与展开', 'http://[2001:0db8:0:0:0:0:0:1]:8080/v1', 'http://[2001:db8::1]:8080/v1'),
+    ('IPv6 大小写', 'http://[2001:DB8::1]/v1', 'http://[2001:db8::1]/v1'),
+    ('同样写坏的 URL', 'http://[::1/v1', 'http://[::1/v1'),
+]
+
+# (标签, a, b) —— 这些差异**必须**判为不同端点，否则凭证会跨边界
+DIFFERENT = [
+    ('path 大小写', 'https://api.example.com/v1/TenantA', 'https://api.example.com/v1/tenanta'),
+    ('query 大小写', 'https://api.example.com/v1?Key=A', 'https://api.example.com/v1?key=a'),
+    ('userinfo 大小写', 'https://User:PASS@api.example.com/v1', 'https://user:pass@api.example.com/v1'),
+    ('重复尾斜杠', 'https://api.example.com/v1/', 'https://api.example.com/v1//'),
+    ('非默认端口', 'https://api.example.com:8443/v1', 'https://api.example.com/v1'),
+    ('不同端口', 'https://api.example.com:8443/v1', 'https://api.example.com:9443/v1'),
+    ('不同 host', 'https://api.example.com/v1', 'https://api.other.com/v1'),
+    ('不同 scheme', 'https://api.example.com/v1', 'http://api.example.com/v1'),
+    ('不同 path', 'https://api.example.com/v1', 'https://api.example.com/v2'),
+    ('不同 IPv6', 'http://[2001:db8::1]/v1', 'http://[2001:db8::2]/v1'),
+    ('写坏但不同', 'http://[::1/v1', 'http://[::2/v1'),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('label,a,b', SAME, ids=[c[0] for c in SAME])
+def test_cosmetic_differences_keep_one_identity(label, a, b):
+    assert same_endpoint(a, b) is True, f'{label}: {a!r} 应与 {b!r} 同源'
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('label,a,b', DIFFERENT, ids=[c[0] for c in DIFFERENT])
+def test_significant_differences_split_identity(label, a, b):
+    assert same_endpoint(a, b) is False, f'{label}: {a!r} 不应与 {b!r} 同源'
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('blank', ['', '   ', None])
+def test_blank_never_matches_anything(blank):
+    """A blank URL has no identity, so it matches nothing — including itself."""
+    assert endpoint_identity(blank) is None
+    assert same_endpoint(blank, 'https://api.example.com/v1') is False
+    assert same_endpoint(blank, blank) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('bad', [
+    'http://[::1',            # 未闭合 IPv6 —— urlsplit 自己会抛
+    'http://[::1/v1',
+    'http://h:not-a-port/v1',  # 非数字端口 —— 读 .port 会抛
+    'http://h:99999999/v1',    # 越界端口
+    '::::',
+    'not a url at all',
+])
+def test_predicate_is_total(bad):
+    """It runs inside constructors and config reads; raising means nothing works."""
+    endpoint_identity(bad)
+    same_endpoint(bad, 'https://api.example.com/v1')
+    same_endpoint('https://api.example.com/v1', bad)
+
+
+@pytest.mark.unit
+def test_identity_tuples_have_a_uniform_shape():
+    """Parsed and unparsed branches must not rely on differing tuple lengths."""
+    ok = endpoint_identity('https://api.example.com/v1')
+    bad = endpoint_identity('http://[::1')
+    assert len(ok) == len(bad), f'{len(ok)} vs {len(bad)}'
+    assert ok[0] is True and bad[0] is False

--- a/tests/unit/test_endpoint_identity.py
+++ b/tests/unit/test_endpoint_identity.py
@@ -34,6 +34,8 @@ SAME = [
     ('非默认端口前导零', 'https://api.example.com:08443/v1', 'https://api.example.com:8443/v1'),
     ('IPv6 压缩与展开', 'http://[2001:0db8:0:0:0:0:0:1]:8080/v1', 'http://[2001:db8::1]:8080/v1'),
     ('IPv6 大小写', 'http://[2001:DB8::1]/v1', 'http://[2001:db8::1]/v1'),
+    ('host 尾点(DNS 根)', 'https://api.example.com./v1', 'https://api.example.com/v1'),
+    ('尾点+大小写', 'https://API.Example.COM./v1', 'https://api.example.com/v1'),
     ('同样写坏的 URL', 'http://[::1/v1', 'http://[::1/v1'),
 ]
 
@@ -49,6 +51,7 @@ DIFFERENT = [
     ('不同 scheme', 'https://api.example.com/v1', 'http://api.example.com/v1'),
     ('不同 path', 'https://api.example.com/v1', 'https://api.example.com/v2'),
     ('不同 IPv6', 'http://[2001:db8::1]/v1', 'http://[2001:db8::2]/v1'),
+    ('host 双尾点', 'https://api.example.com../v1', 'https://api.example.com/v1'),
     ('写坏但不同', 'http://[::1/v1', 'http://[::2/v1'),
 ]
 

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -344,3 +344,63 @@ class TestSyncConfigKeyFreeProvider:
         adapter = OpenFangAdapter()
         result = self._run(adapter.sync_config())
         assert result is False
+
+
+# ── _write_openfang_model_config: the persisted config.toml path ──
+
+
+class TestWriteOpenFangModelConfig:
+    """The persisted config.toml must agree with the runtime provider push.
+
+    This path had no coverage at all, which is how a `self` reference slipped
+    into a @staticmethod: nothing ever executed the function.
+    """
+
+    def _write(self, tmp_path, monkeypatch, **kwargs):
+        from brain.openfang_adapter import OpenFangAdapter
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        OpenFangAdapter._write_openfang_model_config(**kwargs)
+        return (tmp_path / ".openfang" / "config.toml").read_text(encoding="utf-8")
+
+    def test_writes_without_a_bound_instance(self, tmp_path, monkeypatch):
+        """It is a @staticmethod — it must not reach for `self`."""
+        content = self._write(
+            tmp_path, monkeypatch,
+            api_key="sk-x", base_url="https://api.openai.com/v1", model="gpt-5",
+        )
+        assert 'provider = "openai"' in content, f"实际写出=\n{content}"
+
+    def test_caller_supplied_provider_info_wins(self, tmp_path, monkeypatch):
+        """A declared Anthropic endpoint must not be re-detected as openai."""
+        content = self._write(
+            tmp_path, monkeypatch,
+            api_key="sk-x",
+            base_url="https://llm.example.com/anthropic",
+            model="claude-sonnet-4",
+            pinfo={
+                "provider": "anthropic",
+                "needs_proxy": False,
+                "effective_url": "https://llm.example.com/anthropic",
+                "api_key_env": "ANTHROPIC_API_KEY",
+            },
+        )
+        assert 'provider = "anthropic"' in content, f"实际写出=\n{content}"
+        assert 'api_key_env = "ANTHROPIC_API_KEY"' in content
+        assert "https://llm.example.com/anthropic" in content
+
+    def test_falls_back_to_detection_when_not_supplied(self, tmp_path, monkeypatch):
+        """Other call sites that pass no pinfo keep the old behaviour."""
+        content = self._write(
+            tmp_path, monkeypatch,
+            api_key="sk-x", base_url="https://api.kimi.com/coding", model="kimi-for-coding",
+        )
+        assert 'provider = "anthropic"' in content, f"实际写出=\n{content}"
+
+    def test_plaintext_key_is_never_persisted(self, tmp_path, monkeypatch):
+        """Guard the existing invariant while touching this function."""
+        content = self._write(
+            tmp_path, monkeypatch,
+            api_key="sk-super-secret-value", base_url="https://api.openai.com/v1", model="gpt-5",
+        )
+        assert "sk-super-secret-value" not in content, "明文密钥不得落盘"

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -440,3 +440,45 @@ class TestProviderTypeIsEvidenceOfLastResort:
         )
         assert r["provider"] == "anthropic", f"实际={r['provider']!r}"
         assert r["needs_proxy"] is False
+
+
+class TestEvidenceOutranksDeclarationOutranksModelName:
+    """The routing order is host/port/path evidence > declaration > model-name guess.
+
+    The middle rung is what makes a self-hosted Anthropic gateway usable: its
+    model IDs are arbitrary, so a name containing another vendor's word must
+    not outrank the slot's explicit protocol declaration.
+    """
+
+    def test_declared_anthropic_beats_a_deepseek_model_name(self):
+        r = _detect_provider_info(
+            "https://llm.example.com/anthropic", "deepseek-r1", provider_type="anthropic"
+        )
+        assert r["provider"] == "anthropic", f"实际={r['provider']!r}"
+        assert r["api_key_env"] == "ANTHROPIC_API_KEY"
+
+    def test_declared_anthropic_beats_a_groq_model_name(self):
+        r = _detect_provider_info(
+            "https://llm.example.com/anthropic", "groq-llama-70b", provider_type="anthropic"
+        )
+        assert r["provider"] == "anthropic", f"实际={r['provider']!r}"
+
+    def test_host_evidence_still_beats_the_declaration(self):
+        """Splitting the branches must not let the declaration climb over hosts."""
+        for url, expected in (
+            ("https://api.groq.com/openai/v1", "groq"),
+            ("https://api.deepseek.com/v1", "deepseek"),
+            ("https://api.openai.com/v1", "openai"),
+            ("http://localhost:11434/v1", "ollama"),
+        ):
+            r = _detect_provider_info(url, "some-model", provider_type="anthropic")
+            assert r["provider"] == expected, f"{url} 实际={r['provider']!r}"
+
+    def test_model_name_guess_still_works_without_a_declaration(self):
+        """The relocated heuristics keep their old behaviour when nothing declares."""
+        assert _detect_provider_info(
+            "https://custom-endpoint.example.com/v1", "groq-llama-70b"
+        )["provider"] == "groq"
+        assert _detect_provider_info(
+            "https://custom.example.com/v1", "deepseek-r1"
+        )["provider"] == "deepseek"

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -404,3 +404,39 @@ class TestWriteOpenFangModelConfig:
             api_key="sk-super-secret-value", base_url="https://api.openai.com/v1", model="gpt-5",
         )
         assert "sk-super-secret-value" not in content, "明文密钥不得落盘"
+
+
+class TestProviderTypeIsEvidenceOfLastResort:
+    """A declared dialect must not outrank what the URL already proves.
+
+    provider_type is a claim carried by the slot; the host checks above it are
+    evidence. If the claim wins, a residual 'anthropic' on a slot whose URL is
+    really an OpenAI-compatible proxy routes the agent to a direct Anthropic
+    call that cannot succeed.
+    """
+
+    def test_declared_anthropic_does_not_hijack_a_known_openai_host(self):
+        r = _detect_provider_info(
+            "https://api.openai.com/v1", "gpt-5", provider_type="anthropic"
+        )
+        assert r["provider"] == "openai", f"实际={r['provider']!r}"
+
+    def test_declared_anthropic_does_not_hijack_an_openrouter_proxy(self):
+        r = _detect_provider_info(
+            "https://openrouter.ai/api/v1", "some-model", provider_type="anthropic"
+        )
+        assert r["provider"] == "openai", f"实际={r['provider']!r}"
+        assert r["needs_proxy"] is True
+
+    def test_declared_anthropic_does_not_hijack_a_local_ollama(self):
+        r = _detect_provider_info(
+            "http://localhost:11434/v1", "llama3", provider_type="anthropic"
+        )
+        assert r["provider"] == "ollama", f"实际={r['provider']!r}"
+
+    def test_declaration_still_wins_when_nothing_else_matched(self):
+        r = _detect_provider_info(
+            "https://llm.example.com/anthropic", "claude-sonnet-4", provider_type="anthropic"
+        )
+        assert r["provider"] == "anthropic", f"实际={r['provider']!r}"
+        assert r["needs_proxy"] is False

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -30,6 +30,38 @@ class TestDetectProviderInfo:
         assert r["needs_proxy"] is False
         assert r["api_key_env"] == "ANTHROPIC_API_KEY"
 
+    def test_kimi_code_is_anthropic_not_an_openai_proxy(self):
+        """kimi_code speaks Anthropic Messages; it must not fall to the proxy.
+
+        The provider was added in #1948 with provider_type=anthropic, but the
+        detector only knew anthropic.com, so an agent slot pinned to kimi_code
+        landed in the openai + needs_proxy catch-all.
+        """
+        r = _detect_provider_info("https://api.kimi.com/coding", "kimi-for-coding")
+        assert r["provider"] == "anthropic", f"实际={r['provider']!r}"
+        assert r["needs_proxy"] is False, "Anthropic 方言端点不应绕 LLM proxy"
+        assert r["effective_url"] == "https://api.kimi.com/coding"
+        assert r["api_key_env"] == "ANTHROPIC_API_KEY"
+
+    def test_declared_anthropic_provider_type_wins_over_unknown_host(self):
+        """A self-hosted Anthropic endpoint is honoured when the slot says so."""
+        r = _detect_provider_info(
+            "https://llm.example.com/anthropic",
+            "claude-sonnet-4",
+            provider_type="anthropic",
+        )
+        assert r["provider"] == "anthropic", f"实际={r['provider']!r}"
+        assert r["needs_proxy"] is False
+
+    def test_openai_compatible_provider_type_is_not_forced_to_anthropic(self):
+        """The new parameter must not hijack ordinary OpenAI-compatible slots."""
+        r = _detect_provider_info(
+            "https://api.deepseek.com/v1",
+            "deepseek-chat",
+            provider_type="openai_compatible",
+        )
+        assert r["provider"] == "deepseek", f"实际={r['provider']!r}"
+
     def test_openai_by_url(self):
         r = _detect_provider_info("https://api.openai.com/v1", "gpt-4.1")
         assert r["provider"] == "openai"

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1797,7 +1797,7 @@ class CoreConfigMixin:
             silence, plus one vendor's credential sent to another. The audio
             stack has exactly one provider identity; a per-slot override cannot
             express a second one, so it is not offered (the omni dropdown lists
-            only follow_* and 自定义) and not honoured here.
+            only the follow options and the custom entry) and not honoured here.
             """
             omni_provider = str(core_config.get('omniModelProvider') or '').strip()
             if omni_provider == 'custom':

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -912,6 +912,13 @@ class CoreConfigMixin:
         neither claims a provider identity of its own.
         """
         candidate = (provider or '').strip()
+        # follow_assist 在这个槽上没有独立含义：实时会话跟的是核心 API。前端早就
+        # 这么做了（omni 分支的 follow_assist 取的是**核心** provider 的 url/key），
+        # 只有后端的 Key 派生还在按 assist 走，于是快照里留下一把「assist 的 Key
+        # 配核心的端点」。目前它到不了下游（follow_* 下 REALTIME_MODEL_URL 恒为空，
+        # 自定义三元组凑不齐），但那是个只等一次改动就会点着的陷阱。归一掉。
+        if candidate == 'follow_assist':
+            return 'follow_core'
         if not candidate or candidate == 'custom' or candidate.startswith('follow_'):
             return candidate
         # 落回 follow_core 而不是空串：空串会让下面的 URL/模型/Key 覆盖分支照旧

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1463,7 +1463,10 @@ class CoreConfigMixin:
                     # 注册表里的 provider）时回落到槽位存储值，保住这些既有路径。
                     cfg_key = core_cfg.get(f'{prefix}ModelApiKey')
                     _book_field = assist_api_key_fields.get(provider) if provider else ''
-                    _book_key = (config.get(_book_field) or '').strip() if _book_field else ''
+                    # core_config.json 是用户可手改的文件，管理簿字段里可能落进任意
+                    # JSON 类型。这里先转字符串再 strip —— 直接 .strip() 会让整个
+                    # get_core_config() 抛 AttributeError，那是启动即崩。
+                    _book_key = str(config.get(_book_field) or '').strip() if _book_field else ''
                     if _book_key:
                         config[apikey_key] = _book_key
                     elif cfg_key is not None:

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -889,6 +889,30 @@ class CoreConfigMixin:
         candidates = set(self._provider_url_candidates(profile, url_key, list_key))
         return saved_url if saved_url in candidates else ''
 
+    @staticmethod
+    def _normalize_realtime_provider(provider: str, core_api_profiles: dict) -> str:
+        """Drop an omni-slot provider that has no realtime implementation.
+
+        The omni dropdown is filled from the assist (text-LLM) provider table,
+        so it offers providers that own no realtime endpoint at all.  Picking
+        one used to be honoured downstream: the frontend auto-fills the slot
+        URL, ``get_model_api_config`` then sees a complete custom triple and
+        stamps ``api_type='local'`` — a branch that was never implemented, and
+        which leaks into the global core api type.  Treating such a pick as
+        "not selected" makes it fall back to the core API, which is what the
+        user already gets today minus the broken realtime session.
+
+        ``follow_*``, ``custom`` and the empty legacy value pass through: they
+        are not claims about a named provider's realtime support.
+        """
+        candidate = (provider or '').strip()
+        if not candidate or candidate == 'custom' or candidate.startswith('follow_'):
+            return candidate
+        # 落回 follow_core 而不是空串：空串会让下面的 URL/模型/Key 覆盖分支照旧
+        # 写入前端自动填好的残留值，follow_core 才是「等同于没选」的既有路径
+        # （URL 跳过、模型回落 CORE_MODEL、Key 取 CORE_API_KEY）。
+        return candidate if candidate in core_api_profiles else 'follow_core'
+
     def get_core_config(self):
         """Read core config dynamically"""
         # Late-bound through the package facade so existing
@@ -1222,8 +1246,13 @@ class CoreConfigMixin:
             'conversation', 'summary', 'gameMain', 'gameSummary', 'correction',
             'emotion', 'vision', 'agent', 'omni', 'tts',
         ):
-            config[f'{_model_provider_prefix}ModelProvider'] = str(
+            _raw_provider = str(
                 core_cfg.get(f'{_model_provider_prefix}ModelProvider', '') or ''
+            )
+            config[f'{_model_provider_prefix}ModelProvider'] = (
+                self._normalize_realtime_provider(_raw_provider, core_api_profiles)
+                if _model_provider_prefix == 'omni'
+                else _raw_provider
             )
         config['ttsModelUrl'] = str(core_cfg.get('ttsModelUrl', '') or '')
         config['ttsModelId'] = str(core_cfg.get('ttsModelId', '') or '')
@@ -1327,7 +1356,10 @@ class CoreConfigMixin:
                 ('tts',          'TTS_MODEL',           'TTS_MODEL_URL',          'TTS_MODEL_API_KEY'),
             ]
             for prefix, model_key, url_key, apikey_key in _custom_api_fields:
-                provider = core_cfg.get(f'{prefix}ModelProvider', '')
+                # 读上面归一化过的快照值而不是 core_cfg 原值：omni 槽选了一个没有
+                # realtime 实现的服务商时，快照已把它落回 follow_core，URL/模型/Key
+                # 三条覆盖必须跟着走同一条路，否则残留的自动填充值还是会被写进去。
+                provider = config.get(f'{prefix}ModelProvider', '')
                 # follow_core / follow_assist 的 URL 是前端联动 readonly 自填的提示值
                 # （static/js/api_key_settings.js: onCustomModelProviderChange），不代表
                 # 用户选择"自定义部署"。但只在 omni/tts 才会出问题：
@@ -1392,7 +1424,8 @@ class CoreConfigMixin:
                 # API Key 处理：
                 #   follow_core   → 从核心 API Key 派生
                 #   follow_assist → 从辅助 API Key 派生（OPENROUTER_API_KEY 已含 assist→core 回退）
-                #   具体服务商/custom/''(老配置) → 使用存储值（空串合法，本地服务商不需要 key）
+                #   具名服务商    → 从 API 管理簿（ASSIST_API_KEY_*）解析，见下方 _book_key
+                #   custom/''(老配置) → 使用存储值（空串合法，本地服务商不需要 key）
                 #
                 # GSV 启用 + prefix='tts' + ttsModelProvider 默认 'follow_*' 时跳过派生：
                 # 派生会把 TTS_MODEL_API_KEY 写成 OPENROUTER_API_KEY / CORE_API_KEY（这俩是
@@ -1417,8 +1450,23 @@ class CoreConfigMixin:
                 elif provider == 'follow_summary':
                     config[apikey_key] = config.get('SUMMARY_MODEL_API_KEY', '')
                 else:
+                    # 具名服务商槽：Key 的唯一真相是 API 管理簿（ASSIST_API_KEY_*），
+                    # 不是槽位字段。前端在选中服务商时把管理簿的值拷进只读的槽位输入框
+                    # （api_key_settings.js: onCustomModelProviderChange → setKeyReadonly），
+                    # 但 GET /core_api 已把管理簿脱敏成哨兵（#2559），拷过去的是哨兵，
+                    # 保存时被 apply_core_config_secret_update 拒写 —— 槽位字段因此永远
+                    # 停在空串，运行时拿空 Key 请求。改为在这里直接读管理簿：
+                    #   - 存量已经写坏的配置无需重新保存即可自愈；
+                    #   - 与「Key 从 API 管理簿自动填充」这个只读 UI 语义对齐；
+                    #   - 不碰哨兵不落盘这条安全不变量。
+                    # 管理簿没有该服务商（custom / 老配置的 '' / gptsovits 这类只在 TTS
+                    # 注册表里的 provider）时回落到槽位存储值，保住这些既有路径。
                     cfg_key = core_cfg.get(f'{prefix}ModelApiKey')
-                    if cfg_key is not None:
+                    _book_field = assist_api_key_fields.get(provider) if provider else ''
+                    _book_key = (config.get(_book_field) or '').strip() if _book_field else ''
+                    if _book_key:
+                        config[apikey_key] = _book_key
+                    elif cfg_key is not None:
                         config[apikey_key] = cfg_key
 
             # TTS Voice ID 作为角色 voice_id 的回退
@@ -1673,6 +1721,23 @@ class CoreConfigMixin:
                 return _normalize_provider_type_value(core_config.get('PROVIDER_TYPE'))
             return _provider_type_from_assist_key(provider)
 
+        def _resolved_realtime_api_type() -> str:
+            """Wire dialect for a custom-configured realtime session.
+
+            ``local`` is reserved for an endpoint the user typed themselves; a
+            named provider keeps its own identity so the session speaks that
+            provider's realtime dialect instead of an unimplemented one.
+            ``get_core_config`` has already dropped names with no realtime
+            implementation, so anything reaching here is either genuine or a
+            follow value.
+            """
+            omni_provider = str(core_config.get('omniModelProvider') or '').strip()
+            if omni_provider == 'custom':
+                return 'local'
+            if omni_provider and not omni_provider.startswith('follow_'):
+                return omni_provider
+            return str(core_config.get('CORE_API_TYPE', '') or '')
+
         if model_type == 'game_main':
             provider = str(core_config.get('gameMainModelProvider') or 'follow_conversation').strip()
             if not treat_as_custom or provider == 'follow_conversation':
@@ -1714,9 +1779,14 @@ class CoreConfigMixin:
                     'base_url': custom_url,
                     'is_custom': treat_as_custom,
                     'provider_type': _resolved_provider_type_for_model(model_type),
-                    # 对于 realtime 模型，自定义配置时 api_type 设为 'local'
-                    # TODO: 后续完善 'local' 类型的具体实现（如本地推理服务等）
-                    'api_type': 'local' if model_type == 'realtime' else None,
+                    # realtime 的 api_type 必须表达「这个 WebSocket 说的是谁家的方言」。
+                    # 原来这里无条件写 'local'，而 'local' 至今没有实现，还会经
+                    # lifecycle 的 core_api_type 赋值污染全局（TTS 因此落 dummy）。
+                    # 只有用户自己填的端点才是真 'local'；显式选中的具名服务商要保住
+                    # 自己的身份，其余（follow_core / 老配置空值）跟随核心 API。
+                    'api_type': (
+                        _resolved_realtime_api_type() if model_type == 'realtime' else None
+                    ),
                 }
         
         # 自定义音色(CosyVoice)的特殊回退逻辑：优先尝试用户保存的 Qwen Cosyvoice API，
@@ -1765,6 +1835,12 @@ class CoreConfigMixin:
                 }
 
         # 根据 fallback_type 回退到不同的 API
+        #
+        # 协议必须与地址同源。这里返回的 base_url / api_key 全部来自 core（或下面的
+        # assist），而 provider_type 原本走 _resolved_provider_type_for_model —— 那是
+        # 按槽位下拉值解析的，且下拉值不受 ENABLE_CUSTOM_API 门控。于是「把某槽选成
+        # claude/kimi_code 之后再关掉自定义 API」会得到 assist 的地址+Key 配 Anthropic
+        # 协议，该槽的请求直接打死。回退分支按回退目标取协议，错配就不可能构造出来。
         if mapping['fallback_type'] == 'core':
             # 回退到核心 API 配置
             return {
@@ -1772,7 +1848,9 @@ class CoreConfigMixin:
                 'api_key': core_config.get('CORE_API_KEY', ''),
                 'base_url': core_config.get('CORE_URL', ''),
                 'is_custom': False,
-                'provider_type': _resolved_provider_type_for_model(model_type),
+                'provider_type': _provider_type_from_core_key(
+                    core_config.get('CORE_API_TYPE', '')
+                ),
                 # 对于 realtime 模型，回退到核心API时使用配置的 CORE_API_TYPE
                 'api_type': core_config.get('CORE_API_TYPE', '') if model_type == 'realtime' else None,
             }
@@ -1781,13 +1859,15 @@ class CoreConfigMixin:
         elif mapping['fallback_type'] == 'summary':
             return self.get_model_api_config('summary', _core_config=core_config)
         else:
-            # 回退到辅助 API 配置
+            # 回退到辅助 API 配置（协议同源，理由见上面 fallback 分支的注释）
             return {
                 'model': core_config.get(mapping['default_model'], ''),
                 'api_key': core_config.get('OPENROUTER_API_KEY', ''),
                 'base_url': core_config.get('OPENROUTER_URL', ''),
                 'is_custom': False,
-                'provider_type': _resolved_provider_type_for_model(model_type),
+                'provider_type': _normalize_provider_type_value(
+                    core_config.get('PROVIDER_TYPE')
+                ),
             }
 
     def is_agent_api_ready(self) -> tuple[bool, list[str]]:

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1807,6 +1807,42 @@ class CoreConfigMixin:
                 return _provider_type_from_core_key(core_config.get('CORE_API_TYPE', ''))
             if provider == 'follow_assist':
                 return _normalize_provider_type_value(core_config.get('PROVIDER_TYPE'))
+            def _fallback_provider_type() -> str:
+                """Protocol of whatever this slot actually falls back to."""
+                fallback_type = model_type_mapping.get(target_model_type, {}).get('fallback_type')
+                if fallback_type == 'core':
+                    return _provider_type_from_core_key(core_config.get('CORE_API_TYPE', ''))
+                if fallback_type == 'conversation':
+                    return _resolved_provider_type_for_model('conversation', seen)
+                if fallback_type == 'summary':
+                    return _resolved_provider_type_for_model('summary', seen)
+                return _normalize_provider_type_value(core_config.get('PROVIDER_TYPE'))
+
+            # 具名服务商的**协议**同样只在「这个槽的 URL 确实属于它」时才成立。
+            # 槽位没填完时上游会把 URL 回填成 assist 的地址（AGENT_MODEL_URL 尤其
+            # 明显：它有一条 VISION → OPENROUTER 的兜底链），此时仍按下拉值取协议，
+            # 就造出「assist 地址 + Anthropic 协议」——这正是 Fix D 要消灭的错配，
+            # 只是从「关掉自定义 API」换成了「开着但槽位没填完」这条入口。
+            #
+            # 判据与凭证那一处共用（same_endpoint + provider 候选集）：协议和凭证
+            # 要么一起给、要么一起不给，不会出现「按 A 家协议、拿 B 家的 key」。
+            if provider:
+                _slot_url = str(
+                    core_config.get(
+                        model_type_mapping.get(target_model_type, {}).get('custom_url', '')
+                    ) or ''
+                ).strip()
+                if _slot_url:
+                    _profile = get_assist_api_profiles().get(provider)
+                    _candidates = (
+                        self._provider_url_candidates(
+                            _profile, 'OPENROUTER_URL', 'OPENROUTER_URLS'
+                        )
+                        if isinstance(_profile, dict)
+                        else []
+                    )
+                    if not any(same_endpoint(_slot_url, c) for c in _candidates):
+                        return _fallback_provider_type()
             if not provider:
                 fallback_type = model_type_mapping.get(target_model_type, {}).get('fallback_type')
                 if fallback_type == 'core':

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1791,7 +1791,18 @@ class CoreConfigMixin:
                     'api_key': resolved_api_key,
                     'base_url': custom_url,
                     'is_custom': treat_as_custom,
-                    'provider_type': _resolved_provider_type_for_model(model_type),
+                    # 槽位下拉值只在「该槽的自定义配置真的生效」时才代表协议。
+                    # agent 槽是唯一会绕过 treat_as_custom 直接进这个分支的
+                    # （上面的 `if treat_as_custom or model_type == 'agent'`），
+                    # 关掉自定义 API 后它的 URL/Key 已经回落 assist，协议必须跟着回落，
+                    # 否则残留的 claude/kimi_code 会配出「assist 地址 + Anthropic 协议」。
+                    # GSV 那条路 treat_as_custom 为真（= enable_custom_api or gsv_enabled），
+                    # 不受影响。
+                    'provider_type': (
+                        _resolved_provider_type_for_model(model_type)
+                        if treat_as_custom
+                        else _normalize_provider_type_value(core_config.get('PROVIDER_TYPE'))
+                    ),
                     # realtime 的 api_type 必须表达「这个 WebSocket 说的是谁家的方言」。
                     # 原来这里无条件写 'local'，而 'local' 至今没有实现，还会经
                     # lifecycle 的 core_api_type 赋值污染全局（TTS 因此落 dummy）。

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -890,36 +890,34 @@ class CoreConfigMixin:
         return saved_url if saved_url in candidates else ''
 
     @staticmethod
-    def _normalize_realtime_provider(provider: str, core_api_profiles: dict) -> str:
-        """Drop an omni-slot provider that has no realtime implementation.
+    def _normalize_realtime_provider(provider: str) -> str:
+        """Drop a named provider from the omni slot.
 
-        The omni dropdown is filled from the assist (text-LLM) provider table,
-        so it offers providers that own no realtime endpoint at all.  Picking
-        one used to be honoured downstream: the frontend auto-fills the slot
-        URL, ``get_model_api_config`` then sees a complete custom triple and
-        stamps ``api_type='local'`` — a branch that was never implemented, and
-        which leaks into the global core api type.  Treating such a pick as
-        "not selected" makes it fall back to the core API, which is what the
-        user already gets today minus the broken realtime session.
+        The omni dropdown used to be filled from the assist (text-LLM) provider
+        table, so it offered a per-slot realtime provider. Picking one was then
+        honoured downstream: the frontend auto-fills the slot URL,
+        ``get_model_api_config`` sees a complete custom triple and stamps an
+        ``api_type`` that becomes the process-wide core api type — which also
+        drives TTS worker selection, native-voice routing and the audio
+        credential. Those follow the core provider, so a divergent pick tore
+        the audio stack in half (see ``_resolved_realtime_api_type``).
 
-        ``follow_*``, ``custom`` and the empty legacy value pass through: they
-        are not claims about a named provider's realtime support.
+        The audio stack carries exactly one provider identity, so this slot
+        cannot express a second one. A named pick is therefore treated as "not
+        selected" and falls back to the core API — which is what the user
+        effectively got before, minus the broken realtime session and the
+        cross-vendor credential.
+
+        ``follow_*``, ``custom`` and the empty legacy value pass through:
+        neither claims a provider identity of its own.
         """
         candidate = (provider or '').strip()
         if not candidate or candidate == 'custom' or candidate.startswith('follow_'):
             return candidate
-        # 判据是「这家有没有可直连的 realtime 端点」，不只是「在不在核心表里」。
-        # gemini 在核心表里但没有 CORE_URL（它作为核心 API 走 SDK，不经这个槽），
-        # 选中后 URL 会是空串 → 自定义三元组永远凑不齐 → 静默回落。既然槽位覆盖
-        # 表达不了它，就别把它当成一个「选中了就生效」的值。
-        _profile = core_api_profiles.get(candidate)
-        _has_realtime_endpoint = (
-            isinstance(_profile, dict) and str(_profile.get('CORE_URL') or '').strip()
-        )
         # 落回 follow_core 而不是空串：空串会让下面的 URL/模型/Key 覆盖分支照旧
         # 写入前端自动填好的残留值，follow_core 才是「等同于没选」的既有路径
         # （URL 跳过、模型回落 CORE_MODEL、Key 取 CORE_API_KEY）。
-        return candidate if _has_realtime_endpoint else 'follow_core'
+        return 'follow_core'
 
     def get_core_config(self):
         """Read core config dynamically"""
@@ -1271,7 +1269,7 @@ class CoreConfigMixin:
                 core_cfg.get(f'{_model_provider_prefix}ModelProvider', '') or ''
             )
             config[f'{_model_provider_prefix}ModelProvider'] = (
-                self._normalize_realtime_provider(_raw_provider, core_api_profiles)
+                self._normalize_realtime_provider(_raw_provider)
                 if _model_provider_prefix == 'omni'
                 else _raw_provider
             )
@@ -1503,7 +1501,15 @@ class CoreConfigMixin:
                     # voice_storage.get_tts_api_key('doubao_tts') 槽位优先、管理簿兜底，
                     # POST 侧的仲裁也刻意保住「只存在 ttsModelApiKey 的 legacy key」。
                     # 这里跟着走管理簿优先就会让同一份凭证出现两条反向的解析路径。
-                    _uses_key_book = bool(provider) and provider != 'doubao_tts'
+                    # TTS 槽整体不走管理簿改道。这个槽的下拉里有一批「注册表认得、
+                    # 但派发根本不读 ttsModelProvider」的伪选项（minimax / elevenlabs /
+                    # cosyvoice…），选中它们时 worker 仍由核心 API 决定；一旦这里把
+                    # 该厂商的真实 Key 解析进 TTS_MODEL_API_KEY，那把 Key 就会被送给
+                    # 核心厂商的 TTS 端点——又一次跨厂商凭证外发。
+                    # TTS 的凭证真相本来就在槽位字段与各 provider 自己的解析路径上
+                    # （voice_storage.get_tts_api_key / workers 直接读 raw ttsModelApiKey），
+                    # 保持原样即可。
+                    _uses_key_book = bool(provider) and prefix != 'tts'
                     _raw_book_field = (
                         assist_api_key_raw_fields.get(provider, '') if _uses_key_book else ''
                     )
@@ -1778,18 +1784,24 @@ class CoreConfigMixin:
         def _resolved_realtime_api_type() -> str:
             """Wire dialect for a custom-configured realtime session.
 
-            ``local`` is reserved for an endpoint the user typed themselves; a
-            named provider keeps its own identity so the session speaks that
-            provider's realtime dialect instead of an unimplemented one.
-            ``get_core_config`` has already dropped names with no realtime
-            implementation, so anything reaching here is either genuine or a
-            follow value.
+            Only two answers are coherent here. ``local`` means an endpoint the
+            user typed themselves. Everything else follows the core provider —
+            including an explicitly named one.
+
+            Returning a named provider's own identity looks like honouring the
+            user's pick, but this value is not just the realtime dialect: it
+            becomes the process-wide core api type, which also selects the TTS
+            worker, the native-voice catalog and the audio credential. Those
+            still resolve against the core provider, so a divergent pick
+            produced e.g. a Qwen TTS worker holding the OpenAI core key —
+            silence, plus one vendor's credential sent to another. The audio
+            stack has exactly one provider identity; a per-slot override cannot
+            express a second one, so it is not offered (the omni dropdown lists
+            only follow_* and 自定义) and not honoured here.
             """
             omni_provider = str(core_config.get('omniModelProvider') or '').strip()
             if omni_provider == 'custom':
                 return 'local'
-            if omni_provider and not omni_provider.startswith('follow_'):
-                return omni_provider
             # 老配置在 omniModelProvider 这个键出现之前就能手填实时端点，那种存量
             # 没有 provider 值可读，但它确实是自配端点，行为必须与改动前一致。
             # 判据是「存盘里真有 omniModelUrl」——profile 默认值填出来的 URL 不进

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1527,6 +1527,33 @@ class CoreConfigMixin:
                     _derived_book = (
                         str(config.get(_book_field) or '').strip() if _book_field else ''
                     )
+                    # 管理簿里这家的 Key 只能配这家的端点。走过 UI 的配置里两者
+                    # 一定同源（选中服务商时 URL 被自动填成该家地址且只读），但
+                    # 存量 / 导入 / 手改的配置可能留着另一家的 URL —— 那时把这家的
+                    # 真 Key 解析出来，就是把 A 家的凭证发给 B 家。
+                    # URL 为空不构成风险：自定义三元组凑不齐，下游整体回退。
+                    # 两个来源装的是**同一把**密钥（_derived_book 只是多一层
+                    # ASSIST_API_KEY_* 派生），所以要一起把关：只 gate 显式那个
+                    # 会从派生那条漏出去。
+                    _slot_url = str(config.get(url_key) or '').strip()
+                    if (_explicit_book or _derived_book) and _slot_url:
+                        _profile = assist_api_profiles.get(provider)
+                        _candidates = (
+                            self._provider_url_candidates(
+                                _profile, 'OPENROUTER_URL', 'OPENROUTER_URLS'
+                            )
+                            if isinstance(_profile, dict)
+                            else []
+                        )
+
+                        def _norm_url(value: str) -> str:
+                            return str(value or '').strip().rstrip('/').lower()
+
+                        if _norm_url(_slot_url) not in {_norm_url(c) for c in _candidates}:
+                            # 端点不是这家的 → 不交出这家的 Key。回落到槽位存量值，
+                            # 请求不带（或带旧的）凭证会 401，比静默发错家可诊断。
+                            _explicit_book = ''
+                            _derived_book = ''
                     if _explicit_book:
                         config[apikey_key] = _explicit_book
                     elif cfg_key:

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -908,10 +908,18 @@ class CoreConfigMixin:
         candidate = (provider or '').strip()
         if not candidate or candidate == 'custom' or candidate.startswith('follow_'):
             return candidate
+        # 判据是「这家有没有可直连的 realtime 端点」，不只是「在不在核心表里」。
+        # gemini 在核心表里但没有 CORE_URL（它作为核心 API 走 SDK，不经这个槽），
+        # 选中后 URL 会是空串 → 自定义三元组永远凑不齐 → 静默回落。既然槽位覆盖
+        # 表达不了它，就别把它当成一个「选中了就生效」的值。
+        _profile = core_api_profiles.get(candidate)
+        _has_realtime_endpoint = (
+            isinstance(_profile, dict) and str(_profile.get('CORE_URL') or '').strip()
+        )
         # 落回 follow_core 而不是空串：空串会让下面的 URL/模型/Key 覆盖分支照旧
         # 写入前端自动填好的残留值，follow_core 才是「等同于没选」的既有路径
         # （URL 跳过、模型回落 CORE_MODEL、Key 取 CORE_API_KEY）。
-        return candidate if candidate in core_api_profiles else 'follow_core'
+        return candidate if _has_realtime_endpoint else 'follow_core'
 
     def get_core_config(self):
         """Read core config dynamically"""
@@ -1117,6 +1125,19 @@ class CoreConfigMixin:
         core_api_profiles = get_core_api_profiles()
         assist_api_profiles = get_assist_api_profiles()
         assist_api_key_fields = get_assist_api_key_fields()
+        # provider → 管理簿在 core_config.json 里的**原始**字段名（assistApiKeyQwen 之类）。
+        # 用来区分「管理簿里真存了一条」和「ASSIST_API_KEY_* 只是被 _fb() 派生成了
+        # CORE_API_KEY」——后者不该压过用户存在槽位里的 Key。
+        try:
+            from utils.api_config_loader import get_config as _get_api_config
+            _api_key_registry = _get_api_config().get('api_key_registry', {}) or {}
+        except Exception:
+            _api_key_registry = {}
+        assist_api_key_raw_fields = {
+            _pk: _entry.get('config_field', '')
+            for _pk, _entry in _api_key_registry.items()
+            if isinstance(_entry, dict) and _entry.get('config_field')
+        }
 
         # Core API profile
         core_api_value = core_cfg.get('coreApi') or config['CORE_API_TYPE']
@@ -1465,14 +1486,30 @@ class CoreConfigMixin:
                     #   - 不碰哨兵不落盘这条安全不变量。
                     # 管理簿没有该服务商（custom / 老配置的 '' / gptsovits 这类只在 TTS
                     # 注册表里的 provider）时回落到槽位存储值，保住这些既有路径。
+                    # 优先级：管理簿里真存的那条 > 槽位存量值 > 管理簿派生值。
+                    #
+                    # 中间那级不能省：ASSIST_API_KEY_* 对匹配 coreApi/assistApi 的
+                    # 服务商会被 _fb() 派生成 CORE_API_KEY。那是「默认值」不是「用户
+                    # 存过」，拿它压掉老配置里槽位自己的 Key 会把能用的配置改坏。
+                    #
+                    # 三处都先转字符串再 strip：core_config.json 用户可手改，字段里
+                    # 可能落进任意 JSON 类型，直接 .strip() 会让整个 get_core_config()
+                    # 抛 AttributeError —— 那是启动即崩，不是某个槽降级。
                     cfg_key = core_cfg.get(f'{prefix}ModelApiKey')
+                    _raw_book_field = assist_api_key_raw_fields.get(provider, '') if provider else ''
+                    _explicit_book = (
+                        str(core_cfg.get(_raw_book_field) or '').strip() if _raw_book_field else ''
+                    )
                     _book_field = assist_api_key_fields.get(provider) if provider else ''
-                    # core_config.json 是用户可手改的文件，管理簿字段里可能落进任意
-                    # JSON 类型。这里先转字符串再 strip —— 直接 .strip() 会让整个
-                    # get_core_config() 抛 AttributeError，那是启动即崩。
-                    _book_key = str(config.get(_book_field) or '').strip() if _book_field else ''
-                    if _book_key:
-                        config[apikey_key] = _book_key
+                    _derived_book = (
+                        str(config.get(_book_field) or '').strip() if _book_field else ''
+                    )
+                    if _explicit_book:
+                        config[apikey_key] = _explicit_book
+                    elif cfg_key:
+                        config[apikey_key] = cfg_key
+                    elif _derived_book:
+                        config[apikey_key] = _derived_book
                     elif cfg_key is not None:
                         config[apikey_key] = cfg_key
 

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1495,12 +1495,22 @@ class CoreConfigMixin:
                     # 三处都先转字符串再 strip：core_config.json 用户可手改，字段里
                     # 可能落进任意 JSON 类型，直接 .strip() 会让整个 get_core_config()
                     # 抛 AttributeError —— 那是启动即崩，不是某个槽降级。
-                    cfg_key = core_cfg.get(f'{prefix}ModelApiKey')
-                    _raw_book_field = assist_api_key_raw_fields.get(provider, '') if provider else ''
+                    _raw_cfg_key = core_cfg.get(f'{prefix}ModelApiKey')
+                    cfg_key = (
+                        str(_raw_cfg_key).strip() if _raw_cfg_key is not None else None
+                    )
+                    # 豆包语音例外：它虽然在管理簿映射里，但凭证真相是槽位字段——
+                    # voice_storage.get_tts_api_key('doubao_tts') 槽位优先、管理簿兜底，
+                    # POST 侧的仲裁也刻意保住「只存在 ttsModelApiKey 的 legacy key」。
+                    # 这里跟着走管理簿优先就会让同一份凭证出现两条反向的解析路径。
+                    _uses_key_book = bool(provider) and provider != 'doubao_tts'
+                    _raw_book_field = (
+                        assist_api_key_raw_fields.get(provider, '') if _uses_key_book else ''
+                    )
                     _explicit_book = (
                         str(core_cfg.get(_raw_book_field) or '').strip() if _raw_book_field else ''
                     )
-                    _book_field = assist_api_key_fields.get(provider) if provider else ''
+                    _book_field = assist_api_key_fields.get(provider) if _uses_key_book else ''
                     _derived_book = (
                         str(config.get(_book_field) or '').strip() if _book_field else ''
                     )

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1254,6 +1254,10 @@ class CoreConfigMixin:
                 if _model_provider_prefix == 'omni'
                 else _raw_provider
             )
+        # omniModelUrl 的**原始存盘值**（不是解析后的 REALTIME_MODEL_URL）：用来区分
+        # 「用户真的手填过一个实时端点」和「URL 只是从 provider profile 默认值填出来的」。
+        # 老配置在 omniModelProvider 这个键存在之前就能手填 URL，那种必须继续按 local 处理。
+        config['omniModelUrl'] = str(core_cfg.get('omniModelUrl', '') or '')
         config['ttsModelUrl'] = str(core_cfg.get('ttsModelUrl', '') or '')
         config['ttsModelId'] = str(core_cfg.get('ttsModelId', '') or '')
         config['ttsVoiceId'] = str(core_cfg.get('ttsVoiceId', '') or '')
@@ -1739,6 +1743,12 @@ class CoreConfigMixin:
                 return 'local'
             if omni_provider and not omni_provider.startswith('follow_'):
                 return omni_provider
+            # 老配置在 omniModelProvider 这个键出现之前就能手填实时端点，那种存量
+            # 没有 provider 值可读，但它确实是自配端点，行为必须与改动前一致。
+            # 判据是「存盘里真有 omniModelUrl」——profile 默认值填出来的 URL 不进
+            # 这个键，所以不会把「什么都没选」误判成自配。
+            if not omni_provider and str(core_config.get('omniModelUrl') or '').strip():
+                return 'local'
             return str(core_config.get('CORE_API_TYPE', '') or '')
 
         if model_type == 'game_main':

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -80,6 +80,8 @@ _OPENCLAW_MIGRATION_ATTEMPTS = 3
 _OPENCLAW_MIGRATION_RETRY_DELAY_S = 0.1
 
 
+from utils.http.url import same_endpoint
+
 class CoreConfigMixin:
     """Core config snapshot, geo checks and model API resolution."""
 
@@ -1545,11 +1547,12 @@ class CoreConfigMixin:
                             if isinstance(_profile, dict)
                             else []
                         )
-
-                        def _norm_url(value: str) -> str:
-                            return str(value or '').strip().rstrip('/').lower()
-
-                        if _norm_url(_slot_url) not in {_norm_url(c) for c in _candidates}:
+                        # 同源判据用 utils.http.url.same_endpoint，不在这里另搓一份：
+                        # 视觉槽的凭证继承已经为这件事打磨过六轮（尾斜杠 / path 大小写 /
+                        # userinfo / 畸形端口 / 默认端口 / 畸形 IPv6），本地再写一个
+                        # 「转小写去尾斜杠」只会把同样的坑重踩一遍——事实上第一版就
+                        # 踩了：把 /V1 当成 /v1，也认不出显式写出的 :443。
+                        if not any(same_endpoint(_slot_url, c) for c in _candidates):
                             # 端点不是这家的 → 不交出这家的 Key。回落到槽位存量值，
                             # 请求不带（或带旧的）凭证会 401，比静默发错家可诊断。
                             _explicit_book = ''

--- a/utils/http/url.py
+++ b/utils/http/url.py
@@ -26,3 +26,73 @@ def encode_url_path(path: str) -> str:
     parts = path.split('/')
     encoded_parts = [quote(unquote(part), safe='') for part in parts]
     return '/'.join(encoded_parts)
+
+
+# 该 scheme 下可以省略的默认端口：写与不写是同一个端点。
+_DEFAULT_PORTS = {'http': '80', 'https': '443', 'ws': '80', 'wss': '443'}
+
+
+def _split_hostinfo(hostinfo: str) -> tuple[str, str]:
+    """Split ``host[:port]`` without tripping over IPv6 brackets."""
+    idx = hostinfo.rfind(':')
+    if idx == -1 or hostinfo.rfind(']') > idx:
+        return hostinfo, ''
+    return hostinfo[:idx], hostinfo[idx + 1:]
+
+
+def endpoint_identity(raw: str | None):
+    """A comparable identity for a configured base URL, or None when blank.
+
+    Folds only what RFC 3986 says is insignificant, because callers use this to
+    decide whether one provider's credential may be paired with a given URL —
+    so it has to be wrong in the safe direction:
+
+    * scheme and host are case-insensitive; userinfo, path and query are NOT
+      (two tenants or routes can differ by case alone),
+    * ports compare by value, and a scheme's default port is dropped,
+    * exactly one trailing slash is cosmetic — ``/v1/`` equals ``/v1`` but not
+      ``/v1//``, which is a different HTTP path.
+
+    Total by construction: a URL that ``urlsplit`` rejects (unclosed IPv6) and
+    one with a malformed port both yield an identity rather than raising, since
+    callers run inside constructors and config reads where an exception means
+    "nothing works" rather than "this endpoint is invalid".
+    """
+    from urllib.parse import urlsplit
+
+    text = (raw or '').strip()
+    if not text:
+        return None
+    if '://' not in text:
+        text = f'//{text}'
+    try:
+        parts = urlsplit(text)
+    except ValueError:
+        # 两个分支返回**同样长度**的元组，首位是「解析成功与否」：长度不同的
+        # 元组比起来虽然也恒不相等，但那是靠巧合而不是靠判据。
+        return (False, text, '', '', '', '', '')
+
+    # netloc 整体转小写是错的：它还装着 userinfo（user:pass@）。拆开 userinfo
+    # 与 host:port，只折叠后者。刻意不碰 parts.port —— 它对非法端口会抛。
+    userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
+    scheme = (parts.scheme or '').lower()
+    host, port = _split_hostinfo(hostinfo.lower())
+    if port.isdigit():
+        port = str(int(port))
+    if port and port == _DEFAULT_PORTS.get(scheme):
+        port = ''
+    return (
+        True,
+        scheme,
+        userinfo,
+        host,
+        port,
+        (parts.path or '').removesuffix('/'),
+        parts.query,
+    )
+
+
+def same_endpoint(a: str | None, b: str | None) -> bool:
+    """Whether two configured base URLs address the same endpoint."""
+    key_a = endpoint_identity(a)
+    return key_a is not None and key_a == endpoint_identity(b)

--- a/utils/http/url.py
+++ b/utils/http/url.py
@@ -40,6 +40,24 @@ def _split_hostinfo(hostinfo: str) -> tuple[str, str]:
     return hostinfo[:idx], hostinfo[idx + 1:]
 
 
+def _canonical_host(host: str) -> str:
+    """Collapse an IPv6 literal to its canonical form; pass anything else through.
+
+    ``[2001:0db8:0:0:0:0:0:1]`` and ``[2001:db8::1]`` are the same address, so
+    they must yield the same identity. A literal that does not parse keeps its
+    original text — callers need this to stay total, and an unparseable host
+    still compares equal to an identically-written one.
+    """
+    if not (host.startswith('[') and host.endswith(']')):
+        return host
+    import ipaddress
+
+    try:
+        return f'[{ipaddress.IPv6Address(host[1:-1]).compressed}]'
+    except ValueError:
+        return host
+
+
 def endpoint_identity(raw: str | None):
     """A comparable identity for a configured base URL, or None when blank.
 
@@ -77,6 +95,7 @@ def endpoint_identity(raw: str | None):
     userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
     scheme = (parts.scheme or '').lower()
     host, port = _split_hostinfo(hostinfo.lower())
+    host = _canonical_host(host)
     if port.isdigit():
         port = str(int(port))
     if port and port == _DEFAULT_PORTS.get(scheme):

--- a/utils/http/url.py
+++ b/utils/http/url.py
@@ -49,7 +49,10 @@ def _canonical_host(host: str) -> str:
     still compares equal to an identically-written one.
     """
     if not (host.startswith('[') and host.endswith(']')):
-        return host
+        # 尾点是 DNS 根，`api.example.com.` 与 `api.example.com` 是同一台主机。
+        # 只去一个，与 path 尾斜杠同一条规则：`example.com..` 不是合法域名，
+        # 保持它与单点形式不同，宁可判成不同端点也不越权归一。
+        return host.removesuffix('.')
     import ipaddress
 
     try:

--- a/utils/http/url.py
+++ b/utils/http/url.py
@@ -49,16 +49,24 @@ def _canonical_host(host: str) -> str:
     still compares equal to an identically-written one.
     """
     if not (host.startswith('[') and host.endswith(']')):
-        # 尾点是 DNS 根，`api.example.com.` 与 `api.example.com` 是同一台主机。
-        # 只去一个，与 path 尾斜杠同一条规则：`example.com..` 不是合法域名，
-        # 保持它与单点形式不同，宁可判成不同端点也不越权归一。
-        return host.removesuffix('.')
+        # DNS 名大小写无关；尾点是 DNS 根，`api.example.com.` 与
+        # `api.example.com` 是同一台主机。只去一个尾点，与 path 尾斜杠同一条
+        # 规则：`example.com..` 不是合法域名，保持它与单点形式不同——宁可判成
+        # 不同端点，也不越权归一。
+        return host.lower().removesuffix('.')
     import ipaddress
 
+    # scoped IPv6 的 zone id（%eth0）是**接口名**，在 Unix 上大小写敏感，
+    # 不能跟着地址一起折叠——那会把两个不同接口判成同一个端点，凭证就送错了。
+    inner = host[1:-1]
+    addr, sep, zone = inner.partition('%')
     try:
-        return f'[{ipaddress.IPv6Address(host[1:-1]).compressed}]'
+        canonical = ipaddress.IPv6Address(addr).compressed
     except ValueError:
+        # 解析不了就原样保留（含大小写）：判据保持 total，且两个写法不同的
+        # 坏地址仍算不同端点。
         return host
+    return f'[{canonical}{sep}{zone}]'
 
 
 def endpoint_identity(raw: str | None):
@@ -97,7 +105,9 @@ def endpoint_identity(raw: str | None):
     # 与 host:port，只折叠后者。刻意不碰 parts.port —— 它对非法端口会抛。
     userinfo, _, hostinfo = (parts.netloc or '').rpartition('@')
     scheme = (parts.scheme or '').lower()
-    host, port = _split_hostinfo(hostinfo.lower())
+    # 不在这里整体转小写：hostinfo 里可能带 scoped IPv6 的 zone id，那是接口名、
+    # 大小写敏感。大小写归一交给 _canonical_host 分部位处理。
+    host, port = _split_hostinfo(hostinfo)
     host = _canonical_host(host)
     if port.isdigit():
         port = str(int(port))


### PR DESCRIPTION
针对 #2886。起因是有反馈说「默认设定坏了，没人能用自定义 API」。逐条核查下来**这个说法不成立**——默认设定（`enableCustomApi` 缺省为假、十个槽全 `follow_*`）下自定义 API 主路径是通的。但**显式配置**的几条路径确实在后端被静默忽略或改写，用户看到的是「界面绿灯、实际不生效」。这个 PR 收口这些。

## 回归报告

### 改了什么、为什么必要

**1. 具名服务商槽的 Key 改为运行时从 API 管理簿解析**（`utils/config_manager/core_config.py`）

选中具名服务商时，槽位的 Key 输入框是 `readonly` 的，placeholder 写着「Key 从 API 管理簿自动填充」，用户根本无法往里输入——它是管理簿的一份**缓存**，不是独立输入源。而 #2559 把管理簿字段也纳入了 GET 脱敏，于是前端拷进槽位的是哨兵，保存时被 `apply_core_config_secret_update` 拒写，槽位字段永远停在空串。

结果就是一个不对称：**连通性检查读管理簿（绿灯），运行时读槽位字段（空 Key）**。改为运行时直接读管理簿后两者同源。

- 改前：`conversationModelProvider='deepseek'` + 管理簿有 deepseek key → 设置页测试通过，真实会话 401。
- 改后：真实会话使用管理簿里的 key。**存量已经写坏的配置不需要重新保存即可自愈**（下次读配置就好）。
- 管理簿没有该服务商时（`custom`、老配置的空 provider、`gptsovits`/`vllm_omni` 这类只在 TTS 注册表里的）回落槽位存储值，这些路径行为不变。

**2. realtime 的 `api_type` 不再无条件写 `'local'`**（同文件）

原来只要 realtime 的 model + url 都非空就写 `'local'`，而这个分支的注释自己写着 TODO 未实现，并且会经 `lifecycle.py` 的 `core_api_type` 赋值污染全局，连带把 TTS 打到 dummy worker。

- 改前：omni 槽选「GLM」→ 前端自动填 GLM 的 WSS URL → `api_type='local'` → 语音链路失效且全程无声。
- 改后：`custom`（用户自填端点）仍是 `'local'`；显式选中的具名服务商保住自己的方言；`follow_*` / 空值跟随核心 API。

**3. 没有 realtime 实现的服务商被选进 omni 槽时按「等同于没选」处理**（同文件）

omni 下拉原本从辅助 LLM 全表铺开，列出了 deepseek/kimi/minimax 这类根本没有 realtime 端点的服务商。选中后前端仍会自动填 URL/Key，残留值流进实时槽。现在快照阶段就把这类选择归一化成 `follow_core`，URL/模型/Key 三条覆盖跟着走同一条路。

**4. 回退分支的 `provider_type` 改为与地址同源**（同文件）

`_resolved_provider_type_for_model` 按槽位下拉值解析协议，而下拉值快照**不受 `ENABLE_CUSTOM_API` 门控**。于是「某槽选 claude 或 kimi_code（全仓唯二 anthropic 协议 provider）之后再关掉自定义 API」会得到「assist 的地址 + assist 的 Key + Anthropic 协议」，该槽的请求直接打死。

现在两个回退分支各自按回退目标取协议（core 分支取 `CORE_API_TYPE` 的协议，assist 分支取 `PROVIDER_TYPE`），错配在结构上不可构造。配置完整的 anthropic 槽仍然真的走 Anthropic 协议。

**5. 视觉端点与视觉 Key 改为成对回退**（`main_logic/omni_offline_client/_client.py`）

两行原本各自独立判空，于是「视觉槽填了自己的 URL、Key 留空」时 URL 停在视觉那家的域名、Key 却继承了对话 provider 的凭证——把用户的付费 Key 发给了另一个厂商。这既是路由错误也是凭证越界。

改后不同源时不继承：本地无鉴权端点本就该不带 Authorization，付费端点会直接 401 报错，比静默把凭证送出去可诊断得多。

**6. realtime 工具下发的方言判据改用真实 `api_type` 词表**（`main_logic/omni_realtime_client/`）

`apply_tools_to_session` 比的是 `api == 'gpt'`，而 `'gpt'` 从来不是 `api_type` 的合法取值（真实值是 `'openai'`，`'gpt'` 是从连接期按模型名匹配那套写法误搬过来的）。OpenAI 会话的**中途**工具更新因此被静默丢弃——切界面语言、插件注册/注销工具、热切换补推全都收不到，而 HTTP `/api/tools` 仍返回成功。`'qwen_intl'` 同样进不了 qwen 分支。

新增 `canonical_realtime_dialect()` 作为共用词表，`'gpt'` 仍被接受（既有调用方与夹具不受影响）。

**7. OpenFang 的 provider 探测复用 llm_client 的 Anthropic 端点判据**（`brain/openfang_adapter.py`）

原来只认 `anthropic.com`，于是 #1948 加进来的 kimi_code（`api.kimi.com/coding`，`provider_type=anthropic`）落到末尾的 `provider=openai + needs_proxy` 兜底，被当成 OpenAI 端点塞进 LLM proxy。现在直接复用聊天链路的同一套判据，并可选接收槽位已解析好的 `provider_type`。

**8. 前端 TTS / 实时全模态下拉按真实能力过滤**（`static/js/api_key_settings.js`）

两个下拉原本把辅助 LLM 全表无差别铺开，没有任何「这家有没有 TTS / realtime 能力」的判据。TTS 下拉里 16 项、omni 下拉里 10 项是伪选项：选中后后端派发完全不看它，但自动填进去的 URL/Key 会污染该槽凭证（这是「静默无声」的一个来源）。

能力真相各有单一来源——TTS 取后端 `tts_provider_registry`，realtime 取 `core_api_providers`——前端不硬编码任何 provider key。注册表用 `aliases` 表达同一家的多地域入口（如 `minimax_intl` → `minimax`），已一并处理。

存量配置里选了无能力服务商的，加载时回落该槽**默认值**而不是走既有的 `'custom'` 兜底——后者会把一个 LLM 端点坐实成用户自配的 TTS/实时端点，反而让原本只是空转的配置真的被拿去请求。

### 潜在回归

- **具名槽 Key 来源变更**：现在管理簿值优先于槽位存储值。若某用户的管理簿与槽位存了**不同**的 key，行为会变。实际不可达——UI 上具名服务商的槽位 Key 框只读、唯一写入者就是从管理簿拷值。真正让用户手填端点的那几家（`custom` / vLLM-Omni / GPT-SoVITS / 豆包语音）不在管理簿映射里，它们那批直接读 raw `ttsModelApiKey` 的读者（`workers/vllm_omni.py`、`workers/openai.py`、`voice_preview.py`）完全没被触碰。
- **omni 槽归一化**：`config['omniModelProvider']` 快照对无 realtime 能力的值会变成 `follow_core`。全仓没有该键的其他读者（已 grep 确认）；`ttsModelProvider` 的四个快照读者比较的都是 `vllm_omni` / `custom` / `doubao_tts` 这类有能力的值，不受影响。
- **`provider_type` 回退语义**：显式选了 anthropic 服务商、但该槽实际在回退的用户，协议会从 anthropic 变成回退目标的协议。这正是修复目标（原状态下该槽必然请求失败）。
- **vision 空 Key**：原先靠借用对话 key 才能工作的配置会开始 401。这是有意的——那条路径把凭证发给了错误的域名。
- **下拉过滤**：两处都 fail-open（`/api_providers` 元数据取不到时不过滤），避免把用户正在用的服务商藏掉。反向断言已进测试，防止「全都过滤掉」也能让用例通过。

### 验证

- 新增 `tests/unit/test_custom_api_slot_resolution.py`（22 例），扩充 `test_openfang_provider_detection.py`（+3）与 `tests/frontend/test_api_settings.py`（+1，Playwright 实测两个下拉的选项集合）。
- **八处修复逐个做过变异验证**：撤掉任一处实现，对应用例都会变红。第一轮变异就抓到我漏测了 core 回退分支，已补 `test_core_fallback_slot_uses_the_core_protocol`。
- 定向回归 421 例通过（`test_api_config_manager` / `test_tool_calling` / `test_core_config_secret_redaction` / `test_gptsovits_dropdown_routing` / `test_gemini_realtime_voice_routing` / `test_openai_compatible_tts` / `test_vllm_omni_voice_clone` / `test_doubao_tts` / `test_browser_use_adapter_anthropic` / `test_config_manager_follow_urls`）；`tests/frontend/test_api_settings.py` 全量 32 例通过。
- 静态闸门：`check_module_layering` / `check_async_blocking` / `check_core_contracts` / `check_startup_import_lazy` / `check_no_loguru` / `check_no_temperature` / `check_api_trailing_slash` / `check_frontend_api_trailing_slash` / `check_i18n_sync` / `check_prompt_hygiene` / `check_llm_budget` / `check_docstring_no_cjk --base origin/main` 全绿。
- `check_i18n` 有 3 个 `Jukebox.*` 缺键报错，是 `static/jukebox/` 的存量问题，本 PR 未触碰该目录。

### 评审轮追加的修复

开 PR 之后又落了 5 个 commit。Greptile / CodeRabbit / Codex 各报了实质问题，我另外对自己的 diff 跑了一轮对抗性复查，两边有重叠也有各自独占的。逐条：

| # | 来源 | 问题 | 处理 |
|---|---|---|---|
| 1 | Greptile P1 + Codex P2 + 我自查 | 视觉槽同源判定用精确字符串比较，尾斜杠/大小写差异被判成「换了一家」，把本来能用的凭证继承掐掉 → 付费视觉 401 | 新增 `_same_endpoint()` 归一化后比较 |
| 2 | CodeRabbit | 管理簿 Key 直接 `.strip()`，值是数字/列表时 `get_core_config()` 抛 `AttributeError` —— 这条路径每次读配置都跑，等于启动即崩 | 先 `str()` 再 strip |
| 3 | CodeRabbit | `_write_openfang_model_config` 自己重算 provider，落盘的 config.toml 与运行时推的对不上 | 从调用方传 `pinfo` |
| 4 | CodeRabbit | `provider_type` 不在 `_compute_config_hash` 里，只改协议不触发重新同步 | 纳入哈希 |
| 5 | **Codex P1** | 上一条我按建议塞了 `getattr(self, ...)`，但那函数是 `@staticmethod`，**每次 OpenFang 同步走到落盘都会 NameError** | 改成参数传入；补 `TestWriteOpenFangModelConfig` |
| 6 | Codex P2 | 收窄 `local` 判据时误伤存量：`omniModelProvider` 这个键出现之前的老配置能手填实时端点，被我落到了 `CORE_API_TYPE` | 加判据「存盘里真有 `omniModelUrl`」→ 继续按 local |
| 7 | Codex P2 | agent 槽绕过 `treat_as_custom` 直接进 custom 分支，回退分支那条修复没盖住它 | custom 分支的 `provider_type` 只在 `treat_as_custom` 为真时用下拉值 |
| 8 | 自查 | `ASSIST_API_KEY_*` 被 `_fb()` 派生成 `CORE_API_KEY` 时被当成「管理簿真存了一条」，压掉老配置槽位里的 Key | 三级优先：管理簿真存 > 槽位存量 > 管理簿派生 |
| 9 | 自查 | OpenFang 探测里 `provider_type`（声明）排在按 URL 认人的分支（证据）**前面**，「残留 anthropic + URL 其实是代理/本地 ollama」会被误判成 Anthropic 直连 | 挪到所有 URL 分支之后、兜底之前 |
| 10 | 自查 | omni 能力判据用「在不在核心表里」，但 gemini 没有 `CORE_URL`，选中后三元组永远凑不齐 → 静默失效 | 判据改成「有没有可直连的 realtime 端点」，前后端对偶 |

| 11 | Greptile P1 + CodeRabbit | 上一条的修法把**整条 URL** 转小写，而 URL 只有 scheme/host 大小写无关，path/query 敏感 —— 只差 path 大小写的两个路由/租户会被判成同一端点，凭证跨边界 | 改 `urlsplit` 后逐段比较 |
| 12 | CodeRabbit（diff 外） | 槽位 Key 未归一化，手改成非字符串会让 openfang 的 `.strip()` 抛 `AttributeError` | 同样先 `str()` 再 strip |
| 13 | 自查 | 豆包语音被我改道管理簿，但它的凭证真相是槽位字段（`get_tts_api_key` 槽位优先、POST 侧刻意保 legacy key）—— 同一份凭证两条反向解析路径 | 排除 doubao_tts |
| 14 | CodeRabbit | 前端只测了首次渲染的过滤，没测存量迁移分支 | 补 `test_saved_incapable_provider_falls_back_and_clears_stale_credentials` |
| 15 | Greptile P1 | `urlsplit` 的 netloc 里还装着 userinfo，整体折叠会把只差用户名/口令大小写的端点判成同一个 | 拆开 userinfo 与 host:port |
| 16 | CodeRabbit | 前端能力判据多认一个 `CORE_URL` 别名，而 `getProviderCoreUrl()` 只读 `core_url` —— 会造出「判定有能力但填不出 URL」 | 两处对齐同一字段 |
| 17 | CodeRabbit | 迁移用例只给 TTS 槽注了残留 Key，omni 槽只注 URL | 补 `omniModelApiKey` 注入与断言（实测实现已一并清掉） |
| 18 | Greptile P1 | `parts.port` 对非法端口抛 `ValueError`，而判据跑在 `__init__` 里 | 改为不读 `.port`，判据对任意输入 total |

| 19 | Greptile P1 | `https://h/v1` 与 `https://h:443/v1` 是同一端点，原始 `host:port` 串比较判成不同 → 掐掉本该继承的凭证 → 401 | 按 scheme 归一化默认端口 |
| 20 | CodeRabbit | 同源且两侧 Key 都空时返回原始 `api_key`（可能是 `''`），而 `self.api_key` 已归一化成 `None` | 统一成 `None` |
| 21 | CodeRabbit | `urlsplit` 自己就会对未闭合 IPv6 抛 `ValueError`（不只是读 `.port`） | 捕获后退回原串比较，判据 total |

**第二条明确未采纳**：Codex 提「管理簿条目被显式清空时不应回落到陈旧的槽位 Key」。语义缺口成立，但它的判据（区分「字段存在但为空」和「字段不存在」）在本仓库不存在——`DEFAULT_CORE_CONFIG` 模板已带全部 18 个 `assistApiKey*` 键，而 `get_core_config()` 起手就 `deepcopy(模板)`，所以 `in core_cfg` 恒为真。按存在性判断会让 legacy 槽位回退永不触发，第 8 条的修复当场失效。缺口的实际影响面也比描述窄：#2559 之后槽位拿到的是哨兵、写不进去，多数用户槽位为空、清空即生效；会被复活的只有 #2559 之前写进过槽位的存量配置，且复活的是同一家 provider 的旧 Key，不构成凭证跨边界。真要修该在保存路径做（管理簿清空时连带清掉指向它的槽位字段，形状同 doubao_tts 的既有仲裁），属独立改动。

关于 `_same_endpoint`：这个谓词吸收了五轮修正（尾斜杠 → path 大小写 → userinfo → 非法端口 → 默认端口 → 畸形 IPv6）。如果还有新边界，我倾向于换掉「让客户端比 URL」这个做法本身（让配置层直接告知视觉槽是否被独立配置过），而不是继续打补丁。

**一条明确未采纳**：CodeRabbit 建议把声明式 anthropic 回退挪到 groq/deepseek 的**模型名启发式**之前。理由写在 thread 里——那两条的主机判据和模型名判据写在同一个 `if` 里，挪过去等于让声明重新盖过 `api.groq.com` / `api.deepseek.com` 这些 URL 证据，与第 9 条刚确立的「证据 > 声明」次序自相矛盾；它描述的场景（Anthropic 网关恰好服务一个名字里带 deepseek 的模型）比这个次序倒转的代价窄得多。要两头都对得把整条启发式链拆开重排，收益撑不起那个回归面。

第 18 条还需更正报告方的影响面：它声称「构造会在发出任何请求前失败」。我按描述写了个「构造应当成功」的用例，结果红在 `httpx._urlparse.InvalidURL` —— 这类 URL 本来就过不了 httpx。所以不是「本可用变不可用」，改动价值是让判据 total。

第 5 条值得单独说一句：它是我照着 review 建议改、**没核对函数绑定方式**引入的，而且能溜过去是因为 `_write_openfang_model_config` 此前零测试覆盖。已补 4 例（含「不得引用 self」与「明文密钥不落盘」）。

二十一条全部做过变异验证。其中 omni 那条第一轮变异**没变红**，查出来是我的用例选错了场景（URL 本来就是空的，改动与否结果一样），换成「存量残留 URL」这个唯一有分界的场景后才真正守住。

回归口径同上：定向 497 例 + 前端 Playwright 32 例通过；`check_docstring_no_cjk --base origin/main`、`ruff`、layering / async / contracts / startup-import / i18n_sync 全绿。

## 本次**未**修的（各自需要独立 PR）

审计里还确认了几条，但都不适合塞进这个 PR：

- **TTS 槽的后端自愈**。前端已经不再提供伪选项，但存量配置里残留的无能力 `ttsModelProvider` 仍会污染 `TTS_MODEL_URL/API_KEY`。正确的后端守卫需要以 `tts_provider_registry` 为单一真相，而该注册表要 `import main_logic.tts_client` 才完成注册，`utils/config_manager` 不能取这个依赖（模块层级 L1）。要么把注册表挪到两边都能看见的层，要么把凭证守卫下沉进 `main_logic/tts_client`——都是结构改动，且落在本仓库风险最高的 TTS 派发路径上，值得单独做和单独回归。
- **`custom` 无法表达 Anthropic Messages 协议**（硬编码 `openai_compatible`，UI 也没有协议选择框）。需要新增 UI 面。
- **空 Key 被当成「未配置」的四处前置闸**（主动搭话 / 休息提醒 / 活动富化 / Agent 就绪），影响 ollama / LM Studio 这类无鉴权本地端点。放开会让空 Key 打云端端点时从静默跳过变成定时 401，需要产品判断取哪一侧。
- **未注册音色兜底落 hosted CosyVoice**：调用侧用跨槽探测、被调侧用当前槽认领，两端不对称。
- **建连鉴权前就报 ready**：cosyvoice 无条件发 `__ready__`；gemini 的 TLS 预热吞异常、mimo 的 setup 一次 HTTP 都不打。三家判据不同，共用骨架其实是对的，得分别下判据。
- **TTS 连通性测试打的是 LLM 端点**，绿灯不代表 TTS 通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 更准确地识别并同步 API 服务商及协议类型，支持声明式 Anthropic 端点。
  * 实时服务支持更多方言别名，提升工具调用兼容性。
  * 模型、TTS 与实时服务选项根据实际能力展示，并支持自定义及跟随配置。
  * 新增统一的端点同源判断，提升不同 URL 配置的兼容性。

* **问题修复**
  * 修复服务商切换时端点、凭证与协议不一致的问题。
  * 防止跨服务商错误复用凭证，并优化无效旧配置的回退处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->