### PR TITLE
Toast可消除、hover时可保留、文本添加黑色阴影

### DIFF
--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -354,21 +354,51 @@ I.mod = window.appUi;
         if (duration == null) duration = 3000;
         const priority = (options && options.important) ? 100 : ((options && options.priority) || 0);
 
+        const statusToast = I.S.dom.statusToast || document.getElementById('status-toast');
+        const statusElement = I.S.dom.statusElement || document.getElementById('status');
+
+        if (!statusToast) {
+            console.error(window.t('console.statusToastNotFound'));
+            return;
+        }
+        I.S.dom.statusToast = statusToast;
+        if (statusElement) I.S.dom.statusElement = statusElement;
+
+        function hideNow() {
+            if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
+            if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
+            if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
+            if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
+            if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
+            if (statusToast._toastFocusIn) { statusToast.removeEventListener('focusin', statusToast._toastFocusIn); statusToast._toastFocusIn = null; }
+            if (statusToast._toastFocusOut) { statusToast.removeEventListener('focusout', statusToast._toastFocusOut); statusToast._toastFocusOut = null; }
+            statusToast.classList.remove('show');
+            statusToast.classList.add('hide');
+            const _cb3 = statusToast.querySelector('#status-toast-close');
+            if (_cb3) { _cb3.disabled = true; _cb3.tabIndex = -1; _cb3.setAttribute('aria-hidden','true'); }
+            I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; if (I.mod.api && I.mod.api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) I.mod.api.setMouseThrough(true); }, 400);
+        }
+        function scheduleHide(ms) {
+            if (I.S.statusToastTimeout) clearTimeout(I.S.statusToastTimeout);
+            I.S._statusToastRemaining = ms;
+            I.S._statusToastStart = Date.now();
+            I.S.statusToastTimeout = setTimeout(hideNow, ms);
+        }
+
         if (!message || message.trim() === '') {
-            const statusToast = I.S.dom.statusToast;
-            if (statusToast) {
-                if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
-                if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
-                if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
-                const _cb2 = statusToast.querySelector('#status-toast-close');
-                if (_cb2) { _cb2.disabled = true; _cb2.tabIndex = -1; _cb2.setAttribute('aria-hidden','true'); if (document.activeElement === _cb2) _cb2.blur(); }
-                if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
-                if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
-                statusToast.classList.remove('show');
-                statusToast.classList.add('hide');
-                I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastCleanupTimer = null; }, 400);
-                I.S._statusToastRemaining = null; I.S._statusToastStart = null;
-            }
+            if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
+            if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
+            if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
+            if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
+            if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
+            if (statusToast._toastFocusIn) { statusToast.removeEventListener('focusin', statusToast._toastFocusIn); statusToast._toastFocusIn = null; }
+            if (statusToast._toastFocusOut) { statusToast.removeEventListener('focusout', statusToast._toastFocusOut); statusToast._toastFocusOut = null; }
+            const _cb2 = statusToast.querySelector('#status-toast-close');
+            if (_cb2) { _cb2.disabled = true; _cb2.tabIndex = -1; _cb2.setAttribute('aria-hidden','true'); if (document.activeElement === _cb2) _cb2.blur(); }
+            statusToast.classList.remove('show');
+            statusToast.classList.add('hide');
+            I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastCleanupTimer = null; if (I.mod.api && I.mod.api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) I.mod.api.setMouseThrough(true); }, 400);
+            I.S._statusToastRemaining = null; I.S._statusToastStart = null;
             I.S._statusToastPriority = 0;
             return;
         }
@@ -380,18 +410,10 @@ I.mod = window.appUi;
 
         console.log(window.t('console.statusToastShow'), message, window.t('console.statusToastDuration'), duration);
 
-        const statusToast = I.S.dom.statusToast || document.getElementById('status-toast');
-        const statusElement = I.S.dom.statusElement || document.getElementById('status');
-
-        if (!statusToast) {
-            console.error(window.t('console.statusToastNotFound'));
-            return;
-        }
-        I.S.dom.statusToast = statusToast;
-        if (statusElement) {
-            I.S.dom.statusElement = statusElement;
-        }
-
+        let textEl = statusToast.querySelector('#status-toast-text');
+        if (!textEl) { textEl = document.createElement('span'); textEl.id = 'status-toast-text'; statusToast.appendChild(textEl); }
+        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
+        textEl.textContent = message;
         let closeBtn = statusToast.querySelector('#status-toast-close');
         if (!closeBtn) {
             closeBtn = document.createElement('button');
@@ -425,7 +447,7 @@ I.mod = window.appUi;
         };
         statusToast._toastLeave = () => {
             if (I.S.statusToastTimeout || statusToast.classList.contains('hide')) return;
-            scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
+            if (!statusToast.matches(':hover, :focus-within')) scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
         };
         statusToast._toastFocusIn = () => {
             if (!I.S.statusToastTimeout) return;
@@ -433,7 +455,7 @@ I.mod = window.appUi;
         };
         statusToast._toastFocusOut = () => {
             if (I.S.statusToastTimeout || statusToast.classList.contains('hide')) return;
-            scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
+            if (!statusToast.matches(':hover, :focus-within')) scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
         };
         statusToast.addEventListener('mouseenter', statusToast._toastEnter);
         statusToast.addEventListener('mouseleave', statusToast._toastLeave);
