### PR TITLE
修复猫咪拖拽后的动作连播，限制桌面窗口事件唤醒动作选择器，并补充拖拽中断节奏恢复、调试时间线和回归测试

### DIFF
--- a/docs/design/cat-idle-state-machine-rules.md
+++ b/docs/design/cat-idle-state-machine-rules.md
@@ -125,14 +125,14 @@ CAT1 本地文字的 `5%` 哈气彩蛋只通过哈气专用窄入口请求既有
 
 | 事件 | 直接五维变化 | 作用 |
 |---|---:|---|
-| `desktop_occlusion_or_layer_change` | 0 | 更新桌面层级/遮挡事实，排入下一轮判断 |
+| `desktop_occlusion_or_layer_change` | 0 | 更新桌面层级/遮挡事实；`source=desktop-window-sensing` 的正式原生窗口流只记录，其他来源仍排入下一轮异步判断 |
 | `return_click` | 0 | 冻结一次性 return 摘要并结束本轮 Cat Mind |
 | `tier_changed` | 仅施加 2.4 的 tier 边界 | 切换当前合法动作池 |
 | `tier_demoted_by_drag` | 由随后 `tier_changed` 施加边界 | 记录既有拖拽降级表现，不成为主动候选 |
 
 这些事件不创建第六个需求字段，也不直接映射动作。`return_click`、tier 变化与动作结果仍遵守异步边界，不能在旧入口同步启动下一动作。
 
-Electron 桌面窗口感知只在真实小猫形态的 CAT1 阶段启用：小猫已经显示且 tier 为 CAT1 时启动；进入 CAT2/CAT3、return、呼吸球切换、猫形态失效或页面卸载时停止；以后重新进入 CAT1 时建立新的正式 sensing session。这里复用的是 CAT1 的进入与退出生命周期，不是把窗口读取改成 Cat Mind 的 30 秒 tick。该 sensing bridge 是 Primary Pet renderer 的通用桌面能力；当前 Cat Mind 只是把初始当前窗口、后续身份/位置/尺寸变化以及 unavailable/current 恢复投影成 `desktop_occlusion_or_layer_change` observation 的一个消费者。其他页面功能可以并列消费同一正式 session 的安全结果，但不能各自再次启动 session 或复制读取周期。Web 页面没有桌面 bridge 时无动作。页面 session owner 不创建底层读取、检查 timer、第二窗口目标或 Cat Mind action request。
+Electron 桌面窗口感知只在真实小猫形态的 CAT1 阶段启用：小猫已经显示且 tier 为 CAT1 时启动；进入 CAT2/CAT3、return、呼吸球切换、猫形态失效或页面卸载时停止；以后重新进入 CAT1 时建立新的正式 sensing session。这里复用的是 CAT1 的进入与退出生命周期，不是把窗口读取改成 Cat Mind 的 30 秒 tick。该 sensing bridge 是 Primary Pet renderer 的通用桌面能力；当前 Cat Mind 只是把初始当前窗口、后续身份/位置/尺寸变化以及 unavailable/current 恢复投影成 `desktop_occlusion_or_layer_change` observation 的一个消费者。`source=desktop-window-sensing` 的正式原生窗口事实只保留在 recent events 和 debug 中，不排入 Cat Mind decision，因此高频移动不能在 runner 完成后串起下一动作；其他来源的同名 observation 保留既有异步判断语义。其他页面功能可以并列消费同一正式 session 的安全结果，但不能各自再次启动 session 或复制读取周期。Web 页面没有桌面 bridge 时无动作。页面 session owner 不创建底层读取、检查 timer、第二窗口目标或 Cat Mind action request。
 
 ### 3.5 动作完成和中断
 
@@ -205,18 +205,21 @@ need_contribution = 78 + 20 × (1 - exp(-(need_surplus - 8) / 8)), need_surplus 
 |---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | 计入余量 | -20 | -14 | -11.8125 | -7 | -2.1875 | 0 | 3.3516 | 12.1875 | 39 | 65.8125 | 78 | 85.8694 | 90.6424 | 渐近 98 |
 
-第二步，所有动作共享同一个连续节奏曲线。`t` 是距最近一次 runner 真实 `started` 的分钟数；本轮还没有 started 时，从进入猫形态算起。完整恢复窗为 `4.85` 分钟，即 `291` 秒：
+第二步，所有动作共享同一个连续节奏曲线。`t` 是距最近一次 runner 真实 `started` 的分钟数；本轮还没有 started 时，从进入猫形态算起。完整恢复窗为 `4.85` 分钟，即 `291` 秒。普通状态使用 `-58` 底部；如果最近的 active action 被下一次真实拖拽中断，由于该动作没有 `done` 完成反馈，恢复底部临时加深为 `-98`，直到下一次动作真实 `started`。两种情况都使用同一条连续曲线，不增加拖拽硬间隔：
 
 ```text
 p = clamp(t / 4.85, 0, 1)
-cadence = -58 + 76 × S(p)
+floor = -98，最近 active action 被拖拽中断且尚无下一次 started
+floor = -58，其他情况
+cadence = floor + (18 - floor) × S(p)
 ```
 
 | 距真实 started | 0 | 0.5 分 | 1 分 | 1.5 分 | 2 分 | 2.425 分 | 3 分 | 4 分 | 4.85 分及以后 |
 |---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 节奏分 | -58 | -55.74 | -49.64 | -40.69 | -29.89 | -20 | -6.74 | +11.82 | +18 |
+| 普通节奏分 | -58 | -55.74 | -49.64 | -40.69 | -29.89 | -20 | -6.74 | +11.82 | +18 |
+| 拖拽中断恢复节奏分 | -98 | -94.56 | -85.24 | -71.58 | -55.09 | -40 | -19.76 | +8.56 | +18 |
 
