### PR TITLE
修复插件生命周期超时误报网络错误

### DIFF
--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -28,6 +28,21 @@ describe('plugin hosted UI API', () => {
     })
   })
 
+  it.each([
+    ['startPlugin', '/plugin/demo%20plugin/start'],
+    ['reloadPlugin', '/plugin/demo%20plugin/reload'],
+  ] as const)('gives %s a dedicated lifecycle timeout and message', async (functionName, url) => {
+    postMock.mockResolvedValue({ success: true })
+    const pluginApi = await import('./plugins')
+
+    await pluginApi[functionName]('demo plugin')
+
+    expect(postMock).toHaveBeenCalledWith(url, undefined, {
+      timeout: 45000,
+      timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+    })
+  })
+
   it('preserves URLSearchParams when merging locale', async () => {
     const { getPlugins } = await import('./plugins')
     const input = new URLSearchParams([

--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -43,15 +43,14 @@ describe('plugin hosted UI API', () => {
     })
   })
 
-  it('gives reloadAllPlugins the dedicated lifecycle timeout and message', async () => {
+  it('does not let Axios truncate an aggregate reload', async () => {
     postMock.mockResolvedValue({ success: true })
     const { reloadAllPlugins } = await import('./plugins')
 
     await reloadAllPlugins()
 
     expect(postMock).toHaveBeenCalledWith('/plugins/reload', undefined, {
-      timeout: 45000,
-      timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+      timeout: 0,
     })
   })
 

--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -43,6 +43,18 @@ describe('plugin hosted UI API', () => {
     })
   })
 
+  it('gives reloadAllPlugins the dedicated lifecycle timeout and message', async () => {
+    postMock.mockResolvedValue({ success: true })
+    const { reloadAllPlugins } = await import('./plugins')
+
+    await reloadAllPlugins()
+
+    expect(postMock).toHaveBeenCalledWith('/plugins/reload', undefined, {
+      timeout: 45000,
+      timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+    })
+  })
+
   it('preserves URLSearchParams when merging locale', async () => {
     const { getPlugins } = await import('./plugins')
     const input = new URLSearchParams([

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -3,7 +3,7 @@
  */
 import { del, get, post } from './index'
 import type { AxiosRequestConfig } from 'axios'
-import { PLUGIN_LIFECYCLE_TIMEOUT } from '@/utils/constants'
+import { PLUGIN_LIFECYCLE_TIMEOUT, PLUGIN_RELOAD_ALL_TIMEOUT } from '@/utils/constants'
 import type {
   PluginMeta,
   PluginStatusData,
@@ -114,8 +114,7 @@ export function reloadAllPlugins(): Promise<{
   message: string
 }> {
   return post('/plugins/reload', undefined, {
-    timeout: PLUGIN_LIFECYCLE_TIMEOUT,
-    timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+    timeout: PLUGIN_RELOAD_ALL_TIMEOUT,
   })
 }
 

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -3,6 +3,7 @@
  */
 import { del, get, post } from './index'
 import type { AxiosRequestConfig } from 'axios'
+import { PLUGIN_LIFECYCLE_TIMEOUT } from '@/utils/constants'
 import type {
   PluginMeta,
   PluginStatusData,
@@ -77,7 +78,10 @@ export function getPluginHealth(pluginId: string): Promise<PluginHealth> {
  */
 export function startPlugin(pluginId: string): Promise<{ success: boolean; plugin_id: string; message: string }> {
   const safeId = encodeURIComponent(pluginId)
-  return post(`/plugin/${safeId}/start`)
+  return post(`/plugin/${safeId}/start`, undefined, {
+    timeout: PLUGIN_LIFECYCLE_TIMEOUT,
+    timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+  })
 }
 
 /**
@@ -93,7 +97,10 @@ export function stopPlugin(pluginId: string): Promise<{ success: boolean; plugin
  */
 export function reloadPlugin(pluginId: string): Promise<{ success: boolean; plugin_id: string; message: string }> {
   const safeId = encodeURIComponent(pluginId)
-  return post(`/plugin/${safeId}/reload`)
+  return post(`/plugin/${safeId}/reload`, undefined, {
+    timeout: PLUGIN_LIFECYCLE_TIMEOUT,
+    timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+  })
 }
 
 /**

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -104,7 +104,7 @@ export function reloadPlugin(pluginId: string): Promise<{ success: boolean; plug
 }
 
 /**
- * 重载所有插件（批量 API，后端并行处理）
+ * 重载所有插件（批量 API，后端按依赖顺序启动）
  */
 export function reloadAllPlugins(): Promise<{
   success: boolean
@@ -113,7 +113,10 @@ export function reloadAllPlugins(): Promise<{
   skipped: string[]
   message: string
 }> {
-  return post('/plugins/reload')
+  return post('/plugins/reload', undefined, {
+    timeout: PLUGIN_LIFECYCLE_TIMEOUT,
+    timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout',
+  })
 }
 
 /**

--- a/frontend/plugin-manager/src/components/plugin/PluginActions.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/PluginActions.test.ts
@@ -183,6 +183,7 @@ describe('PluginActions runtime mutations', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     elementPlusMocks.ElMessage.success.mockClear()
+    elementPlusMocks.ElMessage.error.mockClear()
     elementPlusMocks.ElMessageBox.confirm.mockClear()
   })
 
@@ -226,6 +227,48 @@ describe('PluginActions runtime mutations', () => {
       expect(mutationSpy).toHaveBeenCalledWith('demo')
       expect(refreshHostedPanels).toHaveBeenCalledTimes(1)
       expect(elementPlusMocks.ElMessage.success).toHaveBeenCalledWith(successKey)
+
+      app.unmount()
+      container.remove()
+    },
+  )
+
+  it.each(['start', 'reload'] as const)(
+    'does not add a duplicate fallback toast when %s already failed in the request interceptor',
+    async (action) => {
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const store = usePluginStore()
+      store.plugins = [{
+        id: 'demo',
+        name: 'Demo',
+        description: 'Demo',
+        version: '1.0.0',
+        status: action === 'reload' ? 'running' : 'stopped',
+      }]
+      vi.spyOn(store, action).mockRejectedValue({
+        code: 'ECONNABORTED',
+        request: {},
+        message: 'timeout exceeded',
+      })
+
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      const app = createApp(PluginActions, { pluginId: 'demo' })
+      app.use(pinia)
+      stubButtons(app)
+      app.mount(container)
+      await nextTick()
+
+      const label = action === 'reload' ? 'plugins.reload' : 'plugins.start'
+      const button = Array.from(container.querySelectorAll('button'))
+        .find((candidate) => candidate.textContent?.trim() === label)
+      expect(button).toBeTruthy()
+      button!.dispatchEvent(new Event('click'))
+      await flushPromises()
+
+      expect(store[action]).toHaveBeenCalledWith('demo')
+      expect(elementPlusMocks.ElMessage.error).not.toHaveBeenCalled()
 
       app.unmount()
       container.remove()

--- a/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginConfigEditor.vue
@@ -165,6 +165,7 @@ import {
 } from '@/api/config'
 import { usePluginStore } from '@/stores/plugin'
 import PluginConfigForm from '@/components/plugin/PluginConfigForm.vue'
+import { isRequestTimeout } from '@/utils/request'
 
 interface Props {
   pluginId: string
@@ -689,7 +690,9 @@ async function save() {
             await pluginStore.reload(pluginId)
             ElMessage.success(t('messages.pluginReloaded'))
           } catch (reloadErr: any) {
-            ElMessage.error(reloadErr?.message || t('messages.reloadFailed'))
+            if (!isRequestTimeout(reloadErr)) {
+              ElMessage.error(reloadErr?.message || t('messages.reloadFailed'))
+            }
           }
         }
         // e === 'close' 时用户关闭了对话框，不做任何操作

--- a/frontend/plugin-manager/src/i18n/locales/en-US.ts
+++ b/frontend/plugin-manager/src/i18n/locales/en-US.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: 'Requested resource not found',
     internalServerError: 'Internal server error',
     serviceUnavailable: 'Service unavailable',
-    networkError: 'Network error. Please check your connection.'
+    networkError: 'Network error. Please check your connection.',
+    requestTimeout: 'The request timed out. Please try again.',
+    pluginLifecycleTimeout: 'Plugin startup or restart timed out. Please check the plugin logs.'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/es.ts
+++ b/frontend/plugin-manager/src/i18n/locales/es.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: 'Recurso solicitado no encontrado',
     internalServerError: 'Error interno del servidor',
     serviceUnavailable: 'Servicio no disponible',
-    networkError: 'Error de red. Comprueba tu conexión.'
+    networkError: 'Error de red. Comprueba tu conexión.',
+    requestTimeout: 'La solicitud agotó el tiempo de espera. Inténtalo de nuevo.',
+    pluginLifecycleTimeout: 'El inicio o reinicio del plugin agotó el tiempo de espera. Revisa los registros del plugin.'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/ja.ts
+++ b/frontend/plugin-manager/src/i18n/locales/ja.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: '要求されたリソースが見つかりません',
     internalServerError: 'サーバー内部エラー',
     serviceUnavailable: 'サービスが利用できません',
-    networkError: 'ネットワークエラー。接続を確認してください。'
+    networkError: 'ネットワークエラー。接続を確認してください。',
+    requestTimeout: 'リクエストがタイムアウトしました。もう一度お試しください。',
+    pluginLifecycleTimeout: 'プラグインの起動または再起動がタイムアウトしました。プラグインログを確認してください。'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/ko.ts
+++ b/frontend/plugin-manager/src/i18n/locales/ko.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: '요청한 리소스를 찾을 수 없습니다',
     internalServerError: '서버 내부 오류',
     serviceUnavailable: '서비스를 사용할 수 없습니다',
-    networkError: '네트워크 오류. 연결을 확인하세요.'
+    networkError: '네트워크 오류. 연결을 확인하세요.',
+    requestTimeout: '요청 시간이 초과되었습니다. 다시 시도하세요.',
+    pluginLifecycleTimeout: '플러그인 시작 또는 재시작 시간이 초과되었습니다. 플러그인 로그를 확인하세요.'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/pt.ts
+++ b/frontend/plugin-manager/src/i18n/locales/pt.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: 'Recurso solicitado não encontrado',
     internalServerError: 'Erro interno do servidor',
     serviceUnavailable: 'Serviço indisponível',
-    networkError: 'Erro de rede. Verifique sua conexão.'
+    networkError: 'Erro de rede. Verifique sua conexão.',
+    requestTimeout: 'A solicitação expirou. Tente novamente.',
+    pluginLifecycleTimeout: 'O início ou reinício do plugin expirou. Verifique os logs do plugin.'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/ru.ts
+++ b/frontend/plugin-manager/src/i18n/locales/ru.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: 'Запрошенный ресурс не найден',
     internalServerError: 'Внутренняя ошибка сервера',
     serviceUnavailable: 'Сервис недоступен',
-    networkError: 'Ошибка сети. Проверьте подключение.'
+    networkError: 'Ошибка сети. Проверьте подключение.',
+    requestTimeout: 'Время ожидания запроса истекло. Повторите попытку.',
+    pluginLifecycleTimeout: 'Время запуска или перезапуска плагина истекло. Проверьте журналы плагина.'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/zh-CN.ts
+++ b/frontend/plugin-manager/src/i18n/locales/zh-CN.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: '请求的资源不存在',
     internalServerError: '服务器内部错误',
     serviceUnavailable: '服务不可用',
-    networkError: '网络错误，请检查网络连接'
+    networkError: '网络错误，请检查网络连接',
+    requestTimeout: '请求超时，请稍后重试',
+    pluginLifecycleTimeout: '插件启动或重载超时，请查看插件日志'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/i18n/locales/zh-TW.ts
+++ b/frontend/plugin-manager/src/i18n/locales/zh-TW.ts
@@ -717,7 +717,9 @@ export default {
     resourceNotFound: '請求的資源不存在',
     internalServerError: '伺服器內部錯誤',
     serviceUnavailable: '服務不可用',
-    networkError: '網路錯誤，請檢查網路連線'
+    networkError: '網路錯誤，請檢查網路連線',
+    requestTimeout: '請求逾時，請稍後重試',
+    pluginLifecycleTimeout: '外掛啟動或重載逾時，請查看外掛日誌'
   },
   welcome: {
     about: {

--- a/frontend/plugin-manager/src/utils/constants.ts
+++ b/frontend/plugin-manager/src/utils/constants.ts
@@ -11,6 +11,8 @@ export const API_TIMEOUT = 30000 // 30秒
 // 插件后端的启动超时为 30 秒；前端留出传输和错误序列化余量，
 // 使后端的明确启动错误能先于 Axios 超时返回。
 export const PLUGIN_LIFECYCLE_TIMEOUT = 45000
+// 批量重载按依赖顺序等待每个插件完成；插件数量不定，不能用单插件期限截断整个操作。
+export const PLUGIN_RELOAD_ALL_TIMEOUT = 0
 
 // 插件状态
 export enum PluginStatus {

--- a/frontend/plugin-manager/src/utils/constants.ts
+++ b/frontend/plugin-manager/src/utils/constants.ts
@@ -8,6 +8,9 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || (
   import.meta.env.DEV ? '' : window.location.origin
 )
 export const API_TIMEOUT = 30000 // 30秒
+// 插件后端的启动超时为 30 秒；前端留出传输和错误序列化余量，
+// 使后端的明确启动错误能先于 Axios 超时返回。
+export const PLUGIN_LIFECYCLE_TIMEOUT = 45000
 
 // 插件状态
 export enum PluginStatus {

--- a/frontend/plugin-manager/src/utils/request.test.ts
+++ b/frontend/plugin-manager/src/utils/request.test.ts
@@ -279,6 +279,24 @@ describe('hosted panel error suppression', () => {
     consoleError.mockRestore()
   })
 
+  it('does not repeat a network error when shared probe waiters are already disconnected', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const healthProbe = vi.spyOn(axios, 'get').mockRejectedValue(new Error('health unavailable'))
+    requestMocks.connectionStore.disconnected = true
+
+    const results = await Promise.allSettled([
+      rejectWith({ message: 'Network Error', request: {} }),
+      rejectWith({ message: 'Network Error', request: {} }),
+      rejectWith({ message: 'Network Error', request: {} }),
+    ])
+
+    expect(results.every((result) => result.status === 'rejected')).toBe(true)
+    expect(healthProbe).toHaveBeenCalledTimes(1)
+    expect(requestMocks.errorMessage).not.toHaveBeenCalled()
+    healthProbe.mockRestore()
+    consoleError.mockRestore()
+  })
+
   it('does not hide a network error from an automatic panel request', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const healthProbe = vi.spyOn(axios, 'get').mockRejectedValue(new Error('health unavailable'))

--- a/frontend/plugin-manager/src/utils/request.test.ts
+++ b/frontend/plugin-manager/src/utils/request.test.ts
@@ -314,6 +314,24 @@ describe('hosted panel error suppression', () => {
     consoleError.mockRestore()
   })
 
+  it('counts a shared failed health probe only once', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const healthProbe = vi.spyOn(axios, 'get').mockRejectedValue(new Error('health unavailable'))
+
+    const results = await Promise.allSettled([
+      rejectWith({ message: 'Network Error', request: {} }),
+      rejectWith({ message: 'Network Error', request: {} }),
+      rejectWith({ message: 'Network Error', request: {} }),
+    ])
+
+    expect(results).toHaveLength(3)
+    expect(results.every((result) => result.status === 'rejected')).toBe(true)
+    expect(healthProbe).toHaveBeenCalledTimes(1)
+    expect(requestMocks.connectionStore.markDisconnected).toHaveBeenCalledTimes(1)
+    healthProbe.mockRestore()
+    consoleError.mockRestore()
+  })
+
   it.each([
     ['ECONNABORTED', {}, 'messages.requestTimeout'],
     ['ETIMEDOUT', { timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout' }, 'messages.pluginLifecycleTimeout'],

--- a/frontend/plugin-manager/src/utils/request.test.ts
+++ b/frontend/plugin-manager/src/utils/request.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from 'axios'
 import type { AxiosError, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
 
 const requestMocks = vi.hoisted(() => ({
@@ -280,6 +281,7 @@ describe('hosted panel error suppression', () => {
 
   it('does not hide a network error from an automatic panel request', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const healthProbe = vi.spyOn(axios, 'get').mockRejectedValue(new Error('health unavailable'))
 
     await expect(rejectWith({
       message: 'Network Error',
@@ -290,6 +292,45 @@ describe('hosted panel error suppression', () => {
 
     expect(consoleError).toHaveBeenCalledWith('Response error:', expect.anything())
     expect(requestMocks.errorMessage).toHaveBeenCalledWith('messages.networkError')
+    expect(requestMocks.connectionStore.markDisconnected).toHaveBeenCalledTimes(1)
+    healthProbe.mockRestore()
+    consoleError.mockRestore()
+  })
+
+  it('keeps the connection marked healthy when the failed endpoint is followed by a successful health check', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const healthProbe = vi.spyOn(axios, 'get').mockResolvedValue({ status: 200 })
+
+    await expect(rejectWith({
+      message: 'Network Error',
+      request: {},
+    })).rejects.toThrow('Network Error')
+
+    expect(healthProbe).toHaveBeenCalledWith('/health', expect.objectContaining({ timeout: 5000 }))
+    expect(requestMocks.connectionStore.markConnected).toHaveBeenCalledTimes(1)
+    expect(requestMocks.connectionStore.markDisconnected).not.toHaveBeenCalled()
+    expect(requestMocks.errorMessage).toHaveBeenCalledWith('messages.requestFailed')
+    healthProbe.mockRestore()
+    consoleError.mockRestore()
+  })
+
+  it.each([
+    ['ECONNABORTED', {}, 'messages.requestTimeout'],
+    ['ETIMEDOUT', { timeoutErrorMessageKey: 'messages.pluginLifecycleTimeout' }, 'messages.pluginLifecycleTimeout'],
+  ] as const)('reports %s as a timeout without probing health or marking a disconnect', async (code, config, messageKey) => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const healthProbe = vi.spyOn(axios, 'get')
+
+    await expect(rejectWith({
+      message: 'timeout exceeded',
+      code,
+      request: {},
+    }, config as AxiosRequestConfig)).rejects.toMatchObject({ code })
+
+    expect(healthProbe).not.toHaveBeenCalled()
+    expect(requestMocks.connectionStore.markDisconnected).not.toHaveBeenCalled()
+    expect(requestMocks.errorMessage).toHaveBeenCalledWith(messageKey)
+    healthProbe.mockRestore()
     consoleError.mockRestore()
   })
 

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -16,6 +16,8 @@ export type ErrorDisplayRequestConfig = AxiosRequestConfig & {
   /** Suppress only the expected stopped-plugin response for panel probes. */
   suppressPluginNotRunningMessage?: boolean
   preserveMessagesOn404?: boolean
+  /** i18n key used when Axios, rather than the server, times this request out. */
+  timeoutErrorMessageKey?: string
 }
 
 type HeaderBag = Record<string, unknown> & {
@@ -123,6 +125,26 @@ export function shouldSuppressErrorMessage(error: AxiosError): boolean {
     || shouldSuppressPluginNotRunningMessage(error)
 }
 
+export function isRequestTimeout(error: AxiosError): boolean {
+  return error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT'
+}
+
+let pendingHealthProbe: Promise<boolean> | null = null
+
+/** Verify the server independently of the failed request, without re-entering this interceptor. */
+export function probeServerHealth(): Promise<boolean> {
+  if (pendingHealthProbe) return pendingHealthProbe
+  pendingHealthProbe = axios.get('/health', {
+    baseURL: API_BASE_URL,
+    timeout: 5000,
+  }).then((response) => response.status >= 200 && response.status < 300)
+    .catch(() => false)
+    .finally(() => {
+      pendingHealthProbe = null
+    })
+  return pendingHealthProbe
+}
+
 // 创建 axios 实例
 const service: AxiosInstance = axios.create({
   baseURL: API_BASE_URL,
@@ -168,6 +190,7 @@ service.interceptors.response.use(
     }
 
     let message = i18n.global.t('messages.requestFailed')
+    let confirmedDisconnected = false
     
     if (error.response) {
       try {
@@ -207,20 +230,35 @@ service.interceptors.response.use(
         default:
           message = formatHttpError(error) || i18n.global.t('messages.requestFailedWithStatus', { status })
       }
+    } else if (error.request && isRequestTimeout(error)) {
+      // Axios 超时只说明当前请求未按时完成，不能据此标记服务器断连。
+      const timeoutMessageKey = (error.config as ErrorDisplayRequestConfig | undefined)
+        ?.timeoutErrorMessageKey || 'messages.requestTimeout'
+      message = i18n.global.t(timeoutMessageKey)
     } else if (error.request) {
-      // 请求已发出，但没有收到响应
-      message = i18n.global.t('messages.networkError')
+      // 只有独立健康检查也失败时，才将无响应请求归类为断网。
+      const serverHealthy = await probeServerHealth()
+      message = serverHealthy
+        ? i18n.global.t('messages.requestFailed')
+        : i18n.global.t('messages.networkError')
+      confirmedDisconnected = !serverHealthy
+      let wasDisconnected = false
       try {
         const connectionStore = useConnectionStore()
-        const wasDisconnected = connectionStore.disconnected
-        connectionStore.markDisconnected()
-        const now = Date.now()
-        if (!suppressErrorMessage && !wasDisconnected && now - lastNetworkErrorShownAt > 15000) {
-          lastNetworkErrorShownAt = now
-          ElMessage.error(message)
+        if (serverHealthy) {
+          connectionStore.markConnected()
+        } else {
+          wasDisconnected = connectionStore.disconnected
+          connectionStore.markDisconnected()
         }
       } catch (err) {
         console.debug('Connection store not available:', err)
+      }
+      const now = Date.now()
+      if (confirmedDisconnected && !suppressErrorMessage && !wasDisconnected
+        && now - lastNetworkErrorShownAt > 15000) {
+        lastNetworkErrorShownAt = now
+        ElMessage.error(message)
       }
     } else {
       // 其他错误
@@ -232,7 +270,7 @@ service.interceptors.response.use(
       return Promise.reject(error)
     }
     
-    if (error.request && !error.response) {
+    if (confirmedDisconnected) {
       return Promise.reject(error)
     }
 

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -262,10 +262,10 @@ service.interceptors.response.use(
       let wasDisconnected = false
       try {
         const connectionStore = useConnectionStore()
+        wasDisconnected = connectionStore.disconnected
         if (serverHealthy) {
           connectionStore.markConnected()
         } else if (initiatedByThisRequest) {
-          wasDisconnected = connectionStore.disconnected
           connectionStore.markDisconnected()
         }
       } catch (err) {

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -131,18 +131,35 @@ export function isRequestTimeout(error: AxiosError): boolean {
 
 let pendingHealthProbe: Promise<boolean> | null = null
 
+type HealthProbeResult = {
+  serverHealthy: boolean
+  /** Only the request that created the probe may advance the failure counter. */
+  initiatedByThisRequest: boolean
+}
+
 /** Verify the server independently of the failed request, without re-entering this interceptor. */
-export function probeServerHealth(): Promise<boolean> {
-  if (pendingHealthProbe) return pendingHealthProbe
-  pendingHealthProbe = axios.get('/health', {
+export function probeServerHealth(): Promise<HealthProbeResult> {
+  if (pendingHealthProbe) {
+    return pendingHealthProbe.then((serverHealthy) => ({
+      serverHealthy,
+      initiatedByThisRequest: false,
+    }))
+  }
+  const probe = axios.get('/health', {
     baseURL: API_BASE_URL,
     timeout: 5000,
   }).then((response) => response.status >= 200 && response.status < 300)
     .catch(() => false)
-    .finally(() => {
+  pendingHealthProbe = probe
+  void probe.finally(() => {
+    if (pendingHealthProbe === probe) {
       pendingHealthProbe = null
-    })
-  return pendingHealthProbe
+    }
+  })
+  return probe.then((serverHealthy) => ({
+    serverHealthy,
+    initiatedByThisRequest: true,
+  }))
 }
 
 // 创建 axios 实例
@@ -237,7 +254,7 @@ service.interceptors.response.use(
       message = i18n.global.t(timeoutMessageKey)
     } else if (error.request) {
       // 只有独立健康检查也失败时，才将无响应请求归类为断网。
-      const serverHealthy = await probeServerHealth()
+      const { serverHealthy, initiatedByThisRequest } = await probeServerHealth()
       message = serverHealthy
         ? i18n.global.t('messages.requestFailed')
         : i18n.global.t('messages.networkError')
@@ -247,7 +264,7 @@ service.interceptors.response.use(
         const connectionStore = useConnectionStore()
         if (serverHealthy) {
           connectionStore.markConnected()
-        } else {
+        } else if (initiatedByThisRequest) {
           wasDisconnected = connectionStore.disconnected
           connectionStore.markDisconnected()
         }

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -474,6 +474,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import type { AxiosError } from 'axios'
 import { Refresh, DataAnalysis, RefreshRight, Box, Connection, Finished, Sort, CircleClose, Close, VideoPlay, VideoPause, Delete, Upload, Download, ShoppingCart, ArrowRight, ArrowLeft, InfoFilled, User } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { usePluginStore } from '@/stores/plugin'
@@ -504,7 +505,7 @@ import { usePluginListContextActions, type ResolvedPluginListAction } from '@/co
 import { usePluginWorkbench } from '@/composables/usePluginWorkbench'
 import { useMarketAuth } from '@/composables/useMarketAuth'
 import { METRICS_REFRESH_INTERVAL } from '@/utils/constants'
-import { formatHttpError } from '@/utils/request'
+import { formatHttpError, isRequestTimeout } from '@/utils/request'
 import { resolvePluginPackageErrorMessage } from '@/utils/pluginPackageError'
 import { resolveLocalizedText } from '@/utils/i18nLabel'
 import { findDuplicatePluginDisplayNameIds } from '@/utils/pluginDisplay'
@@ -975,6 +976,9 @@ function resolveActionErrorMessage(error: any): string {
 }
 
 function shouldShowLocalError(error: any): boolean {
+  if (isRequestTimeout(error)) {
+    return false
+  }
   const status = error?.response?.status
   if (status === 401 || status === 403 || status === 404) {
     return true
@@ -1370,7 +1374,9 @@ async function handleReloadAll() {
     }
   } catch (error) {
     console.error('Failed to reload all plugins:', error)
-    ElMessage.error(t('messages.reloadFailed'))
+    if (!isRequestTimeout(error as AxiosError)) {
+      ElMessage.error(t('messages.reloadFailed'))
+    }
   } finally {
     reloadingAll.value = false
   }


### PR DESCRIPTION
## 改动概述

插件启动和重载原先沿用通用请求超时，前端可能先于后端的明确启动错误超时，并把插件生命周期故障误报成网络断开。本 PR 为生命周期请求留出后端返回错误的余量，同时区分请求超时、普通请求失败和真实断网。

## 关键技术决策

- 仅为插件启动和重载设置 45 秒生命周期超时，并通过请求配置指定生命周期超时提示。
- Axios 超时和主动取消不触发断连；普通无响应请求使用绕过业务拦截器的独立健康检查，只有健康检查也失败时才显示网络错误并更新断连状态。
- 健康检查并发合并，避免同一时刻重复探测；新增提示同步全部八种语言。

## 风险与边界

改动仅覆盖插件管理器通用前端。全局请求拦截器的无响应分支存在跨插件回归风险，插件重载还覆盖单插件操作、批量操作和配置保存后的重载入口。未修改后端、#2943 插件来源基础设施、Galgame 专用逻辑、停止插件、Hosted UI 或其他接口的超时合同。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化插件启动、重载及批量重载的超时处理，区分请求超时与服务器连接中断。
  * 批量重载不再因单个请求超时提前中断，提升操作可靠性。
  * 请求失败时增加健康状态检测并减少重复探测，避免误报服务器断开。
  * 超时期间不再重复显示额外失败提示，改善插件管理体验。

* **本地化**
  * 为支持的多语言界面新增请求超时和插件生命周期超时提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->