### PR TITLE
fix(realtime,core): 收口 #2837 延后的四项工具/流水线所有权缺口

### DIFF
--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -1121,8 +1121,28 @@ class AsrRuntimeMixin:
                 self.lanlan_name,
             )
 
-    async def _abort_independent_asr(self, reason: str) -> None:
+    async def _abort_independent_asr(
+        self,
+        reason: str,
+        *,
+        still_current: Callable[[], bool] | None = None,
+    ) -> None:
+        """Abort the independent run and drop the audio that belonged to it.
+
+        ``still_current`` is for callers that no longer hold the pipeline
+        transition lock across this: ``self._asr_runtime.abort`` is an await,
+        and a session restart or route replacement landing inside it installs
+        a NEW route. Invalidating afterwards would then clear the successor's
+        queued and hot-swap audio and drop its microphone input. Re-checked
+        after the await for exactly that reason -- checking only on entry
+        would leave the window this argument exists to close.
+        """
+
+        if still_current is not None and not still_current():
+            return
         await self._asr_runtime.abort(reason)
+        if still_current is not None and not still_current():
+            return
         self._invalidate_voice_pcm_sync(reason)
         await self._voice_input_registry.wait_idle()
 
@@ -1861,7 +1881,15 @@ class AsrRuntimeMixin:
         """
 
         if failure.independent_route:
-            await self._abort_independent_asr("audio_preprocessing_failed")
+            await self._abort_independent_asr(
+                "audio_preprocessing_failed",
+                # This phase runs without the pipeline transition lock, so a
+                # restart can install a newer route while the abort is in
+                # flight; its audio is not this failure's to clear.
+                still_current=lambda: self._asr_route_operation_matches(
+                    failure.route_operation_generation
+                ),
+            )
 
         def preprocessing_failure_is_current() -> bool:
             # The route-operation generation is deliberately NOT repeated here:

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -508,6 +508,12 @@ class AsrRuntimeMixin:
         if mode != self._asr_route_mode:
             self._microphone_route_generation += 1
         if mode != "blocked":
+            # A live route means no committed pipeline failure owns it any
+            # more, so release the ingress fail-closed latch here -- the one
+            # place that decides the route is usable again. Leaving it to the
+            # pipeline replacement instead is what let an unrelated toggle
+            # reopen ingress mid-failure.
+            self._voice_input_pipeline_failure_token = None
             # Re-arm the one-shot text-mode notice for the next episode, and
             # the lease-resync signal now that a live route exists again.
             self._blocked_text_mode_microphone_signal_state = None
@@ -1921,7 +1927,21 @@ class AsrRuntimeMixin:
             ingress_sequence = self._reserve_hot_swap_ingress_sequence()
         if audio_stream_epoch is None:
             audio_stream_epoch = self._audio_stream_epoch
-        if self._voice_input_pipeline_failed:
+        if (
+            self._voice_input_pipeline_failed
+            # The flag alone stopped being the whole answer once the notify
+            # phase left the transition lock. ANY pipeline replacement clears
+            # it -- a noise-reduction toggle included -- and a toggle can now
+            # land while a backpressured status send is still in flight, i.e.
+            # while this failure still owns a blocked route whose lease has
+            # not been revoked yet. Frames would then be parsed, queued and
+            # run through the replacement DSP until _route_microphone_audio
+            # discards them, refilling the bounded queue and tripping ingress
+            # backpressure during what must stay a fail-closed interval.
+            # The token is cleared only when the route is live again.
+            or getattr(self, "_voice_input_pipeline_failure_token", None)
+            is not None
+        ):
             if sequence_owned:
                 self._complete_hot_swap_ingress_sequence(ingress_sequence)
             return

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -162,6 +162,28 @@ class _AudioDurationQueue:
 
 
 @dataclass(frozen=True, slots=True)
+class _VoiceInputPipelineFailure:
+    """One committed audio-preprocessing failure, as its notify phase sees it.
+
+    Everything the notify/revoke phase fences on, captured at commit time so
+    that phase can run without the pipeline transition lock. ``failure_token``
+    is the identity: it is replaced only by a NEWER commit, unlike
+    ``_voice_input_pipeline_failed``, which any pipeline replacement clears.
+    """
+
+    failure_token: object
+    independent_route: bool
+    provider: str
+    session_epoch: int
+    connection_id: str
+    lease_generation: int
+    transition_generation: int
+    route_operation_generation: int
+    session_ref: object
+    audio_epoch: int
+
+
+@dataclass(frozen=True, slots=True)
 class _HotSwapAudioFrame:
     pcm16: bytes
     token: VoiceIngressToken
@@ -274,6 +296,9 @@ class AsrRuntimeMixin:
         )
         self._core_asr_cleanup_tasks: set[asyncio.Task[Any]] = set()
         self._voice_input_pipeline_failed = False
+        # Identity of the committed pipeline failure that owns the blocked
+        # route, if any. See _VoiceInputPipelineFailure.
+        self._voice_input_pipeline_failure_token: object | None = None
         self._blocked_text_mode_microphone_signal_state: tuple[
             int,
             str,
@@ -362,6 +387,8 @@ class AsrRuntimeMixin:
             self._core_voice_session_swap_barrier_timeout_s = 5.0
         if not hasattr(self, "_voice_input_pipeline_transition_lock"):
             self._voice_input_pipeline_transition_lock = asyncio.Lock()
+        if not hasattr(self, "_voice_input_pipeline_failure_token"):
+            self._voice_input_pipeline_failure_token = None
         if not hasattr(self, "_voice_input_transition_generation"):
             self._voice_input_transition_generation = 0
         if not hasattr(self, "_voice_lease_resync_signal_state"):
@@ -1697,13 +1724,31 @@ class AsrRuntimeMixin:
         audio_epoch: int,
         pipeline_ref: VoiceInputAudioPipeline,
     ) -> None:
+        """Commit the failure under the lock, notify and revoke outside it.
+
+        The lock is shared with session start, independent-ASR close and the
+        noise-reduction toggle, and the notify/revoke phase below ends in
+        ``_fail_closed_voice_route`` -- which writes to the frontend socket.
+        A backpressured client would otherwise hold every one of those
+        recovery operations behind an unrelated write.
+
+        What the lock still has to cover is the COMMIT: validating that this
+        failure is the live state and stamping it, so two failures cannot both
+        decide they own the route. Everything after that is fenced by the
+        stamp instead, which is why it can leave the lock -- see
+        ``_voice_input_pipeline_failure_token``.
+        """
+
         async with self._voice_input_pipeline_transition_lock:
-            await self._fail_voice_input_pipeline_locked(
+            committed = self._commit_voice_input_pipeline_failure(
                 ingress_token=ingress_token,
                 session_ref=session_ref,
                 audio_epoch=audio_epoch,
                 pipeline_ref=pipeline_ref,
             )
+        if committed is None:
+            return
+        await self._finish_voice_input_pipeline_failure(committed)
 
     async def _fail_voice_input_pipeline_locked(
         self,
@@ -1713,6 +1758,38 @@ class AsrRuntimeMixin:
         audio_epoch: int,
         pipeline_ref: VoiceInputAudioPipeline,
     ) -> None:
+        """Caller already holds the transition lock; commit and finish here.
+
+        Kept as the locked-caller entry point. The finish phase runs with the
+        lock still held, so a caller that needs the whole failure serialized
+        against its own pipeline work still gets that.
+        """
+
+        committed = self._commit_voice_input_pipeline_failure(
+            ingress_token=ingress_token,
+            session_ref=session_ref,
+            audio_epoch=audio_epoch,
+            pipeline_ref=pipeline_ref,
+        )
+        if committed is None:
+            return
+        await self._finish_voice_input_pipeline_failure(committed)
+
+    def _commit_voice_input_pipeline_failure(
+        self,
+        *,
+        ingress_token: VoiceIngressToken,
+        session_ref: object,
+        audio_epoch: int,
+        pipeline_ref: VoiceInputAudioPipeline,
+    ) -> _VoiceInputPipelineFailure | None:
+        """Validate and stamp one pipeline failure. Synchronous on purpose.
+
+        No await between the validation above and the writes below, so this
+        whole step is atomic against the event loop and the lock only has to
+        span the call itself.
+        """
+
         if (
             self._voice_input_pipeline_failed
             or ingress_token != self._capture_ingress_token()
@@ -1721,7 +1798,7 @@ class AsrRuntimeMixin:
             or self._voice_input_audio_pipeline is not pipeline_ref
             or not self.is_active
         ):
-            return
+            return None
         source_session_epoch = ingress_token.session_epoch
         source_connection_id = ingress_token.connection_id
         source_lease_generation = ingress_token.lease_generation
@@ -1729,9 +1806,20 @@ class AsrRuntimeMixin:
         route_operation_generation = self._asr_route_operation_generation
         source_session_ref = session_ref
         source_audio_epoch = audio_epoch
-        source_pipeline_ref = pipeline_ref
         source_route_mode = self._asr_route_mode
         self._voice_input_pipeline_failed = True
+        # The commit's own identity. `_voice_input_pipeline_failed` says
+        # "frames are being dropped right now" and ANY pipeline replacement
+        # clears it -- including a noise-reduction toggle, which does not end
+        # the blocked route or revoke anything. Testing that flag in the
+        # predicate below is what made the notify/revoke phase unable to leave
+        # the lock: a toggle landing in the middle cleared it, the predicate
+        # went False, the revoke was skipped, and the route stayed blocked
+        # with the lease never revoked (commit 94c26715). The token is cleared
+        # by nothing except a NEWER commit, so the predicate can ask about
+        # this failure instead of about the world.
+        failure_token = object()
+        self._voice_input_pipeline_failure_token = failure_token
         independent_route = source_route_mode == "independent"
         source_provider = (
             self._independent_asr_provider
@@ -1741,25 +1829,59 @@ class AsrRuntimeMixin:
         self._set_microphone_route("blocked")
         self._clear_audio_stream_queue("audio_preprocessing_failed")
         self.hot_swap_audio_cache.clear()
-        if independent_route:
+        return _VoiceInputPipelineFailure(
+            failure_token=failure_token,
+            independent_route=independent_route,
+            provider=source_provider,
+            session_epoch=source_session_epoch,
+            connection_id=source_connection_id,
+            lease_generation=source_lease_generation,
+            transition_generation=voice_transition_generation,
+            route_operation_generation=route_operation_generation,
+            session_ref=source_session_ref,
+            audio_epoch=source_audio_epoch,
+        )
+
+    async def _finish_voice_input_pipeline_failure(
+        self,
+        failure: "_VoiceInputPipelineFailure",
+    ) -> None:
+        """Abort the ASR run, tell the client, revoke the lease.
+
+        Runs outside the pipeline transition lock. Everything here is fenced
+        on ``failure.failure_token`` instead, so a concurrent session restart
+        or noise-reduction toggle is free to take the lock while a
+        backpressured frontend socket is still absorbing the status send.
+        """
+
+        if failure.independent_route:
             await self._abort_independent_asr("audio_preprocessing_failed")
+
         def preprocessing_failure_is_current() -> bool:
             # The route-operation generation is deliberately NOT repeated here:
             # _fail_closed_voice_route fences on it already, with the identical
             # comparison, and re-checks it after the status send too.
+            #
+            # The pipeline REF is not repeated either, for the same reason the
+            # failure flag is not: a noise-reduction toggle replaces the
+            # pipeline without ending the blocked route, and treating that as
+            # "someone else owns this now" is precisely how the revoke went
+            # missing. A start or a close does replace the pipeline and DOES
+            # invalidate this failure -- both advance the route operation
+            # generation, which _fail_closed_voice_route already checks.
             return not (
-                not self._voice_input_pipeline_failed
-                or self._voice_lease_connection_id != source_connection_id
-                or self._voice_lease_generation != source_lease_generation
+                self._voice_input_pipeline_failure_token
+                is not failure.failure_token
+                or self._voice_lease_connection_id != failure.connection_id
+                or self._voice_lease_generation != failure.lease_generation
                 or (
                     self._voice_input_transition_generation
-                    != voice_transition_generation
+                    != failure.transition_generation
                 )
                 or self._capture_ingress_token().session_epoch
-                != source_session_epoch
-                or self.session is not source_session_ref
-                or self._audio_stream_epoch != source_audio_epoch
-                or self._voice_input_audio_pipeline is not source_pipeline_ref
+                != failure.session_epoch
+                or self.session is not failure.session_ref
+                or self._audio_stream_epoch != failure.audio_epoch
                 or not self.is_active
                 or self._asr_route_mode != "blocked"
                 or (
@@ -1767,7 +1889,7 @@ class AsrRuntimeMixin:
                     or self._independent_asr_route_key
                     or "unknown"
                 )
-                != source_provider
+                != failure.provider
             )
 
         # Ingress backstop. _voice_input_pipeline_failed already drops frames,
@@ -1777,12 +1899,12 @@ class AsrRuntimeMixin:
         # would clear the voice socket and leave the notice with no target.
         await self._fail_closed_voice_route(
             "audio_preprocessing_failed",
-            operation_generation=route_operation_generation,
+            operation_generation=failure.route_operation_generation,
             still_current=preprocessing_failure_is_current,
             status=AsrStatusEvent(
                 code="ASR_AUDIO_PREPROCESSING_FAILED",
-                provider=source_provider,
-                session_epoch=source_session_epoch,
+                provider=failure.provider,
+                session_epoch=failure.session_epoch,
             ),
         )
 

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -1591,6 +1591,21 @@ class AsrRuntimeMixin:
 
     async def _enqueue_audio_stream_data(self, message: dict) -> None:
         self._ensure_asr_runtime_state()
+        if (
+            self._voice_input_pipeline_failed
+            # The same latch the ingress worker checks, one step earlier.
+            # Nothing below this line closes during the failure notice on a
+            # NATIVE route: that route never reaches _abort_independent_asr,
+            # so the voice PCM sync is never invalidated, and
+            # _voice_input_accepts_pcm is lease-only -- it reads neither the
+            # route mode nor this latch. So while a backpressured status send
+            # holds the failure open, the client's PCM kept filling the
+            # bounded queue, and overflowing it takes the QueueFull path,
+            # which aborts the run all over again.
+            or getattr(self, "_voice_input_pipeline_failure_token", None)
+            is not None
+        ):
+            return
         if not self._voice_input_accepts_pcm():
             await self._maybe_signal_voice_lease_resync()
             return

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -163,7 +163,18 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # report the completed input transcript. Track whether server VAD has
         # already advanced this input's tool scope so the transcript can fill
         # that gap without advancing a normal provider's turn twice.
+        #
+        # Two markers, because the providers this covers are inconsistent.
+        # ``_raw_speech_started_scoped_item_ids`` is the real one: the
+        # utterance ids a ``speech_started`` already scoped, so a transcript
+        # is matched against ITS OWN utterance rather than against "some
+        # utterance was scoped at some point". The bool is the fallback for a
+        # proxy that sends neither event an ``item_id``; it is all the
+        # pre-identity shape ever had, and on its own it survives an utterance
+        # whose transcript never arrives -- the next turn's transcript then
+        # reads as already scoped and a stale tool result can cross into it.
         self._raw_speech_started_scope_pending_transcript = False
+        self._raw_speech_started_scoped_item_ids: List[str] = []
         self._tool_tasks: set[asyncio.Task] = set()
         # Tool tasks that can no longer produce a usable result, whatever
         # retired them. Recorded rather than re-derived: see

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -830,11 +830,34 @@ class _ResponseMixin:
         for owner, results in self._retire_tool_tasks_as_abandoned(tasks):
             if not results:
                 continue
-            await self._send_tool_result_gemini(
-                results,
-                provider_session=owner.provider_session,
-                owner=owner,
+            # BOUNDED, and shielded so the bound only releases US. The settle
+            # budget promises that the proactive message always gets out, and
+            # this write goes to the same session that just proved it can be
+            # slow: awaiting it outright would let a wedged session restore
+            # the unbounded tool-turn gate #2837 removed. Shielded rather than
+            # cancelled because the reply is still worth delivering late -- it
+            # just no longer gets to hold the notification.
+            send = self._create_tool_task(
+                self._send_tool_result_gemini(
+                    results,
+                    provider_session=owner.provider_session,
+                    owner=owner,
+                )
             )
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(send),
+                    timeout=self._TOOL_TASK_CANCEL_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                # Tracked as a tool task, so it is still awaited on close and
+                # its failure is still logged -- it simply no longer holds the
+                # notification.
+                logger.warning(
+                    "Gemini abandoned-call reply is still in flight after "
+                    "%.1fs; proceeding with the proactive inject",
+                    self._TOOL_TASK_CANCEL_TIMEOUT_S,
+                )
 
     def _settle_gemini_proactive_inject(
         self,

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -759,6 +759,13 @@ class _ResponseMixin:
         removed had no TTL and could block proactive messages forever; here a
         tool that outlives the budget loses its ordering guarantee, never the
         message. Returns whether everything settled -- for the log only.
+
+        What happens to a call that outlives the budget is
+        ``_abandon_tool_calls_for_gemini_proactive``: it is answered with an
+        abandoned ``function_call_output`` and retired, so the conversation
+        never keeps a ``function_call`` nobody replied to and a result landing
+        afterwards is dropped instead of being injected into the proactive
+        turn.
         """
 
         current = asyncio.current_task()
