### PR TITLE
将屏幕捕获错误信息上报给 Electron，以识别特定的 Windows WGC 捕获故障

### DIFF
--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -167,6 +167,7 @@
             return await provider.requestWindowsGraphicsCaptureFallback({
                 name: String(error && error.name || ''),
                 message: String(error && error.message || ''),
+                deferRestartUntilConfirmed: true,
                 sourceType: typeof sourceId === 'string' && sourceId.startsWith('window:')
                     ? 'window'
                     : 'screen'
@@ -174,6 +175,23 @@
         } catch (fallbackRequestError) {
             console.warn('[屏幕源] 请求 Windows Graphics Capture 兼容模式失败:', fallbackRequestError);
             return null;
+        }
+    }
+
+    async function confirmWindowsGraphicsCaptureFallback(provider, fallback) {
+        if (!fallback || fallback.restartApproved !== true || !fallback.restartToken
+            || !provider || typeof provider.restartWindowsGraphicsCaptureFallback !== 'function') {
+            return fallback;
+        }
+        try {
+            return await provider.restartWindowsGraphicsCaptureFallback(fallback.restartToken);
+        } catch (restartError) {
+            console.warn('[屏幕源] 确认 Windows Graphics Capture 兼容模式重启失败:', restartError);
+            return {
+                prompted: true,
+                restarting: false,
+                reason: 'restart-confirmation-failed'
+            };
         }
     }
 
@@ -2088,6 +2106,15 @@
                                     windowsGraphicsCaptureFallback
                                     && windowsGraphicsCaptureFallback.prompted
                                 );
+                                if (windowsGraphicsCaptureFallback
+                                    && windowsGraphicsCaptureFallback.restartApproved === true) {
+                                    if (discardCancelledScreenSharingStart(attempt)) return;
+                                    if (!manualCaptureIdentityIsCurrent()) return;
+                                    windowsGraphicsCaptureFallback = await confirmWindowsGraphicsCaptureFallback(
+                                        desktopProvider,
+                                        windowsGraphicsCaptureFallback
+                                    );
+                                }
                                 if (windowsGraphicsCaptureFallback && windowsGraphicsCaptureFallback.restarting) {
                                     return;
                                 }
@@ -2099,6 +2126,7 @@
                         }
                     } else if (!isNativeFrameProvider(desktopProvider)) {
                         // 使用标准的getDisplayMedia（显示系统选择器）
+                        var displayCaptureGeneration = screenSourceSelectionGeneration;
                         try {
                             captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getDisplayMedia({
                                 video: {
@@ -2121,6 +2149,14 @@
                                 displayWgcFallback
                                 && displayWgcFallback.prompted
                             );
+                            if (displayWgcFallback && displayWgcFallback.restartApproved === true) {
+                                if (discardCancelledScreenSharingStart(attempt)) return;
+                                if (displayCaptureGeneration !== screenSourceSelectionGeneration) return;
+                                displayWgcFallback = await confirmWindowsGraphicsCaptureFallback(
+                                    desktopProvider,
+                                    displayWgcFallback
+                                );
+                            }
                             if (displayWgcFallback && displayWgcFallback.restarting) {
                                 return;
                             }

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -159,6 +159,24 @@
         return !!(provider && provider.sourceEnumerationMayPrompt === true);
     }
 
+    async function requestWindowsGraphicsCaptureFallback(provider, error, sourceId) {
+        if (!provider || typeof provider.requestWindowsGraphicsCaptureFallback !== 'function') {
+            return null;
+        }
+        try {
+            return await provider.requestWindowsGraphicsCaptureFallback({
+                name: String(error && error.name || ''),
+                message: String(error && error.message || ''),
+                sourceType: typeof sourceId === 'string' && sourceId.startsWith('window:')
+                    ? 'window'
+                    : 'screen'
+            });
+        } catch (fallbackRequestError) {
+            console.warn('[屏幕源] 请求 Windows Graphics Capture 兼容模式失败:', fallbackRequestError);
+            return null;
+        }
+    }
+
     function hasVisibleModelSurface() {
         var modelContainerIds = [
             'live2d-container',
@@ -1701,6 +1719,7 @@
             return;
         }
 
+        var windowsGraphicsCapturePrompted = false;
         try {
             var nativeCapture = null;
             // Capture into a local reference first. A cancelled browser picker may
@@ -1987,6 +2006,18 @@
                                 return;
                             }
                             console.warn('[屏幕源] 指定源捕获失败:', captureErr);
+                            var windowsGraphicsCaptureFallback = await requestWindowsGraphicsCaptureFallback(
+                                desktopProvider,
+                                captureErr,
+                                selectedSourceId
+                            );
+                            windowsGraphicsCapturePrompted = !!(
+                                windowsGraphicsCaptureFallback
+                                && windowsGraphicsCaptureFallback.prompted
+                            );
+                            if (windowsGraphicsCaptureFallback && windowsGraphicsCaptureFallback.restarting) {
+                                return;
+                            }
                             var fallbackSucceeded = false;
 
                             // Remember-window is a fail-closed privacy boundary: once
@@ -2077,6 +2108,18 @@
                             // 用户主动取消则直接抛出，不兜底
                             if (displayErr.name === 'NotAllowedError') throw displayErr;
                             console.warn('[屏幕源] getDisplayMedia 失败，停止屏幕分享:', displayErr);
+                            var displayWgcFallback = await requestWindowsGraphicsCaptureFallback(
+                                desktopProvider,
+                                displayErr,
+                                null
+                            );
+                            windowsGraphicsCapturePrompted = !!(
+                                displayWgcFallback
+                                && displayWgcFallback.prompted
+                            );
+                            if (displayWgcFallback && displayWgcFallback.restarting) {
+                                return;
+                            }
                         }
                     }
                 }
@@ -2211,7 +2254,9 @@
                     '屏幕捕获已停止，请检查系统权限或重新选择来源'
                 );
             }