@@ -444,7 +466,6 @@ I.mod = window.appUi;
             I.S._statusToastStart = Date.now();
         } else scheduleHide(duration);
 
-        // 同时更新隐藏的 status 元素（保持兼容性）
         if (statusElement) {
             statusElement.textContent = message || '';
         }

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -416,6 +416,10 @@ I.mod = window.appUi;
             statusToast.appendChild(closeBtn);
         }
         Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
+        if (I.S._statusToastCleanupTimer) {
+            clearTimeout(I.S._statusToastCleanupTimer);
+            I.S._statusToastCleanupTimer = null;
+        }
         textEl.textContent = message;
         closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -350,22 +350,22 @@ I.mod = window.appUi;
      * @param {number} [options.priority=0]  Priority level (higher = more important, won't be overwritten by lower priority)
      * @param {boolean} [options.important=false]  Whether this is an important message (same as priority=100)
      */
-    I.showStatusToast = function showStatusToast(message, duration = 3000, options = {}) {
-        const priority = options.important ? 100 : (options.priority || 0);
+    I.showStatusToast = function showStatusToast(message, duration, options = {}) {
+        if (duration == null) duration = 3000;
+        const priority = (options && options.important) ? 100 : ((options && options.priority) || 0);
 
         if (!message || message.trim() === '') {
             const statusToast = I.S.dom.statusToast;
             if (statusToast) {
-                if (I.S._statusToastCleanupTimer) {
-                    clearTimeout(I.S._statusToastCleanupTimer);
-                    I.S._statusToastCleanupTimer = null;
-                }
+                if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
+                if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
+                if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
+                if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
+                if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
-                I.S._statusToastCleanupTimer = setTimeout(() => {
-                    statusToast.textContent = '';
-                    I.S._statusToastCleanupTimer = null;
-                }, 300);
+                I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastCleanupTimer = null; }, 300);
+                I.S._statusToastRemaining = null; I.S._statusToastStart = null;
             }
             I.S._statusToastPriority = 0;
             return;
@@ -390,42 +390,63 @@ I.mod = window.appUi;
             I.S.dom.statusElement = statusElement;
         }
 
-        // 清除之前的定时器
-        if (I.S.statusToastTimeout) {
-            clearTimeout(I.S.statusToastTimeout);
-            I.S.statusToastTimeout = null;
-        }
-        if (I.S._statusToastCleanupTimer) {
-            clearTimeout(I.S._statusToastCleanupTimer);
-            I.S._statusToastCleanupTimer = null;
-        }
-
-        // 更新内容
-        statusToast.textContent = message;
-        I.S._statusToastPriority = priority;
-
-        // 确保元素可见
-        statusToast.style.display = 'block';
-        statusToast.style.visibility = 'visible';
-
-        // 显示气泡框
-        statusToast.classList.remove('hide');
-        // 使用 setTimeout 确保样式更新
-        setTimeout(() => {
-            statusToast.classList.add('show');
-            console.log(window.t('console.statusToastClassAdded'), statusToast, window.t('console.statusToastClassList'), statusToast.classList);
-        }, 10);
-
-        // 自动隐藏
-        I.S.statusToastTimeout = setTimeout(() => {
+        if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
+        if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
+        if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
+        function hideNow() {
+            if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
+            if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
+            if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
-            I.S._statusToastCleanupTimer = setTimeout(() => {
-                statusToast.textContent = '';
-                I.S._statusToastPriority = 0;
-                I.S._statusToastCleanupTimer = null;
-            }, 300);
-        }, duration);
+            if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
+            if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
+            I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; }, 300);
+        }
+        function scheduleHide(ms) {
+            if (I.S.statusToastTimeout) clearTimeout(I.S.statusToastTimeout);
+            I.S._statusToastRemaining = ms;
+            I.S._statusToastStart = Date.now();
+            I.S.statusToastTimeout = setTimeout(hideNow, ms);
+        }
+        let textEl = statusToast.querySelector('#status-toast-text');
+        if (!textEl) { textEl = document.createElement('span'); textEl.id = 'status-toast-text'; statusToast.appendChild(textEl); }
+        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n.nodeType === 3) n.textContent = ''; });
+        textEl.textContent = message;
+        let closeBtn = statusToast.querySelector('#status-toast-close');
+        if (!closeBtn) {
+            closeBtn = document.createElement('button');
+            closeBtn.id = 'status-toast-close';
+            closeBtn.type = 'button';
+            closeBtn.setAttribute('aria-label', 'close');
+            statusToast.appendChild(closeBtn);
+        }
+        closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };
+        I.S._statusToastPriority = priority;
+        statusToast.style.display = 'block';
+        statusToast.style.visibility = 'visible';
+        statusToast.classList.remove('hide');
+        I.S._statusToastShowTimer = setTimeout(() => {
+            statusToast.classList.add('show');
+            I.S._statusToastShowTimer = null;
+            console.log(window.t('console.statusToastClassAdded'), statusToast, window.t('console.statusToastClassList'), statusToast.classList);
+        }, 10);
+        if (statusToast._toastEnter) statusToast.removeEventListener('mouseenter', statusToast._toastEnter);
+        if (statusToast._toastLeave) statusToast.removeEventListener('mouseleave', statusToast._toastLeave);
+        statusToast._toastEnter = () => {
+            if (!I.S.statusToastTimeout) return;
+            clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null;
+            const elapsed = Date.now() - (I.S._statusToastStart || Date.now());
+            const base = I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration;
+            I.S._statusToastRemaining = Math.max(0, base - elapsed);
+        };
+        statusToast._toastLeave = () => {
+            if (I.S.statusToastTimeout || statusToast.classList.contains('hide')) return;
+            scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
+        };
+        statusToast.addEventListener('mouseenter', statusToast._toastEnter);
+        statusToast.addEventListener('mouseleave', statusToast._toastLeave);
+        scheduleHide(duration);
 
         // 同时更新隐藏的 status 元素（保持兼容性）
         if (statusElement) {

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -353,11 +353,23 @@ I.mod = window.appUi;
     I.showStatusToast = function showStatusToast(message, duration, options = {}) {
         if (duration == null) duration = 3000;
         const priority = (options && options.important) ? 100 : ((options && options.priority) || 0);
+
         const statusToast = I.S.dom.statusToast || document.getElementById('status-toast');
         const statusElement = I.S.dom.statusElement || document.getElementById('status');
-        if (!statusToast) { console.error(window.t('console.statusToastNotFound')); return; }
+
+        if (!statusToast) {
+            console.error(window.t('console.statusToastNotFound'));
+            return;
+        }
         I.S.dom.statusToast = statusToast;
         if (statusElement) I.S.dom.statusElement = statusElement;
+
+        function scheduleHide(ms) {
+            if (I.S.statusToastTimeout) clearTimeout(I.S.statusToastTimeout);
+            I.S._statusToastRemaining = ms;
+            I.S._statusToastStart = Date.now();
+            I.S.statusToastTimeout = setTimeout(hideNow, ms);
+        }
 
         function hideNow() {
             if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
@@ -372,12 +384,6 @@ I.mod = window.appUi;
             const _cb3 = statusToast.querySelector('#status-toast-close');
             if (_cb3) { _cb3.disabled = true; _cb3.tabIndex = -1; _cb3.setAttribute('aria-hidden','true'); }
             I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; if (I.mod.api && I.mod.api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) I.mod.api.setMouseThrough(true); }, 400);
-        }
-        function scheduleHide(ms) {
-            if (I.S.statusToastTimeout) clearTimeout(I.S.statusToastTimeout);
-            I.S._statusToastRemaining = ms;
-            I.S._statusToastStart = Date.now();
-            I.S.statusToastTimeout = setTimeout(hideNow, ms);
         }
 
         if (!message || message.trim() === '') {
@@ -415,11 +421,11 @@ I.mod = window.appUi;
             closeBtn.setAttribute('aria-label', 'close');
             statusToast.appendChild(closeBtn);
         }
