### PR TITLE
fix(proactive): dedupe meme captions

### DIFF
--- a/config/session_settings.py
+++ b/config/session_settings.py
@@ -128,20 +128,15 @@ ANTI_REPEAT_MIN_DRAFT_TOKENS = 12
 - 用途：避免"嗯。"、"好"这种短回复被错杀。
 - 设计依据：~12 个 ngram token 才能形成稳定的 BM25 信号。"""
 
-ANTI_REPEAT_EXEMPT_SOURCE_TAGS = frozenset({"MUSIC", "MEME"})
+ANTI_REPEAT_EXEMPT_SOURCE_TAGS = frozenset({"MUSIC"})
 """主动搭话里"复读判定从台词切到素材维度"的来源标签。
-- 动机：BM25 防的是"话题/措辞复读"，但素材推送类 channel 的开场白天生模板
-  化（推歌"换首歌 / 这旋律 / 听听看"、表情包"看这个 / 笑死"），台词长一个
-  样、而推送的素材（曲目 / 表情包搜索关键词）却不同；用台词 BM25 判它属于
-  天生误杀——博士连点几首后 FG 窗被音乐 intro 占满，分数爆表，后续自发推
-  歌全被 drop，表现为"放音乐频率极低"。
-- 语义：这类 channel 的复读按"素材本身"去重——MUSIC 看曲目、MEME 看搜索
-  关键词（不是图片）。本轮素材与近期不雷同时，豁免台词级硬拦截（字面相似
-  度 + BM25 regen/drop）直接放行；素材雷同（反复推同一曲目 / 同一关键词）
-  才回落到正常台词判定，台词没雷同则依然能发。
-- 另：这类 channel 的台词不录进 anti-repeat corpus（见 finish_proactive_
-  delivery），免得模板化 intro 污染 FG 窗、漂移其它 channel 的复读基线；
-  素材标识的近期去重走 system_router 的 _proactive_material_history。"""
+- 动机：推歌开场白天生模板化（"换首歌 / 这旋律 / 听听看"），即使曲目不同，
+  BM25 也容易误杀；因此 MUSIC 在曲目新鲜时按素材维度放行。
+- MEME 不在豁免范围：表情包配文始终经过字面相似度、未回应重复和 BM25
+  检查，并在成功投递后写入 anti-repeat corpus，避免换图片或换关键词时复用
+  相同配文绕过去重。
+- MUSIC 台词不录进 anti-repeat corpus（见 finish_proactive_delivery），素材标识
+  的近期去重走 system_router 的 _proactive_material_history。"""
 
 AVATAR_INTERACTION_DEDUPE_MAX_ITEMS = 32
 """_recent_avatar_interaction_ids deque maxlen。

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -376,10 +376,10 @@ _proactive_chat_history: dict[str, deque] = {}
 
 # --- 主动搭话"素材标识"近期去重暂存区（ANTI_REPEAT_EXEMPT_SOURCE_TAGS 用）---
 # {lanlan_name: {source_tag: deque([(timestamp, material_key), ...], maxlen=N)}}
-# 素材推送类 channel（MUSIC/MEME）豁免台词级复读判定，改按"素材本身"去重：
-# MUSIC 看曲目（title|artist），MEME 看搜索关键词。本轮素材与近期不雷同就放行；
-# 雷同才回落到台词判定。进程内、重启清零——短期复读保护，与 _proactive_chat_
-# history / _mini_game_invite_state 同样是内存态即可。
+# 豁免台词级复读判定的素材 channel 在这里保存近期素材标识；当前仅 MUSIC
+# 使用该豁免。MEME 配文始终走文字去重，仍保留关键词标识供既有记录与兼容调用
+# 使用。进程内、重启清零——短期复读保护，与 _proactive_chat_history /
+# _mini_game_invite_state 同样是内存态即可。
 _proactive_material_history: dict[str, dict[str, deque]] = {}
 
 

--- a/tests/unit/test_proactive_material_dedup.py
+++ b/tests/unit/test_proactive_material_dedup.py
@@ -1,8 +1,7 @@
-"""Material-level dedup contract for proactive chat (ANTI_REPEAT_EXEMPT_SOURCE_TAGS).
+"""Material-key helper contract for proactive chat.
 
-Material-push channels (MUSIC/MEME) are exempt from caption-level repeat checks and
-deduped on the material itself: MUSIC keys on the track, MEME on the search keyword
-(not the image). Coverage:
+MUSIC uses its material key for the text-dedup exemption. MEME keeps a keyword key
+for compatibility/history, but its caption is always text-deduped. Coverage:
 
 1. _proactive_material_key: MUSIC -> track, MEME -> search keyword, non-material
    channel / empty material -> empty key; normalized (lowercase + collapsed space).

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -607,6 +607,54 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
     corpus.record_output.assert_not_called()
 
 
+async def test_finish_records_meme_caption_but_exempts_music(monkeypatch):
+    """MEME captions enter the corpus; only MUSIC keeps the template exemption."""
+    import memory.anti_repeat as anti_repeat
+
+    corpus = MagicMock()
+    corpus.stage_output = MagicMock(return_value=("Test", {"window": []}, 1))
+    corpus.flush_staged_detached = MagicMock()
+    monkeypatch.setattr(
+        anti_repeat,
+        "get_anti_repeat_corpus",
+        lambda: corpus,
+    )
+
+    meme_mgr = _make_mgr()
+    meme_mgr.current_speech_id = "meme-sid"
+    result = await LLMSessionManager.finish_proactive_delivery(
+        meme_mgr,
+        "快看这个，真的笑死我了。",
+        expected_speech_id="meme-sid",
+        source_tag="MEME",
+    )
+
+    assert result is True
+    corpus.stage_output.assert_called_once_with(
+        "Test",
+        "快看这个，真的笑死我了。",
+        is_proactive=True,
+        now=None,
+    )
+    corpus.flush_staged_detached.assert_called_once_with(
+        corpus.stage_output.return_value
+    )
+
+    corpus.reset_mock()
+    music_mgr = _make_mgr()
+    music_mgr.current_speech_id = "music-sid"
+    result = await LLMSessionManager.finish_proactive_delivery(
+        music_mgr,
+        "这首歌很适合现在听。",
+        expected_speech_id="music-sid",
+        source_tag="MUSIC",
+    )
+
+    assert result is True
+    corpus.stage_output.assert_not_called()
+    corpus.flush_staged_detached.assert_not_called()
+
+
 async def test_finish_proactive_delivery_sid_mismatch_skips_all_writes():
     """关键：Phase 2 结束→finish 之间用户打断，finish 内所有副作用必须跳过，且返回 False。
 