-            window.showStatusToast(err.name + ': ' + err.message + (hint ? '\n' + hint : ''), 5000);
+            if (!windowsGraphicsCapturePrompted) {
+                window.showStatusToast(err.name + ': ' + err.message + (hint ? '\n' + hint : ''), 5000);
+            }
         }
     }
     mod.startScreenSharing = startScreenSharing;

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -2006,18 +2006,6 @@
                                 return;
                             }
                             console.warn('[屏幕源] 指定源捕获失败:', captureErr);
-                            var windowsGraphicsCaptureFallback = await requestWindowsGraphicsCaptureFallback(
-                                desktopProvider,
-                                captureErr,
-                                selectedSourceId
-                            );
-                            windowsGraphicsCapturePrompted = !!(
-                                windowsGraphicsCaptureFallback
-                                && windowsGraphicsCaptureFallback.prompted
-                            );
-                            if (windowsGraphicsCaptureFallback && windowsGraphicsCaptureFallback.restarting) {
-                                return;
-                            }
                             var fallbackSucceeded = false;
 
                             // Remember-window is a fail-closed privacy boundary: once
@@ -2087,6 +2075,18 @@
                             }
 
                             if (!fallbackSucceeded) {
+                                var windowsGraphicsCaptureFallback = await requestWindowsGraphicsCaptureFallback(
+                                    desktopProvider,
+                                    captureErr,
+                                    selectedSourceId
+                                );
+                                windowsGraphicsCapturePrompted = !!(
+                                    windowsGraphicsCaptureFallback
+                                    && windowsGraphicsCaptureFallback.prompted
+                                );
+                                if (windowsGraphicsCaptureFallback && windowsGraphicsCaptureFallback.restarting) {
+                                    return;
+                                }
                                 console.warn('[屏幕源] 所有前端持续流方式均失败，停止屏幕分享');
                             }
                         }

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -188,7 +188,7 @@
         } catch (restartError) {
             console.warn('[屏幕源] 确认 Windows Graphics Capture 兼容模式重启失败:', restartError);
             return {
-                prompted: true,
+                prompted: false,
                 restarting: false,
                 reason: 'restart-confirmation-failed'
             };
@@ -2114,6 +2114,10 @@
                                         desktopProvider,
                                         windowsGraphicsCaptureFallback
                                     );
