### PR TITLE
fix(pngtuber): 补齐模型越界回弹行为

### DIFF
--- a/static/js/model_manager/background-model-drag.js
+++ b/static/js/model_manager/background-model-drag.js
@@ -175,6 +175,9 @@
         const container = manager && manager.container;
         if (!manager || !container || event.target !== container || manager.isLocked) return null;
         if (!manager.image || !isVisible(container)) return null;
+        if (typeof manager.beginExternalPositionDrag === 'function') {
+            manager.beginExternalPositionDrag();
+        }
 
         return {
             type: 'pngtuber',

--- a/static/js/model_manager/background-model-drag.js
+++ b/static/js/model_manager/background-model-drag.js
@@ -208,6 +208,11 @@
                 if (typeof manager.restartLayeredAnimationLoop === 'function') {
                     manager.restartLayeredAnimationLoop();
                 }
+                if (dragSequence !== null &&
+                    typeof manager.isExternalPositionDragCurrent === 'function' &&
+                    !manager.isExternalPositionDragCurrent(dragSequence)) {
+                    return;
+                }
                 if (typeof manager.snapModelIntoScreen === 'function') {
                     await manager.snapModelIntoScreen({ animate: true });
                 }

--- a/static/js/model_manager/background-model-drag.js
+++ b/static/js/model_manager/background-model-drag.js
@@ -175,14 +175,15 @@
         const container = manager && manager.container;
         if (!manager || !container || event.target !== container || manager.isLocked) return null;
         if (!manager.image || !isVisible(container)) return null;
-        if (typeof manager.beginExternalPositionDrag === 'function') {
-            manager.beginExternalPositionDrag();
-        }
+        let dragSequence = null;
 
         return {
             type: 'pngtuber',
             surface: container,
             move(deltaX, deltaY) {
+                if (dragSequence === null && typeof manager.beginExternalPositionDrag === 'function') {
+                    dragSequence = manager.beginExternalPositionDrag();
+                }
                 if (typeof manager.beginModelManagerPositionEditing === 'function') {
                     manager.beginModelManagerPositionEditing();
                 }
@@ -206,6 +207,14 @@
                 if (!moved) return;
                 if (typeof manager.restartLayeredAnimationLoop === 'function') {
                     manager.restartLayeredAnimationLoop();
+                }
+                if (typeof manager.snapModelIntoScreen === 'function') {
+                    await manager.snapModelIntoScreen({ animate: true });
+                }
+                if (dragSequence !== null &&
+                    typeof manager.isExternalPositionDragCurrent === 'function' &&
+                    !manager.isExternalPositionDragCurrent(dragSequence)) {
+                    return;
                 }
                 if (typeof window.stageModelManagerPNGTuberPlacement === 'function') {
                     window.stageModelManagerPNGTuberPlacement(manager.config);

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3246,15 +3246,18 @@
             if (this._dragState) return;
             event.preventDefault();
             event.stopPropagation();
-            this._dragSequence += 1;
-            const zoomSequence = this._dragSequence;
-            this.cancelEdgeSnapAnimation();
-            this.beginModelManagerPositionEditing();
             const absDelta = Math.abs(event.deltaY);
             const zoomStep = Math.min(absDelta / 1000, 0.08);
             const scaleFactor = 1 + zoomStep;
             const currentScale = this.getActivePlacement().scale;
-            const nextScale = event.deltaY < 0 ? currentScale * scaleFactor : currentScale / scaleFactor;
+            const requestedScale = event.deltaY < 0 ? currentScale * scaleFactor : currentScale / scaleFactor;
+            const nextScale = clampNumber(requestedScale, SCALE_MIN, SCALE_MAX, currentScale);
+            if (nextScale === currentScale) return;
+
+            this._dragSequence += 1;
+            const zoomSequence = this._dragSequence;
+            this.cancelEdgeSnapAnimation();
+            this.beginModelManagerPositionEditing();
             this.applyScale(nextScale);
             this.snapModelIntoScreen({ animate: true }).then(() => {
                 if (zoomSequence === this._dragSequence) {
@@ -3324,6 +3327,19 @@
             state.lastAt = now;
             const changed = Math.abs(scaleChange - 1) > 0.01 || Math.hypot(dx, dy) > 4;
             if (changed && !state.changed) {
+                const candidatePlacement = this.getRenderPlacement(this.getActivePlacement());
+                const nextScale = clampNumber(
+                    candidatePlacement.scale * scaleChange,
+                    SCALE_MIN,
+                    SCALE_MAX,
+                    candidatePlacement.scale
+                );
+                const nextOffsetX = Math.max(-5000, Math.min(5000, candidatePlacement.offsetX + dx));
+                const nextOffsetY = Math.max(-5000, Math.min(5000, candidatePlacement.offsetY + dy));
+                if (nextScale === candidatePlacement.scale
+                    && nextOffsetX === candidatePlacement.offsetX
+                    && nextOffsetY === candidatePlacement.offsetY) return;
+
                 this.cancelEdgeSnapAnimation();
                 this._dragSequence += 1;
                 state.dragSequence = this._dragSequence;

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -24,6 +24,8 @@
     const REMIX_LAYERED_CANVAS_PADDING_MIN = 48;
     const REMIX_LAYERED_CANVAS_PADDING_MAX = 160;
     const PNGTUBER_LAYERED_CANVAS_MAX_RENDER_EDGE = 1024;
+    const PNGTUBER_EDGE_SNAP_MIN_VISIBLE_PX = 200;
+    const PNGTUBER_EDGE_SNAP_DURATION_MS = 260;
     const REMIX_MESH_DEFORM_STRENGTH = 0.28;
     const PNGTUBER_PLUS_VISIBLE_VALUES = new Set([0, 10, 20, 30, 1, 21, 12, 32, 3, 13, 4, 15, 26, 36, 27, 38]);
     // 空闲低频驱动（对齐 live2d-core.js round-2 模式）：呼吸是 0.32Hz 正弦、
@@ -207,6 +209,8 @@
             this._dragSequence = 0;
             this._isDraggingModel = false;
             this.isDragging = false;
+            this._edgeSnapAnimationFrame = null;
+            this._edgeSnapResolve = null;
             this._saveInFlight = null;
             this._lastSavedPositionKey = '';
             this._saveTimer = null;
@@ -326,6 +330,7 @@
             this._dragListenersAttached = false;
             this._dragState = null;
             this._dragSequence += 1;
+            this.cancelEdgeSnapAnimation();
             this._touchZoomState = null;
             this.setModelDraggingState(false);
         }
@@ -2819,6 +2824,118 @@
             return true;
         }
 
+        getEdgeSnapTarget({ minVisiblePixels = PNGTUBER_EDGE_SNAP_MIN_VISIBLE_PX } = {}) {
+            if (!this.image || typeof this.image.getBoundingClientRect !== 'function') return null;
+            const rect = this.image.getBoundingClientRect();
+            const left = Number(rect?.left);
+            const top = Number(rect?.top);
+            const width = Number(rect?.width);
+            const height = Number(rect?.height);
+            const viewportWidth = Number(window.innerWidth);
+            const viewportHeight = Number(window.innerHeight);
+            if (![left, top, width, height, viewportWidth, viewportHeight].every(Number.isFinite)
+                || width <= 0 || height <= 0 || viewportWidth <= 0 || viewportHeight <= 0) {
+                return null;
+            }
+
+            const right = left + width;
+            const bottom = top + height;
+            const effectiveMinX = Math.min(Math.max(0, Number(minVisiblePixels) || 0), viewportWidth);
+            const effectiveMinY = Math.min(Math.max(0, Number(minVisiblePixels) || 0), viewportHeight);
+            const visibleWidth = Math.max(0, Math.min(viewportWidth, right) - Math.max(0, left));
+            const visibleHeight = Math.max(0, Math.min(viewportHeight, bottom) - Math.max(0, top));
+            const needsClampH = (left < 0 || right > viewportWidth) && visibleWidth < effectiveMinX;
+            const needsClampV = (top < 0 || bottom > viewportHeight) && visibleHeight < effectiveMinY;
+            if (!needsClampH && !needsClampV) return null;
+
+            let moveX = 0;
+            let moveY = 0;
+            if (needsClampH) {
+                if (right < effectiveMinX) {
+                    moveX = effectiveMinX - right;
+                } else if (left > viewportWidth - effectiveMinX) {
+                    moveX = (viewportWidth - effectiveMinX) - left;
+                }
+            }
+            if (needsClampV) {
+                if (bottom < effectiveMinY) {
+                    moveY = effectiveMinY - bottom;
+                } else if (top > viewportHeight - effectiveMinY) {
+                    moveY = (viewportHeight - effectiveMinY) - top;
+                }
+            }
+            if (!moveX && !moveY) return null;
+
+            const placement = this.getActivePlacement();
+            return {
+                offsetX: placement.offsetX + moveX,
+                offsetY: placement.offsetY + moveY
+            };
+        }
+
+        cancelEdgeSnapAnimation() {
+            if (this._edgeSnapAnimationFrame !== null) {
+                cancelAnimationFrame(this._edgeSnapAnimationFrame);
+                this._edgeSnapAnimationFrame = null;
+            }
+            if (this._edgeSnapResolve) {
+                const resolve = this._edgeSnapResolve;
+                this._edgeSnapResolve = null;
+                resolve(false);
+            }
+        }
+
+        applyEdgeSnapOffsets(offsetX, offsetY) {
+            this.setActiveOffsets(offsetX, offsetY);
+            this.applyTransform();
+            if (this.isLayeredActive()) this.drawLayeredState();
+            this.syncGlobalConfig();
+            if (typeof this.updateFloatingButtonsPosition === 'function') {
+                this.updateFloatingButtonsPosition();
+            }
+            this.updateLockIconPosition();
+        }
+
+        snapModelIntoScreen({ animate = true, durationMs = PNGTUBER_EDGE_SNAP_DURATION_MS } = {}) {
+            this.cancelEdgeSnapAnimation();
+            const target = this.getEdgeSnapTarget();
+            if (!target) return Promise.resolve(false);
+
+            const placement = this.getActivePlacement();
+            const startOffsetX = placement.offsetX;
+            const startOffsetY = placement.offsetY;
+            const duration = Math.max(0, Number(durationMs) || 0);
+            if (!animate || duration === 0) {
+                this.applyEdgeSnapOffsets(target.offsetX, target.offsetY);
+                return Promise.resolve(true);
+            }
+
+            const startedAt = performance.now();
+            return new Promise((resolve) => {
+                this._edgeSnapResolve = resolve;
+                const step = (timestamp) => {
+                    const elapsed = Math.max(0, Number(timestamp) - startedAt);
+                    const progress = Math.min(1, elapsed / duration);
+                    const c1 = 1.70158;
+                    const c3 = c1 + 1;
+                    const eased = 1 + c3 * Math.pow(progress - 1, 3) + c1 * Math.pow(progress - 1, 2);
+                    this.applyEdgeSnapOffsets(
+                        startOffsetX + (target.offsetX - startOffsetX) * eased,
+                        startOffsetY + (target.offsetY - startOffsetY) * eased
+                    );
+                    if (progress < 1) {
+                        this._edgeSnapAnimationFrame = requestAnimationFrame(step);
+                        return;
+                    }
+                    this._edgeSnapAnimationFrame = null;
+                    this._edgeSnapResolve = null;
+                    this.applyEdgeSnapOffsets(target.offsetX, target.offsetY);
+                    resolve(true);
+                };
+                this._edgeSnapAnimationFrame = requestAnimationFrame(step);
+            });
+        }
+
         async checkAndSwitchDisplayAfterDrag(state) {
             const bridge = window.electronScreen;
             if (isModelManagerPage() || !bridge
@@ -2936,6 +3053,7 @@
             if (event.target && event.target.closest && event.target.closest('[id$="-floating-buttons"], [id$="-lock-icon"], [id$="-return-button-container"]')) return;
             event.preventDefault();
             event.stopPropagation();
+            this.cancelEdgeSnapAnimation();
             const placement = this.getActivePlacement();
             this._dragSequence += 1;
             this._dragState = {
@@ -3019,6 +3137,10 @@
                     await this.recordDragHintPointerEdgeRelease(state);
                 }
                 if (!this.isDragCompletionCurrent(state)) return;
+                if (!displaySwitched) {
+                    await this.snapModelIntoScreen({ animate: true });
+                }
+                if (!this.isDragCompletionCurrent(state)) return;
                 await this.saveCurrentConfig();
             }
         }
@@ -3077,6 +3199,7 @@
             if (!event.touches || event.touches.length !== 2) return;
             event.preventDefault();
             event.stopPropagation();
+            this.cancelEdgeSnapAnimation();
             const center = this.getTouchCenter(event.touches[0], event.touches[1]);
             const placement = this.getActivePlacement();
             this._dragSequence += 1;

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2885,6 +2885,11 @@
             }
         }
 
+        beginExternalPositionDrag() {
+            this._dragSequence += 1;
+            this.cancelEdgeSnapAnimation();
+        }
+
         applyEdgeSnapOffsets(offsetX, offsetY) {
             this.setActiveOffsets(offsetX, offsetY);
             this.applyTransform();
@@ -3205,6 +3210,7 @@
             this._dragSequence += 1;
             this._dragState = null;
             this._touchZoomState = {
+                dragSequence: this._dragSequence,
                 initialDistance: this.getTouchDistance(event.touches[0], event.touches[1]),
                 initialScale: placement.scale,
                 startCenterX: center.x,
@@ -3255,6 +3261,8 @@
             }
             this.updateLockIconPosition();
             if (state.changed) {
+                await this.snapModelIntoScreen({ animate: true });
+                if (!this.isDragCompletionCurrent(state)) return;
                 await this.saveCurrentConfig();
             }
         }

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3103,12 +3103,16 @@
             state.lastAt = now;
             this.rememberDragScreenPoint(state, event);
             if (Math.hypot(dx, dy) > 4 && !state.moved) {
+                const takingOverSnap = this._edgeSnapAnimationFrame !== null || this._edgeSnapResolve !== null;
                 this.cancelEdgeSnapAnimation();
                 this._dragSequence += 1;
                 state.dragSequence = this._dragSequence;
                 const placement = this.getActivePlacement();
                 state.startOffsetX = placement.offsetX;
                 state.startOffsetY = placement.offsetY;
+                if (takingOverSnap) {
+                    this.rememberDragScreenPoint(state, event, { start: true });
+                }
                 state.moved = true;
                 this.setModelDraggingState(true, true);
                 this.showDragImage();
@@ -3197,7 +3201,12 @@
             this.applyScale(nextScale);
             this.snapModelIntoScreen({ animate: true }).then(() => {
                 if (zoomSequence === this._dragSequence) {
-                    this.scheduleSaveCurrentConfig();
+                    if (isModelManagerPage() &&
+                        typeof window.stageModelManagerPNGTuberPlacement === 'function') {
+                        window.stageModelManagerPNGTuberPlacement(this.config);
+                    } else {
+                        this.scheduleSaveCurrentConfig();
+                    }
                 }
             });
         }
@@ -3221,13 +3230,11 @@
             if (!event.touches || event.touches.length !== 2) return;
             event.preventDefault();
             event.stopPropagation();
-            this.cancelEdgeSnapAnimation();
             const center = this.getTouchCenter(event.touches[0], event.touches[1]);
             const placement = this.getActivePlacement();
-            this._dragSequence += 1;
             this._dragState = null;
             this._touchZoomState = {
-                dragSequence: this._dragSequence,
+                dragSequence: null,
                 initialDistance: this.getTouchDistance(event.touches[0], event.touches[1]),
                 initialScale: placement.scale,
                 startCenterX: center.x,
@@ -3241,8 +3248,7 @@
             };
             this.resetLayeredDragVelocity();
             if (this.layeredPointer) this.layeredPointer.active = false;
-            this.setModelDraggingState(true, true);
-            this.showDragImage();
+            this.setModelDraggingState(true, false);
         }
 
         moveTouchZoom(event) {
@@ -3259,7 +3265,20 @@
             state.lastCenterX = center.x;
             state.lastCenterY = center.y;
             state.lastAt = now;
-            state.changed = Math.abs(scaleChange - 1) > 0.01 || Math.hypot(dx, dy) > 4;
+            const changed = Math.abs(scaleChange - 1) > 0.01 || Math.hypot(dx, dy) > 4;
+            if (changed && !state.changed) {
+                this.cancelEdgeSnapAnimation();
+                this._dragSequence += 1;
+                state.dragSequence = this._dragSequence;
+                const placement = this.getActivePlacement();
+                state.initialScale = placement.scale;
+                state.startOffsetX = placement.offsetX;
+                state.startOffsetY = placement.offsetY;
+                state.changed = true;
+                this.setModelDraggingState(true, true);
+                this.showDragImage();
+            }
+            if (!state.changed) return;
             this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);
             this.applyScale(state.initialScale * scaleChange);
             if (this.isLayeredActive()) this.drawLayeredState();

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2860,8 +2860,9 @@
             }
             const right = contentLeft + contentWidth;
             const bottom = contentTop + contentHeight;
-            const effectiveMinX = Math.min(Math.max(0, Number(minVisiblePixels) || 0), viewportWidth);
-            const effectiveMinY = Math.min(Math.max(0, Number(minVisiblePixels) || 0), viewportHeight);
+            const requestedMin = Math.max(0, Number(minVisiblePixels) || 0);
+            const effectiveMinX = Math.min(requestedMin, contentWidth, viewportWidth);
+            const effectiveMinY = Math.min(requestedMin, contentHeight, viewportHeight);
             const visibleWidth = Math.max(0, Math.min(viewportWidth, right) - Math.max(0, contentLeft));
             const visibleHeight = Math.max(0, Math.min(viewportHeight, bottom) - Math.max(0, contentTop));
             const needsClampH = horizontalDirection !== 0

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2950,7 +2950,18 @@
                 this._edgeSnapResolve = resolve;
                 const step = (timestamp) => {
                     const refreshedTarget = this.getEdgeSnapTarget({ horizontalDirection, verticalDirection });
-                    if (refreshedTarget) target = refreshedTarget;
+                    if (refreshedTarget) {
+                        const reversesHorizontalDirection = horizontalDirection > 0
+                            ? refreshedTarget.offsetX < startOffsetX
+                            : horizontalDirection < 0 && refreshedTarget.offsetX > startOffsetX;
+                        const reversesVerticalDirection = verticalDirection > 0
+                            ? refreshedTarget.offsetY < startOffsetY
+                            : verticalDirection < 0 && refreshedTarget.offsetY > startOffsetY;
+                        target = {
+                            offsetX: reversesHorizontalDirection ? target.offsetX : refreshedTarget.offsetX,
+                            offsetY: reversesVerticalDirection ? target.offsetY : refreshedTarget.offsetY
+                        };
+                    }
                     const elapsed = Math.max(0, Number(timestamp) - startedAt);
                     const progress = Math.min(1, elapsed / duration);
                     const c1 = 1.70158;

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2739,9 +2739,10 @@
         }
 
         isDragCompletionCurrent(state) {
+            const activeDrag = this._dragState;
             return !!state
                 && state.dragSequence === this._dragSequence
-                && this._dragState === null;
+                && (!activeDrag || activeDrag.dragSequence === null);
         }
 
         async recordDragHintPointerEdgeApproach(state) {
@@ -2908,7 +2909,7 @@
 
         snapModelIntoScreen({ animate = true, durationMs = PNGTUBER_EDGE_SNAP_DURATION_MS } = {}) {
             this.cancelEdgeSnapAnimation();
-            const target = this.getEdgeSnapTarget();
+            let target = this.getEdgeSnapTarget();
             if (!target) return Promise.resolve(false);
 
             const placement = this.getActivePlacement();
@@ -2924,6 +2925,8 @@
             return new Promise((resolve) => {
                 this._edgeSnapResolve = resolve;
                 const step = (timestamp) => {
+                    const refreshedTarget = this.getEdgeSnapTarget();
+                    if (refreshedTarget) target = refreshedTarget;
                     const elapsed = Math.max(0, Number(timestamp) - startedAt);
                     const progress = Math.min(1, elapsed / duration);
                     const c1 = 1.70158;
@@ -3162,7 +3165,7 @@
                     await this.snapModelIntoScreen({ animate: true });
                 }
                 if (!this.isDragCompletionCurrent(state)) return;
-                await this.saveCurrentConfig();
+                await this.saveOrStageCurrentConfig();
             }
         }
 
@@ -3302,7 +3305,7 @@
                 if (!this.isDragCompletionCurrent(state)) return;
                 await this.snapModelIntoScreen({ animate: true });
                 if (!this.isDragCompletionCurrent(state)) return;
-                await this.saveCurrentConfig();
+                await this.saveOrStageCurrentConfig();
             }
         }
 
@@ -3452,6 +3455,17 @@
             } catch (_) {
                 return '';
             }
+        }
+
+        async saveOrStageCurrentConfig() {
+            if (isModelManagerPage()) {
+                if (typeof window.stageModelManagerPNGTuberPlacement === 'function') {
+                    window.stageModelManagerPNGTuberPlacement(this.config);
+                    return true;
+                }
+                return false;
+            }
+            return this.saveCurrentConfig();
         }
 
         async saveCurrentConfig() {

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3063,11 +3063,9 @@
             if (event.target && event.target.closest && event.target.closest('[id$="-floating-buttons"], [id$="-lock-icon"], [id$="-return-button-container"]')) return;
             event.preventDefault();
             event.stopPropagation();
-            this.cancelEdgeSnapAnimation();
             const placement = this.getActivePlacement();
-            this._dragSequence += 1;
             this._dragState = {
-                dragSequence: this._dragSequence,
+                dragSequence: null,
                 pointerId: event.pointerId,
                 startX: event.clientX,
                 startY: event.clientY,
@@ -3105,11 +3103,18 @@
             state.lastAt = now;
             this.rememberDragScreenPoint(state, event);
             if (Math.hypot(dx, dy) > 4 && !state.moved) {
+                this.cancelEdgeSnapAnimation();
+                this._dragSequence += 1;
+                state.dragSequence = this._dragSequence;
+                const placement = this.getActivePlacement();
+                state.startOffsetX = placement.offsetX;
+                state.startOffsetY = placement.offsetY;
                 state.moved = true;
                 this.setModelDraggingState(true, true);
                 this.showDragImage();
             }
-            if (state.moved) void this.recordDragHintPointerEdgeApproach(state);
+            if (!state.moved) return;
+            void this.recordDragHintPointerEdgeApproach(state);
             this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);
             this.applyTransform();
             if (this.isLayeredActive()) this.drawLayeredState();
@@ -3273,6 +3278,7 @@
             }
             this.updateLockIconPosition();
             if (state.changed) {
+                if (!this.isDragCompletionCurrent(state)) return;
                 await this.snapModelIntoScreen({ animate: true });
                 if (!this.isDragCompletionCurrent(state)) return;
                 await this.saveCurrentConfig();

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2825,7 +2825,11 @@
             return true;
         }
 