-        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
         if (I.S._statusToastCleanupTimer) {
             clearTimeout(I.S._statusToastCleanupTimer);
             I.S._statusToastCleanupTimer = null;
         }
+        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
         textEl.textContent = message;
         closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };
@@ -468,7 +474,9 @@ I.mod = window.appUi;
             I.S._statusToastStart = Date.now();
         } else scheduleHide(duration);
 
-        if (statusElement) statusElement.textContent = message || '';
+        if (statusElement) {
+            statusElement.textContent = message || '';
+        }
     }
 
     I.mod.showStatusToast = I.showStatusToast;

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -392,31 +392,6 @@ I.mod = window.appUi;
             I.S.dom.statusElement = statusElement;
         }
 
-        if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
-        if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
-        if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
-        function hideNow() {
-            if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
-            if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
-            if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
-            statusToast.classList.remove('show');
-            statusToast.classList.add('hide');
-            const _closeBtn = statusToast.querySelector('#status-toast-close');
-            if (_closeBtn) { _closeBtn.disabled = true; _closeBtn.tabIndex = -1; _closeBtn.setAttribute('aria-hidden','true'); if (document.activeElement === _closeBtn) _closeBtn.blur(); }
-            if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
-            if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
-            I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; }, 400);
-        }
-        function scheduleHide(ms) {
-            if (I.S.statusToastTimeout) clearTimeout(I.S.statusToastTimeout);
-            I.S._statusToastRemaining = ms;
-            I.S._statusToastStart = Date.now();
-            I.S.statusToastTimeout = setTimeout(hideNow, ms);
-        }
-        let textEl = statusToast.querySelector('#status-toast-text');
-        if (!textEl) { textEl = document.createElement('span'); textEl.id = 'status-toast-text'; statusToast.appendChild(textEl); }
-        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n.nodeType === 3) n.textContent = ''; });
-        textEl.textContent = message;
         let closeBtn = statusToast.querySelector('#status-toast-close');
         if (!closeBtn) {
             closeBtn = document.createElement('button');
@@ -427,6 +402,7 @@ I.mod = window.appUi;
         }
         closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };
+        if (I.mod.api && I.mod.api.setMouseThrough) I.mod.api.setMouseThrough(false);
         I.S._statusToastPriority = priority;
         statusToast.style.display = 'block';
         statusToast.style.visibility = 'visible';