-这是连续评分，不是 3 分钟 gate 或 5 分钟强制触发。当前参数由项目的 30 秒 tick、五维自然流、runner 真实终态和完成反馈共同校准：无/少交互的持续平均目标是约 3–5 分钟一次，高需求可以更早进入下一次竞争，需求不足则继续等待。
+这是连续评分，不是 3 分钟 gate 或 5 分钟强制触发。当前参数由项目的 30 秒 tick、五维自然流、runner 真实终态和完成反馈共同校准：无/少交互的持续平均目标仍是约 3–5 分钟一次，高需求可以更早产生首次响应；但如果这次响应又被下一次拖拽打断，残留的高需求不能让随后每次松手都启动一个动作。拖拽中断恢复只影响共享节奏，不补写动作完成反馈、不修改五维，也不改变 provider 和 cooldown 语义。
 
 第三步加入对应动作的短时意图贡献。意图是选择器上下文，不是第六维，也不直接启动动作。证据合并采用饱和式累积；`current` 和 `strength` 均限制在 `0–1`：
 
@@ -301,13 +304,14 @@ queued decision
 
 - provider `dryRun` 必须只读。provider 拒绝发生在 request 之前；adapter 也可对已发 request 回 `rejected`。两者都不写 cooldown、done/failed/result、五维完成反馈或 episode，也不消费意图。
 - request 没有 ack 时的租约为 `5s`；accepted 后没有 started 时的租约为 `12s`。deadline 到达时由独立 timer 异步释放 pending 并记录协议失败；pending 期间若合并了用户触发，只排入一次后续判断，无输入时不自动重发 request，也不伪造终态或在 timer 回调里同步启动 runner。
-- `accepted` 必须带唯一 `runId`，只绑定 request；`started` 必须匹配同一个 `actionId + requestId + runId`。只有 started 才建立本动作 cooldown、重置 cadence 并消费对应 Cat Mind 动作意图。
+- `accepted` 必须带唯一 `runId`，只绑定 request；`started` 必须匹配同一个 `actionId + requestId + runId`。只有 started 才建立本动作 cooldown、重置 cadence、清除上一轮拖拽中断恢复状态，并消费对应 Cat Mind 动作意图。
 - 音频 runner 必须等 `audio.play()` 成功才报告 started；创建 `Audio`、选择素材或显示准备态都不算 started。
 - 严格终态只接受 `source=cat_mind` 且完整匹配 active 三元组的 `done/failed/cancelled/interrupted`。不匹配的 legacy/presentation 结果只留作调试，不结算。
 - accepted 后若终态先于 started，释放 request 并记录 `result_before_started`，但不写 cooldown、五维完成反馈、episode 或 started 观察标记。
-- done 结算动作完成反馈，并把 CAT1 活动或 CAT2/CAT3 休息写入有界 episode accumulator；其他终态永远不是完成经历。interrupted 先执行动作自身取消语义，再追加零五维的 interruption 元数据。
+- done 结算动作完成反馈，并把 CAT1 活动或 CAT2/CAT3 休息写入有界 episode accumulator；其他终态永远不是完成经历。interrupted 先执行动作自身取消语义，再追加零五维的 interruption 元数据；若 active action 明确被拖拽中断，则启用 `-98` 的连续节奏恢复底部，防止未领取完成反馈的残余高需求形成逐次拖拽连播。
 - pending/active 期间到达的用户触发按 observation type 合并保存。终态后的第一轮只完成 post-settle，随后用 `setTimeout(0)` 排入一次新判断；wakeup、observation 和 action result 都不能在旧同步栈里连播。
 - 有新鲜明确意图但 provider 暂不可用时保留 `providerRecheckNeeded`。既有 walk/stretch 的完成只可唤醒一次重新 dry-run，仍不是 selector 候选。
+- 桌面层级/遮挡 observation 是 provider 事实，不是自主时钟。连续窗口移动可高频更新 recent events 和调试状态，但不能绕过 30 秒 tick 在动作完成后立刻唤醒下一动作；仅当仍有新鲜明确意图且 `providerRecheckNeeded` 为真时才可触发一次可用性重试。
 
 ## 五、交互强度验收包络
 

--- a/docs/design/cat-idle-states-feature.md
+++ b/docs/design/cat-idle-states-feature.md
@@ -83,7 +83,7 @@ Cat Mind 不写 DOM、不直接播放素材、不直接操作窗口，也不保�
 
 avatar 侧另有只读 observation adapter：它只汇总已有的毛线拖拽阶段、坐标和猫/毛线矩形，生成完整手势事实；不写 journey 状态、不选动作，也不启动 runner。输入适配和动作执行因此仍是两个方向明确、职责分离的边界。
 
-只有 runner 真实进入 `started` 后，Cat Mind 才写 cooldown 并重置共享节奏分。provider dry-run 必须只读；provider 拒绝、adapter 接受后启动失败或终态先于 started 都不得写 cooldown、不得伪造完成反馈或经历。未确认的 request 最多占用 `5s`，已经 accepted 但没有 started 的 request 最多占用 `12s`，超时只释放调度租约并记录协议失败，避免 selector 永久卡住。音频动作只有 `audio.play()` 成功后才能报告 started，不能在仅创建 `Audio` 时提前开始冷却。所有已接入动作统一使用连续恢复曲线；cooldown 不从实际动作分数中扣除，只产生 `0–1` 的独立排序位。有多个合法候选时，更久没执行的动作优先；只有一个动作达到资格时，新鲜 cooldown 也不会阻止它执行。没有额外的连续重复 gate、负分或 idle 禁止结果。
+只有 runner 真实进入 `started` 后，Cat Mind 才写 cooldown 并重置共享节奏分。provider dry-run 必须只读；provider 拒绝、adapter 接受后启动失败或终态先于 started 都不得写 cooldown、不得伪造完成反馈或经历。未确认的 request 最多占用 `5s`，已经 accepted 但没有 started 的 request 最多占用 `12s`，超时只释放调度租约并记录协议失败，避免 selector 永久卡住。音频动作只有 `audio.play()` 成功后才能报告 started，不能在仅创建 `Audio` 时提前开始冷却。所有已接入动作统一使用连续恢复曲线；普通状态使用原节奏底部，只有 active action 被下一次真实拖拽中断时临时加深连续恢复底部，避免没有完成反馈的高需求在随后每次拖拽后连播。cooldown 不从实际动作分数中扣除，只产生 `0–1` 的独立排序位。有多个合法候选时，更久没执行的动作优先；只有一个动作达到资格时，新鲜 cooldown 也不会阻止它执行。没有额外的连续重复 gate、负分或 idle 禁止结果。
 
 动作进行中到达的用户 observation 不会丢失，也不会在旧回调内同步连播。Cat Mind 会把同类触发合并为一次 deferred reevaluation，在 runner 终态和表现恢复后异步重新计分。明确毛线意图暂时被 provider 拒绝时，后续既有 walk/stretch 完成可以作为“条件已变化”的唤醒事实；它们仍不是主动候选，也不直接指定玩球。
 
