### PR TITLE
test(jukebox): 用当前两列 grid 的不变量重写长歌名布局守卫

### DIFF
--- a/tests/frontend/test_jukebox_manager_standalone.py
+++ b/tests/frontend/test_jukebox_manager_standalone.py
@@ -1196,10 +1196,17 @@ def test_jukebox_manager_bindings_filter_hidden_songs(mock_page: Page):
 
 @pytest.mark.frontend
 def test_jukebox_manager_long_song_name_scrolls_without_pushing_actions(mock_page: Page):
+    """长歌名只在名字列里滚动，不改变条目里其它列的位置。
+
+    条目是 `.sam-item` 上的两列 grid：`.sam-item-info`（含 `.sam-item-header`）占第一列，
+    `.sam-item-actions` 占第二列，所以操作按钮本来就在名字列右边。这里用短歌名条目做基线，
+    比对两者的列边界，来验证名字长度不会撑开第一列。
+    """
     setup_song_manager_page(
         mock_page,
         """
         {
+          shortSong: { name: 'Short', artist: 'A', visible: true },
           longSong: {
             name: 'This is a very very very very very very very very very very long song name that should stay inside the name column',
             artist: 'A',
@@ -1213,26 +1220,43 @@ def test_jukebox_manager_long_song_name_scrolls_without_pushing_actions(mock_pag
         """
         () => {
           const panel = document.querySelector('.jukebox-sam-panel');
+          // 面板有 420px 的 min-width，这里量到的实际宽度是被 min-width 兜住的 420。
           panel.style.width = '360px';
           panel.style.height = '420px';
         }
         """
     )
 
-    metrics = mock_page.locator('.sam-item[data-id="longSong"]').evaluate(
+    metrics = mock_page.evaluate(
         """
-        (item) => {
-          const header = item.querySelector('.sam-item-header');
-          const name = item.querySelector('.sam-item-name');
-          const actions = item.querySelector('.sam-item-actions');
+        () => {
+          const geometry = (id) => {
+            const item = document.querySelector(`.sam-item[data-id="${id}"]`);
+            const style = getComputedStyle(item);
+            const inset = parseFloat(style.paddingRight) + parseFloat(style.borderRightWidth);
+            const header = item.querySelector('.sam-item-header');
+            const actions = item.querySelector('.sam-item-actions');
+            const name = item.querySelector('.sam-item-name');
+            return {
+              itemContentRight: item.getBoundingClientRect().right - inset,
+              itemClientWidth: item.clientWidth,
+              itemScrollWidth: item.scrollWidth,
+              headerRight: header.getBoundingClientRect().right,
+              actionsLeft: actions.getBoundingClientRect().left,
+              actionsRight: actions.getBoundingClientRect().right,
+              nameClientWidth: name.clientWidth,
+              nameScrollWidth: name.scrollWidth,
+            };
+          };
+          const short = geometry('shortSong');
+          const long = geometry('longSong');
+          const name = document.querySelector('.sam-item[data-id="longSong"] .sam-item-name');
           const before = name.getBoundingClientRect();
           name.focus();
           const after = name.getBoundingClientRect();
           return {
-            headerRight: header.getBoundingClientRect().right,
-            actionsRight: actions.getBoundingClientRect().right,
-            nameClientWidth: name.clientWidth,
-            nameScrollWidth: name.scrollWidth,
+            short,
+            long,
             beforeWidth: before.width,
             afterWidth: after.width,
           };
@@ -1240,8 +1264,19 @@ def test_jukebox_manager_long_song_name_scrolls_without_pushing_actions(mock_pag
         """
     )
 
-    assert metrics["actionsRight"] <= metrics["headerRight"] + 1
-    assert metrics["nameScrollWidth"] > metrics["nameClientWidth"]
+    long_item = metrics["long"]
+    short_item = metrics["short"]
+
+    # 操作按钮排在名字列右边，并且整列留在条目的内容盒里
+    assert long_item["actionsLeft"] >= long_item["headerRight"] - 1
+    assert long_item["actionsRight"] <= long_item["itemContentRight"] + 1
+    # 条目不产生横向溢出：名字不会溢出去盖在按钮上
+    assert long_item["itemScrollWidth"] <= long_item["itemClientWidth"] + 1
+    # 名字长度不改变列边界：长歌名没有把按钮挤走
+    assert abs(long_item["actionsRight"] - short_item["actionsRight"]) < 1
+    assert abs(long_item["headerRight"] - short_item["headerRight"]) < 1
+    # 长歌名在自己那一列里滚动，且聚焦不改变它的宽度
+    assert long_item["nameScrollWidth"] > long_item["nameClientWidth"]
     assert abs(metrics["beforeWidth"] - metrics["afterWidth"]) < 1
 
 

--- a/tests/frontend/test_jukebox_manager_standalone.py
+++ b/tests/frontend/test_jukebox_manager_standalone.py
@@ -1196,11 +1196,13 @@ def test_jukebox_manager_bindings_filter_hidden_songs(mock_page: Page):
 
 @pytest.mark.frontend
 def test_jukebox_manager_long_song_name_scrolls_without_pushing_actions(mock_page: Page):
-    """长歌名只在名字列里滚动，不改变条目里其它列的位置。
+    """A long song name scrolls inside its own column without moving the other columns.
 
-    条目是 `.sam-item` 上的两列 grid：`.sam-item-info`（含 `.sam-item-header`）占第一列，
-    `.sam-item-actions` 占第二列，所以操作按钮本来就在名字列右边。这里用短歌名条目做基线，
-    比对两者的列边界，来验证名字长度不会撑开第一列。
+    ``.sam-item`` is a two-column grid: ``.sam-item-info`` (which wraps
+    ``.sam-item-header``) takes column 1 and ``.sam-item-actions`` takes column 2, so
+    the action buttons always sit to the right of the name column. A short-name row is
+    rendered alongside as a baseline, and the two rows' column edges are compared to
+    show that name length does not stretch column 1.
     """
     setup_song_manager_page(
         mock_page,


### PR DESCRIPTION
## 结论先说

**`static/jukebox` 上没有布局 bug。** 红的是测试自己的断言过期了，本 PR 只改 `tests/frontend/test_jukebox_manager_standalone.py`，不动任何产品代码。

## 现状

`test_jukebox_manager_long_song_name_scrolls_without_pushing_actions` 在 main 上一直是红的：

```
assert 393 <= (340 + 1)
```

这条 `actionsRight <= headerRight + 1` 是 #1745 写下的结构假设——那时 `.sam-item-actions` 是 `.sam-item-header` 的**子节点**，按钮当然落在 header 右边界之内。

#2761 把 `.sam-item` 改成了两列 grid：

```css
.sam-item        { display: grid; grid-template-columns: minmax(0, 1fr) auto; }
.sam-item-main   { display: contents; }
.sam-item-info   { grid-column: 1; min-width: 0; }   /* 里面才是 .sam-item-header */
.sam-item-actions{ grid-column: 2; }
```

`.sam-item-header` 从此只占第一列，操作按钮在第二列，`actionsRight > headerRight` 成了**几何上的必然**，跟布局对不对无关。`tests/frontend` 不进 PR CI（`.github/workflows/` 里没有引用它的 job），所以这条红线一直没人碰到。

## 实测数据

用 playwright 在 430x500 视口、面板 360px（被面板自身 `min-width: 420px` 兜到 420）下量真实盒模型，长歌名 vs 短歌名条目：

| | 长歌名 | 短歌名 |
|---|---|---|
| `headerRight` | 340 | 340 |
| `actionsRight` | 393 | 393 |
| `nameClientWidth` | 280 | 280 |
| `nameScrollWidth` | 795 | 280 |
| `item.scrollWidth / clientWidth` | 386 / 386 | 386 / 386 |

条目内容盒右边界是 393，操作列右边界正好 393。名字长度**没有**改变任何一条列边界，只有名字自己的 `scrollWidth` 变大——即它确实只在自己那一列里滚动。歌曲 / 动作 / 绑定三个 tab、以及无空格的中英混排超长名字（marquee 激活状态）都扫过一遍，面板内没有任何元素越界。

## 改成什么

把断言换成对当前 DOM 有效、且表达同一个意图的守卫：

- 操作列排在名字列右边（`actionsLeft >= headerRight - 1`），并整体留在条目内容盒里（`actionsRight <= itemContentRight + 1`）
- 条目 `scrollWidth <= clientWidth + 1` —— 名字不会溢出去盖在按钮上
- **以短歌名条目为基线**，比对两者的 `actionsRight` / `headerRight`，直接验证「名字长度不改变布局」这个原意
- 保留原有的「名字在自己列里滚动」和「聚焦不改变名字宽度」

## 变异验证

直接改 `static/jukebox/jukebox/manager.js` 的真实 CSS 跑，跑完还原（不是运行时注入）：

| 变异 | 结果 |
|---|---|
| `.jukebox-sam-panel [data-neko-marquee]` 的 `overflow` 改 `visible` | **红** — `scrollWidth 834 > 387` |
| `.sam-item` 第一列改 `max-content` | **红** — `actionsRight 907 > 394` |
| `.sam-item-info` 去掉 `min-width: 0` | 绿（存活） |
| `.sam-item-header` 去掉 `min-width: 0` | 绿（存活） |
| 第一列 `minmax(0, 1fr)` → `1fr` | 绿（存活） |

两条不同的断言各抓到一个真实回归，守卫不是空转。三个存活的变异是真冗余：只要名字列还被裁剪（`overflow: hidden` 让它的 min-content 贡献为 0），grid 轨道就撑不开——顺带说明**真正承重的是 `[data-neko-marquee]` 那条裁剪规则**，而不是 `.sam-item-name` 自己的 `overflow`（后者被前者按特异度盖掉了，改它毫无效果）。

## 回归风险

只动测试文件，产品代码零改动，风险仅限于「守卫是否会误报」。同文件 35 条用例全绿。

## 顺带记一笔（本 PR 不改）

`.jukebox-sam-panel` 同时写了 `min-width: 420px` 和 `max-width: calc(100vw - 24px)`；CSS 里 `min-width` 优先级高于 `max-width`，所以在窄于 444px 的视口下面板会突破 `max-width` 的意图。当前测的 430 视口下面板贴到 420、仍在视口内，没有实际溢出，属于独立话题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 增强点唱机界面长歌名布局回归测试，新增短歌名基线对比。
  * 验证标题列与操作列边界一致，条目内容不发生横向溢出。
  * 确保长歌名仅在标题区域滚动，且聚焦前后布局尺寸保持稳定。
  * 测试说明已更新为英文。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->