+                                    windowsGraphicsCapturePrompted = !!(
+                                        windowsGraphicsCaptureFallback
+                                        && windowsGraphicsCaptureFallback.prompted
+                                    );
                                 }
                                 if (windowsGraphicsCaptureFallback && windowsGraphicsCaptureFallback.restarting) {
                                     return;
@@ -2155,6 +2159,10 @@
                                 displayWgcFallback = await confirmWindowsGraphicsCaptureFallback(
                                     desktopProvider,
                                     displayWgcFallback
+                                );
+                                windowsGraphicsCapturePrompted = !!(
+                                    displayWgcFallback
+                                    && displayWgcFallback.prompted
                                 );
                             }
                             if (displayWgcFallback && displayWgcFallback.restarting) {

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -2069,7 +2069,11 @@
                                     pushSelectedSourceToMain(null);
                                     fallbackSucceeded = true;
                                 } catch (fallback2Err) {
+                                    if (discardCancelledScreenSharingStart(attempt)) return;
                                     if (!manualCaptureIdentityIsCurrent()) return;
+                                    // 用户关闭系统选择器时沿用标准路径的取消语义，
+                                    // 不要把此前的指定源失败误报为 WGC 故障。
+                                    if (fallback2Err.name === 'NotAllowedError') throw fallback2Err;
                                     console.warn('[屏幕源] getDisplayMedia 回退也失败:', fallback2Err);
                                 }
                             }

