### PR TITLE
修复完整聊天框时无法触发教程的问题，并适配教程结束后的破冰对话通信

### DIFF
--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -468,6 +468,34 @@
             || action === 'icebreaker_free_text_submitted';
     }
 
+    var _pendingIcebreakerIdentityMessages = [];
+    var ICEBREAKER_IDENTITY_QUEUE_MAX = 80;
+
+    function queueIcebreakerBridgeMessageUntilIdentity(data) {
+        if (!data || !I.isIcebreakerBridgeAction(data.action)) return;
+        if (_pendingIcebreakerIdentityMessages.length >= ICEBREAKER_IDENTITY_QUEUE_MAX) {
+            _pendingIcebreakerIdentityMessages.shift();
+        }
+        _pendingIcebreakerIdentityMessages.push(data);
+    }
+
+    I.flushPendingIcebreakerIdentityMessages = function flushPendingIcebreakerIdentityMessages() {
+        if (!I.getCurrentLanlanName() || !_pendingIcebreakerIdentityMessages.length) {
+            return false;
+        }
+        var batch = _pendingIcebreakerIdentityMessages.splice(0);
+        batch.forEach(function (message) {
+            I.handleIcebreakerBridgeData(message);
+        });
+        return true;
+    };
+
+    function schedulePendingIcebreakerIdentityFlush() {
+        I.yuiGuideInterpageResources.setTimeout(function () {
+            I.flushPendingIcebreakerIdentityMessages();
+        }, 0);
+    }
+
     function isIcebreakerBridgeForCurrentLanlan(data) {
         if (!data || !data.lanlan_name) return false;
         var currentName = I.getCurrentLanlanName();
@@ -476,6 +504,14 @@
 
     I.handleIcebreakerBridgeData = function handleIcebreakerBridgeData(data) {
         if (!data || !data.action) return false;
+        if (!I.isIcebreakerBridgeAction(data.action)) return false;
+        if (!data.lanlan_name) return false;
+        if (!I.getCurrentLanlanName()) {
+            // Full Chat 的 preload 队列会早于异步配置注入排空。身份未知时不能把
+            // 首批 append / prompt 当成跨角色消息丢弃；配置就绪后再按原顺序去重处理。
+            queueIcebreakerBridgeMessageUntilIdentity(data);
+            return true;
+        }
         if (!isIcebreakerBridgeForCurrentLanlan(data)) return false;
         switch (data.action) {
             case 'icebreaker_append_chat_message':
@@ -989,6 +1025,14 @@
     pendingIcebreakerBridgeMessages.forEach(function (message) {
         I.handleIcebreakerBridgeData(message);
     });
+    I.yuiGuideInterpageResources.addEventListener(
+        window,
+        'neko:config-injected',
+        schedulePendingIcebreakerIdentityFlush
+    );
+    if (window.pageConfigReady && typeof window.pageConfigReady.then === 'function') {
+        window.pageConfigReady.then(schedulePendingIcebreakerIdentityFlush).catch(function () {});
+    }
 
     I.yuiGuideInterpageResources.addEventListener(window, 'storage', handleIcebreakerStorageBridgeEvent);
     I.yuiGuideInterpageResources.addEventListener(window, 'storage', handleYuiGuideChatBridgeStorageEvent);

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -524,6 +524,12 @@
         }
     }
 
+    function handleIcebreakerElectronBridgeEvent(event) {
+        var message = event && event.detail;
+        if (!message || typeof message !== 'object') return;
+        I.handleIcebreakerBridgeData(message);
+    }
+
     I.postIcebreakerBridgeEvent = function postIcebreakerBridgeEvent(action, payload) {
         var message = Object.assign({
             action: action,
@@ -546,6 +552,14 @@
             }, 0);
         } catch (error) {
             console.warn('[NewUserIcebreaker] storage bridge post failed:', action, error);
+        }
+        try {
+            var electronBridge = window.nekoElectronIcebreakerBridge;
+            if (electronBridge && typeof electronBridge.send === 'function') {
+                electronBridge.send(message);
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] Electron bridge post failed:', action, error);
         }
     }
 
@@ -962,6 +976,19 @@
         }
         handleYuiGuideRelayedMessage(message);
     };
+
+    I.yuiGuideInterpageResources.addEventListener(
+        window,
+        'neko:electron-icebreaker-bridge',
+        handleIcebreakerElectronBridgeEvent
+    );
+    window.__nekoIcebreakerBridgeReady = true;
+    var pendingIcebreakerBridgeMessages = Array.isArray(window.__nekoPendingIcebreakerBridgeMessages)
+        ? window.__nekoPendingIcebreakerBridgeMessages.splice(0)
+        : [];
+    pendingIcebreakerBridgeMessages.forEach(function (message) {
+        I.handleIcebreakerBridgeData(message);
+    });
 
     I.yuiGuideInterpageResources.addEventListener(window, 'storage', handleIcebreakerStorageBridgeEvent);
     I.yuiGuideInterpageResources.addEventListener(window, 'storage', handleYuiGuideChatBridgeStorageEvent);

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -464,6 +464,14 @@
         } catch (error) {
             console.warn('[NewUserIcebreaker] storage bridge failed:', action, error);
         }