@@ -438,6 +414,8 @@ I.mod = window.appUi;
         }, 10);
         if (statusToast._toastEnter) statusToast.removeEventListener('mouseenter', statusToast._toastEnter);
         if (statusToast._toastLeave) statusToast.removeEventListener('mouseleave', statusToast._toastLeave);
+        if (statusToast._toastFocusIn) statusToast.removeEventListener('focusin', statusToast._toastFocusIn);
+        if (statusToast._toastFocusOut) statusToast.removeEventListener('focusout', statusToast._toastFocusOut);
         statusToast._toastEnter = () => {
             if (!I.S.statusToastTimeout) return;
             clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null;
@@ -449,10 +427,22 @@ I.mod = window.appUi;
             if (I.S.statusToastTimeout || statusToast.classList.contains('hide')) return;
             scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
         };
+        statusToast._toastFocusIn = () => {
+            if (!I.S.statusToastTimeout) return;
+            clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null;
+        };
+        statusToast._toastFocusOut = () => {
+            if (I.S.statusToastTimeout || statusToast.classList.contains('hide')) return;
+            scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
+        };
         statusToast.addEventListener('mouseenter', statusToast._toastEnter);
         statusToast.addEventListener('mouseleave', statusToast._toastLeave);
-        if (statusToast.matches(':hover')) { I.S._statusToastRemaining = duration; I.S._statusToastStart = Date.now(); }
-        else scheduleHide(duration);
+        statusToast.addEventListener('focusin', statusToast._toastFocusIn);
+        statusToast.addEventListener('focusout', statusToast._toastFocusOut);
+        if (statusToast.matches(':hover, :focus-within')) {
+            I.S._statusToastRemaining = duration;
+            I.S._statusToastStart = Date.now();
+        } else scheduleHide(duration);
 
         // 同时更新隐藏的 status 元素（保持兼容性）
         if (statusElement) {

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -353,14 +353,9 @@ I.mod = window.appUi;
     I.showStatusToast = function showStatusToast(message, duration, options = {}) {
         if (duration == null) duration = 3000;
         const priority = (options && options.important) ? 100 : ((options && options.priority) || 0);
-
         const statusToast = I.S.dom.statusToast || document.getElementById('status-toast');
         const statusElement = I.S.dom.statusElement || document.getElementById('status');
-
-        if (!statusToast) {
-            console.error(window.t('console.statusToastNotFound'));
-            return;
-        }
+        if (!statusToast) { console.error(window.t('console.statusToastNotFound')); return; }
         I.S.dom.statusToast = statusToast;
         if (statusElement) I.S.dom.statusElement = statusElement;
 
@@ -412,8 +407,6 @@ I.mod = window.appUi;
 
         let textEl = statusToast.querySelector('#status-toast-text');
         if (!textEl) { textEl = document.createElement('span'); textEl.id = 'status-toast-text'; statusToast.appendChild(textEl); }
-        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
-        textEl.textContent = message;
         let closeBtn = statusToast.querySelector('#status-toast-close');
         if (!closeBtn) {
             closeBtn = document.createElement('button');
@@ -422,6 +415,8 @@ I.mod = window.appUi;
             closeBtn.setAttribute('aria-label', 'close');
             statusToast.appendChild(closeBtn);
         }
+        Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
+        textEl.textContent = message;
         closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };
         if (I.mod.api && I.mod.api.setMouseThrough) I.mod.api.setMouseThrough(false);
@@ -452,6 +447,9 @@ I.mod = window.appUi;
         statusToast._toastFocusIn = () => {
             if (!I.S.statusToastTimeout) return;
             clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null;
+            const elapsed = Date.now() - (I.S._statusToastStart || Date.now());
+            const base = I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration;
+            I.S._statusToastRemaining = Math.max(0, base - elapsed);
         };
         statusToast._toastFocusOut = () => {
             if (I.S.statusToastTimeout || statusToast.classList.contains('hide')) return;
@@ -466,13 +464,10 @@ I.mod = window.appUi;
             I.S._statusToastStart = Date.now();
         } else scheduleHide(duration);
 
-        if (statusElement) {
-            statusElement.textContent = message || '';
-        }
+        if (statusElement) statusElement.textContent = message || '';
     }
 
     I.mod.showStatusToast = I.showStatusToast;
-    // 全局兼容
     window.showStatusToast = I.showStatusToast;
 
     // ================================================================

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -360,11 +360,13 @@ I.mod = window.appUi;
                 if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
                 if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
                 if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
+                const _cb2 = statusToast.querySelector('#status-toast-close');
+                if (_cb2) { _cb2.disabled = true; _cb2.tabIndex = -1; _cb2.setAttribute('aria-hidden','true'); if (document.activeElement === _cb2) _cb2.blur(); }
                 if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
                 if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
-                I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastCleanupTimer = null; }, 300);
+                I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastCleanupTimer = null; }, 400);
                 I.S._statusToastRemaining = null; I.S._statusToastStart = null;
             }
             I.S._statusToastPriority = 0;
@@ -399,9 +401,11 @@ I.mod = window.appUi;
             if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
