### PR TITLE
fix(ci): 修复 nightly 桌面构建在 macOS 上的 bash 3.2 空数组崩溃

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1094,6 +1094,12 @@ jobs:
             fi
           fi
 
+      # 三个 Portable 更新步骤都用 `PREVIOUS_ARGS` 这个可能为空的数组来传可选的
+      # `--previous`。展开必须写成 `${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}`：
+      # macOS runner 的 /bin/bash 是 3.2，在 `set -u` 下展开空数组会直接报
+      # `PREVIOUS_ARGS[@]: unbound variable`（bash 4.4 才修）。写成 `"${PREVIOUS_ARGS[@]}"`
+      # 在 Linux / Git Bash（bash 5）上是绿的，只有 macOS 两个 job 会红 —— #2439 就是
+      # 这样让 nightly 桌面构建的 mac-x64 / mac-arm64 连续红了下去。
       - name: Create Windows Portable full and differential update assets
         if: runner.os == 'Windows'
         working-directory: electron-app
@@ -1109,7 +1115,7 @@ jobs:
             --dir dist/win-unpacked \
             --version "$PORTABLE_VERSION" \
             --out dist/portable-update \
-            "${PREVIOUS_ARGS[@]}"
+            ${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
 
       - name: Create macOS/Linux Portable directory update assets
         if: runner.os != 'Windows'
@@ -1134,7 +1140,7 @@ jobs:
             --arch "$ARCH" \
             --version "$PORTABLE_VERSION" \
             --out dist/portable-update \
-            "${PREVIOUS_ARGS[@]}"
+            ${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
 
       - name: Create Linux AppImage full and differential update assets
         if: runner.os == 'Linux'
@@ -1154,7 +1160,7 @@ jobs:
             --arch x64 \
             --version "$PORTABLE_VERSION" \
             --out dist/portable-update \
-            "${PREVIOUS_ARGS[@]}"
+            ${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
 
       - name: List build output
         working-directory: electron-app/dist


### PR DESCRIPTION
## 问题

nightly 的 **Build Desktop App (Cross-Platform)** 从 2026-08-07 起就没有绿过。最近这一段（build-python macOS 的 `IndentationError` 修掉之后）稳定卡在同一个地方 —— `mac-x64` / `mac-arm64` 两个 `build-electron` job：

```
/Users/runner/work/_temp/xxxx.sh: line 10: PREVIOUS_ARGS[@]: unbound variable
##[error]Process completed with exit code 1.
```

## 原因

#2439（`f1bc33bfa`，2026-08-06）加的三个 Portable 更新步骤都是这个形状：

```bash
set -euo pipefail
PREVIOUS_ARGS=()
if [[ -f "$PREVIOUS" ]]; then PREVIOUS_ARGS=(--previous "$PREVIOUS"); fi
node scripts/create-portable-update.js ... "${PREVIOUS_ARGS[@]}"
```

macOS runner 的 `/bin/bash` 是 **3.2**（Apple 因为 GPLv3 一直没升）。bash < 4.4 在 `set -u` 下展开空数组 `"${arr[@]}"` 会当成未绑定变量直接报错，4.4 才改成展开为零个参数。Linux runner 和 Windows 的 Git Bash 都是 bash 5，所以同一段脚本在那两边一路绿灯，**只有 macOS 两个 job 会红**。

而且这条路径是必然命中的：nightly 不传 `previous_portable_release`，`previous-portable/` 里没有 manifest，`PREVIOUS_ARGS` 必然为空。

时间线也对得上 —— 最后一次绿的 nightly `d54016535` 不含 `f1bc33bfa`，第一次红的 `fc0b5ed7f` 含。

## 改动

三处统一改成 bash 3.2 也安全的展开：

```bash
${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
```

空数组 → 零个参数；非空 → 原样保留分词和路径里的空格。三个步骤（Windows / macOS+Linux / Linux AppImage）一起改保持对偶，虽然只有 macOS 那条现在会红。

## 验证

把 macOS/Linux 那一步的脚本原样抽出来跑（stub 掉 `create-portable-update.js`）：

- 无 previous manifest（就是线上崩的那种情况）→ `--dir ... --platform darwin --arch arm64 --version 9.9.9 --out dist/portable-update`，不再报错
- 有 previous manifest → 末尾正确追加 `--previous previous-portable/previous-mac_arm64-manifest.json`

`bash 3.2` 的行为差异没法在本机复现（Windows 上只有 bash 5），依据是 CI 日志里 macOS 独有的报错 + bash 4.4 的 changelog。合并后看下一次 nightly 即可确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 macOS 构建在严格错误处理模式下可能因空参数导致失败的问题。
  * 提升 Windows Portable、macOS/Linux Portable 及 Linux AppImage 更新流程的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->