### PR TITLE
feat(market): query installed plugin versions directly

### DIFF
--- a/frontend/plugin-manager/src/api/market.test.ts
+++ b/frontend/plugin-manager/src/api/market.test.ts
@@ -15,6 +15,7 @@ vi.mock('axios', () => ({
 
 import {
   fetchMarketPluginReadme,
+  fetchMarketLatestVersions,
   fetchMarketPlugins,
   normalizeMarketPlugin,
   resetMarketClient,
@@ -74,6 +75,23 @@ describe('Market API transport', () => {
     )
     expect(mocks.marketGet).toHaveBeenCalledWith('/plugins', {
       params: { page: 2 },
+    })
+  })
+
+  it('fetches installed-plugin latest versions through the local catalog bridge', async () => {
+    mocks.marketGet.mockResolvedValueOnce({
+      data: {
+        items: [
+          { plugin_id: 15, channel: 'stable', version: '1.2.3', published_at: '2026-01-01T00:00:00Z' },
+        ],
+      },
+    })
+
+    await expect(fetchMarketLatestVersions([15, 18], 'stable')).resolves.toEqual([
+      { plugin_id: 15, channel: 'stable', version: '1.2.3', published_at: '2026-01-01T00:00:00Z' },
+    ])
+    expect(mocks.marketGet).toHaveBeenCalledWith('/plugins/latest-versions', {
+      params: { ids: '15,18', channel: 'stable' },
     })
   })
 

--- a/frontend/plugin-manager/src/api/market.test.ts
+++ b/frontend/plugin-manager/src/api/market.test.ts
@@ -95,6 +95,13 @@ describe('Market API transport', () => {
     })
   })
 
+  it('skips Market client initialization when no installed plugin ids are supplied', async () => {
+    await expect(fetchMarketLatestVersions([], 'stable')).resolves.toEqual([])
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(mocks.statusGet).not.toHaveBeenCalled()
+  })
+
   it('preserves full-detail fields for the in-app detail dialog', () => {
     const plugin = normalizeMarketPlugin({
       id: 7,

--- a/frontend/plugin-manager/src/api/market.ts
+++ b/frontend/plugin-manager/src/api/market.ts
@@ -143,6 +143,14 @@ export interface MarketPluginVersion {
   created_at: string
 }
 
+/** A compact latest-version row for one installed Market plugin. */
+export interface MarketLatestVersion {
+  plugin_id: number
+  channel: 'stable' | 'beta'
+  version: string
+  published_at: string
+}
+
 /** 已审核版本的 README；由 Market 单独的公开接口提供。 */
 export interface MarketPluginReadme {
   availability: 'available' | 'unavailable'
@@ -390,6 +398,32 @@ export async function fetchMarketPluginVersions(
     return res.data
   } catch (err) {
     console.warn('[Market] Failed to fetch versions:', err)
+    return null
+  }
+}
+
+/**
+ * Fetch latest versions for a bounded group of installed Market plugin ids.
+ *
+ * The public Market endpoint intentionally caps a request at 100 ids.  The
+ * versions store chunks larger sets before calling this helper, avoiding a
+ * full catalog scan merely to render local "update available" badges.
+ */
+export async function fetchMarketLatestVersions(
+  pluginIds: Array<string | number>,
+  channel: 'stable' | 'beta',
+): Promise<MarketLatestVersion[] | null> {
+  const client = await getClient()
+  if (!client) return null
+  if (pluginIds.length === 0) return []
+
+  try {
+    const res = await client.get<{ items: MarketLatestVersion[] }>('/plugins/latest-versions', {
+      params: { ids: pluginIds.join(','), channel },
+    })
+    return Array.isArray(res.data?.items) ? res.data.items : null
+  } catch (err) {
+    console.warn('[Market] Failed to fetch latest versions:', err)
     return null
   }
 }

--- a/frontend/plugin-manager/src/api/market.ts
+++ b/frontend/plugin-manager/src/api/market.ts
@@ -413,9 +413,10 @@ export async function fetchMarketLatestVersions(
   pluginIds: Array<string | number>,
   channel: 'stable' | 'beta',
 ): Promise<MarketLatestVersion[] | null> {
+  if (pluginIds.length === 0) return []
+
   const client = await getClient()
   if (!client) return null
-  if (pluginIds.length === 0) return []
 
   try {
     const res = await client.get<{ items: MarketLatestVersion[] }>('/plugins/latest-versions', {

--- a/frontend/plugin-manager/src/stores/marketVersions.test.ts
+++ b/frontend/plugin-manager/src/stores/marketVersions.test.ts
@@ -51,6 +51,7 @@ describe('market versions store', () => {
       { pluginId: '18', channel: 'stable' },
     ])
 
+    expect(fetchMarketLatestVersions).toHaveBeenLastCalledWith(['15', '18'], 'stable')
     expect(store.latest('15', 'stable')).toBe('1.2.0')
     expect(store.latest('18', 'stable')).toBeNull()
     expect(store.loadError).toContain('latest-version lookup failed')

--- a/frontend/plugin-manager/src/stores/marketVersions.test.ts
+++ b/frontend/plugin-manager/src/stores/marketVersions.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { fetchMarketLatestVersions } from '@/api/market'
+import { useMarketVersionsStore } from './marketVersions'
+
+vi.mock('@/api/market', () => ({
+  fetchMarketLatestVersions: vi.fn(),
+}))
+
+describe('market versions store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('checks only installed ids, grouped by their installed channel', async () => {
+    vi.mocked(fetchMarketLatestVersions).mockImplementation(async (ids, channel) =>
+      ids.map((pluginId) => ({
+        plugin_id: Number(pluginId),
+        channel,
+        version: channel === 'beta' ? '2.0.0-beta.1' : '1.2.0',
+        published_at: '2026-01-01T00:00:00Z',
+      })),
+    )
+    const store = useMarketVersionsStore()
+
+    await store.ensureFresh([
+      { pluginId: '15', channel: 'stable' },
+      { pluginId: '18', channel: 'beta' },
+      { pluginId: '15', channel: 'stable' },
+    ])
+
+    expect(fetchMarketLatestVersions).toHaveBeenCalledTimes(2)
+    expect(fetchMarketLatestVersions).toHaveBeenCalledWith(['15'], 'stable')
+    expect(fetchMarketLatestVersions).toHaveBeenCalledWith(['18'], 'beta')
+    expect(store.latest('15', 'stable')).toBe('1.2.0')
+    expect(store.latest('18', 'beta')).toBe('2.0.0-beta.1')
+  })
+
+  it('keeps the previous full snapshot when a later lookup fails', async () => {
+    vi.mocked(fetchMarketLatestVersions).mockResolvedValueOnce([
+      { plugin_id: 15, channel: 'stable', version: '1.2.0', published_at: '2026-01-01T00:00:00Z' },
+    ])
+    const store = useMarketVersionsStore()
+    await store.ensureFresh([{ pluginId: '15', channel: 'stable' }])
+
+    vi.mocked(fetchMarketLatestVersions).mockResolvedValueOnce(null)
+    await store.ensureFresh([
+      { pluginId: '15', channel: 'stable' },
+      { pluginId: '18', channel: 'stable' },
+    ])
+
+    expect(store.latest('15', 'stable')).toBe('1.2.0')
+    expect(store.latest('18', 'stable')).toBeNull()
+    expect(store.loadError).toContain('latest-version lookup failed')
+  })
+})

--- a/frontend/plugin-manager/src/stores/marketVersions.ts
+++ b/frontend/plugin-manager/src/stores/marketVersions.ts
@@ -2,26 +2,31 @@
  * Lightweight cache of "what's the latest version of market plugin X on channel C".
  *
  * Loaded lazily when the plugin list view first asks about any installed
- * market plugin. We hit the same ``/plugins`` Market Bridge endpoint that
- * ``MarketPanel`` uses, but we DON'T try to compete with ``MarketPanel``
- * for data ownership — ``MarketPanel`` keeps its own local ref, this
- * store is purely for the install-source "update available" badge on
- * the main plugin list.
+ * market plugin. We use the Market Bridge's compact
+ * ``/plugins/latest-versions`` endpoint rather than competing with
+ * ``MarketPanel`` for catalog data; this store is purely for the
+ * install-source "update available" badge on the main plugin list.
  *
- * Cache is keyed by ``${channel}::${slugOrId}``. ``_fetchAll`` fetches
- * the stable and beta channels separately so a plugin installed from
- * beta compares against the beta latest (and stable against stable);
- * otherwise the badge would compare apples to oranges and either hide
- * a real beta update or invent one against the wrong channel.
+ * Cache is keyed by ``${channel}::${slugOrId}``.  Rather than scanning every
+ * page of the Market catalog, ``_fetchAll`` asks the compact latest-versions
+ * endpoint only about plugin ids recorded in local market install sources.
  */
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { fetchMarketPlugins, type MarketPlugin } from '@/api/market'
+import {
+  fetchMarketLatestVersions,
+  type MarketPlugin,
+} from '@/api/market'
 
 const _REFRESH_INTERVAL_MS = 5 * 60 * 1000  // 5 minutes
 
 export type MarketChannelKey = 'stable' | 'beta'
-const _CHANNELS: MarketChannelKey[] = ['stable', 'beta']
+export interface MarketVersionTarget {
+  pluginId: string | number
+  channel: MarketChannelKey
+}
+
+const _LOOKUP_CHUNK_SIZE = 100
 
 function _cacheKey(channel: MarketChannelKey, slugOrId: string): string {
   return `${channel}::${slugOrId}`
@@ -37,7 +42,9 @@ export const useMarketVersionsStore = defineStore('marketVersions', () => {
   const lastFetchedAt = ref<number>(0)
   const loading = ref(false)
   const loadError = ref<string | null>(null)
-  let inflight: Promise<void> | null = null
+  let lastTargetSignature = ''
+  let refreshSequence = 0
+  let inflight: { signature: string; promise: Promise<void> } | null = null
 
   /** Merge a page of market plugins into the cache.
    *
@@ -63,83 +70,103 @@ export const useMarketVersionsStore = defineStore('marketVersions', () => {
     latestByKey.value = next
   }
 
-  /** Fetch all pages of the market's plugin list for one channel.
-   *
-   *  Pages accumulate into the shared accumulator; the caller does the
-   *  atomic swap into ``latestByKey`` once every channel has finished
-   *  so a partial fetch never overwrites a previous good snapshot. */
+  /** Fetch compact latest-version rows for one channel in bounded batches. */
   async function _fetchChannel(
     channel: MarketChannelKey,
+    pluginIds: string[],
     accumulator: Record<string, string>,
   ): Promise<void> {
-    let page = 1
-    const pageSize = 100
-    // Defensive cap — no market we care about has >10k plugins per channel.
-    const maxPages = 100
-    while (page <= maxPages) {
-      const result = await fetchMarketPlugins({ page, page_size: pageSize, channel })
-      // ``fetchMarketPlugins`` returns ``null`` on network / API error.
-      // Throwing here lets ``_fetchAll`` keep the previous snapshot instead
-      // of swapping in a partial/empty accumulator and marking it fresh.
-      if (result === null) {
-        throw new Error(`marketVersions: ${channel} channel fetch failed at page ${page}`)
+    for (let offset = 0; offset < pluginIds.length; offset += _LOOKUP_CHUNK_SIZE) {
+      const chunk = pluginIds.slice(offset, offset + _LOOKUP_CHUNK_SIZE)
+      const versions = await fetchMarketLatestVersions(chunk, channel)
+      // A failed chunk makes the whole snapshot untrustworthy: retain the
+      // previous complete one rather than making absent ids look up-to-date.
+      if (versions === null) {
+        throw new Error(`marketVersions: ${channel} latest-version lookup failed`)
       }
-      if (!result.items?.length) break
-      for (const p of result.items) {
-        if (p.slug) accumulator[_cacheKey(channel, p.slug)] = p.version
-        const idKey = p.id != null ? String(p.id) : ''
-        if (idKey) accumulator[_cacheKey(channel, idKey)] = p.version
+      for (const version of versions) {
+        accumulator[_cacheKey(channel, String(version.plugin_id))] = version.version
       }
-      const total = result.total ?? 0
-      if (total && page * pageSize >= total) break
-      if (result.items.length < pageSize) break
-      page += 1
     }
   }
 
-  /** Fetch every supported channel's plugin list. Swap-on-success
-   *  semantics: pages accumulate into a local map and ``latestByKey``
-   *  is replaced atomically only after every channel finishes. Any
-   *  thrown exception leaves the previous successful snapshot intact —
-   *  partial coverage that could mark a plugin as "no longer in market"
-   *  just because we failed before reaching its page would be worse
-   *  than serving a slightly stale snapshot. */
-  async function _fetchAll(): Promise<void> {
+  function _normalizeTargets(targets: MarketVersionTarget[]): MarketVersionTarget[] {
+    const unique = new Map<string, MarketVersionTarget>()
+    for (const target of targets) {
+      const pluginId = String(target.pluginId || '').trim()
+      if (!pluginId || !/^\d+$/.test(pluginId) || target.channel !== 'stable' && target.channel !== 'beta') {
+        continue
+      }
+      unique.set(_cacheKey(target.channel, pluginId), { pluginId, channel: target.channel })
+    }
+    return [...unique.values()]
+  }
+
+  function _signatureFor(targets: MarketVersionTarget[]): string {
+    return targets
+      .map((target) => _cacheKey(target.channel, String(target.pluginId)))
+      .sort()
+      .join('|')
+  }
+
+  /** Fetch exactly the locally installed Market plugins.  Results build in a
+   *  local accumulator and atomically replace the cache only on success. */
+  async function _fetchAll(
+    targets: MarketVersionTarget[],
+    signature: string,
+    sequence: number,
+  ): Promise<void> {
     loading.value = true
     loadError.value = null
     const accumulator: Record<string, string> = {}
     try {
-      for (const channel of _CHANNELS) {
-        await _fetchChannel(channel, accumulator)
+      const idsByChannel = new Map<MarketChannelKey, string[]>()
+      for (const target of targets) {
+        const ids = idsByChannel.get(target.channel) ?? []
+        ids.push(String(target.pluginId))
+        idsByChannel.set(target.channel, ids)
       }
-      latestByKey.value = accumulator
-      lastFetchedAt.value = Date.now()
+      for (const [channel, pluginIds] of idsByChannel) {
+        await _fetchChannel(channel, pluginIds, accumulator)
+      }
+      if (sequence === refreshSequence) {
+        latestByKey.value = accumulator
+        lastFetchedAt.value = Date.now()
+        lastTargetSignature = signature
+      }
     } catch (err: any) {
-      loadError.value = err?.message ?? String(err)
+      if (sequence === refreshSequence) {
+        loadError.value = err?.message ?? String(err)
+      }
       // Intentionally do NOT touch ``latestByKey.value`` — the previous
       // successful snapshot stays live so ``latest()`` callers still get
       // an answer for plugins they care about. ``isReady`` likewise
       // stays based on ``lastFetchedAt`` so the UI doesn't flip into a
       // "never loaded" state on transient network errors.
     } finally {
-      loading.value = false
+      if (sequence === refreshSequence) loading.value = false
     }
   }
 
-  /** Trigger a refresh if the cache is stale or empty. Callers can await
-   *  this, but they don't have to — latest() will still return whatever
-   *  was cached previously while the new fetch is in flight. */
-  function ensureFresh(): Promise<void> {
+  /** Trigger a refresh for the currently installed Market plugin targets. */
+  function ensureFresh(targets: MarketVersionTarget[]): Promise<void> {
+    const normalizedTargets = _normalizeTargets(targets)
+    const signature = _signatureFor(normalizedTargets)
     const stale = Date.now() - lastFetchedAt.value > _REFRESH_INTERVAL_MS
-    if (!stale && !loadError.value) {
+    if (!stale && !loadError.value && signature === lastTargetSignature) {
       return Promise.resolve()
     }
-    if (!inflight) {
-      inflight = _fetchAll().finally(() => {
-        inflight = null
-      })
+    if (inflight?.signature === signature) {
+      return inflight.promise
     }
-    return inflight
+    const sequence = ++refreshSequence
+    const promise = _fetchAll(normalizedTargets, signature, sequence)
+    inflight = { signature, promise }
+    void promise.then(
+      () => { if (inflight?.promise === promise) inflight = null },
+      () => { if (inflight?.promise === promise) inflight = null },
+    )
+    return promise
   }
 
   /** Synchronous lookup against the current cache.

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -646,16 +646,33 @@ function installedMarketVersionTargets(): MarketVersionTarget[] {
   return targets
 }
 
+function refreshInstalledMarketVersions(): void {
+  // Fire-and-forget; if Market is unreachable the badge simply won't appear.
+  // ``ensureFresh`` compares the target signature, so status-only updates do
+  // not cause a network request while a newly installed Market plugin does.
+  marketVersionsStore.ensureFresh(installedMarketVersionTargets()).catch((err) => {
+    console.warn('Failed to refresh market versions:', err)
+  })
+}
+
 async function toggleSourceDetail() {
   showSourceDetail.value = !showSourceDetail.value
   if (showSourceDetail.value) {
-    // Fire-and-forget; if Market is unreachable the badge simply won't
-    // appear, which is a fine degraded state.
-    marketVersionsStore.ensureFresh(installedMarketVersionTargets()).catch((err) => {
-      console.warn('Failed to refresh market versions:', err)
-    })
+    refreshInstalledMarketVersions()
   }
 }
+
+// The initial plugin fetch and a Market install can both finish after source
+// details become visible. Recompute the target set on either change so update
+// badges are not held to the empty/stale snapshot from the original toggle.
+watch(
+  () => pluginStore.plugins,
+  () => {
+    if (showSourceDetail.value) refreshInstalledMarketVersions()
+  },
+  { deep: true },
+)
+
 const pluginSections = computed(() => [
   {
     key: 'plugin',

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -477,7 +477,7 @@ import { Refresh, DataAnalysis, RefreshRight, Box, Connection, Finished, Sort, C
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { usePluginStore } from '@/stores/plugin'
 import { useMetricsStore } from '@/stores/metrics'
-import { useMarketVersionsStore } from '@/stores/marketVersions'
+import { useMarketVersionsStore, type MarketVersionTarget } from '@/stores/marketVersions'
 import PluginGridSection from '@/components/plugin/PluginGridSection.vue'
 import PluginContextMenu from '@/components/plugin/PluginContextMenu.vue'
 import PluginDangerConfirmDialog from '@/components/plugin/PluginDangerConfirmDialog.vue'
@@ -508,7 +508,11 @@ import { resolveLocalizedText } from '@/utils/i18nLabel'
 import { openExternalUrl } from '@/utils/openExternal'
 import { isOpenUiNavigationAction } from '@/utils/pluginListActions'
 import { useI18n } from 'vue-i18n'
-import type { PluginListAction, PluginMeta } from '@/types/api'
+import type {
+  PluginInstallSourceDetailMarket,
+  PluginListAction,
+  PluginMeta,
+} from '@/types/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -626,12 +630,28 @@ let metricsRefreshTimer: number | null = null
 const showSourceDetail = ref(false)
 const marketVersionsStore = useMarketVersionsStore()
 
+function installedMarketVersionTargets(): MarketVersionTarget[] {
+  const targets: MarketVersionTarget[] = []
+  for (const plugin of pluginStore.pluginsWithStatus) {
+    const installSource = plugin.install_source
+    if (installSource?.source !== 'market') continue
+    const detail = installSource.source_detail as PluginInstallSourceDetailMarket | null
+    const pluginId = String(detail?.plugin_market_id || '').trim()
+    if (!/^\d+$/.test(pluginId)) continue
+    targets.push({
+      pluginId,
+      channel: detail?.channel === 'beta' ? 'beta' : 'stable',
+    })
+  }
+  return targets
+}
+
 async function toggleSourceDetail() {
   showSourceDetail.value = !showSourceDetail.value
   if (showSourceDetail.value) {
     // Fire-and-forget; if Market is unreachable the badge simply won't
     // appear, which is a fine degraded state.
-    marketVersionsStore.ensureFresh().catch((err) => {
+    marketVersionsStore.ensureFresh(installedMarketVersionTargets()).catch((err) => {
       console.warn('Failed to refresh market versions:', err)
     })
   }

--- a/plugin/tests/integration/test_market_bridge_e2e.py
+++ b/plugin/tests/integration/test_market_bridge_e2e.py
@@ -408,6 +408,54 @@ async def test_market_catalog_plugins_use_same_origin_bridge(
 
 
 @pytest.mark.asyncio
+async def test_market_catalog_latest_versions_use_same_origin_bridge(
+    bridge_e2e_env: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compact update-check endpoint stays on the fixed catalog proxy."""
+    from plugin.server.routes import market_bridge as market_bridge_module
+
+    seen_urls: list[str] = []
+    payload = {
+        "items": [
+            {"plugin_id": 15, "channel": "stable", "version": "1.2.3", "published_at": "2026-01-01T00:00:00"},
+        ]
+    }
+
+    class CatalogResponse:
+        status_code = 200
+        content = json.dumps(payload).encode("utf-8")
+        headers = {"content-type": "application/json"}
+
+    class CatalogClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "CatalogClient":
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, *args: Any, **kwargs: Any) -> CatalogResponse:
+            seen_urls.append(url)
+            return CatalogResponse()
+
+    monkeypatch.setattr(market_bridge_module.httpx, "AsyncClient", CatalogClient)
+    monkeypatch.setattr(market_bridge_module, "MARKET_API_URL", "https://market.test")
+
+    response = await bridge_e2e_env["client"].get(
+        "/market/catalog/api/v1/plugins/latest-versions?ids=15,18&channel=stable"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == payload
+    assert seen_urls == [
+        "https://market.test/api/v1/plugins/latest-versions?ids=15,18&channel=stable"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_market_catalog_readme_uses_same_origin_bridge(
     bridge_e2e_env: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- replace full catalog pagination scans for update badges with targeted latest-version lookups for locally installed Market plugins
- preserve channel-aware comparisons, 100-ID batching, five-minute caching, request coalescing, and the last complete snapshot on failures
- cover the local same-origin Market bridge path and frontend API/cache behavior

## Validation
- `uv run pytest plugin/tests/integration/test_market_bridge_e2e.py -k latest_versions`
- `vitest run src/api/market.test.ts src/stores/marketVersions.test.ts`
- `vue-tsc --build --force`

Depends on the PluginMarket `latest-versions` API PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 插件管理器现在可针对已安装的市场插件检查最新版本。
  - 支持 Stable 与 Beta 更新渠道，并展示对应版本信息。
  - 仅检查有效的市场插件，减少无关目录请求，提升更新检查效率。
- **改进**
  - 更新检查失败时保留已有版本信息，避免界面数据意外丢失。
  - 支持更稳定地处理重复请求及过期的检查结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->