+            const _closeBtn = statusToast.querySelector('#status-toast-close');
+            if (_closeBtn) { _closeBtn.disabled = true; _closeBtn.tabIndex = -1; _closeBtn.setAttribute('aria-hidden','true'); if (document.activeElement === _closeBtn) _closeBtn.blur(); }
             if (statusToast._toastEnter) { statusToast.removeEventListener('mouseenter', statusToast._toastEnter); statusToast._toastEnter = null; }
             if (statusToast._toastLeave) { statusToast.removeEventListener('mouseleave', statusToast._toastLeave); statusToast._toastLeave = null; }
-            I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; }, 300);
+            I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; }, 400);
         }
         function scheduleHide(ms) {
             if (I.S.statusToastTimeout) clearTimeout(I.S.statusToastTimeout);
@@ -421,6 +425,7 @@ I.mod = window.appUi;
             closeBtn.setAttribute('aria-label', 'close');
             statusToast.appendChild(closeBtn);
         }
+        closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };
         I.S._statusToastPriority = priority;
         statusToast.style.display = 'block';
@@ -446,7 +451,8 @@ I.mod = window.appUi;
         };
         statusToast.addEventListener('mouseenter', statusToast._toastEnter);
         statusToast.addEventListener('mouseleave', statusToast._toastLeave);