+        try {
+            var electronBridge = window.nekoElectronIcebreakerBridge;
+            if (electronBridge && typeof electronBridge.send === 'function') {
+                electronBridge.send(message);
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] Electron bridge failed:', action, error);
+        }
     }
 
     function broadcastIcebreakerAppendMessage(message) {

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -1522,10 +1522,19 @@ def test_icebreaker_uses_electron_bridge_for_isolated_full_chat_partition():
     assert "window.nekoElectronIcebreakerBridge" in runtime
     assert "electronBridge.send(message)" in runtime
     assert "window.nekoElectronIcebreakerBridge" in interpage
-    assert "'neko:electron-icebreaker-bridge'" in interpage
-    assert "handleIcebreakerBridgeData(message)" in interpage
     assert "window.__nekoPendingIcebreakerBridgeMessages" in interpage
     assert "window.__nekoIcebreakerBridgeReady = true" in interpage
+    assert re.search(
+        r"yuiGuideInterpageResources\.addEventListener\(\s*window,\s*"
+        r"['\"]neko:electron-icebreaker-bridge['\"]\s*,\s*"
+        r"handleIcebreakerElectronBridgeEvent\s*\)",
+        interpage,
+    )
+    assert re.search(
+        r"pendingIcebreakerBridgeMessages\.forEach\(function \(message\) \{\s*"
+        r"handleIcebreakerBridgeData\(message\)",
+        interpage,
+    )
 
 
 def test_icebreaker_electron_messages_wait_for_async_chat_identity():

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -1513,3 +1513,16 @@ def test_react_chat_assets_use_react_chat_cache_version():
         assert f'{asset}?v={{{{ react_chat_asset_version }}}}' in chat_html
 
     assert pages_router.count('_PROJECT_ROOT.glob("static/app/app-interpage/*.js")') == 1
+
+
+def test_icebreaker_uses_electron_bridge_for_isolated_full_chat_partition():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    interpage = read_js_parts(APP_INTERPAGE_PATH)
+
+    assert "window.nekoElectronIcebreakerBridge" in runtime
+    assert "electronBridge.send(message)" in runtime
+    assert "window.nekoElectronIcebreakerBridge" in interpage
+    assert "'neko:electron-icebreaker-bridge'" in interpage
+    assert "handleIcebreakerBridgeData(message)" in interpage
+    assert "window.__nekoPendingIcebreakerBridgeMessages" in interpage
+    assert "window.__nekoIcebreakerBridgeReady = true" in interpage

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -1526,3 +1526,16 @@ def test_icebreaker_uses_electron_bridge_for_isolated_full_chat_partition():
     assert "handleIcebreakerBridgeData(message)" in interpage
     assert "window.__nekoPendingIcebreakerBridgeMessages" in interpage
     assert "window.__nekoIcebreakerBridgeReady = true" in interpage
+
+
+def test_icebreaker_electron_messages_wait_for_async_chat_identity():
+    interpage = read_js_parts(APP_INTERPAGE_PATH)
+
+    assert "_pendingIcebreakerIdentityMessages" in interpage
+    assert "ICEBREAKER_IDENTITY_QUEUE_MAX = 80" in interpage
+    assert "function queueIcebreakerBridgeMessageUntilIdentity(data)" in interpage
+    assert "flushPendingIcebreakerIdentityMessages" in interpage
+    assert "if (!getCurrentLanlanName())" in interpage
+    assert "queueIcebreakerBridgeMessageUntilIdentity(data);" in interpage
+    assert "'neko:config-injected',\n        schedulePendingIcebreakerIdentityFlush" in interpage
+    assert "window.pageConfigReady.then(schedulePendingIcebreakerIdentityFlush)" in interpage


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复完整聊天框时无法触发教程的问题，并适配教程结束后的破冰对话通信
[修复主页教程期间完整与紧凑聊天框的临时切换及结束恢复，并补齐完整聊天框破冰对话的 Electron IPC 桥接](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/459)

## 测试 / Testing

手动重置教程确认可以触发


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Electron 桥接支持，使新用户引导消息可在隔离聊天环境中可靠传递。
  * 支持应用初始化前暂存消息，并在身份与桥接就绪后按顺序自动处理，最多缓存 80 条。
  * 桥接发送失败时保留现有消息传递流程，避免影响正常使用。

* **测试**
  * 增加 Electron 桥接接线及消息队列处理的静态契约测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->