### PR TITLE
fix(proactive): 队列字节淘汰选错对象 + 纯图片 push 的空 HUD 通知

### DIFF
--- a/app/main_server/character_runtime.py
+++ b/app/main_server/character_runtime.py
@@ -1490,6 +1490,23 @@ async def _handle_agent_event(event: dict):
                         _vis,
                         lanlan,
                     )
+                elif not text:
+                    # The HUD toast renders TEXT and nothing else -- it has no
+                    # image sink. The gate above this block used to be
+                    # ``if text:``; widening it to ``text or
+                    # deferred_callback_images`` was for the LLM delivery
+                    # channel, which genuinely treats images as payload. This
+                    # branch shares that gate but not that property, so an
+                    # image-only push started arriving here and emitting an
+                    # agent_notification whose text is "".
+                    #
+                    # Restoring the precondition locally rather than narrowing
+                    # the shared gate: the callback path must keep accepting
+                    # image-only pushes. The image is not lost either way --
+                    # it rides the proactive callback built above.
+                    logger.debug(
+                        "[EventBus] agent_notification skipped: push carried images but no text",
+                    )
                 elif _is_websocket_connected(ws):
                     try:
                         # HUD agent_notification renders verbatim to the user;

--- a/config/network.py
+++ b/config/network.py
@@ -168,8 +168,20 @@ def resolve_user_plugin_base() -> str:
     """The plugin server's ACTUAL loopback origin, right now.
 
     ``USER_PLUGIN_BASE`` is the configured origin. It is not always the live
-    one: when the preferred port is busy the plugin server binds elsewhere and
-    publishes the real port in ``NEKO_USER_PLUGIN_SERVER_PORT``.
+    one: when the preferred port is busy, the LAUNCHER picks a free one and
+    publishes it in ``NEKO_USER_PLUGIN_SERVER_PORT`` before spawning anything,
+    so every child inherits the same answer.
+
+    The launcher is named deliberately. An earlier version of this docstring
+    said "the plugin server binds elsewhere and publishes the real port", which
+    reads as though the server arbitrates its own port and announces it
+    afterwards. It does not, and the difference matters to anyone auditing this
+    path: a server that re-bound on its own could only publish into its OWN
+    environment, which no sibling process would ever see. Port arbitration
+    happens exactly once, in ``launcher_core.runtime.apply_port_strategy``,
+    ahead of every consumer; the plugin HTTP app is hosted in-process by
+    agent_server (``_start_embedded_user_plugin_server``) and merely binds the
+    port it is given, failing loudly if it cannot.
 
     This lives in config, at the bottom of the layering, because four separate
     layers need the same answer -- the process that MINTS media URLs, the main

--- a/main_logic/proactive_delivery.py
+++ b/main_logic/proactive_delivery.py
@@ -412,11 +412,29 @@ class ProactiveDeliveryManager:
     def _enforce_queue_budget(self) -> list[str]:
         """Bound what the queue holds, by cue count and by queued image bytes.
 
-        Drops in REVERSE release order -- the cue that would have gone out last
-        goes first -- so an over-budget burst sheds its own least important,
-        most recent tail instead of the important cue that has waited longest.
-        Release order is (priority DESC, FIFO), so that victim is simply the
-        maximum sort_key.
+        Both axes drop in REVERSE release order -- the cue that would have gone
+        out last goes first -- so an over-budget burst sheds its own least
+        important, most recent tail instead of the important cue that has
+        waited longest. Release order is (priority DESC, FIFO), so that victim
+        is simply the maximum sort_key.
+
+        The two axes do NOT share a candidate pool, and that is the whole point
+        of splitting the loop. "Shed your own tail" holds for the DEPTH axis,
+        where every cue occupies exactly one slot, so evicting any cue makes
+        progress. It does not hold for the BYTE axis, where only image-bearing
+        cues occupy budget: picking the global maximum sort_key there selects a
+        text-only cue with a near-certain probability -- text cues outnumber
+        image cues and the lowest priority in the system belongs to first-party
+        text (topic hooks submit at -20). Evicting it frees zero bytes, the
+        loop does not terminate, and it keeps eating text cues until the image
+        cues it was supposed to bound finally come into range. Measured on the
+        shared-pool version: a burst of 48 text cues plus 8 full-size image
+        cues left a queue of 4, against a depth ceiling of 50, with all 48 text
+        cues acked False.
+
+        That ack is not a silent drop -- topic hooks resolve a delivery future
+        on it and burn their one-shot quota -- so the cost of picking the wrong
+        victim lands on first-party features that never touched an image.
 
         Dropped cues are acked False, the same as a TTL drop: the producer is
         told its cue will not be delivered rather than being left waiting.
