### PR TITLE
perf(plugin-manager): eliminate blank startup and reduce initial payload

### DIFF
--- a/frontend/plugin-manager/.gitignore
+++ b/frontend/plugin-manager/.gitignore
@@ -27,6 +27,7 @@ coverage
 __screenshots__/
 /cypress/videos/
 /cypress/screenshots/
+/test-results/
 
 # Environment variables
 .env

--- a/frontend/plugin-manager/index.html
+++ b/frontend/plugin-manager/index.html
@@ -5,8 +5,66 @@
     <link rel="icon" href="favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>N.E.K.O 插件管理</title>
+    <script>
+      (() => {
+        // Keep this pre-bundle subset aligned with useDarkMode.ts so the static shell
+        // matches the Vue application theme before main.ts is downloaded and evaluated.
+        let savedTheme = null
+        try {
+          savedTheme = window.localStorage.getItem('neko-dark-mode')
+        } catch (_) {}
+
+        let prefersDark = false
+        if (savedTheme === null) {
+          try {
+            prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+          } catch (_) {}
+        }
+
+        const dark = savedTheme === null ? prefersDark : savedTheme === 'true'
+        document.documentElement.classList.toggle('dark', dark)
+        if (dark) {
+          document.documentElement.setAttribute('data-theme', 'dark')
+        } else {
+          document.documentElement.removeAttribute('data-theme')
+        }
+      })()
+    </script>
+    <style>
+      #plugin-manager-boot-shell {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483000;
+        display: grid;
+        place-items: center;
+        box-sizing: border-box;
+        background: #ffffff;
+        color: #2c3e50;
+        pointer-events: none;
+      }
+
+      html.dark #plugin-manager-boot-shell {
+        background: #181818;
+        color: #f8f8f8;
+      }
+
+      #plugin-manager-boot-shell .boot-shell__label {
+        font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 15px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+      }
+    </style>
   </head>
   <body>
+    <div
+      id="plugin-manager-boot-shell"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span class="boot-shell__label">N.E.K.O</span>
+    </div>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/frontend/plugin-manager/package-lock.json
+++ b/frontend/plugin-manager/package-lock.json
@@ -40,6 +40,7 @@
         "npm-run-all2": "^8.0.4",
         "prettier": "3.6.2",
         "typescript": "~5.9.0",
+        "unplugin-vue-components": "^31.1.0",
         "vite": "^7.2.4",
         "vite-plugin-vue-devtools": "^8.0.5",
         "vitest": "^4.1.5",
@@ -1388,49 +1389,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nuxt/kit": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmmirror.com/@nuxt/kit/-/kit-3.21.2.tgz",
-      "integrity": "sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "c12": "^3.3.3",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
-        "jiti": "^2.6.1",
-        "klona": "^2.0.6",
-        "knitwork": "^1.3.0",
-        "mlly": "^1.8.1",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^3.0.0",
-        "scule": "^1.3.0",
-        "semver": "^7.7.4",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unctx": "^2.5.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
-    "node_modules/@nuxt/kit/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmmirror.com/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -2751,6 +2709,39 @@
         "vue": ">=3.0.0"
       }
     },
+    "node_modules/@vueuse/motion/node_modules/@nuxt/kit": {
+      "version": "3.21.11",
+      "resolved": "https://registry.npmmirror.com/@nuxt/kit/-/kit-3.21.11.tgz",
+      "integrity": "sha512-0Xi3tgwN77w43Q8GCPIrvWmF1J7Peehkts44E0uKNIml9lB8WoUn8YxyUjxBv47XtVR86NWoWALAT+/IEMHJEA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "c12": "^3.3.4",
+        "consola": "^3.4.2",
+        "defu": "^6.1.7",
+        "destr": "^2.0.5",
+        "errx": "^0.1.2",
+        "exsolve": "^1.1.1",
+        "ignore": "^7.0.6",
+        "jiti": "^2.7.0",
+        "klona": "^2.0.6",
+        "knitwork": "^1.3.0",
+        "mlly": "^1.8.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.1",
+        "rc9": "^3.0.1",
+        "scule": "^1.3.0",
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17",
+        "ufo": "^1.6.4",
+        "unctx": "^2.5.0",
+        "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/@vueuse/motion/node_modules/@vueuse/core": {
       "version": "13.9.0",
       "resolved": "https://registry.npmmirror.com/@vueuse/core/-/core-13.9.0.tgz",
@@ -2789,6 +2780,39 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/@vueuse/motion/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vueuse/motion/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@vueuse/motion/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmmirror.com/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
     "node_modules/@vueuse/shared": {
       "version": "14.2.1",
       "resolved": "https://registry.npmmirror.com/@vueuse/shared/-/shared-14.2.1.tgz",
@@ -2802,9 +2826,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -3157,8 +3181,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -3231,8 +3255,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -3598,9 +3622,9 @@
       }
     },
     "node_modules/errx": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmmirror.com/errx/-/errx-0.1.0.tgz",
-      "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmmirror.com/errx/-/errx-0.1.2.tgz",
+      "integrity": "sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==",
       "license": "MIT",
       "optional": true
     },
@@ -4021,11 +4045,11 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmmirror.com/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "license": "MIT",
-      "optional": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "4.7.0",
@@ -4566,9 +4590,9 @@
       "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -4705,6 +4729,24 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4876,8 +4918,8 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmmirror.com/mlly/-/mlly-1.8.2.tgz",
       "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "acorn": "^8.16.0",
         "pathe": "^2.0.3",
@@ -4889,15 +4931,15 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/mlly/node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmmirror.com/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
@@ -5297,14 +5339,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -5509,6 +5551,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmmirror.com/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5566,8 +5625,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -5690,9 +5749,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -5917,13 +5976,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5950,9 +6009,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6071,34 +6130,11 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/unctx": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmmirror.com/unctx/-/unctx-2.5.0.tgz",
-      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21",
-        "unplugin": "^2.3.11"
-      }
-    },
-    "node_modules/unctx/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
+      "version": "1.6.4",
+      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -6111,8 +6147,8 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmmirror.com/unplugin/-/unplugin-2.3.11.tgz",
       "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "acorn": "^8.15.0",