@@ -97,7 +97,7 @@ Web 主页面与 NEKO-PC 的 Pet renderer 页面运行同一套页面内 Cat Min
 - 毛线球临时隐藏与恢复；
 - 桌面窗口命中、遮挡和层级安全。
 
-桌面壳不持有 Cat Mind 运行状态，不维护五维、短时意图、cooldown、pending/active action 或 return episode，不运行 selector，也不发 action request。它把安全的真实桌面事实提供给 Primary Pet renderer；需要进入 Cat Mind 的事实再由页面 consumer 转换为 observation，其他 renderer 功能可以并列消费对应的通用窗口、坐标与命中能力。后续计分、选择、request、Cat Mind runner 结果和 return 摘要仍由 Pet renderer 内的同一条 Cat Mind 链处理。
+桌面壳不持有 Cat Mind 运行状态，不维护五维、短时意图、cooldown、pending/active action 或 return episode，不运行 selector，也不发 action request。它把安全的真实桌面事实提供给 Primary Pet renderer；需要进入 Cat Mind 的事实再由页面 consumer 转换为 observation，其他 renderer 功能可以并列消费对应的通用窗口、坐标与命中能力。窗口移动时可能连续产生桌面事实：`source=desktop-window-sensing` 的正式原生窗口 observation 只进入 recent events 和 debug，不排入 Cat Mind decision，因此不能在 runner 完成后立即串起下一动作；其他来源的同名 observation 保留既有异步判断语义。后续计分、选择、request、Cat Mind runner 结果和 return 摘要仍由 Pet renderer 内的同一条 Cat Mind 链处理。
 
 桌面窗口感知只覆盖真实小猫形态的 CAT1 阶段：小猫已经出现并且当前 tier 为 CAT1 时启动正式 sensing session；进入 CAT2/CAT3、return commit、切换为呼吸球、猫容器失败或页面卸载时停止；从 CAT2/CAT3 重新回到 CAT1 时建立新 session。普通模型形态、呼吸球形态、CAT2 和 CAT3 都不启动窗口感知。这里复用的是 CAT1 生命周期，不是 Cat Mind 的 30 秒自主时钟。
 