-        scheduleHide(duration);
+        if (statusToast.matches(':hover')) { I.S._statusToastRemaining = duration; I.S._statusToastStart = Date.now(); }
+        else scheduleHide(duration);
 
         // 同时更新隐藏的 status 元素（保持兼容性）
         if (statusElement) {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -56,8 +56,7 @@ body {
     /* 移除备用背景色，避免白色边框 */
     color: #fff;
     /* 纯白色文字 */
-    text-shadow: none;
-    /* 移除文字阴影 */
+    text-shadow: 0 1px 3px rgba(0,0,0,0.35);
     border-radius: 12px;
     font-size: 18px;
     /* 字体大小 */
@@ -92,18 +91,14 @@ body {
     content: '🐾';
     position: absolute;
     top: 50%;
-    /* 垂直居中 */
     left: 12px;
     transform: translateY(-50%);
-    /* 配合top: 50%实现垂直居中 */
     font-size: 50px;
-    /* 增大猫爪图标 */
     line-height: 1;
     opacity: 1;
     filter: brightness(0) invert(1);
-    /* 将emoji变成纯白色，移除阴影 */
-    z-index: 1;
-    /* 确保猫爪在遮罩层之上 */
+    z-index: 0;
+    pointer-events: none;
 }
 
 /* 弹跳动画只在 toast 可见时运行：默认态 toast 以 opacity:0 隐藏（非 display:none），
@@ -153,11 +148,22 @@ body {
     }
 }
 
+#status-toast-text{position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere}
+#status-toast-close{position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;transition:background 0.15s,opacity 0.15s;pointer-events:auto;text-shadow:none;font-size:0;line-height:0}
+#status-toast-close::before,#status-toast-close::after{content:"";position:absolute;left:50%;top:50%;width:10px;height:2px;border-radius:999px;background:#fff;pointer-events:none}
+#status-toast-close::before{transform:translate(-50%,-50%) rotate(45deg)}
+#status-toast-close::after{transform:translate(-50%,-50%) rotate(-45deg)}
+#status-toast-close:hover{background:rgba(255,255,255,0.38);opacity:1}
+#status-toast-close:active{transform:scale(0.92)}
+#status-toast-close:focus-visible{outline:2px solid rgba(255,255,255,0.9);outline-offset:2px}
+#status-toast{padding-right:36px}
+
 /* 状态提示气泡框滑动出动画 */
 #status-toast.hide {
     opacity: 0;
     transform: translateY(-20px) scale(0.95);
     animation: none;
+    pointer-events: none;
 }
 
 .home-avatar-floating-guide-player {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -132,7 +132,6 @@ body {
     opacity: 1;
     transform: translateY(0) scale(1);
     pointer-events: auto;
-    animation: slide-in-toast 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
 
 /* 状态提示气泡框滑动入动画 */
@@ -269,6 +268,7 @@ body {
         /* 移动端字体大小 */
         padding: 16px 20px;
         padding-left: 45px;
+        padding-right: 36px;
         /* 为左上角的猫爪留出空间 */
     }
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -148,7 +148,8 @@ body {
 }
 
 #status-toast-text{position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere}
-#status-toast-close{position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;transition:background 0.15s,opacity 0.15s;pointer-events:auto;text-shadow:none;font-size:0;line-height:0}
+#status-toast-close{position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;transition:background 0.15s,opacity 0.15s;text-shadow:none;font-size:0;line-height:0}
+#status-toast.show #status-toast-close{pointer-events:auto}
 #status-toast-close::before,#status-toast-close::after{content:"";position:absolute;left:50%;top:50%;width:10px;height:2px;border-radius:999px;background:#fff;pointer-events:none}
 #status-toast-close::before{transform:translate(-50%,-50%) rotate(45deg)}
 #status-toast-close::after{transform:translate(-50%,-50%) rotate(-45deg)}
@@ -156,6 +157,10 @@ body {
 #status-toast-close:active{transform:scale(0.92)}
 #status-toast-close:focus-visible{outline:2px solid rgba(255,255,255,0.9);outline-offset:2px}
 #status-toast{padding-right:36px}
+
+@media (max-width:600px){
+    #status-toast{padding-right:36px}
+}
 
 /* 状态提示气泡框滑动出动画 */
 #status-toast.hide {

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -131,6 +131,8 @@
             showTimer = setTimeout(function() { statusToast.classList.add('show'); showTimer=null; }, 10);
             if (statusToast._enter) statusToast.removeEventListener('mouseenter', statusToast._enter);
             if (statusToast._leave) statusToast.removeEventListener('mouseleave', statusToast._leave);
+            if (statusToast._focusIn) statusToast.removeEventListener('focusin', statusToast._focusIn);
+            if (statusToast._focusOut) statusToast.removeEventListener('focusout', statusToast._focusOut);
             statusToast._enter = function() {
                 if (!statusTimeout) return;
                 clearTimeout(statusTimeout); statusTimeout = null;
@@ -142,9 +144,19 @@
                 if (statusTimeout || statusToast.classList.contains('hide')) return;
                 scheduleHide(toastRemaining!=null ? toastRemaining : duration);
             };
+            statusToast._focusIn = function() {
+                if (!statusTimeout) return;
+                clearTimeout(statusTimeout); statusTimeout = null;
+            };
+            statusToast._focusOut = function() {
+                if (statusTimeout || statusToast.classList.contains('hide')) return;
+                scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+            };
             statusToast.addEventListener('mouseenter', statusToast._enter);
             statusToast.addEventListener('mouseleave', statusToast._leave);
-            if (statusToast.matches(':hover')) { toastRemaining = duration; toastStart = Date.now(); }
+            statusToast.addEventListener('focusin', statusToast._focusIn);
+            statusToast.addEventListener('focusout', statusToast._focusOut);
+            if (statusToast.matches(':hover, :focus-within')) { toastRemaining = duration; toastStart = Date.now(); }
             else scheduleHide(duration);
         }
 
@@ -422,8 +434,8 @@
                 overlay.style.animation = 'pnOverlayOut 0.2s ease forwards';
                 setTimeout(function() {
                     overlay.remove();
-                    // 恢复鼠标穿透
-                    if (api) api.setMouseThrough(true);
+                    // 恢复鼠标穿透：仅当 #status-toast 不再展示时才恢复
+                    if (api && !document.getElementById('status-toast').classList.contains('show')) api.setMouseThrough(true);
                     onDismiss();
                 }, 200);
             }

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -105,6 +105,7 @@
             var textEl = statusToast.querySelector('#status-toast-text');
             if (!textEl) { textEl=document.createElement('span'); textEl.id='status-toast-text'; textEl.style.cssText='position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere;'; statusToast.appendChild(textEl); }
             Array.from(statusToast.childNodes).forEach(function(n){ if(n!==textEl && n.nodeType===3) n.textContent=''; });
+            if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
             textEl.textContent = message;
             var closeBtn = statusToast.querySelector('#status-toast-close');
             if (!closeBtn) {

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -90,9 +90,11 @@
                 if (showTimer) { clearTimeout(showTimer); showTimer=null; }
                 if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
                 if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
-                var _cb2=statusToast.querySelector('#status-toast-close'); if(_cb2){ _cb2.disabled=true; _cb2.tabIndex=-1; _cb2.setAttribute('aria-hidden','true'); if(document.activeElement===_cb2) _cb2.blur(); }
                 if (statusToast._enter) { statusToast.removeEventListener('mouseenter', statusToast._enter); statusToast._enter = null; }
                 if (statusToast._leave) { statusToast.removeEventListener('mouseleave', statusToast._leave); statusToast._leave = null; }
+                if (statusToast._focusIn) { statusToast.removeEventListener('focusin', statusToast._focusIn); statusToast._focusIn = null; }
+                if (statusToast._focusOut) { statusToast.removeEventListener('focusout', statusToast._focusOut); statusToast._focusOut = null; }
+                var _cb2=statusToast.querySelector('#status-toast-close'); if(_cb2){ _cb2.disabled=true; _cb2.tabIndex=-1; _cb2.setAttribute('aria-hidden','true'); if(document.activeElement===_cb2) _cb2.blur(); }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
                 cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; if (api && api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) api.setMouseThrough(true); }, 400);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -142,15 +142,18 @@
             };
             statusToast._leave = function() {
                 if (statusTimeout || statusToast.classList.contains('hide')) return;
-                scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+                if (!statusToast.matches(':hover, :focus-within')) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
             };
             statusToast._focusIn = function() {
                 if (!statusTimeout) return;
                 clearTimeout(statusTimeout); statusTimeout = null;
+                var elapsed = Date.now() - toastStart;
+                var base = toastRemaining!=null ? toastRemaining : duration;
+                toastRemaining = Math.max(0, base - elapsed);
             };
             statusToast._focusOut = function() {
                 if (statusTimeout || statusToast.classList.contains('hide')) return;
-                scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+                if (!statusToast.matches(':hover, :focus-within')) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
             };
             statusToast.addEventListener('mouseenter', statusToast._enter);
             statusToast.addEventListener('mouseleave', statusToast._leave);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -71,11 +71,13 @@
             if (showTimer) { clearTimeout(showTimer); showTimer = null; }
             if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
             if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