@@ -787,10 +794,11 @@ class _ResponseMixin:
             if remaining <= 0:
                 logger.warning(
                     "Gemini proactive inject proceeding with %d tool call(s) "
-                    "still running after %.1fs; the provider may drop them",
+                    "still running after %.1fs; answering them as abandoned",
                     len(pending),
                     _GEMINI_PROACTIVE_TOOL_SETTLE_SECONDS,
                 )
+                await self._abandon_tool_calls_for_gemini_proactive(pending)
                 return False
             await asyncio.wait(
                 pending,
@@ -799,6 +807,33 @@ class _ResponseMixin:
             )
             poll_interval = min(
                 poll_interval * 2, self._TOOL_BATCH_POLL_CEILING_S
+            )
+
+    async def _abandon_tool_calls_for_gemini_proactive(self, tasks) -> None:
+        """Answer the calls the settle budget gave up on, before injecting.
+
+        The inject that follows is an interruption -- that is how
+        ``cancel_response`` implements Gemini barge-in -- so the generation
+        that issued these calls is about to be discarded. Sent BEFORE the
+        inject, while that generation is still the current one, so the
+        outputs bind to the calls they answer rather than arriving inside the
+        proactive turn.
+
+        Owner-scoped end to end: ``_retire_tool_tasks_as_abandoned`` groups
+        the replies by the owner each call was captured with, and
+        ``_send_tool_result_gemini`` re-checks
+        ``_tool_task_owner_is_current`` before it writes -- an abandoned-call
+        reply must not be the one thing that crosses into a replacement
+        connection.
+        """
+
+        for owner, results in self._retire_tool_tasks_as_abandoned(tasks):
+            if not results:
+                continue
+            await self._send_tool_result_gemini(
+                results,
+                provider_session=owner.provider_session,
+                owner=owner,
             )
 
     def _settle_gemini_proactive_inject(

--- a/main_logic/omni_realtime_client/_tools.py
+++ b/main_logic/omni_realtime_client/_tools.py
@@ -193,6 +193,7 @@ class _ToolingMixin:
             tool_tasks.discard(completed)
             self._retired_tool_task_registry().discard(completed)
             self._tool_batch_entries_by_task().pop(completed, None)
+            self._tool_batch_by_collector_task().pop(completed, None)
             for call_id in tracked_ids:
                 tasks = tasks_by_call_id.get(call_id)
                 if tasks is None:
@@ -235,6 +236,32 @@ class _ToolingMixin:
             registry = {}
             self._tool_batch_entry_by_task = registry
         return registry
+
+    def _tool_batch_by_collector_task(self) -> Dict[asyncio.Task, _ToolBatch]:
+        """Which batch a collector task speaks for.
+
+        A collector owns no call of its own, so without this it is invisible
+        to anything reasoning about calls. That gap had teeth: when a tool
+        finished just before the proactive settle deadline but its collector
+        had not flushed yet, the only unsettled task was the collector --
+        retiring it answered nothing and did not stop it from sending the
+        real result straight into the proactive turn.
+        """
+
+        registry = getattr(self, "_tool_batch_collector_tasks", None)
+        if registry is None:
+            registry = {}
+            self._tool_batch_collector_tasks = registry
+        return registry
+
+    def _register_tool_batch_collector(
+        self,
+        batch: _ToolBatch,
+        task: asyncio.Task,
+    ) -> asyncio.Task:
+        batch.collector = task
+        self._tool_batch_by_collector_task()[task] = batch
+        return task
 
     def _tool_batch_registry(self) -> Dict[Any, _ToolBatch]:
         """Open raw batches, keyed by the provider response that issued them."""
@@ -384,18 +411,31 @@ class _ToolingMixin:
         """
 
         entries_by_task = self._tool_batch_entries_by_task()
+        batches_by_collector = self._tool_batch_by_collector_task()
         retired = self._retired_tool_task_registry()
         grouped: List[tuple[_ToolTaskOwner, List[ToolResult]]] = []
         slot_by_owner: Dict[int, int] = {}
+        giving_up: List[_ToolBatchEntry] = []
         for task in tasks:
             if task.done():
                 continue
-            entry = entries_by_task.get(task)
             retired.add(task)
-            if entry is None or entry.abandoned:
-                # The collector task of a batch has no entry of its own. It is
-                # retired all the same so nothing else waits on it, but there
-                # is no call to answer for it.
+            entry = entries_by_task.get(task)
+            if entry is not None:
+                giving_up.append(entry)
+            batch = batches_by_collector.get(task)
+            if batch is not None and not batch.sealed:
+                # A pending collector gives up its WHOLE batch, including
+                # calls that already finished but whose result it has not
+                # flushed yet. Retiring the collector alone answers nothing --
+                # it owns no call -- and does not stop it from sending that
+                # finished result, which after the inject below would land in
+                # the proactive turn: exactly the cross-turn injection this
+                # path exists to prevent. A sealed batch is already committed
+                # to its own answer and is left alone.
+                giving_up.extend(batch.entries)
+        for entry in giving_up:
+            if entry.abandoned:
                 continue
             entry.abandoned = True
             slot = slot_by_owner.get(id(entry.owner))
@@ -560,8 +600,9 @@ class _ToolingMixin:
         batch = self._open_raw_tool_batch(owner, response_id)
         self._register_tool_batch_entry(batch, call, owner, task)
         if batch.collector is None:
-            batch.collector = self._create_tool_task(
-                self._answer_raw_tool_batch(batch, owner)
+            self._register_tool_batch_collector(
+                batch,
+                self._create_tool_task(self._answer_raw_tool_batch(batch, owner)),
             )
         return task
 
@@ -604,8 +645,10 @@ class _ToolingMixin:
                     owner=owner,
                 )
 
-        batch.collector = self._create_tool_task(_collect())
-        return batch.collector
+        return self._register_tool_batch_collector(
+            batch,
+            self._create_tool_task(_collect()),
+        )
 
     def _tools_for_openai_realtime(self) -> List[Dict[str, Any]]:
         """OpenAI Realtime / GLM Realtime schema — flat (type/name/

--- a/main_logic/omni_realtime_client/_tools.py
+++ b/main_logic/omni_realtime_client/_tools.py
@@ -570,6 +570,9 @@ class _ToolingMixin:
                         timeout=self._TOOL_TASK_CANCEL_TIMEOUT_S,
                     )
                 except asyncio.TimeoutError:
+                    # The grace expired with no sibling and no terminal.
+                    # Answering what is in hand is the intended fallback, so
+                    # there is nothing to handle -- fall through and send.
                     pass
                 continue
             # Deliberately NOT a total budget. Bailing out after a fixed

--- a/main_logic/omni_realtime_client/_tools.py
+++ b/main_logic/omni_realtime_client/_tools.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 
 from ._shared import (
@@ -40,6 +40,47 @@ class _ToolTaskOwner:
     host_turn_id: str | None
     provider_turn_host_id: str | None
     provider_session: Any
+
+
+@dataclass
+class _ToolBatchEntry:
+    """One function call of a batch, plus the task computing its result."""
+
+    call: ToolCall
+    owner: _ToolTaskOwner
+    task: asyncio.Task
+    # Set when something decided this call can no longer be answered with its
+    # real result -- today only the Gemini proactive settle timeout. Kept on
+    # the ENTRY rather than in a task registry on purpose: the retired-task
+    # set drops a task the moment it completes, so a marker living there loses
+    # the race against a tool that finishes right after being abandoned and
+    # its result would still be collected.
+    abandoned: bool = False
+
+
+@dataclass
+class _ToolBatch:
+    """The calls one provider response issued, answered as one unit.
+
+    Gemini hands the whole list over in a single ``tool_call`` event, so its
+    batch is complete the moment it is built. The raw protocols emit one
+    ``response.function_call_arguments.done`` per call instead, so entries are
+    appended as they arrive and the collector re-reads ``entries`` on every
+    round -- a sibling announced while it waits still joins.
+    """
+
+    registry_key: Any = None
+    entries: List[_ToolBatchEntry] = field(default_factory=list)
+    collector: Optional[asyncio.Task] = None
+    sealed: bool = False
+
+
+# Payload of the ``function_call_output`` sent for a call the client gave up
+# on. English on purpose: it goes to the model, not to the user.
+_ABANDONED_TOOL_CALL_REASON = (
+    "This tool call was abandoned by the client before it produced a result "
+    "and must not be waited for. Continue without its output."
+)
 
 
 
@@ -151,6 +192,7 @@ class _ToolingMixin:
         def _done(completed: asyncio.Task) -> None:
             tool_tasks.discard(completed)
             self._retired_tool_task_registry().discard(completed)
+            self._tool_batch_entries_by_task().pop(completed, None)
             for call_id in tracked_ids:
                 tasks = tasks_by_call_id.get(call_id)
                 if tasks is None:
@@ -187,11 +229,62 @@ class _ToolingMixin:
             call_ids=call_ids,
         )
 
+    def _tool_batch_entries_by_task(self) -> Dict[asyncio.Task, _ToolBatchEntry]:
+        registry = getattr(self, "_tool_batch_entry_by_task", None)
+        if registry is None:
+            registry = {}
+            self._tool_batch_entry_by_task = registry
+        return registry
+
+    def _tool_batch_registry(self) -> Dict[Any, _ToolBatch]:
+        """Open raw batches, keyed by the provider response that issued them."""
+
+        registry = getattr(self, "_open_tool_batches", None)
+        if registry is None:
+            registry = {}
+            self._open_tool_batches = registry
+        return registry
+
+    def _register_tool_batch_entry(
+        self,
+        batch: _ToolBatch,
+        call: ToolCall,
+        owner: _ToolTaskOwner,
+        task: asyncio.Task,
+    ) -> _ToolBatchEntry:
+        entry = _ToolBatchEntry(call=call, owner=owner, task=task)
+        batch.entries.append(entry)
+        self._tool_batch_entries_by_task()[task] = entry
+        return entry
+
+    def _seal_tool_batch(self, batch: _ToolBatch) -> None:
+        """Stop a batch from accepting siblings once its answer is going out.
+
+        Called with no await between the collector deciding that nothing is
+        pending and this, so a straggler cannot slip into a batch that has
+        already been answered -- it opens a new one under the same response id
+        instead, which is exactly the one-result-one-create shape this
+        replaced. Degrading to that is the point: the alternative is holding
+        every result until the issuing response terminates, and a provider
+        that drops that terminal would then never get any answer at all.
+        """
+
+        batch.sealed = True
+        if batch.registry_key is not None:
+            registry = self._tool_batch_registry()
+            if registry.get(batch.registry_key) is batch:
+                registry.pop(batch.registry_key, None)
+
     def _advance_tool_scope(self) -> tuple[asyncio.Task, ...]:
         """Retire every tool owned by the preceding user/connection scope."""
 
         self._tool_scope_generation = getattr(self, "_tool_scope_generation", 0) + 1
         getattr(self, "_cancelled_tool_call_ids", set()).clear()
+        # Batches are keyed by the scope they were opened in, so the entries
+        # below could never be matched again anyway; dropping them keeps the
+        # registry from growing for the life of the connection. Their
+        # collectors are tool tasks and are cancelled with everything else.
+        getattr(self, "_open_tool_batches", {}).clear()
         current_task = asyncio.current_task()
         tasks = tuple(getattr(self, "_tool_tasks", ()))
         retired = self._retired_tool_task_registry()
@@ -273,6 +366,123 @@ class _ToolingMixin:
             call_id,
         ) in getattr(self, "_cancelled_tool_call_ids", set())
 