@@ -6124,14 +6160,14 @@
       }
     },
     "node_modules/unplugin-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -6141,9 +6177,55 @@
       }
     },
     "node_modules/unplugin-utils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/unplugin-vue-components": {
+      "version": "31.1.0",
+      "resolved": "https://registry.npmmirror.com/unplugin-vue-components/-/unplugin-vue-components-31.1.0.tgz",
+      "integrity": "sha512-9EbV5ark21A4BOBt6RJGJXCVD2I1eoxTZL1TAvNgYTokcrFIiuxpufb8owyWn7n+z2x8daz/ltZq6IRRKL3ydQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.2",
+        "obug": "^2.1.1",
+        "picomatch": "^4.0.3",
+        "tinyglobby": "^0.2.15",
+        "unplugin": "^2.3.11",
+        "unplugin-utils": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": "^3.2.2 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-vue-components/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6154,11 +6236,11 @@
       }
     },
     "node_modules/unplugin/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -6717,8 +6799,8 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmmirror.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/frontend/plugin-manager/package.json
+++ b/frontend/plugin-manager/package.json
@@ -15,6 +15,7 @@
     "test:hosted": "vitest run src/components/plugin/hosted --exclude \"src/components/plugin/hosted/e2e/**\"",
     "test:hosted-script": "node --test scripts/check-hosted-tsx.test.mjs",
     "test:hosted:e2e": "playwright test",
+    "test:boot:e2e": "npm run build-only && playwright test --config playwright.boot.config.ts",
     "test:hosted:watch": "vitest src/components/plugin/hosted --exclude \"src/components/plugin/hosted/e2e/**\"",
     "check:hosted": "npm run type-check && npm run test:hosted-script && npm run check-hosted-tsx && npm run test:hosted && npm run test:hosted:e2e",
     "check-hosted-tsx": "node scripts/check-hosted-tsx.mjs",

--- a/frontend/plugin-manager/package.json
+++ b/frontend/plugin-manager/package.json
@@ -56,6 +56,7 @@
     "npm-run-all2": "^8.0.4",
     "prettier": "3.6.2",
     "typescript": "~5.9.0",
+    "unplugin-vue-components": "^31.1.0",
     "vite": "^7.2.4",
     "vite-plugin-vue-devtools": "^8.0.5",
     "vitest": "^4.1.5",