--- a/tests/unit/test_proactive_unanswered_repeat.py
+++ b/tests/unit/test_proactive_unanswered_repeat.py
@@ -774,6 +774,58 @@ async def test_regenerated_fresh_music_recomputes_text_exemption(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fresh_meme_caption_still_runs_text_dedup(monkeypatch):
+    """A new meme/keyword must not exempt a repeated caption from text dedup."""
+    literal_guard = MagicMock(return_value=(True, 1.0))
+    monkeypatch.setattr(
+        "main_logic.proactive_chat.generation._is_similar_to_recent_proactive_chat",
+        literal_guard,
+    )
+
+    mgr = SimpleNamespace(
+        current_speech_id="sid",
+        state=_NeverPreemptedState(),
+        handle_new_message=AsyncMock(),
+    )
+
+    output = await _guard_phase2_output(
+        mgr=mgr,
+        proactive_sid="sid",
+        lanlan_name="fresh-meme-caption-dedup-test",
+        response_text="快看这个，真的笑死我了。",
+        full_text="快看这个，真的笑死我了。",
+        source_tag="MEME",
+        active_channels=["meme"],
+        selected_music_link=None,
+        selected_meme_link={"title": "新表情包", "url": "https://example.test/new.png"},
+        music_content=None,
+        meme_content={"keyword": "全新关键词"},
+        is_playing_music=False,
+        music_cooldown=False,
+        expects_source_tag=True,
+        make_llm=AsyncMock(),
+        messages=[
+            SystemMessage(content="system"),
+            HumanMessage(content="begin"),
+        ],
+        human_text="begin",
+        screenshot_b64=None,
+        phase2_use_vision=False,
+        phase2_disable_thinking=True,
+        proactive_lang="zh",
+        master_name="博士",
+    )
+
+    literal_guard.assert_called_once_with(
+        "fresh-meme-caption-dedup-test",
+        "快看这个，真的笑死我了。",
+    )
+    mgr.handle_new_message.assert_awaited_once()
+    assert output.result is not None
+    assert output.result.body["reason_code"] == PROACTIVE_REASON_PASS_DUPLICATE
+
+
+@pytest.mark.asyncio
 async def test_regenerated_music_without_material_keeps_text_rechecks(monkeypatch):
     """A bare MUSIC tag cannot exempt a rewrite that has no selected track."""
     initial_signal = anti_repeat_module.UnansweredProactiveRepeatSignal(


### PR DESCRIPTION
## 改动概述 / Summary

修复主动搭话中 meme 配文绕过文字去重的问题。将 `MEME` 从文字去重豁免名单移除，仅保留 `MUSIC` 的素材级豁免，并补充即时拦截与投递后语料记录的回归测试。

## 回归报告 / Regression Report

- 改动了什么：`ANTI_REPEAT_EXEMPT_SOURCE_TAGS` 从 `MUSIC + MEME` 调整为仅 `MUSIC`；更新对应契约说明，并增加 meme 配文去重测试。
- 理由 / 必要性：原逻辑在 meme 图片或搜索关键词被视为新素材时，会跳过字面相似度、未回应重复和 BM25 检查，导致相同配文可以通过更换素材绕过去重。
- 改动前：新 meme 素材直接豁免文字去重，且成功投递的 meme 配文不会写入 anti-repeat corpus。
- 改动后：无论图片或关键词是否变化，meme 配文始终经过字面相似度、未回应重复和 BM25 检查；成功投递后也会进入 anti-repeat corpus。音乐素材的既有豁免保持不变。
- 潜在回归点：模板化 meme 配文可能更频繁触发改写或丢弃；音乐推荐链路不受影响。通过针对 meme 与 music 分支的回归用例验证边界。

## 不拆分理由 / Why Not Split

不适用。改动规模小于 20 个计入上限的文件，属于同一项去重行为修复。

## 测试 / Testing

使用项目 Python 3.11 虚拟环境运行：

`python -m pytest -p no:cacheprovider tests/unit/test_proactive_unanswered_repeat.py tests/unit/test_proactive_material_dedup.py tests/unit/test_proactive_sid_guard.py::test_finish_records_meme_caption_but_exempts_music -q`

结果：`40 passed, 2 warnings`。两条 warning 均为既有依赖/API 的弃用提醒，无测试失败。