+    def _retire_tool_tasks_as_abandoned(
+        self,
+        tasks,
+    ) -> List[tuple[_ToolTaskOwner, List[ToolResult]]]:
+        """Give up on unsettled tool calls and build their abandoned replies.
+
+        Retired, deliberately NOT cancelled. Retirement is what stops the
+        batch collector from sending the real result later -- it would land in
+        a turn the call no longer belongs to, referencing a function call the
+        provider has already dropped. Cancelling on top of that would abort a
+        side effect the user asked for halfway through, and the caller here is
+        a proactive notification: it has no business killing the user's tool.
+
+        Grouped by owner because a reply must go out under the fences the call
+        was captured with; the send path re-checks them.
+        """
+
+        entries_by_task = self._tool_batch_entries_by_task()
+        retired = self._retired_tool_task_registry()
+        grouped: List[tuple[_ToolTaskOwner, List[ToolResult]]] = []
+        slot_by_owner: Dict[int, int] = {}
+        for task in tasks:
+            if task.done():
+                continue
+            entry = entries_by_task.get(task)
+            retired.add(task)
+            if entry is None or entry.abandoned:
+                # The collector task of a batch has no entry of its own. It is
+                # retired all the same so nothing else waits on it, but there
+                # is no call to answer for it.
+                continue
+            entry.abandoned = True
+            slot = slot_by_owner.get(id(entry.owner))
+            if slot is None:
+                slot = len(grouped)
+                slot_by_owner[id(entry.owner)] = slot
+                grouped.append((entry.owner, []))
+            grouped[slot][1].append(
+                ToolResult(
+                    call_id=entry.call.call_id,
+                    name=entry.call.name,
+                    output={"abandoned": True, "error": _ABANDONED_TOOL_CALL_REASON},
+                    is_error=True,
+                    error_message=_ABANDONED_TOOL_CALL_REASON,
+                )
+            )
+        return grouped
+
+    async def _collect_tool_batch(
+        self,
+        batch: _ToolBatch,
+        owner: _ToolTaskOwner,
+    ) -> List[ToolResult]:
+        """Wait for a batch to settle, then return the results that may be sent.
+
+        Deliberately not one ``gather``. A call the provider cancelled is
+        dropped from the results below anyway, so continuing to WAIT for it
+        buys nothing -- and a handler that swallows CancelledError (or sits in
+        cancellation-resistant I/O) would otherwise hold every sibling's
+        ``function_call_output`` hostage and stall the whole provider turn.
+        Re-check the retired set on the same bound the close path already
+        allows a tool to ignore cancellation for.
+
+        Keyed by POSITION, not call_id. Gemini may omit ids, and the ingestion
+        path normalizes a missing one to "" -- so keying by call_id collapses
+        an anonymous parallel batch into a single entry, sending the last
+        result twice and dropping the other function's real response. The
+        batch is positional; keep it that way, exactly as the blanket gather
+        this replaced was.
+        """
+
+        collected: Dict[int, ToolResult] = {}
+        poll_interval = self._TOOL_TASK_CANCEL_TIMEOUT_S
+        while True:
+            retired_tasks = self._retired_tool_tasks()
+            pending = []
+            # Re-enumerated every round: on the raw protocols a sibling can
+            # still be announced while this waits, and it belongs to the same
+            # provider response.
+            for index, entry in enumerate(batch.entries):
+                if index in collected or entry.abandoned:
+                    continue
+                task = entry.task
+                if task.done():
+                    if not task.cancelled() and task.exception() is None:
+                        value = task.result()
+                        if isinstance(value, ToolResult):
+                            collected[index] = value
+                elif task not in retired_tasks:
+                    pending.append(task)
+            if not pending:
+                break
+            # Deliberately NOT a total budget. Bailing out after a fixed
+            # deadline would discard the result of a legitimately slow tool --
+            # a long web lookup is not a stuck one, and dropping its output
+            # leaves the provider with an unanswered call, which is the
+            # failure this collector exists to prevent. Bound the polling COST
+            # instead of the wait.
+            await asyncio.wait(
+                pending,
+                timeout=poll_interval,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            poll_interval = min(
+                poll_interval * 2, self._TOOL_BATCH_POLL_CEILING_S
+            )
+        self._seal_tool_batch(batch)
+        if not self._tool_task_owner_is_current(owner):
+            return []
+        return [
+            collected[index]
+            for index, entry in enumerate(batch.entries)
+            if index in collected
+            and not entry.abandoned
+            and not self._tool_call_was_cancelled(entry.owner, entry.call.call_id)
+        ]
+
     async def _await_retired_tool_tasks(
         self,
         tasks: tuple[asyncio.Task, ...],
@@ -291,20 +501,78 @@ class _ToolingMixin:
                 len(still_pending),
             )
 
+    def _open_raw_tool_batch(
+        self,
+        owner: _ToolTaskOwner,
+        response_id: str | None,
+    ) -> _ToolBatch:
+        """The batch a raw call joins, opening one if its response has none.
+
+        Keyed by the provider response, because that is the unit the model
+        asked in: it emitted several parallel function calls and will not
+        continue correctly until every one of them has an output. Without a
+        response id there is no way to prove two calls are siblings, so each
+        gets a batch of its own -- the pre-batch behaviour, kept rather than
+        guessed at.
+        """
+
+        registry = self._tool_batch_registry()
+        key = None
+        if response_id:
+            key = (owner.connection_generation, owner.scope_generation, response_id)
+            open_batch = registry.get(key)
+            if open_batch is not None and not open_batch.sealed:
+                return open_batch
+        batch = _ToolBatch(registry_key=key)
+        if key is not None:
+            registry[key] = batch
+        return batch
+
     def _start_raw_tool_call(
         self,
         call: ToolCall,
         owner: _ToolTaskOwner,
+        *,
+        response_id: str | None = None,
     ) -> asyncio.Task:
-        async def _run() -> None:
-            if not self._tool_task_owner_is_current(owner):
-                return
-            result = await self._execute_tool_call(call)
-            if not self._tool_task_owner_is_current(owner):
-                return
-            await self._send_tool_result_openai_realtime(result, owner=owner)
+        """Run one raw function call, answered together with its siblings.
 
-        return self._create_tool_task(_run(), call_ids=(call.call_id,))
+        One task per call, as before -- the tools themselves still run in
+        parallel and start the moment their arguments land. What changed is
+        the REPLY: a batch collector waits for every sibling of the issuing
+        response and submits all the ``conversation.item.create`` items plus a
+        single ``response.create``.
+
+        Sending per result could not be made safe by ordering alone. Each
+        result enqueued its own continuation, so when the first of two
+        parallel calls finished, the arbiter sent its output and immediately
+        started a new response while the sibling's ticket was still queued --
+        the provider saw a continuation with a required parallel-call output
+        missing, and answered without it.
+        """
+
+        async def _run() -> ToolResult | None:
+            if not self._tool_task_owner_is_current(owner):
+                return None
+            return await self._execute_tool_call(call)
+
+        task = self._create_tool_task(_run(), call_ids=(call.call_id,))
+        batch = self._open_raw_tool_batch(owner, response_id)
+        self._register_tool_batch_entry(batch, call, owner, task)
+        if batch.collector is None:
+            batch.collector = self._create_tool_task(
+                self._answer_raw_tool_batch(batch, owner)
+            )
+        return task
+
+    async def _answer_raw_tool_batch(
+        self,
+        batch: _ToolBatch,
+        owner: _ToolTaskOwner,
+    ) -> None:
+        results = await self._collect_tool_batch(batch, owner)
+        if results:
+            await self._send_tool_results_openai_realtime(results, owner=owner)
 
     def _start_gemini_tool_batch(
         self,
@@ -316,64 +584,19 @@ class _ToolingMixin:
                 return None
             return await self._execute_tool_call(call)
 
-        call_tasks = [
-            self._create_tool_task(_execute(call), call_ids=(call.call_id,))
-            for call in calls
-        ]
+        # Gemini delivers the whole parallel batch in one ``tool_call`` event,
+        # so this is complete on construction and never grows.
+        batch = _ToolBatch()
+        for call in calls:
+            self._register_tool_batch_entry(
+                batch,
+                call,
+                owner,
+                self._create_tool_task(_execute(call), call_ids=(call.call_id,)),
+            )
 
         async def _collect() -> None:
-            # Deliberately not one ``gather``. A call the provider cancelled is
-            # dropped from the results below anyway, so continuing to WAIT for
-            # it buys nothing -- and a handler that swallows CancelledError (or
-            # sits in cancellation-resistant I/O) would otherwise hold every
-            # sibling's ``function_call_output`` hostage and stall the whole
-            # provider turn. Re-check the cancelled set on the same bound the
-            # close path already allows a tool to ignore cancellation for.
-            # Keyed by POSITION, not call_id. Gemini may omit ids, and the
-            # ingestion path normalizes a missing one to "" -- so keying by
-            # call_id collapses an anonymous parallel batch into a single
-            # entry, sending the last result twice and dropping the other
-            # function's real response. The batch is positional; keep it that
-            # way, exactly as the blanket gather this replaced was.
-            pending = list(enumerate(call_tasks))
-            outcomes: Dict[int, ToolResult] = {}
-            poll_interval = self._TOOL_TASK_CANCEL_TIMEOUT_S
-            while pending:
-                retired_tasks = self._retired_tool_tasks()
-                still_pending = []
-                for index, task in pending:
-                    if task.done():
-                        if not task.cancelled() and task.exception() is None:
-                            value = task.result()
-                            if isinstance(value, ToolResult):
-                                outcomes[index] = value
-                    elif task not in retired_tasks:
-                        still_pending.append((index, task))
-                pending = still_pending
-                if not pending:
-                    break
-                # Deliberately NOT a total budget. Bailing out after a fixed
-                # deadline would discard the result of a legitimately slow
-                # tool -- a long web lookup is not a stuck one, and dropping
-                # its output leaves the provider with an unanswered call,
-                # which is the failure this collector exists to prevent.
-                # Bound the polling COST instead of the wait.
-                await asyncio.wait(
-                    [task for _, task in pending],
-                    timeout=poll_interval,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                poll_interval = min(
-                    poll_interval * 2, self._TOOL_BATCH_POLL_CEILING_S
-                )
-            if not self._tool_task_owner_is_current(owner):
-                return
-            results = [
-                outcomes[index]
-                for index, call in enumerate(calls)
-                if index in outcomes
-                and not self._tool_call_was_cancelled(owner, call.call_id)
-            ]
+            results = await self._collect_tool_batch(batch, owner)
             if results:
                 await self._send_tool_result_gemini(
                     results,
@@ -381,7 +604,8 @@ class _ToolingMixin:
                     owner=owner,
                 )
 
-        return self._create_tool_task(_collect())
+        batch.collector = self._create_tool_task(_collect())
+        return batch.collector
 
     def _tools_for_openai_realtime(self) -> List[Dict[str, Any]]:
         """OpenAI Realtime / GLM Realtime schema — flat (type/name/
@@ -505,9 +729,25 @@ class _ToolingMixin:
         *,
         owner: _ToolTaskOwner | None = None,
     ) -> None:
+        """Single-result form of :meth:`_send_tool_results_openai_realtime`."""
+
+        await self._send_tool_results_openai_realtime([result], owner=owner)
+
+    async def _send_tool_results_openai_realtime(
+        self,
+        results: List[ToolResult],
+        *,
+        owner: _ToolTaskOwner | None = None,
+    ) -> None:
         """OpenAI Realtime / GLM Realtime / StepFun / Qwen / Free —
-        send tool result via ``conversation.item.create`` of type
-        ``function_call_output``, then ``response.create``.
+        send every tool result of one provider response as
+        ``conversation.item.create`` items of type ``function_call_output``,
+        then ONE ``response.create``.
+
+        One ticket, not one per result: the arbiter serializes tickets, so a
+        per-result ticket let the first output's continuation start while a
+        sibling's was still queued, and the model answered a parallel call
+        whose output had not arrived yet.
 
         ⚠️ Provider differences:
         - OpenAI gpt / StepFun / Qwen / Free: ``call_id`` is required;
@@ -523,20 +763,24 @@ class _ToolingMixin:
         if owner is not None and not self._tool_task_owner_is_current(owner):
             return
 
-        item: Dict[str, Any] = {
-            "type": "function_call_output",
-            "output": result.output_as_json_string(),
-        }
         api = canonical_realtime_dialect(self._api_type)
-        if api == 'glm':
-            # GLM 协议不接受 call_id。哪怕我们内部合成了，也不外传。
-            pass
-        elif result.call_id:
-            item["call_id"] = result.call_id
-        item_event = {
-            "type": "conversation.item.create",
-            "item": item,
-        }
+        item_events: List[Dict[str, Any]] = []
+        for result in results:
+            item: Dict[str, Any] = {
+                "type": "function_call_output",
+                "output": result.output_as_json_string(),
+            }
+            if api == 'glm':
+                # GLM 协议不接受 call_id。哪怕我们内部合成了，也不外传。
+                pass
+            elif result.call_id:
+                item["call_id"] = result.call_id
+            item_events.append({
+                "type": "conversation.item.create",
+                "item": item,
+            })
+        if not item_events:
+            return
         arbiter = self._ensure_response_arbiter()
 
         async def _send_owned_event(event: Dict[str, Any]) -> None:
@@ -552,7 +796,7 @@ class _ToolingMixin:
 
         ticket = await arbiter.enqueue(
             source="tool_result",
-            events_before_response=(item_event,),
+            events_before_response=tuple(item_events),
             response_event={"type": "response.create"},
             event_sender=_send_owned_event if owner is not None else None,
             priority=5,

--- a/main_logic/omni_realtime_client/_tools.py
+++ b/main_logic/omni_realtime_client/_tools.py
@@ -73,6 +73,14 @@ class _ToolBatch:
     entries: List[_ToolBatchEntry] = field(default_factory=list)
     collector: Optional[asyncio.Task] = None
     sealed: bool = False
+    # Whether every call of this batch is known. True from construction for
+    # Gemini (one event carries the whole list) and for a raw call with no
+    # response identity (nothing can be proven a sibling of it). A raw batch
+    # keyed by a response id stays open until that response terminates.
+    closed: bool = False
+    # Pulsed when an entry joins or the batch closes, so a collector that has
+    # run out of work can wake on either instead of sleeping out a poll.
+    changed: asyncio.Event = field(default_factory=asyncio.Event)
 
 
 # Payload of the ``function_call_output`` sent for a call the client gave up
@@ -282,7 +290,50 @@ class _ToolingMixin:
         entry = _ToolBatchEntry(call=call, owner=owner, task=task)
         batch.entries.append(entry)
         self._tool_batch_entries_by_task()[task] = entry
+        batch.changed.set()
         return entry
+
+    def close_raw_tool_batch(self, response_id: str | None) -> None:
+        """Mark the batch a provider response issued as complete.
+
+        Called from the receive loop when that response terminates: no further
+        ``function_call_arguments.done`` can name it, so its collector may
+        answer as soon as its own calls settle. Without this the collector had
+        to guess, and a tool that finished before the receive loop had read
+        its sibling's event made it guess wrong -- it sealed a batch of one,
+        and the sibling opened a second batch, so the provider got two
+        continuations each missing the other's parallel output.
+        """
+
+        if not response_id:
+            return
+        batch = self._tool_batch_registry().get(
+            (
+                self._connection_generation,
+                getattr(self, "_tool_scope_generation", 0),
+                str(response_id),
+            )
+        )
+        if batch is None:
+            return
+        batch.closed = True
+        batch.changed.set()
+
+    def _raw_tool_batch_response_is_open(self, batch: _ToolBatch) -> bool:
+        """Whether the response that issued this batch can still add to it.
+
+        Evidence, not a timer: the batch is keyed by a response id, so it can
+        only grow while that response is the one this connection is tracking.
+        A provider that never announced a response leaves the tracked id None
+        and gets no grace at all -- which is the pre-batch behaviour, and the
+        right answer, since nothing there can prove two calls are siblings.
+        """
+
+        key = batch.registry_key
+        if key is None:
+            return False
+        tracked = self._current_response_id
+        return tracked is not None and str(tracked) == key[2]
 
     def _seal_tool_batch(self, batch: _ToolBatch) -> None:
         """Stop a batch from accepting siblings once its answer is going out.
@@ -479,6 +530,7 @@ class _ToolingMixin:
 
         collected: Dict[int, ToolResult] = {}
         poll_interval = self._TOOL_TASK_CANCEL_TIMEOUT_S
+        waited_for_closure = False
         while True:
             retired_tasks = self._retired_tool_tasks()
             pending = []
@@ -497,7 +549,29 @@ class _ToolingMixin:
                 elif task not in retired_tasks:
                     pending.append(task)
             if not pending:
-                break
+                if (
+                    batch.closed
+                    or waited_for_closure
+                    or not self._raw_tool_batch_response_is_open(batch)
+                ):
+                    break
+                # Every known call has settled, but the provider response that
+                # issued them has not terminated, so a sibling may still be
+                # announced. ONE grace round, not the backoff ramp: an event
+                # already sitting in the socket buffer arrives in microseconds,
+                # while a provider that never terminates its responses must not
+                # be able to hold every tool result for seconds. Falling
+                # through answers what is in hand -- the pre-batch shape.
+                waited_for_closure = True
+                batch.changed.clear()
+                try:
+                    await asyncio.wait_for(
+                        batch.changed.wait(),
+                        timeout=self._TOOL_TASK_CANCEL_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    pass
+                continue
             # Deliberately NOT a total budget. Bailing out after a fixed
             # deadline would discard the result of a legitimately slow tool --
             # a long web lookup is not a stuck one, and dropping its output
@@ -563,7 +637,7 @@ class _ToolingMixin:
             open_batch = registry.get(key)
             if open_batch is not None and not open_batch.sealed:
                 return open_batch
-        batch = _ToolBatch(registry_key=key)
+        batch = _ToolBatch(registry_key=key, closed=key is None)
         if key is not None:
             registry[key] = batch
         return batch
@@ -627,7 +701,7 @@ class _ToolingMixin:
 
         # Gemini delivers the whole parallel batch in one ``tool_call`` event,
         # so this is complete on construction and never grows.
-        batch = _ToolBatch()
+        batch = _ToolBatch(closed=True)
         for call in calls:
             self._register_tool_batch_entry(
                 batch,

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -2093,6 +2093,19 @@ class _TransportMixin:
                 elif event_type == "conversation.item.created":
                     self._response_arbiter.notify_item_created(event)
                 elif event_type == "response.done":
+                    # No further function call can name this response, so its
+                    # tool batch may answer as soon as its own calls settle.
+                    # Ahead of the finalize branches below on purpose: several
+                    # of them `continue`, and a stale or non-finalizing
+                    # terminal still proves the response is over.
+                    self.close_raw_tool_batch(
+                        _response_id_text(event.get("response_id"))
+                        or _response_id_text(
+                            (event.get("response") or {}).get("id")
+                            if isinstance(event.get("response"), dict)
+                            else None
+                        )
+                    )
                     finalize_response = (
                         self._response_arbiter.notify_response_terminal(event)
                     )
@@ -2466,13 +2479,20 @@ class _TransportMixin:
         """
 
         utterance = str(item_id) if item_id else ""
+        if utterance:
+            # Answered from the id list ALONE, and deliberately without
+            # consuming the id-less fallback marker. Transcription is
+            # asynchronous, so on a proxy that omitted `item_id` for the
+            # NEWER utterance an older identified transcript can arrive
+            # first; consuming the marker there would make that newer
+            # utterance's own id-less transcript read as an unscoped turn and
+            # retire tool work that legitimately belongs to it.
+            return utterance in self._raw_speech_started_scoped_item_ids
+        # Neither side carries identity: this is the pre-identity shape, and
+        # the flag is the only answer available. It is one-shot, so consume it.
         already_pending = self._raw_speech_started_scope_pending_transcript
         self._raw_speech_started_scope_pending_transcript = False
-        if not utterance:
-            # Neither side carries identity: this is the pre-identity shape,
-            # and the flag is the only answer available.
-            return already_pending
-        return utterance in self._raw_speech_started_scoped_item_ids
+        return already_pending
 
     def _on_connection_attached(self) -> None:
         """Mark a replacement connection as live and hand it the teardown latches.

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -2438,9 +2438,16 @@ class _TransportMixin:
     def _note_raw_speech_started_scope(self, item_id: Any) -> None:
         """Record that a ``speech_started`` already scoped this utterance."""
 
-        self._raw_speech_started_scope_pending_transcript = True
         utterance = str(item_id) if item_id else ""
         if not utterance:
+            # ONLY an id-less speech_started arms the fallback marker. An
+            # identified one is answered from the id list below, and an
+            # identified transcript deliberately does not consume the marker
+            # -- so arming it here would leave it set for the rest of the
+            # connection, and the next id-less transcript would read as
+            # already scoped. That is the original stale-marker bug, rebuilt
+            # one turn further along.
+            self._raw_speech_started_scope_pending_transcript = True
             return
         scoped = self._raw_speech_started_scoped_item_ids
         if utterance in scoped:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -70,6 +70,13 @@ _STUCK_RELEASE_STEP_TIMEOUT = 0.5
 # interleaved between them; it is a leak guard, not a history.
 _USAGE_RECORDED_ID_LIMIT = 32
 
+# How many utterance ids a ``speech_started`` may have scoped and still be
+# recognised when that utterance's transcript arrives. Input transcription is
+# its own job on these providers, so a transcript can land several turns after
+# the speech it describes; anything older than this is indistinguishable from a
+# new user turn, which is also the safe reading -- it retires stale tool work.
+_RAW_SCOPED_UTTERANCE_MEMORY = 8
+
 # `error` 事件的致命性判定是一串子串匹配（'429' / '1008' / '503' / 'quota' ...）。它
 # 过去匹配在 `str(event['error'])` 上，也就是整个 dict 的 repr —— 里面回显着我们自己
 # 生成的客户端相关性 id（`event_user_item_<uuid4().hex>` 之类）。hex 的字符集是
@@ -2072,6 +2079,16 @@ class _TransportMixin:
                                 raw_arguments=raw_args,
                             ),
                             owner,
+                            # Groups this call with the parallel siblings the
+                            # SAME provider response issued, so they are
+                            # answered as one batch with a single
+                            # response.create. Absent on a provider that omits
+                            # response identity -- there is then nothing that
+                            # can prove two calls are siblings, and each is
+                            # answered on its own as before.
+                            response_id=_response_id_text(
+                                event.get("response_id")
+                            ),
                         )
                 elif event_type == "conversation.item.created":
                     self._response_arbiter.notify_item_created(event)
@@ -2151,7 +2168,7 @@ class _TransportMixin:
                 # Handle interruptions
                 elif event_type == "input_audio_buffer.speech_started":
                     self.note_user_turn_started()
-                    self._raw_speech_started_scope_pending_transcript = True
+                    self._note_raw_speech_started_scope(event.get("item_id"))
                     self._speech_started_total += 1
                     logger.info("Speech detected")
                     self._response_arbiter.notify_server_vad_started()
@@ -2206,16 +2223,15 @@ class _TransportMixin:
                     self._client_vad_last_speech_time = _now
                     self._user_recent_activity_time = _now
                 elif event_type == "conversation.item.input_audio_transcription.completed":
-                    if (
-                        not self._has_server_vad
-                        and not self._raw_speech_started_scope_pending_transcript
-                    ):
+                    already_scoped = self._raw_transcript_was_already_scoped(
+                        event.get("item_id")
+                    )
+                    if not self._has_server_vad and not already_scoped:
                         # Compatibility proxies may omit both server-VAD
                         # boundary events. The completed transcript is then the
                         # first authoritative signal that a new user turn has
                         # begun, so stale tool work must retire here.
                         self.note_user_turn_started()
-                    self._raw_speech_started_scope_pending_transcript = False
                     self._print_input_transcript = True
                     transcript = event.get("transcript", "")
                     if self.on_input_transcript:
@@ -2406,6 +2422,58 @@ class _TransportMixin:
             )
         )
 
+    def _note_raw_speech_started_scope(self, item_id: Any) -> None:
+        """Record that a ``speech_started`` already scoped this utterance."""
+
+        self._raw_speech_started_scope_pending_transcript = True
+        utterance = str(item_id) if item_id else ""
+        if not utterance:
+            return
+        scoped = self._raw_speech_started_scoped_item_ids
+        if utterance in scoped:
+            return
+        scoped.append(utterance)
+        del scoped[:-_RAW_SCOPED_UTTERANCE_MEMORY]
+
+    def _raw_transcript_was_already_scoped(self, item_id: Any) -> bool:
+        """Whether this transcript's OWN utterance already began a turn here.
+
+        The question the no-server-VAD fallback has to answer is per
+        utterance, and the flag alone answers a different one -- "did any
+        ``speech_started`` happen and not get a transcript yet". Those come
+        apart on a proxy that emits ``speech_started`` for one turn, drops
+        that turn's transcript, then drops ``speech_started`` for the NEXT
+        turn: nothing clears the flag between them (neither
+        ``speech_stopped`` nor ``response.done`` touches it), so the next
+        turn's transcript reads as already scoped, ``note_user_turn_started``
+        is skipped, and a cancellation-resistant tool from the previous turn
+        can still inject its result into the new one.
+
+        None of the cheap lifecycle expiry points fix that. The tool scope
+        does not advance between those two turns -- that IS the failure --
+        and ``_turn_epoch`` moves at ``speech_stopped``, before the transcript
+        normally arrives, so keying on either would fire a spurious extra
+        ``note_user_turn_started`` every healthy turn. Clearing at
+        ``speech_stopped`` breaks the same normal order. Clearing at
+        ``response.done`` would only hold if a transcript could never land
+        after it, which is not something these proxies promise: input
+        transcription runs as its own job alongside the response.
+
+        So the marker is scoped by utterance instead of by lifecycle. The
+        remembered ids are bounded and matching one is a no-op, which also
+        makes a transcript that arrives late -- after its successor's turn has
+        already begun -- stop re-advancing the scope.
+        """
+
+        utterance = str(item_id) if item_id else ""
+        already_pending = self._raw_speech_started_scope_pending_transcript
+        self._raw_speech_started_scope_pending_transcript = False
+        if not utterance:
+            # Neither side carries identity: this is the pre-identity shape,
+            # and the flag is the only answer available.
+            return already_pending
+        return utterance in self._raw_speech_started_scoped_item_ids
+
     def _on_connection_attached(self) -> None:
         """Mark a replacement connection as live and hand it the teardown latches.
 
@@ -2454,6 +2522,7 @@ class _TransportMixin:
                 expected_outcome_token=retired_outcome_owner[2],
             )
         self._raw_speech_started_scope_pending_transcript = False
+        self._raw_speech_started_scoped_item_ids = []
         # Provider response identity and interruption state belong to the
         # retired connection. Some raw proxies never announce responses, so a
         # stale interrupt would mute the replacement for its entire lifetime,

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -149,6 +149,7 @@ MIXIN_SUPPORT_CLASSES = {
         "_AudioDurationQueue",
         "_HotSwapAudioFrame",
         "_HotSwapAudioBuffer",
+        "_VoiceInputPipelineFailure",
     },
 }
 PATCH_CALL_NAMES = {"setattr", "patch", "delattr"}

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -6298,6 +6298,114 @@ async def test_noise_reduction_replacement_waits_for_pipeline_failure_revoke() -
     assert runtime._voice_input_pipeline_failed is False
 
 
+async def test_pipeline_failure_still_revokes_after_a_bare_pipeline_swap() -> None:
+    """A replacement that does not end the route must not skip the revoke.
+
+    The mirror image of the case above. Replacing the pipeline clears
+    ``_voice_input_pipeline_failed`` -- that is all a noise-reduction toggle
+    does -- but it neither unblocks the route nor revokes the lease, so
+    reading it as "someone else owns this failure now" leaves the microphone
+    blocked forever with the lease still held. That is the race commit
+    94c26715 was written for, and it is why the notify phase fences on the
+    failure's own token instead: a replacement that genuinely retires this
+    failure (a start, a close) advances the route operation generation, which
+    ``_fail_closed_voice_route`` checks on its own.
+    """
+
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "glm"
+    assert runtime._begin_voice_input_connection("socket-a") is True
+    runtime._voice_lease_owner = "core"
+    runtime._voice_lease_synchronized = True
+    abort_started = asyncio.Event()
+    release_abort = asyncio.Event()
+
+    async def delayed_abort(_reason: str) -> None:
+        abort_started.set()
+        await release_abort.wait()
+
+    runtime._asr_runtime.abort = AsyncMock(side_effect=delayed_abort)
+    failure = asyncio.create_task(
+        runtime._fail_voice_input_pipeline(
+            ingress_token=runtime._capture_ingress_token(),
+            session_ref=runtime.session,
+            audio_epoch=runtime._audio_stream_epoch,
+            pipeline_ref=runtime._voice_input_audio_pipeline,
+        )
+    )
+    await asyncio.wait_for(abort_started.wait(), 1)
+
+    runtime._voice_input_audio_pipeline = SimpleNamespace(
+        process=AsyncMock(),
+        close=AsyncMock(),
+    )
+    runtime._voice_input_pipeline_failed = False
+
+    release_abort.set()
+    await asyncio.wait_for(failure, 1)
+
+    runtime.send_status.assert_awaited()
+    assert runtime._voice_lease_connection_id == ""
+    assert runtime._voice_lease_owner == "none"
+
+
+async def test_backpressured_status_send_does_not_block_pipeline_transitions() -> None:
+    """The frontend socket is unbounded; the transition lock must not wait on it.
+
+    ``_fail_closed_voice_route`` writes the failure notice to the voice owner,
+    and a throttled or backpressured client can stall that write for as long
+    as it likes. Session restart, independent-ASR close and the
+    noise-reduction toggle all need the same pipeline transition lock, so
+    holding it across the notify phase parked every recovery operation behind
+    one unrelated client write.
+    """
+
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "glm"
+    assert runtime._begin_voice_input_connection("socket-a") is True
+    runtime._voice_lease_owner = "core"
+    runtime._voice_lease_synchronized = True
+    runtime._asr_runtime.abort = AsyncMock()
+    status_started = asyncio.Event()
+    release_status = asyncio.Event()
+
+    async def backpressured_status(_payload) -> None:
+        status_started.set()
+        await release_status.wait()
+
+    runtime.send_status = AsyncMock(side_effect=backpressured_status)
+    failure = asyncio.create_task(
+        runtime._fail_voice_input_pipeline(
+            ingress_token=runtime._capture_ingress_token(),
+            session_ref=runtime.session,
+            audio_epoch=runtime._audio_stream_epoch,
+            pipeline_ref=runtime._voice_input_audio_pipeline,
+        )
+    )
+    await asyncio.wait_for(status_started.wait(), 1)
+
+    source_pipeline = runtime._voice_input_audio_pipeline
+    # The client is still absorbing the notice. A toggle must not queue behind
+    # it: this is the whole point of shrinking the lock.
+    assert await asyncio.wait_for(
+        runtime.apply_voice_input_noise_reduction(False),
+        1,
+    ) is True
+    assert runtime._voice_input_audio_pipeline is not source_pipeline
+
+    release_status.set()
+    await asyncio.wait_for(failure, 1)
+
+    # ...and the failure still finishes fail-closed once the client catches up.
+    assert runtime._asr_route_mode == "blocked"
+    assert runtime._voice_lease_connection_id == ""
+    assert runtime._voice_lease_owner == "none"
+
+
 async def test_pipeline_failure_from_replaced_connection_is_silent() -> None:
     runtime = _Runtime()
     runtime.is_active = True
@@ -6350,7 +6458,6 @@ async def test_pipeline_failure_from_replaced_connection_is_silent() -> None:
         "focus_suppression",
         "game_takeover",
         "route_operation",
-        "pipeline",
         "core_session",
     ],
 )
