### PR TITLE
fix(gemini): 取消欠账的作废判据与宣告新回合对齐，并给欠账加界

### DIFF
--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -558,6 +558,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._gemini_external_outcome_token: Optional[object] = None
         self._gemini_cancelled_terminal_pending = False
         self._gemini_cancelled_terminal_deadline: Optional[float] = None
+        self._gemini_cancelled_terminal_awaiting_delivery = False
         self._gemini_external_quarantine_task: Optional[asyncio.Task] = None
         self._gemini_proactive_outcome_owner: Optional[tuple] = None
 

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -556,6 +556,8 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # Keep a distinct token because the submit coroutine itself may already
         # be finished when the next external-ASR utterance starts.
         self._gemini_external_outcome_token: Optional[object] = None
+        self._gemini_cancelled_terminal_pending = False
+        self._gemini_cancelled_terminal_deadline: Optional[float] = None
         self._gemini_external_quarantine_task: Optional[asyncio.Task] = None
         self._gemini_proactive_outcome_owner: Optional[tuple] = None
 

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -559,6 +559,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._gemini_cancelled_terminal_pending = False
         self._gemini_cancelled_terminal_deadline: Optional[float] = None
         self._gemini_cancelled_terminal_awaiting_delivery = False
+        self._gemini_cancelled_terminal_id: Optional[object] = None
         self._gemini_external_quarantine_task: Optional[asyncio.Task] = None
         self._gemini_proactive_outcome_owner: Optional[tuple] = None
 

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -357,6 +357,14 @@ class _GeminiMixin:
             parts=parts,
             role="user",
         )