--- a/tests/frontend/test_screen_source_progressive_loading.py
+++ b/tests/frontend/test_screen_source_progressive_loading.py
@@ -2424,6 +2424,106 @@ def test_manual_picker_fallback_discards_late_stream_after_source_change(
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize("capture_path", ["selected-source", "display-picker"])
+@pytest.mark.parametrize("invalidation", ["current", "cancel", "source-change"])
+def test_wgc_restart_approval_requires_current_attempt(
+    page: Page,
+    capture_path: str,
+    invalidation: str,
+) -> None:
+    _install_screen_source_harness(
+        page,
+        source_enumeration_may_prompt=True,
+        initial_storage=(
+            {"selectedScreenSourceId": "window:old"}
+            if capture_path == "selected-source"
+            else None
+        ),
+    )
+    page.evaluate(
+        """() => {
+            document.body.insertAdjacentHTML('beforeend', `
+                <div id="live2d-container"></div>
+                <button id="micButton"></button><button id="muteButton"></button>
+                <button id="screenButton"></button><button id="stopButton" disabled></button>
+                <button id="resetSessionButton"></button>
+            `);
+            window.appState.isRecording = true;
+            window.appState.voiceChatActive = true;
+            window.appState.audioPlayerContext = { state: 'running' };
+            window.__wgcRequests = [];
+            window.__wgcRestartCalls = [];
+            window.__wgcRequestStarted = false;
+            window.__desktopProvider.requestWindowsGraphicsCaptureFallback = (payload) => {
+                window.__wgcRequests.push(payload);
+                window.__wgcRequestStarted = true;
+                return new Promise((resolve) => {
+                    window.__resolveWgcRequest = resolve;
+                });
+            };
+            window.__desktopProvider.restartWindowsGraphicsCaptureFallback = (token) => {
+                window.__wgcRestartCalls.push(token);
+                return Promise.resolve({ restarting: true, reason: 'restarting' });
+            };
+            Object.defineProperty(navigator, 'mediaDevices', {
+                configurable: true,
+                value: {
+                    async getUserMedia() {
+                        const error = new Error('Could not start video source');
+                        error.name = 'NotReadableError';
+                        throw error;
+                    },
+                    async getDisplayMedia() {
+                        throw new Error('fallback picker failed');
+                    },
+                },
+            });
+            window.__manualStartPromise = window.startScreenSharing();
+        }"""
+    )
+    page.wait_for_function("window.__wgcRequestStarted === true")
+
+    result = page.evaluate(
+        """async (invalidation) => {
+            if (invalidation === 'cancel') {
+                window.appScreen.cancelPendingScreenSharingStart();
+            } else if (invalidation === 'source-change') {
+                await window.selectScreenSource('window:new', 'Browser', 'Browser');
+            }
+            window.__resolveWgcRequest({
+                prompted: true,
+                restarting: false,
+                restartApproved: true,
+                restartToken: 'approval-1',
+                reason: 'restart-approved',
+            });
+            await window.__manualStartPromise;
+            return {
+                pending: window.isScreenSharingStartPending(),
+                restartCalls: window.__wgcRestartCalls,
+                requestCount: window.__wgcRequests.length,
+                deferred: window.__wgcRequests[0].deferRestartUntilConfirmed,
+                selectedId: window.appState.selectedScreenSourceId,
+            };
+        }""",
+        invalidation,
+    )
+
+    expected_selected_id = None
+    if capture_path == "selected-source":
+        expected_selected_id = "window:old"
+    if invalidation == "source-change":
+        expected_selected_id = "window:new"
+    assert result == {
+        "pending": False,
+        "restartCalls": ["approval-1"] if invalidation == "current" else [],
+        "requestCount": 1,
+        "deferred": True,
+        "selectedId": expected_selected_id,
+    }
+
+
+@pytest.mark.frontend
 def test_cached_acquisition_without_trusted_title_does_not_widen_to_screen(
     page: Page,
 ) -> None:

--- a/tests/frontend/test_screen_source_progressive_loading.py
+++ b/tests/frontend/test_screen_source_progressive_loading.py
@@ -2425,7 +2425,10 @@ def test_manual_picker_fallback_discards_late_stream_after_source_change(
 
 @pytest.mark.frontend
 @pytest.mark.parametrize("capture_path", ["selected-source", "display-picker"])
-@pytest.mark.parametrize("invalidation", ["current", "cancel", "source-change"])
+@pytest.mark.parametrize(
+    "invalidation",
+    ["current", "cancel", "source-change", "confirmation-error"],
+)
 def test_wgc_restart_approval_requires_current_attempt(
     page: Page,
     capture_path: str,
@@ -2453,6 +2456,10 @@ def test_wgc_restart_approval_requires_current_attempt(
             window.appState.audioPlayerContext = { state: 'running' };
             window.__wgcRequests = [];
             window.__wgcRestartCalls = [];
+            window.__statusToasts = [];
+            window.showStatusToast = (message) => {
+                window.__statusToasts.push(String(message));
+            };
             window.__wgcRequestStarted = false;
             window.__desktopProvider.requestWindowsGraphicsCaptureFallback = (payload) => {
                 window.__wgcRequests.push(payload);
@@ -2463,6 +2470,9 @@ def test_wgc_restart_approval_requires_current_attempt(
             };
             window.__desktopProvider.restartWindowsGraphicsCaptureFallback = (token) => {
                 window.__wgcRestartCalls.push(token);
+                if (window.__rejectWgcRestart) {
+                    return Promise.reject(new Error('restart IPC unavailable'));
+                }
                 return Promise.resolve({ restarting: true, reason: 'restarting' });
             };
             Object.defineProperty(navigator, 'mediaDevices', {
@@ -2490,6 +2500,7 @@ def test_wgc_restart_approval_requires_current_attempt(
             } else if (invalidation === 'source-change') {
                 await window.selectScreenSource('window:new', 'Browser', 'Browser');
             }
+            window.__rejectWgcRestart = invalidation === 'confirmation-error';
             window.__resolveWgcRequest({
                 prompted: true,
                 restarting: false,
@@ -2504,6 +2515,9 @@ def test_wgc_restart_approval_requires_current_attempt(
                 requestCount: window.__wgcRequests.length,
                 deferred: window.__wgcRequests[0].deferRestartUntilConfirmed,
                 selectedId: window.appState.selectedScreenSourceId,
+                captureFailureToasts: window.__statusToasts.filter(
+                    (message) => message.startsWith('NotReadableError:')
+                ).length,
             };
         }""",
         invalidation,
@@ -2516,10 +2530,15 @@ def test_wgc_restart_approval_requires_current_attempt(
         expected_selected_id = "window:new"
     assert result == {
         "pending": False,
-        "restartCalls": ["approval-1"] if invalidation == "current" else [],
+        "restartCalls": (
+            ["approval-1"]
+            if invalidation in {"current", "confirmation-error"}
+            else []
+        ),
         "requestCount": 1,
         "deferred": True,
         "selectedId": expected_selected_id,
+        "captureFailureToasts": 1 if invalidation == "confirmation-error" else 0,
     }
 
 

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -36,6 +36,26 @@ def test_manual_screen_share_never_polls_the_backend_screenshot_endpoint():
 
 
 @pytest.mark.unit
+def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
+    source = APP_SCREEN_JS.read_text(encoding="utf-8")
+    helper = source.split(
+        "async function requestWindowsGraphicsCaptureFallback", 1
+    )[1].split("function hasVisibleModelSurface", 1)[0]
+    start_once = source.split("async function startScreenSharingOnce(attempt)", 1)[
+        1
+    ].split("mod.startScreenSharing = startScreenSharing;", 1)[0]
+
+    assert "provider.requestWindowsGraphicsCaptureFallback" in helper
+    assert "name: String(error && error.name || '')" in helper
+    assert "message: String(error && error.message || '')" in helper
+    assert "sourceType:" in helper
+    assert "sourceId:" not in helper
+    assert start_once.count("requestWindowsGraphicsCaptureFallback(") == 2
+    assert start_once.count("Fallback.restarting") == 2
+    assert "if (!windowsGraphicsCapturePrompted)" in start_once
+
+
+@pytest.mark.unit
 def test_linux_portal_screen_share_does_not_reenumerate_sources_during_fallbacks():
     source = APP_SCREEN_JS.read_text(encoding="utf-8")
     start_once = source.split("async function startScreenSharingOnce(attempt)", 1)[1].split(

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -60,6 +60,12 @@ def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
     assert selected_source_failure.index("if (!fallbackSucceeded)") < (
         selected_source_failure.index("requestWindowsGraphicsCaptureFallback(")
     )
+    fallback_picker_failure = selected_source_failure.split(
+        "} catch (fallback2Err) {", 1
+    )[1].split("if (!fallbackSucceeded)", 1)[0]
+    assert "if (fallback2Err.name === 'NotAllowedError') throw fallback2Err;" in (
+        fallback_picker_failure
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -48,6 +48,7 @@ def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
     assert "provider.requestWindowsGraphicsCaptureFallback" in helper
     assert "name: String(error && error.name || '')" in helper
     assert "message: String(error && error.message || '')" in helper
+    assert "deferRestartUntilConfirmed: true" in helper
     assert "sourceType:" in helper
     assert "sourceId:" not in helper
     assert start_once.count("requestWindowsGraphicsCaptureFallback(") == 2
@@ -66,6 +67,10 @@ def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
     assert "if (fallback2Err.name === 'NotAllowedError') throw fallback2Err;" in (
         fallback_picker_failure
     )
+    assert fallback_picker_failure.index(
+        "discardCancelledScreenSharingStart(attempt)"
+    ) < fallback_picker_failure.index("fallback2Err.name === 'NotAllowedError'")
+    assert start_once.count("confirmWindowsGraphicsCaptureFallback(") == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -51,6 +51,7 @@ def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
     assert "deferRestartUntilConfirmed: true" in helper
     assert "sourceType:" in helper
     assert "sourceId:" not in helper
+    assert "prompted: false" in helper
     assert start_once.count("requestWindowsGraphicsCaptureFallback(") == 2
     assert start_once.count("Fallback.restarting") == 2
     assert "if (!windowsGraphicsCapturePrompted)" in start_once
@@ -71,6 +72,8 @@ def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
         "discardCancelledScreenSharingStart(attempt)"
     ) < fallback_picker_failure.index("fallback2Err.name === 'NotAllowedError'")
     assert start_once.count("confirmWindowsGraphicsCaptureFallback(") == 2
+    assert start_once.count("&& windowsGraphicsCaptureFallback.prompted") == 2
+    assert start_once.count("&& displayWgcFallback.prompted") == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -54,6 +54,13 @@ def test_windows_wgc_failure_offers_an_explicit_compatibility_restart():
     assert start_once.count("Fallback.restarting") == 2
     assert "if (!windowsGraphicsCapturePrompted)" in start_once
 
+    selected_source_failure = start_once.split(
+        "} catch (captureErr) {", 1
+    )[1].split("} else if (!isNativeFrameProvider(desktopProvider)) {", 1)[0]
+    assert selected_source_failure.index("if (!fallbackSucceeded)") < (
+        selected_source_failure.index("requestWindowsGraphicsCaptureFallback(")
+    )
+
 
 @pytest.mark.unit
 def test_linux_portal_screen_share_does_not_reenumerate_sources_during_fallbacks():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

将屏幕捕获错误信息上报给 Electron，以识别特定的 Windows WGC 捕获故障
相关pr:[识别特定 Windows WGC 捕获故障，提供关闭 WGC 并重启的兼容性兜底及托盘开关](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/462)

## 测试 / Testing

手动测试是否可以正确识别关闭后是否可用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Windows Graphics Capture 兼容模式，在屏幕共享捕获失败时提供额外恢复流程。
  * 支持根据来源类型执行分阶段回退，并提供明确的重启确认。

* **问题修复**
  * 修复兼容模式重启确认失败时错误标记为已提示的问题。
  * 确保重启确认后及时更新错误提示状态，避免重复或遗漏提示。
  * 避免重复重启，并阻止过期请求触发兼容模式重启。
  * 用户取消系统屏幕选择器时，正确保留取消状态，不再误报故障。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->