@@ -6398,12 +6505,6 @@ async def test_stale_pipeline_failure_never_reports_to_current_identity(
             "_asr_route_operation_generation",
             runtime._asr_route_operation_generation + 1,
         )
-    elif changed_identity == "pipeline":
-        runtime._voice_input_audio_pipeline = SimpleNamespace(
-            process=AsyncMock(),
-            close=AsyncMock(),
-        )
-        runtime._voice_input_pipeline_failed = False
     elif changed_identity == "core_session":
         runtime.session = SimpleNamespace(stream_audio=AsyncMock())
     else:

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -6506,6 +6506,69 @@ async def test_a_live_route_releases_the_pipeline_failure_ingress_latch() -> Non
     assert runtime._voice_input_pipeline_failure_token is None
 
 
+async def test_pipeline_failure_stops_accepting_pcm_at_ingress() -> None:
+    """The latch drops frames before the queue, not after the worker dequeues.
+
+    NATIVE route and the fixture's DEFAULT lease state, both load-bearing.
+    The independent route reaches `_abort_independent_asr` on the way here and
+    that invalidates the voice PCM sync, which closes the lease gate one step
+    below the latch; and `_begin_voice_input_connection` also leaves the lease
+    in a state that refuses PCM. Either one makes this test pass without ever
+    exercising the latch -- the first version of it did exactly that, and the
+    mutant survived.
+
+    On the native route with a live lease nothing else stands in the way:
+    `_voice_input_accepts_pcm` is lease-only and reads neither the route mode
+    nor the latch, so a backpressured status send left the client free to fill
+    the bounded queue -- and overflowing it takes the QueueFull path, which
+    aborts the run all over again.
+    """
+
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime._set_microphone_route("native")
+    runtime._asr_runtime.abort = AsyncMock()
+    status_started = asyncio.Event()
+    release_status = asyncio.Event()
+
+    async def backpressured_status(_payload) -> None:
+        status_started.set()
+        await release_status.wait()
+
+    runtime.send_status = AsyncMock(side_effect=backpressured_status)
+    # Keep the worker from draining what the queue accepts, so the depth below
+    # measures what ingress ADMITTED rather than what survived a race with it.
+    runtime._ensure_audio_stream_worker = lambda: None
+
+    failure = asyncio.create_task(
+        runtime._fail_voice_input_pipeline(
+            ingress_token=runtime._capture_ingress_token(),
+            session_ref=runtime.session,
+            audio_epoch=runtime._audio_stream_epoch,
+            pipeline_ref=runtime._voice_input_audio_pipeline,
+        )
+    )
+    await asyncio.wait_for(status_started.wait(), 1)
+
+    # Premise: everything DOWNSTREAM of the latch would still take this PCM.
+    # Without this the test can pass for the wrong reason.
+    assert runtime._voice_input_accepts_pcm() is True
+
+    for _ in range(4):
+        await runtime._enqueue_audio_stream_data(
+            {"input_type": "audio", "sample_rate_hz": 48_000, "data": [1] * 480}
+        )
+
+    assert runtime._audio_stream_queue.qsize() == 0, (
+        "PCM arriving during the failure notice must be dropped at ingress "
+        "rather than queued behind it"
+    )
+
+    release_status.set()
+    await asyncio.wait_for(failure, 1)
+    assert runtime._asr_route_mode == "blocked"
+
+
 async def test_stale_failure_abort_does_not_clear_successor_route_audio() -> None:
     """A restart landing inside the abort keeps its own queued audio.
 

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -6406,6 +6406,106 @@ async def test_backpressured_status_send_does_not_block_pipeline_transitions() -
     assert runtime._voice_lease_owner == "none"
 
 
+async def test_pipeline_toggle_during_failure_notify_keeps_ingress_closed() -> None:
+    """A toggle must not reopen the microphone while the route is failing.
+
+    `_voice_input_pipeline_failed` is the ingress gate, and ANY pipeline
+    replacement clears it -- a noise-reduction toggle included. Once the
+    notify phase left the transition lock, such a toggle can land while a
+    backpressured status send is still in flight, i.e. while this failure
+    still owns a blocked route whose lease has not been revoked. Frames would
+    then be parsed, queued and run through the replacement DSP until the route
+    discards them: bounded queue refilled, preprocessing burnt, ingress
+    backpressure tripped, all during what must stay a fail-closed interval.
+    """
+
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime.is_hot_swap_imminent = False
+    runtime.is_flushing_hot_swap_cache = False
+    runtime.session.stream_audio = AsyncMock()
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "glm"
+    assert runtime._begin_voice_input_connection("socket-a") is True
+    runtime._voice_lease_owner = "core"
+    runtime._voice_lease_synchronized = True
+    runtime._asr_runtime.abort = AsyncMock()
+    runtime._asr_runtime.submit = AsyncMock()
+    token = runtime._capture_ingress_token()
+    status_started = asyncio.Event()
+    release_status = asyncio.Event()
+
+    async def backpressured_status(_payload) -> None:
+        status_started.set()
+        await release_status.wait()
+
+    runtime.send_status = AsyncMock(side_effect=backpressured_status)
+    failure = asyncio.create_task(
+        runtime._fail_voice_input_pipeline(
+            ingress_token=token,
+            session_ref=runtime.session,
+            audio_epoch=runtime._audio_stream_epoch,
+            pipeline_ref=runtime._voice_input_audio_pipeline,
+        )
+    )
+    await asyncio.wait_for(status_started.wait(), 1)
+
+    assert await asyncio.wait_for(
+        runtime.apply_voice_input_noise_reduction(False),
+        1,
+    ) is True
+    # Premise: the toggle really did clear the old gate, so anything still
+    # holding ingress closed is the committed failure's own latch.
+    assert runtime._voice_input_pipeline_failed is False
+    replacement = runtime._voice_input_audio_pipeline
+    replacement.process = AsyncMock()
+
+    # Captured HERE, not before the failure. A live client keeps sending PCM
+    # with a current token, so `_ingress_token_matches` passes and the frame
+    # reaches the DSP without any lease check in between -- which is the whole
+    # point. A token snapshotted before the route was blocked would be dropped
+    # by the token fence instead, and this test would prove nothing.
+    live_token = runtime._capture_ingress_token()
+    assert runtime._ingress_token_matches(live_token) is True
+
+    await runtime._process_microphone_stream_data(
+        {"input_type": "audio", "sample_rate_hz": 48_000, "data": [1] * 480},
+        ingress_token=live_token,
+    )
+
+    replacement.process.assert_not_awaited()
+    runtime._asr_runtime.submit.assert_not_awaited()
+    runtime.session.stream_audio.assert_not_awaited()
+
+    release_status.set()
+    await asyncio.wait_for(failure, 1)
+    assert runtime._asr_route_mode == "blocked"
+    assert runtime._voice_lease_connection_id == ""
+
+
+async def test_a_live_route_releases_the_pipeline_failure_ingress_latch() -> None:
+    """The latch is fail-closed, not permanent: a live route clears it."""
+
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "glm"
+    runtime._asr_runtime.abort = AsyncMock()
+    runtime._voice_input_audio_pipeline.process = AsyncMock(
+        side_effect=RuntimeError("soxr failed")
+    )
+    token = runtime._capture_ingress_token()
+    await runtime._process_microphone_stream_data(
+        {"input_type": "audio", "sample_rate_hz": 48_000, "data": [1] * 480},
+        ingress_token=token,
+    )
+    assert runtime._asr_route_mode == "blocked"
+    assert runtime._voice_input_pipeline_failure_token is not None
+
+    runtime._set_microphone_route("independent")
+    assert runtime._voice_input_pipeline_failure_token is None
+
+
 async def test_pipeline_failure_from_replaced_connection_is_silent() -> None:
     runtime = _Runtime()
     runtime.is_active = True

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -6506,6 +6506,60 @@ async def test_a_live_route_releases_the_pipeline_failure_ingress_latch() -> Non
     assert runtime._voice_input_pipeline_failure_token is None
 
 
+async def test_stale_failure_abort_does_not_clear_successor_route_audio() -> None:
+    """A restart landing inside the abort keeps its own queued audio.
+
+    `_abort_independent_asr` invalidates the voice PCM sync AFTER awaiting the
+    runtime abort. That await is no longer covered by the pipeline transition
+    lock, so a session restart can install a newer route inside it -- and the
+    old failure would then clear the successor's queued and hot-swap audio and
+    drop its microphone input.
+    """
+
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "glm"
+    assert runtime._begin_voice_input_connection("socket-a") is True
+    runtime._voice_lease_owner = "core"
+    runtime._voice_lease_synchronized = True
+    abort_started = asyncio.Event()
+    release_abort = asyncio.Event()
+
+    async def blocking_abort(_reason: str) -> None:
+        abort_started.set()
+        await release_abort.wait()
+
+    runtime._asr_runtime.abort = AsyncMock(side_effect=blocking_abort)
+    invalidated: list[str] = []
+    runtime._invalidate_voice_pcm_sync = lambda reason: invalidated.append(reason)
+
+    failure = asyncio.create_task(
+        runtime._fail_voice_input_pipeline(
+            ingress_token=runtime._capture_ingress_token(),
+            session_ref=runtime.session,
+            audio_epoch=runtime._audio_stream_epoch,
+            pipeline_ref=runtime._voice_input_audio_pipeline,
+        )
+    )
+    await asyncio.wait_for(abort_started.wait(), 1)
+
+    # A newer route operation claims the route while the abort is in flight.
+    object.__setattr__(
+        runtime,
+        "_asr_route_operation_generation",
+        runtime._asr_route_operation_generation + 1,
+    )
+    release_abort.set()
+    await asyncio.wait_for(failure, 1)
+
+    assert invalidated == [], (
+        "the successor route owns the voice PCM sync now; this failure must "
+        "not clear it"
+    )
+    runtime.send_status.assert_not_awaited()
+
+
 async def test_pipeline_failure_from_replaced_connection_is_silent() -> None:
     runtime = _Runtime()
     runtime.is_active = True

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -227,7 +227,9 @@ async def test_proactive_inject_does_not_cancel_current_turn_tool_task(
         client._send_tool_result_gemini = AsyncMock()
     else:
         client.ws = _QueueSocket()
-        client._send_tool_result_openai_realtime = AsyncMock()
+        # The plural is what the batch collector calls; the singular is only a
+        # convenience wrapper around it, so patching that one records nothing.
+        client._send_tool_results_openai_realtime = AsyncMock()
     client._on_connection_attached()
     if api_type != "gemini":
         sent = asyncio.get_running_loop().create_future()
@@ -258,7 +260,7 @@ async def test_proactive_inject_does_not_cancel_current_turn_tool_task(
     if api_type == "gemini":
         client._send_tool_result_gemini.assert_awaited_once()
     else:
-        client._send_tool_result_openai_realtime.assert_awaited_once()
+        client._send_tool_results_openai_realtime.assert_awaited_once()
 
 
 @pytest.mark.unit
@@ -762,8 +764,14 @@ async def test_raw_tool_cancel_survives_tool_scope_replacement() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_parallel_raw_tool_results_survive_a_sibling_response_created() -> None:
-    """The first result's own response.created must not orphan its siblings."""
+async def test_parallel_raw_tool_results_are_answered_as_one_batch() -> None:
+    """One provider response, one continuation -- no sibling left behind.
+
+    Submitting per result enqueued a response.create with the FIRST output, so
+    the arbiter sent that output and immediately started a continuation while
+    the sibling's ticket was still queued. The provider saw a continuation
+    with a required parallel-call output missing and answered without it.
+    """
 
     host_turn = ["turn-1"]
     started = {"call-1": asyncio.Event(), "call-2": asyncio.Event()}
