### PR TITLE
fix(plugin-config): show manifest defaults in profile editor

### DIFF
--- a/frontend/plugin-manager/src/api/config.ts
+++ b/frontend/plugin-manager/src/api/config.ts
@@ -56,10 +56,18 @@ export function getPluginConfigToml(pluginId: string): Promise<PluginConfigToml>
 }
 
 /**
- * 获取插件基础配置（直接来自 plugin.toml，不包含 profile 叠加）
+ * 获取运行时插件基础配置（不包含 profile 叠加）
  */
 export function getPluginBaseConfig(pluginId: string): Promise<PluginBaseConfig> {
   return get(`/plugin/${encodeURIComponent(pluginId)}/config/base`)
+}
+
+/**
+ * 获取用于编辑 profile 的配置基线：插件清单默认值与运行时配置合并，
+ * 不包含任何 profile 覆盖项。
+ */
+export function getPluginEffectiveBaseConfig(pluginId: string): Promise<PluginBaseConfig> {
+  return get(`/plugin/${encodeURIComponent(pluginId)}/config/base/effective`)
 }
 
 /**
@@ -211,4 +219,3 @@ export function hotUpdatePluginConfig(
     profile: profile ?? null
   })
 }
-

--- a/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
@@ -157,7 +157,7 @@ import * as Diff from 'diff'
 
 import {
   getPluginConfig,
-  getPluginBaseConfig,
+  getPluginEffectiveBaseConfig,
   getPluginProfilesState,
   getPluginProfileConfig,
   upsertPluginProfileConfig,
@@ -494,7 +494,7 @@ async function loadAll() {
   try {
     const prevSelected = selectedProfileName.value
     const [baseRes, effectiveRes, profilesRes] = await Promise.all([
-      getPluginBaseConfig(props.pluginId),
+      getPluginEffectiveBaseConfig(props.pluginId),
       getPluginConfig(props.pluginId),
       getPluginProfilesState(props.pluginId)
     ])

--- a/plugin/server/routes/config.py
+++ b/plugin/server/routes/config.py
@@ -129,6 +129,18 @@ async def get_plugin_base_config_endpoint(plugin_id: str, _: str = require_admin
         raise_http_from_domain(error, logger=logger)
 
 
+@router.get("/plugin/{plugin_id}/config/base/effective")
+async def get_plugin_effective_base_config_endpoint(
+    plugin_id: str,
+    _: str = require_admin,
+) -> dict[str, object]:
+    """Return manifest defaults merged with runtime config, without a profile overlay."""
+    try:
+        return await config_query_service.get_plugin_effective_base_config(plugin_id=plugin_id)
+    except ServerDomainError as error:
+        raise_http_from_domain(error, logger=logger)
+
+
 @router.get("/plugin/{plugin_id}/config/profiles")
 async def get_plugin_profiles_state_endpoint(plugin_id: str, _: str = require_admin) -> dict[str, object]:
     try:


### PR DESCRIPTION
## Summary
- expose an effective base-config endpoint that merges manifest defaults with runtime config
- use that endpoint as the profile editor baseline
- allow newly added plugin defaults to appear in existing profiles without overwriting saved values

## Validation
- npm run type-check
- uv run pytest plugin/tests/unit/server/test_config_query_effective.py -q --basetemp workspace-temp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增获取插件有效基础配置的能力，合并插件默认值与运行时配置，同时排除 Profile 覆盖项。
  * 配置编辑器现可基于该有效基础配置加载和编辑插件配置。
  * 新增管理员接口，用于查询插件的有效基础配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->