+            var _cb = statusToast.querySelector('#status-toast-close');
+            if (_cb) { _cb.disabled = true; _cb.tabIndex = -1; _cb.setAttribute('aria-hidden','true'); if (document.activeElement === _cb) _cb.blur(); }
             if (statusToast._enter) { statusToast.removeEventListener('mouseenter', statusToast._enter); statusToast._enter = null; }
             if (statusToast._leave) { statusToast.removeEventListener('mouseleave', statusToast._leave); statusToast._leave = null; }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
-            cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 300);
+            cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; if (api && api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) api.setMouseThrough(true); }, 400);
         }
         function scheduleHide(ms) {
             if (statusTimeout) clearTimeout(statusTimeout);
@@ -88,11 +90,12 @@
                 if (showTimer) { clearTimeout(showTimer); showTimer=null; }
                 if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
                 if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
+                var _cb2=statusToast.querySelector('#status-toast-close'); if(_cb2){ _cb2.disabled=true; _cb2.tabIndex=-1; _cb2.setAttribute('aria-hidden','true'); if(document.activeElement===_cb2) _cb2.blur(); }
                 if (statusToast._enter) { statusToast.removeEventListener('mouseenter', statusToast._enter); statusToast._enter = null; }
                 if (statusToast._leave) { statusToast.removeEventListener('mouseleave', statusToast._leave); statusToast._leave = null; }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
-                cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 300);
+                cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; if (api && api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) api.setMouseThrough(true); }, 400);
                 toastRemaining=null; toastStart=null;
                 return;
             }
@@ -118,7 +121,9 @@
                 closeBtn.style.cssText = 'position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;font-size:0;line-height:0;';
                 statusToast.appendChild(closeBtn);
             }
+            closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
             closeBtn.onclick = function(e){ e.stopPropagation(); hideStatusNow(); };
+            if (api && api.setMouseThrough) api.setMouseThrough(false);
             statusToast.style.display = 'block';
             statusToast.style.visibility = 'visible';
             statusToast.style.paddingRight = '36px';
@@ -139,7 +144,8 @@
             };
             statusToast.addEventListener('mouseenter', statusToast._enter);
             statusToast.addEventListener('mouseleave', statusToast._leave);
-            scheduleHide(duration);
+            if (statusToast.matches(':hover')) { toastRemaining = duration; toastStart = Date.now(); }
+            else scheduleHide(duration);
         }
 
         // ===== Voice Preparing Toast =====

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -71,10 +71,12 @@
             if (showTimer) { clearTimeout(showTimer); showTimer = null; }
             if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
             if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
-            var _cb = statusToast.querySelector('#status-toast-close');
-            if (_cb) { _cb.disabled = true; _cb.tabIndex = -1; _cb.setAttribute('aria-hidden','true'); if (document.activeElement === _cb) _cb.blur(); }
             if (statusToast._enter) { statusToast.removeEventListener('mouseenter', statusToast._enter); statusToast._enter = null; }
             if (statusToast._leave) { statusToast.removeEventListener('mouseleave', statusToast._leave); statusToast._leave = null; }
+            if (statusToast._focusIn) { statusToast.removeEventListener('focusin', statusToast._focusIn); statusToast._focusIn = null; }
+            if (statusToast._focusOut) { statusToast.removeEventListener('focusout', statusToast._focusOut); statusToast._focusOut = null; }
+            var _cb = statusToast.querySelector('#status-toast-close');
+            if (_cb) { _cb.disabled = true; _cb.tabIndex = -1; _cb.setAttribute('aria-hidden','true'); if (document.activeElement === _cb) _cb.blur(); }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
             cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; if (api && api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) api.setMouseThrough(true); }, 400);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -66,37 +66,80 @@
         var statusTimeout = null;
         var cleanupTimer = null;
 
