### PR TITLE
跟进 #2835 之后失效的 push_message v2 注释、测试名与一条 frontend 断言

### DIFF
--- a/app/main_server/character_runtime.py
+++ b/app/main_server/character_runtime.py
@@ -1463,6 +1463,18 @@ async def _handle_agent_event(event: dict):
                 # orthogonal question of whether a HUD toast also fires, so
                 # visibility=["chat","hud"] lights both sinks and
                 # visibility=["chat"] only the chat one.
+                #
+                # ai_behavior is deliberately NOT read here. It used to be:
+                # a local `_ai_behavior` fed a chat branch gated on
+                # visibility=="chat" AND ai_behavior=="blind", which #2835
+                # removed when chat rendering moved above and stopped caring
+                # about ai_behavior. The variable outlived that branch as a
+                # dead assignment and is now gone. If you find yourself adding
+                # it back, check first whether the thing you want actually
+                # belongs in the chat-render block above -- the HUD gate is
+                # visibility-only by design, and reintroducing an ai_behavior
+                # read here would silently re-couple two axes the v2 schema
+                # defines as orthogonal.
                 _vis_raw = event.get("visibility")
                 _vis_present = isinstance(_vis_raw, list)
                 _vis = _vis_raw if _vis_present else []

--- a/app/main_server/character_runtime.py
+++ b/app/main_server/character_runtime.py
@@ -685,7 +685,8 @@ async def join_sync_connector_tasks(timeout: float = 3.0) -> list[str]:
     return pending
 
 
-# 兼容别名：旧名 join_sync_connector_threads 在文件内有调用，先保留 alias 减小 diff
+# 兼容别名：旧名 join_sync_connector_threads 仍被 app/main_server/__init__.py 引用
+# （上帝文件拆包时调用点搬走了，别名留在定义侧），删名字前先改那边
 join_sync_connector_threads = join_sync_connector_tasks
 
 
@@ -1029,8 +1030,9 @@ async def _handle_agent_event(event: dict):
             return
         if event_type in ("task_result", "proactive_message"):
             raw_text = event.get("text") or ""
-            # Why: chat-blind passthrough must preserve verbatim whitespace;
-            # only the empty-check / log / callback paths use the stripped form.
+            # Why: the chat render must preserve verbatim whitespace (the
+            # plugin authored the text, indentation included); only the
+            # empty-check / log / callback paths use the stripped form.
             text = raw_text.strip()
 
             # v2 push_message: media parts (image/audio/video) ride on the
@@ -1386,8 +1388,10 @@ async def _handle_agent_event(event: dict):
                 # internal deadline on the receiving host instead.
                 expires_at_monotonic = _resolve_callback_expiry(event, origin)
                 # Proactive-delivery hints from push_message (priority +
-                # coalesce_key). Lower priority = more urgent; unspecified
-                # (0) is normalised to a neutral band by the manager.
+                # coalesce_key). HIGHER number = more important; a missing or
+                # unparseable priority falls back to 0 = least important. The
+                # manager does not rescale it (effective_priority just int()s
+                # the value and sorts by (-priority, seq)).
                 try:
                     # OverflowError: JSON Infinity/-Infinity → float → int() raises;
                     # must not let a malformed priority drop the whole callback.
@@ -1453,21 +1457,15 @@ async def _handle_agent_event(event: dict):
                         event_type,
                     )
 
-                # v2 chat+blind passthrough: render verbatim into chat
-                # bubble WITHOUT entering chat-LLM context. Distinct from
-                # mirror_assistant_output (which writes to sync_message_queue
-                # so cross_server may add an AIMessage). Both this branch
-                # and the HUD agent_notification below can fire when
-                # visibility=["chat","hud"] — they're orthogonal sinks.
-                #
-                # Gated on visibility containing "chat" AND ai_behavior=="blind"
-                # because non-blind ai_behavior already enqueues the LLM
-                # callback above and the AI's own response is what the
-                # user should see in the chat bubble.
+                # Visibility, read once for the HUD gate below. Chat
+                # rendering of the plugin's own parts already happened
+                # further up, for every ai_behavior; what is left here is the
+                # orthogonal question of whether a HUD toast also fires, so
+                # visibility=["chat","hud"] lights both sinks and
+                # visibility=["chat"] only the chat one.
                 _vis_raw = event.get("visibility")
                 _vis_present = isinstance(_vis_raw, list)
                 _vis = _vis_raw if _vis_present else []