--- a/frontend/plugin-manager/playwright.boot.config.ts
+++ b/frontend/plugin-manager/playwright.boot.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+
+export default defineConfig({
+  testDir: './src/e2e',
+  testMatch: '**/*.e2e.ts',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  reporter: [['list']],
+  webServer: {
+    command: 'npm run preview -- --host 127.0.0.1 --strictPort',
+    url: 'http://127.0.0.1:4173/ui/',
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+  use: {
+    ...devices['Desktop Chrome'],
+    headless: true,
+    launchOptions: executablePath ? { executablePath } : {},
+  },
+})

--- a/frontend/plugin-manager/src/App.vue
+++ b/frontend/plugin-manager/src/App.vue
@@ -1,3 +1,35 @@
 <template>
-  <router-view />
+  <el-config-provider
+    :locale="elementLocale"
+    :z-index="ELEMENT_Z_INDEX"
+    :message="ELEMENT_MESSAGE_CONFIG"
+  >
+    <router-view />
+  </el-config-provider>
 </template>
+
+<script setup lang="ts">
+import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
+import zhTw from 'element-plus/dist/locale/zh-tw.mjs'
+import en from 'element-plus/dist/locale/en.mjs'
+import jaLocale from 'element-plus/dist/locale/ja.mjs'
+import koLocale from 'element-plus/dist/locale/ko.mjs'
+import ruLocale from 'element-plus/dist/locale/ru.mjs'
+import esLocale from 'element-plus/dist/locale/es.mjs'
+import ptLocale from 'element-plus/dist/locale/pt.mjs'
+import { getLocale } from './i18n'
+
+const ELEMENT_Z_INDEX = 12000
+const ELEMENT_MESSAGE_CONFIG = { offset: 54 }
+const elementLocaleMap: Record<string, typeof zhCn> = {
+  'zh-CN': zhCn,
+  'zh-TW': zhTw,
+  'en-US': en,
+  ja: jaLocale,
+  ko: koLocale,
+  ru: ruLocale,
+  es: esLocale,
+  pt: ptLocale,
+}
+const elementLocale = elementLocaleMap[getLocale()] ?? zhCn
+</script>

--- a/frontend/plugin-manager/src/assets/base.css
+++ b/frontend/plugin-manager/src/assets/base.css
@@ -89,9 +89,14 @@ body {
 }
 
 img,
-svg {
+svg,
+a[href] {
   -webkit-user-drag: none;
   -khtml-user-drag: none;
+}
+
+img,
+svg {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;

--- a/frontend/plugin-manager/src/components/layout/AppLayout.vue
+++ b/frontend/plugin-manager/src/components/layout/AppLayout.vue
@@ -88,6 +88,7 @@ import { useConnectionStore } from '@/stores/connection'
 
 const { t } = useI18n()
 const connectionStore = useConnectionStore()
+const PLUGIN_MANAGER_BOOT_SHELL_ID = 'plugin-manager-boot-shell'
 const PIN_STATE_RETRY_DELAYS_MS = [50, 150, 350, 750]
 const isMaximized = ref(false)
 const pinAvailable = ref(false)
@@ -228,6 +229,7 @@ function closeWindow() {
 }
 
 onMounted(() => {
+  document.getElementById(PLUGIN_MANAGER_BOOT_SHELL_ID)?.remove()
   void refreshPinState()
   void refreshMaximizeState()
   window.addEventListener('resize', handleWindowResize)

--- a/frontend/plugin-manager/src/e2e/boot-shell.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/boot-shell.e2e.ts
@@ -1,0 +1,129 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const BOOT_SHELL_ID = 'plugin-manager-boot-shell'
+
+async function stubDashboardApis(page: Page) {
+  await page.route('**/health', (route) => route.fulfill({ json: { status: 'ok' } }))
+  await page.route('**/plugins?*', (route) => route.fulfill({ json: { plugins: [], message: '' } }))
+  await page.route('**/plugin/status', (route) => route.fulfill({ json: { plugins: {} } }))
+  await page.route('**/server/info', (route) =>
+    route.fulfill({
+      json: { sdk_version: 'test', plugins_count: 0, time: '2026-08-21T00:00:00Z' },
+    })
+  )
+  await page.route('**/plugin/metrics', (route) =>
+    route.fulfill({
+      json: {
+        global: {
+          total_cpu_percent: 0,
+          total_memory_percent: 0,
+          total_memory_mb: 0,
+          total_threads: 0,
+          active_plugins: 0,
+        },
+      },
+    })
+  )
+}
+
+async function pauseMainModule(page: Page) {
+  let releaseMainModule: (() => void) | undefined
+  const mainModuleGate = new Promise<void>((resolve) => {
+    releaseMainModule = resolve
+  })
+  await page.route('**/ui/assets/index-*.js', async (route) => {
+    await mainModuleGate
+    await route.continue()
+  })
+  return () => releaseMainModule?.()
+}
+
+test.beforeEach(async ({ page }) => {
+  await stubDashboardApis(page)
+})
+
+test('shows a theme-matched shell until the plugin manager layout is ready', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('neko-dark-mode', 'true')
+    ;(window as typeof window & { __pluginManagerBlankGap?: boolean }).__pluginManagerBlankGap =
+      false
+    let shellObserved = false
+    const observer = new MutationObserver(() => {
+      const shell = document.getElementById('plugin-manager-boot-shell')
+      const layout = document.querySelector('.app-root')
+      shellObserved ||= shell !== null
+      const layoutStyle = layout ? window.getComputedStyle(layout) : null
+      const layoutBounds = layout?.getBoundingClientRect()
+      const layoutCanPaint = Boolean(
+        layout &&
+          layoutStyle &&
+          layoutBounds &&
+          layoutStyle.display !== 'none' &&
+          layoutStyle.visibility !== 'hidden' &&
+          layoutStyle.opacity !== '0' &&
+          layoutBounds.width > 0 &&
+          layoutBounds.height > 0
+      )
+      if (shellObserved && shell === null && !layoutCanPaint) {
+        ;(window as typeof window & { __pluginManagerBlankGap?: boolean }).__pluginManagerBlankGap =
+          true
+      }
+    })
+    observer.observe(document.documentElement, { childList: true, subtree: true })
+  })
+  const releaseMainModule = await pauseMainModule(page)
+
+  await page.goto('http://127.0.0.1:4173/ui/', { waitUntil: 'commit' })
+
+  const shell = page.locator(`#${BOOT_SHELL_ID}`)
+  await expect(shell).toBeVisible()
+  await expect(shell).toContainText('N.E.K.O')
+  await expect(shell).toHaveCSS('background-color', 'rgb(24, 24, 24)')
+
+  releaseMainModule()
+
+  await expect(page.locator('.app-root')).toBeVisible()
+  await expect(shell).toHaveCount(0)
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __pluginManagerBlankGap?: boolean }).__pluginManagerBlankGap
+      )
+    )
+    .toBe(false)
+})
+
+test('uses the system dark theme when no stored theme exists', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' })
+  const releaseMainModule = await pauseMainModule(page)
+
+  await page.goto('http://127.0.0.1:4173/ui/', { waitUntil: 'commit' })
+
+  const shell = page.locator(`#${BOOT_SHELL_ID}`)
+  await expect(shell).toBeVisible()
+  await expect(shell).toHaveCSS('background-color', 'rgb(24, 24, 24)')
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+  releaseMainModule()
+  await expect(page.locator('.app-root')).toBeVisible()
+})
+
+test('uses the stored light theme instead of the system dark theme', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' })
+  await page.addInitScript(() => {
+    window.localStorage.setItem('neko-dark-mode', 'false')
+  })
+  const releaseMainModule = await pauseMainModule(page)
+
+  await page.goto('http://127.0.0.1:4173/ui/', { waitUntil: 'commit' })
+
+  const shell = page.locator(`#${BOOT_SHELL_ID}`)
+  await expect(shell).toBeVisible()
+  await expect(shell).toHaveCSS('background-color', 'rgb(255, 255, 255)')
+  await expect(page.locator('html')).not.toHaveClass(/dark/)
+  await expect(page.locator('html')).not.toHaveAttribute('data-theme', 'dark')
+
+  releaseMainModule()
+  await expect(page.locator('.app-root')).toBeVisible()
+})

--- a/frontend/plugin-manager/src/e2e/boot-shell.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/boot-shell.e2e.ts
@@ -1,30 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
+import { PREVIEW_ORIGIN, stubCorePluginManagerApis } from './plugin-manager-test-helpers'
 
 const BOOT_SHELL_ID = 'plugin-manager-boot-shell'
