### PR TITLE
ci: 把 react-neko-chat 的类型检查和单测纳入 PR CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,3 +119,37 @@ jobs:
         # 格式，由 test:hosted-script 单独跑，被 vitest 收进来只会报 no test suite。
         working-directory: frontend/plugin-manager
         run: npm run test:unit
+
+  react-neko-chat-checks:
+    name: React chat typecheck & vitest
+    # 和 plugin-manager 一样的洞，只是更深一层：frontend/react-neko-chat 的
+    # 17 个 vitest 文件此前没有任何 PR workflow 会执行，而唯一跑过它类型检查的
+    # build-desktop.yml 是 `on: workflow_call`，不是 PR 触发。结果是这个包的
+    # 类型错误和测试回归只有打包发版时才会暴露 —— #2948 里就有一个真实的编译
+    # 错误（调用点多传了一个不存在的标识符）一路活到 review 才被发现。
+    #
+    # typecheck 用 `npm run typecheck`（tsc -b --noEmit）。注意不能退回裸的
+    # `tsc --noEmit`：tsconfig.json 是 solution-style（"files": [] + references），
+    # 那条命令一个文件都不检查，永远绿。
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/react-neko-chat/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend/react-neko-chat
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: frontend/react-neko-chat
+        run: npm run typecheck
+
+      - name: Run react-neko-chat unit suite
+        working-directory: frontend/react-neko-chat
+        run: npm test


### PR DESCRIPTION
## 洞在哪

`frontend/react-neko-chat` 的类型检查和单测**不在 PR CI 里**。和 plugin-manager 当初是同一个洞（#2870 那一批补的），只是更深一层：

- PR 的 checks 里 `Plugin manager vitest` 覆盖的是 `frontend/plugin-manager`，不是这个包。
- 唯一跑过 react-neko-chat 类型检查的是 `build-desktop.yml`（`npm run build` → `tsc -b`），而它是 `on: workflow_call` 触发的，**不是 PR check**。

结果：这个包的类型错误和测试回归只有打包发版时才会暴露。

## 不是假想的风险

#2948 的评审过程里，`AvatarToolItemManager` 的拖拽路径上有一处调用多传了一个不存在的标识符：

```ts
const ids = compactSlots(slots, validIds).filter(...)
//                              ^^^^^^^^ TS2304: Cannot find name
//                                       TS2554: Expected 1 arguments, but got 2
```

它在分支上活了整整一轮，PR 的 10 项 check 没有一项能看见——那条路径也没有任何用例覆盖，而 vitest 本身不做类型检查。最后是 reviewer 读出来的。

## 这个 job 做什么

`.github/workflows/unit-tests.yml` 新增 `react-neko-chat-checks`，跑两步：`npm run typecheck` 和 `npm test`。

**一个值得写进注释的坑**：typecheck 必须用 `npm run typecheck`（`tsc -b --noEmit`），不能退回裸的 `tsc --noEmit`。`tsconfig.json` 是 solution-style（`"files": []` + `references`），后者**一个文件都不检查、永远绿**。这个包的 `typecheck` 脚本一度就是那条命令，所以「typecheck 通过」这个信号本身曾经是假的。

## 验证

不假设护栏有效，做了 A/B：

| 注入 | 结果 |
| --- | --- |
| 往 `AvatarToolItemManager.tsx` 注入同类编译错误 | `npm run typecheck` exit 1 |
| 往 `App.test.tsx` 注入一条失败用例 | `npm test` exit 1 |
| 当前 main 原样 | 两条都绿（17 files / 514 tests） |

所以合并后不会立刻变红。

## 影响面

给所有 PR 新增一项必过 check，约 1–2 分钟（ubuntu + node 22 + npm 缓存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增持续集成检查，自动执行项目级 TypeScript 类型检查。
  - 新增 Vitest 单元测试验证，提升代码质量与变更可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->