-        getEdgeSnapTarget({ minVisiblePixels = PNGTUBER_EDGE_SNAP_MIN_VISIBLE_PX } = {}) {
+        getEdgeSnapTarget({
+            minVisiblePixels = PNGTUBER_EDGE_SNAP_MIN_VISIBLE_PX,
+            horizontalDirection = 0,
+            verticalDirection = 0
+        } = {}) {
             if (!this.image || typeof this.image.getBoundingClientRect !== 'function') return null;
             const rect = this.image.getBoundingClientRect();
             const left = Number(rect?.left);
@@ -2839,30 +2843,47 @@
                 return null;
             }
 
-            const right = left + width;
-            const bottom = top + height;
+            let contentLeft = left;
+            let contentTop = top;
+            let contentWidth = width;
+            let contentHeight = height;
+            if (this.isLayeredActive()) {
+                const padding = Math.max(0, Number(this.layeredCanvasPadding) || 0);
+                const logicalWidth = Math.max(1, Number(this.layeredCanvasLogicalWidth) || width);
+                const logicalHeight = Math.max(1, Number(this.layeredCanvasLogicalHeight) || height);
+                const paddingX = Math.min(width / 2, (padding / logicalWidth) * width);
+                const paddingY = Math.min(height / 2, (padding / logicalHeight) * height);
+                contentLeft += paddingX;
+                contentTop += paddingY;
+                contentWidth -= paddingX * 2;
+                contentHeight -= paddingY * 2;
+            }
+            const right = contentLeft + contentWidth;
+            const bottom = contentTop + contentHeight;
             const effectiveMinX = Math.min(Math.max(0, Number(minVisiblePixels) || 0), viewportWidth);
             const effectiveMinY = Math.min(Math.max(0, Number(minVisiblePixels) || 0), viewportHeight);
-            const visibleWidth = Math.max(0, Math.min(viewportWidth, right) - Math.max(0, left));
-            const visibleHeight = Math.max(0, Math.min(viewportHeight, bottom) - Math.max(0, top));
-            const needsClampH = (left < 0 || right > viewportWidth) && visibleWidth < effectiveMinX;
-            const needsClampV = (top < 0 || bottom > viewportHeight) && visibleHeight < effectiveMinY;
+            const visibleWidth = Math.max(0, Math.min(viewportWidth, right) - Math.max(0, contentLeft));
+            const visibleHeight = Math.max(0, Math.min(viewportHeight, bottom) - Math.max(0, contentTop));
+            const needsClampH = horizontalDirection !== 0
+                || ((contentLeft < 0 || right > viewportWidth) && visibleWidth < effectiveMinX);
+            const needsClampV = verticalDirection !== 0
+                || ((contentTop < 0 || bottom > viewportHeight) && visibleHeight < effectiveMinY);
             if (!needsClampH && !needsClampV) return null;
 
             let moveX = 0;
             let moveY = 0;
             if (needsClampH) {
-                if (right < effectiveMinX) {
+                if (horizontalDirection > 0 || (!horizontalDirection && right < effectiveMinX)) {
                     moveX = effectiveMinX - right;
-                } else if (left > viewportWidth - effectiveMinX) {
-                    moveX = (viewportWidth - effectiveMinX) - left;
+                } else if (horizontalDirection < 0 || contentLeft > viewportWidth - effectiveMinX) {
+                    moveX = (viewportWidth - effectiveMinX) - contentLeft;
                 }
             }
             if (needsClampV) {
-                if (bottom < effectiveMinY) {
+                if (verticalDirection > 0 || (!verticalDirection && bottom < effectiveMinY)) {
                     moveY = effectiveMinY - bottom;
-                } else if (top > viewportHeight - effectiveMinY) {
-                    moveY = (viewportHeight - effectiveMinY) - top;
+                } else if (verticalDirection < 0 || contentTop > viewportHeight - effectiveMinY) {
+                    moveY = (viewportHeight - effectiveMinY) - contentTop;
                 }
             }
             if (!moveX && !moveY) return null;
@@ -2915,6 +2936,8 @@
             const placement = this.getActivePlacement();
             const startOffsetX = placement.offsetX;
             const startOffsetY = placement.offsetY;
+            const horizontalDirection = Math.sign(target.offsetX - startOffsetX);
+            const verticalDirection = Math.sign(target.offsetY - startOffsetY);
             const duration = Math.max(0, Number(durationMs) || 0);
             if (!animate || duration === 0) {
                 this.applyEdgeSnapOffsets(target.offsetX, target.offsetY);
@@ -2925,7 +2948,7 @@
             return new Promise((resolve) => {
                 this._edgeSnapResolve = resolve;
                 const step = (timestamp) => {
-                    const refreshedTarget = this.getEdgeSnapTarget();
+                    const refreshedTarget = this.getEdgeSnapTarget({ horizontalDirection, verticalDirection });
                     if (refreshedTarget) target = refreshedTarget;
                     const elapsed = Math.max(0, Number(timestamp) - startedAt);
                     const progress = Math.min(1, elapsed / duration);
@@ -3110,6 +3133,7 @@
                 this.cancelEdgeSnapAnimation();
                 this._dragSequence += 1;
                 state.dragSequence = this._dragSequence;
+                this.beginModelManagerPositionEditing();
                 const placement = this.getActivePlacement();
                 state.startOffsetX = placement.offsetX;
                 state.startOffsetY = placement.offsetY;
@@ -3198,6 +3222,7 @@
             this._dragSequence += 1;
             const zoomSequence = this._dragSequence;
             this.cancelEdgeSnapAnimation();
+            this.beginModelManagerPositionEditing();
             const absDelta = Math.abs(event.deltaY);
             const zoomStep = Math.min(absDelta / 1000, 0.08);
             const scaleFactor = 1 + zoomStep;
@@ -3275,6 +3300,7 @@
                 this.cancelEdgeSnapAnimation();
                 this._dragSequence += 1;
                 state.dragSequence = this._dragSequence;
+                this.beginModelManagerPositionEditing();
                 const placement = this.getActivePlacement();
                 state.initialScale = placement.scale;
                 state.startOffsetX = placement.offsetX;

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2720,6 +2720,17 @@
             return { x: screenX, y: screenY };
         }
 
+        rememberModelCenterPointerOffset(state, event) {
+            if (!state) return false;
+            const center = this.getModelCenterInWindow();
+            const clientX = Number(event?.clientX);
+            const clientY = Number(event?.clientY);
+            state.modelCenterPointerOffset = center && Number.isFinite(clientX) && Number.isFinite(clientY)
+                ? { x: center.x - clientX, y: center.y - clientY }
+                : { x: 0, y: 0 };
+            return !!center && Number.isFinite(clientX) && Number.isFinite(clientY);
+        }
+
         rememberDragScreenPoint(state, event, { start = false } = {}) {
             if (!state) return null;
             const point = this.captureDragScreenPoint(event);
@@ -2728,12 +2739,7 @@
             state.dragHintLastPointer = point;
             if (!start) return point;
 
-            const center = this.getModelCenterInWindow();
-            const clientX = Number(event?.clientX);
-            const clientY = Number(event?.clientY);
-            state.modelCenterPointerOffset = center && Number.isFinite(clientX) && Number.isFinite(clientY)
-                ? { x: center.x - clientX, y: center.y - clientY }
-                : { x: 0, y: 0 };
+            this.rememberModelCenterPointerOffset(state, event);
             state.dragHintStartPointer = Object.assign({ startedAt: Date.now() }, point);
             return point;
         }
@@ -2935,6 +2941,7 @@
             if (!target) return Promise.resolve(false);
 
             const placement = this.getActivePlacement();
+            const layoutFields = placement.fields;
             const startOffsetX = placement.offsetX;
             const startOffsetY = placement.offsetY;
             const horizontalDirection = Math.sign(target.offsetX - startOffsetX);
@@ -2949,6 +2956,17 @@
             return new Promise((resolve) => {
                 this._edgeSnapResolve = resolve;
                 const step = (timestamp) => {
+                    const activeLayoutFields = this.getActiveLayoutFields();
+                    if (activeLayoutFields.scale !== layoutFields.scale
+                        || activeLayoutFields.offsetX !== layoutFields.offsetX
+                        || activeLayoutFields.offsetY !== layoutFields.offsetY) {
+                        this._edgeSnapAnimationFrame = null;
+                        this._edgeSnapResolve = null;
+                        this.applyTransform();
+                        if (this.isLayeredActive()) this.drawLayeredState();
+                        this.snapModelIntoScreen({ animate: true, durationMs: duration }).then(resolve);
+                        return;
+                    }
                     const refreshedTarget = this.getEdgeSnapTarget({ horizontalDirection, verticalDirection });
                     if (refreshedTarget) {
                         const reversesHorizontalDirection = horizontalDirection > 0
@@ -3140,8 +3158,8 @@
             state.lastY = event.clientY;
             state.lastAt = now;
             this.rememberDragScreenPoint(state, event);
+            let startedMoving = false;
             if (Math.hypot(dx, dy) > 4 && !state.moved) {
-                const takingOverSnap = this._edgeSnapAnimationFrame !== null || this._edgeSnapResolve !== null;
                 this.cancelEdgeSnapAnimation();
                 this._dragSequence += 1;
                 state.dragSequence = this._dragSequence;
@@ -3149,8 +3167,8 @@
                 const placement = this.getActivePlacement();
                 state.startOffsetX = placement.offsetX;
                 state.startOffsetY = placement.offsetY;
-                state.refreshGrabOffset = takingOverSnap;
                 state.moved = true;
+                startedMoving = true;
                 this.setModelDraggingState(true, true);
                 this.showDragImage();
             }
@@ -3163,10 +3181,7 @@
                 this.updateFloatingButtonsPosition();
             }
             this.updateLockIconPosition();
-            if (state.refreshGrabOffset) {
-                this.rememberDragScreenPoint(state, event, { start: true });
-                state.refreshGrabOffset = false;
-            }
+            if (startedMoving) this.rememberModelCenterPointerOffset(state, event);
             void this.recordDragHintPointerEdgeApproach(state);
         }
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2888,6 +2888,11 @@
         beginExternalPositionDrag() {
             this._dragSequence += 1;
             this.cancelEdgeSnapAnimation();
+            return this._dragSequence;
+        }
+
+        isExternalPositionDragCurrent(dragSequence) {
+            return dragSequence === this._dragSequence;
         }
 
         applyEdgeSnapOffsets(offsetX, offsetY) {
@@ -3176,13 +3181,20 @@
             if (this._dragState) return;
             event.preventDefault();
             event.stopPropagation();
+            this._dragSequence += 1;
+            const zoomSequence = this._dragSequence;
+            this.cancelEdgeSnapAnimation();
             const absDelta = Math.abs(event.deltaY);
             const zoomStep = Math.min(absDelta / 1000, 0.08);
             const scaleFactor = 1 + zoomStep;
             const currentScale = this.getActivePlacement().scale;
             const nextScale = event.deltaY < 0 ? currentScale * scaleFactor : currentScale / scaleFactor;
             this.applyScale(nextScale);
-            this.scheduleSaveCurrentConfig();
+            this.snapModelIntoScreen({ animate: true }).then(() => {
+                if (zoomSequence === this._dragSequence) {
+                    this.scheduleSaveCurrentConfig();
+                }
+            });
         }
 
         getTouchDistance(touch1, touch2) {

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3243,7 +3243,7 @@
         handleWheelZoom(event) {
             if (!canInteractWithAvatar()) return;
             if (this.isLocked) return;
-            if (this._dragState) return;
+            if (this._dragState || this._touchZoomState) return;
             event.preventDefault();
             event.stopPropagation();
             const absDelta = Math.abs(event.deltaY);

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3110,15 +3110,12 @@
                 const placement = this.getActivePlacement();
                 state.startOffsetX = placement.offsetX;
                 state.startOffsetY = placement.offsetY;
-                if (takingOverSnap) {
-                    this.rememberDragScreenPoint(state, event, { start: true });
-                }
+                state.refreshGrabOffset = takingOverSnap;
                 state.moved = true;
                 this.setModelDraggingState(true, true);
                 this.showDragImage();
             }
             if (!state.moved) return;
-            void this.recordDragHintPointerEdgeApproach(state);
             this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);
             this.applyTransform();
             if (this.isLayeredActive()) this.drawLayeredState();
@@ -3127,6 +3124,11 @@
                 this.updateFloatingButtonsPosition();
             }
             this.updateLockIconPosition();
+            if (state.refreshGrabOffset) {
+                this.rememberDragScreenPoint(state, event, { start: true });
+                state.refreshGrabOffset = false;
+            }
+            void this.recordDragHintPointerEdgeApproach(state);
         }
 
         async endDrag(event) {

--- a/tests/unit/test_model_manager_background_drag.py
+++ b/tests/unit/test_model_manager_background_drag.py
@@ -159,12 +159,14 @@ const container = {{
 }};
 let renderedPlacement = null;
 let stagedConfig = null;
+let externalDrags = 0;
 const manager = {{
   container,
   image: {{}},
   isLocked: false,
   config: {{ offset_x: 100, offset_y: 50 }},
   editing: false,
+  beginExternalPositionDrag() {{ externalDrags += 1; }},
   beginModelManagerPositionEditing() {{
     if (!this.editing) this.setActiveOffsets(0, 0);
     this.editing = true;
@@ -213,6 +215,7 @@ function pointer(x, y) {{
 
 (async () => {{
   documentListeners.get('pointerdown')(pointer(400, 300));
+  assert.equal(externalDrags, 1);
   windowListeners.get('pointermove')(pointer(430, 320));
   assert.deepEqual(renderedPlacement, {{ x: 30, y: 20 }});
   windowListeners.get('pointerup')(pointer(430, 320));

--- a/tests/unit/test_model_manager_background_drag.py
+++ b/tests/unit/test_model_manager_background_drag.py
@@ -160,13 +160,21 @@ const container = {{
 let renderedPlacement = null;
 let stagedConfig = null;
 let externalDrags = 0;
+let snapCalls = 0;
 const manager = {{
   container,
   image: {{}},
   isLocked: false,
   config: {{ offset_x: 100, offset_y: 50 }},
   editing: false,
-  beginExternalPositionDrag() {{ externalDrags += 1; }},
+  beginExternalPositionDrag() {{ externalDrags += 1; return externalDrags; }},
+  isExternalPositionDragCurrent(sequence) {{ return sequence === externalDrags; }},
+  async snapModelIntoScreen() {{
+    snapCalls += 1;
+    this.config.offset_x = 15;
+    this.config.offset_y = 10;
+    return true;
+  }},
   beginModelManagerPositionEditing() {{
     if (!this.editing) this.setActiveOffsets(0, 0);
     this.editing = true;
@@ -215,13 +223,15 @@ function pointer(x, y) {{
 
 (async () => {{
   documentListeners.get('pointerdown')(pointer(400, 300));
-  assert.equal(externalDrags, 1);
+  assert.equal(externalDrags, 0, 'pointerdown alone must not cancel an active snap');
   windowListeners.get('pointermove')(pointer(430, 320));
+  assert.equal(externalDrags, 1);
   assert.deepEqual(renderedPlacement, {{ x: 30, y: 20 }});
   windowListeners.get('pointerup')(pointer(430, 320));
   await new Promise(resolve => setImmediate(resolve));
-  assert.equal(stagedConfig.offset_x, 30);
-  assert.equal(stagedConfig.offset_y, 20);
+  assert.equal(snapCalls, 1);
+  assert.equal(stagedConfig.offset_x, 15);
+  assert.equal(stagedConfig.offset_y, 10);
 }})().catch(error => {{ console.error(error); process.exit(1); }});
 """
     run_node_script(node, script, check=True, cwd=Path.cwd())

--- a/tests/unit/test_model_manager_background_drag.py
+++ b/tests/unit/test_model_manager_background_drag.py
@@ -232,6 +232,16 @@ function pointer(x, y) {{
   assert.equal(snapCalls, 1);
   assert.equal(stagedConfig.offset_x, 15);
   assert.equal(stagedConfig.offset_y, 10);
+
+  stagedConfig = null;
+  snapCalls = 0;
+  documentListeners.get('pointerdown')(pointer(400, 300));
+  windowListeners.get('pointermove')(pointer(430, 320));
+  externalDrags += 1; // A newer position interaction invalidates this completion.
+  windowListeners.get('pointerup')(pointer(430, 320));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(snapCalls, 0);
+  assert.equal(stagedConfig, null);
 }})().catch(error => {{ console.error(error); process.exit(1); }});
 """
     run_node_script(node, script, check=True, cwd=Path.cwd())

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -353,6 +353,23 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   window.innerWidth = 1000;
   manager.config.mobile_offset_x = 0;
 
+  // Wheel input clamped at the scale boundary leaves the active rebound untouched.
+  manager.config.scale = 0.1;
+  manager.config.offset_x = -750;
+  const minScaleWheelSnap = manager.snapModelIntoScreen();
+  const sequenceBeforeClampedWheel = manager._dragSequence;
+  manager.handleWheelZoom({{
+    deltaY: 1000,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  assert.equal(manager._dragSequence, sequenceBeforeClampedWheel);
+  assert.equal(frames.size, 1, 'clamped wheel input must not cancel the rebound');
+  runNextFrame(0);
+  runNextFrame(260);
+  assert.equal(await minScaleWheelSnap, true);
+  manager.config.scale = 1;
+
   // Wheel zoom cancels the old rebound and targets the resized model geometry.
   manager.config.offset_x = -750;
   const preZoomSnap = manager.snapModelIntoScreen();
@@ -387,6 +404,30 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   runNextFrame(260);
   assert.equal(await untouchedSnap, true);
   assert.equal(manager.config.offset_x, -500);
+
+  // A pinch clamped at the scale boundary with no pan also preserves the rebound.
+  manager.config.scale = 5;
+  manager.config.offset_x = -3000;
+  const maxScaleTouchSnap = manager.snapModelIntoScreen();
+  const sequenceBeforeClampedTouch = manager._dragSequence;
+  manager.startTouchZoom({{
+    touches: [{{ clientX: 100, clientY: 100 }}, {{ clientX: 200, clientY: 100 }}],
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  manager.moveTouchZoom({{
+    touches: [{{ clientX: 90, clientY: 100 }}, {{ clientX: 210, clientY: 100 }}],
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  assert.equal(manager._touchZoomState.changed, false);
+  assert.equal(manager._dragSequence, sequenceBeforeClampedTouch);
+  await manager.endTouchZoom();
+  assert.equal(frames.size, 1, 'clamped touch scale must not cancel the rebound');
+  runNextFrame(0);
+  runNextFrame(260);
+  assert.equal(await maxScaleTouchSnap, true);
+  manager.config.scale = 1;
 
   // A rebound that finishes during a pending click refreshes the first drag grab offset.
   manager.config.offset_x = -750;

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -224,10 +224,11 @@ manager.image = {{
   removeAttribute() {{}},
   setPointerCapture() {{}},
   getBoundingClientRect() {{
-    const width = modelWidth * manager.config.scale;
-    const height = 400 * manager.config.scale;
-    const centerX = window.innerWidth / 2 + manager.config.offset_x;
-    const centerY = window.innerHeight / 2 + manager.config.offset_y;
+    const placement = manager.getActivePlacement();
+    const width = modelWidth * placement.scale;
+    const height = 400 * placement.scale;
+    const centerX = window.innerWidth / 2 + placement.offsetX;
+    const centerY = window.innerHeight / 2 + placement.offsetY;
     return {{ left: centerX - width / 2, top: centerY - height / 2, width, height }};
   }},
 }};
@@ -337,6 +338,21 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.equal(manager.config.offset_x, -500);
   modelWidth = 400;
 
+  // Crossing the responsive breakpoint restarts against the new layout fields.
+  manager.config.offset_x = -750;
+  manager.config.mobile_offset_x = -500;
+  const responsiveSnap = manager.snapModelIntoScreen();
+  runNextFrame(0);
+  window.innerWidth = 600;
+  runNextFrame(130);
+  runNextFrame(130);
+  runNextFrame(260);
+  assert.equal(await responsiveSnap, true);
+  assert.equal(manager.config.offset_x, -750);
+  assert.equal(manager.config.mobile_offset_x, -300);
+  window.innerWidth = 1000;
+  manager.config.mobile_offset_x = 0;
+
   // Wheel zoom cancels the old rebound and targets the resized model geometry.
   manager.config.offset_x = -750;
   const preZoomSnap = manager.snapModelIntoScreen();
@@ -371,6 +387,36 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   runNextFrame(260);
   assert.equal(await untouchedSnap, true);
   assert.equal(manager.config.offset_x, -500);
+
+  // A rebound that finishes during a pending click refreshes the first drag grab offset.
+  manager.config.offset_x = -750;
+  const completedPendingSnap = manager.snapModelIntoScreen();
+  manager.startDrag({{
+    target: manager.image,
+    button: 0,
+    pointerId: 8,
+    clientX: 100,
+    clientY: 100,
+    screenX: 100,
+    screenY: 100,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  runNextFrame(0);
+  runNextFrame(260);
+  assert.equal(await completedPendingSnap, true);
+  manager.moveDrag({{
+    pointerId: 8,
+    clientX: 110,
+    clientY: 100,
+    screenX: 110,
+    screenY: 100,
+    preventDefault() {{}},
+  }});
+  const centerAfterPendingCompletionMove = manager.getModelCenterInWindow();
+  assert.equal(manager._dragState.modelCenterPointerOffset.x, centerAfterPendingCompletionMove.x - 110);
+  assert.equal(manager._dragState.modelCenterPointerOffset.y, centerAfterPendingCompletionMove.y - 100);
+  manager._dragState = null;
 
   // Model-manager wheel replacement stages the final snapped placement.
   window.location.pathname = '/model_manager';

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -127,6 +127,124 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
     assert "result.windowBounds" in drag_block
     assert "this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);" in drag_block
     assert "helper.markDisplaySwitchSuccess('pngtuber');" in drag_block
+    assert "await this.snapModelIntoScreen({ animate: true });" in drag_block
+    assert drag_block.index("await this.recordDragHintPointerEdgeRelease(state);") < drag_block.index(
+        "await this.snapModelIntoScreen({ animate: true });"
+    )
+    assert drag_block.index("await this.snapModelIntoScreen({ animate: true });") < drag_block.index(
+        "await this.saveCurrentConfig();"
+    )
+
+
+def test_pngtuber_drag_snaps_back_when_less_than_200_pixels_remain_visible():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for PNGTuber edge snap tests")
+
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const frames = [];
+const requestAnimationFrame = (callback) => {{
+  frames.push(callback);
+  return frames.length;
+}};
+const cancelAnimationFrame = () => {{}};
+const window = {{
+  location: {{ pathname: '/' }},
+  innerWidth: 1000,
+  innerHeight: 800,
+  lanlan_config: {{ model_type: 'pngtuber' }},
+}};
+const document = {{
+  body: {{ classList: {{ contains() {{ return false; }} }} }},
+  getElementById() {{ return null; }},
+  querySelectorAll() {{ return []; }},
+}};
+const context = {{
+  cancelAnimationFrame,
+  console,
+  document,
+  performance: {{ now: () => 0 }},
+  requestAnimationFrame,
+  window,
+}};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
+
+const manager = new window.PNGTuberManager();
+manager.config = {{
+  scale: 1,
+  offset_x: 0,
+  offset_y: 0,
+  mobile_scale: 1,
+  mobile_offset_x: 0,
+  mobile_offset_y: 0,
+  position_anchor: 'center',
+  mirror: false,
+}};
+manager.image = {{
+  getBoundingClientRect() {{
+    const centerX = window.innerWidth / 2 + manager.config.offset_x;
+    const centerY = window.innerHeight / 2 + manager.config.offset_y;
+    return {{ left: centerX - 200, top: centerY - 200, width: 400, height: 400 }};
+  }},
+}};
+manager.applyTransform = () => {{}};
+manager.isLayeredActive = () => false;
+manager.syncGlobalConfig = () => {{}};
+manager.updateFloatingButtonsPosition = () => {{}};
+manager.updateLockIconPosition = () => {{}};
+
+(async () => {{
+  manager.config.offset_x = -750;
+  let target = manager.getEdgeSnapTarget();
+  assert.equal(target.offsetX, -500);
+  assert.equal(target.offsetY, 0);
+  assert.equal(await manager.snapModelIntoScreen({{ animate: false }}), true);
+  assert.equal(manager.config.offset_x, -500);
+
+  // Exactly 200 px remains visible, so ordinary edge placement is preserved.
+  assert.equal(manager.getEdgeSnapTarget(), null);
+  assert.equal(await manager.snapModelIntoScreen({{ animate: false }}), false);
+
+  manager.config.offset_x = 750;
+  target = manager.getEdgeSnapTarget();
+  assert.equal(target.offsetX, 500);
+  assert.equal(await manager.snapModelIntoScreen({{ animate: false }}), true);
+  assert.equal(manager.config.offset_x, 500);
+
+  manager.config.offset_x = 0;
+  manager.config.offset_y = -650;
+  target = manager.getEdgeSnapTarget();
+  assert.equal(target.offsetY, -400);
+  assert.equal(await manager.snapModelIntoScreen({{ animate: false }}), true);
+  assert.equal(manager.config.offset_y, -400);
+
+  manager.config.offset_y = 650;
+  target = manager.getEdgeSnapTarget();
+  assert.equal(target.offsetY, 400);
+  assert.equal(await manager.snapModelIntoScreen({{ animate: false }}), true);
+  assert.equal(manager.config.offset_y, 400);
+
+  manager.config.offset_x = -750;
+  manager.config.offset_y = 0;
+  const animatedSnap = manager.snapModelIntoScreen();
+  assert.equal(frames.length, 1);
+  frames.shift()(0);
+  frames.shift()(130);
+  assert.ok(manager.config.offset_x > -500, 'easeOutBack should briefly overshoot the target');
+  frames.shift()(260);
+  assert.equal(await animatedSnap, true);
+  assert.equal(manager.config.offset_x, -500);
+  assert.equal(manager.config.offset_y, 0);
+}})().catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
 
 
 def test_pngtuber_drag_hint_edge_approach_allows_only_one_in_flight_call():

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -140,6 +140,9 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
     ]
     assert "await this.snapModelIntoScreen({ animate: true });" in touch_end_block
     assert "if (!this.isDragCompletionCurrent(state)) return;" in touch_end_block
+    assert touch_end_block.index("if (!this.isDragCompletionCurrent(state)) return;") < touch_end_block.index(
+        "await this.snapModelIntoScreen({ animate: true });"
+    )
     assert touch_end_block.index("await this.snapModelIntoScreen({ animate: true });") < touch_end_block.index(
         "await this.saveCurrentConfig();"
     )
@@ -289,8 +292,7 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
 
   manager.config.offset_x = -750;
   const cancelledSnap = manager.snapModelIntoScreen();
-  runNextFrame(0);
-  runNextFrame(130);
+  assert.equal(frames.size, 1);
   manager.startDrag({{
     target: manager.image,
     button: 0,
@@ -301,6 +303,17 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
     screenY: 100,
     preventDefault() {{}},
     stopPropagation() {{}},
+  }});
+  assert.equal(frames.size, 1, 'pointerdown alone must not cancel the rebound');
+  runNextFrame(0);
+  runNextFrame(130);
+  manager.moveDrag({{
+    pointerId: 9,
+    clientX: 110,
+    clientY: 100,
+    screenX: 110,
+    screenY: 100,
+    preventDefault() {{}},
   }});
   manager.setActiveOffsets(-123, 45);
   assert.equal(await cancelledSnap, false);

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -459,6 +459,39 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.equal(manager._dragState.modelCenterPointerOffset.y, centerAfterPendingCompletionMove.y - 100);
   manager._dragState = null;
 
+  // Wheel input cannot steal ownership from an active two-finger interaction.
+  manager.config.scale = 1;
+  manager.config.offset_x = 0;
+  manager.config.offset_y = 0;
+  manager.startTouchZoom({{
+    touches: [{{ clientX: 100, clientY: 100 }}, {{ clientX: 200, clientY: 100 }}],
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  manager.moveTouchZoom({{
+    touches: [{{ clientX: 110, clientY: 100 }}, {{ clientX: 210, clientY: 100 }}],
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  const activeTouchSequence = manager._dragSequence;
+  const activeTouchState = manager._touchZoomState;
+  manager.handleWheelZoom({{
+    deltaY: 1000,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  assert.equal(manager._dragSequence, activeTouchSequence);
+  assert.equal(manager._touchZoomState, activeTouchState);
+  assert.equal(manager.config.scale, 1);
+  manager.moveTouchZoom({{
+    touches: [{{ clientX: 120, clientY: 100 }}, {{ clientX: 220, clientY: 100 }}],
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  assert.equal(manager.config.offset_x, 20);
+  await manager.endTouchZoom();
+  assert.equal(manager._touchZoomState, null);
+
   // Model-manager wheel replacement stages the final snapped placement.
   window.location.pathname = '/model_manager';
   manager._modelManagerUseCurrentPlacement = true;

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -96,8 +96,10 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
     assert "startOffsetX: placement.offsetX" in drag_block
     assert "this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);" in drag_block
     assert "const currentScale = this.getActivePlacement().scale;" in wheel_block
+    assert "this.beginModelManagerPositionEditing();" in wheel_block
     assert "window.stageModelManagerPNGTuberPlacement(this.config);" in wheel_block
     assert "initialScale: placement.scale" in touch_block
+    assert "this.beginModelManagerPositionEditing();" in touch_block
     assert "this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);" in touch_block
     assert "window.stageModelManagerPNGTuberPlacement(this.config);" in save_block
     assert "this.config.mobile_offset_x" in runtime_save_block
@@ -129,6 +131,7 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
     assert "state.dragHintApproachPending = true;" in drag_block
     assert "state.dragHintApproachPending = false;" in drag_block
     assert "this.isDragCompletionCurrent(state)" in drag_block
+    assert "this.beginModelManagerPositionEditing();" in drag_block
     assert "bridge.moveWindowToDisplay(switchScreenX, switchScreenY)" in drag_block
     assert "result.windowBounds" in drag_block
     assert "this.moveModelCenterToWindowPoint(desiredCenterX, desiredCenterY);" in drag_block
@@ -283,6 +286,16 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.equal(manager.config.offset_x, -500);
   assert.equal(manager.config.offset_y, 0);
 
+  // Layered-canvas padding is transparent and does not count as visible avatar content.
+  manager.isLayeredActive = () => true;
+  manager.layeredCanvasPadding = 100;
+  manager.layeredCanvasLogicalWidth = 600;
+  manager.layeredCanvasLogicalHeight = 600;
+  manager.config.offset_x = -700;
+  const layeredTarget = manager.getEdgeSnapTarget();
+  assert.ok(Math.abs(layeredTarget.offsetX - (-433.3333333333333)) < 0.001);
+  manager.isLayeredActive = () => false;
+
   // State image geometry changes retarget an in-flight rebound.
   manager.config.offset_x = -750;
   modelWidth = 400;
@@ -293,6 +306,17 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   runNextFrame(260);
   assert.equal(await resizedImageSnap, true);
   assert.equal(manager.config.offset_x, -400);
+
+  // A size change during ease-out-back overshoot still replaces the stale target.
+  manager.config.offset_x = -750;
+  modelWidth = 400;
+  const overshootResizeSnap = manager.snapModelIntoScreen();
+  runNextFrame(0);
+  runNextFrame(130);
+  modelWidth = 370;
+  runNextFrame(260);
+  assert.equal(await overshootResizeSnap, true);
+  assert.ok(Math.abs(manager.config.offset_x - (-485)) < 0.001);
   modelWidth = 400;
 
   // Wheel zoom cancels the old rebound and targets the resized model geometry.
@@ -332,6 +356,7 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
 
   // Model-manager wheel replacement stages the final snapped placement.
   window.location.pathname = '/model_manager';
+  manager._modelManagerUseCurrentPlacement = true;
   manager.config.offset_x = -750;
   manager.handleWheelZoom({{
     deltaY: 1000,

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -92,6 +92,7 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
     assert "startOffsetX: placement.offsetX" in drag_block
     assert "this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);" in drag_block
     assert "const currentScale = this.getActivePlacement().scale;" in wheel_block
+    assert "window.stageModelManagerPNGTuberPlacement(this.config);" in wheel_block
     assert "initialScale: placement.scale" in touch_block
     assert "this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);" in touch_block
     assert "this.config.mobile_offset_x" in save_block
@@ -173,11 +174,13 @@ const runNextFrame = (timestamp) => {{
   frames.delete(frameId);
   callback(timestamp);
 }};
+let stagedPlacement = null;
 const window = {{
   location: {{ pathname: '/' }},
   innerWidth: 1000,
   innerHeight: 800,
   lanlan_config: {{ model_type: 'pngtuber' }},
+  stageModelManagerPNGTuberPlacement(config) {{ stagedPlacement = {{ ...config }}; }},
 }};
 const document = {{
   body: {{ classList: {{ contains() {{ return false; }}, toggle() {{}} }} }},
@@ -223,6 +226,8 @@ manager.applyTransform = () => {{}};
 manager.isLayeredActive = () => false;
 manager.resetLayeredDragVelocity = () => {{}};
 manager.showDragImage = () => {{}};
+manager.restoreStateImage = () => {{}};
+manager.restartLayeredAnimationLoop = () => {{}};
 manager.syncGlobalConfig = () => {{}};
 manager.updateFloatingButtonsPosition = () => {{}};
 manager.updateLockIconPosition = () => {{}};
@@ -290,6 +295,39 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.ok(Math.abs(resizedRight - 200) < 0.001);
   assert.equal(scheduledSaves, 1);
 
+  // An unchanged two-finger gesture leaves the active rebound untouched.
+  manager.config.scale = 1;
+  manager.config.offset_x = -750;
+  const untouchedSnap = manager.snapModelIntoScreen();
+  manager.startTouchZoom({{
+    touches: [{{ clientX: 100, clientY: 100 }}, {{ clientX: 200, clientY: 100 }}],
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  assert.equal(frames.size, 1);
+  await manager.endTouchZoom();
+  assert.equal(frames.size, 1, 'unchanged touch must not cancel the rebound');
+  runNextFrame(0);
+  runNextFrame(260);
+  assert.equal(await untouchedSnap, true);
+  assert.equal(manager.config.offset_x, -500);
+
+  // Model-manager wheel replacement stages the final snapped placement.
+  window.location.pathname = '/model_manager';
+  manager.config.offset_x = -750;
+  manager.handleWheelZoom({{
+    deltaY: 1000,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  runNextFrame(0);
+  runNextFrame(260);
+  await Promise.resolve();
+  assert.ok(stagedPlacement);
+  assert.equal(stagedPlacement.offset_x, manager.config.offset_x);
+  assert.equal(scheduledSaves, 1, 'model-manager placement must be staged instead of auto-saved');
+  window.location.pathname = '/';
+
   manager.config.offset_x = -750;
   const cancelledSnap = manager.snapModelIntoScreen();
   assert.equal(frames.size, 1);
@@ -307,6 +345,7 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.equal(frames.size, 1, 'pointerdown alone must not cancel the rebound');
   runNextFrame(0);
   runNextFrame(130);
+  const centerBeforeTakeover = manager.getModelCenterInWindow();
   manager.moveDrag({{
     pointerId: 9,
     clientX: 110,
@@ -315,6 +354,8 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
     screenY: 100,
     preventDefault() {{}},
   }});
+  assert.equal(manager._dragState.modelCenterPointerOffset.x, centerBeforeTakeover.x - 110);
+  assert.equal(manager._dragState.modelCenterPointerOffset.y, centerBeforeTakeover.y - 100);
   manager.setActiveOffsets(-123, 45);
   assert.equal(await cancelledSnap, false);
   assert.equal(frames.size, 0);

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -345,7 +345,6 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.equal(frames.size, 1, 'pointerdown alone must not cancel the rebound');
   runNextFrame(0);
   runNextFrame(130);
-  const centerBeforeTakeover = manager.getModelCenterInWindow();
   manager.moveDrag({{
     pointerId: 9,
     clientX: 110,
@@ -354,8 +353,9 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
     screenY: 100,
     preventDefault() {{}},
   }});
-  assert.equal(manager._dragState.modelCenterPointerOffset.x, centerBeforeTakeover.x - 110);
-  assert.equal(manager._dragState.modelCenterPointerOffset.y, centerBeforeTakeover.y - 100);
+  const centerAfterTakeover = manager.getModelCenterInWindow();
+  assert.equal(manager._dragState.modelCenterPointerOffset.x, centerAfterTakeover.x - 110);
+  assert.equal(manager._dragState.modelCenterPointerOffset.y, centerAfterTakeover.y - 100);
   manager.setActiveOffsets(-123, 45);
   assert.equal(await cancelledSnap, false);
   assert.equal(frames.size, 0);

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -134,6 +134,15 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
     assert drag_block.index("await this.snapModelIntoScreen({ animate: true });") < drag_block.index(
         "await this.saveCurrentConfig();"
     )
+    touch_end_block = source[
+        source.index("        async endTouchZoom() {"):
+        source.index("        setupHTMLLockIcon()")
+    ]
+    assert "await this.snapModelIntoScreen({ animate: true });" in touch_end_block
+    assert "if (!this.isDragCompletionCurrent(state)) return;" in touch_end_block
+    assert touch_end_block.index("await this.snapModelIntoScreen({ animate: true });") < touch_end_block.index(
+        "await this.saveCurrentConfig();"
+    )
 
 
 def test_pngtuber_drag_snaps_back_when_less_than_200_pixels_remain_visible():
@@ -146,12 +155,21 @@ def test_pngtuber_drag_snaps_back_when_less_than_200_pixels_remain_visible():
 const assert = require('node:assert/strict');
 const vm = require('node:vm');
 
-const frames = [];
+let nextFrameId = 0;
+const frames = new Map();
 const requestAnimationFrame = (callback) => {{
-  frames.push(callback);
-  return frames.length;
+  const frameId = ++nextFrameId;
+  frames.set(frameId, callback);
+  return frameId;
 }};
-const cancelAnimationFrame = () => {{}};
+const cancelAnimationFrame = (frameId) => {{ frames.delete(frameId); }};
+const runNextFrame = (timestamp) => {{
+  const next = frames.entries().next();
+  assert.equal(next.done, false, 'expected a pending animation frame');
+  const [frameId, callback] = next.value;
+  frames.delete(frameId);
+  callback(timestamp);
+}};
 const window = {{
   location: {{ pathname: '/' }},
   innerWidth: 1000,
@@ -159,7 +177,7 @@ const window = {{
   lanlan_config: {{ model_type: 'pngtuber' }},
 }};
 const document = {{
-  body: {{ classList: {{ contains() {{ return false; }} }} }},
+  body: {{ classList: {{ contains() {{ return false; }}, toggle() {{}} }} }},
   getElementById() {{ return null; }},
   querySelectorAll() {{ return []; }},
 }};
@@ -185,6 +203,11 @@ manager.config = {{
   mirror: false,
 }};
 manager.image = {{
+  classList: {{ toggle() {{}} }},
+  closest() {{ return null; }},
+  setAttribute() {{}},
+  removeAttribute() {{}},
+  setPointerCapture() {{}},
   getBoundingClientRect() {{
     const centerX = window.innerWidth / 2 + manager.config.offset_x;
     const centerY = window.innerHeight / 2 + manager.config.offset_y;
@@ -193,6 +216,8 @@ manager.image = {{
 }};
 manager.applyTransform = () => {{}};
 manager.isLayeredActive = () => false;
+manager.resetLayeredDragVelocity = () => {{}};
+manager.showDragImage = () => {{}};
 manager.syncGlobalConfig = () => {{}};
 manager.updateFloatingButtonsPosition = () => {{}};
 manager.updateLockIconPosition = () => {{}};
@@ -231,14 +256,35 @@ manager.updateLockIconPosition = () => {{}};
   manager.config.offset_x = -750;
   manager.config.offset_y = 0;
   const animatedSnap = manager.snapModelIntoScreen();
-  assert.equal(frames.length, 1);
-  frames.shift()(0);
-  frames.shift()(130);
+  assert.equal(frames.size, 1);
+  runNextFrame(0);
+  runNextFrame(130);
   assert.ok(manager.config.offset_x > -500, 'easeOutBack should briefly overshoot the target');
-  frames.shift()(260);
+  runNextFrame(260);
   assert.equal(await animatedSnap, true);
   assert.equal(manager.config.offset_x, -500);
   assert.equal(manager.config.offset_y, 0);
+
+  manager.config.offset_x = -750;
+  const cancelledSnap = manager.snapModelIntoScreen();
+  runNextFrame(0);
+  runNextFrame(130);
+  manager.startDrag({{
+    target: manager.image,
+    button: 0,
+    pointerId: 9,
+    clientX: 100,
+    clientY: 100,
+    screenX: 100,
+    screenY: 100,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  manager.setActiveOffsets(-123, 45);
+  assert.equal(await cancelledSnap, false);
+  assert.equal(frames.size, 0);
+  assert.equal(manager.config.offset_x, -123);
+  assert.equal(manager.config.offset_y, 45);
 }})().catch((error) => {{
   console.error(error);
   process.exit(1);

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -296,6 +296,13 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.ok(Math.abs(layeredTarget.offsetX - (-433.3333333333333)) < 0.001);
   manager.isLayeredActive = () => false;
 
+  // Content smaller than 200 px stops once it is fully visible.
+  modelWidth = 100;
+  manager.config.offset_x = -480;
+  const smallTarget = manager.getEdgeSnapTarget();
+  assert.equal(smallTarget.offsetX, -450);
+  modelWidth = 400;
+
   // State image geometry changes retarget an in-flight rebound.
   manager.config.offset_x = -750;
   modelWidth = 400;

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -68,6 +68,10 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
         source.index("async endTouchZoom()")
     ]
     save_block = source[
+        source.index("async saveOrStageCurrentConfig()"):
+        source.index("        scheduleSaveCurrentConfig")
+    ]
+    runtime_save_block = source[
         source.index("async saveCurrentConfig()"):
         source.index("        scheduleSaveCurrentConfig")
     ]
@@ -95,11 +99,12 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
     assert "window.stageModelManagerPNGTuberPlacement(this.config);" in wheel_block
     assert "initialScale: placement.scale" in touch_block
     assert "this.setActiveOffsets(state.startOffsetX + dx, state.startOffsetY + dy);" in touch_block
-    assert "this.config.mobile_offset_x" in save_block
-    assert "this.config.mobile_offset_y" in save_block
-    assert "this.config.mobile_scale" in save_block
-    assert "this.config.position_anchor" in save_block
-    assert "apply_runtime: false" in save_block
+    assert "window.stageModelManagerPNGTuberPlacement(this.config);" in save_block
+    assert "this.config.mobile_offset_x" in runtime_save_block
+    assert "this.config.mobile_offset_y" in runtime_save_block
+    assert "this.config.mobile_scale" in runtime_save_block
+    assert "this.config.position_anchor" in runtime_save_block
+    assert "apply_runtime: false" in runtime_save_block
 
 
 def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
@@ -133,7 +138,7 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
         "await this.snapModelIntoScreen({ animate: true });"
     )
     assert drag_block.index("await this.snapModelIntoScreen({ animate: true });") < drag_block.index(
-        "await this.saveCurrentConfig();"
+        "await this.saveOrStageCurrentConfig();"
     )
     touch_end_block = source[
         source.index("        async endTouchZoom() {"):
@@ -145,7 +150,7 @@ def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():
         "await this.snapModelIntoScreen({ animate: true });"
     )
     assert touch_end_block.index("await this.snapModelIntoScreen({ animate: true });") < touch_end_block.index(
-        "await this.saveCurrentConfig();"
+        "await this.saveOrStageCurrentConfig();"
     )
 
 
@@ -175,6 +180,7 @@ const runNextFrame = (timestamp) => {{
   callback(timestamp);
 }};
 let stagedPlacement = null;
+let modelWidth = 400;
 const window = {{
   location: {{ pathname: '/' }},
   innerWidth: 1000,
@@ -215,7 +221,7 @@ manager.image = {{
   removeAttribute() {{}},
   setPointerCapture() {{}},
   getBoundingClientRect() {{
-    const width = 400 * manager.config.scale;
+    const width = modelWidth * manager.config.scale;
     const height = 400 * manager.config.scale;
     const centerX = window.innerWidth / 2 + manager.config.offset_x;
     const centerY = window.innerHeight / 2 + manager.config.offset_y;
@@ -276,6 +282,18 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.equal(await animatedSnap, true);
   assert.equal(manager.config.offset_x, -500);
   assert.equal(manager.config.offset_y, 0);
+
+  // State image geometry changes retarget an in-flight rebound.
+  manager.config.offset_x = -750;
+  modelWidth = 400;
+  const resizedImageSnap = manager.snapModelIntoScreen();
+  runNextFrame(0);
+  modelWidth = 200;
+  runNextFrame(130);
+  runNextFrame(260);
+  assert.equal(await resizedImageSnap, true);
+  assert.equal(manager.config.offset_x, -400);
+  modelWidth = 400;
 
   // Wheel zoom cancels the old rebound and targets the resized model geometry.
   manager.config.offset_x = -750;
@@ -639,6 +657,30 @@ function pointer(type, clientX, clientY, screenX, screenY, pointerId = 7) {{
   assert.equal(await manager.checkAndSwitchDisplayAfterDrag(invalidWindowState), false);
   assert.equal(movedPoint, null);
   manager.getModelCenterInWindow = getModelCenterInWindow;
+
+  // A second pointerdown without movement must not invalidate the prior completion.
+  currentDisplay = primary;
+  currentWindowBounds = {{ ...primaryWindowBounds }};
+  window.innerWidth = currentWindowBounds.width;
+  window.innerHeight = currentWindowBounds.height;
+  manager.config.offset_x = -700;
+  manager.config.offset_y = 0;
+  movedPoint = null;
+  saves = 0;
+  deferredFrames = [];
+  manager.startDrag(pointer('pointerdown', 154, 534, 155, 535));
+  manager.moveDrag(pointer('pointermove', -201, 534, -200, 535));
+  const pendingClickEnd = manager.endDrag(pointer('pointerup', -201, 534, -200, 535));
+  while (deferredFrames.length === 0) await new Promise(setImmediate);
+  manager.startDrag(pointer('pointerdown', 100, 100, -2459, 101, 8));
+  deferredFrames.shift()(0);
+  await new Promise(setImmediate);
+  deferredFrames.shift()(0);
+  await pendingClickEnd;
+  assert.equal(manager._dragState.pointerId, 8);
+  assert.equal(manager._dragState.dragSequence, null);
+  assert.equal(saves, 1);
+  await manager.endDrag(pointer('pointerup', 100, 100, -2459, 101, 8));
 
   currentDisplay = primary;
   currentWindowBounds = {{ ...primaryWindowBounds }};

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -209,9 +209,11 @@ manager.image = {{
   removeAttribute() {{}},
   setPointerCapture() {{}},
   getBoundingClientRect() {{
+    const width = 400 * manager.config.scale;
+    const height = 400 * manager.config.scale;
     const centerX = window.innerWidth / 2 + manager.config.offset_x;
     const centerY = window.innerHeight / 2 + manager.config.offset_y;
-    return {{ left: centerX - 200, top: centerY - 200, width: 400, height: 400 }};
+    return {{ left: centerX - width / 2, top: centerY - height / 2, width, height }};
   }},
 }};
 manager.applyTransform = () => {{}};
@@ -221,6 +223,8 @@ manager.showDragImage = () => {{}};
 manager.syncGlobalConfig = () => {{}};
 manager.updateFloatingButtonsPosition = () => {{}};
 manager.updateLockIconPosition = () => {{}};
+let scheduledSaves = 0;
+manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
 
 (async () => {{
   manager.config.offset_x = -750;
@@ -264,6 +268,24 @@ manager.updateLockIconPosition = () => {{}};
   assert.equal(await animatedSnap, true);
   assert.equal(manager.config.offset_x, -500);
   assert.equal(manager.config.offset_y, 0);
+
+  // Wheel zoom cancels the old rebound and targets the resized model geometry.
+  manager.config.offset_x = -750;
+  const preZoomSnap = manager.snapModelIntoScreen();
+  manager.handleWheelZoom({{
+    deltaY: 1000,
+    preventDefault() {{}},
+    stopPropagation() {{}},
+  }});
+  assert.equal(await preZoomSnap, false);
+  assert.equal(frames.size, 1);
+  runNextFrame(0);
+  runNextFrame(260);
+  await Promise.resolve();
+  const resizedBounds = manager.image.getBoundingClientRect();
+  const resizedRight = resizedBounds.left + resizedBounds.width;
+  assert.ok(Math.abs(resizedRight - 200) < 0.001);
+  assert.equal(scheduledSaves, 1);
 
   manager.config.offset_x = -750;
   const cancelledSnap = manager.snapModelIntoScreen();

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -326,6 +326,17 @@ manager.scheduleSaveCurrentConfig = () => {{ scheduledSaves += 1; }};
   assert.ok(Math.abs(manager.config.offset_x - (-485)) < 0.001);
   modelWidth = 400;
 
+  // Growing content cannot reverse the snap target past its starting offset.
+  manager.config.offset_x = -750;
+  const growingImageSnap = manager.snapModelIntoScreen();
+  runNextFrame(0);
+  modelWidth = 2000;
+  runNextFrame(130);
+  runNextFrame(260);
+  assert.equal(await growingImageSnap, true);
+  assert.equal(manager.config.offset_x, -500);
+  modelWidth = 400;
+
   // Wheel zoom cancels the old rebound and targets the resized model geometry.
   manager.config.offset_x = -750;
   const preZoomSnap = manager.snapModelIntoScreen();


### PR DESCRIPTION
## 改动概述 / Summary

- 为 PNGTuber 补齐与 VRM/MMD 一致的屏幕边缘回弹行为
- 拖拽结束且未成功跨屏时，若模型在任一方向剩余可见区域不足 200px，则以 260ms easeOutBack 动画拉回
- 成功跨屏时不触发回弹；回弹期间重新拖动会取消旧动画，避免旧状态覆盖新位置
- 正常贴边且仍保留至少 200px 可见区域时不强制纠正

## 测试 / Testing

- `uv run pytest tests/unit/test_pngtuber_static_contracts.py tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py tests/unit/test_mmd_interaction_static_contracts.py`（40 passed）
- `node --test static/avatar-multiscreen-drag.test.cjs static/avatar-multiscreen-drag-hint.test.cjs`（15 passed）
- `node --check static/pngtuber-core.js`
- `uv run ruff check tests/unit/test_pngtuber_static_contracts.py`
- `git diff origin/main...HEAD --check`

## 回归报告

不适用：本 PR 仅修改前端 PNGTuber 交互逻辑与对应测试。

## 不拆分理由

不适用：仅包含一处功能修复及其回归测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 拖拽、滚轮缩放或触摸缩放后，模型可见区域不足 200 像素时会自动吸附回屏幕内。
  - 支持平滑动画回弹或立即调整位置，并在新操作开始时取消正在进行的回弹动画。
  - 优化透明画布边距、连续操作及模型尺寸变化时的吸附表现。
  - 模型管理页面暂存位置调整，运行时位置仍会自动保存。

- **Bug 修复**
  - 优化缩放边界、连续拖拽与异步回弹处理，避免较新的操作被旧操作覆盖。

- **测试**
  - 增加多方向吸附、动画取消、缩放、连续拖拽及异步操作场景的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->