@@ -424,22 +442,48 @@ class ProactiveDeliveryManager:
         evicted_keys: list[str] = []
         if not self._queue:
             return evicted_keys
-        queued_bytes = sum(self._cue_image_bytes(c) for c in self._queue)
-        while self._queue and (
-            len(self._queue) > QUEUED_CUE_MAX_COUNT
-            or queued_bytes > QUEUED_IMAGE_MAX_TOTAL_BYTES
-        ):
-            victim = max(self._queue, key=lambda c: c.sort_key)
+
+        def _evict(victim: "_QueuedCue", reason: str, remaining_bytes: int) -> int:
             self._queue.remove(victim)
-            queued_bytes -= self._cue_image_bytes(victim)
+            freed = self._cue_image_bytes(victim)
             if victim.coalesce_key:
                 evicted_keys.append(victim.coalesce_key)
             resolve_callback_delivery_ack(victim.callback, False)
             logger.info(
-                "[proactive%s] dropping queued cue key=%r reason=queue_budget "
+                "[proactive%s] dropping queued cue key=%r reason=%s "
                 "(depth=%d bytes=%d)",
-                self._suffix(), victim.coalesce_key, len(self._queue), queued_bytes,
+                self._suffix(), victim.coalesce_key, reason,
+                len(self._queue), remaining_bytes - freed,
             )
+            return freed
+
+        queued_bytes = sum(self._cue_image_bytes(c) for c in self._queue)
+
+        # Depth axis: every cue occupies a slot, so any cue is a valid victim
+        # and the rule is unchanged from the shared-pool version.
+        while len(self._queue) > QUEUED_CUE_MAX_COUNT:
+            victim = max(self._queue, key=lambda c: c.sort_key)
+            queued_bytes -= _evict(victim, "queue_depth", queued_bytes)
+
+        # Byte axis: same ordering rule, but only among cues that actually hold
+        # bytes. Run second because freeing bytes can only shrink the queue --
+        # it can never push the depth axis back over its ceiling, so no loop
+        # back to the first pass is needed.
+        while queued_bytes > QUEUED_IMAGE_MAX_TOTAL_BYTES:
+            carriers = [c for c in self._queue if self._cue_image_bytes(c) > 0]
+            if not carriers:
+                # Unreachable while the running total is accurate: bytes can
+                # only come from carriers. Kept as an accounting backstop so a
+                # future bookkeeping bug degrades to "budget not enforced"
+                # instead of spinning forever.
+                logger.warning(
+                    "[proactive%s] byte budget over (%d) with no image-bearing "
+                    "cue to evict; leaving queue as-is",
+                    self._suffix(), queued_bytes,
+                )
+                break
+            victim = max(carriers, key=lambda c: c.sort_key)
+            queued_bytes -= _evict(victim, "queue_bytes", queued_bytes)
         return evicted_keys
 
     def retract(self, callback: dict) -> bool:

--- a/tests/unit/test_plugin_image_delivery.py
+++ b/tests/unit/test_plugin_image_delivery.py
@@ -2662,3 +2662,77 @@ def test_per_source_quotas_alone_can_exceed_the_request_ceiling() -> None:
         USER_PENDING_IMAGE_MAX_BYTES + PLUGIN_PENDING_IMAGE_MAX_BYTES
         > TURN_ATTACHED_IMAGE_MAX_TOTAL_BYTES
     )