-        function showStatusToast(message, duration) {
-            duration = duration || 3000;
-
-            if (!message || !message.trim()) {
-                if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
-                statusToast.classList.remove('show');
-                statusToast.classList.add('hide');
-                cleanupTimer = setTimeout(function() {
-                    statusToast.textContent = '';
-                    cleanupTimer = null;
-                }, 300);
-                return;
-            }
-
+        var toastRemaining = 3000; var toastStart = 0; var showTimer = null;
+        function hideStatusNow() {
+            if (showTimer) { clearTimeout(showTimer); showTimer = null; }
             if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
             if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
-
-            statusToast.textContent = message;
-            statusToast.style.display = 'block';
-            statusToast.style.visibility = 'visible';
-            statusToast.classList.remove('hide');
-            setTimeout(function() { statusToast.classList.add('show'); }, 10);
-
-            statusTimeout = setTimeout(function() {
+            if (statusToast._enter) { statusToast.removeEventListener('mouseenter', statusToast._enter); statusToast._enter = null; }
+            if (statusToast._leave) { statusToast.removeEventListener('mouseleave', statusToast._leave); statusToast._leave = null; }
+            statusToast.classList.remove('show');
+            statusToast.classList.add('hide');
+            cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 300);
+        }
+        function scheduleHide(ms) {
+            if (statusTimeout) clearTimeout(statusTimeout);
+            toastRemaining = ms; toastStart = Date.now();
+            statusTimeout = setTimeout(hideStatusNow, ms);
+        }
+        function showStatusToast(message, duration) {
+            if (duration == null) duration = 3000;
+            if (!message || !message.trim()) {
+                if (showTimer) { clearTimeout(showTimer); showTimer=null; }
+                if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
+                if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
+                if (statusToast._enter) { statusToast.removeEventListener('mouseenter', statusToast._enter); statusToast._enter = null; }
+                if (statusToast._leave) { statusToast.removeEventListener('mouseleave', statusToast._leave); statusToast._leave = null; }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
-                cleanupTimer = setTimeout(function() {
-                    statusToast.textContent = '';
-                    cleanupTimer = null;
-                }, 300);
-            }, duration);
+                cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 300);
+                toastRemaining=null; toastStart=null;
+                return;
+            }
+            if (showTimer) { clearTimeout(showTimer); showTimer=null; }
+            if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
+            if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
+            var textEl = statusToast.querySelector('#status-toast-text');
+            if (!textEl) { textEl=document.createElement('span'); textEl.id='status-toast-text'; textEl.style.cssText='position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere;'; statusToast.appendChild(textEl); }
+            Array.from(statusToast.childNodes).forEach(function(n){ if(n!==textEl && n.nodeType===3) n.textContent=''; });
+            textEl.textContent = message;
+            var closeBtn = statusToast.querySelector('#status-toast-close');
+            if (!closeBtn) {
+                closeBtn = document.createElement('button');
+                closeBtn.id = 'status-toast-close';
+                closeBtn.type = 'button';
+                closeBtn.setAttribute('aria-label','close');
+                if(!document.querySelector('style[data-toast-close]')){
+                    var cs=document.createElement('style');
+                    cs.setAttribute('data-toast-close','true');
+                    cs.textContent='#status-toast-close::before,#status-toast-close::after{content:"";position:absolute;left:50%;top:50%;width:10px;height:2px;border-radius:999px;background:#fff;pointer-events:none}#status-toast-close::before{transform:translate(-50%,-50%) rotate(45deg)}#status-toast-close::after{transform:translate(-50%,-50%) rotate(-45deg)}#status-toast-close:focus-visible{outline:2px solid rgba(255,255,255,0.9);outline-offset:2px}';
+                    document.head.appendChild(cs);
+                }
+                closeBtn.style.cssText = 'position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;font-size:0;line-height:0;';
+                statusToast.appendChild(closeBtn);
+            }
+            closeBtn.onclick = function(e){ e.stopPropagation(); hideStatusNow(); };
+            statusToast.style.display = 'block';
+            statusToast.style.visibility = 'visible';
+            statusToast.style.paddingRight = '36px';
+            statusToast.classList.remove('hide');
+            showTimer = setTimeout(function() { statusToast.classList.add('show'); showTimer=null; }, 10);
+            if (statusToast._enter) statusToast.removeEventListener('mouseenter', statusToast._enter);
+            if (statusToast._leave) statusToast.removeEventListener('mouseleave', statusToast._leave);
+            statusToast._enter = function() {
+                if (!statusTimeout) return;
+                clearTimeout(statusTimeout); statusTimeout = null;
+                var elapsed = Date.now() - toastStart;
+                var base = toastRemaining!=null ? toastRemaining : duration;
+                toastRemaining = Math.max(0, base - elapsed);
+            };
+            statusToast._leave = function() {
+                if (statusTimeout || statusToast.classList.contains('hide')) return;
+                scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+            };
+            statusToast.addEventListener('mouseenter', statusToast._enter);
+            statusToast.addEventListener('mouseleave', statusToast._leave);
+            scheduleHide(duration);
         }
 
         // ===== Voice Preparing Toast =====


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

- toast添加关闭按钮，有时候挡在哪里太烦了
- 鼠标悬浮的时候不会消失，因为有时候想看报错信息来不及看
- 修复一个样式问题：`::before`原本会挡住也是白色的文本，现在不会了，还加了阴影好将白色文本从白色装饰中区分开来

<img width="514" height="121" alt="screenshot_1788063984391" src="https://github.com/user-attachments/assets/11bd1852-2cea-4a9a-8071-7e8737151cde" />


## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->

## 不拆分理由 / Why Not Split

<!--
仅当本 PR 改动计入上限的文件 > 20 个时必填：为什么不拆成多个更小的 PR。
计入上限的文件数 ≤ 20：写「不适用」或删除本节。（新增文件、i18n locale 文件、测试文件不计入这个上限）
-->

## 测试 / Testing

好像没什么相关的测试文件，手动测试没问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 状态提示在鼠标悬停或获得键盘焦点时暂停自动隐藏，离开或失焦后按剩余时间恢复倒计时。
  * 优化提示更新、清空及延迟隐藏行为，提升显示稳定性。
  * 隐藏状态下自动禁用并移除关闭按钮焦点，显示时恢复可用。
  * 改善提示关闭后的交互状态，避免影响页面操作。

* **样式**
  * 移动端为关闭按钮预留更多空间。
  * 隐藏状态下不再阻挡页面交互，改善鼠标操作体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->