-                _ai_behavior = (event.get("ai_behavior") or "").strip()
                 # Plugin chat output is rendered above, as a system message,
                 # for every ai_behavior. It used to go through
                 # passthrough_to_chat_bubble here, which wore the assistant's

--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -152,8 +152,8 @@ class TurnMixin:
         # ``_tts_done_queued_for_turn=True`` 直接 early-return，下一轮的 TTS
         # flush sentinel 永远不入队，server 拿不到 ``tts.flush`` 句尾音频
         # 可能挂在 buffer 里、长句 utterance 不会 finalize。``handle_new_message``
-        # 在 speech_stopped 路径也是这样 reset 的（[core.py:1214](main_logic/core.py:1214)），
-        # 这里和它对偶。
+        # 在 speech_stopped 路径也是这样 reset 的（本文件同名方法；上帝文件
+        # main_logic/core.py 拆包后两者同住 main_logic/core/turn.py），这里和它对偶。
         self._tts_done_queued_for_turn = False
         self._tts_done_pending_until_ready = False
         async with self.lock:

--- a/plugin/server/messaging/proactive_bridge.py
+++ b/plugin/server/messaging/proactive_bridge.py
@@ -33,10 +33,17 @@ except Exception:  # pragma: no cover
 logger = get_logger("server.messaging.proactive_bridge")
 
 
-# Map (visibility, ai_behavior) → legacy delivery_mode the existing
-# main_server proactive_message handler understands.  ``visibility`` is
-# treated as a set; we only consult ``"hud"`` membership because
-# proactive_message always also fires the agent_notification HUD path.
+# Map ai_behavior → the legacy delivery_mode the existing main_server
+# proactive_message handler understands: respond → "proactive", read →
+# "passive", blind → "silent" (LLM channel skipped).
+#
+# ``visibility`` is NOT consulted here, despite the signature: it decides
+# where the plugin's own parts render, which is a separate question the
+# host answers on its own. Chat rendering is gated on "chat" membership in
+# ``_handle_agent_event``; the HUD agent_notification is gated on "hud"
+# membership there too, so a proactive_message no longer implies a HUD
+# toast. The parameter is kept so the call site reads as the full
+# (visibility, ai_behavior) pair the schema defines.
 def _resolve_delivery_mode(visibility: list[str], ai_behavior: str) -> str:
     if ai_behavior == "respond":
         return "proactive"