-
-async function stubDashboardApis(page: Page) {
-  await page.route('**/health', (route) => route.fulfill({ json: { status: 'ok' } }))
-  await page.route('**/plugins?*', (route) => route.fulfill({ json: { plugins: [], message: '' } }))
-  await page.route('**/plugin/status', (route) => route.fulfill({ json: { plugins: {} } }))
-  await page.route('**/server/info', (route) =>
-    route.fulfill({
-      json: { sdk_version: 'test', plugins_count: 0, time: '2026-08-21T00:00:00Z' },
-    })
-  )
-  await page.route('**/plugin/metrics', (route) =>
-    route.fulfill({
-      json: {
-        global: {
-          total_cpu_percent: 0,
-          total_memory_percent: 0,
-          total_memory_mb: 0,
-          total_threads: 0,
-          active_plugins: 0,
-        },
-      },
-    })
-  )
-}
 
 async function pauseMainModule(page: Page) {
   let releaseMainModule: (() => void) | undefined
@@ -39,7 +16,7 @@ async function pauseMainModule(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await stubDashboardApis(page)
+  await stubCorePluginManagerApis(page)
 })
 
 test('shows a theme-matched shell until the plugin manager layout is ready', async ({ page }) => {
@@ -73,7 +50,7 @@ test('shows a theme-matched shell until the plugin manager layout is ready', asy
   })
   const releaseMainModule = await pauseMainModule(page)
 
-  await page.goto('http://127.0.0.1:4173/ui/', { waitUntil: 'commit' })
+  await page.goto(`${PREVIEW_ORIGIN}/ui/`, { waitUntil: 'commit' })
 
   const shell = page.locator(`#${BOOT_SHELL_ID}`)
   await expect(shell).toBeVisible()
@@ -98,7 +75,7 @@ test('uses the system dark theme when no stored theme exists', async ({ page }) 
   await page.emulateMedia({ colorScheme: 'dark' })
   const releaseMainModule = await pauseMainModule(page)
 
-  await page.goto('http://127.0.0.1:4173/ui/', { waitUntil: 'commit' })
+  await page.goto(`${PREVIEW_ORIGIN}/ui/`, { waitUntil: 'commit' })
 
   const shell = page.locator(`#${BOOT_SHELL_ID}`)
   await expect(shell).toBeVisible()
@@ -116,7 +93,7 @@ test('uses the stored light theme instead of the system dark theme', async ({ pa
   })
   const releaseMainModule = await pauseMainModule(page)
 
-  await page.goto('http://127.0.0.1:4173/ui/', { waitUntil: 'commit' })
+  await page.goto(`${PREVIEW_ORIGIN}/ui/`, { waitUntil: 'commit' })
 
   const shell = page.locator(`#${BOOT_SHELL_ID}`)
   await expect(shell).toBeVisible()

--- a/frontend/plugin-manager/src/e2e/boot-shell.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/boot-shell.e2e.ts
@@ -19,6 +19,14 @@ test.beforeEach(async ({ page }) => {
   await stubCorePluginManagerApis(page)
 })
 
+test('redirects unknown routes and completes the boot shell handoff', async ({ page }) => {
+  await page.goto(`${PREVIEW_ORIGIN}/ui/route-that-does-not-exist`)
+
+  await expect(page).toHaveURL(`${PREVIEW_ORIGIN}/ui/`)
+  await expect(page.locator('.dashboard')).toBeVisible()
+  await expect(page.locator(`#${BOOT_SHELL_ID}`)).toHaveCount(0)
+})
+
 test('shows a theme-matched shell until the plugin manager layout is ready', async ({ page }) => {
   await page.addInitScript(() => {
     window.localStorage.setItem('neko-dark-mode', 'true')

--- a/frontend/plugin-manager/src/e2e/drag-guard.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/drag-guard.e2e.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test'
+import { PREVIEW_ORIGIN, stubCorePluginManagerApis } from './plugin-manager-test-helpers'
+
+test.beforeEach(async ({ page }) => {
+  await stubCorePluginManagerApis(page)
+})
+
+test('prevents native dragging for dynamically rendered links and images', async ({ page }) => {
+  await page.goto(`${PREVIEW_ORIGIN}/ui/`)
+  await expect(page.locator('.app-root')).toBeVisible()
+
+  const result = await page.evaluate(() => {
+    const link = document.createElement('a')
+    link.href = '/plugins'
+    link.textContent = 'Plugins'
+    const image = document.createElement('img')
+    image.alt = ''
+    image.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
+    document.querySelector('.app-root')?.append(link, image)
+
+    const linkDragEvent = new DragEvent('dragstart', { bubbles: true, cancelable: true })
+    const imageDragEvent = new DragEvent('dragstart', { bubbles: true, cancelable: true })
+
+    return {
+      linkUserDrag: getComputedStyle(link).getPropertyValue('-webkit-user-drag'),
+      imageUserDrag: getComputedStyle(image).getPropertyValue('-webkit-user-drag'),
+      linkDragAllowed: link.dispatchEvent(linkDragEvent),
+      imageDragAllowed: image.dispatchEvent(imageDragEvent),
+    }
+  })
+
+  expect(result).toEqual({
+    linkUserDrag: 'none',
+    imageUserDrag: 'none',
+    linkDragAllowed: false,
+    imageDragAllowed: false,
+  })
+})

--- a/frontend/plugin-manager/src/e2e/element-plus.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/element-plus.e2e.ts
@@ -1,0 +1,195 @@
+import { expect, test, type Page } from '@playwright/test'
+import {
+  PREVIEW_ORIGIN,
+  collectVueResolutionWarnings,
+  stubCorePluginManagerApis,
+} from './plugin-manager-test-helpers'
+
+async function stubPluginManagerApis(page: Page) {
+  await stubCorePluginManagerApis(page)
+  await page.route('**/plugins/refresh', (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        added: [],
+        updated: [],
+        removed: [],
+        removed_running: [],
+        unchanged: [],
+        failed: [],
+        scanned_count: 0,
+      },
+    })
+  )
+  await page.route('**/market/status', (route) =>
+    route.fulfill({
+      json: {
+        market_url: 'https://market.example.test',
+        market_web_url: 'https://market.example.test',
+      },
+    })
+  )
+  await page.route('**/market/bridge-token', (route) =>
+    route.fulfill({
+      json: { bridge_token: 'test-bridge-token' },
+    })
+  )
+  await page.route('**/market/oauth/status', (route) =>
+    route.fulfill({
+      json: {
+        authenticated: true,
+        auth_state: 'connected',
+        profile: { username: 'neko', display_name: 'Neko' },
+      },
+    })
+  )
+  await page.route('**/plugin/*/logs*', (route) =>
+    route.fulfill({
+      json: { plugin_id: 'demo', logs: [], total_lines: 0, returned_lines: 0 },
+    })
+  )
+  await page.route('**/plugin/metrics/*', (route) =>
+    route.fulfill({ json: { plugin_id: 'demo', metrics: null } })
+  )
+  await page.route('**/plugin/*/config/base', (route) =>
+    route.fulfill({ json: { schema: {}, config: {} } })
+  )
+  await page.route('**/plugin/*/config/profiles', (route) =>
+    route.fulfill({ json: { profiles: [], active_profile: null } })
+  )
+  await page.route('**/plugin/*/config', (route) =>
+    route.fulfill({ json: { schema: {}, config: {} } })
+  )
+  await page.route('**/market/installed?*', (route) => route.fulfill({ json: { items: [] } }))
+  await page.routeWebSocket('**/ws/**', () => {})
+}
+
+test.beforeEach(async ({ page }) => {
+  await stubPluginManagerApis(page)
+})
+
+test('preserves the global message offset and overlay z-index', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('neko-dark-mode', 'true')
+  })
+  await page.goto(`${PREVIEW_ORIGIN}/ui/`)
+  await page.locator('.header__actions .header-btn').last().click()
+
+  const message = page.locator('.el-message')
+  await expect(message).toBeVisible()
+  await expect(message).toHaveCSS('top', '54px')
+  expect(
+    Number(await message.evaluate((element) => getComputedStyle(element).zIndex))
+  ).toBeGreaterThan(12000)
+  await expect(page.locator('html')).toHaveClass(/dark/)
+})
+
+test('resolves routed components and the loading directive on the plugin list', async ({
+  page,
+}) => {
+  let finishAccountSummary: (() => void) | undefined
+  const accountSummaryGate = new Promise<void>((resolve) => {
+    finishAccountSummary = resolve
+  })
+  const resolutionWarnings = collectVueResolutionWarnings(page)
+  await page.addInitScript(() => {
+    window.localStorage.setItem('neko_bridge_token', 'test-bridge-token')
+  })
+  await page.route('**/market/oauth/account-summary', async (route) => {
+    await accountSummaryGate
+    await route.fulfill({
+      json: {
+        authenticated: true,
+        profile: { username: 'neko', display_name: 'Neko' },
+        market: { plugins_count: 0, downloads_count: 0 },
+      },
+    })
+  })
+
+  await page.goto(`${PREVIEW_ORIGIN}/ui/plugins`)
+  await expect(page.locator('.plugin-workbench')).toBeVisible()
+  await page.locator('.market-auth-trigger--connected').click()
+
+  const accountCard = page.locator('.market-account-card')
+  await expect(accountCard).toBeVisible()
+  await expect(accountCard.locator('.el-loading-mask')).toBeVisible()
+
+  finishAccountSummary?.()
+  await expect(accountCard.locator('.el-loading-mask')).toHaveCount(0)
+  expect(resolutionWarnings).toEqual([])
+})
+
+test('preserves the configured Element Plus locale on plugin detail dialogs', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('locale', 'ja')
+    window.localStorage.setItem('neko-dark-mode', 'true')
+  })
+  await page.route('**/plugins?*', (route) =>
+    route.fulfill({
+      json: {
+        plugins: [
+          {
+            id: 'demo',
+            name: 'Demo',
+            description: '',
+            version: '1.0.0',
+            type: 'plugin',
+            status: 'running',
+            runtime_enabled: true,
+            runtime_auto_start: false,
+            entries: [],
+            list_actions: [],
+          },
+        ],
+        message: '',
+      },
+    })
+  )
+  await page.route('**/plugin/status?*', (route) =>
+    route.fulfill({ json: { status: 'running', plugin_id: 'demo' } })
+  )
+  await page.route('**/plugin/demo/surfaces?*', (route) =>
+    route.fulfill({ json: { surfaces: [], warnings: [] } })
+  )
+
+  await page.goto(`${PREVIEW_ORIGIN}/ui/plugins/demo`)
+  await expect(page.locator('.plugin-detail')).toBeVisible()
+  await page.getByRole('button', { name: '停止' }).click()
+
+  const messageBox = page.locator('.el-message-box')
+  const overlay = page.locator('.el-overlay.is-message-box')
+  await expect(messageBox).toBeVisible()
+  await expect(overlay).toBeVisible()
+  await expect(messageBox.getByRole('button', { name: 'キャンセル' })).toBeVisible()
+  expect(
+    Number(await overlay.evaluate((element) => getComputedStyle(element).zIndex))
+  ).toBeGreaterThan(12000)
+  expect(
+    await messageBox.evaluate((element) => getComputedStyle(element).backgroundColor)
+  ).not.toBe('rgb(255, 255, 255)')
+  await messageBox.getByRole('button', { name: 'キャンセル' }).click()
+  await expect(messageBox).toHaveCount(0)
+})
+
+test('renders every top-level route without unresolved Element Plus components', async ({
+  page,
+}) => {
+  const resolutionWarnings = collectVueResolutionWarnings(page)
+
+  const routes = [
+    { path: '/', selector: '.dashboard' },
+    { path: '/plugins', selector: '.plugin-workbench' },
+    { path: '/runs', selector: '.runs-page' },
+    { path: '/packages', selector: '.package-manager' },
+    { path: '/logs/_server', selector: '.logs-page' },
+    { path: '/market', selector: '.market-workbench' },
+    { path: '/adapter/demo/ui', selector: '.adapter-ui' },
+  ]
+
+  for (const route of routes) {
+    await page.goto(`${PREVIEW_ORIGIN}/ui${route.path}`)
+    await expect(page.locator(route.selector)).toBeVisible()
+  }
+
+  expect(resolutionWarnings).toEqual([])
+})