+
+
+# ---------------------------------------------------------------------------
+# HUD toasts render text and nothing else.
+#
+# The gate above the delivery block widened from `if text:` to
+# `if text or deferred_callback_images:` so image-only pushes could reach the
+# LLM channel. The HUD branch shares that gate but has no image sink, so an
+# image-only push started emitting an agent_notification with text "".
+# ---------------------------------------------------------------------------
+
+
+def _notifications(manager) -> list:
+    return [
+        call.args[0]
+        for call in manager.websocket.send_json.call_args_list
+        if isinstance(call.args[0], dict)
+        and call.args[0].get("type") == "agent_notification"
+    ]
+
+
+async def _push_image_only_with_hud(monkeypatch, *, text: str):
+    from app import main_server
+
+    manager = _manager()
+    manager.websocket = MagicMock()
+    manager.websocket.send_json = AsyncMock()
+    monkeypatch.setattr(
+        "app.main_server.character_runtime._get_session_manager",
+        lambda _name: manager,
+    )
+    monkeypatch.setattr(
+        "app.main_server.character_runtime._is_websocket_connected",
+        lambda _ws: True,
+    )
+    monkeypatch.setattr(
+        "app.main_server.character_runtime._fetch_plugin_image_base64",
+        AsyncMock(return_value=base64.b64encode(b"img").decode("ascii")),
+    )
+
+    await main_server._handle_agent_event({
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": text,
+        "channel": "plugin:demo",
+        "delivery_mode": "proactive",
+        "ai_behavior": "respond",
+        "visibility": ["hud"],
+        "media_parts": [{"type": "image", "url": _IMAGE_URL, "mime": "image/jpeg"}],
+    })
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_image_only_push_does_not_emit_an_empty_hud_toast(monkeypatch) -> None:
+    manager = await _push_image_only_with_hud(monkeypatch, text="")
+
+    assert _notifications(manager) == [], "HUD has no image sink; an empty toast carries nothing"
+    # The image is NOT lost -- it rides the proactive callback, which is the
+    # whole reason the shared gate was widened. Suppressing the toast must not
+    # suppress delivery.
+    manager.submit_proactive_callback.assert_called_once()
+    assert manager.submit_proactive_callback.call_args.args[0]["media_images"]
+
+
+@pytest.mark.asyncio
+async def test_push_with_text_and_images_still_emits_its_hud_toast(monkeypatch) -> None:
+    """Dual: the fix must key on empty text, not on "this push carried images"."""
+    manager = await _push_image_only_with_hud(monkeypatch, text="有人送了礼物")
+
+    notifs = _notifications(manager)
+    assert len(notifs) == 1
+    assert notifs[0]["text"] == "有人送了礼物"
+    manager.submit_proactive_callback.assert_called_once()

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -1220,3 +1220,128 @@ def test_submit_reports_nothing_when_nothing_was_evicted():
     delivered = []
     mgr = _make(delivered)
     assert mgr.submit({"text": "fits"}, coalesce_key="k") == []