@@ -59,7 +66,13 @@ def _aggregate_text_parts(parts: list[dict[str, Any]]) -> str:
 
 
 def _media_parts(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Filter for image/audio/video parts (passed through to the AI session)."""
+    """Filter for image/audio/video parts.
+
+    The result is only used to decide whether this push carries a payload
+    worth forwarding (``has_ai_payload``). The canonical ``parts`` list is
+    what actually rides on the event; the host derives its own model and
+    chat views from it.
+    """
     out: list[dict[str, Any]] = []
     for p in parts:
         if not isinstance(p, dict):
@@ -216,8 +229,12 @@ class ProactiveBridge:
         parts = payload.get("parts") if isinstance(payload.get("parts"), list) else []
         # Proactive-delivery hints (priority ordering + coalescing). Carried
         # through to the main_server callback so ProactiveDeliveryManager can
-        # order/coalesce. Lower priority = more urgent; unspecified (0) is
-        # normalised to a neutral band downstream.
+        # order/coalesce. Repo-wide convention: HIGHER number = more
+        # important (bilibili gift/SC=9, memo reminder=8). A missing or
+        # unparseable priority falls back to 0 = least important, so a cue
+        # that never set one cannot preempt a cue that did. Nothing rescales
+        # it downstream — main_logic.proactive_delivery.effective_priority
+        # just int()s the value and the queue sorts by (-priority, seq).
         try:
             # OverflowError: plugin payload is boundary input; JSON
             # Infinity/-Infinity → non-finite float → int() raises. Must not
@@ -329,10 +346,12 @@ class ProactiveBridge:
                 "priority": priority,
                 "coalesce_key": coalesce_key,
             }
-            # When ai_behavior=blind we still want the HUD agent_notification
-            # to fire (handled by main_server's existing branch).  Setting
-            # delivery_mode="silent" tells the proactive_message handler to
-            # skip the LLM injection but keep the WS notif.
+            # delivery_mode="silent" (ai_behavior=blind) tells the
+            # proactive_message handler to skip the LLM injection. Whether a
+            # HUD agent_notification still fires is decided separately, by
+            # "hud" membership in visibility — blind + visibility=["chat"]
+            # renders the parts in chat and stays out of the HUD, and
+            # blind + visibility=[] produces no user-facing output at all.
             events_out.append(proactive_event)
 
         if not events_out:

--- a/static/app/app-chat-adapter.js
+++ b/static/app/app-chat-adapter.js
@@ -792,8 +792,12 @@
             emitCompactCaptionUpdate(streamingText);
         }
 
-        // Plugin chat passthrough can carry an image URL alongside text. It
-        // still participates in the normal assistant turn lifecycle, but the
+        // Reached only by a gemini_response frame carrying `blocks`, which
+        // today is emitted solely by LLMSessionManager.passthrough_to_chat_bubble
+        // — a helper with no production caller (see main_logic/core/turn.py).
+        // Plugin chat pushes render through chat_blocks / appendReactChatBlocks
+        // as system messages instead, so this branch is test-only for now.
+        // It still participates in the normal assistant turn lifecycle, and the
         // React host receives the already-structured blocks directly instead
         // of forcing them through the text sentence/markdown pipeline.
         if (sender === 'gemini' && structuredResponseBlocks.length > 0) {

--- a/tests/frontend/test_plugin_image_chat.py
+++ b/tests/frontend/test_plugin_image_chat.py
@@ -139,13 +139,17 @@ def test_display_only_plugin_image_uses_existing_host_retry(
 
     assert result["accepted"] is True
     assert result["beforeRestore"] == 0
+    # Plugin pushes queue in their own bucket while the host is unmounted:
+    # _PENDING_HOST_PLUGIN_MAX = 20 in static/app/app-chat-adapter.js (a burst
+    # of plugin pushes must not evict a waiting assistant message, so the two
+    # sources get separate caps). 55 pushes therefore keep the newest 20.
     mock_page.wait_for_function(
-        "window.reactChatWindowHost.getState().messages.length === 50"
+        "window.reactChatWindowHost.getState().messages.length === 20"
     )
     messages = mock_page.evaluate(
         "window.reactChatWindowHost.getState().messages"
     )
-    assert "host-startup-race-5" in messages[0]["id"]
+    assert "host-startup-race-35" in messages[0]["id"]
     assert "host-startup-race-54" in messages[-1]["id"]
     assert messages[0]["blocks"] == [
         {"type": "image", "url": _ONE_PIXEL_PNG}

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -1,24 +1,32 @@
-"""Tests for ``LLMSessionManager.passthrough_to_chat_bubble`` and the
-``main_server`` proactive_message → passthrough wiring.
+"""Tests for ``LLMSessionManager.passthrough_to_chat_bubble`` and for the
+``main_server`` proactive_message → chat-render wiring that replaced it.
 
-Background — see PR-1110 (squashed ``c49d6fe89``) and PR-4 brief:
+Background — see PR-1110 (squashed ``c49d6fe89``), the PR-4 brief, and
+#2835 (``1d654e302``), which rewired the host side:
 
 The plugin v2 schema (``plugin/sdk/shared/core/push_message_schema.py``)
-defines ``visibility=["chat"]`` + ``ai_behavior="blind"`` to mean
-"render verbatim into the chat bubble, but never feed to the LLM."
-PR-4 implements that path — distinct from PR-1110's mirror channel,
-which DOES enter chat history as an ``AIMessage``.
+defines ``visibility=["chat"]`` to mean "render the plugin's own parts
+verbatim in chat", orthogonally to ``ai_behavior``. The host renders that
+through :py:meth:`LLMSessionManager.render_chat_blocks` as a source-labelled
+SYSTEM message, for every ``ai_behavior`` — a plugin bubble must not wear
+the assistant's identity, and with ``ai_behavior="blind"`` the content never
+reaches the model at all.
+
+``passthrough_to_chat_bubble`` was the previous receiver of that branch and
+has NO production caller left; the unit tests below still cover it directly,
+because it remains the only way to render verbatim text *as the assistant*
+without touching chat history.
 
 Two distinguishing assertions matter:
 
 * mirror writes to ``sync_message_queue`` (cross_server picks it up
   and may inject into chat history).
-* passthrough does NOT — frontend sees the bubble, LLM never does.
+* passthrough / render_chat_blocks do NOT — frontend sees the bubble,
+  LLM never does.
 
 We construct the manager via ``__new__`` (skipping the heavy real
 ``__init__`` that needs a config_manager) and stub only the attributes
-``passthrough_to_chat_bubble`` reads: ``websocket``, ``lanlan_name``,
-``sync_message_queue``.
+these helpers read: ``websocket``, ``lanlan_name``, ``sync_message_queue``.
 """
 
 from __future__ import annotations
@@ -287,21 +295,24 @@ async def test_passthrough_synthesizes_turn_id_when_missing():
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Integration-ish: main_server proactive_message → passthrough wiring
+# Integration-ish: main_server proactive_message → chat-render wiring
 # ──────────────────────────────────────────────────────────────────────
 #
-# Verifies that the visibility=["chat"] + ai_behavior="blind" branch in
-# ``_handle_agent_event`` actually invokes ``passthrough_to_chat_bubble``
-# on the resolved manager. We don't run the main_server package wholesale —
+# Verifies that the visibility contains "chat" branch in
+# ``_handle_agent_event`` invokes ``render_chat_blocks`` — not
+# ``passthrough_to_chat_bubble`` — on the resolved manager. The branch is
+# gated on visibility alone; ai_behavior only decides whether the same parts
+# also reach the model. We don't run the main_server package wholesale —
 # we extract the function under test and call it with a stubbed event +
 # a stubbed manager.
 
 
 @pytest.mark.unit
-async def test_main_server_proactive_chat_blind_invokes_passthrough(monkeypatch):
+async def test_main_server_proactive_chat_blind_renders_system_blocks(monkeypatch):
     """main_server's _handle_agent_event with visibility=["chat"] +
-    ai_behavior="blind" must call mgr.passthrough_to_chat_bubble exactly
-    once with the event's text, source_kind, and task_id."""
+    ai_behavior="blind" must call mgr.render_chat_blocks exactly once with
+    the event's text, source_kind, and task_id — and must NOT reach for
+    passthrough_to_chat_bubble, which would wear the assistant's identity."""
     # Late import: main_server is heavy; only import when needed.
     from app import main_server
 
@@ -353,8 +364,8 @@ async def test_main_server_proactive_chat_blind_invokes_passthrough(monkeypatch)
 
 @pytest.mark.unit
 async def test_main_server_proactive_chat_blind_preserves_verbatim_whitespace(monkeypatch):
-    """Verbatim contract: passthrough must receive the RAW event text with
-    leading/trailing whitespace intact, even though the empty-check / log /
+    """Verbatim contract: the chat render must receive the RAW event text
+    with leading/trailing whitespace intact, even though the empty-check / log /
     callback paths in _handle_agent_event use a stripped local. CodeRabbit
     PR #1128 r3182231689 — pre-fix the call shared the stripped local and
     silently swallowed surrounding whitespace/newlines."""
@@ -765,31 +776,31 @@ async def test_visibility_absent_field_legacy_fires_hud(monkeypatch):
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Turn-end emission after chat-blind passthrough (codex P2 — PR #1128)
+# NO turn-end after a plugin chat render (was codex P2 — PR #1128)
 # ──────────────────────────────────────────────────────────────────────
 #
-# Background: ``passthrough_to_chat_bubble`` sends a ``gemini_response``
+# History: ``passthrough_to_chat_bubble`` sends a ``gemini_response``
 # frame, which on the frontend opens an assistant turn lifecycle via
 # ``ensureAssistantTurnStarted``. Without a matching ``turn end`` /
-# ``turn end agent_callback`` system event, the assistant bubble stays
-# "in-progress" and proactive rescheduling never fires. The canonical
-# helper that emits this turn-end is
-# :py:meth:`LLMSessionManager.handle_proactive_complete`; the direct
-# task_result reply path in character_runtime.py already calls it. The
-# chat-blind passthrough branch must do the same.
+# ``turn end agent_callback`` system event, the assistant bubble stayed
+# "in-progress" and proactive rescheduling never fired — so back when the
+# chat-blind branch went through that helper, it had to emit a turn-end via
+# :py:meth:`LLMSessionManager.handle_proactive_complete`.
 #
-# The HUD-only branch (agent_notification) does NOT open an assistant
-# turn lifecycle on the frontend, so it does NOT need turn-end. This
-# means the dedup strategy is "emit once iff chat passthrough fired",
-# not "per-sink emit with explicit dedup".
+# Since #2835 the branch sends a ``chat_blocks`` frame instead, which opens
+# no assistant turn — exactly like the HUD-only branch (agent_notification).
+# There is therefore no lifecycle to close on either sink, and emitting a
+# turn-end would close one that never started. The tests below lock in
+# "no turn-end", which is the inverse of what they originally asserted.
 
 
 @pytest.mark.unit
-async def test_chat_blind_passthrough_emits_turn_end_via_proactive_complete(monkeypatch):
-    """visibility=["chat"] + blind → handle_proactive_complete called
-    exactly once after passthrough_to_chat_bubble returns. This is the
-    codex P2 regression: prior code dispatched the gemini_response bubble
-    but never closed the assistant turn lifecycle on the frontend.
+async def test_chat_blind_render_emits_no_turn_end(monkeypatch):
+    """visibility=["chat"] + blind → render_chat_blocks fires and
+    handle_proactive_complete is NOT called. The chat_blocks frame opens no
+    assistant turn, so there is none to close; the codex P2 regression this
+    used to guard (gemini_response bubble left "in-progress") can no longer
+    happen on this path.
     """
     from app import main_server
 
@@ -828,11 +839,11 @@ async def test_chat_blind_passthrough_emits_turn_end_via_proactive_complete(monk
 
 
 @pytest.mark.unit
-async def test_chat_and_hud_blind_emits_turn_end_exactly_once(monkeypatch):
-    """visibility=["chat","hud"] + blind → BOTH chat passthrough AND HUD
-    fire (per the existing visibility contract), but turn-end must be
-    emitted EXACTLY ONCE. The HUD branch doesn't open an assistant turn,
-    so a single emit gated on the chat passthrough is correct.
+async def test_chat_and_hud_blind_emits_no_turn_end(monkeypatch):
+    """visibility=["chat","hud"] + blind → BOTH the chat render AND the HUD
+    fire (per the existing visibility contract), and neither emits a
+    turn-end: a system chat bubble opens no assistant turn, and the HUD
+    never did.
     """
     from app import main_server
 
@@ -953,8 +964,8 @@ async def test_chat_blind_passthrough_unexpected_raise_skips_turn_end(monkeypatc
 
 
 @pytest.mark.unit
-async def test_chat_blind_passthrough_real_helper_swallowed_send_skips_turn_end(monkeypatch):
-    """Lower-level integration: drive the REAL ``passthrough_to_chat_bubble``
+async def test_chat_blind_render_real_helper_swallowed_send_skips_turn_end(monkeypatch):
+    """Lower-level integration: drive the REAL ``render_chat_blocks``
     against a websocket whose ``send_json`` raises. The helper must
     swallow the exception, return False, and ``main_server`` must NOT
     call ``handle_proactive_complete``.

--- a/tests/unit/test_role_placeholder_substitution.py
+++ b/tests/unit/test_role_placeholder_substitution.py
@@ -10,8 +10,9 @@ same substitution helper:
    hot-swap rendering into ``prime_context``.
 3. ``app/main_server/character_runtime.py`` direct_reply — plugin text bypassing the LLM and
    going verbatim to TTS via ``send_lanlan_response``.
-4. ``app/main_server/character_runtime.py`` ``passthrough_to_chat_bubble`` — ``visibility=["chat"]``
-   + ``ai_behavior="blind"`` blind chat-bubble passthrough.
+4. ``app/main_server/character_runtime.py`` ``render_chat_blocks`` — the text
+   blocks of a ``visibility=["chat"]`` push, rendered as a system message for
+   every ``ai_behavior`` (blind included).
 5. ``app/main_server/character_runtime.py`` HUD ``agent_notification`` — ``visibility=["hud"]``
    toast text.
 
@@ -252,8 +253,8 @@ async def test_main_server_direct_reply_substitutes_master_name(monkeypatch, cap
 @pytest.mark.unit
 async def test_main_server_chat_passthrough_substitutes_master_name(monkeypatch):
     """visibility=["chat"] + ai_behavior="blind" → text goes verbatim to
-    ``passthrough_to_chat_bubble`` (skipping the LLM). Without substitution
-    the literal placeholder renders in the chat bubble. This is the codex
+    ``render_chat_blocks`` (skipping the LLM). Without substitution the
+    literal placeholder renders in the chat bubble. This is the codex
     P2 finding on PR #1422."""
     from app import main_server
 


### PR DESCRIPTION
## 改动概述 / Summary

#2835 把 `visibility=["chat"]` 的插件推送从 `passthrough_to_chat_bubble`（助手气泡 + 开 assistant turn）改成 `render_chat_blocks`（source-labelled system chip，不开 turn），并让 chat 渲染只按 `visibility` 门控、与 `ai_behavior` 无关。本 PR 收拾停在改动之前的注释、测试名和一条真会挂的断言。

## ⚠️ 唯一的代码删除：`_ai_behavior` 局部变量

除注释外，本 PR 只删了一行可执行代码：`app/main_server/character_runtime.py` 的 `_ai_behavior` 赋值。

**它为什么在那儿**：#2835 之前，那个位置下面有一条 chat 渲染分支，门控条件是 `visibility` 含 `"chat"` **且** `ai_behavior == "blind"`，`_ai_behavior` 就是为它取的值。

**为什么现在能删**：#2835 把 chat 渲染整体上移，并改成只看 `visibility`、对 `respond`/`read`/`blind` 一视同仁。分支被删掉了，`_ai_behavior` 却留了下来——赋值后全文件零引用（`grep -n "_ai_behavior\b"` 只命中该行本身）。

**给后来人的提示**（已写进该处注释，不只在 PR 描述里）：这个位置**刻意不读** `ai_behavior`。如果你想把它加回来，先确认要做的事是不是该放进上方的 chat-render 块——HUD 闸门按设计只看 `visibility`，在这里重新读 `ai_behavior` 等于把 v2 schema 明确定义为正交的两个轴又悄悄耦合回去。

## 其余改动

**真实缺陷（不只是措辞）**

- `tests/frontend/test_plugin_image_chat.py` 仍按「待发队列共享 50」断言，而 #2835 同一个 commit 把队列改成按来源分桶（`_PENDING_HOST_PLUGIN_MAX = 20`）。55 条 plugin push 只会留下 20 条，该用例必然在 `wait_for_function` 超时。CI 不跑 `tests/frontend`（`unit-tests.yml` 只跑 `tests/unit`，`plugin-tests.yml` 只跑 `plugin/tests`），所以没有被拦下。

**注释纠错**

- `proactive_bridge.py` `_resolve_delivery_mode` 头注释声称「只看 visibility 的 hud 成员」「proactive_message 总会触发 HUD」——函数体根本没读 `visibility`，且 HUD 今天由宿主按 `"hud"` 成员单独门控（`character_runtime.py` `_hud_allowed`）。
- **priority 方向说反了**：仓库全局约定是数字越大越重要（bilibili gift/SC=9、memo reminder=8），缺失/非法回落 0 = 最不重要，下游 `effective_priority` 只做 `int()`、队列按 `(-priority, seq)` 排，没有任何「归一化到中性档」。桥接层与 `character_runtime.py` 两处孪生注释同改。
- `character_runtime.py` 描述「chat+blind passthrough 分支」的 11 行注释，所描述的分支已被 #2835 删除。
- `app-chat-adapter.js` 的 `structuredResponseBlocks` 分支被写成「插件图片直出入口」，实际它只由已无生产调用者的 `passthrough_to_chat_bubble` 触发。
- `turn.py` 一处注释链接指向上帝文件拆分前的 `main_logic/core.py`（该文件已不存在）。
- `character_runtime.py` 的 `join_sync_connector_threads` 别名注释说「文件内有调用」，调用点在拆包时已搬到 `app/main_server/__init__.py`。

**测试名/docstring 与用例体断言方向相反**（体已随 #2835 更新，名字没有）：四个 `test_*_passthrough_*` 用例今天断言的是「不调用 passthrough / 不发 turn-end」。

**刻意未改**：`docs/changelog/plugin-push-message-v2.md` 与 `docs/design/proactive-chat-domain-refactor-design.md` 都是带日期戳的历史快照（分别注明 verified 2026-07-16 / 基于 2026-07-15 的仓库结构），按当前状态改写等于伪造历史。

## 回归报告 / Regression Report

**改了什么**：`app/main_server/character_runtime.py` 与 `main_logic/core/turn.py` 的改动**只有注释**，外加删除上文详述的死局部变量 `_ai_behavior`。没有任何控制流、条件、参数或返回值变化。

**为什么必要**：这些注释描述的分支已被 #2835 删除，priority 方向更是与实现相反——照注释写新代码会把最紧急的 cue 排到最后。注释错得越具体，误导性越强。

**前后行为**：运行时行为不变。`_ai_behavior` 删除前后都不参与任何判断；HUD 门控继续读 `_vis` / `_vis_present`。

**潜在回归**：
- 死变量删除：若将来有人想按 `ai_behavior` 再加分支，需要自己重新取值——删除点的注释已写明为什么这里刻意不读它，以及该先去哪儿确认。
- 测试重命名：四个用例改名，无外部引用（全仓 grep 旧名只命中定义行本身），`-k` 过滤脚本、文档、workflow 均未引用。
- `tests/frontend` 断言修正把一个必然超时的用例改成能过的用例；该目录不在 CI 中，需本地带 playwright 跑。

**验证**：`uv run pytest tests/unit/test_passthrough_to_chat_bubble.py tests/unit/test_role_placeholder_substitution.py -q` → 42 passed。`uv run python scripts/check_docstring_no_cjk.py --base origin/main` → 无输出（通过）。

## 测试 / Testing

- `uv run pytest tests/unit/test_passthrough_to_chat_bubble.py tests/unit/test_role_placeholder_substitution.py -q`：42 passed。
- `tests/frontend/test_plugin_image_chat.py` 的断言修正依据 `static/app/app-chat-adapter.js` 的 `_PENDING_HOST_ASSISTANT_MAX = 50` / `_PENDING_HOST_PLUGIN_MAX = 20` 与 `_queuePendingHostMessage` 的同类裁剪逻辑推出（55 条 plugin push → 保留最新 20 条，最旧为 `host-startup-race-35`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 聊天渲染与 HUD 通知现可独立控制，支持仅显示聊天、仅显示 HUD 或不产生可见输出。
  * AI 行为与消息可见性分离，盲模式下仍可按配置发送 HUD 通知。
  * 消息优先级规则更加明确，无法识别时采用默认优先级。

* **Bug 修复**
  * 优化主机启动期间插件图片消息的保留数量，避免刷新后丢失过多最新消息。

* **测试**
  * 更新聊天消息、占位符替换、HUD 通知及回合结束场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->