@@ -342,10 +342,10 @@ request -> accepted -> started -> done | failed | cancelled | interrupted
 ```
 
 - `accepted`：adapter 接受，并绑定唯一 runId；尚不写 cooldown。
-- `started`：runner 已实际起效；此时写本动作 cooldown、重置共享节奏并消费对应动作意图。
+- `started`：runner 已实际起效；此时写本动作 cooldown、重置共享节奏、清除上一轮拖拽中断恢复状态并消费对应动作意图。
 - `done`：runner 在恢复完成后报告；此时结算五维完成反馈，并可写 return episode。
 - `rejected`：provider 或 adapter 未启动；不写 cooldown、结果或经历。
-- `cancelled / failed / interrupted`：不得当成完成经历；small move 或既有 walk 取消时只结算已经发生且可去重的物理路程。中断原因是生命周期元数据，本身不再追加一份五维反馈；拖拽、tier 或 return 的源 observation 已各自拥有唯一的状态反馈，避免同一事实双计。
+- `cancelled / failed / interrupted`：不得当成完成经历；small move 或既有 walk 取消时只结算已经发生且可去重的物理路程。中断原因是生命周期元数据，本身不再追加一份五维反馈；拖拽、tier 或 return 的源 observation 已各自拥有唯一的状态反馈，避免同一事实双计。只有 active action 被拖拽中断时会启用更深的共享节奏恢复底部；它不修改五维，下一次真实 started 会清除该状态。
 
 一个 active action 未终结时，selector 不再启动另一个动作。动作进行期间的高频用户触发会合并保留；动作结果只释放调度并排入一次下一轮判断，不在结束回调里同步连播。严格结果必须匹配 `actionId + requestId + runId`；终态早于 started 只作为协议失败释放 request，不能结算五维、cooldown 或 episode。
 
@@ -386,13 +386,15 @@ debug 默认不显示，仅影响观察：
 
 URL 参数优先于全局变量和 localStorage，方便单次排查后用 `0` 明确关闭。关闭 debug 时不派发完整 snapshot/state-change 调试数据，动作运行语义不变。
 
+调试模式还会保留最近 `600` 条结构化时间线，并以 `[CatMindTrace]` 输出到 DevTools。记录覆盖 observation、五维、30 秒时钟、决策分数、request、started 和 terminal 生命周期；detail 只采用物理距离、时长、阶段、reason 和运行 ID 等允许字段，不保存聊天文本。复现前可调用 `window.nekoCatMind.clearDebugTimeline()` 清空，复现后调用 `window.nekoCatMind.exportDebugTimeline()` 得到可复制的 JSON。
+
 ## 十二、验证与完成标准
 
 ### 12.1 自动验证
 
 1. 修改 Cat Mind 或 avatar split 后，所有相关脚本通过 `node --check`。
 2. Cat Mind 静态 Node harness 覆盖 observation、去重、异步 scheduler、provider、生命周期、cooldown、五维反馈、短时意图、物理活动一次性结算、动作分数与 return episode；avatar harness 另覆盖毛线阶段兼容、只读几何、重复 terminal、active/settling gate、后台 RAF fallback，以及各拖拽/走路/取消终态的稳定物理事实。
-3. 短时矩阵必须按生产事实覆盖从不交互、一次 hover、普通拖拽、单次 rapid drag 和短时多轮交互；fake clock 与事件时间一致，每轮拖拽分别经过 drag-pending、drag-active、return-pending 和 settled 步骤，并覆盖 settled near-chat / far-chat、真实各 runner 时长、拖拽对 active runner 的取消以及 started 前终态。它不替代真实桌面几何验收，也不把所有 runner 伪装成统一时长。
+3. 短时矩阵必须按生产事实覆盖从不交互、一次 hover、普通拖拽、单次 rapid drag 和短时多轮交互；fake clock 与事件时间一致，每轮拖拽分别经过 drag-pending、drag-active、return-pending 和 settled 步骤，并覆盖 settled near-chat / far-chat、真实各 runner 时长、拖拽对 active runner 的取消、连续六次普通拖拽不会在首次响应后形成逐次 started，以及 started 前终态。它不替代真实桌面几何验收，也不把所有 runner 伪装成统一时长。
 4. 交互梯度按可验证区间验收：从不/少量交互持续平均约 `3–5` 分钟一次，正常交互在短时和一段时间内比无/少更早且更多；短时间大量交互在 gate/provider 可用时应在数秒到数十秒内出现首个真实 started，并在前几分钟拉开数量和动作种类。高频输入停止后逐步回到普通节奏，不能留下永久高频。最小化聊天球 near-chat、展开/compact 的 solo small move、以及确实没有移动/玩球能力的场景必须分开验证；测试只验证相对包络，不锁死具体动作顺序、精确分钟序列或单一真人节奏。
 5. return 测试覆盖大量交互并完成动作、正常互动并完成动作、无用户交互但有自主完成动作、只有互动没有完成动作、短时 started/done 仍静默、失败/取消/打断、一次性消费及无 socket/send failure。
 6. 后端测试覆盖 enum allowlist、canonical 覆盖、非法组合、独立 cat greeting 路由和 prompt 格式化。

--- a/static/app/app-cat-mind.js
+++ b/static/app/app-cat-mind.js
@@ -120,6 +120,39 @@
     ]);
     var RECENT_EVENT_LIMIT = 40;
     var SEEN_EVENT_LIMIT = 80;
+    var DEBUG_TIMELINE_LIMIT = 600;
+    var DEBUG_TIMELINE_DETAIL_FIELDS = Object.freeze([
+        'activityId',
+        'pathDistancePx',
+        'distancePx',
+        'movedDistancePx',
+        'displacementPx',
+        'durationMs',
+        'plannedDurationMs',
+        'elapsedMs',
+        'inactiveElapsedMs',
+        'sinceLastActionMs',
+        'type',
+        'status',
+        'reason',
+        'action',
+        'actionId',
+        'requestId',
+        'runId',
+        'result',
+        'phase',
+        'completed',
+        'cancelled',
+        'entry',
+        'targetKind',
+        'userInitiated',
+        'startedFarFromCat',
+        'endedNearCat',
+        'startDistanceToCatPx',
+        'endDistanceToCatPx',
+        'directApproachDistancePx',
+        'movementThresholdPx',
+    ]);
     var CHAT_MOVED_FAR_DISTANCE_PX = 24;
     var AUTONOMOUS_TICK_INTERVAL_MS = 30 * 1000;
     var ACTION_REQUEST_LEASE_MS = 5 * 1000;
@@ -140,6 +173,7 @@
         positiveNeedCurveTailCeiling: 20,
         positiveNeedCurveTailScale: 8,
         cadenceFloor: -58,
+        dragInterruptionCadenceFloor: -98,
         cadenceCeiling: 18,
         cadenceRecoveryMs: 4.85 * 60 * 1000,
         cooldownRecoveryExponent: 1.9,
@@ -207,6 +241,8 @@
     var autonomousClockGeneration = 0;
     var actionRequestLeaseTimer = 0;
     var actionRequestLeaseGeneration = 0;
+    var debugTimeline = [];
+    var debugTimelineSequence = 0;
 
     var runtimeState = createInitialRuntimeState();
 
@@ -359,6 +395,7 @@
                 lastTickAt: 0,
                 lastUserInteractionAt: 0,
                 lastActionStartedAt: 0,
+                dragInterruptionRecoveryActive: false,
             },
             lastResetReason: '',
         };
@@ -482,6 +519,7 @@
         clock.lastTickAt = startedAt;
         clock.lastUserInteractionAt = startedAt;
         clock.lastActionStartedAt = startedAt;
+        clock.dragInterruptionRecoveryActive = false;
         clock.generation = ++autonomousClockGeneration;
         if (typeof window.setInterval !== 'function') return;
         var generation = clock.generation;
@@ -524,6 +562,7 @@
                 lastTickAt: runtimeState.clock.lastTickAt,
                 lastUserInteractionAt: runtimeState.clock.lastUserInteractionAt,
                 lastActionStartedAt: runtimeState.clock.lastActionStartedAt,
+                dragInterruptionRecoveryActive: runtimeState.clock.dragInterruptionRecoveryActive,
             },
             actionIntentEvidence: getActionIntentSnapshot(snapshotAt),
             actionScores: getActionScoreSnapshot(snapshotAt, { prune: false }),
@@ -548,15 +587,181 @@
         return snapshot;
     }
 
+    function normalizeDebugTimelineDetail(detail) {
+        var source = detail && typeof detail === 'object' ? detail : {};
+        var normalized = {};
+        DEBUG_TIMELINE_DETAIL_FIELDS.forEach(function (field) {
+            if (!hasOwn(source, field)) return;
+            var value = sanitizeValue(source[field], 0);
+            if (value !== undefined) normalized[field] = value;
+        });
+        return normalized;
+    }
+
+    function normalizeDebugTimelineObservation(observation) {
+        if (!observation || typeof observation !== 'object') return null;
+        return {
+            type: typeof observation.type === 'string' ? observation.type : '',
+            source: typeof observation.source === 'string' ? observation.source : '',
+            tier: normalizeTier(observation.tier),
+            timestamp: Number.isFinite(Number(observation.timestamp)) ? Number(observation.timestamp) : 0,
+            detail: normalizeDebugTimelineDetail(observation.detail),
+        };
+    }
+
+    function normalizeDebugTimelineAction(action) {
+        if (!action || typeof action !== 'object') return null;
+        return {
+            requestId: typeof action.requestId === 'string' ? action.requestId : '',
+            actionId: typeof action.actionId === 'string' ? action.actionId : '',
+            runId: typeof action.runId === 'string' ? action.runId : '',
+            source: typeof action.source === 'string' ? action.source : '',
+            tier: normalizeTier(action.tier),
+            timestamp: Number.isFinite(Number(action.timestamp)) ? Number(action.timestamp) : 0,
+            acceptedAt: Number.isFinite(Number(action.acceptedAt)) ? Number(action.acceptedAt) : 0,
+            startedAt: Number.isFinite(Number(action.startedAt)) ? Number(action.startedAt) : 0,
+        };
+    }
+
+    function normalizeDebugTimelineScheduler(snapshot) {
+        var scheduler = snapshot && snapshot.scheduler && typeof snapshot.scheduler === 'object'
+            ? snapshot.scheduler
+            : {};
+        return {
+            queued: scheduler.queued === true,
+            pendingTriggers: Array.isArray(scheduler.pendingTriggers) ? scheduler.pendingTriggers.slice(0, 20) : [],
+            deferredTriggers: Array.isArray(scheduler.deferredTriggers) ? scheduler.deferredTriggers.slice(0, 20) : [],
+            providerRecheckNeeded: scheduler.providerRecheckNeeded === true,
+            lastEvaluatedAt: Number.isFinite(Number(scheduler.lastEvaluatedAt))
+                ? Number(scheduler.lastEvaluatedAt)
+                : 0,
+            pendingActionRequest: normalizeDebugTimelineAction(scheduler.pendingActionRequest),
+            activeAction: normalizeDebugTimelineAction(scheduler.activeAction),
+            postActionSettle: normalizeDebugTimelineAction(scheduler.postActionSettle),
+            lastIgnoredActionResult: normalizeDebugTimelineDetail(scheduler.lastIgnoredActionResult),
+            lastProtocolFailure: normalizeDebugTimelineDetail(scheduler.lastProtocolFailure),
+        };
+    }
+
+    function normalizeDebugTimelineNumber(value) {
+        if (value === null || value === undefined || value === '') return null;
+        var number = Number(value);
+        return Number.isFinite(number) ? number : null;
+    }
+
+    function normalizeDebugTimelineDecision(decision) {
+        if (!decision || typeof decision !== 'object') return null;
+        var candidates = Array.isArray(decision.candidates) ? decision.candidates : [];
+        return {
+            trigger: typeof decision.trigger === 'string' ? decision.trigger : '',
+            triggerTypes: Array.isArray(decision.triggerTypes) ? decision.triggerTypes.slice(0, 20) : [],
+            outcome: typeof decision.outcome === 'string' ? decision.outcome : '',
+            reason: typeof decision.reason === 'string' ? decision.reason : '',
+            timestamp: Number.isFinite(Number(decision.timestamp)) ? Number(decision.timestamp) : 0,
+            request: normalizeDebugTimelineAction(decision.request),
+            execution: normalizeActionExecutionForDebug(decision.execution),
+            candidates: candidates.slice(0, 12).map(function (candidate) {
+                var item = candidate && typeof candidate === 'object' ? candidate : {};
+                var providerDetail = item.providerDetail && typeof item.providerDetail === 'object'
+                    ? item.providerDetail
+                    : {};
+                return {
+                    actionId: typeof item.actionId === 'string' ? item.actionId : '',
+                    score: normalizeDebugTimelineNumber(item.score),
+                    threshold: normalizeDebugTimelineNumber(item.threshold),
+                    needSurplus: normalizeDebugTimelineNumber(item.needSurplus),
+                    needContribution: normalizeDebugTimelineNumber(item.needContribution),
+                    cadenceAdjustment: normalizeDebugTimelineNumber(item.cadenceAdjustment),
+                    eligibilityScore: normalizeDebugTimelineNumber(item.eligibilityScore),
+                    cooldownSortRank: normalizeDebugTimelineNumber(item.cooldownSortRank),
+                    allowed: item.allowed === true,
+                    reason: typeof item.reason === 'string' ? item.reason : '',
+                    providerReason: typeof providerDetail.failedCheck === 'string'
+                        ? providerDetail.failedCheck
+                        : '',
+                };
+            }),
+        };
+    }
+
+    function createDebugTimelineEntry(reason, timestamp, detail, snapshot) {
+        var state = snapshot && snapshot.state && typeof snapshot.state === 'object' ? snapshot.state : {};
+        var clock = snapshot && snapshot.clock && typeof snapshot.clock === 'object' ? snapshot.clock : {};
+        var observation = detail && detail.observation;
+        return Object.freeze({
+            sequence: ++debugTimelineSequence,
+            timestamp: timestamp,
+            reason: typeof reason === 'string' ? reason : 'state-update',
+            observation: normalizeDebugTimelineObservation(observation),
+            detail: normalizeDebugTimelineDetail(detail),
+            active: state.active === true,
+            tier: normalizeTier(state.tier),
+            fields: clonePlain(state.fields) || {},
+            interactionGesture: runtimeState.interactionGesture ? {
+                startedAt: Number(runtimeState.interactionGesture.startedAt) || 0,
+                rapidApplied: runtimeState.interactionGesture.rapidApplied === true,
+            } : null,
+            clock: {
+                lastTickAt: Number(clock.lastTickAt) || 0,
+                lastUserInteractionAt: Number(clock.lastUserInteractionAt) || 0,
+                lastActionStartedAt: Number(clock.lastActionStartedAt) || 0,
+                dragInterruptionRecoveryActive: clock.dragInterruptionRecoveryActive === true,
+            },
+            scheduler: normalizeDebugTimelineScheduler(snapshot),
+            decision: normalizeDebugTimelineDecision(snapshot && snapshot.lastDecision),
+        });
+    }
+
+    function appendDebugTimeline(reason, timestamp, detail, snapshot) {
+        var entry = createDebugTimelineEntry(reason, timestamp, detail, snapshot);
+        debugTimeline.push(entry);
+        if (debugTimeline.length > DEBUG_TIMELINE_LIMIT) {
+            debugTimeline.splice(0, debugTimeline.length - DEBUG_TIMELINE_LIMIT);
+        }
+        // Debug mode is explicitly opt-in. Keep the trace both in memory for a
+        // deterministic export and in DevTools for cases where the page exits.
+        // Entries contain only allowlisted runtime facts, never chat text.
+        try {
+            if (typeof console !== 'undefined' && console && typeof console.log === 'function') {
+                console.log('[CatMindTrace] ' + JSON.stringify(entry));
+            }
+        } catch (_) {}
+        return entry;
+    }
+
+    function getDebugTimeline() {
+        return clonePlain(debugTimeline) || [];
+    }
+
+    function clearDebugTimeline() {
+        debugTimeline = [];
+        debugTimelineSequence = 0;
+        return true;
+    }
+
+    function exportDebugTimeline() {
+        return JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: nowMs(),
+            entryCount: debugTimeline.length,
+            entries: getDebugTimeline(),
+        }, null, 2);
+    }
+
     function emitStateChange(reason, detail) {
         // State-change carries a complete debug snapshot and is only consumed by
         // the opt-in inspector. Keep Cat Mind's runtime independent from it.
         if (!isDebugEnabled()) return false;
+        var normalizedReason = typeof reason === 'string' ? reason : 'state-update';
+        var timestamp = nowMs();
+        var eventDetail = clonePlain(detail) || {};
+        var snapshot = getDebugSnapshot();
+        appendDebugTimeline(normalizedReason, timestamp, eventDetail, snapshot);
         return dispatchRuntimeEvent(EVENT_NAMES.STATE_CHANGE, {
-            reason: typeof reason === 'string' ? reason : 'state-update',
-            timestamp: nowMs(),
-            detail: clonePlain(detail) || {},
-            snapshot: getDebugSnapshot(),
+            reason: normalizedReason,
+            timestamp: timestamp,
+            detail: eventDetail,
+            snapshot: snapshot,
         });
     }
 
@@ -806,6 +1011,7 @@
                 fullCooldownMs: scoreConfig ? scoreConfig.cooldownMs : 0,
             };
             runtimeState.clock.lastActionStartedAt = timestamp;
+            runtimeState.clock.dragInterruptionRecoveryActive = false;
             // Intent is consumed only after the existing runner proves it
             // really started. accepted/rejected/provider dry-run never spend it.
             clearActionIntentEvidence(pending.actionId);
@@ -893,6 +1099,8 @@
             active.actionId === actionId &&
             active.requestId === requestId &&
             active.runId === runId) {
+            runtimeState.clock.dragInterruptionRecoveryActive = result.result === 'interrupted' &&
+                actionInterruptionObservationType(result.reason) === OBSERVATION_TYPES.ACTION_INTERRUPTED_BY_DRAG;
             scheduler.activeAction = null;
             scheduler.postActionSettle = {
                 requestId: active.requestId,
@@ -1147,8 +1355,17 @@
         var elapsedMs = Math.max(0, scoreAt - anchor);
         var progress = Math.min(1, elapsedMs / ACTION_SCORE_POLICY.cadenceRecoveryMs);
         var curveFactor = smoothstep01(progress);
-        var adjustment = ACTION_SCORE_POLICY.cadenceFloor +
-            (ACTION_SCORE_POLICY.cadenceCeiling - ACTION_SCORE_POLICY.cadenceFloor) * curveFactor;
+        // A drag that interrupts a just-started response does not receive the
+        // runner's completion feedback. Use a deeper floor for that recovery
+        // window so the remaining saturated needs cannot turn each following
+        // drag into another action. The same continuous cadence curve still
+        // recovers naturally; normal completion and the first response keep the
+        // established idle rhythm.
+        var cadenceFloor = runtimeState.clock.dragInterruptionRecoveryActive
+            ? ACTION_SCORE_POLICY.dragInterruptionCadenceFloor
+            : ACTION_SCORE_POLICY.cadenceFloor;
+        var adjustment = cadenceFloor +
+            (ACTION_SCORE_POLICY.cadenceCeiling - cadenceFloor) * curveFactor;
         return {
             elapsedMs: elapsedMs,
             progress: progress,
@@ -1542,12 +1759,14 @@
 
     function shouldScheduleDecisionForObservation(observation) {
         var type = observation && typeof observation.type === 'string' ? observation.type : '';
-        // Native desktop-window facts are consumed directly by dedicated
-        // renderer presentations. Keep them in Cat Mind's observable context,
-        // but do not turn a window move/cancel into an unrelated ordinary CAT1
-        // action opportunity.
-        if (type === OBSERVATION_TYPES.DESKTOP_OCCLUSION_OR_LAYER_CHANGE
-            && observation.source === 'desktop-window-sensing') {
+        // Formal native-window facts are consumed directly by dedicated
+        // renderer presentations. Keep the high-frequency sensing stream in
+        // Cat Mind's observable context, but never turn it into an unrelated
+        // ordinary CAT1 action opportunity. Other sources using this broad
+        // observation type, such as return-ball state, keep their established
+        // asynchronous decision semantics.
+        if (type === OBSERVATION_TYPES.DESKTOP_OCCLUSION_OR_LAYER_CHANGE &&
+            observation.source === 'desktop-window-sensing') {
             return false;
         }
         // These two events close the existing walk-to-yarn local presentation
@@ -2706,6 +2925,7 @@
                 lastTickAt: runtimeState.clock.lastTickAt,
                 lastUserInteractionAt: runtimeState.clock.lastUserInteractionAt,
                 lastActionStartedAt: runtimeState.clock.lastActionStartedAt,
+                dragInterruptionRecoveryActive: runtimeState.clock.dragInterruptionRecoveryActive,
             },
             lastResetReason: runtimeState.lastResetReason,
             returnSummaryDraft: clonePlain(runtimeState.returnSummaryDraft),
@@ -2743,6 +2963,9 @@
         getReturnSummaryDraft: getReturnSummaryDraft,
         consumeReturnSummaryDraft: consumeReturnSummaryDraft,
         getDebugSnapshot: getDebugSnapshot,
+        getDebugTimeline: getDebugTimeline,
+        exportDebugTimeline: exportDebugTimeline,
+        clearDebugTimeline: clearDebugTimeline,
         recordDecision: recordDecision,
         acknowledgeActionRequest: acknowledgeActionRequest,
         observe: observe,

--- a/tests/frontend/cat_mind_scheduler_recheck.test.cjs
+++ b/tests/frontend/cat_mind_scheduler_recheck.test.cjs
@@ -191,6 +191,19 @@ test('active user observations coalesce into one evaluation after terminal settl
     runtime.observe('cat_hover_reaction');
   }
   assert.equal(runtime.dryRunCalls(), dryRunsBeforeInput, 'active runner blocks selector dry-runs');
+  const lastEvaluatedAfterInput = runtime.win.nekoCatMind.getDebugSnapshot().scheduler.lastEvaluatedAt;
+  for (let index = 0; index < 20; index += 1) {
+    runtime.observe('desktop_occlusion_or_layer_change', {
+      status: 'changed',
+      changes: ['position'],
+      movement: { x: index % 2 === 0 ? 1 : -1, y: 0 },
+    }, 'cat1', 'desktop-window-sensing');
+  }
+  assert.equal(
+    runtime.win.nekoCatMind.getDebugSnapshot().scheduler.lastEvaluatedAt,
+    lastEvaluatedAfterInput,
+    'desktop churn must not wake evaluations while user input is already deferred'
+  );
 
   reportResult(runtime, request, 'social-active-run', 'done', 'social-finished');
   assert.equal(
@@ -201,6 +214,58 @@ test('active user observations coalesce into one evaluation after terminal settl
   assert.ok(
     runtime.win.nekoCatMind.getDebugSnapshot().lastDecision.triggerTypes.includes('cat_hover_reaction')
   );
+});
+
+test('desktop sensing churn remains observable without chaining settled actions', () => {
+  const runtime = createRuntime('cat1_social_ping');
+  runtime.enter();
+  runtime.advanceNeed();
+  assert.equal(runtime.requests.length, 1);
+  const request = runtime.requests[0];
+  startRequest(runtime, request, 'social-before-desktop-churn');
+  reportResult(runtime, request, 'social-before-desktop-churn', 'done', 'social-finished');
+
+  const dryRunsAfterSettle = runtime.dryRunCalls();
+  for (let index = 0; index < 20; index += 1) {
+    runtime.observe('desktop_occlusion_or_layer_change', {
+      status: 'changed',
+      changes: ['position'],
+      movement: { x: index % 2 === 0 ? 1 : -1, y: 0 },
+    }, 'cat1', 'desktop-window-sensing');
+  }
+
+  assert.equal(runtime.requests.length, 1, 'desktop facts must not start the next action');
+  assert.equal(runtime.dryRunCalls(), dryRunsAfterSettle, 'desktop facts must not wake selector dry-runs');
+  assert.equal(
+    runtime.win.nekoCatMind.getRecentEvents().at(-1).type,
+    'desktop_occlusion_or_layer_change'
+  );
+});
+
+test('non-native desktop provider changes may wake one retained explicit intent', () => {
+  const runtime = createRuntime('cat1_play_yarn', { providerReady: false });
+  runtime.enter();
+  runtime.observe('chat_yarn_drag_completed', {
+    userInitiated: true,
+    startedFarFromCat: true,
+    endedNearCat: true,
+    startDistanceToCatPx: 320,
+    endDistanceToCatPx: 20,
+    directApproachDistancePx: 300,
+    pathDistancePx: 310,
+    movementThresholdPx: 24,
+  });
+  assert.equal(runtime.requests.length, 0);
+  assert.equal(runtime.win.nekoCatMind.getDebugSnapshot().scheduler.providerRecheckNeeded, true);
+
+  runtime.setProviderReady(true);
+  runtime.observe('desktop_occlusion_or_layer_change', {
+    status: 'changed',
+    changes: ['position'],
+    movement: { x: 1, y: 0 },
+  }, 'cat1', 'return-ball');
+  assert.equal(runtime.requests.length, 1);
+  assert.equal(runtime.requests[0].actionId, 'cat1_play_yarn');
 });
 
 test('provider-ready presentation wakes retained yarn intent without waiting for clock', () => {

--- a/tests/unit/test_cat_idle_state_machine_static.py
+++ b/tests/unit/test_cat_idle_state_machine_static.py
@@ -127,6 +127,9 @@ def test_cat_mind_runtime_keeps_dom_free_observation_and_request_boundaries():
         "getReturnSummaryDraft",
         "consumeReturnSummaryDraft",
         "getDebugSnapshot",
+        "getDebugTimeline",
+        "exportDebugTimeline",
+        "clearDebugTimeline",
         "recordDecision",
         "acknowledgeActionRequest",
         "observe",
@@ -1199,6 +1202,9 @@ def test_cat_mind_phase1_runtime_observes_without_dispatching_actions():
         assert.ok(win.nekoCatMind);
         assert.equal(typeof win.nekoCatMind.getState, 'function');
         assert.equal(typeof win.nekoCatMind.getRecentEvents, 'function');
+        assert.equal(typeof win.nekoCatMind.getDebugTimeline, 'function');
+        assert.equal(typeof win.nekoCatMind.exportDebugTimeline, 'function');
+        assert.equal(typeof win.nekoCatMind.clearDebugTimeline, 'function');
         assert.equal(typeof win.nekoCatMind.observe, 'function');
         assert.equal(typeof win.nekoCatMind.reset, 'function');
 
@@ -1247,6 +1253,15 @@ def test_cat_mind_phase1_runtime_observes_without_dispatching_actions():
         }}));
         win.dispatchEvent(new CustomEventLike('neko:cat-mind:observation', {{
           detail: {{
+            type: 'cat_local_text_received',
+            source: 'cat-local-chat',
+            tier: 'cat2',
+            timestamp: 2450,
+            detail: {{ requestId: 'local-text-debug-1', text: 'private-conversation-text' }}
+          }}
+        }}));
+        win.dispatchEvent(new CustomEventLike('neko:cat-mind:observation', {{
+          detail: {{
             type: 'cat1_walk_done_near_chat',
             source: 'cat1-journey',
             tier: 'cat1',
@@ -1281,6 +1296,20 @@ def test_cat_mind_phase1_runtime_observes_without_dispatching_actions():
         assert.equal(debugSnapshot.lastDecision.candidates[1].reason, 'near_chat_unavailable');
         assert.ok(stateChanges.some((change) => change.reason === 'observation'));
         assert.ok(stateChanges.some((change) => change.reason === 'decision'));
+        const debugTimeline = win.nekoCatMind.getDebugTimeline();
+        assert.ok(debugTimeline.some((entry) =>
+          entry.reason === 'observation' && entry.observation && entry.observation.type === 'drag_end'
+        ));
+        assert.ok(debugTimeline.some((entry) =>
+          entry.reason === 'decision' && entry.decision && entry.decision.outcome === 'cat1_eat_snack'
+        ));
+        const exportedTimeline = win.nekoCatMind.exportDebugTimeline();
+        assert.equal(exportedTimeline.includes('private-conversation-text'), false);
+        const parsedTimeline = JSON.parse(exportedTimeline);
+        assert.equal(parsedTimeline.schemaVersion, 1);
+        assert.equal(parsedTimeline.entryCount, debugTimeline.length);
+        win.nekoCatMind.clearDebugTimeline();
+        assert.equal(win.nekoCatMind.getDebugTimeline().length, 0);
 
         win.dispatchEvent(new CustomEventLike('neko:cat-local-active-change', {{
           detail: {{ active: false, returnCommitted: true, returnSource: 'live2d-return-click' }}
@@ -2727,6 +2756,20 @@ def test_cat_mind_cat1_score_feedback_forms_a_bounded_near_chat_cycle():
             {{ atMs: 6500, type: 'drag_end', phase: 'drag_end' }},
             {{ atMs: 6620, type: 'cat1_stretch_done_near_chat', phase: 'settled' }},
           ] }},
+          interruptedDragChain: {{ burstTimeline: Array.from({{ length: 6 }}, (_, index) => {{
+            const offset = 500 + index * 4000;
+            return [
+              {{ atMs: offset, type: 'drag_start', phase: 'drag_start' }},
+              {{ atMs: offset + 200, phase: 'drag_active' }},
+              {{ atMs: offset + 1050, type: 'drag_end', phase: 'drag_end', detail: {{
+                activityId: 'interrupted-drag-chain-' + index,
+                pathDistancePx: 110,
+                displacementPx: 85,
+                durationMs: 850,
+              }} }},
+              {{ atMs: offset + 1170, type: 'cat1_stretch_done_near_chat', phase: 'settled' }},
+            ];
+          }}).flat() }},
         }};
         const total = (result) => Object.values(result.counts).reduce((sum, count) => sum + count, 0);
         const startsInWindow = (result, startMinute) => result.starts.filter(
@@ -2780,6 +2823,7 @@ def test_cat_mind_cat1_score_feedback_forms_a_bounded_near_chat_cycle():
         const shortOrdinaryHigh = simulate(true, shortBurstProfiles.ordinaryHigh);
         const shortOrdinaryHighFullLoad = simulate(true, shortBurstProfiles.ordinaryHighFullLoad);
         const shortHigh = simulate(true, shortBurstProfiles.high);
+        const interruptedDragChain = simulate(true, shortBurstProfiles.interruptedDragChain);
         const timingVariants = [
           {{ socialDurationMs: 936, smallMoveDurationMs: 720 }},
           {{ socialDurationMs: 2040, smallMoveDurationMs: 1320 }},
@@ -2954,6 +2998,14 @@ def test_cat_mind_cat1_score_feedback_forms_a_bounded_near_chat_cycle():
           'three ordinary drags must still respond promptly after their real physical load is settled: ' +
             JSON.stringify(shortOrdinaryHighFullLoad.starts.slice(0, 3)));
         assert.ok(startsByMinute(shortHigh, 3).length >= 3 && startsByMinute(shortHigh, 3).length <= 5);
+        const interruptedDragChainEarlyStarts = startsByMinute(interruptedDragChain, 0.5);
+        assert.equal(interruptedDragChainEarlyStarts.length, 1,
+          'six compressed drags may advance the first response but must not start one action per drag: ' +
+            JSON.stringify(interruptedDragChainEarlyStarts));
+        assert.equal(interruptedDragChain.terminals.filter(
+          (item) => item.result === 'interrupted' && item.reason === 'return-ball-drag-active'
+        ).length, 1);
+        assertLifecycle(interruptedDragChain);
         assert.ok(startsByMinute(shortNone, 10).length <= startsByMinute(shortLow, 10).length,
           'one easy hover may preserve the quiet count instead of forcing an extra action');
         assert.ok(startsByMinute(shortLow, 10).length <= startsByMinute(shortNormal, 10).length);
@@ -3187,6 +3239,7 @@ def test_cat_mind_scores_use_five_dimensions_shared_cadence_and_ranking_cooldown
     assert "positiveNeedCurveRange: 8" in source
     assert "positiveNeedCurveCeiling: 78" in source
     assert "cadenceFloor: -58" in source
+    assert "dragInterruptionCadenceFloor: -98" in source
     assert "cadenceCeiling: 18" in source
     assert "cooldownMultiplier" not in source
     assert "immediateRepeat" not in source
@@ -4161,6 +4214,7 @@ def test_cat_mind_phase4_return_episode_uses_only_strict_completed_chapters():
           detail: {{ source: 'desktop-window', tier: 'cat1', timestamp: now, visible: true }}
         }}));
         flushDecision();
+        assert.equal(win.nekoCatMind.getRecentEvents().at(-1).type, 'desktop_occlusion_or_layer_change');
         assert.equal(Object.prototype.hasOwnProperty.call(returnSummary(), 'episode'), false);
 
         // Reset/new entry always starts with an empty local accumulator.


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复猫咪拖拽后的动作连播，限制桌面窗口事件唤醒动作选择器

## 测试 / Testing

手动进行复现确认修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 Cat Mind 调试时间线，支持查看、导出和清除，最多保留 600 条记录。
  - 优化拖拽中断后的动作恢复节奏，重新开始动作时自动恢复正常状态。
  - 桌面窗口变化可记录到最近事件和调试信息，但不会直接触发后续动作决策。

- **问题修复**
  - 修复连续拖拽中断可能导致重复启动动作的问题。
  - 优化桌面感知事件及非原生来源事件的处理逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->