+        # 身份要在**发送之前**取。这个 await 期间可能有一笔新欠账被武装，而它不是
+        # 这次发送送达的 —— 事后只读全局状态，会让一次更早发起、此刻才返回的发送
+        # 把它错认成自己送的，从而在后继内容还没上线时就起算 TTL。
+        delivering_debt_id = (
+            getattr(self, "_gemini_cancelled_terminal_id", None)
+            if getattr(self, "_gemini_cancelled_terminal_awaiting_delivery", False)
+            else None
+        )
         await self._gemini_session.send_client_content(
             turns=[content],
             turn_complete=True,
@@ -367,8 +375,14 @@ class _GeminiMixin:
         # 中断之前就到点，A 的终结随后被当成当前回合去结算了后继的 token —— 正是
         # 这个改动要修的那个回归。
         # 只重打一次：每次发送都续命的话，一笔始终没被终结抵掉的欠账会被无限延寿。
+        # 两个字段都走 getattr：这条 send 会被没走完整构造的替身客户端直接调用
+        # （tests/unit/test_proactive_sm_integration.py 就有一个），而
+        # _consume_cancelled_terminal() 对同一组字段本来也是这么读的。
         if (
-            self._gemini_cancelled_terminal_pending
+            delivering_debt_id is not None
+            and getattr(self, "_gemini_cancelled_terminal_id", None)
+            is delivering_debt_id
+            and getattr(self, "_gemini_cancelled_terminal_pending", False)
             and getattr(
                 self, "_gemini_cancelled_terminal_awaiting_delivery", False
             )
@@ -913,6 +927,7 @@ class _GeminiMixin:
                         # 是成对清的，留一个孤儿期限只会让状态读起来有歧义。
                         self._gemini_cancelled_terminal_deadline = None
                         self._gemini_cancelled_terminal_awaiting_delivery = False
+                        self._gemini_cancelled_terminal_id = None
                     if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only
                         # after SDK transcription or a quiet gap proves this is not a canceled tail.

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -860,10 +860,22 @@ class _GeminiMixin:
                     self._turn_epoch += 1
                     self._current_turn_epoch = self._turn_epoch
                     self._current_turn_host_id = self._read_host_turn_id()
-                    if _is_new_turn:
+                    if _is_new_turn and _can_clear_interrupted:
                         # 新回合开始就说明旧回合已经收场：欠账作废，免得旧回合
                         # 永不终结时把下一条**合法**终结也吃掉，让 token 永远结算
                         # 不掉、会话被钉成「忙」而主动搭话彻底哑掉。
+                        #
+                        # ⚠️ 判据必须与下面宣告新回合的那条**一字不差**。只看
+                        # _is_new_turn 时，被取消那一轮的迟到内容自己就满足它
+                        # （用户已经在 AI 最后一帧之后发过声），于是欠账在它真正
+                        # 的终结到达之前就被清掉，那条终结转而去结算刚铸出的
+                        # external token —— 回合还在飞就显示空闲。
+                        #
+                        # 反向风险（旧回合永不终结）有两道界，都不依赖这里：
+                        # _interrupted 为真时两个 _ai_recent_activity_time 刷新点
+                        # 都被跳过，3s 后 _still_within_ai_window 转假、本判据自动
+                        # 放行；而「此后再无 AI 内容」那种连本分支都进不来的情形，
+                        # 由 _consume_cancelled_terminal() 的期限兜底。
                         self._gemini_cancelled_terminal_pending = False
                     if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -877,6 +877,9 @@ class _GeminiMixin:
                         # 放行；而「此后再无 AI 内容」那种连本分支都进不来的情形，
                         # 由 _consume_cancelled_terminal() 的期限兜底。
                         self._gemini_cancelled_terminal_pending = False
+                        # 期限跟着欠账一起清：另外两条退路（消费、连接替换）都
+                        # 是成对清的，留一个孤儿期限只会让状态读起来有歧义。
+                        self._gemini_cancelled_terminal_deadline = None
                     if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only
                         # after SDK transcription or a quiet gap proves this is not a canceled tail.

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -888,6 +888,21 @@ class _GeminiMixin:
                         # 的终结到达之前就被清掉，那条终结转而去结算刚铸出的
                         # external token —— 回合还在飞就显示空闲。
                         #
+                        # ⚠️ 已知残留、经产品判断后接受，别再改回松判据：
+                        # 「A 的迟到内容」与「后继 B 的第一条内容」在协议层长得
+                        # 一模一样（都是 model_turn / output_transcription、都不带
+                        # 回合标识、都在打断之后），_turn_epoch 对两者也都自增，
+                        # 区分不出来。于是只有两种取法，互斥：
+                        #   看到内容就作废 → A 的终结去结算了 B 的 token，B 还在
+                        #     说话会话已读作空闲（抢话时的**常见**路径）；
+                        #   不作废（现在这样）→ 欠账是虚的、或 A 两种终结都没发
+                        #     时，B 自己的终结被吃掉，B 的 token 没人结算。
+                        # 取后者：那条残留只影响主动搭话（is_active_response 的
+                        # 读取点全在 proactive 一线），而且第一道闸
+                        # proactive.py 的 trigger_agent_callbacks 在**生成台词之前**
+                        # 就 defer 掉，是纯跳过、不烧 token，用户自己的对话链路
+                        # 一个读取点都不碰、不会卡顿。
+                        #
                         # 反向风险（旧回合永不终结）有两道界，都不依赖这里：
                         # _interrupted 为真时两个 _ai_recent_activity_time 刷新点
                         # 都被跳过，3s 后 _still_within_ai_window 转假、本判据自动

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from ._shared import (
+    GEMINI_CANCELLED_TERMINAL_TTL_SECONDS,
     Any,
     List,
     Path,
@@ -360,6 +361,22 @@ class _GeminiMixin:
             turns=[content],
             turn_complete=True,
         )
+        # Gemini 没有 response.cancel：被打断那一轮是**这条内容送达**才被叫停的，
+        # provider 也是从这一刻起才欠它一条终结。期限若一直按 handle_interruption
+        # 的时刻算，ASR 交接加这次发送（多模态还要压图）一慢就会在 provider 收到
+        # 中断之前就到点，A 的终结随后被当成当前回合去结算了后继的 token —— 正是
+        # 这个改动要修的那个回归。
+        # 只重打一次：每次发送都续命的话，一笔始终没被终结抵掉的欠账会被无限延寿。
+        if (
+            self._gemini_cancelled_terminal_pending
+            and getattr(
+                self, "_gemini_cancelled_terminal_awaiting_delivery", False
+            )
+        ):
+            self._gemini_cancelled_terminal_awaiting_delivery = False
+            self._gemini_cancelled_terminal_deadline = (
+                time.monotonic() + GEMINI_CANCELLED_TERMINAL_TTL_SECONDS
+            )
 
     async def _create_response_gemini(
         self,
@@ -880,6 +897,7 @@ class _GeminiMixin:
                         # 期限跟着欠账一起清：另外两条退路（消费、连接替换）都
                         # 是成对清的，留一个孤儿期限只会让状态读起来有歧义。
                         self._gemini_cancelled_terminal_deadline = None
+                        self._gemini_cancelled_terminal_awaiting_delivery = False
                     if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only
                         # after SDK transcription or a quiet gap proves this is not a canceled tail.

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -773,6 +773,7 @@ class _ResponseMixin:
         )
         self._gemini_cancelled_terminal_deadline = None
         self._gemini_cancelled_terminal_awaiting_delivery = False
+        self._gemini_cancelled_terminal_id = None
         if (
             deadline is not None
             and not awaiting_delivery

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -761,6 +761,7 @@ class _ResponseMixin:
         self._gemini_cancelled_terminal_pending = False
         deadline = getattr(self, "_gemini_cancelled_terminal_deadline", None)
         self._gemini_cancelled_terminal_deadline = None
+        self._gemini_cancelled_terminal_awaiting_delivery = False
         if deadline is not None and time.monotonic() >= deadline:
             logger.debug(
                 "Gemini: cancelled-terminal debt expired unconsumed; this "

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -755,14 +755,29 @@ class _ResponseMixin:
         a debt that outlives that window is stale -- and honouring it would skip
         the settlement of a turn that is not the cancelled one, leaving an
         external token nobody settles and a session that reads busy.
+
+        The clock does not run until the interrupt reaches the provider. Gemini
+        is interrupted by the successor's content, so until that send lands
+        nothing else has been submitted and the first terminal can only be the
+        cancelled turn's -- expiring in that window would hand its terminal to a
+        successor that does not exist yet. The send both re-stamps the deadline
+        and lowers the flag, but it does so after its await returns, and the
+        receive loop can deliver that terminal inside the gap.
         """
         if not getattr(self, "_gemini_cancelled_terminal_pending", False):
             return False
         self._gemini_cancelled_terminal_pending = False
         deadline = getattr(self, "_gemini_cancelled_terminal_deadline", None)
+        awaiting_delivery = getattr(
+            self, "_gemini_cancelled_terminal_awaiting_delivery", False
+        )
         self._gemini_cancelled_terminal_deadline = None
         self._gemini_cancelled_terminal_awaiting_delivery = False
-        if deadline is not None and time.monotonic() >= deadline:
+        if (
+            deadline is not None
+            and not awaiting_delivery
+            and time.monotonic() >= deadline
+        ):
             logger.debug(
                 "Gemini: cancelled-terminal debt expired unconsumed; this "
                 "terminal settles the current turn instead"

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -749,10 +749,24 @@ class _ResponseMixin:
         One-shot: the first terminal after the cancellation is that response's,
         no matter what has been minted since. Returns whether this terminal was
         the owed one.
+
+        Bounded: a debt past its deadline is spent but not honoured. The
+        cancelled response owes its terminal within one provider round trip, so
+        a debt that outlives that window is stale -- and honouring it would skip
+        the settlement of a turn that is not the cancelled one, leaving an
+        external token nobody settles and a session that reads busy.
         """
         if not getattr(self, "_gemini_cancelled_terminal_pending", False):
             return False
         self._gemini_cancelled_terminal_pending = False
+        deadline = getattr(self, "_gemini_cancelled_terminal_deadline", None)
+        self._gemini_cancelled_terminal_deadline = None
+        if deadline is not None and time.monotonic() >= deadline:
+            logger.debug(
+                "Gemini: cancelled-terminal debt expired unconsumed; this "
+                "terminal settles the current turn instead"
+            )
+            return False
         return True
 
     def _settle_gemini_external_turn(self, token: object | None = None) -> None:

--- a/main_logic/omni_realtime_client/_shared.py
+++ b/main_logic/omni_realtime_client/_shared.py
@@ -151,6 +151,15 @@ _REALTIME_DIALECT_ALIASES = {
 }
 
 
+# 取消欠账的存活上限。被取消的那一轮欠一条终结事件，而 Gemini 没有
+# response.cancel —— 它是被**后继内容送达**叫停的，所以计时从那一刻起算
+# （_gemini_send_user_turn），不是从 handle_interruption 决定取消那一刻。
+# 取值方向不对称：取小了最多多一次早结算，会话读作空闲，下一轮自愈；取大了会让
+# 陈旧欠账吃掉一条**合法**终结，那一轮的 external token 没人结算，
+# is_active_response() 恒真、主动搭话彻底哑。所以宁可短。
+GEMINI_CANCELLED_TERMINAL_TTL_SECONDS = 3.0
+
+
 def canonical_realtime_dialect(api_type: object) -> str:
     """Map a provider key to the wire dialect its session speaks."""
 

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -2262,6 +2262,10 @@ class _TransportMixin:
         # 一次；这里先打是为了让下面任何一条 return 路径都带着期限离开，不至于落进
         # deadline is None 的 fail-open。只允许重打一次，免得后续每次发送都续命。
         self._gemini_cancelled_terminal_awaiting_delivery = True
+        # 身份：让 _gemini_send_user_turn 能认出「这笔欠账是不是我这次发送送达的」。
+        # 那边是 await 之后才读全局状态的，没有身份的话，一次**更早**发起、此刻才
+        # 返回的发送会把刚武装的这笔当成自己送的，提前起算 TTL。
+        self._gemini_cancelled_terminal_id = object()
 
         # 1. Cancel the current response
         # Presence, not truthiness — the third site in this file where a
@@ -3079,6 +3083,7 @@ class _TransportMixin:
         self._gemini_cancelled_terminal_pending = False
         self._gemini_cancelled_terminal_deadline = None
         self._gemini_cancelled_terminal_awaiting_delivery = False
+        self._gemini_cancelled_terminal_id = None
         self._raw_speech_started_scope_pending_transcript = False
         self._raw_speech_started_scoped_item_ids = []
         # Provider response identity and interruption state belong to the

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -67,6 +67,14 @@ class _RealtimeEventOwnerRetired(ConnectionError):
 # when the coroutine returns, and the outer budget still reaches the rotation.
 _STUCK_RELEASE_STEP_TIMEOUT = 0.5
 
+# 取消欠账的存活上限。被取消的那一轮欠一条终结事件，而那条终结是一次 provider
+# 往返的量级。与 _ai_recent_activity_window 同为 3.0 秒，但回答的是不同的问题
+# （「provider 还欠不欠我一条终结」而非「AI 静默了多久」），所以不复用那个字段。
+# 取值方向不对称：取小了最多多一次早结算，会话读作空闲，下一轮自愈；取大了会让
+# 陈旧欠账吃掉一条**合法**终结，那一轮的 external token 没人结算，
+# is_active_response() 恒真、主动搭话彻底哑。所以宁可短。
+_GEMINI_CANCELLED_TERMINAL_TTL_SECONDS = 3.0
+
 # How many finished response ids to remember for usage deduplication. A repeat
 # arrives right behind its original, so this only has to outlive the events
 # interleaved between them; it is a leak guard, not a history.
@@ -2246,8 +2254,15 @@ class _TransportMixin:
         # interrupted / turn_complete）。记一笔「欠账」：那条终结属于**这一轮**，
         # 不能让它去结算之后才铸造的 external turn token —— 逐事件捕获的实现会
         # 让它捕获到新 token 并清掉，会话随即显得空闲而外部回合还活着。
-        # 一次性的：由下一个到达的终结消费掉，或在真正的新回合开始时作废。
+        # 一次性的：由下一个到达的终结消费掉，或在真正的新回合开始时作废
+        # （_gemini_support.py 的 turn-start 块），或到期。
         self._gemini_cancelled_terminal_pending = True
+        # 期限是独立于内容的第二道界。turn-start 那处作废只在「合法终结之前先来了
+        # AI 内容」时才跑得到；裸 turn_complete 绕过它，此后再无内容的情形也绕过
+        # 它。没有期限时，陈旧欠账会一直挂着直到吃掉某一条不属于它的终结。
+        self._gemini_cancelled_terminal_deadline = (
+            time.monotonic() + _GEMINI_CANCELLED_TERMINAL_TTL_SECONDS
+        )
 
         # 1. Cancel the current response
         # Presence, not truthiness — the third site in this file where a
@@ -3058,6 +3073,12 @@ class _TransportMixin:
                 expected_provider_session=retired_outcome_owner[1],
                 expected_outcome_token=retired_outcome_owner[2],
             )
+        # 取消欠账同样属于退役的那条连接：替换连接上的第一条终结是**它自己**的，
+        # 被上一条连接的欠账吃掉就等于新回合的 token 没人结算。与上面退役 proactive
+        # outcome 同一判据。隔离重连那条路上 connect() 跑在 handle_interruption()
+        # 之前（_responses.py 的 prepare_external_voice_turn），不会抹掉刚武装的那笔。
+        self._gemini_cancelled_terminal_pending = False
+        self._gemini_cancelled_terminal_deadline = None
         self._raw_speech_started_scope_pending_transcript = False
         self._raw_speech_started_scoped_item_ids = []
         # Provider response identity and interruption state belong to the

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -2273,6 +2273,17 @@ class _TransportMixin:
         if self._current_response_id is not None:
             try:
                 await self.cancel_response(send_guard=connection_still_ours)
+                # provider 是从**取消落地**那一刻起欠这条终结的，不是从我们决定
+                # 取消那一刻。这个 await 会被传输背压拖住，期限若还从上面那次
+                # 打点起算，就可能在这里等着的时候就过期，后继回合拿到一笔已经
+                # 过期的欠账 —— 正好把本次要修的那个回归又放回来。
+                # 上面先武装是为了让任何一条 return 路径都带着期限离开；这里只是
+                # 在真的等过之后把起点校准回来。
+                if self._gemini_cancelled_terminal_pending:
+                    self._gemini_cancelled_terminal_deadline = (
+                        time.monotonic()
+                        + _GEMINI_CANCELLED_TERMINAL_TTL_SECONDS
+                    )
             except ConnectionError:
                 if (
                     connection_still_ours is not None

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from ._shared import (
+    GEMINI_CANCELLED_TERMINAL_TTL_SECONDS,
     Any,
     Callable,
     Dict,
@@ -67,13 +68,6 @@ class _RealtimeEventOwnerRetired(ConnectionError):
 # when the coroutine returns, and the outer budget still reaches the rotation.
 _STUCK_RELEASE_STEP_TIMEOUT = 0.5
 
-# 取消欠账的存活上限。被取消的那一轮欠一条终结事件，而那条终结是一次 provider
-# 往返的量级。与 _ai_recent_activity_window 同为 3.0 秒，但回答的是不同的问题
-# （「provider 还欠不欠我一条终结」而非「AI 静默了多久」），所以不复用那个字段。
-# 取值方向不对称：取小了最多多一次早结算，会话读作空闲，下一轮自愈；取大了会让
-# 陈旧欠账吃掉一条**合法**终结，那一轮的 external token 没人结算，
-# is_active_response() 恒真、主动搭话彻底哑。所以宁可短。
-_GEMINI_CANCELLED_TERMINAL_TTL_SECONDS = 3.0
 
 # How many finished response ids to remember for usage deduplication. A repeat
 # arrives right behind its original, so this only has to outlive the events
@@ -2261,8 +2255,13 @@ class _TransportMixin:
         # AI 内容」时才跑得到；裸 turn_complete 绕过它，此后再无内容的情形也绕过
         # 它。没有期限时，陈旧欠账会一直挂着直到吃掉某一条不属于它的终结。
         self._gemini_cancelled_terminal_deadline = (
-            time.monotonic() + _GEMINI_CANCELLED_TERMINAL_TTL_SECONDS
+            time.monotonic() + GEMINI_CANCELLED_TERMINAL_TTL_SECONDS
         )
+        # 期限的起点要等中断真正送达 provider 才算数。Gemini 没有 response.cancel，
+        # 中断是靠后继内容送出去才生效的，所以 _gemini_send_user_turn 会把它重打
+        # 一次；这里先打是为了让下面任何一条 return 路径都带着期限离开，不至于落进
+        # deadline is None 的 fail-open。只允许重打一次，免得后续每次发送都续命。
+        self._gemini_cancelled_terminal_awaiting_delivery = True
 
         # 1. Cancel the current response
         # Presence, not truthiness — the third site in this file where a
@@ -2273,17 +2272,6 @@ class _TransportMixin:
         if self._current_response_id is not None:
             try:
                 await self.cancel_response(send_guard=connection_still_ours)
-                # provider 是从**取消落地**那一刻起欠这条终结的，不是从我们决定
-                # 取消那一刻。这个 await 会被传输背压拖住，期限若还从上面那次
-                # 打点起算，就可能在这里等着的时候就过期，后继回合拿到一笔已经
-                # 过期的欠账 —— 正好把本次要修的那个回归又放回来。
-                # 上面先武装是为了让任何一条 return 路径都带着期限离开；这里只是
-                # 在真的等过之后把起点校准回来。
-                if self._gemini_cancelled_terminal_pending:
-                    self._gemini_cancelled_terminal_deadline = (
-                        time.monotonic()
-                        + _GEMINI_CANCELLED_TERMINAL_TTL_SECONDS
-                    )
             except ConnectionError:
                 if (
                     connection_still_ours is not None
@@ -3090,6 +3078,7 @@ class _TransportMixin:
         # 之前（_responses.py 的 prepare_external_voice_turn），不会抹掉刚武装的那笔。
         self._gemini_cancelled_terminal_pending = False
         self._gemini_cancelled_terminal_deadline = None
+        self._gemini_cancelled_terminal_awaiting_delivery = False
         self._raw_speech_started_scope_pending_transcript = False
         self._raw_speech_started_scoped_item_ids = []
         # Provider response identity and interruption state belong to the

--- a/tests/unit/test_external_visual_delivery.py
+++ b/tests/unit/test_external_visual_delivery.py
@@ -1674,6 +1674,56 @@ async def test_a_slow_handoff_restarts_the_debt_deadline_at_the_gemini_send():
 
 
 @pytest.mark.asyncio
+async def test_the_debt_does_not_expire_before_the_interrupt_is_delivered():
+    """The clock cannot run while the provider has not been interrupted.
+
+    ``send_client_content()`` puts the successor on the wire before it returns,
+    and the re-stamp happens after that await. The receive loop can deliver the
+    cancelled turn's terminal inside that gap, where the deadline is still the
+    one stamped at the interruption and may already be spent. Expiring there
+    hands the terminal to a successor whose own turn has not started.
+
+    Until that send lands nothing else has been submitted, so the first
+    terminal can only belong to the cancelled turn.
+    """
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client._connection_generation = 1
+    client._still_owns_connection = lambda _gen: True
+    client._read_host_turn_id = lambda: None
+    client.on_response_done = None
+    client.on_new_message = None
+    client.on_text_delta = None
+    client._settle_gemini_proactive_inject = MagicMock()
+
+    token = object()
+    client._gemini_external_outcome_token = token
+    client._gemini_cancelled_terminal_pending = True
+    # 交接拖过了 TTL，而中断还没送达 —— 重打时间戳那一步还没轮到。
+    client._gemini_cancelled_terminal_deadline = time.monotonic() - 1.0
+    client._gemini_cancelled_terminal_awaiting_delivery = True
+    client._is_responding = True
+    client._interrupted = True
+
+    terminal = SimpleNamespace(
+        model_turn=None,
+        input_transcription=None,
+        output_transcription=None,
+        interrupted=False,
+        turn_complete=True,
+    )
+    await client._process_gemini_response(
+        SimpleNamespace(server_content=terminal, tool_call=None),
+        connection_generation=1,
+    )
+
+    # 这条终结抵的是欠账，不能去结算后继的 token。
+    assert client._gemini_external_outcome_token is token
+    assert client._gemini_cancelled_terminal_pending is False
+    assert client._gemini_cancelled_terminal_awaiting_delivery is False
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_an_expired_debt_does_not_eat_a_legitimate_terminal():
     """A debt that outlived its window is spent but not honoured.
 
@@ -1761,10 +1811,18 @@ def test_arming_the_cancellation_debt_always_sets_a_deadline():
     ]
     assert arming, "the arming site moved; update this guard"
     for index in arming:
-        window = chr(10).join(source[index : index + 8])
+        # 窗口要盖住两条赋值以及它们各自的解释注释。
+        window = chr(10).join(source[index : index + 16])
         assert "self._gemini_cancelled_terminal_deadline = (" in window, (
             f"line {index + 1}: arming the debt must also set its deadline, "
             f"got: {window!r}"
+        )
+        assert (
+            "self._gemini_cancelled_terminal_awaiting_delivery = True" in window
+        ), (
+            f"line {index + 1}: arming the debt must mark it as awaiting "
+            f"delivery, or the deadline starts before the provider is "
+            f"interrupted; got: {window!r}"
         )
 
 

--- a/tests/unit/test_external_visual_delivery.py
+++ b/tests/unit/test_external_visual_delivery.py
@@ -1586,7 +1586,11 @@ async def test_voiding_the_debt_also_drops_its_deadline():
     client._gemini_cancelled_terminal_pending = True
     client._gemini_cancelled_terminal_deadline = time.monotonic() + 60.0
     client._is_responding = False
-    client._interrupted = False
+    # 外部 ASR 送的是文本，provider 不回 input_transcription，所以打断标志会一直
+    # 挂着 —— 用生产上的状态，别用 _interrupted=False 把判据绕过去。这里靠的是
+    # AI 静默超窗（_can_clear_interrupted 的第三个析取项）。
+    client._interrupted = True
+    client._gemini_user_transcript_after_interrupt = False
     client._user_recent_activity_time = 200.0
     client._ai_recent_activity_time = 100.0
 

--- a/tests/unit/test_external_visual_delivery.py
+++ b/tests/unit/test_external_visual_delivery.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+from pathlib import Path
 from types import MethodType
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -1500,6 +1501,165 @@ async def test_one_event_with_both_terminal_flags_spends_the_debt_once():
     assert client._gemini_external_outcome_token is token
     assert client._gemini_cancelled_terminal_pending is False
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_late_content_from_the_cancelled_turn_keeps_the_debt():
+    """The cancelled turn's own late content must not void its debt.
+
+    Voiding on ``_is_new_turn`` alone is satisfied by that content: the user
+    already spoke after the AI's last frame, which is exactly what the
+    cancellation means. The debt then dies before the terminal it was owed,
+    and that terminal settles the freshly minted external token -- the turn
+    reads idle while it is still in flight.
+
+    The line below this one declares the new turn under the stricter
+    ``_is_new_turn and _can_clear_interrupted``; voiding has to use the same
+    definition of "the old turn is over".
+    """
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client._connection_generation = 1
+    client._still_owns_connection = lambda _gen: True
+    client._read_host_turn_id = lambda: None
+    client.on_response_done = None
+    client.on_new_message = None
+    client.on_text_delta = None
+    client._settle_gemini_proactive_inject = MagicMock()
+
+    token = object()
+    client._gemini_external_outcome_token = token
+    client._gemini_cancelled_terminal_pending = True
+    # handle_interruption() 之后的状态：这一轮被叫停，不再 responding。
+    client._is_responding = False
+    client._interrupted = True
+    # 外部回合把用户活动刷到了 AI 最后一帧之后，且仍在 3s 窗口内。
+    client._ai_recent_activity_time = time.time()
+    client._user_recent_activity_time = client._ai_recent_activity_time + 0.1
+
+    late_content = SimpleNamespace(
+        model_turn=SimpleNamespace(parts=[]),
+        input_transcription=None,
+        output_transcription=None,
+        interrupted=False,
+        turn_complete=False,
+    )
+    await client._process_gemini_response(
+        SimpleNamespace(server_content=late_content, tool_call=None),
+        connection_generation=1,
+    )
+    # 被取消那一轮的迟到内容不是「新回合开始」的证据。
+    assert client._gemini_cancelled_terminal_pending is True
+
+    real_terminal = SimpleNamespace(
+        model_turn=None,
+        input_transcription=None,
+        output_transcription=None,
+        interrupted=False,
+        turn_complete=True,
+    )
+    await client._process_gemini_response(
+        SimpleNamespace(server_content=real_terminal, tool_call=None),
+        connection_generation=1,
+    )
+    # 那条终结属于被取消的旧回合，不能拿去结算新铸的 token。
+    assert client._gemini_external_outcome_token is token
+    assert client._gemini_cancelled_terminal_pending is False
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_an_expired_debt_does_not_eat_a_legitimate_terminal():
+    """A debt that outlived its window is spent but not honoured.
+
+    The turn-start void only runs when AI content arrives before the terminal.
+    A bare ``turn_complete`` -- which this provider does emit -- skips it, so
+    without a deadline a stale debt waits indefinitely and absorbs a terminal
+    that belongs to someone else. That leaves an external token nobody settles
+    and a session pinned busy, which is the worse of the two failure
+    directions.
+    """
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client._connection_generation = 1
+    client._still_owns_connection = lambda _gen: True
+    client._read_host_turn_id = lambda: None
+    client.on_response_done = None
+    client.on_new_message = None
+    client.on_text_delta = None
+    client._settle_gemini_proactive_inject = MagicMock()
+
+    token = object()
+    client._gemini_external_outcome_token = token
+    client._gemini_cancelled_terminal_pending = True
+    client._gemini_cancelled_terminal_deadline = time.monotonic() - 0.001
+    client._is_responding = True
+    client._interrupted = True
+
+    bare_terminal = SimpleNamespace(
+        model_turn=None,
+        input_transcription=None,
+        output_transcription=None,
+        interrupted=False,
+        turn_complete=True,
+    )
+    await client._process_gemini_response(
+        SimpleNamespace(server_content=bare_terminal, tool_call=None),
+        connection_generation=1,
+    )
+
+    # 过期的欠账被花掉但不认账：这条终结照常结算当前回合。
+    assert client._gemini_cancelled_terminal_pending is False
+    assert client._gemini_cancelled_terminal_deadline is None
+    assert client._gemini_external_outcome_token is None
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_a_replacement_connection_does_not_inherit_the_debt():
+    """The debt belongs to the connection that armed it.
+
+    The replacement's first terminal is its own. Absorbed by the predecessor's
+    debt, the turn that produced it never settles its token.
+    """
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client._connection_generation = 1
+    client._gemini_cancelled_terminal_pending = True
+    client._gemini_cancelled_terminal_deadline = time.monotonic() + 60.0
+
+    client._on_connection_attached()
+
+    assert client._gemini_cancelled_terminal_pending is False
+    assert client._gemini_cancelled_terminal_deadline is None
+    await client.close()
+
+
+@pytest.mark.unit
+def test_arming_the_cancellation_debt_always_sets_a_deadline():
+    """The expiry fails open on a missing deadline, so arming must set one.
+
+    ``_consume_cancelled_terminal`` treats ``deadline is None`` as "never
+    expires" so that state built directly by tests keeps the old semantics. A
+    production arming site that forgot the deadline would silently opt out of
+    the bound.
+    """
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "main_logic"
+        / "omni_realtime_client"
+        / "_transport.py"
+    ).read_text(encoding="utf-8").split(chr(10))
+
+    arming = [
+        index
+        for index, line in enumerate(source)
+        if line.strip() == "self._gemini_cancelled_terminal_pending = True"
+    ]
+    assert arming, "the arming site moved; update this guard"
+    for index in arming:
+        window = chr(10).join(source[index : index + 8])
+        assert "self._gemini_cancelled_terminal_deadline = (" in window, (
+            f"line {index + 1}: arming the debt must also set its deadline, "
+            f"got: {window!r}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_external_visual_delivery.py
+++ b/tests/unit/test_external_visual_delivery.py
@@ -1568,6 +1568,80 @@ async def test_late_content_from_the_cancelled_turn_keeps_the_debt():
 
 
 @pytest.mark.asyncio
+async def test_voiding_the_debt_also_drops_its_deadline():
+    """The two fields are one piece of state; retiring one orphans the other.
+
+    The consume and connection-replacement paths already clear them together.
+    A deadline left behind by the turn-start void is inert only because the one
+    arming site always overwrites it -- a second arming site would inherit it.
+    """
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client._connection_generation = 1
+    client._still_owns_connection = lambda _gen: True
+    client._read_host_turn_id = lambda: None
+    client.on_response_done = None
+    client.on_new_message = None
+    client.on_text_delta = None
+    client._settle_gemini_proactive_inject = MagicMock()
+    client._gemini_cancelled_terminal_pending = True
+    client._gemini_cancelled_terminal_deadline = time.monotonic() + 60.0
+    client._is_responding = False
+    client._interrupted = False
+    client._user_recent_activity_time = 200.0
+    client._ai_recent_activity_time = 100.0
+
+    content_start = SimpleNamespace(
+        model_turn=SimpleNamespace(parts=[]),
+        input_transcription=None,
+        output_transcription=None,
+        interrupted=False,
+        turn_complete=False,
+    )
+    await client._process_gemini_response(
+        SimpleNamespace(server_content=content_start, tool_call=None),
+        connection_generation=1,
+    )
+
+    assert client._gemini_cancelled_terminal_pending is False
+    assert client._gemini_cancelled_terminal_deadline is None
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_a_slow_cancel_send_restarts_the_debt_deadline():
+    """The provider owes the terminal from when the cancel lands.
+
+    ``handle_interruption`` arms the debt before awaiting the cancellation
+    send so every early return carries a deadline. If transport backpressure
+    holds that await for longer than the TTL, a deadline stamped before it
+    is already expired by the time the successor turn is submitted, and the
+    cancelled turn's terminal settles the successor -- the regression this
+    whole change exists to prevent. So the stamp is taken again once the send
+    actually completes.
+    """
+    client = _make_client("openai", "gpt-4o-realtime-preview")
+    client._is_responding = True
+    client._current_response_id = "resp-1"
+
+    async def _slow_cancel(*_args, **_kwargs):
+        await asyncio.sleep(0)
+        # 模拟被背压拖过了 TTL：此刻已武装的期限早就到点了。
+        assert client._gemini_cancelled_terminal_deadline is not None
+        client._gemini_cancelled_terminal_deadline = time.monotonic() - 1.0
+
+    client.cancel_response = _slow_cancel
+
+    await client.handle_interruption()
+
+    assert client._gemini_cancelled_terminal_pending is True
+    deadline = client._gemini_cancelled_terminal_deadline
+    assert deadline is not None
+    # 期限从「取消落地」重新起算，不再是过期的那个。
+    assert deadline > time.monotonic()
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_an_expired_debt_does_not_eat_a_legitimate_terminal():
     """A debt that outlived its window is spent but not honoured.
 

--- a/tests/unit/test_external_visual_delivery.py
+++ b/tests/unit/test_external_visual_delivery.py
@@ -1643,6 +1643,7 @@ async def test_a_slow_handoff_restarts_the_debt_deadline_at_the_gemini_send():
     # 打断已经发生，但 ASR 交接 + 压图拖过了 TTL：期限已经到点。
     client._gemini_cancelled_terminal_pending = True
     client._gemini_cancelled_terminal_awaiting_delivery = True
+    client._gemini_cancelled_terminal_id = object()
     client._gemini_cancelled_terminal_deadline = time.monotonic() - 1.0
 
     await client._gemini_send_user_turn("successor")
@@ -1724,6 +1725,45 @@ async def test_the_debt_does_not_expire_before_the_interrupt_is_delivered():
     assert client._gemini_external_outcome_token is token
     assert client._gemini_cancelled_terminal_pending is False
     assert client._gemini_cancelled_terminal_awaiting_delivery is False
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_only_the_send_that_delivered_the_debt_restarts_its_clock():
+    """A send restamps the debt it delivered, not whatever is armed on return.
+
+    An earlier send can still be inside ``send_client_content`` when a barge-in
+    arms a fresh debt. Reading the flags after that await lets the earlier send
+    claim the new debt, lowering awaiting-delivery and starting the TTL while
+    the successor's content has not been sent at all -- so a slow handoff
+    afterwards spends the window before the provider is interrupted.
+    """
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client.note_user_turn_started = MagicMock()
+
+    armed = {}
+
+    async def _arm_midflight(**_kw):
+        # 这次发送在飞的时候，用户抢话武装了一笔**新**欠账。
+        client._gemini_cancelled_terminal_pending = True
+        client._gemini_cancelled_terminal_awaiting_delivery = True
+        client._gemini_cancelled_terminal_id = object()
+        client._gemini_cancelled_terminal_deadline = time.monotonic() + 60.0
+        armed["id"] = client._gemini_cancelled_terminal_id
+
+    client._gemini_session = SimpleNamespace(
+        send_client_content=AsyncMock(side_effect=_arm_midflight),
+    )
+    # 这次发送开始时没有任何欠账挂着。
+    client._gemini_cancelled_terminal_pending = False
+    client._gemini_cancelled_terminal_awaiting_delivery = False
+    client._gemini_cancelled_terminal_id = None
+
+    await client._gemini_send_user_turn("earlier turn")
+
+    # 那笔欠账不是这次发送送达的：它必须仍然在等自己的送达。
+    assert client._gemini_cancelled_terminal_id is armed["id"]
+    assert client._gemini_cancelled_terminal_awaiting_delivery is True
     await client.close()
 
 

--- a/tests/unit/test_external_visual_delivery.py
+++ b/tests/unit/test_external_visual_delivery.py
@@ -1608,36 +1608,68 @@ async def test_voiding_the_debt_also_drops_its_deadline():
 
 
 @pytest.mark.asyncio
-async def test_a_slow_cancel_send_restarts_the_debt_deadline():
-    """The provider owes the terminal from when the cancel lands.
+async def test_a_slow_handoff_restarts_the_debt_deadline_at_the_gemini_send():
+    """The clock starts when the provider is actually interrupted.
 
-    ``handle_interruption`` arms the debt before awaiting the cancellation
-    send so every early return carries a deadline. If transport backpressure
-    holds that await for longer than the TTL, a deadline stamped before it
-    is already expired by the time the successor turn is submitted, and the
-    cancelled turn's terminal settles the successor -- the regression this
-    whole change exists to prevent. So the stamp is taken again once the send
-    actually completes.
+    Gemini has no ``response.cancel``: ``handle_interruption`` only marks local
+    state, and the provider learns of the barge-in when the successor's content
+    lands. Timing the debt from the interruption means a slow ASR handoff or a
+    heavy multimodal send burns the whole window before the provider has even
+    been told, so the cancelled turn's terminal is judged current and settles
+    the successor token -- the regression this change exists to prevent.
+
+    Arming still happens at the interruption so every early return carries a
+    deadline; the send re-stamps it, once.
     """
-    client = _make_client("openai", "gpt-4o-realtime-preview")
-    client._is_responding = True
-    client._current_response_id = "resp-1"
+    client = _make_client("gemini", "gemini-2.0-flash-live-001")
+    client._connection_generation = 1
+    client._still_owns_connection = lambda _gen: True
+    client._read_host_turn_id = lambda: None
+    client.on_response_done = None
+    client.on_new_message = None
+    client.on_text_delta = None
+    client._settle_gemini_proactive_inject = MagicMock()
+    client.note_user_turn_started = MagicMock()
 
-    async def _slow_cancel(*_args, **_kwargs):
-        await asyncio.sleep(0)
-        # 模拟被背压拖过了 TTL：此刻已武装的期限早就到点了。
-        assert client._gemini_cancelled_terminal_deadline is not None
-        client._gemini_cancelled_terminal_deadline = time.monotonic() - 1.0
+    sent = []
+    client._gemini_session = SimpleNamespace(
+        send_client_content=AsyncMock(side_effect=lambda **kw: sent.append(kw)),
+    )
 
-    client.cancel_response = _slow_cancel
+    # 打断已经发生，但 ASR 交接 + 压图拖过了 TTL：期限已经到点。
+    client._gemini_cancelled_terminal_pending = True
+    client._gemini_cancelled_terminal_awaiting_delivery = True
+    client._gemini_cancelled_terminal_deadline = time.monotonic() - 1.0
 
-    await client.handle_interruption()
+    await client._gemini_send_user_turn("successor")
 
-    assert client._gemini_cancelled_terminal_pending is True
+    assert sent, "the successor content must actually be sent"
     deadline = client._gemini_cancelled_terminal_deadline
-    assert deadline is not None
-    # 期限从「取消落地」重新起算，不再是过期的那个。
-    assert deadline > time.monotonic()
+    assert deadline is not None and deadline > time.monotonic()
+    # 只续一次：后面每次发送都续命的话，一笔没人抵掉的欠账会被无限延寿。
+    assert client._gemini_cancelled_terminal_awaiting_delivery is False
+    client._gemini_cancelled_terminal_deadline = time.monotonic() - 1.0
+    await client._gemini_send_user_turn("another")
+    assert client._gemini_cancelled_terminal_deadline < time.monotonic()
+
+    # 行为层：续期之后，被取消那一轮的终结仍然抵的是欠账，不碰后继的 token。
+    client._gemini_cancelled_terminal_deadline = time.monotonic() + 60.0
+    token = object()
+    client._gemini_external_outcome_token = token
+    client._is_responding = True
+    client._interrupted = True
+    terminal = SimpleNamespace(
+        model_turn=None,
+        input_transcription=None,
+        output_transcription=None,
+        interrupted=False,
+        turn_complete=True,
+    )
+    await client._process_gemini_response(
+        SimpleNamespace(server_content=terminal, tool_call=None),
+        connection_generation=1,
+    )
+    assert client._gemini_external_outcome_token is token
     await client.close()
 
 


### PR DESCRIPTION
承接 #2964 的评审遗留（codex 在 `_gemini_support.py:867` 报的那条），本轮单独收。

## 原本是什么样

Gemini 没有 `response.created` 这类事件，被打断的那一轮仍然欠一条终结（`turn_complete` / `interrupted`）。`handle_interruption()` 会记一笔「欠账」`_gemini_cancelled_terminal_pending`，由**下一条到达的终结**消费掉——因为同一条连接上终结是 FIFO 的，取消之后的第一条终结必然属于被取消的那一轮。这笔欠账的作用是拦住它去结算之后才铸出的 external turn token。

同时，为了防止「旧回合永不终结」把欠账永久挂住、进而吃掉一条**合法**终结（那会让某个 token 没人结算、会话被钉成「忙」、主动搭话彻底哑掉），代码在检测到新回合开始时会把欠账作废。

## 问题

作废用的是 `if _is_new_turn:`，而**紧接着下一行**宣告新回合用的是更严的 `if _is_new_turn and _can_clear_interrupted:`。同一段代码里对「新回合开始」有两个不一致的定义。

而被取消那一轮的**迟到内容**恰好满足松的那个——`_is_new_turn` 的第一个析取项是「用户在 AI 最后一帧之后发过声」，这正是「被打断」的定义。于是：

1. Gemini 正在放 A；
2. 用户开口，`prepare_external_voice_turn` → `handle_interruption()`：武装欠账、`_interrupted=True`、`_is_responding=False`；
3. `_submit_external_gemini_turn` 把 `_user_recent_activity_time` 刷到 A 之后，铸出 B 的 token；
4. **A 的迟到内容**到达，进入 turn-start 块，`_is_new_turn` 为真 → 欠账被清；
5. A 自己的终结随后到达，`_consume_cancelled_terminal()` 拿不到欠账 → 这条终结去结算了 **B** 的 token。

结果：B 还在飞，会话已经读作空闲，主动搭话可以在 B 说话中间插进来。

## 改成什么样

**① 作废改用与宣告新回合完全相同的判据。**

**② 给欠账加一个期限。** 只做 ① 的话，会把失败方向从本仓允许的一侧（早结算一次）翻到禁止的一侧（把会话钉成忙）——旧回合永不终结时，欠账会活下来吃掉 B 的合法终结。所以反向要有界，而且不能依赖 ① 那条路径本身：

- 第一道界是既有的：`_interrupted` 为真时 `_ai_recent_activity_time` 的两个刷新点（`_gemini_support.py:905/922`）**都被跳过**，所以 3.0s（`_client.py:428` 的 `_ai_recent_activity_window`）之后 `_still_within_ai_window` 转假，`_can_clear_interrupted` 自动放行。这一条不需要新代码。
- 第二道界是新加的：上面那条只在「合法终结之前先来了 AI 内容」时才跑得到。裸 `turn_complete`（本仓已有用例把它钉成 provider 的合法行为）和「此后再无内容」都绕过它。所以 `_consume_cancelled_terminal()` 对过期的欠账**花掉但不认账**。

两处兜不住时的落点都是「按当前回合的终结去结算」，也就是早结算一次——本仓判据是「泄漏忙标志比早结算一次糟得多」。

**③ 替换连接不继承欠账。** 替换连接上的第一条终结是它自己的。隔离重连那条路上 `connect()` 跑在 `handle_interruption()` 之前，所以这一步不会抹掉刚武装的那笔。

## 为什么不是别的改法

- **只做 ①**：把常见路径的「早结算」换成罕见路径的「忙泄漏」，方向违背判据。
- **只做 ②**：codex 报的那条时序照旧复现——欠账在到期之前就被 ① 那处松判据清掉了。
- **把欠账绑到所属回合**：provider 侧的终结事件不带任何回合标识（`LiveServerContent` 只有 bool 和内容字段），同连接内只能靠到达顺序推断，等于原地打转。连接代次是唯一可用的身份，已经以 ③ 的形式收进来了。

## 回归报告 / Regression Report

**改动了什么**

- `main_logic/omni_realtime_client/_gemini_support.py`：取消欠账的作废判据由 `_is_new_turn` 改为 `_is_new_turn and _can_clear_interrupted`，与紧接其后宣告新回合的判据一致。
- `main_logic/omni_realtime_client/_transport.py`：`handle_interruption()` 武装欠账时同时写入 `_gemini_cancelled_terminal_deadline`（新常量 `_GEMINI_CANCELLED_TERMINAL_TTL_SECONDS = 3.0`）；`_on_connection_attached()` 清掉欠账与期限。
- `main_logic/omni_realtime_client/_responses.py`：`_consume_cancelled_terminal()` 对过期欠账「花掉但不认账」。
- `main_logic/omni_realtime_client/_client.py`：两个字段的初始化。

**理由 / 必要性**

同一段代码里对「新回合开始」有两个不一致的定义，而被取消那一轮的迟到内容恰好满足松的那个（`_is_new_turn` 的第一个析取项就是「用户在 AI 最后一帧之后发过声」，这正是被打断的定义）。于是欠账在它真正的终结到达之前被清掉，那条终结转而结算了刚铸出的 external turn token。

**改动前后的表现对比**

- 前：用户抢话打断 A、系统开始 B 之后，A 的迟到内容一到就把欠账清掉；A 的终结随即把 **B** 的 token 结算掉。B 还在说话，会话已读作空闲，主动搭话可以在 B 中间插进来。
- 后：A 的迟到内容不再被当成「新回合开始」的证据，欠账留到 A 自己的终结把它抵掉，B 的 token 不受影响。

**潜在回归点（影响哪些链路、怎么验证的）**

主要风险是反向的：旧回合永不终结时，欠账活下来吃掉一条**合法**终结 → 那一轮的 token 没人结算 → `is_active_response()` 恒真 → 主动搭话彻底哑。本仓判据是「泄漏忙标志比早结算一次糟得多」，所以这个方向必须有界：

1. 既有的界：`_interrupted` 为真时 `_ai_recent_activity_time` 的两个刷新点（`_gemini_support.py:905/922`）都被跳过，3.0s 后 `_still_within_ai_window` 转假，`_can_clear_interrupted` 自动放行。
2. 新加的界：上面那条只在「合法终结之前先来了 AI 内容」时才跑得到，裸 `turn_complete` 与「此后再无内容」绕过它，故由消费时的期限兜底。
3. 连接边界：替换连接不继承前一条连接的欠账。

以上三处兜不住时的落点都是「按当前回合的终结去结算」，即早结算一次——允许的方向。

影响链路仅限 Gemini realtime 的取消/终结记账（`_process_gemini_response` 的终结分支、external turn token 结算、`is_active_response()`）。非 Gemini provider 走 arbiter，不经过这套机制。

验证：新增 4 条用例，每条都做了变异验证（判据放松回 `_is_new_turn`、去掉消费时过期、去掉连接边界清除、武装时不设期限——四个变异各自对应一条用例变红）。`test_external_text_turns` / `test_external_visual_delivery` / `test_realtime_proactive_text` / `test_realtime_tool_ownership` / `test_core_independent_asr` / `test_hot_swap_cancellation` 共 743 passed；docstring 禁 CJK、core contracts、ruff 均绿。

## 不拆分理由 / No-split Rationale

不适用（计入上限的文件 4 个）。

## 验证

新增 4 条用例，逐条做了变异验证：

| 用例 | 变异 | 结果 |
|---|---|---|
| `test_late_content_from_the_cancelled_turn_keeps_the_debt` | 判据放松回 `_is_new_turn` | 红 |
| `test_an_expired_debt_does_not_eat_a_legitimate_terminal` | 去掉消费时过期 | 红 |
| `test_a_replacement_connection_does_not_inherit_the_debt` | 去掉连接边界清除 | 红 |
| `test_arming_the_cancellation_debt_always_sets_a_deadline` | 武装时不设期限 | 红 |

最后一条是结构守卫：`_consume_cancelled_terminal` 对 `deadline is None` 是 fail-open（保持既有用例直接置 flag 的语义），所以要有东西盯着生产侧的武装点必须同时设期限。

另外记一笔：改动前，现有 302 条相关用例对两种判据**完全无差别**——`test_...credit must not outlive...`（`_interrupted=False`）和 `test_non_terminal_content_does_not_spend_the_cancellation_debt`（`_is_responding=True`，进不了 turn-start 块）都绕开了 codex 那个格子。

`tests/unit/test_external_text_turns.py` + `test_external_visual_delivery.py` + `test_realtime_proactive_text.py` + `test_realtime_tool_ownership.py` + `test_core_independent_asr.py` + `test_hot_swap_cancellation.py`：**743 passed**。docstring 禁 CJK、core contracts、ruff 均绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进 Gemini 回合取消后的终结事件处理，避免取消状态误影响后续回合。
  * 仅在中断内容实际送达且状态仍有效时更新取消状态，减少延迟交付造成的误判。
  * 优化状态在超时、新回合及重新连接后的清理，统一 3 秒有效期限。

* **测试**
  * 增加取消回合延迟送达及连续状态变化场景的覆盖，提升实时交互稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->