@@ -788,25 +796,27 @@ async def test_parallel_raw_tool_results_survive_a_sibling_response_created() ->
     client._current_turn_host_id = host_turn[0]
     receive_loop = asyncio.create_task(client.handle_messages())
 
-    socket.feed(_raw_tool_event("call-1"))
-    socket.feed(_raw_tool_event("call-2"))
+    # Same response_id: these are the parallel calls of ONE provider response.
+    socket.feed(_raw_tool_event("call-1", response_id="response-1"))
+    socket.feed(_raw_tool_event("call-2", response_id="response-1"))
     await asyncio.wait_for(started["call-1"].wait(), timeout=1)
     await asyncio.wait_for(started["call-2"].wait(), timeout=1)
 
-    # The faster sibling answers first; its response.create is announced only
-    # after response.done has already rotated the host speech id.
     release["call-1"].set()
-    await _wait_for_socket_sends(socket, 2)
-    host_turn[0] = "turn-2"
-    socket.feed({"type": "response.created", "response": {"id": "tool-response-1"}})
-    socket.feed({"type": "response.done", "response": {"id": "tool-response-1"}})
-    await client._response_arbiter.wait_until_idle(timeout=1)
-    # Premise of this regression: the provider-turn snapshot really did move.
-    assert client._current_turn_host_id == "turn-2"
+    await asyncio.sleep(0.05)
+    assert socket.sent == [], (
+        "the finished sibling must not start a continuation while the other "
+        "call of the same response is still running"
+    )
 
     release["call-2"].set()
     await _wait_for_tool_tasks(client)
 
+    assert [event["type"] for event in socket.sent] == [
+        "conversation.item.create",
+        "conversation.item.create",
+        "response.create",
+    ], "every output first, then exactly one continuation"
     answered = [
         event["item"]["call_id"]
         for event in socket.sent
@@ -814,6 +824,47 @@ async def test_parallel_raw_tool_results_survive_a_sibling_response_created() ->
         and event.get("item", {}).get("type") == "function_call_output"
     ]
     assert answered == ["call-1", "call-2"]
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raw_tool_call_without_response_identity_still_answers() -> None:
+    """No response_id means no provable siblings -- answer each on its own.
+
+    The degradation the batch key accepts: without response identity there is
+    nothing to group by, and holding a result for a sibling that may never be
+    announced would be worse than the per-result shape it replaced.
+    """
+
+    async def handler(call):
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gpt-realtime",
+        api_type="gpt",
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    event = _raw_tool_event("call-1")
+    event.pop("response_id")
+    socket.feed(event)
+    await _wait_for_socket_sends(socket, 2)
+    await _wait_for_tool_tasks(client)
+
+    assert [item["type"] for item in socket.sent] == [
+        "conversation.item.create",
+        "response.create",
+    ]
+    assert socket.sent[0]["item"]["call_id"] == "call-1"
 
     socket.finish()
     await asyncio.wait_for(receive_loop, timeout=1)