--- a/frontend/plugin-manager/src/e2e/payload-budget.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/payload-budget.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Response } from '@playwright/test'
 import { PREVIEW_ORIGIN, stubCorePluginManagerApis } from './plugin-manager-test-helpers'
 
 test('keeps the initial plugin manager payload within the cold-start budget', async ({
@@ -17,6 +17,8 @@ test('keeps the initial plugin manager payload within the cold-start budget', as
     request.get(`${PREVIEW_ORIGIN}${entryPath}`),
     request.get(`${PREVIEW_ORIGIN}${stylesheetPath}`),
   ])
+  expect(entryResponse.ok()).toBe(true)
+  expect(stylesheetResponse.ok()).toBe(true)
   const [entryBody, stylesheetBody] = await Promise.all([
     entryResponse.body(),
     stylesheetResponse.body(),
@@ -28,22 +30,26 @@ test('keeps the initial plugin manager payload within the cold-start budget', as
 
 test('keeps the complete initial route script and stylesheet payload bounded', async ({ page }) => {
   await stubCorePluginManagerApis(page)
-  const scriptBodies: Array<Promise<Uint8Array>> = []
-  const stylesheetBodies: Array<Promise<Uint8Array>> = []
+  const scriptResponses: Response[] = []
+  const stylesheetResponses: Response[] = []
   page.on('response', (response) => {
     if (!response.url().startsWith(PREVIEW_ORIGIN)) return
     const resourceType = response.request().resourceType()
-    if (resourceType === 'script') scriptBodies.push(response.body())
-    if (resourceType === 'stylesheet') stylesheetBodies.push(response.body())
+    if (resourceType === 'script') scriptResponses.push(response)
+    if (resourceType === 'stylesheet') stylesheetResponses.push(response)
   })
 
   await page.goto(`${PREVIEW_ORIGIN}/ui/`)
   await expect(page.locator('.app-root')).toBeVisible()
   await expect(page.locator('.dashboard')).toBeVisible()
 
+  for (const response of [...scriptResponses, ...stylesheetResponses]) {
+    expect(response.ok(), `${response.status()} ${response.url()}`).toBe(true)
+  }
+
   const [scripts, stylesheets] = await Promise.all([
-    Promise.all(scriptBodies),
-    Promise.all(stylesheetBodies),
+    Promise.all(scriptResponses.map((response) => response.body())),
+    Promise.all(stylesheetResponses.map((response) => response.body())),
   ])
   const scriptBytes = scripts.reduce((total, body) => total + body.byteLength, 0)
   const stylesheetBytes = stylesheets.reduce((total, body) => total + body.byteLength, 0)

--- a/frontend/plugin-manager/src/e2e/payload-budget.e2e.ts
+++ b/frontend/plugin-manager/src/e2e/payload-budget.e2e.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import { PREVIEW_ORIGIN, stubCorePluginManagerApis } from './plugin-manager-test-helpers'
+
+test('keeps the initial plugin manager payload within the cold-start budget', async ({
+  request,
+}) => {
+  const indexResponse = await request.get(`${PREVIEW_ORIGIN}/ui/`)
+  expect(indexResponse.ok()).toBe(true)
+  const indexHtml = await indexResponse.text()
+  const entryPath = indexHtml.match(/<script[^>]+src="([^"]+index-[^"]+\.js)"/)?.[1]
+  const stylesheetPath = indexHtml.match(/<link[^>]+href="([^"]+index-[^"]+\.css)"/)?.[1]
+
+  expect(entryPath).toBeTruthy()
+  expect(stylesheetPath).toBeTruthy()
+
+  const [entryResponse, stylesheetResponse] = await Promise.all([
+    request.get(`${PREVIEW_ORIGIN}${entryPath}`),
+    request.get(`${PREVIEW_ORIGIN}${stylesheetPath}`),
+  ])
+  const [entryBody, stylesheetBody] = await Promise.all([
+    entryResponse.body(),
+    stylesheetResponse.body(),
+  ])
+
+  expect(entryBody.byteLength).toBeLessThan(750_000)
+  expect(stylesheetBody.byteLength).toBeLessThan(80_000)
+})
+
+test('keeps the complete initial route script and stylesheet payload bounded', async ({ page }) => {
+  await stubCorePluginManagerApis(page)
+  const scriptBodies: Array<Promise<Uint8Array>> = []
+  const stylesheetBodies: Array<Promise<Uint8Array>> = []
+  page.on('response', (response) => {
+    if (!response.url().startsWith(PREVIEW_ORIGIN)) return
+    const resourceType = response.request().resourceType()
+    if (resourceType === 'script') scriptBodies.push(response.body())
+    if (resourceType === 'stylesheet') stylesheetBodies.push(response.body())
+  })
+
+  await page.goto(`${PREVIEW_ORIGIN}/ui/`)
+  await expect(page.locator('.app-root')).toBeVisible()
+  await expect(page.locator('.dashboard')).toBeVisible()
+
+  const [scripts, stylesheets] = await Promise.all([
+    Promise.all(scriptBodies),
+    Promise.all(stylesheetBodies),
+  ])
+  const scriptBytes = scripts.reduce((total, body) => total + body.byteLength, 0)
+  const stylesheetBytes = stylesheets.reduce((total, body) => total + body.byteLength, 0)
+
+  expect(scriptBytes).toBeLessThan(1_000_000)
+  expect(stylesheetBytes).toBeLessThan(120_000)
+})

--- a/frontend/plugin-manager/src/e2e/plugin-manager-test-helpers.ts
+++ b/frontend/plugin-manager/src/e2e/plugin-manager-test-helpers.ts
@@ -1,0 +1,37 @@
+import type { Page } from '@playwright/test'
+
+export const PREVIEW_ORIGIN = 'http://127.0.0.1:4173'
+
+export function collectVueResolutionWarnings(page: Page) {
+  const warnings: string[] = []
+  page.on('console', (message) => {
+    if (/Failed to resolve (component|directive)/.test(message.text())) {
+      warnings.push(message.text())
+    }
+  })
+  return warnings
+}
+
+export async function stubCorePluginManagerApis(page: Page) {
+  await page.route('**/health', (route) => route.fulfill({ json: { status: 'ok' } }))
+  await page.route('**/plugins?*', (route) => route.fulfill({ json: { plugins: [], message: '' } }))
+  await page.route('**/plugin/status', (route) => route.fulfill({ json: { plugins: {} } }))
+  await page.route('**/server/info', (route) =>
+    route.fulfill({
+      json: { sdk_version: 'test', plugins_count: 0, time: '2026-08-21T00:00:00Z' },
+    })
+  )
+  await page.route('**/plugin/metrics', (route) =>
+    route.fulfill({
+      json: {
+        global: {
+          total_cpu_percent: 0,
+          total_memory_percent: 0,
+          total_memory_mb: 0,
+          total_threads: 0,
+          active_plugins: 0,
+        },
+      },
+    })
+  )
+}

--- a/frontend/plugin-manager/src/main.ts
+++ b/frontend/plugin-manager/src/main.ts
@@ -17,19 +17,6 @@ initDarkMode()
 initPluginDashboardYuiGuideRuntime()
 
 function initNativeDragGuard() {
-  const markNativeDragSource = (element: HTMLAnchorElement | HTMLImageElement) => {
-    element.draggable = false
-    element.setAttribute('draggable', 'false')
-  }
-
-  const markNativeDragSources = (root: ParentNode | HTMLAnchorElement | HTMLImageElement = document) => {
-    if (root instanceof HTMLAnchorElement || root instanceof HTMLImageElement) {
-      markNativeDragSource(root)
-      return
-    }
-    root.querySelectorAll<HTMLAnchorElement | HTMLImageElement>('a[href], img').forEach(markNativeDragSource)
-  }
-
   const handleDragStart = (event: DragEvent) => {
     const rawTarget = event.target
     let target: Element | null = null
@@ -48,19 +35,7 @@ function initNativeDragGuard() {
     }
   }
 
-  markNativeDragSources(document)
   document.addEventListener('dragstart', handleDragStart, true)
-
-  const observer = new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      mutation.addedNodes.forEach((node) => {
-        if (node instanceof Element) {
-          markNativeDragSources(node)
-        }
-      })
-    })
-  })
-  observer.observe(document.documentElement, { childList: true, subtree: true })
 }
 
 initNativeDragGuard()

--- a/frontend/plugin-manager/src/main.ts
+++ b/frontend/plugin-manager/src/main.ts
@@ -1,23 +1,14 @@
 import './assets/main.css'
 
-import * as ElementPlusIconsVue from '@element-plus/icons-vue'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import ElementPlus from 'element-plus'
-import 'element-plus/dist/index.css'
+import 'element-plus/es/components/message/style/css'
+import 'element-plus/es/components/message-box/style/css'
 import 'element-plus/theme-chalk/dark/css-vars.css'
-import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
-import zhTw from 'element-plus/dist/locale/zh-tw.mjs'
-import en from 'element-plus/dist/locale/en.mjs'
-import jaLocale from 'element-plus/dist/locale/ja.mjs'
-import koLocale from 'element-plus/dist/locale/ko.mjs'
-import ruLocale from 'element-plus/dist/locale/ru.mjs'
-import esLocale from 'element-plus/dist/locale/es.mjs'
-import ptLocale from 'element-plus/dist/locale/pt.mjs'
 import { MotionPlugin } from '@vueuse/motion'
 import App from './App.vue'
 import { initDarkMode } from './composables/useDarkMode'
-import { i18n, getLocale } from './i18n'
+import { i18n } from './i18n'
 import router from './router'
 import { useConnectionStore } from './stores/connection'
 import { initPluginDashboardYuiGuideRuntime } from './yui-guide-runtime'
@@ -76,10 +67,6 @@ initNativeDragGuard()
 
 const app = createApp(App)
 
-for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
-  app.component(key, component)
-}
-
 const pinia = createPinia()
 app.use(pinia)
 
@@ -88,25 +75,6 @@ app.use(router)
 app.use(i18n)
 
 app.use(MotionPlugin)
-
-const currentLocale = getLocale()
-const elLocaleMap: Record<string, typeof zhCn> = {
-  'zh-CN': zhCn,
-  'zh-TW': zhTw,
-  'en-US': en,
-  'ja': jaLocale,
-  'ko': koLocale,
-  'ru': ruLocale,
-  'es': esLocale,
-  'pt': ptLocale
-}
-app.use(ElementPlus, {
-  locale: elLocaleMap[currentLocale] ?? zhCn,
-  zIndex: 12000,
-  message: {
-    offset: 54
-  }
-})
 
 app.mount('#app')
 

--- a/frontend/plugin-manager/src/router/index.ts
+++ b/frontend/plugin-manager/src/router/index.ts
@@ -77,6 +77,10 @@ const routes: RouteRecordRaw[] = [
         meta: {
           titleKey: 'nav.adapterUI'
         }
+      },
+      {
+        path: ':pathMatch(.*)*',
+        redirect: '/'
       }
     ]
   }
