### PR TITLE
fix(plugin-ui): allow static plugin modal dialogs

### DIFF
--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -11,6 +11,7 @@
       @close="runtimeError = ''"
     />
 
+    <!-- Preserve standard alert/confirm/prompt behavior authored by static plugins. -->
     <iframe
       v-if="surface.mode === 'static' && surfaceUrl"
       ref="iframeRef"
@@ -18,7 +19,7 @@
       :src="surfaceUrl"
       :title="surfaceTitle"
       class="hosted-surface-frame__iframe"
-      sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+      sandbox="allow-scripts allow-forms allow-popups allow-same-origin allow-modals"
       @load="handleLoad"
       @error="handleError"
     />

--- a/frontend/plugin-manager/src/components/plugin/PluginUIFrame.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/PluginUIFrame.test.ts
@@ -33,6 +33,7 @@ async function mountFrame() {
   const iframe = container.querySelector('iframe') as HTMLIFrameElement
   iframe.dispatchEvent(new Event('load'))
   return {
+    iframe,
     dispatch(payload: Record<string, unknown>) {
       window.dispatchEvent(new MessageEvent('message', {
         data: { type: 'neko-study-open-surface', payload },
@@ -59,6 +60,13 @@ describe('PluginUIFrame open-surface bridge', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it('preserves native modal dialogs for legacy static plugin UIs', async () => {
+    const frame = await mountFrame()
+
+    expect(frame.iframe.getAttribute('sandbox')?.split(/\s+/)).toContain('allow-modals')
+    frame.unmount()
   })
 
   it('passes through only a non-negative safe activation revision', async () => {

--- a/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginUIFrame.vue
@@ -24,6 +24,7 @@
       <p>{{ t('plugins.ui.noUI') }}</p>
     </div>
     
+    <!-- Legacy static plugins may rely on standard browser modal dialogs. -->
     <iframe
       v-show="!loading && !error && hasUI"
       :key="iframeKey"
@@ -32,7 +33,7 @@
       :title="pluginId"
       :data-load-generation="iframeGeneration"
       class="plugin-iframe"
-      sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+      sandbox="allow-scripts allow-forms allow-popups allow-same-origin allow-modals"
       @load="onIframeLoad"
       @error="onIframeError"
     />

--- a/frontend/plugin-manager/src/components/plugin/hosted/HostedSurfaceFrame.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/HostedSurfaceFrame.test.ts
@@ -210,6 +210,12 @@ describe('HostedSurfaceFrame automatic startup retry', () => {
     vi.useRealTimers()
   })
 
+  it('preserves native modal dialogs for static plugin surfaces', async () => {
+    const frame = await mountFrame()
+
+    expect(frame.iframe()?.getAttribute('sandbox')?.split(/\s+/)).toContain('allow-modals')
+  })
+
   it('retries an automatic PLUGIN_NOT_RUNNING response until the host becomes ready', async () => {
     apiMocks.callPluginHostedSurfaceAction
       .mockRejectedValueOnce(makeNotRunningError())


### PR DESCRIPTION
## Summary

- add the allow-modals sandbox capability to both static plugin iframe render paths
- preserve plugin-authored alert, confirm, prompt, and print behavior without modifying individual plugins
- add regression coverage for the standard static surface and legacy compatibility iframe

## Problem

Static plugin pages are sandboxed without allow-modals. Browsers therefore ignore native confirm calls. For example, app_launcher's delete handler returns before calling remove_app, so clicking delete leaves the registered application in place.

The compatibility behavior belongs in the static UI host: plugin authors who intentionally use standard browser modal APIs should not require source rewrites.

Hosted TSX and Markdown iframe sandbox policies remain unchanged.

## Validation

- npm exec vitest run src/components/plugin/PluginUIFrame.test.ts src/components/plugin/hosted/HostedSurfaceFrame.test.ts (31 passed)
- npm run type-check
- Playwright reproduction: app_launcher delete now calls remove_app and removes the list item
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 静态插件现支持使用浏览器原生的 `alert`、`confirm` 和 `prompt` 对话框。
  - 其他插件界面行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->