@@ -1076,6 +1127,7 @@ async def test_raw_transcript_does_not_advance_scope_twice_after_speech_started(
     socket.feed({"type": "input_audio_buffer.speech_started"})
     socket.feed(_raw_tool_event())
     await asyncio.wait_for(started.wait(), timeout=1)
+    scope_after_speech_started = client._tool_scope_generation
 
     socket.feed(
         {
@@ -1085,7 +1137,10 @@ async def test_raw_transcript_does_not_advance_scope_twice_after_speech_started(
     )
     await asyncio.wait_for(transcript_seen.wait(), timeout=1)
     assert not cancelled.is_set()
-    assert len(client._tool_tasks) == 1
+    assert client._tool_scope_generation == scope_after_speech_started, (
+        "the transcript of an utterance speech_started already scoped must "
+        "not advance the tool scope a second time"
+    )
 
     release.set()
     await _wait_for_tool_tasks(client)
@@ -3190,3 +3245,284 @@ async def test_cancelled_prompt_ephemeral_leaves_a_new_user_turn_alone() -> None
     assert len(session.client_contents) == sends_after_inject, (
         "the cancellation cleanup interrupted the user's own generation"
     )
+
+
+def _no_server_vad_client(**hooks):
+    """A client whose no-server-VAD transcript fallback is really reachable.
+
+    The lanlan.app host is load-bearing, not decoration: ``_is_free_proxy``
+    keys on it, and that is what makes ``_has_server_vad`` False. With any
+    other host the same ``api_type="free"`` client HAS server VAD and the
+    transcript branch below never reaches the fallback at all.
+    """
+
+    client = OmniRealtimeClient(
+        "wss://www.lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        **hooks,
+    )
+    assert client._has_server_vad is False, (
+        "this helper exists to cover the transcript-only turn boundary"
+    )
+    return client
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transcript_of_a_new_utterance_retires_a_dropped_turns_tool() -> None:
+    """A speech_started whose transcript never arrives must not scope the NEXT turn.
+
+    The proxy shape this covers is inconsistent on purpose, because the real
+    ones are: it announces speech_started for turn N, drops turn N's
+    transcript, then drops speech_started for turn N+1 and delivers ITS
+    transcript. Nothing between those two turns clears a plain pending flag --
+    not speech_stopped, not response.done -- so the new turn's transcript read
+    as already scoped, note_user_turn_started was skipped, and a
+    cancellation-resistant tool from turn N could still answer into turn N+1.
+    """
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    transcript_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(call):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            # Re-raised, not swallowed: a swallowed CancelledError turns a
+            # failing assertion below into a hang at loop teardown instead of
+            # a failure.
+            raise
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    async def on_input_transcript(_transcript: str) -> None:
+        transcript_seen.set()
+
+    client = _no_server_vad_client(
+        on_input_transcript=on_input_transcript,
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    # Turn N: the proxy announces the utterance, then never transcribes it.
+    socket.feed({"type": "input_audio_buffer.speech_started", "item_id": "item-a"})
+    socket.feed(_raw_tool_event())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    scope_after_turn_n = client._tool_scope_generation
+
+    # Turn N+1: no speech_started at all, only the completed transcript -- of a
+    # DIFFERENT utterance.
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-b",
+            "transcript": "the next thing the user said",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+
+    assert client._tool_scope_generation != scope_after_turn_n, (
+        "a transcript for an utterance no speech_started scoped begins a new "
+        "user turn, whatever an earlier utterance left behind"
+    )
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    release.set()
+    await _wait_for_tool_tasks(client)
+
+    assert socket.sent == []
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transcript_of_its_own_utterance_does_not_rescope_the_turn() -> None:
+    """The healthy no-VAD path: one turn, one note_user_turn_started."""
+
+    transcript_seen = asyncio.Event()
+
+    async def on_input_transcript(_transcript: str) -> None:
+        transcript_seen.set()
+
+    client = _no_server_vad_client(on_input_transcript=on_input_transcript)
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "input_audio_buffer.speech_started", "item_id": "item-a"})
+    await asyncio.sleep(0)
+    scope_after_speech_started = client._tool_scope_generation
+
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-a",
+            "transcript": "what the user just said",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+
+    assert client._tool_scope_generation == scope_after_speech_started
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_late_transcript_does_not_rescope_an_already_started_turn() -> None:
+    """Input transcription is its own job; its output can land out of order.
+
+    Turn N's transcript arriving after turn N+1 has begun must not retire
+    turn N+1's tool work -- which is what expiring the marker on a response
+    lifecycle point would have caused.
+    """
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    transcripts: list[str] = []
+    transcript_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(call):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    async def on_input_transcript(transcript: str) -> None:
+        transcripts.append(transcript)
+        transcript_seen.set()
+
+    client = _no_server_vad_client(
+        on_input_transcript=on_input_transcript,
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "input_audio_buffer.speech_started", "item_id": "item-a"})
+    socket.feed({"type": "input_audio_buffer.speech_started", "item_id": "item-b"})
+    socket.feed(_raw_tool_event())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    scope_after_turn_b = client._tool_scope_generation
+
+    # item-a's transcript only shows up now, a turn late.
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-a",
+            "transcript": "the previous utterance",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+
+    assert transcripts == ["the previous utterance"]
+    assert client._tool_scope_generation == scope_after_turn_b, (
+        "a transcript for an utterance already scoped is not a new user turn"
+    )
+    assert not cancelled.is_set()
+
+    release.set()
+    await _wait_for_tool_tasks(client)
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gemini_proactive_answers_the_calls_it_gave_up_on(monkeypatch) -> None:
+    """A tool the settle budget abandoned still gets a function_call_output.
+
+    The inject that follows interrupts the generation that issued the call, so
+    without this the conversation keeps a function_call nobody ever replied to.
+    The abandoned reply goes out BEFORE the inject, and the call is retired so
+    a result arriving afterwards is dropped instead of landing in the
+    proactive turn.
+    """
+
+    import main_logic.omni_realtime_client._responses as responses
+
+    monkeypatch.setattr(responses, "_GEMINI_PROACTIVE_TOOL_SETTLE_SECONDS", 0.05)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    order: list[str] = []
+
+    async def handler(call):
+        started.set()
+        await release.wait()
+        order.append("tool")
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    class _OrderedSession(_GeminiSession):
+        async def send_client_content(self, *, turns, turn_complete) -> None:
+            order.append("proactive")
+
+        async def send_tool_response(self, *, function_responses) -> None:
+            order.append("tool_response")
+            await super().send_tool_response(function_responses=function_responses)
+
+    monkeypatch.setattr(
+        __import__(
+            "main_logic.omni_realtime_client._gemini_support",
+            fromlist=["types"],
+        ),
+        "types",
+        SimpleNamespace(FunctionResponse=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gemini-live",
+        api_type="gemini",
+        on_tool_call=handler,
+    )
+    session = _OrderedSession()
+    client._gemini_session = session
+    client.ws = session
+    client._on_connection_attached()
+
+    await client._process_gemini_response(
+        _gemini_response(calls=(("call-a", "lookup"),)),
+        provider_session=session,
+        connection_generation=client._connection_generation,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await asyncio.wait_for(
+        client.inject_text_and_request_response("proactive body"), timeout=2
+    )
+
+    assert order == ["tool_response", "proactive"], (
+        "the abandoned reply must go out while the generation that issued the "
+        "call is still the current one"
+    )
+    assert len(session.tool_responses) == 1
+    abandoned = session.tool_responses[0]
+    assert [r.id for r in abandoned] == ["call-a"]
+    assert [r.name for r in abandoned] == ["lookup"]
+    assert abandoned[0].response["abandoned"] is True
+
+    # The real result lands late and must be dropped, not injected into the
+    # proactive turn it would now be part of.
+    release.set()
+    await _wait_for_tool_tasks(client)
+    assert len(session.tool_responses) == 1, (
+        "an abandoned call is retired; its late result must not be sent"
+    )
+    assert order == ["tool_response", "proactive", "tool"]

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -3531,3 +3531,98 @@ async def test_gemini_proactive_answers_the_calls_it_gave_up_on(monkeypatch) -> 
         "an abandoned call is retired; its late result must not be sent"
     )
     assert order == ["tool_response", "proactive", "tool"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gemini_proactive_gives_up_a_pending_collectors_whole_batch(
+    monkeypatch,
+) -> None:
+    """A finished-but-unflushed sibling is as abandoned as the running one.
+
+    At the settle deadline the only unsettled task of a batch can be its
+    COLLECTOR -- the calls are done, their results just have not been flushed
+    yet. A collector owns no call, so retiring it answers nothing and does not
+    stop it from sending those results, which after the inject below land in
+    the proactive turn: the cross-turn injection this path exists to prevent.
+    Whatever the collector has not flushed by the deadline is given up with
+    the rest of its batch.
+    """
+
+    import main_logic.omni_realtime_client._responses as responses
+
+    monkeypatch.setattr(responses, "_GEMINI_PROACTIVE_TOOL_SETTLE_SECONDS", 0.05)
+    started_slow = asyncio.Event()
+    release_slow = asyncio.Event()
+    order: list[str] = []
+
+    async def handler(call):
+        if call.call_id == "call-fast":
+            return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+        started_slow.set()
+        await release_slow.wait()
+        order.append("slow tool")
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    class _OrderedSession(_GeminiSession):
+        async def send_client_content(self, *, turns, turn_complete) -> None:
+            order.append("proactive")
+
+        async def send_tool_response(self, *, function_responses) -> None:
+            order.append("tool_response")
+            await super().send_tool_response(function_responses=function_responses)
+
+    monkeypatch.setattr(
+        __import__(
+            "main_logic.omni_realtime_client._gemini_support",
+            fromlist=["types"],
+        ),
+        "types",
+        SimpleNamespace(FunctionResponse=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gemini-live",
+        api_type="gemini",
+        on_tool_call=handler,
+    )
+    session = _OrderedSession()
+    client._gemini_session = session
+    client.ws = session
+    client._on_connection_attached()
+
+    await client._process_gemini_response(
+        _gemini_response(calls=(("call-fast", "alpha"), ("call-slow", "beta"))),
+        provider_session=session,
+        connection_generation=client._connection_generation,
+    )
+    await asyncio.wait_for(started_slow.wait(), timeout=1)
+
+    # Premise: the fast call really did finish, and its result is sitting in
+    # the collector unflushed because its sibling has not settled.
+    entries = client._tool_batch_by_collector_task()[
+        next(iter(client._tool_batch_collector_tasks))
+    ].entries
+    fast_entry = next(e for e in entries if e.call.call_id == "call-fast")
+    await asyncio.wait_for(fast_entry.task, timeout=1)
+    assert session.tool_responses == []
+
+    await asyncio.wait_for(
+        client.inject_text_and_request_response("proactive body"), timeout=2
+    )
+
+    assert len(session.tool_responses) == 1
+    abandoned = session.tool_responses[0]
+    assert sorted(r.id for r in abandoned) == ["call-fast", "call-slow"]
+    assert all(r.response["abandoned"] is True for r in abandoned), (
+        "the finished sibling's real result must not be flushed after the "
+        "inject interrupted the generation that issued it"
+    )
+    assert order == ["tool_response", "proactive"]
+
+    release_slow.set()
+    await _wait_for_tool_tasks(client)
+    assert len(session.tool_responses) == 1
+    assert order == ["tool_response", "proactive", "slow tool"]

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -4065,3 +4065,68 @@ async def test_gemini_proactive_waits_for_a_tool_response_still_being_written(
     await _wait_for_tool_tasks(client)
 
     assert order == ["tool_response", "proactive"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raw_batch_answers_when_its_response_done_is_stale_filtered() -> None:
+    """A batch whose terminal never reaches the close hook still answers.
+
+    ``close_raw_tool_batch`` sits after the stale-response filter, so a
+    ``response.done`` for A arriving once B is current is dropped before it --
+    A's batch is never explicitly closed. That is survivable because the grace
+    is gated on EVIDENCE rather than on a timer: the collector waits only
+    while the issuing response is still the tracked one, and here it is not.
+    Without that gate this batch would sit out a grace round it can never win.
+    """
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(call):
+        started.set()
+        await release.wait()
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gpt-realtime",
+        api_type="gpt",
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "response-a"}})
+    socket.feed(_raw_tool_event("call-1", response_id="response-a"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    # B becomes current, then A's terminal finally shows up -- and is dropped
+    # by the stale filter before it can reach the close hook.
+    socket.feed({"type": "response.created", "response": {"id": "response-b"}})
+    socket.feed({"type": "response.done", "response": {"id": "response-a"}})
+    socket.feed({"type": "response.done", "response": {"id": "response-b"}})
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    assert client._current_response_id != "response-a", (
+        "premise: A is no longer the tracked response"
+    )
+
+    release.set()
+    await _wait_for_socket_sends(socket, 2)
+    await _wait_for_tool_tasks(client)
+
+    answered = [
+        event["item"]["call_id"]
+        for event in socket.sent
+        if event.get("type") == "conversation.item.create"
+    ]
+    assert answered == ["call-1"], (
+        "A's tool result must still be sent even though its terminal never "
+        "reached the batch close hook"
+    )
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -3626,3 +3626,280 @@ async def test_gemini_proactive_gives_up_a_pending_collectors_whole_batch(
     await _wait_for_tool_tasks(client)
     assert len(session.tool_responses) == 1
     assert order == ["tool_response", "proactive", "slow tool"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raw_batch_waits_for_a_sibling_announced_after_the_first_finishes() -> None:
+    """A fast tool must not seal the batch out from under a sibling in flight.
+
+    The calls of one provider response arrive as separate events. If the first
+    tool finishes before the receive loop has read the second event, a
+    collector that answered on "nothing of mine is running" would seal a batch
+    of one -- and the sibling would open a second batch, so the provider gets
+    two continuations, each missing the other's parallel output. While the
+    issuing response is still the tracked one, the collector waits.
+    """
+
+    started = {"call-2": asyncio.Event()}
+    release = {"call-2": asyncio.Event()}
+
+    async def handler(call):
+        if call.call_id == "call-1":
+            return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+        started[call.call_id].set()
+        await release[call.call_id].wait()
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gpt-realtime",
+        api_type="gpt",
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "response-1"}})
+    socket.feed(_raw_tool_event("call-1", response_id="response-1"))
+    await asyncio.sleep(0.05)
+    # Premise: the fast call is done and its response is still the tracked
+    # one, so the collector has no proof the batch is complete.
+    assert client._current_response_id == "response-1"
+    # Asserted on the BATCH, not on socket.sent. The arbiter holds a
+    # tool_result ticket for as long as response-1 is live, so nothing has
+    # reached the socket yet either way -- `socket.sent == []` here is true of
+    # the broken behaviour too and would prove nothing. What distinguishes
+    # them is whether the batch is still open for its sibling to join: sealing
+    # it pops it from this registry, and call-2 would then open a second one
+    # and earn its own continuation.
+    assert len(client._open_tool_batches) == 1, (
+        "the batch must stay open while its response can still announce "
+        "another parallel call"
+    )
+
+    socket.feed(_raw_tool_event("call-2", response_id="response-1"))
+    await asyncio.wait_for(started["call-2"].wait(), timeout=1)
+    assert len(client._open_tool_batches) == 1, "both calls share one batch"
+    # Only now does the issuing response terminate. Fed here rather than
+    # earlier because it does two things at once: it closes the batch, and it
+    # frees the arbiter lane this response was holding -- without it the
+    # batch's own ticket would never be sent and the assertions below would
+    # time out instead of failing.
+    socket.feed({"type": "response.done", "response": {"id": "response-1"}})
+    release["call-2"].set()
+    await _wait_for_tool_tasks(client)
+
+    assert [event["type"] for event in socket.sent] == [
+        "conversation.item.create",
+        "conversation.item.create",
+        "response.create",
+    ]
+    answered = [
+        event["item"]["call_id"]
+        for event in socket.sent
+        if event.get("type") == "conversation.item.create"
+    ]
+    assert answered == ["call-1", "call-2"]
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raw_batch_answers_once_its_response_terminates() -> None:
+    """response.done closes the batch, so the answer is not held for a grace."""
+
+    async def handler(call):
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gpt-realtime",
+        api_type="gpt",
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "response-1"}})
+    socket.feed(_raw_tool_event("call-1", response_id="response-1"))
+    socket.feed({"type": "response.done", "response": {"id": "response-1"}})
+    await _wait_for_socket_sends(socket, 2)
+    await _wait_for_tool_tasks(client)
+
+    assert [event["type"] for event in socket.sent] == [
+        "conversation.item.create",
+        "response.create",
+    ]
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_identified_transcript_does_not_consume_an_idless_utterances_marker() -> None:
+    """An older identified transcript must leave the newer marker alone.
+
+    Transcription is asynchronous, so on a proxy that omitted `item_id` for
+    the NEWER utterance, an older transcript carrying its own id can arrive
+    first. That one is answered from the id list; consuming the id-less
+    fallback marker on the way would make the newer utterance's own transcript
+    read as an unscoped turn and retire tool work that belongs to it.
+    """
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+    transcripts: list[str] = []
+    transcript_seen = asyncio.Event()
+
+    async def handler(call):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    async def on_input_transcript(transcript: str) -> None:
+        transcripts.append(transcript)
+        transcript_seen.set()
+
+    client = _no_server_vad_client(
+        on_input_transcript=on_input_transcript,
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    # Utterance A is identified; utterance B is not, so B falls back to the
+    # one-shot marker.
+    socket.feed({"type": "input_audio_buffer.speech_started", "item_id": "item-a"})
+    socket.feed({"type": "input_audio_buffer.speech_started"})
+    socket.feed(_raw_tool_event())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    scope_after_b = client._tool_scope_generation
+    assert client._raw_speech_started_scope_pending_transcript is True
+
+    # A's transcript finally lands, out of order.
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-a",
+            "transcript": "the older utterance",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+    assert client._raw_speech_started_scope_pending_transcript is True, (
+        "an identified transcript is answered from the id list; it must not "
+        "consume the marker that belongs to the id-less utterance"
+    )
+    assert client._tool_scope_generation == scope_after_b
+
+    # Now B's own id-less transcript. It was already scoped by B's
+    # speech_started, so it must not start yet another turn.
+    transcript_seen.clear()
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "the current utterance",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+
+    assert transcripts == ["the older utterance", "the current utterance"]
+    assert client._tool_scope_generation == scope_after_b, (
+        "the live utterance's own transcript must not retire its own tool"
+    )
+    assert not cancelled.is_set()
+
+    release.set()
+    await _wait_for_tool_tasks(client)
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_wedged_abandoned_reply_still_lets_the_proactive_message_out(
+    monkeypatch,
+) -> None:
+    """The settle budget's promise survives a session that will not accept writes.
+
+    The abandoned-call reply goes to the same session that just proved it can
+    be slow. Awaiting it outright would let a wedged session hold the
+    proactive notification forever -- restoring exactly the unbounded
+    tool-turn gate this path replaced.
+    """
+
+    import main_logic.omni_realtime_client._responses as responses
+
+    monkeypatch.setattr(responses, "_GEMINI_PROACTIVE_TOOL_SETTLE_SECONDS", 0.05)
+    started = asyncio.Event()
+    never = asyncio.Event()
+    order: list[str] = []
+
+    async def handler(call):
+        started.set()
+        await never.wait()
+        return ToolResult(call_id=call.call_id, name=call.name, output={})
+
+    class _WedgedSession(_GeminiSession):
+        async def send_tool_response(self, *, function_responses) -> None:
+            order.append("tool_response started")
+            await never.wait()
+
+        async def send_client_content(self, *, turns, turn_complete) -> None:
+            order.append("proactive")
+
+    monkeypatch.setattr(
+        __import__(
+            "main_logic.omni_realtime_client._gemini_support",
+            fromlist=["types"],
+        ),
+        "types",
+        SimpleNamespace(FunctionResponse=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gemini-live",
+        api_type="gemini",
+        on_tool_call=handler,
+    )
+    session = _WedgedSession()
+    client._gemini_session = session
+    client.ws = session
+    client._TOOL_TASK_CANCEL_TIMEOUT_S = 0.05
+    client._on_connection_attached()
+
+    await client._process_gemini_response(
+        _gemini_response(calls=(("call-a", "lookup"),)),
+        provider_session=session,
+        connection_generation=client._connection_generation,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await asyncio.wait_for(
+        client.inject_text_and_request_response("proactive body"), timeout=2
+    )
+
+    assert order == ["tool_response started", "proactive"], (
+        "the inject must proceed even though the abandoned reply never "
+        "finished writing"
+    )
+
+    never.set()
+    await _wait_for_tool_tasks(client)

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -3903,3 +3903,83 @@ async def test_a_wedged_abandoned_reply_still_lets_the_proactive_message_out(
 
     never.set()
     await _wait_for_tool_tasks(client)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_identified_speech_start_does_not_arm_the_idless_marker() -> None:
+    """An identified turn must not leave the fallback marker armed behind it.
+
+    Identified transcripts are answered from the id list and never consume the
+    marker, so arming it for an identified speech_started would leave it set
+    for the rest of the connection. The next turn that arrives WITHOUT a
+    speech_started and without a transcript id would then read as already
+    scoped -- the original stale-marker bug, rebuilt one turn further along.
+    """
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+    transcript_seen = asyncio.Event()
+
+    async def handler(call):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    async def on_input_transcript(_transcript: str) -> None:
+        transcript_seen.set()
+
+    client = _no_server_vad_client(
+        on_input_transcript=on_input_transcript,
+        on_tool_call=handler,
+    )
+    socket = _QueueSocket()
+    client.ws = socket
+    client._on_connection_attached()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    # A fully identified turn, start to transcript.
+    socket.feed({"type": "input_audio_buffer.speech_started", "item_id": "item-a"})
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-a",
+            "transcript": "the identified turn",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+    assert client._raw_speech_started_scope_pending_transcript is False, (
+        "an identified speech_started is tracked by id; it must not also arm "
+        "the id-less fallback marker"
+    )
+
+    socket.feed(_raw_tool_event())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    scope_before = client._tool_scope_generation
+
+    # The next turn arrives with neither a speech_started nor a transcript id.
+    transcript_seen.clear()
+    socket.feed(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "an unidentified new turn",
+        }
+    )
+    await asyncio.wait_for(transcript_seen.wait(), timeout=1)
+
+    assert client._tool_scope_generation != scope_before, (
+        "an id-less transcript with no speech_started of its own is a new "
+        "user turn and must retire the previous turn's tool work"
+    )
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    release.set()
+    await _wait_for_tool_tasks(client)
+
+    assert socket.sent == []
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -4041,12 +4041,11 @@ async def test_gemini_proactive_waits_for_a_tool_response_still_being_written(
     client.ws = session
     client._on_connection_attached()
 
-    collector = client._process_gemini_response(
+    await client._process_gemini_response(
         _gemini_response(calls=(("call-a", "lookup"),)),
         provider_session=session,
         connection_generation=client._connection_generation,
     )
-    await collector
     await asyncio.wait_for(write_entered.wait(), timeout=1)
 
     # Premise: the batch really is sealed already -- there was no window

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -3983,3 +3983,85 @@ async def test_identified_speech_start_does_not_arm_the_idless_marker() -> None:
     assert socket.sent == []
     socket.finish()
     await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gemini_proactive_waits_for_a_tool_response_still_being_written(
+    monkeypatch,
+) -> None:
+    """A sealed batch whose write is in flight still holds the inject back.
+
+    Sealing marks "this batch has decided its answer", and there is no await
+    between it and the provider write -- so by the time anything else can
+    observe `sealed`, the write has already started and cannot be recalled.
+    What keeps the ordering is that the collector task is still PENDING while
+    it writes, so the settle waits for it exactly like any other unsettled
+    tool work, within the same budget. This pins that; its bounded twin is
+    ``test_a_wedged_abandoned_reply_still_lets_the_proactive_message_out``.
+    """
+
+    import main_logic.omni_realtime_client._responses as responses
+
+    monkeypatch.setattr(responses, "_GEMINI_PROACTIVE_TOOL_SETTLE_SECONDS", 5.0)
+    write_entered = asyncio.Event()
+    release_write = asyncio.Event()
+    order: list[str] = []
+
+    async def handler(call):
+        return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
+
+    class _SlowWriteSession(_GeminiSession):
+        async def send_tool_response(self, *, function_responses) -> None:
+            write_entered.set()
+            await release_write.wait()
+            order.append("tool_response")
+
+        async def send_client_content(self, *, turns, turn_complete) -> None:
+            order.append("proactive")
+
+    monkeypatch.setattr(
+        __import__(
+            "main_logic.omni_realtime_client._gemini_support",
+            fromlist=["types"],
+        ),
+        "types",
+        SimpleNamespace(FunctionResponse=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="gemini-live",
+        api_type="gemini",
+        on_tool_call=handler,
+    )
+    session = _SlowWriteSession()
+    client._gemini_session = session
+    client.ws = session
+    client._on_connection_attached()
+
+    collector = client._process_gemini_response(
+        _gemini_response(calls=(("call-a", "lookup"),)),
+        provider_session=session,
+        connection_generation=client._connection_generation,
+    )
+    await collector
+    await asyncio.wait_for(write_entered.wait(), timeout=1)
+
+    # Premise: the batch really is sealed already -- there was no window
+    # between sealing and the write in which anything could have suppressed it.
+    batch = next(iter(client._tool_batch_collector_tasks.values()))
+    assert batch.sealed is True
+
+    inject = asyncio.create_task(
+        client.inject_text_and_request_response("proactive body")
+    )
+    await asyncio.sleep(0.05)
+    assert order == [], "the inject must not overtake a tool response mid-write"
+
+    release_write.set()
+    await asyncio.wait_for(inject, timeout=2)
+    await _wait_for_tool_tasks(client)
+
+    assert order == ["tool_response", "proactive"]

--- a/tests/unit/test_realtime_tool_ownership.py
+++ b/tests/unit/test_realtime_tool_ownership.py
@@ -3495,6 +3495,11 @@ async def test_gemini_proactive_answers_the_calls_it_gave_up_on(monkeypatch) -> 
     session = _OrderedSession()
     client._gemini_session = session
     client.ws = session
+    # Long enough that the batch collector can only wake by its call
+    # COMPLETING, never by a poll timeout. That pins the ordering the retired
+    # set alone cannot survive: the task finishes, its done callback drops it
+    # from the retired registry, and only then does the collector look.
+    client._TOOL_TASK_CANCEL_TIMEOUT_S = 5.0
     client._on_connection_attached()
 
     await client._process_gemini_response(


### PR DESCRIPTION
Follow-up to #2837 / #2740

## 改动概述 / Summary

#2837 合入时明确延后了四项缺口（都不是那个 PR 引入的回归，因而不在它的范围内）。这里一次性收口，四项彼此独立：

1. **raw 并行工具结果合批后再发一次 `response.create`**（Codex P1 on #2837，inline 3877942618）。
2. **`speech_started` 标记按 utterance 定身份**，不再是一个没人会清的全局 bool（Codex P2 on #2837，inline 3877665218）。
3. **Gemini 主动搭话 settle 超时放弃的调用补一条 `function_call_output` 并标 retired**。
4. **收窄 `_voice_input_pipeline_transition_lock`**，让无界的前端状态推送不再堵住会话重启和降噪开关（Codex P2 on #2837，inline 3877841894）。

## 回归报告 / Regression Report

### 改动与必要性

#### 1. raw 并行工具结果合批（`main_logic/omni_realtime_client/_tools.py`、`_transport.py`）

`_send_tool_result_openai_realtime` 过去每个结果各自向 response arbiter 入队一张票，每张都带自己的 `response.create`。一次 provider response 发出多个并行 function call、其中两个在原 response 终止前先后跑完时，arbiter 把第一个 output 发出去并立刻开始续写，兄弟的票还排在队列里 —— provider 收到的续写请求缺一个必需的并行调用输出，模型在少一个工具结果的情况下作答，第二个 output 要到下一轮 response 才落地。

现在按**发起这些调用的 provider response** 分组：每个调用仍然一个任务、参数一到就开跑，改变的是**回复**——一个批次收集器等齐同一 response 的兄弟，然后一次性提交所有 `conversation.item.create`，最后一个 `response.create`。等待形状照抄 `_start_gemini_tool_batch._collect`（退避轮询、每轮重新对 `_retired_tool_tasks()` 过滤、只限制轮询开销不设总预算），两条路径现在共用同一个 `_collect_tool_batch`。批次按**位置**记账而不是 call_id：provider 可以不给 id，接入路径把缺失的 id 归一成 `""`，按 call_id 记账会把匿名并行批次塌成一条。

没有 `response_id` 的 provider 无从证明谁是兄弟，退化成原来的一结果一票 —— 这是刻意接受的降级：为一个可能永远不会宣告的兄弟扣住结果，比原来的形状更糟。

#### 2. `speech_started` 标记按 utterance 定身份（`_transport.py`、`_client.py`）

`_raw_speech_started_scope_pending_transcript` 是个全局 bool。代理为第 N 轮发了 `speech_started` 却漏掉该轮转录时，没有任何东西会清掉它（`speech_stopped` 和 `response.done` 都不碰）；第 N+1 轮该代理又漏掉 `speech_started` 只发转录，这个陈旧标记就被读成"已经 scope 过"，`note_user_turn_started()` 被跳过，上一轮抗取消的工具可以把结果注入新的用户轮。

几个便宜的失效点在 #2837 里都已被逐一否掉，这里不再重复尝试：挂在 `_tool_scope_generation` 上没用（两轮之间根本没有东西推进 scope，这正是问题本身）；挂在 `_turn_epoch` 上会改坏正常路径（`speech_stopped` 在 `on_new_message` 之前就 bump 了 epoch，正常轮每轮都会多打一次 `note_user_turn_started()`）；在 `speech_stopped` 清同样破坏正常次序。剩下的 `response.done` 只有在"转录绝不会晚于 response.done"成立时才安全 —— 这些代理没有给出这个保证：input transcription 在这些 provider 上是与生成并行的独立任务，其相对次序未被承诺。仓库里也找不到能确立该次序的抓包或日志。

所以改成按 utterance 定身份，这在两种次序下都成立：`speech_started` 把它 scope 过的 utterance id 记进一个有界表，转录拿自己的 `item_id` 去比对。两端都不带 `item_id` 的代理落回原来的 bool（前身形状，一字不改）。附带效果：晚到的转录（其后继轮次已经开始）不再重复推进 scope。

#### 3. Gemini 主动搭话超时放弃的调用（`_responses.py`、`_tools.py`）

`_settle_tools_before_gemini_proactive` 的有界闸门本身不变（无 TTL 的工具轮闸正是 #2837 删掉的东西）。缺口在超时之后：原本只打一条 warning 就继续，而紧接着的 `send_client_content` 会打断发起这些调用的那轮生成，对话里就留下一个没有 `function_call_output` 的 `function_call`；同时这些调用没有被标 retired，之后才跑完的工具仍会把结果发出去，指向一个 provider 可能已经放弃的调用。

现在在 inject **之前**、发起生成还是当前轮时，走 `_send_tool_result_gemini` 补一条标记放弃的输出（保留 `_tool_task_owner_is_current(owner)` 围栏，按 owner 分组发送，放弃回包不会越进替换连接），并把这些调用标为 retired，晚到的真结果被丢弃而不是落进主动搭话那一轮。

**只标 retired、不取消**：retired 已经足以让批次收集器丢掉晚到结果；额外取消会把用户要的副作用从中间打断，而这里的调用方只是一条主动通知，没有资格杀掉用户的工具。

「放弃」这一位记在**批次条目**上而不是任务集合里：retired 集合在任务完成的那一刻就把它剔除了，标记放在那里会输给"刚被放弃就跑完"的时序 —— 这一点有独立的变异验证（见下表 M3b）。

关于 provider 行为：vendored `google-genai` SDK 与 Live API 文档都写明 `toolCallCancellation`「only in cases where the clients interrupt server turns」，正是本场景，仓库也已经在处理它；但文档既没保证一定会发，也没说明悬空的 `function_call` 会不会报错。在这个不确定性下按维护者决定采用"补发 + 标 retired"。

#### 4. 收窄流水线失败锁（`main_logic/core/asr_runtime.py`）

`_fail_voice_input_pipeline` 过去在 `_voice_input_pipeline_transition_lock` 里跑完整条失败路径，包括 `_fail_closed_voice_route` 里**无界的前端状态推送**。会话重启/关闭和降噪开关都要同一把锁，一个背压的前端 socket 会把每一项恢复操作堵在一次无关的客户端写后面。

直接"锁只覆盖校验和落定、通知/撤销阶段沿用捕获的 generation 谓词"是错的，在 #2837 里已经被否掉：那会重新引入这把锁本来要修的竞态（commit `94c26715`，守卫测试 `test_noise_reduction_replacement_waits_for_pipeline_failure_revoke`）。被清掉的不是某个 generation，而是失败标志本身 —— 降噪开关替换流水线时会把 `_voice_input_pipeline_failed` 清成 False，而 `preprocessing_failure_is_current()` 的第一条子句正是 `not self._voice_input_pipeline_failed`，于是谓词返回 False、撤销被跳过、路由停在 blocked 而租约永不回收。

所以给"这次失败已落定"这件事一个自己的 owner token：落定时铸一个 token，谓词问的是"这次失败还是不是当前那次"，而不是任何人都能清掉的全局标志。锁只覆盖"校验 + 落定"（中间没有 await，对事件循环是原子的），通知/撤销阶段在锁外跑。

谓词里同时去掉了 `_voice_input_audio_pipeline is not source_pipeline_ref` 这条，理由同上：降噪开关会替换流水线但既不解除 blocked 也不撤销任何东西，把它读成"别人接手了"正是撤销消失的原因；真正让这次失败作废的替换（一次 start、一次 close）都会推进 `_asr_route_operation_generation`，而 `_fail_closed_voice_route` 本来就检查它。

### 改动前后行为

| | 改动前 | 改动后 |
|---|---|---|
| raw 并行工具 | 每个结果一张票、各带一个 `response.create`；先完成的那个立刻开续写，兄弟的 output 缺席 | 同一 provider response 的结果合批：所有 `conversation.item.create` 在前，单个 `response.create` 在后 |
| 无 `response_id` 的 provider | 一结果一票 | 不变（无从证明兄弟关系） |
| 漏转录的一轮之后 | 下一轮转录被当成"已 scope"，跳过 `note_user_turn_started()`，旧工具可跨轮注入 | 转录按自己的 `item_id` 判定，未被 scope 过就开新用户轮并撤销旧工具 |
| 两端都不带 `item_id` 的代理 | bool 标记 | 不变，落回同一 bool |
| 晚到的转录 | 已经开始的新轮会被它再推进一次 scope | 已 scope 过的 utterance 不再重复推进（有界记忆 8 条） |
| Gemini settle 超时 | 只打 warning；调用无人应答，晚到结果仍会发进主动搭话那一轮 | inject 前补一条标记放弃的 output，调用标 retired，晚到结果被丢弃 |
| Gemini 有界闸门 | 3s 上限，卡死工具不会永久阻塞主动消息 | 不变 |
| 流水线失败 | 整条路径（含无界前端推送）持锁；会话重启/降噪开关被堵 | 锁只覆盖校验+落定；通知/撤销在锁外，靠 failure token 围栏 |
| 失败通知期间的降噪开关 | 被锁串行到失败之后（所以撤销能完成） | 可以立刻拿锁；撤销仍然完成，因为谓词问的是自己的 token |

### 潜在回归点与验证

每一项修复都配了会随修复回滚而变红的回归测试，且逐条做了变异验证（改回旧实现 → 确认目标断言变红 → 还原 → 确认变绿）：

| 变异 | 改回什么 | 变红的测试与断言 |
|---|---|---|
| M1a | `_start_raw_tool_call` 恢复"跑完即发"的旧形状 | `test_parallel_raw_tool_results_are_answered_as_one_batch` — `assert socket.sent == []`（先完成的兄弟不得开续写） |
| M1b | `_collect_tool_batch` 改成按 call_id 记账 | `test_gemini_anonymous_parallel_calls_keep_separate_results` — 匿名批次的两个结果塌成一条 |
| M2a | `_raw_transcript_was_already_scoped` 忽略 `item_id`，退回纯 bool | `test_transcript_of_a_new_utterance_retires_a_dropped_turns_tool` — scope 未推进 |
| M2b | `_RAW_SCOPED_UTTERANCE_MEMORY` 收成 1 | `test_late_transcript_does_not_rescope_an_already_started_turn` — 晚到转录重复推进 scope |
| M3a | 去掉 `_abandon_tool_calls_for_gemini_proactive` 调用 | `test_gemini_proactive_answers_the_calls_it_gave_up_on` — `order` 里没有 `tool_response` |
| M3b | 只留 retired 集合、去掉 `entry.abandoned` | 同上 — 晚到的真结果被发出（`tool_responses` 变 2 条） |
| M4a | 把通知/撤销阶段放回锁内 | `test_backpressured_status_send_does_not_block_pipeline_transitions` — 降噪开关在 1s 内拿不到锁 |
| M4b | 谓词改回 `not self._voice_input_pipeline_failed` | `test_backpressured_...`、`test_pipeline_failure_still_revokes_after_a_bare_pipeline_swap`，**以及 #2837 的守卫测试 `test_noise_reduction_replacement_waits_for_pipeline_failure_revoke`** |
| M5 | collector 不认领自己的批次 | `test_gemini_proactive_gives_up_a_pending_collectors_whole_batch` — 只有慢调用被放弃，快调用的真结果照发 |
| M6 | 入口闸退回纯 `_voice_input_pipeline_failed` | `test_pipeline_toggle_during_failure_notify_keeps_ingress_closed` — 替换后的 `pipeline.process` 真的被 await |
| M7 | `_set_microphone_route` 不释放 latch | `test_a_live_route_releases_the_pipeline_failure_ingress_latch` — 路由恢复后麦克风永久 fail-closed |
| M8 | 批次「我这边没在跑」就立即封口 | `test_raw_batch_waits_for_a_sibling_announced_after_the_first_finishes` — 批次注册表已空，兄弟只能另开一批 |
| M9 | `_abort_independent_asr` 只在入口查一次 | `test_stale_failure_abort_does_not_clear_successor_route_audio` — 后继路由的 PCM sync 被清 |
| M11 | 带 id 的转录也消费无 id 兜底标记 | `test_identified_transcript_does_not_consume_an_idless_utterances_marker` — 标记被吞 |
| M12 | 放弃回包裸 `await` | `test_a_wedged_abandoned_reply_still_lets_the_proactive_message_out` — 主动消息被卡死的 session 挡住 |
| M13 | 整条入队侧失败闸禁用 | `test_pipeline_failure_stops_accepting_pcm_at_ingress` — `assert 4 == 0`，帧全部入队 |
| M14 | 带 id 的 speech_started 也武装兜底标记 | `test_identified_speech_start_does_not_arm_the_idless_marker` — 标记残留为 True |
| M15 | settle 跳过 sealed 批次的 collector | `test_gemini_proactive_waits_for_a_tool_response_still_being_written` — 主动搭话越过在飞的工具回包 |

M4b 那一行是本 PR 最重要的证据：它证明 token 正是"锁收窄之后仍然堵住 `94c26715` 那个竞态"的那一环，而不是把它悄悄放掉。

⚠️ M6 第一版是**假绿**：ingress token 在路由变 blocked 之前捕获，帧在 `_ingress_token_matches` 就被丢了，纯 flag 的变异体照样通过。改成在故障之后捕获实时 token（真实客户端每帧带的就是当前 token，`_ingress_token_matches` 直接通过、中间没有任何 lease 检查）之后才真正命中那条路径。记在这里因为它同时是"这个缺陷确实可达"的证据。

### 第六轮：把「为什么不改」写成测试（`5076d47c`）

CodeRabbit 提出把 `sealed` 与「已发送」状态分离，好让结算超时能把正在发送的 collector 也标成 abandoned。**不改实现**，理由是它依赖的窗口不存在，而它想要的保证已经成立：

- `_seal_tool_batch()` 与 `session.send_tool_response()` 之间**没有任何 await** —— 封存之后只剩同步的 owner 检查和列表推导，`_send_tool_result_gemini` 到真正写入前也全同步。所以任何人观察到 `sealed is True` 时写入已经开始，没有调度点可以插进去阻止它。
- 真正维持顺序的是：collector 任务在写入期间**仍然 pending**，因此 settle 的 `pending` 集合本来就包含它，会像等待任何未结工具一样等它，用同一份预算。

补了 `test_gemini_proactive_waits_for_a_tool_response_still_being_written` 钉住这一点，与 `test_a_wedged_abandoned_reply_still_lets_the_proactive_message_out` 构成一对：写入在预算内完成则顺序保证成立，预算耗尽则放行主动消息。变异成「settle 跳过 sealed 批次的 collector」（该重构最可能被误实现成的样子）后主动搭话立刻越过在飞回包，断言变红。

### 第五轮：一次自我更正 + 一条自造回归（`fad48d23`、`49c6c3b1`）

- **入队侧失败闸：我第四轮驳回错了，已恢复。** 当时我说构造不出「帧走到入队路径、而租约闸仍开着」的状态。CodeRabbit 给了具体构造，实测成立：**native 路由**不走 `_abort_independent_asr`，因此从不 `_invalidate_voice_pcm_sync`；而 `_voice_input_accepts_pcm()` 是纯租约判定，既不读路由模式也不读失败令牌 —— 于是在整个背压窗口里它返回 True，单帧让队列 `0 -> 1`。我上次测不出来是因为夹具里多加了 `_begin_voice_input_connection()`，它把租约变成拒收 PCM，帧在下一道闸就被丢。**那不是「闸门不可达」的证据，只是我的测试没走到那里。**
- **带 id 的 `speech_started` 不再武装无 id 兜底标记**（Codex P2，我第四轮修复引入的回归）。第四轮定下「带 id 的转录只查 id 表、不消费标记」之后，带 id 的 `speech_started` 却仍无条件置标记为 True —— 标记于是在一次带 id 的回合后永远为 True，下一个既无 `speech_started`、转录也无 id 的回合被读成「已 scope」。**这就是 item 2 的原始缺陷，往后挪了一个回合重建出来。**

**不收：** Greptile「固定宽限仍会过早封批」。场景成立，但该角落的落点正是本 PR 之前的行为（一结果一票），不是新增退化；而唯一能彻底消除它的做法是无界地等 `response.done`，那会让丢失终止事件的 provider 把全部工具结果永久扣住 —— 与同一轮 Codex 要求的有界性直接冲突。方向性建议（拿 `_inflight_tool_args` 当「兄弟参数仍在流式传输」的证据）已写在 thread 上，建议另开 issue。

### 第三/四轮：Greptile 两条 P1 + Codex 后续（`f2579b5a`）

**收：**

- **批次过早封口**（Greptile P1）。同一 provider response 的调用是分开的事件；第一个工具在接收循环读到兄弟事件之前跑完时，「我这边没在跑」就封口，兄弟另开一批 —— provider 拿到两次续写、各缺对方的并行输出。改为 `response.done` 关闭批次（`close_raw_tool_batch`），并在批次未关闭、且发起它的 response 仍是 `_current_response_id` 时给**一轮**宽限。凭据而非定时器：从不宣告 response 的 provider 一轮宽限都不付；正常路径 `response.done` 早于工具完成，零延迟；只宣告不终止的 provider 最多多等一轮。
- **陈旧失败清掉后继路由的音频**（Greptile P1 = Codex 同一条）。`_abort_independent_asr` 在 await 之后才 `_invalidate_voice_pcm_sync`，而这段已不在锁内。新增可选 `still_current`，**await 前后各查一次**。
- **带 id 的转录不该消费无 id 那一轮的兜底标记**（Codex P2，我上一轮引入的缺陷）。带 id 的转录一律只查 id 表。
- **放弃回包的发送必须有界**（Codex P2，我上一轮引入的缺陷）。上一轮新增的裸 `await _send_tool_result_gemini` 是无界的，卡死的 session 能借它把主动消息永久挡住 —— 正是 #2837 删掉的那道无 TTL 工具轮闸。改成 shield + 有界等待，超时后作为 tool task 在后台继续送达。

**不收：**

- Codex「批次只有在回包发完之后才算 settle」：该修法把无界等待放回 settle 路径，与上面最后一条直接冲突，会重新引入无 TTL 的工具轮闸（五条测试钉着它的有界性）。
- ~~CodeRabbit「在 `_enqueue_audio_stream_data` 入口加失败闸」：回退~~ —— **这个驳回是错的，第五轮已恢复**，见下。
- github-code-quality「不必要的 lambda」：该写法与同文件已有的四处完全一致，只改我这两处反而破坏一致性。thread 保持 open。

### 第二轮：Codex 两条 P2（`99c56c46`）

- **`_tools.py` — collector 整批放弃。** settle 截止时唯一未结的任务可能只是 collector：调用已完成、结果还没冲刷。collector 不拥有任何 call，所以退役它既答不了任何东西、也拦不住它随后把真结果发进主动搭话那一轮 —— 正是这条路径要防的跨轮注入。现在 collector 与它的批次登记在一起（`_tool_batch_by_collector_task()`），截止时遇到一个未 sealed 的 collector 就把整批还没冲刷的 entry 一起放弃，**包括已经跑完但未冲刷的那些**；已 sealed 的批次答案集合已定、不再干预。`entry.abandoned` 的幂等保证两条路进来不会重复回包。
- **`asr_runtime.py` — 入口闸改挂 failure token。这条是本 PR 引入的回归。** `_process_microphone_stream_data` 的入口闸就是 `_voice_input_pipeline_failed`，而任何流水线替换都会清掉它；锁一收窄，并发的降噪开关就能在背压的状态推送窗口里把它清成 False，帧重新进队列、走新 DSP，直到路由把它们丢掉 —— 有界队列被重新灌满、白烧预处理、还可能触发入口背压导致的回合作废，而这段时间本该 fail-closed。入口闸改挂已落定的 failure token，token 只在路由重新可用时（`_set_microphone_route` 切到非 `blocked`）释放，所以降噪开关照旧清 `_voice_input_pipeline_failed`（#2837 的守卫测试仍断言这一点），却清不掉 fail-closed 闩，而一次真正的新 start 会把闩释放、不会把麦克风永久锁死。

其余需要说明的改动：

- **`test_stale_pipeline_failure_never_reports_to_current_identity` 去掉了 `pipeline` 参数化。** 它断言"通知阶段中途换掉流水线 ⇒ 这次失败作废"，而这正是 `94c26715` 修的那个错误推理。在 HEAD 上这个 case 在生产里不可达（每条替换路径都要拿同一把锁，而失败全程持锁），所以它锁的是一条只有绕开锁才会触发的纵深防御。锁收窄之后同一事件的正确结果是相反的，因此换成了断言相反行为的 `test_pipeline_failure_still_revokes_after_a_bare_pipeline_swap`。真正会让失败作废的替换（start / close）由路由操作 generation 覆盖，那条参数化保留未动。
- **`scripts/check_core_contracts.py` 的 `MIXIN_SUPPORT_CLASSES` 登记了 `_VoiceInputPipelineFailure`。** 该清单是显式注册表，新增私有支持类本来就要"有意识地编辑这条检查"。
- **`test_proactive_inject_does_not_cancel_current_turn_tool_task[gpt]` 的 mock 改成复数版 `_send_tool_results_openai_realtime`。** 批次收集器调的是复数版，单数版只是它的便捷封装（对外签名不变，`test_tool_calling.py` / `test_realtime_arbiter_native_path.py` / `test_external_text_turns.py` 三处真实调用照旧）。
- **`handle_messages` 只多传了一个 `response_id=` 参数**，没有结构性改动，AST 守卫 `test_realtime_receive_loop_ownership_static.py` 原样通过，未放宽。

### 未做的事

- Gemini 有界闸门的语义没有改动，#2837 pin 住的五条测试全部照旧通过；没有任何路径能让卡死的工具重新永久阻塞主动消息。
- 没有碰插件实现、插件协议、依赖，也没有无关重构。

## 不拆分理由 / Why Not Split

用户明确要求把这四项延后项做成**一个**后续 PR，不要拆开。

四项本身相互独立（3 个 realtime + 1 个 core ASR），单看确实可以各自成 PR；但它们是同一次评审在同一个 issue（#2740）上留下的同一批延后项，共同的判据是"#2837 没引入、但 #2837 的所有权模型必须继续成立"。放在一起，评审可以一次性对着 #2837 的围栏（`_tool_task_owner_is_current`、`_retired_tool_tasks`、`_fail_closed_voice_route` 的 notify→fence→revoke 次序）核对全部四处，而不必在四个 PR 之间反复重建同一套上下文。item 1 和 item 3 还共用同一个批次结构与收集器（`_collect_tool_batch`），拆开会让其中一个 PR 先落一份没有第二个消费者的抽象。

## 测试 / Testing

按**符号**而非按模块挑选测试文件：

```
grep -rl -E "_send_tool_result_openai_realtime|_send_tool_results_openai_realtime|_start_raw_tool_call|_start_gemini_tool_batch|_collect_tool_batch|_settle_tools_before_gemini_proactive|_raw_speech_started_scope|_raw_transcript_was_already_scoped|_fail_voice_input_pipeline|_track_tool_task|_create_tool_task|_send_tool_result_gemini|_retired_tool_task|_voice_input_pipeline_fail|handle_messages|_advance_tool_scope|_tool_batch" tests/unit/ --include='*.py'
```

- 上述 18 个文件全量：`1135 passed, 4 skipped`
- `uv run ruff check`：`All checks passed!`
- `uv run python scripts/check_core_contracts.py`：exit 0
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main`：exit 0
- 变异验证每轮结束后 `grep -rn "MUTANT" main_logic/ tests/ scripts/` 与 `find . -name '*.bak'` 均为空，工作树 `git diff --quiet` 干净

新增测试：

- `test_parallel_raw_tool_results_are_answered_as_one_batch`（替换 `test_parallel_raw_tool_results_survive_a_sibling_response_created`，后者锁的是被本 PR 取代的一结果一票形状）
- `test_raw_tool_call_without_response_identity_still_answers`
- `test_transcript_of_a_new_utterance_retires_a_dropped_turns_tool`
- `test_transcript_of_its_own_utterance_does_not_rescope_the_turn`
- `test_late_transcript_does_not_rescope_an_already_started_turn`
- `test_gemini_proactive_answers_the_calls_it_gave_up_on`
- `test_pipeline_failure_still_revokes_after_a_bare_pipeline_swap`
- `test_backpressured_status_send_does_not_block_pipeline_transitions`
- `test_gemini_proactive_gives_up_a_pending_collectors_whole_batch`（第二轮）
- `test_pipeline_toggle_during_failure_notify_keeps_ingress_closed`（第二轮）
- `test_a_live_route_releases_the_pipeline_failure_ingress_latch`（第二轮）
- `test_raw_batch_waits_for_a_sibling_announced_after_the_first_finishes`（第三轮）
- `test_raw_batch_answers_once_its_response_terminates`（第三轮）
- `test_stale_failure_abort_does_not_clear_successor_route_audio`（第三轮）
- `test_identified_transcript_does_not_consume_an_idless_utterances_marker`（第四轮）
- `test_a_wedged_abandoned_reply_still_lets_the_proactive_message_out`（第四轮）
- `test_pipeline_failure_stops_accepting_pcm_at_ingress`（第五轮）
- `test_identified_speech_start_does_not_arm_the_idless_marker`（第五轮）
- `test_gemini_proactive_waits_for_a_tool_response_still_being_written`（第六轮）

三条无服务端 VAD 的测试走 `_no_server_vad_client()`，URL 用 `wss://www.lanlan.app/realtime` 并断言 `client._has_server_vad is False` —— 换任何别的 host，同样 `api_type="free"` 的 client **有** server VAD，测试会静默地根本走不到那条分支（#2837 里踩过这个坑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 提升语音输入失败后的恢复能力，失败期间及时停止接收音频，避免重复处理。
  - 优化语音转写与对话轮次识别，减少乱序、串联和重复响应。
  - 工具调用按响应批次统一返回，提升实时结果的一致性。
  - 工具调用超时后自动结束未完成操作，再继续主动回复。
  - 优化实时语音会话衔接，避免过期工具结果影响后续对话。
  - 增强并发场景下的状态隔离，降低会话切换期间的异常风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->