@@ -100,4 +104,3 @@ router.beforeEach((to, from, next) => {
 })
 
 export default router
-

--- a/frontend/plugin-manager/vite.config.ts
+++ b/frontend/plugin-manager/vite.config.ts
@@ -3,14 +3,21 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
+import Components from 'unplugin-vue-components/vite'
+import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
 const BACKEND_TARGET = process.env.VITE_BACKEND_URL || 'http://localhost:48916'
+const elementPlusImportStyle = process.env.VITEST === 'true' ? false : 'css'
 
 // https://vite.dev/config/
 export default defineConfig({
   base: '/ui/',
   plugins: [
     vue(),
+    Components({
+      dts: false,
+      resolvers: [ElementPlusResolver({ importStyle: elementPlusImportStyle })],
+    }),
     vueDevTools(),
   ],
   resolve: {

--- a/plugin/server/application/plugins/query_service.py
+++ b/plugin/server/application/plugins/query_service.py
@@ -498,6 +498,7 @@ def _build_plugin_list_sync(locale: str | None = None) -> list[dict[str, object]
 
             plugin_meta = _normalize_mapping(plugin_meta_obj, context=f"plugins[{plugin_id}]")
             plugin_info = dict(plugin_meta)
+            plugin_info.pop("entries_preview", None)
             plugin_info["status"] = _resolve_plugin_status(
                 plugin_id=plugin_id,
                 plugin_meta=plugin_meta,

--- a/plugin/tests/unit/server/test_plugin_query_status.py
+++ b/plugin/tests/unit/server/test_plugin_query_status.py
@@ -113,6 +113,27 @@ def test_build_plugin_list_reports_source_missing_status(monkeypatch: pytest.Mon
     ]
 
 
+def test_build_plugin_list_omits_internal_entries_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry_meta = {
+        "id": "demo",
+        "name": "Demo",
+        "entries_preview": [{"id": "ping", "name": "Ping"}],
+    }
+    monkeypatch.setattr(
+        query_module.state,
+        "get_plugins_snapshot_cached",
+        lambda timeout=2.0: {"demo": registry_meta},
+    )
+    monkeypatch.setattr(query_module.state, "get_plugin_hosts_snapshot_cached", lambda timeout=2.0: {})
+    monkeypatch.setattr(query_module.state, "get_event_handlers_snapshot_cached", lambda timeout=2.0: {})
+
+    results = query_module._build_plugin_list_sync()
+
+    assert "entries_preview" in registry_meta
+    assert "entries_preview" not in results[0]
+    assert [entry["id"] for entry in results[0]["entries"]] == ["ping"]
+
+
 def test_resolve_plugin_display_fields_preserves_empty_description_without_translation() -> None:
     plugin_info: dict[str, object] = {
         "id": "empty_description_plugin",


### PR DESCRIPTION
## Summary

- render a theme-matched static `N.E.K.O` boot shell before Vue evaluates, then remove it only after the root layout is paintable
- load Element Plus components, directives, styles, and icons on demand while preserving the existing locale, `zIndex=12000`, Message offset, dark theme, `v-loading`, and programmatic API behavior
- replace the document-wide native-drag `MutationObserver` with CSS plus the existing capture-phase `dragstart` guard
- omit the internal duplicate `entries_preview` field from `/plugins` responses while preserving registry state and formal `entries`
- add production Preview E2E coverage for cold boot, theme precedence, all top-level routes, Element Plus overlays/locale/loading, drag behavior, and payload budgets

## Performance

| Metric | Before | After |
|---|---:|---:|
| visible startup FCP, normal CPU | ~388 ms | ~28 ms |
| visible startup FCP, 4x CPU | ~724 ms | ~56 ms |
| entry JS | 1,647 KB | 617 KB |
| entry CSS | 354 KB | 52 KB |
| complete initial-route payload | not bounded | 834 KB JS / 84 KB CSS |
| 4x CPU root-layout ready | ~674 ms | ~595 ms |
| 4x CPU max startup long task | ~406 ms | ~343 ms |
| `/plugins` response, 22 local plugins | ~557 KB | 285,170 bytes |

The optimized `/plugins` response still contains all 22 plugins and 341 formal entries; only the duplicate internal preview field is omitted.

## Regression report / 回归报告

### What changed

The plugin-manager boot path now has a static pre-Vue shell, Element Plus is resolved on demand, native drag protection no longer scans every DOM mutation, and the plugin list API no longer serializes duplicate preview entries.

### Why this is necessary

Cold opening previously displayed a blank window while a 1.65 MB entry bundle evaluated. The same startup also registered every Element Plus component/icon and scanned every inserted DOM subtree. Separately, `/plugins` returned the same entry metadata twice.

### Before / after behavior

- before: blank white/dark window until Vue's first paint
- after: theme-matched shell appears immediately and remains until `.app-root` is visible and non-zero-size
- existing plugin-manager routes, locale behavior, overlays, Message offset/z-index, hosted UI, Yui startup order, backend routes, and drag prevention remain unchanged

### Potential regression areas

- Element Plus components or directives referenced only by a rarely visited route
- programmatic Message/MessageBox styles and overlay stacking
- Electron native dragging of dynamically inserted anchors/images
- clients that incorrectly depended on the undocumented `/plugins[].entries_preview` duplicate instead of `entries`

These areas are covered by route-matrix, overlay, locale, `v-loading`, dynamic-drag, and plugin-query contract tests.

## Validation

- `npm ci --include=dev`
- plugin-manager production build and `vue-tsc`
- 10 production Preview Playwright E2E tests
- 82 focused plugin-server tests
- Ruff checks for changed backend files
- 8-locale synchronization check
- 35 hosted TSX script tests
- two-axis standards/spec review with no remaining actionable findings

Known unrelated baseline: the hosted Vitest cohort reports 86 passing tests and one Node 26 environment failure (`No such built-in module: node:` in `tsxRuntime.test.ts`); this PR did not add that failure.

## Visual evidence

- Before: the new window remained visually blank until Vue produced its first contentful paint (~388 ms normal CPU; ~724 ms at 4x throttling).
- After: a theme-matched `N.E.K.O` shell paints in ~28 ms normal CPU / ~56 ms at 4x throttling, then hands off without a blank frame.
- [ ] Attach before/after screenshots or a short recording before marking this PR ready for review.

## Why not split / 不拆分理由

The changes are kept in four independently reviewable commits, but submitted as one PR because the user-visible startup fix and its safety envelope are coupled: the shell fixes perceived blankness, on-demand loading reduces the real boot workload, drag-guard cleanup reduces the remaining long task, and API deduplication removes the post-paint payload spike. Each concern can still be reverted independently by commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件管理器启动时支持根据保存设置或系统偏好自动匹配深色/浅色主题。
  * 新增启动加载界面，减少页面加载期间的空白感。
  * 未匹配的页面路径将自动返回插件管理器首页。

* **改进**
  * 优化图片、链接及图标的拖拽行为，避免误操作。
  * 优化插件列表返回内容，提升数据展示的整洁性。
  * 优化组件加载方式、提示信息、弹窗层级及多语言表现。

* **测试**
  * 增加启动主题、页面加载、组件渲染、拖拽行为及资源大小检查。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->