### PR TITLE
优化 Live2D 左右侧挂边的动态探身姿态

### DIFF
--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -166,6 +166,10 @@ const LIVE2D_PEEK_VISIBLE_RATIO = 0.22;
 const LIVE2D_PEEK_VISIBLE_MIN_PX = 96;
 const LIVE2D_PEEK_VISIBLE_MAX_PX = 180;
 const LIVE2D_PEEK_SIDE_ROTATION_DEGREES = 60;
+const LIVE2D_PEEK_SIDE_ROTATION_MAX_DEGREES = 55;
+const LIVE2D_PEEK_SIDE_ROTATION_MIN_DEGREES = 28;
+const LIVE2D_PEEK_SIDE_ROTATION_RATIO_START = 0.20;
+const LIVE2D_PEEK_SIDE_ROTATION_RATIO_END = 0.80;
 const LIVE2D_PEEK_CORNER_ROTATION_DEGREES = 45;
 // live2d-core.js performs its final cross-display renderer resize after 120ms.
 // Restore the semantic edge anchor only after that pass can no longer clear it.
@@ -632,12 +636,34 @@ function settleLive2DBaseAtEdgeContact(model, contact) {
     return true;
 }
 
-function getLive2DPeekRotationDegrees(anchor) {
+function getLive2DPeekSideRotationMagnitude(headAnchorRatio) {
+    if (headAnchorRatio === null || headAnchorRatio === undefined || headAnchorRatio === '') {
+        return LIVE2D_PEEK_SIDE_ROTATION_DEGREES;
+    }
+    const ratio = Number(headAnchorRatio);
+    if (!Number.isFinite(ratio)) return LIVE2D_PEEK_SIDE_ROTATION_DEGREES;
+    const progress = clampLive2DPeekCoordinate(
+        (ratio - LIVE2D_PEEK_SIDE_ROTATION_RATIO_START) /
+            (LIVE2D_PEEK_SIDE_ROTATION_RATIO_END - LIVE2D_PEEK_SIDE_ROTATION_RATIO_START),
+        0,
+        1
+    );
+    const smoothProgress = progress * progress * (3 - 2 * progress);
+    return LIVE2D_PEEK_SIDE_ROTATION_MAX_DEGREES +
+        (LIVE2D_PEEK_SIDE_ROTATION_MIN_DEGREES - LIVE2D_PEEK_SIDE_ROTATION_MAX_DEGREES) *
+            smoothProgress;
+}
+
+function getLive2DPeekRotationDegrees(anchor, headAnchorRatio = undefined) {
     if (!anchor || !anchor.side) return 0;
     if (!anchor.verticalEdge) {
+        const sideHeadAnchorRatio = headAnchorRatio === undefined
+            ? anchor.headAnchorRatio
+            : headAnchorRatio;
+        const rotationMagnitude = getLive2DPeekSideRotationMagnitude(sideHeadAnchorRatio);
         return anchor.side === 'left'
-            ? LIVE2D_PEEK_SIDE_ROTATION_DEGREES
-            : -LIVE2D_PEEK_SIDE_ROTATION_DEGREES;
+            ? rotationMagnitude
+            : -rotationMagnitude;
     }
     if (anchor.verticalEdge === 'top') {
         return anchor.side === 'left'
@@ -663,6 +689,25 @@ function getLive2DPeekHeadAnchor(manager) {
     if (!manager || typeof manager.getHeadScreenAnchor !== 'function') return null;
     try {
         const anchor = manager.getHeadScreenAnchor();
+        if (!anchor) return null;
+        const x = Number(anchor && anchor.x);
+        const y = Number(anchor && anchor.y);
+        return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function getLive2DPeekReliableHeadAnchor(manager) {
+    if (!manager || typeof manager.getHeadDetectionGeometryInfo !== 'function') return null;
+    try {
+        const info = manager.getHeadDetectionGeometryInfo();
+        if (!info || !info.reliableHeadRect) return null;
+        let anchor = info.headAnchor || info.rawHeadAnchor;
+        if (!anchor && typeof manager.getHeadScreenAnchor === 'function') {
+            anchor = manager.getHeadScreenAnchor();
+        }
+        if (!anchor) return null;
         const x = Number(anchor && anchor.x);
         const y = Number(anchor && anchor.y);
         return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null;
@@ -743,19 +788,43 @@ function getLive2DPeekPlacement(model, bounds, manager = null, anchor = null) {
     const baseY = Number(model.y) || 0;
     const baseRotation = Number.isFinite(Number(model.rotation)) ? Number(model.rotation) : 0;
     const baseScaleX = model.scale && Number.isFinite(Number(model.scale.x)) ? Number(model.scale.x) : 1;
-    const targetRotationDegrees = getLive2DPeekRotationDegrees(anchor);
-    const targetRotation = targetRotationDegrees * Math.PI / 180;
     let targetScaleX = getLive2DPeekInwardScaleX(model, side);
     if (side === 'right') {
         targetScaleX = Math.abs(targetScaleX);
     }
     const baseHeadAnchor = getLive2DPeekHeadAnchor(manager);
+    const baseReliableHeadAnchor = getLive2DPeekReliableHeadAnchor(manager);
     const fallbackHeadLocalPoint = baseHeadAnchor
         ? null
         : getLive2DPeekFallbackHeadLocalPoint(model, bounds);
     const fallbackBaseHeadAnchor = getLive2DPeekGlobalPoint(model, fallbackHeadLocalPoint);
     const effectiveBaseHeadAnchor = baseHeadAnchor || fallbackBaseHeadAnchor;
     const baseBodyRect = getLive2DPeekBodyRect(manager);
+    const baseRevealWidth = getLive2DPeekRevealWidth(bounds);
+    const sideHeadInsetY = clampLive2DPeekCoordinate(baseRevealWidth * 0.32, 36, 64);
+    const restoredHeadAnchorRatio = anchor.headAnchorRatio !== null &&
+            anchor.headAnchorRatio !== undefined &&
+            anchor.headAnchorRatio !== '' &&
+            Number.isFinite(Number(anchor.headAnchorRatio))
+        ? clampLive2DPeekCoordinate(Number(anchor.headAnchorRatio), 0, 1)
+        : null;
+    const rawSideHeadAnchorRatio = !verticalEdge && baseReliableHeadAnchor && viewport.height > 0
+        ? (restoredHeadAnchorRatio !== null
+            ? restoredHeadAnchorRatio
+            : clampLive2DPeekCoordinate((baseReliableHeadAnchor.y - viewport.top) / viewport.height, 0, 1))
+        : null;
+    const desiredSideHeadY = rawSideHeadAnchorRatio !== null
+        ? clampLive2DPeekCoordinate(
+            viewport.top + viewport.height * rawSideHeadAnchorRatio,
+            viewport.top + sideHeadInsetY,
+            viewport.bottom - sideHeadInsetY
+        )
+        : null;
+    const headAnchorRatio = desiredSideHeadY !== null && viewport.height > 0
+        ? clampLive2DPeekCoordinate((desiredSideHeadY - viewport.top) / viewport.height, 0, 1)
+        : null;
+    const targetRotationDegrees = getLive2DPeekRotationDegrees(anchor, headAnchorRatio);
+    const targetRotation = targetRotationDegrees * Math.PI / 180;
     const baseHeadY = effectiveBaseHeadAnchor
         ? effectiveBaseHeadAnchor.y
         : bounds.top + bounds.height * LIVE2D_PEEK_HEAD_Y_RATIO;
@@ -767,6 +836,7 @@ function getLive2DPeekPlacement(model, bounds, manager = null, anchor = null) {
 
     let transformedBounds = null;
     let transformedHeadAnchor = null;
+    let transformedReliableHeadAnchor = null;
     let transformedHeadAnchorSource = '';
     let transformedBodyRect = null;
     try {
@@ -776,6 +846,7 @@ function getLive2DPeekPlacement(model, bounds, manager = null, anchor = null) {
         if (model.scale) model.scale.x = targetScaleX;
         transformedBounds = getLive2DPeekBounds(model);
         transformedHeadAnchor = getLive2DPeekHeadAnchor(manager);
+        transformedReliableHeadAnchor = getLive2DPeekReliableHeadAnchor(manager);
         if (transformedHeadAnchor) {
             transformedHeadAnchorSource = 'manager';
         } else {
@@ -798,29 +869,50 @@ function getLive2DPeekPlacement(model, bounds, manager = null, anchor = null) {
     const desiredHeadX = side === 'left'
         ? viewport.left + headInset
         : viewport.right - headInset;
-    const useHeadAnchor = !!verticalEdge && !!transformedHeadAnchor;
-    const useWaistAnchor = !verticalEdge && !!(baseBodyRect && transformedBodyRect);
+    const useCornerHeadAnchor = !!verticalEdge && !!transformedHeadAnchor;
+    const useSideHeadAnchor = !verticalEdge &&
+        !!transformedReliableHeadAnchor &&
+        headAnchorRatio !== null;
+    const useWaistFallback = !verticalEdge &&
+        !useSideHeadAnchor &&
+        !!(baseBodyRect && transformedBodyRect);
     const desiredWaistX = side === 'left' ? viewport.left - 8 : viewport.right + 8;
-    let offsetX = useHeadAnchor
-        ? desiredHeadX - transformedHeadAnchor.x
-        : (useWaistAnchor
+    const placementHeadAnchor = useSideHeadAnchor
+        ? transformedReliableHeadAnchor
+        : transformedHeadAnchor;
+    let offsetX = useCornerHeadAnchor || useSideHeadAnchor
+        ? desiredHeadX - placementHeadAnchor.x
+        : (useWaistFallback
         ? desiredWaistX - transformedBodyRect.centerX
         : (transformedHeadAnchor
             ? desiredHeadX - transformedHeadAnchor.x
             : (side === 'left'
             ? viewport.left + revealWidth - transformedBounds.right
             : viewport.right - revealWidth - transformedBounds.left)));
+    if (useSideHeadAnchor && transformedBodyRect) {
+        const waistOffsetX = desiredWaistX - transformedBodyRect.centerX;
+        const minimumHeadInset = 36;
+        if (side === 'left') {
+            const minimumHeadOffsetX = viewport.left + minimumHeadInset - placementHeadAnchor.x;
+            offsetX = Math.max(Math.min(offsetX, waistOffsetX), minimumHeadOffsetX);
+        } else {
+            const maximumHeadOffsetX = viewport.right - minimumHeadInset - placementHeadAnchor.x;
+            offsetX = Math.min(Math.max(offsetX, waistOffsetX), maximumHeadOffsetX);
+        }
+    }
     const targetHeadY = transformedHeadAnchor
         ? transformedHeadAnchor.y
         : transformedBounds.top + transformedBounds.height * LIVE2D_PEEK_HEAD_Y_RATIO;
     let offsetY;
-    if (useHeadAnchor) {
+    if (useCornerHeadAnchor) {
         const desiredHeadInsetY = clampLive2DPeekCoordinate(revealWidth * 0.32, 36, 64);
         const desiredHeadYAtEdge = verticalEdge === 'bottom'
             ? viewport.bottom - desiredHeadInsetY
             : viewport.top + desiredHeadInsetY;
         offsetY = desiredHeadYAtEdge - transformedHeadAnchor.y;
-    } else if (useWaistAnchor) {
+    } else if (useSideHeadAnchor) {
+        offsetY = desiredSideHeadY - placementHeadAnchor.y;
+    } else if (useWaistFallback) {
         offsetY = baseBodyRect.bottom - transformedBodyRect.bottom;
     } else if (verticalEdge === 'top') {
         offsetY = viewport.top + revealWidth - transformedBounds.bottom;
@@ -869,6 +961,13 @@ function getLive2DPeekPlacement(model, bounds, manager = null, anchor = null) {
         0,
         1
     );
+    const resolvedHeadAnchorRatio = useSideHeadAnchor && viewport.height > 0
+        ? clampLive2DPeekCoordinate(
+            (placementHeadAnchor.y + offsetY - viewport.top) / viewport.height,
+            0,
+            1
+        )
+        : null;
     const hiddenOffsetX = side === 'left'
         ? viewport.left - targetBounds.right - LIVE2D_PEEK_HIDDEN_MARGIN_PX
         : viewport.right - targetBounds.left + LIVE2D_PEEK_HIDDEN_MARGIN_PX;
@@ -881,11 +980,12 @@ function getLive2DPeekPlacement(model, bounds, manager = null, anchor = null) {
         rotation: targetRotation,
         rotationDegrees: targetRotationDegrees,
         scaleX: targetScaleX,
-        headAnchored: useHeadAnchor || !!transformedHeadAnchor,
-        headAnchorSource: transformedHeadAnchorSource,
-        waistAnchored: useWaistAnchor,
+        headAnchored: useCornerHeadAnchor || useSideHeadAnchor,
+        headAnchorSource: useSideHeadAnchor ? 'manager' : transformedHeadAnchorSource,
+        waistAnchored: useWaistFallback,
         revealWidth,
         edgeAnchorRatio,
+        headAnchorRatio: resolvedHeadAnchorRatio,
         visibleBounds,
         hiddenX: baseX + offsetX + hiddenOffsetX,
         hiddenY: baseY + offsetY
@@ -1209,6 +1309,7 @@ Live2DManager.prototype._tryApplyLive2DPeek = async function (model, edgeContact
         headAnchorSource: target.headAnchorSource,
         waistAnchored: target.waistAnchored,
         edgeAnchorRatio: target.edgeAnchorRatio,
+        headAnchorRatio: target.headAnchorRatio,
         visibleBounds: target.visibleBounds
     };
     if (document.body) {
@@ -1292,7 +1393,7 @@ function captureLive2DPeekRestoreAnchor() {
     const visibleBounds = state.visibleBounds || getLive2DPeekViewportIntersection(bounds, viewport);
     if (!viewport || !visibleBounds || viewport.height <= 0) return null;
     const storedEdgeAnchorRatio = Number(state.edgeAnchorRatio);
-    return {
+    const restoreAnchor = {
         kind: 'live2d-edge-peek',
         edge,
         side: state.side,
@@ -1311,6 +1412,15 @@ function captureLive2DPeekRestoreAnchor() {
             scaleFactor: Number(window.devicePixelRatio) || 1
         }
     };
+    const storedHeadAnchorRatio = state.headAnchorRatio !== null &&
+            state.headAnchorRatio !== undefined &&
+            state.headAnchorRatio !== ''
+        ? Number(state.headAnchorRatio)
+        : NaN;
+    if ((edge === 'left' || edge === 'right') && Number.isFinite(storedHeadAnchorRatio)) {
+        restoreAnchor.headAnchorRatio = clampLive2DPeekCoordinate(storedHeadAnchorRatio, 0, 1);
+    }
+    return restoreAnchor;
 }
 
 async function restoreLive2DPeekAnchor(anchor) {
@@ -1349,10 +1459,18 @@ async function restoreLive2DPeekAnchor(anchor) {
     const verticalEdge = edge.startsWith('top-')
         ? 'top'
         : (edge.startsWith('bottom-') ? 'bottom' : '');
+    const restoredHeadAnchorRatio = !verticalEdge &&
+            anchor.headAnchorRatio !== null &&
+            anchor.headAnchorRatio !== undefined &&
+            anchor.headAnchorRatio !== '' &&
+            Number.isFinite(Number(anchor.headAnchorRatio))
+        ? clampLive2DPeekCoordinate(Number(anchor.headAnchorRatio), 0, 1)
+        : null;
     return await manager._tryApplyLive2DPeek(model, {
         edge,
         side,
         verticalEdge,
+        headAnchorRatio: restoredHeadAnchorRatio,
         geometry: getLive2DModelGeometryBounds(manager, model),
         workArea: viewport
     });

--- a/tests/unit/live2d_peek_behavior.test.js
+++ b/tests/unit/live2d_peek_behavior.test.js
@@ -163,6 +163,8 @@ function createHarness({
         controls,
         getLive2DPeekViewport: context.getLive2DPeekViewport,
         getLive2DPeekEdgeContact: context.getLive2DPeekEdgeContact,
+        getLive2DPeekRotationDegrees: context.getLive2DPeekRotationDegrees,
+        getLive2DPeekSideRotationMagnitude: context.getLive2DPeekSideRotationMagnitude,
         refreshLive2DPeekDisplayContext: context.refreshLive2DPeekDisplayContext,
         validateLive2DPeekEdgeContact: context.validateLive2DPeekEdgeContact,
         settleLive2DBaseAtEdgeContact: context.settleLive2DBaseAtEdgeContact,
@@ -295,6 +297,13 @@ function flushNextFrame(harness, time = 400) {
     const callback = harness.rafQueue.shift();
     assert.equal(typeof callback, 'function');
     callback(time);
+}
+
+function assertClose(actual, expected, message, tolerance = 1e-6) {
+    assert.ok(
+        Math.abs(actual - expected) <= tolerance,
+        `${message}: expected ${expected}, got ${actual}`
+    );
 }
 
 async function waitForQueuedFrame(harness, attempts = 10) {
@@ -1275,22 +1284,30 @@ test('locked edge validation cannot reclassify an oversize model to the opposite
     );
 });
 
-test('restoring a peek transform keeps the grabbed model-local point under the pointer', () => {
+test('restoring any dynamic side-peek transform keeps the grabbed model-local point under the pointer', () => {
     const harness = createHarness();
-    const model = createRotatingModel({ x: -180, y: 100, width: 300, height: 600 });
-    model.rotation = Math.PI / 3;
-    model.scale.x = -1;
-    const pointer = model.toGlobal({ x: 70, y: 90 });
-    const localGrab = harness.getLive2DModelLocalGrabPoint(model, pointer);
+    for (const degrees of [55, 41.5, 28, -55, -41.5, -28]) {
+        const model = createRotatingModel({ x: -180, y: 100, width: 300, height: 600 });
+        model.rotation = degrees * Math.PI / 180;
+        model.scale.x = degrees > 0 ? 1 : -1;
+        const pointer = model.toGlobal({ x: 70, y: 90 });
+        const localGrab = harness.getLive2DModelLocalGrabPoint(model, pointer);
 
-    model.x = 40;
-    model.y = 120;
-    model.rotation = 0;
-    model.scale.x = 1;
-    assert.equal(harness.placeLive2DGrabPointAtPointer(model, localGrab, pointer), true);
-    const restored = model.toGlobal(localGrab);
-    assert.ok(Math.abs(restored.x - pointer.x) < 1e-9, `x mismatch: ${restored.x} vs ${pointer.x}`);
-    assert.ok(Math.abs(restored.y - pointer.y) < 1e-9, `y mismatch: ${restored.y} vs ${pointer.y}`);
+        model.x = 40;
+        model.y = 120;
+        model.rotation = 0;
+        model.scale.x = 1;
+        assert.equal(harness.placeLive2DGrabPointAtPointer(model, localGrab, pointer), true);
+        const restored = model.toGlobal(localGrab);
+        assert.ok(
+            Math.abs(restored.x - pointer.x) < 1e-9,
+            `${degrees}deg x mismatch: ${restored.x} vs ${pointer.x}`
+        );
+        assert.ok(
+            Math.abs(restored.y - pointer.y) < 1e-9,
+            `${degrees}deg y mismatch: ${restored.y} vs ${pointer.y}`
+        );
+    }
 });
 
 test('edge peek enter naturally moves model offscreen and reports visible bounds', async () => {
@@ -1340,10 +1357,103 @@ test('restore anchor stores semantic display identity without absolute coordinat
     assert.equal('screenY' in anchor.display, false);
 });
 
+test('goodbye capture and semantic restore preserve a precise side head pose', async () => {
+    const harness = createHarness({ reducedMotion: true });
+    const manager = new harness.Live2DManager();
+    const ratio = 0.65;
+    const model = createRotatingModel({ x: 0, y: ratio * 800 - 110 });
+    manager.currentModel = model;
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getHeadDetectionGeometryInfo = () => {
+        const anchor = model.transformPoint(150, 110);
+        return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+    };
+    manager.getBodyScreenRectInfo = () => {
+        const waist = model.transformPoint(150, 330);
+        return { rect: { centerX: waist.x, bottom: waist.y } };
+    };
+    harness.window.live2dManager = manager;
+    const workArea = { left: 0, top: 0, right: 1000, bottom: 800, width: 1000, height: 800 };
+
+    assert.equal(await manager._tryApplyLive2DPeek(model, {
+        edge: 'left',
+        side: 'left',
+        verticalEdge: '',
+        geometry: model.getBounds(),
+        workArea
+    }), true);
+    const originalRotation = manager._live2DPeekState.peekRotation;
+    const goodbyeEvent = { type: 'live2d-goodbye-click', detail: {} };
+    harness.window.dispatchEvent(goodbyeEvent);
+    const anchor = goodbyeEvent.detail.edgeAnchor;
+
+    assert.equal(anchor.kind, 'live2d-edge-peek');
+    assert.equal(anchor.edge, 'left');
+    assertClose(anchor.headAnchorRatio, ratio, 'captured head ratio');
+    assert.equal(manager.isLive2DPeekActive(), false);
+
+    model.x = 350;
+    model.y = 100;
+    assert.equal(await harness.window.nekoLive2DPeek.restoreAnchor(anchor), true);
+    assertClose(manager._live2DPeekState.headAnchorRatio, ratio, 'restored head ratio');
+    assertClose(manager._live2DPeekState.peekRotation, originalRotation, 'restored rotation');
+    assertClose(manager.getHeadScreenAnchor().y, ratio * workArea.height, 'restored head y', 0.001);
+});
+
+test('legacy and invalid side restore anchors safely recompute a finite current pose', async () => {
+    const invalidRatios = [undefined, null, '', Number.NaN, Number.POSITIVE_INFINITY];
+    for (const headAnchorRatio of invalidRatios) {
+        const harness = createHarness({ reducedMotion: true });
+        const manager = new harness.Live2DManager();
+        const model = createRotatingModel({ x: 350, y: 100 });
+        manager.currentModel = model;
+        manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+        manager.getHeadDetectionGeometryInfo = () => {
+            const anchor = model.transformPoint(150, 110);
+            return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+        };
+        manager.getBodyScreenRectInfo = () => {
+            const waist = model.transformPoint(150, 330);
+            return { rect: { centerX: waist.x, bottom: waist.y } };
+        };
+        harness.window.live2dManager = manager;
+        const anchor = {
+            kind: 'live2d-edge-peek',
+            edge: 'left',
+            side: 'left',
+            edgeAnchorRatio: 0.5,
+            facing: 'inward'
+        };
+        if (headAnchorRatio !== undefined) anchor.headAnchorRatio = headAnchorRatio;
+
+        assert.equal(await harness.window.nekoLive2DPeek.restoreAnchor(anchor), true);
+        const state = manager._live2DPeekState;
+        assert.ok(Number.isFinite(model.x) && Number.isFinite(model.y) && Number.isFinite(model.rotation));
+        assert.ok(
+            Number.isFinite(state.headAnchorRatio) && state.headAnchorRatio >= 0 && state.headAnchorRatio <= 1,
+            `invalid ${String(headAnchorRatio)} must recompute a safe ratio`
+        );
+        assert.equal(state.headAnchored, true);
+        assert.equal(state.waistAnchored, false);
+        const magnitude = Math.abs(state.peekRotation * 180 / Math.PI);
+        assert.ok(magnitude >= 28 && magnitude <= 55, `invalid ${String(headAnchorRatio)} pose must stay bounded`);
+    }
+});
+
 test('detail-less goodbye events preserve the edge anchor for later listeners', async () => {
     const harness = createHarness();
     const manager = new harness.Live2DManager();
-    const model = createModel({ x: 0 });
+    const ratio = 0.35;
+    const model = createRotatingModel({ x: 0, y: ratio * 800 - 110 });
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getHeadDetectionGeometryInfo = () => {
+        const anchor = model.transformPoint(150, 110);
+        return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+    };
+    manager.getBodyScreenRectInfo = () => {
+        const waist = model.transformPoint(150, 330);
+        return { rect: { centerX: waist.x, bottom: waist.y } };
+    };
     harness.window.live2dManager = manager;
 
     const enterPromise = manager._tryApplyLive2DPeek(model);
@@ -1359,37 +1469,253 @@ test('detail-less goodbye events preserve the edge anchor for later listeners', 
 
     assert.equal(receivedAnchor.kind, 'live2d-edge-peek');
     assert.equal(receivedAnchor.edge, 'left');
+    assertClose(receivedAnchor.headAnchorRatio, ratio, 'detail-less goodbye head ratio');
     assert.equal(manager.isLive2DPeekActive(), false);
 });
 
-test('head anchor keeps the face visible when a tail widens the model bounds', async () => {
+test('side rotation follows the locked smoothstep curve continuously', () => {
+    const harness = createHarness();
+    assert.equal(typeof harness.getLive2DPeekSideRotationMagnitude, 'function');
+    const cases = [
+        { ratio: 0, degrees: 55 },
+        { ratio: 0.20, degrees: 55 },
+        { ratio: 0.35, degrees: 50.78125 },
+        { ratio: 0.50, degrees: 41.5 },
+        { ratio: 0.65, degrees: 32.21875 },
+        { ratio: 0.80, degrees: 28 },
+        { ratio: 1, degrees: 28 }
+    ];
+
+    for (const item of cases) {
+        assertClose(
+            harness.getLive2DPeekSideRotationMagnitude(item.ratio),
+            item.degrees,
+            `ratio ${item.ratio}`
+        );
+    }
+
+    for (const invalidRatio of [undefined, null, '', Number.NaN, Number.POSITIVE_INFINITY]) {
+        assert.equal(
+            harness.getLive2DPeekRotationDegrees({ side: 'left', verticalEdge: '' }, invalidRatio),
+            60,
+            `left must retain the legacy fallback for ${String(invalidRatio)}`
+        );
+        assert.equal(
+            harness.getLive2DPeekRotationDegrees({ side: 'right', verticalEdge: '' }, invalidRatio),
+            -60,
+            `right must retain the legacy fallback for ${String(invalidRatio)}`
+        );
+    }
+    assert.equal(
+        harness.getLive2DPeekRotationDegrees({ side: 'left', verticalEdge: '' }, 0),
+        55,
+        'numeric zero is valid and clamps to the upper-pose endpoint'
+    );
+
+    let previous = harness.getLive2DPeekSideRotationMagnitude(0);
+    for (let step = 1; step <= 100; step += 1) {
+        const next = harness.getLive2DPeekSideRotationMagnitude(step / 100);
+        assert.ok(next <= previous, `curve must be monotonic at ratio ${step / 100}`);
+        assert.ok(previous - next < 1, `curve must not jump at ratio ${step / 100}`);
+        previous = next;
+    }
+});
+
+test('precise head anchors drive mirrored upper middle and lower side poses', async () => {
+    const expectedMagnitude = (ratio) => {
+        const t = Math.min(1, Math.max(0, (ratio - 0.20) / 0.60));
+        const smooth = t * t * (3 - 2 * t);
+        return 55 + (28 - 55) * smooth;
+    };
+    const cases = [
+        { name: 'left-upper', side: 'left', ratio: 0.20 },
+        { name: 'left-middle', side: 'left', ratio: 0.50 },
+        { name: 'left-lower', side: 'left', ratio: 0.80 },
+        { name: 'right-upper', side: 'right', ratio: 0.20 },
+        { name: 'right-middle', side: 'right', ratio: 0.50 },
+        { name: 'right-lower', side: 'right', ratio: 0.80 }
+    ];
+
+    for (const item of cases) {
+        const harness = createHarness();
+        const manager = new harness.Live2DManager();
+        const model = createRotatingModel({
+            x: item.side === 'left' ? 0 : 700,
+            y: item.ratio * 800 - 110,
+            scaleX: 1,
+            width: 300,
+            height: 600
+        });
+        manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+        manager.getHeadDetectionGeometryInfo = () => {
+            const anchor = model.transformPoint(150, 110);
+            return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+        };
+        manager.getBodyScreenRectInfo = () => {
+            const waist = model.transformPoint(150, 330);
+            return { rect: { centerX: waist.x, bottom: waist.y } };
+        };
+        const workArea = { left: 0, top: 0, right: 1000, bottom: 800, width: 1000, height: 800 };
+        const enterPromise = manager._tryApplyLive2DPeek(model, {
+            edge: item.side,
+            side: item.side,
+            verticalEdge: '',
+            geometry: model.getBounds(),
+            workArea
+        });
+        flushNextFrame(harness);
+        assert.equal(await enterPromise, true, `${item.name} should enter`);
+
+        const state = manager._live2DPeekState;
+        const expectedDegrees = expectedMagnitude(item.ratio) * (item.side === 'left' ? 1 : -1);
+        assertClose(state.peekRotation * 180 / Math.PI, expectedDegrees, `${item.name} rotation`);
+        assertClose(state.headAnchorRatio, item.ratio, `${item.name} stored head ratio`);
+        assert.equal(state.headAnchored, true, `${item.name} should use the precise head anchor`);
+        assert.equal(state.headAnchorSource, 'manager', `${item.name} should reject bounds fallback as precise`);
+        assert.equal(state.waistAnchored, false, `${item.name} must not use the waist anchor`);
+
+        const head = manager.getHeadScreenAnchor();
+        const waist = manager.getBodyScreenRectInfo().rect;
+        const headXRange = item.side === 'left' ? [36, 84] : [916, 964];
+        assert.ok(
+            head.x >= headXRange[0] && head.x <= headXRange[1],
+            `${item.name} head x must remain visible, got ${head.x}`
+        );
+        assertClose(head.y, item.ratio * workArea.height, `${item.name} head y`, 0.001);
+        assert.ok(
+            item.side === 'left' ? waist.centerX <= 0 : waist.centerX >= 1000,
+            `${item.name} waist should remain outside when head visibility allows it, got ${waist.centerX}`
+        );
+        assert.ok(state.visibleBounds && state.visibleBounds.width > 0 && state.visibleBounds.height > 0);
+
+        model.x = state.hiddenX;
+        model.y = state.hiddenY;
+        model.rotation = state.peekRotation;
+        model.scale.x = state.peekScaleX;
+        const hiddenBounds = model.getBounds();
+        assert.ok(
+            item.side === 'left' ? hiddenBounds.right < 0 : hiddenBounds.left > 1000,
+            `${item.name} hidden pose must be fully outside the viewport`
+        );
+    }
+});
+
+test('ordinary side peek keeps the legacy waist fallback without a precise manager head anchor', async () => {
+    for (const side of ['left', 'right']) {
+        const harness = createHarness();
+        const manager = new harness.Live2DManager();
+        const model = createRotatingModel({ x: side === 'left' ? 0 : 700, y: 120 });
+        manager.getBodyScreenRectInfo = () => {
+            const waist = model.transformPoint(150, 330);
+            return { rect: { centerX: waist.x, bottom: waist.y } };
+        };
+        const enterPromise = manager._tryApplyLive2DPeek(model);
+        flushNextFrame(harness);
+        assert.equal(await enterPromise, true);
+
+        const state = manager._live2DPeekState;
+        assert.equal(state.headAnchorSource, 'bounds-fallback');
+        assert.equal(state.headAnchored, false);
+        assert.equal(state.waistAnchored, true);
+        assert.equal(state.headAnchorRatio, null);
+        assertClose(
+            Math.abs(state.peekRotation * 180 / Math.PI),
+            60,
+            `${side} fallback rotation`
+        );
+        assertClose(
+            manager.getBodyScreenRectInfo().rect.centerX,
+            side === 'left' ? -8 : 1008,
+            `${side} fallback waist x`,
+            0.001
+        );
+    }
+});
+
+test('ordinary side peek rejects an unreliable detected head and keeps the waist fallback', async () => {
     const harness = createHarness();
     const manager = new harness.Live2DManager();
-    const model = createModel({ x: 0, y: 120, width: 700, height: 600 });
-    const transformedPoint = (localX, localY) => ({
-        x: model.x + localX * Math.cos(model.rotation) - localY * Math.sin(model.rotation),
-        y: model.y + localX * Math.sin(model.rotation) + localY * Math.cos(model.rotation)
-    });
-    manager.getHeadScreenAnchor = () => transformedPoint(140, 110);
+    const model = createRotatingModel({ x: 0, y: 120 });
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getHeadDetectionGeometryInfo = () => {
+        const anchor = model.transformPoint(150, 110);
+        return { reliableHeadRect: false, headAnchor: anchor, rawHeadAnchor: anchor };
+    };
     manager.getBodyScreenRectInfo = () => {
-        const waist = transformedPoint(140, 330);
+        const waist = model.transformPoint(150, 330);
         return { rect: { centerX: waist.x, bottom: waist.y } };
     };
 
     const enterPromise = manager._tryApplyLive2DPeek(model);
     flushNextFrame(harness);
     assert.equal(await enterPromise, true);
+    assert.equal(manager._live2DPeekState.headAnchored, false);
+    assert.equal(manager._live2DPeekState.waistAnchored, true);
+    assert.equal(manager._live2DPeekState.headAnchorRatio, null);
+    assertClose(manager._live2DPeekState.peekRotation * 180 / Math.PI, 60, 'unreliable head fallback');
+    assertClose(manager.getBodyScreenRectInfo().rect.centerX, -8, 'unreliable head waist x', 0.001);
+});
+
+test('side head visibility wins when the waist cannot be pushed outside simultaneously', async () => {
+    const harness = createHarness();
+    const manager = new harness.Live2DManager();
+    const model = createRotatingModel({ x: 0, y: 290 });
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getHeadDetectionGeometryInfo = () => {
+        const anchor = model.transformPoint(150, 110);
+        return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+    };
+    manager.getBodyScreenRectInfo = () => {
+        const nearWaist = model.transformPoint(150, 140);
+        return { rect: { centerX: nearWaist.x, bottom: nearWaist.y } };
+    };
+
+    const enterPromise = manager._tryApplyLive2DPeek(model, {
+        edge: 'left',
+        side: 'left',
+        verticalEdge: '',
+        geometry: model.getBounds(),
+        workArea: { left: 0, top: 0, right: 1000, bottom: 800, width: 1000, height: 800 }
+    });
+    flushNextFrame(harness);
+    assert.equal(await enterPromise, true);
 
     const head = manager.getHeadScreenAnchor();
-    assert.equal(manager._live2DPeekState.side, 'left');
+    const waist = manager.getBodyScreenRectInfo().rect;
+    assert.ok(head.x >= 36, `head must retain the 36px minimum inset, got ${head.x}`);
+    assert.ok(waist.centerX > 0, 'the waist may remain visible when moving it out would crop the head');
     assert.equal(manager._live2DPeekState.headAnchored, true);
-    assert.ok(head.x > 20 && head.x < 260, `head should lean inside the edge, got ${head.x}`);
-    assert.equal(manager._live2DPeekState.waistAnchored, true);
-    assert.ok(Math.abs(manager.getBodyScreenRectInfo().rect.centerX + 8) < 0.001);
-    assert.ok(Math.abs(manager.getBodyScreenRectInfo().rect.bottom - 450) < 0.001);
-    const lowerBody = transformedPoint(140, 600);
-    assert.ok(lowerBody.x < 0, 'lower body should remain outside the side edge');
-    assert.ok(model.x > -500, 'placement must not expose only the tail-side edge of the bounds');
+    assert.equal(manager._live2DPeekState.waistAnchored, false);
+});
+
+test('side head ratio is relative to a non-zero work-area top', async () => {
+    const harness = createHarness({ innerHeight: 800 });
+    const manager = new harness.Live2DManager();
+    const model = createRotatingModel({ x: 0, y: 290 });
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getHeadDetectionGeometryInfo = () => {
+        const anchor = model.transformPoint(150, 110);
+        return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+    };
+    manager.getBodyScreenRectInfo = () => {
+        const waist = model.transformPoint(150, 330);
+        return { rect: { centerX: waist.x, bottom: waist.y } };
+    };
+    const workArea = { left: 0, top: 28, right: 1000, bottom: 772, width: 1000, height: 744 };
+
+    const enterPromise = manager._tryApplyLive2DPeek(model, {
+        edge: 'left',
+        side: 'left',
+        verticalEdge: '',
+        geometry: model.getBounds(),
+        workArea
+    });
+    flushNextFrame(harness);
+    assert.equal(await enterPromise, true);
+
+    assertClose(manager._live2DPeekState.headAnchorRatio, 0.5, 'work-area-relative ratio');
+    assertClose(manager._live2DPeekState.peekRotation * 180 / Math.PI, 41.5, 'work-area-relative pose');
+    assertClose(manager.getHeadScreenAnchor().y, 400, 'work-area-relative head y', 0.001);
 });
 
 test('corner peeks keep the head at the corner and the body outside the matching vertical edge', async () => {
@@ -1492,6 +1818,35 @@ test('corner peeks fall back to model transforms when no head anchor is availabl
             `${item.edge} fallback head y should remain visible, got ${estimatedHead.y}`
         );
         assert.ok(item.bodyOutside(lowerBody.y), `${item.edge} fallback should keep the lower body outside the viewport`);
+    }
+});
+
+test('side-only reliable detection metadata does not change corner bounds fallback', async () => {
+    const cases = [
+        { edge: 'top-left', y: 0, rotation: 135, headYRange: [36, 64] },
+        { edge: 'bottom-left', y: 200, rotation: 45, headYRange: [736, 764] }
+    ];
+
+    for (const item of cases) {
+        const harness = createHarness();
+        const manager = new harness.Live2DManager();
+        const model = createRotatingModel({ x: 0, y: item.y, scaleX: 1 });
+        manager.getHeadScreenAnchor = () => null;
+        manager.getHeadDetectionGeometryInfo = () => {
+            const anchor = model.transformPoint(150, 110);
+            return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+        };
+
+        const enterPromise = manager._tryApplyLive2DPeek(model);
+        flushNextFrame(harness);
+        assert.equal(await enterPromise, true);
+
+        const estimatedHead = model.transformPoint(150, 600 * 0.24);
+        assert.equal(manager._live2DPeekState.edge, item.edge);
+        assert.equal(manager._live2DPeekState.headAnchorSource, 'bounds-fallback');
+        assertClose(model.rotation * 180 / Math.PI, item.rotation, `${item.edge} rotation`);
+        assert.ok(estimatedHead.x >= 48 && estimatedHead.x <= 84);
+        assert.ok(estimatedHead.y >= item.headYRange[0] && estimatedHead.y <= item.headYRange[1]);
     }
 });
 
@@ -2835,6 +3190,55 @@ test('display change rebuilds the active anchor against the refreshed display', 
     assert.equal(model.rotation, hiddenRotation);
     assert.equal(model.scale.x, hiddenScaleX);
     assert.equal(model.interactive, false);
+});
+
+test('display change preserves a precise side head ratio and pose', async () => {
+    const currentDisplay = {
+        id: 'display-test',
+        screenX: 0,
+        screenY: 0,
+        bounds: { x: 0, y: 0, width: 1000, height: 800 },
+        workArea: { x: 0, y: 0, width: 1000, height: 800 }
+    };
+    const harness = createHarness({ currentDisplay, reducedMotion: true });
+    const manager = new harness.Live2DManager();
+    const ratio = 0.65;
+    const model = createRotatingModel({ x: 0, y: ratio * 800 - 110 });
+    manager.currentModel = model;
+    manager.getHeadScreenAnchor = () => model.transformPoint(150, 110);
+    manager.getHeadDetectionGeometryInfo = () => {
+        const anchor = model.transformPoint(150, 110);
+        return { reliableHeadRect: true, headAnchor: anchor, rawHeadAnchor: anchor };
+    };
+    manager.getBodyScreenRectInfo = () => {
+        const waist = model.transformPoint(150, 330);
+        return { rect: { centerX: waist.x, bottom: waist.y } };
+    };
+    harness.window.live2dManager = manager;
+
+    assert.equal(await manager._tryApplyLive2DPeek(model, {
+        edge: 'left',
+        side: 'left',
+        verticalEdge: '',
+        geometry: model.getBounds(),
+        workArea: { left: 0, top: 0, right: 1000, bottom: 800, width: 1000, height: 800 }
+    }), true);
+    const originalRotation = manager._live2DPeekState.peekRotation;
+
+    currentDisplay.bounds.height = 1000;
+    currentDisplay.workArea.height = 1000;
+    harness.window.innerHeight = 1000;
+    harness.window.screen.height = 1000;
+    harness.window.dispatchEvent({ type: 'electron-display-changed' });
+    await new Promise((resolve) => setImmediate(resolve));
+    harness.window.dispatchEvent({ type: 'electron-display-changed' });
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(manager.isLive2DPeekActive(), true);
+    assertClose(manager._live2DPeekState.headAnchorRatio, ratio, 'display-restored head ratio');
+    assertClose(manager._live2DPeekState.peekRotation, originalRotation, 'display-restored pose');
+    assertClose(manager.getHeadScreenAnchor().y, ratio * 1000, 'display-restored head y', 0.001);
 });
 
 test('non-display clear invalidates a pending display anchor restore', async () => {

--- a/tests/unit/test_live2d_peek_static.py
+++ b/tests/unit/test_live2d_peek_static.py
@@ -38,6 +38,10 @@ def test_live2d_widget_mode_edge_peek_is_widget_mode_gated_and_uses_six_anchors(
     assert "LIVE2D_PEEK_VISIBLE_MIN_PX = 96" in source
     assert "LIVE2D_PEEK_VISIBLE_MAX_PX = 180" in source
     assert "LIVE2D_PEEK_SIDE_ROTATION_DEGREES = 60" in source
+    assert "LIVE2D_PEEK_SIDE_ROTATION_MAX_DEGREES = 55" in source
+    assert "LIVE2D_PEEK_SIDE_ROTATION_MIN_DEGREES = 28" in source
+    assert "LIVE2D_PEEK_SIDE_ROTATION_RATIO_START = 0.20" in source
+    assert "LIVE2D_PEEK_SIDE_ROTATION_RATIO_END = 0.80" in source
     assert "LIVE2D_PEEK_CORNER_ROTATION_DEGREES = 45" in source
     assert "LIVE2D_PEEK_HEAD_Y_RATIO = 0.24" in source
     assert "function isLive2DPeekEnabled()" in source
@@ -124,20 +128,31 @@ def test_live2d_widget_mode_edge_peek_prefers_head_anchor_and_preserves_vertical
 
     assert "LIVE2D_PEEK_HEAD_Y_RATIO" in edge_peek_source
     assert "const baseHeadAnchor = getLive2DPeekHeadAnchor(manager);" in edge_peek_source
+    assert "const baseReliableHeadAnchor = getLive2DPeekReliableHeadAnchor(manager);" in edge_peek_source
     assert "const baseBodyRect = getLive2DPeekBodyRect(manager);" in edge_peek_source
+    assert "function getLive2DPeekSideRotationMagnitude(headAnchorRatio)" in edge_peek_source
+    assert "progress * progress * (3 - 2 * progress)" in edge_peek_source
+    assert "(baseReliableHeadAnchor.y - viewport.top) / viewport.height" in edge_peek_source
     assert "bounds.top + bounds.height * LIVE2D_PEEK_HEAD_Y_RATIO" in edge_peek_source
     assert "const desiredHeadX = side === 'left'" in edge_peek_source
-    assert "desiredHeadX - transformedHeadAnchor.x" in edge_peek_source
+    assert "desiredHeadX - placementHeadAnchor.x" in edge_peek_source
     assert "desiredWaistX - transformedBodyRect.centerX" in edge_peek_source
     assert "baseBodyRect.bottom - transformedBodyRect.bottom" in edge_peek_source
     assert "transformedBounds.top + transformedBounds.height * LIVE2D_PEEK_HEAD_Y_RATIO" in edge_peek_source
-    assert "const useHeadAnchor = !!verticalEdge && !!transformedHeadAnchor;" in edge_peek_source
-    assert "const useWaistAnchor = !verticalEdge && !!(baseBodyRect && transformedBodyRect);" in edge_peek_source
+    assert "const useCornerHeadAnchor = !!verticalEdge && !!transformedHeadAnchor;" in edge_peek_source
+    assert "const useSideHeadAnchor = !verticalEdge &&" in edge_peek_source
+    assert "!!transformedReliableHeadAnchor" in edge_peek_source
+    assert "const useWaistFallback = !verticalEdge &&" in edge_peek_source
+    assert "!useSideHeadAnchor" in edge_peek_source
+    assert "const minimumHeadInset = 36;" in edge_peek_source
     assert "? viewport.bottom - desiredHeadInsetY" in edge_peek_source
     assert ": viewport.top + desiredHeadInsetY;" in edge_peek_source
     assert "offsetY = desiredHeadYAtEdge - transformedHeadAnchor.y;" in edge_peek_source
+    assert "offsetY = desiredSideHeadY - placementHeadAnchor.y;" in edge_peek_source
     assert "offsetY = baseBodyRect.bottom - transformedBodyRect.bottom;" in edge_peek_source
     assert "offsetY = desiredHeadY - targetHeadY;" in edge_peek_source
+    assert "headAnchorRatio: target.headAnchorRatio" in edge_peek_source
+    assert "restoreAnchor.headAnchorRatio" in edge_peek_source
     assert "getLive2DPeekVerticalCorrection" in edge_peek_source
 
 


### PR DESCRIPTION
## 改动概述

普通左右侧挂边此前使用固定倾角，YUI 在不同纵向位置时容易出现脸部裁切或身体大面积侵入屏幕。本 PR 根据可靠头部锚点的纵向比例，以 smoothstep 连续计算 55° 到 28° 的侧边倾角，并让左右姿态保持镜像。

同时将普通侧边的精确头部锚定与角落头锚、腰部/包围盒回退明确分离。仅在 manager 提供可靠头部几何时启用新姿态；第三方模型缺少可靠头部数据时继续走旧回退策略。

新增独立的 `headAnchorRatio` 运行时状态，用于跨显示器以及变猫返回后的头部高度和姿态恢复；原有 `edgeAnchorRatio` 仍只负责最终可见区域的粗定位。

## 关键技术决策

- 侧边倾角使用纯计算函数和平滑插值，避免上下移动时出现角度跳变。
- 横向定位优先将腰部推出屏幕，同时保留至少约 36px 的头部可见范围；两者冲突时优先保证脸部可见。
- `headAnchorRatio` 只在前端运行时链路中传递，不写入后端、磁盘配置或 IPC。
- 旧锚点、非法比例和无可靠头部数据均安全回退，不产生 NaN 或改变返回球语义。

## 风险与边界

本 PR 只调整 Live2D 普通 left/right 挂边姿态及对应测试。四个角落的角度与定位合同、8px 边缘判定、六锚点合同、动画时长、easing、右侧 scaleX、动作/表情/物理参数和 Widget/Stealth Mode 状态机均保持不变。

未修改 Electron 宿主、后端、配置、数据库、i18n、模型资源或 N.E.K.O-PC。主要回归风险集中在不同模型头部/腰部几何差异导致的视觉参数表现；无可靠头部数据的模型保持旧回退路径。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 Live2D 侧边及角落探身效果，旋转角度更加平滑自然。
  * 改善头部定位与内缩约束，减少探身时头部被遮挡或位置异常。
  * 增强拖拽、吸附及显示器切换后的姿态恢复，能够更准确地保留头部位置和探身状态。
  * 在头部检测不可靠时，自动使用腰部或备用位置，提升不同布局下的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->