+
+
+# ---------------------------------------------------------------------------
+# Byte-axis eviction must not eat text-only cues.
+#
+# Both axes drop "the cue that would go out last". For DEPTH that always makes
+# progress -- every cue holds a slot. For BYTES only image-bearing cues hold
+# budget, so the global maximum sort_key is almost always a text cue whose
+# eviction frees nothing, and the loop keeps going until it happens to reach
+# the image cues. The lowest priority in the system is first-party text
+# (topic hooks submit at -20), so the wrong victim is picked by default.
+# ---------------------------------------------------------------------------
+
+
+def _img_cue_payload(decoded_bytes: int, filler: str) -> dict:
+    """A callback whose media_images decode to roughly ``decoded_bytes``."""
+    return {"text": "img", "media_images": [filler * ((decoded_bytes * 4 // 3) // len(filler))]}
+
+
+def test_byte_axis_evicts_image_cues_not_text_cues():
+    from main_logic import proactive_delivery as pd
+
+    delivered = []
+    mgr = _make(delivered)
+
+    # ORDER IS LOAD-BEARING. The text cues must already be queued when the byte
+    # budget blows, because _enforce_queue_budget runs on every submit: if the
+    # image cues are submitted first they are trimmed into budget before any
+    # text cue exists, and a shared victim pool would look identical to a split
+    # one. Submitting text first is what makes the two versions diverge --
+    # verified by mutation (reverting to a shared pool must turn this red).
+    #
+    # priority=-20 is the value first-party topic hooks really submit at
+    # (main_logic/topic/delivery.py), which is BELOW the 0 an unspecified
+    # plugin priority normalises to -- so these are the first cues a shared
+    # pool would reach for.
+    for i in range(10):
+        mgr.submit({"text": f"hook-{i}"}, priority=-20, coalesce_key=f"hook{i}")
+
+    # Now overflow the 32 MiB queue ceiling: 8 MiB each, the per-push model
+    # budget a single cue can carry.
+    per_cue = pd.CALLBACK_IMAGE_MAX_TOTAL_BYTES
+    for i in range(5):
+        mgr.submit(_img_cue_payload(per_cue, "I"), priority=9, coalesce_key=f"img{i}")
+
+    survivors = [c.callback.get("text") for c in mgr._queue]
+    # Every text cue survives: they never held a single byte of the budget.
+    for i in range(10):
+        assert f"hook-{i}" in survivors, f"text cue hook-{i} was evicted by the byte axis"
+    # And the budget is actually enforced -- this is not "the loop did nothing".
+    assert sum(mgr._cue_image_bytes(c) for c in mgr._queue) <= pd.QUEUED_IMAGE_MAX_TOTAL_BYTES
+    # Which means image cues DID get dropped.
+    assert sum(1 for c in mgr._queue if mgr._cue_image_bytes(c) > 0) < 5
+
+
+def test_byte_axis_keeps_the_queue_within_the_depth_ceiling_too():
+    """The shared-pool version cut a 56-cue burst down to 4 against a 50 ceiling.
+
+    Enforcing the byte budget must not collapse the queue far below the depth
+    limit it also advertises.
+    """
+    from main_logic import proactive_delivery as pd
+
+    delivered = []
+    mgr = _make(delivered)
+    per_cue = pd.CALLBACK_IMAGE_MAX_TOTAL_BYTES
+    # Text first -- see the ordering note in the test above.
+    for i in range(40):
+        mgr.submit({"text": f"plain-{i}"}, priority=0, coalesce_key=f"p{i}")
+    for i in range(8):
+        mgr.submit(_img_cue_payload(per_cue, "I"), priority=9, coalesce_key=f"img{i}")
+
+    assert len(mgr._queue) > 40, f"queue collapsed to {len(mgr._queue)}"
+    assert len(mgr._queue) <= pd.QUEUED_CUE_MAX_COUNT
+    assert sum(mgr._cue_image_bytes(c) for c in mgr._queue) <= pd.QUEUED_IMAGE_MAX_TOTAL_BYTES
+
+
+def test_byte_axis_victim_is_the_last_image_cue_to_release():
+    """Ordering rule is unchanged -- only the candidate pool narrowed."""
+    from main_logic import proactive_delivery as pd
+
+    delivered = []
+    mgr = _make(delivered)
+    per_cue = pd.CALLBACK_IMAGE_MAX_TOTAL_BYTES
+    # Same priority, so FIFO decides: the newest image cue goes first.
+    for i in range(5):
+        cb = _img_cue_payload(per_cue, "I")
+        cb["tag"] = f"img{i}"
+        mgr.submit(cb, priority=5, coalesce_key=f"img{i}")
+
+    remaining = [c.callback.get("tag") for c in mgr._queue]
+    assert "img0" in remaining, "the longest-waiting image cue must survive"
+    assert "img4" not in remaining, "the newest image cue must be the first evicted"
+
+
+def test_depth_axis_victim_rule_is_unchanged():
+    """Guards the half of the loop that was NOT supposed to change."""
+    from main_logic import proactive_delivery as pd
+
+    delivered = []
+    mgr = _make(delivered)
+    mgr.submit({"text": "important"}, priority=9, coalesce_key="imp")
+    for i in range(pd.QUEUED_CUE_MAX_COUNT):
+        mgr.submit({"text": f"noise-{i}"}, priority=0, coalesce_key=f"n{i}")
+
+    survivors = [c.callback.get("text") for c in mgr._queue]
+    assert len(survivors) == pd.QUEUED_CUE_MAX_COUNT
+    # High-priority waiter survives; the newest low-priority cue is the victim.
+    assert "important" in survivors
+    assert f"noise-{pd.QUEUED_CUE_MAX_COUNT - 1}" not in survivors
+    assert "noise-0" in survivors
+
+
+def test_byte_axis_still_acks_the_cues_it_drops():
+    """Dropped cues must be told, same as a TTL drop."""
+    from main_logic import proactive_delivery as pd
+
+    delivered = []
+    mgr = _make(delivered)
+    per_cue = pd.CALLBACK_IMAGE_MAX_TOTAL_BYTES
+    keys = []
+    for i in range(6):
+        keys.append(mgr.submit(_img_cue_payload(per_cue, "I"), priority=5, coalesce_key=f"img{i}"))
+
+    assert any(k for k in keys), "byte-axis eviction must report evicted keys"


### PR DESCRIPTION
承接 #2835 review 中留下的三条遗留项。其中两条确认为缺陷并修复，第三条经实证诊断**不成立**，只保留了引发误判的 docstring 修正。

## 改动概述 / Summary

| 遗留项 | 结论 | 本 PR 动作 |
|---|---|---|
| 队列字节预算淘汰了不占字节的纯文本 cue | 属实（medium） | 拆成两条轴，字节轴只在带图 cue 里挑淘汰对象 |
| 纯图片 push 发出空 text 的 HUD 通知 | 属实（low） | HUD 分支恢复「必须有文本」前提 |
| standalone 插件服务器端口回落未跨进程发布 | **不成立** | 不改代码，只修正误导性 docstring |

## 回归报告 / Regression Report

### 改动与必要性

**1. `main_logic/proactive_delivery.py::_enforce_queue_budget`**

原来是一个 `while (条数超 OR 字节超)` 循环，共用一条 victim 规则 `max(sort_key)`（= 最后才会释放的那条）。这条规则对**条数轴**成立——每条 cue 都占一个槽位，删谁都推进；对**字节轴**不成立——只有带图 cue 占字节预算。

字节轴上 `max(sort_key)` 几乎必然选中纯文本 cue：文本 cue 数量占多数，而系统里优先级最低的恰恰是首方文本——`main_logic/topic/delivery.py` 的 topic hook 硬编码 `priority: -20`，比「插件未设优先级」归一化出的 0 还低。删掉它释放 0 字节，循环不收敛，于是持续吞噬文本 cue，直到本该被约束的图片 cue 终于进入射程。

实测旧版：40 条文本 cue + 8 条满额图片 cue → 队列被削到 **4**（深度上限是 50），40 条文本全部 ack(False)。

这不是静默丢弃：topic hook 在这个 ack 上 resolve 投递 future 并烧掉它的一次性配额。所以选错 victim 的代价，落在了从未碰过图片的首方功能上；触发条件只是「有插件往繁忙对话里推图片」——而这正是字节上限当初被加进来要应对的场景。

**2. `app/main_server/character_runtime.py` HUD 分支**

投递块上方的闸从 `if text:` 放宽成 `if text or deferred_callback_images:`，是为了让纯图片 push 能进 LLM 通道（那条通道确实把图片当有效载荷）。HUD 分支共用这个闸，但它只有文本渲染面、没有图片 sink，于是纯图片 push 开始发出 `{"type": "agent_notification", "text": ""}`。

**3. `config/network.py::resolve_user_plugin_base` docstring**

原文写「when the preferred port is busy the plugin server binds elsewhere and publishes the real port」，读起来像是服务器自己仲裁端口、事后广播。事实不是这样，而且这个措辞描述的是一个**不存在且行不通**的设计：一个自行改绑的服务器只能把端口写进自己进程的 environ，兄弟进程永远看不到。

这条措辞已经产生了实际成本：自动 reviewer 针对这一行提了 finding（"publish the fallback media port across processes"），追查它花掉一整轮调查才确认真相——端口仲裁只发生一次，在 `launcher_core.runtime.apply_port_strategy`，早于所有 spawn；插件 HTTP 应用由 agent_server 通过 `_start_embedded_user_plugin_server` 进程内托管，**完全不做回落**，绑不上就直接失败。

### 前后行为

- **字节轴淘汰**：改前，字节超限时按全局 `max(sort_key)` 选人，纯文本 cue 被逐条 ack(False) 删光才轮到图片 cue。改后，字节轴的候选集限定为 `_cue_image_bytes(c) > 0` 的 cue，每轮必然使总量严格下降。**条数轴规则逐字未动**，条数超标期间的淘汰序列与改前完全一致。
- 两轴执行顺序为「先条数、后字节」：释放字节只会让队列变短，不可能把条数轴重新顶over，因此无需回环。
- 日志 `reason=queue_budget` 拆成 `queue_depth` / `queue_bytes`，线上可区分是哪条轴触发。全仓 grep 无消费方依赖旧字符串。
- **HUD**：改前，纯图片 + `visibility` 含 `"hud"` + `ai_behavior="respond"` 会发一条空 text 的 agent_notification。改后跳过并记 debug 日志。图片**不受影响**——它挂在上方构建的 proactive callback 上，投递路径未变。
- 严重度如实说明：前端 `app-websocket.js` 的 `if (notifMsg)` 本来就把空 text 整条挡掉，所以这在今天是一帧浪费的 WS 流量，而不是用户可见的空 toast。自带插件也都打不中（带图 push 一律 `visibility=[]`；活跃的 `visibility=["hud"] + respond` 发送方永远带文本）。可达面是按新图片 API 编写的第三方插件——这足以构成「不该继续发这帧」的理由，但不必夸大成正在冒烟的回归。

### 潜在回归点与控制

- **条数轴不能被误伤**：新增 `test_depth_axis_victim_rule_is_unchanged` 断言幸存者集合（高优先级等待者存活、最新的低优先级 cue 先走、同优先级 FIFO 保序）。既有的 `test_an_important_waiting_cue_survives_a_flood_of_trivial_ones` / `test_budget_eviction_reports_the_keys_it_dropped` / `test_queue_depth_is_bounded_and_drops_are_acked` 全部原样通过。
- **不能死循环**：候选集判据是 `_cue_image_bytes(c) > 0` 而非「有没有 media_images 这个键」，所以每轮必然让总量严格变小。`carriers` 为空的分支是记账兜底（字节只可能来自 carriers），不是可达路径，走到就记 warning 并退出而非空转。
- **字节轴放行后队列变满**：这是本次修复的目的，但下游要扛得住。`split_callbacks_by_image_budget` 已经把单轮释放的图片切成「可交付前缀 + overflow」，纯文本 cue 不占图片预算，所以单轮请求的图片量不变；多出来的文本 cue 会进同一轮 instruction 使该轮文本变长。这本就是它们应得的行为，不该靠误杀文本来顺带压制。
- **`evicted_keys` 契约不变**：两条轴走同一个 `_evict`，照旧 append `coalesce_key`。改后被淘汰的 key 变少，方向上只会让 owner 少做 stale 回收而非多做。
- **HUD 修法不能反向误伤**：判据必须是「没有文本」而不是「这条 push 带了图片」，否则带图的礼物通知会丢掉 toast。为此配了对偶用例 `test_push_with_text_and_images_still_emits_its_hud_toast`。

### 为什么第三条不修

诊断结论：Codex 把回落逻辑的归属搞错了。实证如下（均为实跑）：

- 占住 48916 后调用真实的 `apply_port_strategy()`，它选中 48919 并在 spawn 前写入 `os.environ["NEKO_USER_PLUGIN_SERVER_PORT"]`；新起的干净子进程里 `resolve_user_plugin_base()` 与 `USER_PLUGIN_BASE` **都**是 `http://127.0.0.1:48919`。回落端口确实跨进程发布了。
- 把该 env 设成 48926 并占住它，调用真实的 `_start_embedded_user_plugin_server()`：抛 RuntimeError 启动失败，不回落、不改 env。生产唯一路径不存在「悄悄换端口」。
- `plugin/user_plugin_server.py` 的私有回落只存在于 `if __name__ == "__main__"` 块，而全仓没有任何 shipped 启动路径以 `__main__` 方式跑它（Electron 走 launcher.py，Docker 直接 `python -m app.agent_server`，PyInstaller spec 只是 hiddenimport）。

补充一点边界澄清：这条与 #2835 已记为「已判定不改」的 `/media/` 白名单接受任意 loopback 端口**不是同一根因**（前者管「反代往哪个端口取」，后者管「肯不肯认这个 URL」），不应被并进那条；但既然判定不可达，两条都不需要动。

诊断顺带撞出一条**不在本 PR 范围**的观察，记录备查：standalone 那段回落用 `_find_available_port(host, 48916)` 从 48916 线性向上扫，实测直接落到 **48917 = AGENT_MQ_PORT**，完全不认 `launcher_core/runtime.py` 的 `AVOID_FALLBACK_PORTS` 保留区。因为该入口无 shipped 路径，这里不处理。

## 测试 / Testing

- 定向回归：`tests/unit/` 下 `proactive / plugin_image / passthrough / role_placeholder / voice_bridge / music_allowlist / topic` 全集 —— **3566 passed, 4 skipped**
- `tests/unit/test_proactive_delivery.py` —— 68 passed（含新增 5 例）
- `tests/unit/test_plugin_image_delivery.py` —— 含新增 2 例
- Ruff：通过
- `check_module_layering` / `check_async_blocking` / `check_core_contracts`：exit 0
- `check_docstring_no_cjk --base origin/main`（commit 后跑）：exit 0

### 变异验证

新增护栏全部做了 A/B，确认不是空转：

| 变异 | 预期变红 | 实际 |
|---|---|---|
| 字节轴退回共用 victim 池 | 2 条字节轴用例 | ✅ |
| 字节轴 `max` → `min` | `..._victim_is_the_last_image_cue_to_release` | ✅ |
| 条数轴 `max` → `min` | `..._depth_axis_victim_rule_is_unchanged` + 2 条既有 | ✅ |
| HUD 空文本守卫失效 | `..._does_not_emit_an_empty_hud_toast`（对偶用例保持绿） | ✅ |

**新增用例里 submit 的顺序是承重的**：`_enforce_queue_budget` 在每次 submit 时都跑，若先提交图片 cue，它们会在任何文本 cue 存在之前就被削进预算，共用池与分离池的行为**完全一致**——这版测试的初稿正因如此在未修复的代码上通过了。改成文本先入队才使两版分叉。这一点已写进测试注释，避免后人「整理」时把顺序调回去。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 仅包含图片的 HUD 推送不再显示空白通知，图片仍会正常投递。
  * 队列容量和图片数据预算分别管理，超限时优先移除可释放图片空间的项目。
  * 队列淘汰继续遵循既有优先级和先进先出规则，并提供更准确的丢弃反馈。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->