### PR TITLE
fix(plugin): bind Market evidence to run attempts

### DIFF
--- a/.github/workflows/plugin-market-release.yml
+++ b/.github/workflows/plugin-market-release.yml
@@ -111,6 +111,7 @@ jobs:
               "version": os.environ["GITHUB_REF_NAME"].removeprefix("v"),
               "source_commit": os.environ["GITHUB_SHA"],
               "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "neko_repository": os.environ["NEKO_REPOSITORY"],
               "neko_ref": os.environ["NEKO_REF"],
               "neko_commit": os.environ["NEKO_COMMIT"],

--- a/.github/workflows/plugin-market-verify.yml
+++ b/.github/workflows/plugin-market-verify.yml
@@ -91,6 +91,7 @@ jobs:
               "plugin_id": os.environ["PLUGIN_ID"],
               "source_commit": os.environ["GITHUB_SHA"],
               "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "neko_repository": os.environ["NEKO_REPOSITORY"],
               "neko_ref": os.environ["NEKO_REF"],
               "neko_commit": os.environ["NEKO_COMMIT"],

--- a/plugin/tests/unit/test_plugin_market_workflows.py
+++ b/plugin/tests/unit/test_plugin_market_workflows.py
@@ -24,6 +24,10 @@ def test_reusable_verify_workflow_owns_the_market_checks_and_small_evidence() ->
     assert "check -r" in workflow
     assert "market-evidence.json" in workflow
     assert "Upload Market evidence" in workflow
+    assert (
+        '"workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"])'
+        in workflow
+    )
     assert '[[ ! "$PLUGIN_ID" =~ ^[a-z][a-z0-9_]*$ ]]' in workflow
 
 
@@ -44,6 +48,10 @@ def test_reusable_release_workflow_publishes_package_digest_evidence() -> None:
     assert "market-evidence.json" in workflow
     assert '"ref_type": os.environ["GITHUB_REF_TYPE"]' in workflow
     assert '"ref_name": os.environ["GITHUB_REF_NAME"]' in workflow
+    assert (
+        '"workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"])'
+        in workflow
+    )
     assert "softprops/action-gh-release" in workflow
     assert "fail_on_unmatched_files: true" in workflow
     assert '[[ ! "$PLUGIN_ID" =~ ^[a-z][a-z0-9_]*$ ]]' in workflow


### PR DESCRIPTION
## Summary

- Add workflow_run_attempt to verification Market evidence.
- Add workflow_run_attempt to release Market evidence.
- Add exact contract assertions for both reusable workflows.

Existing plugin repositories keep their current lightweight wrappers. Callers using the official reusable workflows at main receive the field on future runs without a repository update.

## 回归报告 / Regression Report

Before: rerun evidence included the stable workflow_run_id but omitted the incrementing attempt number, so a consumer could not bind it to one exact rerun.

After: both official evidence producers serialize GITHUB_RUN_ATTEMPT as an integer next to GITHUB_RUN_ID. No CLI template, plugin wrapper, schema version, packaging, tag, or release behavior changes. The only material failure mode is GitHub omitting its documented default variable, in which case the evidence-writing step fails closed instead of publishing ambiguous evidence.

## Validation

- plugin/tests/unit/test_plugin_market_workflows.py: 2 passed
- Complete plugin unit suite: 4197 passed, 26 skipped; 12 unrelated existing platform/environment failures in Galgame/Study/Windows capture, Web Search timing, and browser UI tests
- Standards review: 0 findings
- Spec review: 0 findings
- git diff --check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 市场发布与验证流程生成的证据记录现包含工作流运行尝试次数，便于准确追踪重复运行情况。

* **测试**
  * 增加了对运行尝试次数记录的自动验证，确保发布和验证流程行为一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->