### PR TITLE
refactor(plugin): move uninstall into an installation transaction

### DIFF
--- a/plugin/server/application/plugins/installation_transactions/__init__.py
+++ b/plugin/server/application/plugins/installation_transactions/__init__.py
@@ -10,12 +10,24 @@ from .ownership import (
     can_neko_uninstall,
     require_uninstall_ownership,
 )
+from .uninstall import (
+    UninstallPluginError,
+    UninstallPluginResult,
+    retry_deferred_plugin_code_cleanup_sync,
+    retry_deferred_profile_cleanup_sync,
+    uninstall_plugin,
+)
 
 __all__ = [
     "UninstallOwnershipError",
+    "UninstallPluginError",
+    "UninstallPluginResult",
     "can_neko_uninstall",
     "is_manual_takeover_entry",
     "local_manual_takeover_confirmation_token",
     "manual_takeover_snapshot_sha256",
     "require_uninstall_ownership",
+    "retry_deferred_plugin_code_cleanup_sync",
+    "retry_deferred_profile_cleanup_sync",
+    "uninstall_plugin",
 ]

--- a/plugin/server/application/plugins/installation_transactions/uninstall.py
+++ b/plugin/server/application/plugins/installation_transactions/uninstall.py
@@ -748,10 +748,18 @@ def _finalize_committed_plugin_code_sync(
         raise ValueError(
             "uninstall code cleanup marker does not match staged directory"
         )
+    # Keep the marker outside the recursive delete target.  ``rmtree`` may
+    # partially remove a locked tree before raising; retaining the marker lets
+    # startup authenticate and retry the remaining payload safely.
     try:
-        shutil.rmtree(transaction_dir)
+        shutil.rmtree(staged.staged_dir)
     except FileNotFoundError:
-        return False
+        pass
+    committed.marker_path.unlink(missing_ok=True)
+    try:
+        transaction_dir.rmdir()
+    except FileNotFoundError:
+        pass
     try:
         backup_root.rmdir()
     except OSError:
@@ -852,28 +860,26 @@ def _registry_failure_matches_target(
     if not isinstance(failure, dict):
         return False
 
+    failure_config_path = failure.get("config_path")
+    if isinstance(failure_config_path, str) and failure_config_path:
+        try:
+            resolved_failure_path = Path(failure_config_path).resolve(strict=False)
+        except (OSError, RuntimeError):
+            resolved_failure_path = Path(failure_config_path)
+        for config_path in target.config_paths:
+            try:
+                resolved_target_path = config_path.resolve(strict=False)
+            except (OSError, RuntimeError):
+                resolved_target_path = config_path
+            if resolved_failure_path == resolved_target_path:
+                return True
+        return False
+
     failure_plugin_id = failure.get("plugin_id")
-    if isinstance(failure_plugin_id, str) and failure_plugin_id in {
+    return isinstance(failure_plugin_id, str) and failure_plugin_id in {
         target.runtime_plugin_id,
         target.declared_plugin_id,
-    }:
-        return True
-
-    failure_config_path = failure.get("config_path")
-    if not isinstance(failure_config_path, str) or not failure_config_path:
-        return False
-    try:
-        resolved_failure_path = Path(failure_config_path).resolve(strict=False)
-    except (OSError, RuntimeError):
-        resolved_failure_path = Path(failure_config_path)
-    for config_path in target.config_paths:
-        try:
-            resolved_target_path = config_path.resolve(strict=False)
-        except (OSError, RuntimeError):
-            resolved_target_path = config_path
-        if resolved_failure_path == resolved_target_path:
-            return True
-    return False
+    }
 
 
 async def _refresh_registry(

--- a/plugin/server/application/plugins/installation_transactions/uninstall.py
+++ b/plugin/server/application/plugins/installation_transactions/uninstall.py
@@ -1,0 +1,1243 @@
+"""Transactional uninstall of one installer-owned plugin candidate."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+from typing import Literal
+import uuid
+
+from plugin.core.state import state
+from plugin.logging_config import get_logger
+from plugin.server.application.install_source import (
+    InstallSourceError,
+    InstallSourceManager,
+    get_install_source_manager,
+)
+from plugin.server.application.install_source.models import LockEntry
+from plugin.server.application.install_source.scanner import PluginDirectoryScanner
+from plugin.server.application.plugins.operation_lock import serialized_plugin_operation
+from plugin.server.application.plugins.registry_service import PluginRegistryService
+from plugin.server.domain.errors import ServerDomainError
+from plugin.server.infrastructure.runtime_overrides import (
+    clear_runtime_override,
+    get_runtime_auto_start_override,
+    get_runtime_override,
+    set_runtime_override,
+)
+from plugin.settings import (
+    BUILTIN_PLUGIN_CONFIG_ROOT,
+    PLUGIN_CONFIG_ROOTS,
+    ensure_plugin_exec_state_roots_separated,
+    get_plugin_state_root,
+    get_user_package_profiles_root,
+    get_user_plugin_config_root,
+    get_user_plugin_exec_root,
+)
+
+from .ownership import UninstallOwnershipError, require_uninstall_ownership
+
+logger = get_logger("server.application.plugins.installation_transactions.uninstall")
+plugin_registry_service = PluginRegistryService()
+
+_DEFERRED_PROFILE_CLEANUP_FILENAME = "package_profile_cleanup.json"
+_CODE_BACKUP_ROOT_NAME = ".uninstall-backups"
+_CODE_COMMIT_MARKER_FILENAME = "committed.json"
+_CODE_TRANSACTION_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+# ``package_id`` allows dots, so the staged name must too; the leading dot,
+# the ``.deleting-<uuid4hex>`` suffix and full-name anchoring keep it exact.
+_DEFERRED_PROFILE_STAGING_NAME_PATTERN = re.compile(
+    r"^\.[A-Za-z0-9._-]+\.deleting-[0-9a-f]{32}$"
+)
+
+PreferenceAction = Literal["preserved", "cleared"]
+FilesystemRollback = Literal["not_needed", "completed", "incomplete"]
+RuntimeRestart = Literal["not_needed", "succeeded", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class UninstallPluginResult:
+    plugin_id: str
+    plugin_dir: Path
+    deleted_from_disk: bool
+    deleted_profile_dir: Path | None
+    restored_builtin: bool
+    preference_action: PreferenceAction
+    filesystem_rollback: FilesystemRollback
+    runtime_restart: RuntimeRestart
+    cleanup_pending: bool
+    runtime_restart_error: dict[str, str] | None = None
+
+
+class UninstallPluginError(RuntimeError):
+    """Stable uninstall failure with compensation outcomes kept separate."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        message: str,
+        status_code: int,
+        stage: str,
+        filesystem_rollback: FilesystemRollback = "not_needed",
+        runtime_restart: RuntimeRestart = "not_needed",
+        details: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.stage = stage
+        self.filesystem_rollback = filesystem_rollback
+        self.runtime_restart = runtime_restart
+        self.details = {
+            **(details or {}),
+            "stage": stage,
+            "filesystem_rollback": filesystem_rollback,
+            "runtime_restart": runtime_restart,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _StagedPackageProfile:
+    original_dir: Path
+    staged_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _StagedPluginCode:
+    original_dir: Path
+    staged_dir: Path
+    transaction_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class _CommittedPluginCodeCleanup:
+    staged: _StagedPluginCode
+    marker_path: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimePreferenceSnapshot:
+    enabled: bool | None
+    auto_start: bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RegistryRefreshTarget:
+    runtime_plugin_id: str
+    declared_plugin_id: str
+    config_paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _RollbackOutcome:
+    filesystem_rollback: FilesystemRollback
+    runtime_restart: RuntimeRestart
+    preference_restored: bool
+
+
+def _get_plugin_meta_sync(plugin_id: str) -> dict[str, object] | None:
+    # Registration metadata stays owned by the lifecycle module; the
+    # transaction resolves it lazily to avoid an import cycle.
+    from plugin.server.application.plugins.lifecycle_service import (
+        _get_plugin_meta_sync as get_meta,
+    )
+
+    return get_meta(plugin_id)
+
+
+def _resolve_plugin_config_path_sync(
+    plugin_id: str,
+    plugin_meta: dict[str, object],
+) -> Path | None:
+    # Resolution is shared lifecycle knowledge, not a caller-supplied callback.
+    from plugin.server.application.plugins.lifecycle_service import (
+        _resolve_plugin_config_path_sync as resolve,
+    )
+
+    return resolve(plugin_id, plugin_meta)
+
+
+def _plugin_is_running_sync(plugin_id: str) -> bool:
+    from plugin.server.application.plugins.lifecycle_service import (
+        _plugin_is_running_sync as is_running,
+    )
+
+    return is_running(plugin_id)
+
+
+def _path_within_plugin_roots_sync(path: Path) -> bool:
+    try:
+        resolved_path = path.resolve()
+    except Exception:
+        resolved_path = path
+
+    resolved_exec_root = get_user_plugin_exec_root().resolve(strict=False)
+    resolved_builtin_root = BUILTIN_PLUGIN_CONFIG_ROOT.resolve(strict=False)
+    resolved_state_root = get_plugin_state_root().resolve(strict=False)
+    if resolved_exec_root == resolved_state_root:
+        return False
+    allowed_roots: set[Path] = set()
+    if resolved_exec_root not in {resolved_builtin_root, resolved_state_root}:
+        allowed_roots.add(resolved_exec_root)
+    # Preserve injected/test roots while explicitly excluding both immutable
+    # builtin code and the SDK-owned persistent state root.
+    for root in PLUGIN_CONFIG_ROOTS:
+        resolved_root = root.resolve(strict=False)
+        if resolved_root not in {resolved_builtin_root, resolved_state_root}:
+            allowed_roots.add(resolved_root)
+    # Deletion owns one direct child installation only. In particular, the
+    # builtin root and SDK state root are never acceptable lifecycle targets.
+    return resolved_path.parent in allowed_roots
+
+
+def _remove_runtime_metadata_sync(plugin_id: str) -> None:
+    from plugin.server.application.plugins.lifecycle_service import (
+        _pop_plugin_host_sync,
+        _remove_event_handlers_sync,
+    )
+
+    _pop_plugin_host_sync(plugin_id)
+    _remove_event_handlers_sync(plugin_id)
+    removed = False
+    with state.acquire_plugins_write_lock():
+        if plugin_id in state.plugins:
+            state.plugins.pop(plugin_id, None)
+            removed = True
+    if removed:
+        state.invalidate_snapshot_cache("plugins")
+
+
+async def _stop_plugin(plugin_id: str) -> None:
+    from plugin.server.application.plugins.lifecycle_service import (
+        PluginLifecycleService,
+    )
+
+    await PluginLifecycleService().stop_plugin(plugin_id)
+
+
+async def _start_plugin(plugin_id: str) -> None:
+    from plugin.server.application.plugins.lifecycle_service import (
+        PluginLifecycleService,
+    )
+
+    await PluginLifecycleService().start_plugin(plugin_id, refresh_registry=False)
+
+
+def _profile_path_from_entry_sync(entry: LockEntry, profiles_root: Path) -> Path | None:
+    if entry.channel not in {"imported", "market"}:
+        return None
+    if entry.profile_installed is False:
+        return None
+    package_id = entry.package_id or entry.plugin_id
+    if not package_id:
+        return None
+    candidate = (
+        Path(entry.profile_dir).expanduser()
+        if entry.profile_dir
+        else profiles_root / package_id
+    )
+    if _path_has_symlink_ancestor(candidate):
+        return None
+    try:
+        profile_dir = candidate.resolve()
+    except Exception:
+        return None
+    if profile_dir.name != package_id:
+        return None
+    # A recorded profile location remains valid after the configured profile
+    # root changes. Legacy fallback paths are still constrained to that root.
+    if not entry.profile_dir and (
+        profile_dir != profiles_root and profiles_root not in profile_dir.parents
+    ):
+        return None
+    return profile_dir
+
+
+def _path_has_symlink_ancestor(path: Path) -> bool:
+    """Reject a path when resolving it would traverse a symlink."""
+    return any(candidate.is_symlink() for candidate in (path, *path.parents))
+
+
+def _has_other_entry_without_package_id(
+    active_entries: Sequence[LockEntry],
+    current_primary_key: tuple[str, str],
+) -> bool:
+    """Report whether another installed row also predates package id tracking."""
+    for entry in active_entries:
+        if entry.channel not in {"imported", "market"}:
+            continue
+        key = (entry.root_id, entry.directory_name)
+        if key == current_primary_key:
+            continue
+        if not entry.package_id:
+            return True
+    return False
+
+
+def _deferred_profile_cleanup_record_path_sync() -> Path:
+    return (
+        get_plugin_state_root().expanduser().resolve().parent
+        / _DEFERRED_PROFILE_CLEANUP_FILENAME
+    )
+
+
+def _legacy_deferred_profile_cleanup_record_path_sync() -> Path:
+    return (
+        get_user_plugin_config_root().expanduser().resolve().parent
+        / _DEFERRED_PROFILE_CLEANUP_FILENAME
+    )
+
+
+def _load_deferred_profile_cleanup_paths_sync(record_path: Path) -> list[str] | None:
+    """Return the pending paths, or ``None`` when an existing record is unusable.
+
+    Callers must not overwrite a record they could not read: the paths already
+    queued in it would be dropped and their staging directories would then be
+    retained forever.
+    """
+    try:
+        raw = json.loads(record_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    except (OSError, ValueError, TypeError) as exc:
+        logger.error(
+            "uninstall: failed to read deferred profile cleanup record {}: {}",
+            record_path,
+            exc,
+        )
+        return None
+    if not isinstance(raw, dict) or not isinstance(raw.get("staged_paths"), list):
+        logger.error(
+            "uninstall: invalid deferred profile cleanup record: {}", record_path
+        )
+        return None
+    return [path for path in raw["staged_paths"] if isinstance(path, str) and path]
+
+
+def _save_deferred_profile_cleanup_paths_sync(
+    record_path: Path, paths: list[str]
+) -> None:
+    if not paths:
+        try:
+            record_path.unlink()
+        except FileNotFoundError:
+            pass
+        return
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = record_path.with_name(
+        f".{record_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        temporary_path.write_text(
+            json.dumps({"schema_version": 1, "staged_paths": paths}),
+            encoding="utf-8",
+        )
+        temporary_path.replace(record_path)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _record_deferred_profile_cleanup_sync(
+    staged_profile: _StagedPackageProfile,
+) -> bool:
+    try:
+        record_path = _deferred_profile_cleanup_record_path_sync()
+        paths = _load_deferred_profile_cleanup_paths_sync(record_path)
+        if paths is None:
+            return False
+        staged_path = str(staged_profile.staged_dir)
+        if staged_path not in paths:
+            paths.append(staged_path)
+        _save_deferred_profile_cleanup_paths_sync(record_path, paths)
+        return True
+    except Exception as exc:
+        logger.error(
+            "uninstall: failed to persist deferred profile cleanup for {}: {}",
+            staged_profile.staged_dir,
+            exc,
+        )
+        return False
+
+
+def _is_safe_deferred_profile_cleanup_path(path: Path) -> bool:
+    return (
+        path.is_absolute()
+        and _DEFERRED_PROFILE_STAGING_NAME_PATTERN.fullmatch(path.name) is not None
+        and not _path_has_symlink_ancestor(path)
+    )
+
+
+def retry_deferred_profile_cleanup_sync() -> int:
+    """Retry profile cleanup jobs persisted after transient deletion failures."""
+    record_path = _deferred_profile_cleanup_record_path_sync()
+    record_paths = [record_path]
+    legacy_record_path = _legacy_deferred_profile_cleanup_record_path_sync()
+    if legacy_record_path != record_path and legacy_record_path.exists():
+        record_paths.append(legacy_record_path)
+
+    paths: list[str] = []
+    for candidate in record_paths:
+        loaded = _load_deferred_profile_cleanup_paths_sync(candidate)
+        if loaded is None:
+            return 0
+        for raw_path in loaded:
+            if raw_path not in paths:
+                paths.append(raw_path)
+    if not paths:
+        return 0
+
+    remaining_paths: list[str] = []
+    cleaned = 0
+    for raw_path in paths:
+        staged_path = Path(raw_path).expanduser()
+        if not _is_safe_deferred_profile_cleanup_path(staged_path):
+            logger.error(
+                "uninstall: refusing unsafe deferred profile cleanup path: {}",
+                staged_path,
+            )
+            remaining_paths.append(raw_path)
+            continue
+        try:
+            shutil.rmtree(staged_path)
+        except FileNotFoundError:
+            cleaned += 1
+        except OSError as exc:
+            logger.warning(
+                "uninstall: deferred profile cleanup still pending for {}: {}",
+                staged_path,
+                exc,
+            )
+            remaining_paths.append(raw_path)
+        else:
+            cleaned += 1
+    try:
+        _save_deferred_profile_cleanup_paths_sync(record_path, remaining_paths)
+    except OSError as exc:
+        logger.error(
+            "uninstall: failed to update deferred profile cleanup record {}: {}",
+            record_path,
+            exc,
+        )
+    else:
+        for legacy_path in record_paths[1:]:
+            try:
+                legacy_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning(
+                    "uninstall: failed to remove migrated cleanup record {}: {}",
+                    legacy_path,
+                    exc,
+                )
+    return cleaned
+
+
+def _stage_orphaned_package_profile_sync(
+    plugin_dir: Path,
+    *,
+    manager: InstallSourceManager | None = None,
+) -> _StagedPackageProfile | None:
+    """Stage an unshared package profile while deletion is in progress.
+
+    Moving the profile out of its package location prevents a concurrent
+    reinstall from seeing it, but preserves it until executable deletion has
+    succeeded. This lets a failed executable deletion roll back without
+    losing the plugin's persisted configuration.
+    """
+    manager = manager or get_install_source_manager()
+    if manager is None:
+        return None
+
+    try:
+        current_entry = manager.entry_for_directory(
+            plugin_dir,
+            include_removed=False,
+        )
+        active_entries = manager.list_entries()
+    except InstallSourceError as exc:
+        logger.warning(
+            "uninstall: failed to inspect install source for plugin_dir={}: {}",
+            plugin_dir,
+            exc,
+        )
+        return None
+    except Exception as exc:
+        logger.warning(
+            "uninstall: unexpected install-source cleanup failure for plugin_dir={}: {}",
+            plugin_dir,
+            exc,
+        )
+        return None
+
+    # Only package installers own package profiles. A scanner-created manual
+    # entry with no profile record must never infer ownership from a matching
+    # directory name.
+    if current_entry is None or current_entry.channel not in {"imported", "market"}:
+        return None
+
+    current_primary_key = (current_entry.root_id, current_entry.directory_name)
+    recorded_package_id = current_entry.package_id
+    if _has_other_entry_without_package_id(active_entries, current_primary_key):
+        # Rows written before the package id was tracked do not say which
+        # package owns their profile, and a bundle's profile is named after the
+        # package rather than after any member plugin. Such a row may be a
+        # sibling from the same bundle that still uses this profile, and the
+        # sharing check below cannot see it: it can only infer that row's
+        # profile from its plugin id, which is not where a bundle profile
+        # lives. This holds whichever side is missing the package id, so the
+        # guard looks at every other installed row rather than only at ours.
+        #
+        # Cost: one such row suppresses profile cleanup for every deletion
+        # until it is itself removed or reinstalled, which degrades to the
+        # pre-change behaviour (a stale profile blocks a reinstall). That is
+        # strictly better than permanently deleting a sibling's configuration.
+        logger.warning(
+            "uninstall: skipping profile cleanup while an installation "
+            "without a recorded package id may share this profile: {}",
+            plugin_dir,
+        )
+        return None
+
+    package_id = recorded_package_id or current_entry.plugin_id
+    if not package_id:
+        return None
+    recorded_profile_dir = current_entry.profile_dir
+    if current_entry.profile_installed is False:
+        return None
+
+    try:
+        profiles_root = get_user_package_profiles_root().resolve()
+        profile_candidate = (
+            Path(recorded_profile_dir).expanduser()
+            if recorded_profile_dir
+            else profiles_root / package_id
+        )
+        if _path_has_symlink_ancestor(profile_candidate):
+            logger.warning(
+                "uninstall: refusing symlinked package profile path: {}",
+                profile_candidate,
+            )
+            return None
+        current_profile_dir = profile_candidate.resolve()
+    except Exception as exc:
+        logger.warning(
+            "uninstall: failed to resolve package profile for plugin_dir={}: {}",
+            plugin_dir,
+            exc,
+        )
+        return None
+
+    state_root = get_plugin_state_root().expanduser().resolve(strict=False)
+    if (
+        current_profile_dir == state_root
+        or state_root in current_profile_dir.parents
+        or current_profile_dir in state_root.parents
+    ):
+        logger.warning(
+            "uninstall: refusing package profile overlapping the persistent "
+            "state root: {}",
+            current_profile_dir,
+        )
+        return None
+
+    builtin_root = Path(BUILTIN_PLUGIN_CONFIG_ROOT).expanduser().resolve(strict=False)
+    if (
+        current_profile_dir == builtin_root
+        or builtin_root in current_profile_dir.parents
+        or current_profile_dir in builtin_root.parents
+    ):
+        logger.warning(
+            "uninstall: refusing package profile overlapping the builtin "
+            "plugin root: {}",
+            current_profile_dir,
+        )
+        return None
+
+    if current_profile_dir.name != package_id or (
+        not recorded_profile_dir
+        and (
+            current_profile_dir != profiles_root
+            and profiles_root not in current_profile_dir.parents
+        )
+    ):
+        logger.warning(
+            "uninstall: refusing unsafe package profile path: {}",
+            current_profile_dir,
+        )
+        return None
+
+    for entry in active_entries:
+        if (entry.root_id, entry.directory_name) == current_primary_key:
+            continue
+        if _profile_path_from_entry_sync(entry, profiles_root) == current_profile_dir:
+            return None
+
+    staged_profile_dir = current_profile_dir.with_name(
+        f".{current_profile_dir.name}.deleting-{uuid.uuid4().hex}"
+    )
+    try:
+        current_profile_dir.replace(staged_profile_dir)
+    except FileNotFoundError:
+        return None
+    except OSError:
+        logger.exception(
+            "uninstall: failed to stage package profile {}", current_profile_dir
+        )
+        raise
+    return _StagedPackageProfile(
+        original_dir=current_profile_dir,
+        staged_dir=staged_profile_dir,
+    )
+
+
+def _restore_staged_package_profile_sync(staged_profile: _StagedPackageProfile) -> None:
+    """Restore a profile after executable deletion failed."""
+    if not staged_profile.staged_dir.exists():
+        return
+    staged_profile.staged_dir.replace(staged_profile.original_dir)
+
+
+def _finalize_staged_package_profile_sync(
+    staged_profile: _StagedPackageProfile,
+) -> Path | None:
+    """Permanently remove a profile only after executable deletion succeeds."""
+    try:
+        shutil.rmtree(staged_profile.staged_dir)
+    except FileNotFoundError:
+        return None
+    return staged_profile.original_dir
+
+
+def _stage_plugin_code_sync(plugin_dir: Path) -> _StagedPluginCode:
+    """Stage the code directory with a same-filesystem rename, never rmtree."""
+    transaction_id = uuid.uuid4().hex
+    backup_root = plugin_dir.parent / _CODE_BACKUP_ROOT_NAME
+    transaction_dir = backup_root / transaction_id
+    backup_root.mkdir(exist_ok=True)
+    if (
+        backup_root.is_symlink()
+        or backup_root.resolve(strict=False).parent
+        != plugin_dir.parent.resolve(strict=False)
+    ):
+        raise ValueError("uninstall code backup root is not a direct local directory")
+    transaction_dir.mkdir(exist_ok=False)
+    staged_dir = transaction_dir / plugin_dir.name
+    try:
+        plugin_dir.replace(staged_dir)
+    except BaseException:
+        try:
+            transaction_dir.rmdir()
+            backup_root.rmdir()
+        except OSError:
+            pass
+        raise
+    return _StagedPluginCode(plugin_dir, staged_dir, transaction_id)
+
+
+def _restore_staged_plugin_code_sync(staged: _StagedPluginCode) -> None:
+    if staged.staged_dir.exists():
+        staged.staged_dir.replace(staged.original_dir)
+    transaction_dir = staged.staged_dir.parent
+    backup_root = transaction_dir.parent
+    try:
+        (transaction_dir / _CODE_COMMIT_MARKER_FILENAME).unlink()
+    except FileNotFoundError:
+        pass
+    try:
+        transaction_dir.rmdir()
+        backup_root.rmdir()
+    except OSError:
+        pass
+
+
+def _commit_staged_plugin_code_sync(
+    staged: _StagedPluginCode,
+) -> _CommittedPluginCodeCleanup:
+    marker_path = staged.staged_dir.parent / _CODE_COMMIT_MARKER_FILENAME
+    temporary_path = marker_path.with_name(
+        f".{marker_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    )
+    marker = {
+        "schema_version": 1,
+        "transaction_id": staged.transaction_id,
+        "original_dir": str(staged.original_dir),
+        "staged_dir": str(staged.staged_dir),
+    }
+    try:
+        temporary_path.write_text(json.dumps(marker), encoding="utf-8")
+        temporary_path.replace(marker_path)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+    return _CommittedPluginCodeCleanup(staged=staged, marker_path=marker_path)
+
+
+def _load_committed_plugin_code_cleanup_sync(
+    transaction_dir: Path,
+    *,
+    backup_root: Path,
+) -> _CommittedPluginCodeCleanup | None:
+    if (
+        transaction_dir.parent != backup_root
+        or _CODE_TRANSACTION_ID_PATTERN.fullmatch(transaction_dir.name) is None
+        or _path_has_symlink_ancestor(transaction_dir)
+    ):
+        return None
+    marker_path = transaction_dir / _CODE_COMMIT_MARKER_FILENAME
+    try:
+        raw = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        return None
+    transaction_id = raw.get("transaction_id")
+    original_dir_raw = raw.get("original_dir")
+    staged_dir_raw = raw.get("staged_dir")
+    if (
+        transaction_id != transaction_dir.name
+        or not isinstance(original_dir_raw, str)
+        or not isinstance(staged_dir_raw, str)
+    ):
+        return None
+    original_dir = Path(original_dir_raw)
+    staged_dir = Path(staged_dir_raw)
+    if (
+        not original_dir.is_absolute()
+        or not staged_dir.is_absolute()
+        or original_dir.parent != backup_root.parent
+        or staged_dir != transaction_dir / original_dir.name
+    ):
+        return None
+    staged = _StagedPluginCode(
+        original_dir=original_dir,
+        staged_dir=staged_dir,
+        transaction_id=transaction_id,
+    )
+    return _CommittedPluginCodeCleanup(staged=staged, marker_path=marker_path)
+
+
+def _finalize_committed_plugin_code_sync(
+    committed: _CommittedPluginCodeCleanup,
+) -> bool:
+    """Remove code only from this transaction's own committed staging artifact."""
+    staged = committed.staged
+    backup_root = staged.original_dir.parent / _CODE_BACKUP_ROOT_NAME
+    transaction_dir = backup_root / staged.transaction_id
+    if (
+        staged.staged_dir != transaction_dir / staged.original_dir.name
+        or committed.marker_path != transaction_dir / _CODE_COMMIT_MARKER_FILENAME
+        or _load_committed_plugin_code_cleanup_sync(
+            transaction_dir,
+            backup_root=backup_root,
+        )
+        != committed
+    ):
+        raise ValueError(
+            "uninstall code cleanup marker does not match staged directory"
+        )
+    try:
+        shutil.rmtree(transaction_dir)
+    except FileNotFoundError:
+        return False
+    try:
+        backup_root.rmdir()
+    except OSError:
+        pass
+    return True
+
+
+def retry_deferred_plugin_code_cleanup_sync() -> int:
+    """Retry only committed code backups under transaction-owned roots."""
+    candidate_roots = {get_user_plugin_exec_root(), *PLUGIN_CONFIG_ROOTS}
+    builtin_root = BUILTIN_PLUGIN_CONFIG_ROOT.resolve(strict=False)
+    state_root = get_plugin_state_root().resolve(strict=False)
+    cleaned = 0
+    for candidate_root in candidate_roots:
+        root = candidate_root.resolve(strict=False)
+        if root in {builtin_root, state_root}:
+            continue
+        backup_root = root / _CODE_BACKUP_ROOT_NAME
+        try:
+            transaction_dirs = tuple(backup_root.iterdir())
+        except (FileNotFoundError, NotADirectoryError):
+            continue
+        except OSError as exc:
+            logger.warning(
+                "uninstall: failed to inspect deferred code cleanup root {}: {}",
+                backup_root,
+                exc,
+            )
+            continue
+        for transaction_dir in transaction_dirs:
+            committed = _load_committed_plugin_code_cleanup_sync(
+                transaction_dir,
+                backup_root=backup_root,
+            )
+            if committed is None:
+                logger.error(
+                    "uninstall: refusing unmarked deferred code cleanup path: {}",
+                    transaction_dir,
+                )
+                continue
+            try:
+                if _finalize_committed_plugin_code_sync(committed):
+                    cleaned += 1
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "uninstall: deferred code cleanup still pending for {}: {}",
+                    transaction_dir,
+                    exc,
+                )
+    return cleaned
+
+
+def _snapshot_runtime_preference(plugin_id: str) -> _RuntimePreferenceSnapshot:
+    return _RuntimePreferenceSnapshot(
+        enabled=get_runtime_override(plugin_id),
+        auto_start=get_runtime_auto_start_override(plugin_id),
+    )
+
+
+def _restore_runtime_preference(
+    plugin_id: str, snapshot: _RuntimePreferenceSnapshot
+) -> None:
+    if snapshot.enabled is None:
+        clear_runtime_override(plugin_id)
+    else:
+        set_runtime_override(
+            plugin_id, snapshot.enabled, auto_start=snapshot.auto_start
+        )
+
+
+def _registry_refresh_target(
+    *,
+    runtime_plugin_id: str,
+    source_entry: LockEntry,
+    plugin_meta: dict[str, object],
+    config_path: Path,
+) -> _RegistryRefreshTarget:
+    declared_plugin_id = source_entry.plugin_id.strip()
+    if not declared_plugin_id:
+        declared_plugin_id = (
+            PluginDirectoryScanner._load_plugin_id(config_path.parent)
+            or runtime_plugin_id
+        )
+
+    config_paths = [config_path]
+    shadowed_builtin_path = plugin_meta.get("shadowed_builtin_path")
+    if isinstance(shadowed_builtin_path, str) and shadowed_builtin_path:
+        config_paths.append(Path(shadowed_builtin_path))
+    config_paths.append(
+        BUILTIN_PLUGIN_CONFIG_ROOT / declared_plugin_id / config_path.name
+    )
+    return _RegistryRefreshTarget(
+        runtime_plugin_id=runtime_plugin_id,
+        declared_plugin_id=declared_plugin_id,
+        config_paths=tuple(config_paths),
+    )
+
+
+def _registry_failure_matches_target(
+    failure: object,
+    *,
+    target: _RegistryRefreshTarget,
+) -> bool:
+    if not isinstance(failure, dict):
+        return False
+
+    failure_plugin_id = failure.get("plugin_id")
+    if isinstance(failure_plugin_id, str) and failure_plugin_id in {
+        target.runtime_plugin_id,
+        target.declared_plugin_id,
+    }:
+        return True
+
+    failure_config_path = failure.get("config_path")
+    if not isinstance(failure_config_path, str) or not failure_config_path:
+        return False
+    try:
+        resolved_failure_path = Path(failure_config_path).resolve(strict=False)
+    except (OSError, RuntimeError):
+        resolved_failure_path = Path(failure_config_path)
+    for config_path in target.config_paths:
+        try:
+            resolved_target_path = config_path.resolve(strict=False)
+        except (OSError, RuntimeError):
+            resolved_target_path = config_path
+        if resolved_failure_path == resolved_target_path:
+            return True
+    return False
+
+
+async def _refresh_registry(
+    target: _RegistryRefreshTarget,
+) -> dict[str, object]:
+    result = await plugin_registry_service.refresh_registry()
+    failed = result.get("failed")
+    if isinstance(failed, list) and any(
+        _registry_failure_matches_target(failure, target=target)
+        for failure in failed
+    ):
+        raise RuntimeError("plugin registry refresh failed for uninstall target")
+    return result
+
+
+async def _restore_original_runtime(
+    plugin_id: str, *, was_running: bool
+) -> RuntimeRestart:
+    if not was_running:
+        return "not_needed"
+    try:
+        if await asyncio.to_thread(_plugin_is_running_sync, plugin_id):
+            return "succeeded"
+        await _start_plugin(plugin_id)
+    except Exception:
+        logger.exception(
+            "uninstall rollback runtime restart failed plugin_id={}", plugin_id
+        )
+        return "failed"
+    return "succeeded"
+
+
+async def _rollback_precommit(
+    *,
+    plugin_id: str,
+    manager: InstallSourceManager,
+    source_entry: LockEntry,
+    source_update_attempted: bool,
+    staged_code: _StagedPluginCode | None,
+    staged_profile: _StagedPackageProfile | None,
+    preference_snapshot: _RuntimePreferenceSnapshot,
+    preference_update_attempted: bool,
+    was_running: bool,
+    stop_attempted: bool,
+    registry_target: _RegistryRefreshTarget,
+) -> _RollbackOutcome:
+    """Compensate in reverse stage order: source, code, profile, preference,
+    registry, then the original runtime. Each step is best effort."""
+    filesystem_changed = (
+        source_update_attempted or staged_code is not None or staged_profile is not None
+    )
+    filesystem_complete = True
+    if source_update_attempted:
+        try:
+            await asyncio.to_thread(manager.restore_entry_for_rollback, source_entry)
+        except Exception:
+            filesystem_complete = False
+            logger.exception(
+                "uninstall rollback failed to restore source entry plugin_id={}",
+                plugin_id,
+            )
+    if staged_code is not None:
+        try:
+            await asyncio.to_thread(_restore_staged_plugin_code_sync, staged_code)
+        except Exception:
+            filesystem_complete = False
+            logger.exception(
+                "uninstall rollback failed to restore code plugin_id={}", plugin_id
+            )
+    if staged_profile is not None:
+        try:
+            await asyncio.to_thread(
+                _restore_staged_package_profile_sync, staged_profile
+            )
+        except Exception:
+            filesystem_complete = False
+            logger.exception(
+                "uninstall rollback failed to restore profile plugin_id={}",
+                plugin_id,
+            )
+    preference_restored = True
+    if preference_update_attempted:
+        try:
+            await asyncio.to_thread(
+                _restore_runtime_preference, plugin_id, preference_snapshot
+            )
+        except Exception:
+            preference_restored = False
+            logger.exception(
+                "uninstall rollback failed to restore preference plugin_id={}",
+                plugin_id,
+            )
+    if filesystem_changed:
+        try:
+            await _refresh_registry(registry_target)
+        except Exception:
+            # A refresh failure does not undo the physical restores above;
+            # the scan itself is not part of the filesystem rollback report.
+            logger.exception(
+                "uninstall rollback registry refresh failed plugin_id={}",
+                plugin_id,
+            )
+    runtime_restart = await _restore_original_runtime(
+        plugin_id,
+        was_running=was_running and stop_attempted,
+    )
+    filesystem_rollback: FilesystemRollback = (
+        "not_needed"
+        if not filesystem_changed
+        else ("completed" if filesystem_complete else "incomplete")
+    )
+    return _RollbackOutcome(
+        filesystem_rollback=filesystem_rollback,
+        runtime_restart=runtime_restart,
+        preference_restored=preference_restored,
+    )
+
+
+@serialized_plugin_operation
+async def uninstall_plugin(plugin_id: str) -> UninstallPluginResult:
+    """Uninstall the exact managed user candidate with a pre-commit rollback."""
+
+    stage = "preflight"
+    try:
+        await asyncio.to_thread(ensure_plugin_exec_state_roots_separated)
+    except ValueError as exc:
+        if getattr(exc, "code", "") == "PLUGIN_EXEC_STATE_ROOT_COLLISION":
+            raise UninstallPluginError(
+                code="PLUGIN_EXEC_STATE_ROOT_COLLISION",
+                message=str(exc),
+                status_code=409,
+                stage=stage,
+                details={"plugin_id": plugin_id, "error_type": type(exc).__name__},
+            ) from exc
+        raise
+
+    plugin_meta = await asyncio.to_thread(_get_plugin_meta_sync, plugin_id)
+    if plugin_meta is None:
+        raise UninstallPluginError(
+            code="PLUGIN_NOT_FOUND",
+            message=f"Plugin '{plugin_id}' not found",
+            status_code=404,
+            stage=stage,
+            details={"plugin_id": plugin_id, "error_type": "PluginNotFound"},
+        )
+    config_path = await asyncio.to_thread(
+        _resolve_plugin_config_path_sync, plugin_id, plugin_meta
+    )
+    if config_path is None:
+        raise UninstallPluginError(
+            code="PLUGIN_CONFIG_NOT_FOUND",
+            message=f"Plugin '{plugin_id}' configuration not found",
+            status_code=404,
+            stage=stage,
+            details={"plugin_id": plugin_id, "error_type": "ConfigNotFound"},
+        )
+    plugin_dir = config_path.parent
+
+    manager = get_install_source_manager()
+    stage = "ownership"
+    try:
+        if manager is not None:
+            reload_install_source = getattr(manager, "load", None)
+            if callable(reload_install_source):
+                await asyncio.to_thread(reload_install_source)
+        source_entry = await asyncio.to_thread(
+            require_uninstall_ownership,
+            manager=manager,
+            runtime_plugin_id=plugin_id,
+            config_path=config_path,
+        )
+    except UninstallOwnershipError as exc:
+        raise UninstallPluginError(
+            code=exc.code,
+            message=exc.message,
+            status_code=exc.status_code,
+            stage=stage,
+            details={**exc.details, "error_type": type(exc).__name__},
+        ) from exc
+    assert manager is not None
+
+    registry_target = await asyncio.to_thread(
+        _registry_refresh_target,
+        runtime_plugin_id=plugin_id,
+        source_entry=source_entry,
+        plugin_meta=plugin_meta,
+        config_path=config_path,
+    )
+
+    # The existing path guard stays an independent second check: it must not
+    # mask the ownership refusal with a generic forbidden-path error.
+    if not await asyncio.to_thread(_path_within_plugin_roots_sync, plugin_dir):
+        raise UninstallPluginError(
+            code="PLUGIN_DELETE_FORBIDDEN_PATH",
+            message=f"Plugin '{plugin_id}' path is outside managed plugin roots",
+            status_code=403,
+            stage="preflight",
+            details={"plugin_id": plugin_id, "error_type": "ForbiddenDeletePath"},
+        )
+
+    was_running = await asyncio.to_thread(_plugin_is_running_sync, plugin_id)
+    preference_snapshot = await asyncio.to_thread(
+        _snapshot_runtime_preference, plugin_id
+    )
+    stop_attempted = False
+    staged_profile: _StagedPackageProfile | None = None
+    staged_code: _StagedPluginCode | None = None
+    source_update_attempted = False
+    preference_update_attempted = False
+    try:
+        stage = "stop"
+        if was_running:
+            stop_attempted = True
+            await _stop_plugin(plugin_id)
+
+        stage = "stage_profile"
+        staged_profile = await asyncio.to_thread(
+            _stage_orphaned_package_profile_sync,
+            plugin_dir,
+            manager=manager,
+        )
+        stage = "stage_code"
+        staged_code = await asyncio.to_thread(_stage_plugin_code_sync, plugin_dir)
+
+        stage = "update_source"
+        source_update_attempted = True
+        await asyncio.to_thread(manager.mark_removed, directory_path=plugin_dir)
+
+        stage = "refresh_and_preferences"
+        await asyncio.to_thread(_remove_runtime_metadata_sync, plugin_id)
+        await _refresh_registry(registry_target)
+        restored_meta = await asyncio.to_thread(_get_plugin_meta_sync, plugin_id)
+        restored_builtin = bool(
+            restored_meta and restored_meta.get("effective_source") == "builtin"
+        )
+        preference_action: PreferenceAction = (
+            "preserved" if restored_builtin else "cleared"
+        )
+        if not restored_builtin:
+            preference_update_attempted = True
+            await asyncio.to_thread(clear_runtime_override, plugin_id)
+
+        committed_code = await asyncio.to_thread(
+            _commit_staged_plugin_code_sync,
+            staged_code,
+        )
+    except BaseException as exc:
+        rollback = await _rollback_precommit(
+            plugin_id=plugin_id,
+            manager=manager,
+            source_entry=source_entry,
+            source_update_attempted=source_update_attempted,
+            staged_code=staged_code,
+            staged_profile=staged_profile,
+            preference_snapshot=preference_snapshot,
+            preference_update_attempted=preference_update_attempted,
+            was_running=was_running,
+            stop_attempted=stop_attempted,
+            registry_target=registry_target,
+        )
+        if not isinstance(exc, Exception) or isinstance(exc, UninstallPluginError):
+            raise
+        if isinstance(exc, ServerDomainError):
+            # Structured domain failures (e.g. stop_plugin) keep their stable
+            # public code; compensation outcomes ride along in details.
+            raise UninstallPluginError(
+                code=exc.code,
+                message=exc.message,
+                status_code=exc.status_code,
+                stage=stage,
+                filesystem_rollback=rollback.filesystem_rollback,
+                runtime_restart=rollback.runtime_restart,
+                details={
+                    **exc.details,
+                    "error_type": type(exc).__name__,
+                    **(
+                        {}
+                        if rollback.preference_restored
+                        else {"preference_rollback": "incomplete"}
+                    ),
+                },
+            ) from exc
+        raise UninstallPluginError(
+            code="PLUGIN_DELETE_FAILED",
+            message=f"Failed to delete plugin '{plugin_id}'",
+            status_code=500,
+            stage=stage,
+            filesystem_rollback=rollback.filesystem_rollback,
+            runtime_restart=rollback.runtime_restart,
+            details={
+                "plugin_id": plugin_id,
+                "error_type": type(exc).__name__,
+                **(
+                    {}
+                    if rollback.preference_restored
+                    else {"preference_rollback": "incomplete"}
+                ),
+            },
+        ) from exc
+
+    # ---- COMMIT: source record, registry facts and preference contract are
+    # consistent and the original user path is no longer valid. Failures from
+    # here on are reported, never presented as a rolled-back uninstall. ----
+    runtime_restart: RuntimeRestart = "not_needed"
+    runtime_restart_error: dict[str, str] | None = None
+    if was_running and restored_builtin:
+        try:
+            await _start_plugin(plugin_id)
+            runtime_restart = "succeeded"
+        except Exception as exc:
+            runtime_restart = "failed"
+            runtime_restart_error = {
+                "code": "PLUGIN_BUILTIN_RESTORE_START_FAILED",
+                "message": str(exc),
+                "error_type": type(exc).__name__,
+            }
+            logger.error(
+                "uninstall committed but builtin restart failed plugin_id={} err_type={}",
+                plugin_id,
+                type(exc).__name__,
+            )
+
+    cleanup_pending = False
+    deleted_profile_dir: Path | None = None
+    try:
+        await asyncio.to_thread(_finalize_committed_plugin_code_sync, committed_code)
+    except Exception:
+        cleanup_pending = True
+        logger.exception(
+            "uninstall committed but code cleanup is pending plugin_id={}", plugin_id
+        )
+    if staged_profile is not None:
+        try:
+            deleted_profile_dir = await asyncio.to_thread(
+                _finalize_staged_package_profile_sync,
+                staged_profile,
+            )
+        except Exception:
+            cleanup_pending = True
+            recorded = await asyncio.to_thread(
+                _record_deferred_profile_cleanup_sync, staged_profile
+            )
+            logger.exception(
+                "uninstall committed but profile cleanup is pending plugin_id={} persisted={}",
+                plugin_id,
+                recorded,
+            )
+
+    return UninstallPluginResult(
+        plugin_id=plugin_id,
+        plugin_dir=plugin_dir,
+        deleted_from_disk=True,
+        deleted_profile_dir=deleted_profile_dir,
+        restored_builtin=restored_builtin,
+        preference_action=preference_action,
+        filesystem_rollback="not_needed",
+        runtime_restart=runtime_restart,
+        cleanup_pending=cleanup_pending,
+        runtime_restart_error=runtime_restart_error,
+    )

--- a/plugin/server/application/plugins/installation_transactions/uninstall.py
+++ b/plugin/server/application/plugins/installation_transactions/uninstall.py
@@ -821,7 +821,16 @@ def _snapshot_runtime_preference(plugin_id: str) -> _RuntimePreferenceSnapshot:
 def _restore_runtime_preference(
     plugin_id: str, snapshot: _RuntimePreferenceSnapshot
 ) -> None:
-    restore_runtime_override(plugin_id, snapshot.entry)
+    restored = restore_runtime_override(
+        plugin_id,
+        snapshot.entry,
+        expected_current=None,
+    )
+    if not restored:
+        logger.info(
+            "uninstall rollback kept a newer runtime preference plugin_id={}",
+            plugin_id,
+        )
 
 
 def _registry_refresh_target(

--- a/plugin/server/application/plugins/installation_transactions/uninstall.py
+++ b/plugin/server/application/plugins/installation_transactions/uninstall.py
@@ -48,6 +48,7 @@ plugin_registry_service = PluginRegistryService()
 
 _DEFERRED_PROFILE_CLEANUP_FILENAME = "package_profile_cleanup.json"
 _CODE_BACKUP_ROOT_NAME = ".uninstall-backups"
+_CODE_PAYLOAD_DIR_NAME = "payload"
 _CODE_COMMIT_MARKER_FILENAME = "committed.json"
 _CODE_TRANSACTION_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
 # ``package_id`` allows dots, so the staged name must too; the leading dot,
@@ -632,11 +633,14 @@ def _stage_plugin_code_sync(plugin_dir: Path) -> _StagedPluginCode:
     ):
         raise ValueError("uninstall code backup root is not a direct local directory")
     transaction_dir.mkdir(exist_ok=False)
-    staged_dir = transaction_dir / plugin_dir.name
+    payload_dir = transaction_dir / _CODE_PAYLOAD_DIR_NAME
+    payload_dir.mkdir()
+    staged_dir = payload_dir / plugin_dir.name
     try:
         plugin_dir.replace(staged_dir)
     except BaseException:
         try:
+            payload_dir.rmdir()
             transaction_dir.rmdir()
             backup_root.rmdir()
         except OSError:
@@ -648,13 +652,15 @@ def _stage_plugin_code_sync(plugin_dir: Path) -> _StagedPluginCode:
 def _restore_staged_plugin_code_sync(staged: _StagedPluginCode) -> None:
     if staged.staged_dir.exists():
         staged.staged_dir.replace(staged.original_dir)
-    transaction_dir = staged.staged_dir.parent
+    payload_dir = staged.staged_dir.parent
+    transaction_dir = payload_dir.parent
     backup_root = transaction_dir.parent
     try:
         (transaction_dir / _CODE_COMMIT_MARKER_FILENAME).unlink()
     except FileNotFoundError:
         pass
     try:
+        payload_dir.rmdir()
         transaction_dir.rmdir()
         backup_root.rmdir()
     except OSError:
@@ -664,7 +670,7 @@ def _restore_staged_plugin_code_sync(staged: _StagedPluginCode) -> None:
 def _commit_staged_plugin_code_sync(
     staged: _StagedPluginCode,
 ) -> _CommittedPluginCodeCleanup:
-    marker_path = staged.staged_dir.parent / _CODE_COMMIT_MARKER_FILENAME
+    marker_path = staged.staged_dir.parent.parent / _CODE_COMMIT_MARKER_FILENAME
     temporary_path = marker_path.with_name(
         f".{marker_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
     )
@@ -718,7 +724,8 @@ def _load_committed_plugin_code_cleanup_sync(
         not original_dir.is_absolute()
         or not staged_dir.is_absolute()
         or original_dir.parent != backup_root.parent
-        or staged_dir != transaction_dir / original_dir.name
+        or staged_dir
+        != transaction_dir / _CODE_PAYLOAD_DIR_NAME / original_dir.name
     ):
         return None
     staged = _StagedPluginCode(
@@ -737,7 +744,8 @@ def _finalize_committed_plugin_code_sync(
     backup_root = staged.original_dir.parent / _CODE_BACKUP_ROOT_NAME
     transaction_dir = backup_root / staged.transaction_id
     if (
-        staged.staged_dir != transaction_dir / staged.original_dir.name
+        staged.staged_dir
+        != transaction_dir / _CODE_PAYLOAD_DIR_NAME / staged.original_dir.name
         or committed.marker_path != transaction_dir / _CODE_COMMIT_MARKER_FILENAME
         or _load_committed_plugin_code_cleanup_sync(
             transaction_dir,
@@ -753,6 +761,10 @@ def _finalize_committed_plugin_code_sync(
     # startup authenticate and retry the remaining payload safely.
     try:
         shutil.rmtree(staged.staged_dir)
+    except FileNotFoundError:
+        pass
+    try:
+        staged.staged_dir.parent.rmdir()
     except FileNotFoundError:
         pass
     committed.marker_path.unlink(missing_ok=True)

--- a/plugin/server/application/plugins/installation_transactions/uninstall.py
+++ b/plugin/server/application/plugins/installation_transactions/uninstall.py
@@ -26,10 +26,10 @@ from plugin.server.application.plugins.operation_lock import serialized_plugin_o
 from plugin.server.application.plugins.registry_service import PluginRegistryService
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure.runtime_overrides import (
+    RuntimeOverride,
     clear_runtime_override,
-    get_runtime_auto_start_override,
-    get_runtime_override,
-    set_runtime_override,
+    get_runtime_override_entry,
+    restore_runtime_override,
 )
 from plugin.settings import (
     BUILTIN_PLUGIN_CONFIG_ROOT,
@@ -125,8 +125,7 @@ class _CommittedPluginCodeCleanup:
 
 @dataclass(frozen=True, slots=True)
 class _RuntimePreferenceSnapshot:
-    enabled: bool | None
-    auto_start: bool | None
+    entry: RuntimeOverride | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -807,20 +806,14 @@ def retry_deferred_plugin_code_cleanup_sync() -> int:
 
 def _snapshot_runtime_preference(plugin_id: str) -> _RuntimePreferenceSnapshot:
     return _RuntimePreferenceSnapshot(
-        enabled=get_runtime_override(plugin_id),
-        auto_start=get_runtime_auto_start_override(plugin_id),
+        entry=get_runtime_override_entry(plugin_id),
     )
 
 
 def _restore_runtime_preference(
     plugin_id: str, snapshot: _RuntimePreferenceSnapshot
 ) -> None:
-    if snapshot.enabled is None:
-        clear_runtime_override(plugin_id)
-    else:
-        set_runtime_override(
-            plugin_id, snapshot.enabled, auto_start=snapshot.auto_start
-        )
+    restore_runtime_override(plugin_id, snapshot.entry)
 
 
 def _registry_refresh_target(

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -574,6 +574,7 @@ async def _start_host_with_timeout(
 
 
 class PluginLifecycleService:
+    @serialized_plugin_operation
     async def start_plugin(
         self,
         plugin_id: str,
@@ -1021,6 +1022,7 @@ class PluginLifecycleService:
                 error_type=type(exc).__name__,
             ) from exc
 
+    @serialized_plugin_operation
     async def stop_plugin(
         self,
         plugin_id: str,

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -2,13 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import math
-import os
 import re
-import shutil
 import time as time_module
-import uuid
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
@@ -44,17 +40,14 @@ from plugin.server.domain.errors import ServerDomainError
 from plugin.server.application.plugins.operation_lock import serialized_plugin_operation
 from plugin.server.application.plugins.registry_service import PluginRegistryService
 from plugin.server.application.plugins.installation_transactions import (
-    UninstallOwnershipError,
-    require_uninstall_ownership,
-)
-from plugin.server.application.install_source import (
-    InstallSourceError,
-    get_install_source_manager,
+    UninstallPluginError,
+    retry_deferred_plugin_code_cleanup_sync,
+    retry_deferred_profile_cleanup_sync,
+    uninstall_plugin,
 )
 from plugin.server.infrastructure.config_resolver import resolve_plugin_config_from_path
 from plugin.server.infrastructure.runtime_overrides import (
     RuntimeOverridePersistenceError,
-    clear_runtime_override,
     get_runtime_auto_start_override,
     get_runtime_override,
     migrate_runtime_override,
@@ -70,27 +63,13 @@ from plugin.settings import (
     PLUGIN_SHUTDOWN_TIMEOUT,
     PLUGIN_STARTUP_TIMEOUT,
     PLUGIN_SYNC_AUTO_START_ON_TOGGLE,
-    get_plugin_state_root,
-    ensure_plugin_exec_state_roots_separated,
-    get_user_plugin_config_root,
-    get_user_plugin_exec_root,
-    get_user_package_profiles_root,
 )
 from plugin.utils import parse_bool_config
 
 logger = get_logger("server.application.plugins.lifecycle")
 _PLUGIN_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 _PLUGIN_STARTUP_TIMEOUT_MAX = 300.0
-_DEFERRED_PROFILE_CLEANUP_FILENAME = "package_profile_cleanup.json"
-# ``package_id`` allows dots, so the staged name must too; the leading dot,
-# the ``.deleting-<uuid4hex>`` suffix and full-name anchoring keep it exact.
-_DEFERRED_PROFILE_STAGING_NAME_PATTERN = re.compile(
-    r"^\.[A-Za-z0-9._-]+\.deleting-[0-9a-f]{32}$"
-)
 plugin_registry_service = PluginRegistryService()
-# The profile sharing decision and install-source soft-removal must form one
-# operation.  Serializing deletions prevents two members of the same package
-# from both observing the other as active and orphaning the shared profile.
 def _persist_user_runtime_intent(
     plugin_id: str,
     enabled: bool,
@@ -357,465 +336,6 @@ def _resolve_plugin_config_path_sync(
         return config_path.resolve()
     except Exception:
         return config_path
-
-
-def _path_within_plugin_roots_sync(path: Path) -> bool:
-    try:
-        resolved_path = path.resolve()
-    except Exception:
-        resolved_path = path
-
-    resolved_exec_root = get_user_plugin_exec_root().resolve(strict=False)
-    resolved_builtin_root = BUILTIN_PLUGIN_CONFIG_ROOT.resolve(strict=False)
-    resolved_state_root = get_plugin_state_root().resolve(strict=False)
-    if resolved_exec_root == resolved_state_root:
-        return False
-    allowed_roots: set[Path] = set()
-    if resolved_exec_root not in {resolved_builtin_root, resolved_state_root}:
-        allowed_roots.add(resolved_exec_root)
-    # Preserve injected/test roots while explicitly excluding both immutable
-    # builtin code and the SDK-owned persistent state root.
-    for root in PLUGIN_CONFIG_ROOTS:
-        resolved_root = root.resolve(strict=False)
-        if resolved_root not in {resolved_builtin_root, resolved_state_root}:
-            allowed_roots.add(resolved_root)
-    # Deletion owns one direct child installation only. In particular, the
-    # builtin root and SDK state root are never acceptable lifecycle targets.
-    return resolved_path.parent in allowed_roots
-
-
-def _remove_plugin_metadata_sync(plugin_id: str) -> bool:
-    removed = False
-    with state.acquire_plugins_write_lock():
-        if plugin_id in state.plugins:
-            state.plugins.pop(plugin_id, None)
-            removed = True
-    if removed:
-        state.invalidate_snapshot_cache("plugins")
-    return removed
-
-
-def _delete_plugin_directory_sync(plugin_dir: Path) -> bool:
-    if not plugin_dir.exists():
-        return False
-    shutil.rmtree(plugin_dir)
-    return True
-
-
-def _profile_path_from_entry_sync(entry: object, profiles_root: Path) -> Path | None:
-    if getattr(entry, "channel", "") not in {"imported", "market"}:
-        return None
-    if getattr(entry, "profile_installed", None) is False:
-        return None
-    package_id = str(getattr(entry, "package_id", "") or getattr(entry, "plugin_id", ""))
-    if not package_id:
-        return None
-    raw_profile_dir = str(getattr(entry, "profile_dir", "") or "")
-    candidate = (
-        Path(raw_profile_dir).expanduser()
-        if raw_profile_dir
-        else profiles_root / package_id
-    )
-    if _path_has_symlink_ancestor(candidate):
-        return None
-    try:
-        profile_dir = candidate.resolve()
-    except Exception:
-        return None
-    if profile_dir.name != package_id:
-        return None
-    # A recorded profile location remains valid after the configured profile
-    # root changes. Legacy fallback paths are still constrained to that root.
-    if not raw_profile_dir and (
-        profile_dir != profiles_root and profiles_root not in profile_dir.parents
-    ):
-        return None
-    return profile_dir
-
-
-def _path_has_symlink_ancestor(path: Path) -> bool:
-    """Reject a path when resolving it would traverse a symlink."""
-    return any(candidate.is_symlink() for candidate in (path, *path.parents))
-
-
-def _has_other_entry_without_package_id(
-    active_entries: object,
-    current_primary_key: tuple[str, str],
-) -> bool:
-    """Report whether another installed row also predates package id tracking."""
-    for entry in active_entries or ():
-        if getattr(entry, "channel", "") not in {"imported", "market"}:
-            continue
-        key = (getattr(entry, "root_id", ""), getattr(entry, "directory_name", ""))
-        if key == current_primary_key:
-            continue
-        if not str(getattr(entry, "package_id", "") or ""):
-            return True
-    return False
-
-
-@dataclass(frozen=True)
-class _StagedPackageProfile:
-    original_dir: Path
-    staged_dir: Path
-
-
-def _deferred_profile_cleanup_record_path_sync() -> Path:
-    return (
-        get_plugin_state_root().expanduser().resolve().parent
-        / _DEFERRED_PROFILE_CLEANUP_FILENAME
-    )
-
-
-def _legacy_deferred_profile_cleanup_record_path_sync() -> Path:
-    return (
-        get_user_plugin_config_root().expanduser().resolve().parent
-        / _DEFERRED_PROFILE_CLEANUP_FILENAME
-    )
-
-
-def _load_deferred_profile_cleanup_paths_sync(record_path: Path) -> list[str] | None:
-    """Return the pending paths, or ``None`` when an existing record is unusable.
-
-    Callers must not overwrite a record they could not read: the paths already
-    queued in it would be dropped and their staging directories would then be
-    retained forever.
-    """
-    try:
-        raw = json.loads(record_path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return []
-    except (OSError, ValueError, TypeError) as exc:
-        logger.error(
-            "delete_plugin: failed to read deferred profile cleanup record {}: {}",
-            record_path,
-            exc,
-        )
-        return None
-    if not isinstance(raw, dict) or not isinstance(raw.get("staged_paths"), list):
-        logger.error(
-            "delete_plugin: invalid deferred profile cleanup record: {}",
-            record_path,
-        )
-        return None
-    return [path for path in raw["staged_paths"] if isinstance(path, str) and path]
-
-
-def _save_deferred_profile_cleanup_paths_sync(record_path: Path, paths: list[str]) -> None:
-    if not paths:
-        try:
-            record_path.unlink()
-        except FileNotFoundError:
-            pass
-        return
-    record_path.parent.mkdir(parents=True, exist_ok=True)
-    temporary_path = record_path.with_name(
-        f".{record_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
-    )
-    try:
-        temporary_path.write_text(
-            json.dumps({"schema_version": 1, "staged_paths": paths}),
-            encoding="utf-8",
-        )
-        temporary_path.replace(record_path)
-    finally:
-        try:
-            temporary_path.unlink()
-        except FileNotFoundError:
-            pass
-
-
-def _record_deferred_profile_cleanup_sync(staged_profile: _StagedPackageProfile) -> bool:
-    try:
-        record_path = _deferred_profile_cleanup_record_path_sync()
-        paths = _load_deferred_profile_cleanup_paths_sync(record_path)
-        if paths is None:
-            return False
-        staged_path = str(staged_profile.staged_dir)
-        if staged_path not in paths:
-            paths.append(staged_path)
-        _save_deferred_profile_cleanup_paths_sync(record_path, paths)
-        return True
-    except Exception as exc:
-        logger.error(
-            "delete_plugin: failed to persist deferred profile cleanup for {}: {}",
-            staged_profile.staged_dir,
-            exc,
-        )
-        return False
-
-
-def _is_safe_deferred_profile_cleanup_path(path: Path) -> bool:
-    return (
-        path.is_absolute()
-        and _DEFERRED_PROFILE_STAGING_NAME_PATTERN.fullmatch(path.name) is not None
-        and not _path_has_symlink_ancestor(path)
-    )
-
-
-def _retry_deferred_profile_cleanup_sync() -> int:
-    """Retry profile cleanup jobs persisted after transient deletion failures."""
-    record_path = _deferred_profile_cleanup_record_path_sync()
-    record_paths = [record_path]
-    legacy_record_path = _legacy_deferred_profile_cleanup_record_path_sync()
-    if legacy_record_path != record_path and legacy_record_path.exists():
-        record_paths.append(legacy_record_path)
-
-    paths: list[str] = []
-    for candidate in record_paths:
-        loaded = _load_deferred_profile_cleanup_paths_sync(candidate)
-        if loaded is None:
-            return 0
-        for raw_path in loaded:
-            if raw_path not in paths:
-                paths.append(raw_path)
-    if not paths:
-        return 0
-
-    remaining_paths: list[str] = []
-    cleaned = 0
-    for raw_path in paths:
-        staged_path = Path(raw_path).expanduser()
-        if not _is_safe_deferred_profile_cleanup_path(staged_path):
-            logger.error(
-                "delete_plugin: refusing unsafe deferred profile cleanup path: {}",
-                staged_path,
-            )
-            remaining_paths.append(raw_path)
-            continue
-        try:
-            shutil.rmtree(staged_path)
-        except FileNotFoundError:
-            cleaned += 1
-        except OSError as exc:
-            logger.warning(
-                "delete_plugin: deferred profile cleanup still pending for {}: {}",
-                staged_path,
-                exc,
-            )
-            remaining_paths.append(raw_path)
-        else:
-            cleaned += 1
-    try:
-        _save_deferred_profile_cleanup_paths_sync(record_path, remaining_paths)
-    except OSError as exc:
-        logger.error(
-            "delete_plugin: failed to update deferred profile cleanup record {}: {}",
-            record_path,
-            exc,
-        )
-    else:
-        for legacy_path in record_paths[1:]:
-            try:
-                legacy_path.unlink()
-            except FileNotFoundError:
-                pass
-            except OSError as exc:
-                logger.warning(
-                    "delete_plugin: failed to remove migrated cleanup record {}: {}",
-                    legacy_path,
-                    exc,
-                )
-    return cleaned
-
-
-def _stage_orphaned_package_profile_sync(plugin_dir: Path) -> _StagedPackageProfile | None:
-    """Stage an unshared package profile while deletion is in progress.
-
-    Moving the profile out of its package location prevents a concurrent
-    reinstall from seeing it, but preserves it until executable deletion has
-    succeeded. This lets a failed executable deletion roll back without
-    losing the plugin's persisted configuration.
-    """
-    manager = get_install_source_manager()
-    if manager is None:
-        return None
-
-    try:
-        current_entry = manager.entry_for_directory(
-            plugin_dir,
-            include_removed=False,
-        )
-        active_entries = manager.list_entries()
-    except InstallSourceError as exc:
-        logger.warning(
-            "delete_plugin: failed to inspect install source for plugin_dir={}: {}",
-            plugin_dir,
-            exc,
-        )
-        return None
-    except Exception as exc:
-        logger.warning(
-            "delete_plugin: unexpected install-source cleanup failure for plugin_dir={}: {}",
-            plugin_dir,
-            exc,
-        )
-        return None
-
-    # Only package installers own package profiles. A scanner-created manual
-    # entry with no profile record must never infer ownership from a matching
-    # directory name.
-    if current_entry is None or getattr(current_entry, "channel", "") not in {"imported", "market"}:
-        return None
-
-    current_primary_key = (
-        getattr(current_entry, "root_id", ""),
-        getattr(current_entry, "directory_name", ""),
-    )
-    recorded_package_id = str(getattr(current_entry, "package_id", "") or "")
-    if _has_other_entry_without_package_id(active_entries, current_primary_key):
-        # Rows written before the package id was tracked do not say which
-        # package owns their profile, and a bundle's profile is named after the
-        # package rather than after any member plugin. Such a row may be a
-        # sibling from the same bundle that still uses this profile, and the
-        # sharing check below cannot see it: it can only infer that row's
-        # profile from its plugin id, which is not where a bundle profile
-        # lives. This holds whichever side is missing the package id, so the
-        # guard looks at every other installed row rather than only at ours.
-        #
-        # Cost: one such row suppresses profile cleanup for every deletion
-        # until it is itself removed or reinstalled, which degrades to the
-        # pre-change behaviour (a stale profile blocks a reinstall). That is
-        # strictly better than permanently deleting a sibling's configuration.
-        logger.warning(
-            "delete_plugin: skipping profile cleanup while an installation "
-            "without a recorded package id may share this profile: {}",
-            plugin_dir,
-        )
-        return None
-
-    package_id = recorded_package_id or str(getattr(current_entry, "plugin_id", "") or "")
-    if not package_id:
-        return None
-    recorded_profile_dir = str(getattr(current_entry, "profile_dir", "") or "")
-    if getattr(current_entry, "profile_installed", None) is False:
-        return None
-
-    try:
-        profiles_root = get_user_package_profiles_root().resolve()
-        profile_candidate = (
-            Path(recorded_profile_dir).expanduser()
-            if recorded_profile_dir
-            else profiles_root / package_id
-        )
-        if _path_has_symlink_ancestor(profile_candidate):
-            logger.warning(
-                "delete_plugin: refusing to remove symlinked package profile path: {}",
-                profile_candidate,
-            )
-            return None
-        current_profile_dir = profile_candidate.resolve()
-    except Exception as exc:
-        logger.warning(
-            "delete_plugin: failed to resolve package profile for plugin_dir={}: {}",
-            plugin_dir,
-            exc,
-        )
-        return None
-
-    state_root = get_plugin_state_root().expanduser().resolve(strict=False)
-    if (
-        current_profile_dir == state_root
-        or state_root in current_profile_dir.parents
-        or current_profile_dir in state_root.parents
-    ):
-        logger.warning(
-            "delete_plugin: refusing to remove package profile overlapping "
-            "the persistent state root: {}",
-            current_profile_dir,
-        )
-        return None
-
-    builtin_root = Path(BUILTIN_PLUGIN_CONFIG_ROOT).expanduser().resolve(strict=False)
-    if (
-        current_profile_dir == builtin_root
-        or builtin_root in current_profile_dir.parents
-        or current_profile_dir in builtin_root.parents
-    ):
-        logger.warning(
-            "delete_plugin: refusing to remove package profile overlapping "
-            "the builtin plugin root: {}",
-            current_profile_dir,
-        )
-        return None
-
-    if current_profile_dir.name != package_id or (
-        not recorded_profile_dir
-        and (
-            current_profile_dir != profiles_root
-            and profiles_root not in current_profile_dir.parents
-        )
-    ):
-        logger.warning(
-            "delete_plugin: refusing to remove unsafe package profile path: {}",
-            current_profile_dir,
-        )
-        return None
-
-    for entry in active_entries:
-        if (
-            getattr(entry, "root_id", ""),
-            getattr(entry, "directory_name", ""),
-        ) == current_primary_key:
-            continue
-        if _profile_path_from_entry_sync(entry, profiles_root) == current_profile_dir:
-            return None
-
-    staged_profile_dir = current_profile_dir.with_name(
-        f".{current_profile_dir.name}.deleting-{uuid.uuid4().hex}"
-    )
-    try:
-        current_profile_dir.replace(staged_profile_dir)
-    except FileNotFoundError:
-        return None
-    except OSError as exc:
-        logger.error(
-            "delete_plugin: failed to stage package profile {}: {}",
-            current_profile_dir,
-            exc,
-        )
-        raise
-    return _StagedPackageProfile(
-        original_dir=current_profile_dir,
-        staged_dir=staged_profile_dir,
-    )
-
-
-def _restore_staged_package_profile_sync(staged_profile: _StagedPackageProfile) -> None:
-    """Restore a profile after executable deletion failed."""
-    if not staged_profile.staged_dir.exists():
-        return
-    staged_profile.staged_dir.replace(staged_profile.original_dir)
-
-
-def _finalize_staged_package_profile_sync(staged_profile: _StagedPackageProfile) -> Path | None:
-    """Permanently remove a profile only after executable deletion succeeds."""
-    try:
-        shutil.rmtree(staged_profile.staged_dir)
-    except FileNotFoundError:
-        return None
-    return staged_profile.original_dir
-
-
-def _mark_install_source_removed_sync(plugin_dir: Path) -> None:
-    """Soft-delete the source record without blocking lifecycle cleanup."""
-    manager = get_install_source_manager()
-    if manager is None:
-        return
-    try:
-        manager.mark_removed(directory_path=plugin_dir)
-    except InstallSourceError as exc:
-        logger.warning(
-            "delete_plugin: failed to update install source for plugin_dir={}: {}",
-            plugin_dir,
-            exc,
-        )
-    except Exception as exc:
-        logger.warning(
-            "delete_plugin: unexpected install-source update failure for plugin_dir={}: {}",
-            plugin_dir,
-            exc,
-        )
 
 
 def _register_or_replace_host_sync(plugin_id: str, host: PluginHostContract) -> int:
@@ -1677,207 +1197,64 @@ class PluginLifecycleService:
 
     @serialized_plugin_operation
     async def delete_plugin(self, plugin_id: str) -> dict[str, object]:
-        """Delete one plugin without racing package installation transactions."""
-        return await self._delete_plugin_unlocked(plugin_id)
-
-    async def _delete_plugin_unlocked(self, plugin_id: str) -> dict[str, object]:
+        """Invoke the uninstall transaction and preserve the public response."""
         try:
-            await asyncio.to_thread(ensure_plugin_exec_state_roots_separated)
-        except ValueError as exc:
-            if getattr(exc, "code", "") == "PLUGIN_EXEC_STATE_ROOT_COLLISION":
-                raise _to_domain_error(
-                    code="PLUGIN_EXEC_STATE_ROOT_COLLISION",
-                    message=str(exc),
-                    status_code=409,
-                    plugin_id=plugin_id,
-                    error_type=type(exc).__name__,
-                ) from exc
-            raise
-        plugin_meta = await asyncio.to_thread(_get_plugin_meta_sync, plugin_id)
-        if plugin_meta is None:
-            raise _to_domain_error(
-                code="PLUGIN_NOT_FOUND",
-                message=f"Plugin '{plugin_id}' not found",
-                status_code=404,
-                plugin_id=plugin_id,
-                error_type="PluginNotFound",
-            )
-
-        config_path = await asyncio.to_thread(
-            _resolve_plugin_config_path_sync,
-            plugin_id,
-            plugin_meta,
-        )
-        if config_path is None:
-            raise _to_domain_error(
-                code="PLUGIN_CONFIG_NOT_FOUND",
-                message=f"Plugin '{plugin_id}' configuration not found",
-                status_code=404,
-                plugin_id=plugin_id,
-                error_type="ConfigNotFound",
-            )
-        plugin_dir = config_path.parent
-
-        install_source_manager = get_install_source_manager()
-        try:
-            if install_source_manager is not None:
-                reload_install_source = getattr(install_source_manager, "load", None)
-                if callable(reload_install_source):
-                    await asyncio.to_thread(reload_install_source)
-            await asyncio.to_thread(
-                require_uninstall_ownership,
-                manager=install_source_manager,
-                runtime_plugin_id=plugin_id,
-                config_path=config_path,
-            )
-        except UninstallOwnershipError as exc:
+            result = await uninstall_plugin(plugin_id)
+        except UninstallPluginError as exc:
             raise ServerDomainError(
                 code=exc.code,
                 message=exc.message,
                 status_code=exc.status_code,
-                details={
-                    **exc.details,
-                    "error_type": type(exc).__name__,
-                },
+                details=dict(exc.details),
             ) from exc
 
-        path_allowed = await asyncio.to_thread(_path_within_plugin_roots_sync, plugin_dir)
-        if not path_allowed:
-            raise _to_domain_error(
-                code="PLUGIN_DELETE_FORBIDDEN_PATH",
-                message=f"Plugin '{plugin_id}' path is outside managed plugin roots",
-                status_code=403,
-                plugin_id=plugin_id,
-                error_type="ForbiddenDeletePath",
-            )
-
-        is_running = await asyncio.to_thread(_plugin_is_running_sync, plugin_id)
-        if is_running:
-            await self.stop_plugin(plugin_id)
-
-        staged_profile: _StagedPackageProfile | None = None
-        try:
-            staged_profile = await asyncio.to_thread(
-                _stage_orphaned_package_profile_sync,
-                plugin_dir,
-            )
-            deleted_from_disk = await asyncio.to_thread(_delete_plugin_directory_sync, plugin_dir)
-            deleted_profile_dir = None
-            if staged_profile is not None:
-                try:
-                    deleted_profile_dir = await asyncio.to_thread(
-                        _finalize_staged_package_profile_sync,
-                        staged_profile,
-                    )
-                except OSError as exc:
-                    # The executable is already gone, but the profile is in a
-                    # non-conflicting staging location. Do not turn a completed
-                    # plugin deletion into a reinstall-blocking partial state.
-                    deferred_cleanup_recorded = await asyncio.to_thread(
-                        _record_deferred_profile_cleanup_sync,
-                        staged_profile,
-                    )
-                    logger.warning(
-                        "delete_plugin: deferred cleanup of staged package profile {}: {}; persisted={}",
-                        staged_profile.staged_dir,
-                        exc,
-                        deferred_cleanup_recorded,
-                    )
-            await asyncio.to_thread(_mark_install_source_removed_sync, plugin_dir)
-            await asyncio.to_thread(_pop_plugin_host_sync, plugin_id)
-            await asyncio.to_thread(_remove_event_handlers_sync, plugin_id)
-            await asyncio.to_thread(_remove_plugin_metadata_sync, plugin_id)
-            await plugin_registry_service.refresh_registry()
-            restored_meta = await asyncio.to_thread(_get_plugin_meta_sync, plugin_id)
-            restored_builtin = bool(
-                restored_meta
-                and restored_meta.get("effective_source") == "builtin"
-            )
-            restored_builtin_started = False
-            restored_builtin_restart_error: dict[str, str] | None = None
-            if not restored_builtin:
-                await asyncio.to_thread(clear_runtime_override, plugin_id)
-            if is_running and restored_builtin:
-                try:
-                    await self.start_plugin(plugin_id, refresh_registry=False)
-                    restored_builtin_started = True
-                except Exception as restart_exc:
-                    restored_builtin_restart_error = {
-                        "code": "PLUGIN_BUILTIN_RESTORE_START_FAILED",
-                        "message": str(restart_exc),
-                        "error_type": type(restart_exc).__name__,
-                    }
-                    logger.error(
-                        "delete_plugin: builtin source restored but restart failed: "
-                        "plugin_id={}, err_type={}, err={}",
-                        plugin_id,
-                        type(restart_exc).__name__,
-                        restart_exc,
-                    )
-        except ServerDomainError:
-            raise
-        except IO_RUNTIME_ERRORS as exc:
-            if staged_profile is not None:
-                try:
-                    await asyncio.to_thread(_restore_staged_package_profile_sync, staged_profile)
-                except OSError as restore_exc:
-                    logger.error(
-                        "delete_plugin: failed to restore package profile after deletion failure {}: {}",
-                        staged_profile.original_dir,
-                        restore_exc,
-                    )
-            if is_running:
-                try:
-                    await self.start_plugin(plugin_id, refresh_registry=False)
-                except Exception as restart_exc:
-                    logger.error(
-                        "delete_plugin: failed to restart plugin after deletion failure: plugin_id={}, err_type={}, err={}",
-                        plugin_id,
-                        type(restart_exc).__name__,
-                        restart_exc,
-                    )
-            logger.error(
-                "delete_plugin failed: plugin_id={}, plugin_dir={}, err_type={}, err={}",
-                plugin_id,
-                str(plugin_dir),
-                type(exc).__name__,
-                str(exc),
-            )
-            raise _to_domain_error(
-                code="PLUGIN_DELETE_FAILED",
-                message=f"Failed to delete plugin '{plugin_id}'",
-                status_code=500,
-                plugin_id=plugin_id,
-                error_type=type(exc).__name__,
-            ) from exc
+        restored_builtin_started = (
+            result.restored_builtin and result.runtime_restart == "succeeded"
+        )
 
         _emit_lifecycle_event(
             event_type="plugin_deleted",
             plugin_id=plugin_id,
             data={
-                "plugin_dir": str(plugin_dir),
-                "deleted_from_disk": deleted_from_disk,
-                "deleted_profile_dir": str(deleted_profile_dir) if deleted_profile_dir else None,
-                "restored_builtin": restored_builtin,
+                "plugin_dir": str(result.plugin_dir),
+                "deleted_from_disk": result.deleted_from_disk,
+                "deleted_profile_dir": (
+                    str(result.deleted_profile_dir)
+                    if result.deleted_profile_dir
+                    else None
+                ),
+                "restored_builtin": result.restored_builtin,
                 "restored_builtin_started": restored_builtin_started,
-                "restored_builtin_restart_error": restored_builtin_restart_error,
+                "restored_builtin_restart_error": result.runtime_restart_error,
+                "preference_action": result.preference_action,
+                "filesystem_rollback": result.filesystem_rollback,
+                "runtime_restart": result.runtime_restart,
+                "cleanup_pending": result.cleanup_pending,
             },
         )
         response: dict[str, object] = {
             "success": True,
             "plugin_id": plugin_id,
-            "plugin_dir": str(plugin_dir),
-            "deleted_from_disk": deleted_from_disk,
-            "restored_builtin": restored_builtin,
+            "plugin_dir": str(result.plugin_dir),
+            "deleted_from_disk": result.deleted_from_disk,
+            "restored_builtin": result.restored_builtin,
             "restored_builtin_started": restored_builtin_started,
-            "restored_builtin_restart_error": restored_builtin_restart_error,
+            "restored_builtin_restart_error": result.runtime_restart_error,
+            "preference_action": result.preference_action,
+            "filesystem_rollback": result.filesystem_rollback,
+            "runtime_restart": result.runtime_restart,
+            "cleanup_pending": result.cleanup_pending,
             "message": "Plugin deleted successfully",
         }
         return response
 
     async def retry_deferred_profile_cleanup(self) -> int:
-        """Retry persisted profile cleanup jobs during server startup."""
-        return await asyncio.to_thread(_retry_deferred_profile_cleanup_sync)
+        """Retry persisted uninstall cleanup jobs during server startup."""
+        cleaned_profiles = await asyncio.to_thread(
+            retry_deferred_profile_cleanup_sync
+        )
+        await asyncio.to_thread(retry_deferred_plugin_code_cleanup_sync)
+        return cleaned_profiles
 
     async def _safe_stop_for_reload(self, plugin_id: str) -> _ReloadOutcome:
         try:

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -347,16 +347,15 @@ def clear_runtime_override(plugin_id: str) -> None:
 def restore_runtime_override(
     plugin_id: str,
     snapshot: RuntimeOverride | None,
-) -> None:
-    """Restore one exact entry captured before a transactional mutation."""
+    *,
+    expected_current: RuntimeOverride | None,
+) -> bool:
+    """Restore an exact snapshot only if no newer preference replaced it."""
     if not plugin_id:
-        return
-    if snapshot is None:
-        clear_runtime_override(plugin_id)
-        return
+        return False
 
-    restored: RuntimeOverride
-    if isinstance(snapshot, bool):
+    restored: RuntimeOverride | None
+    if snapshot is None or isinstance(snapshot, bool):
         restored = snapshot
     elif isinstance(snapshot, Mapping):
         restored_mapping = dict(snapshot)
@@ -372,13 +371,19 @@ def restore_runtime_override(
     with _cache_lock:
         if _cache is None:
             _cache = _load_from_disk()
+        if _cache.get(plugin_id) != expected_current:
+            return False
         if _cache.get(plugin_id) == restored:
-            return
+            return True
         candidate = dict(_cache)
-        candidate[plugin_id] = restored
+        if restored is None:
+            candidate.pop(plugin_id, None)
+        else:
+            candidate[plugin_id] = restored
         _ensure_cache_can_be_written()
         _save_to_disk(candidate)
         _cache = candidate
+        return True
 
 
 def reset_cache_for_testing() -> None:

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -197,6 +197,12 @@ def _get_runtime_override_entry(plugin_id: str) -> RuntimeOverride | None:
         return None
 
 
+def get_runtime_override_entry(plugin_id: str) -> RuntimeOverride | None:
+    """Return an exact, detached snapshot of one persisted preference entry."""
+    override = _get_runtime_override_entry(plugin_id)
+    return dict(override) if isinstance(override, Mapping) else override
+
+
 def get_runtime_override(plugin_id: str) -> bool | None:
     """Return the persisted override for ``plugin_id`` or ``None`` if unset."""
     override = _get_runtime_override_entry(plugin_id)
@@ -333,6 +339,43 @@ def clear_runtime_override(plugin_id: str) -> None:
             return
         candidate = dict(_cache)
         candidate.pop(plugin_id, None)
+        _ensure_cache_can_be_written()
+        _save_to_disk(candidate)
+        _cache = candidate
+
+
+def restore_runtime_override(
+    plugin_id: str,
+    snapshot: RuntimeOverride | None,
+) -> None:
+    """Restore one exact entry captured before a transactional mutation."""
+    if not plugin_id:
+        return
+    if snapshot is None:
+        clear_runtime_override(plugin_id)
+        return
+
+    restored: RuntimeOverride
+    if isinstance(snapshot, bool):
+        restored = snapshot
+    elif isinstance(snapshot, Mapping):
+        restored_mapping = dict(snapshot)
+        if not restored_mapping or set(restored_mapping) - {"enabled", "auto_start"}:
+            raise ValueError("invalid runtime override snapshot")
+        if any(not isinstance(value, bool) for value in restored_mapping.values()):
+            raise ValueError("invalid runtime override snapshot")
+        restored = restored_mapping
+    else:  # pragma: no cover - guarded by the public type contract
+        raise ValueError("invalid runtime override snapshot")
+
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        if _cache.get(plugin_id) == restored:
+            return
+        candidate = dict(_cache)
+        candidate[plugin_id] = restored
         _ensure_cache_can_be_written()
         _save_to_disk(candidate)
         _cache = candidate

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -14,6 +14,7 @@ from plugin._types.exceptions import PluginLifecycleError
 from plugin.core import registry as registry_module
 from plugin.server.application.plugins import query_service as query_module
 from plugin.server.application.plugins import lifecycle_service as module
+import plugin.server.application.plugins.installation_transactions.uninstall as uninstall_module
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure import runtime_overrides as runtime_overrides_module
 from plugin.sdk.plugin.decorators import plugin_entry
@@ -104,6 +105,7 @@ class _FakeInstallSourceManager:
         self.active_channels = active_channels
         self.list_entries_error = list_entries_error
         self.marked_removed: list[Path] = []
+        self.restored_entries: list[object] = []
         self.is_degraded = False
 
     def package_id_for_directory(
@@ -117,6 +119,9 @@ class _FakeInstallSourceManager:
 
     def mark_removed(self, *, directory_path: Path) -> None:
         self.marked_removed.append(directory_path)
+
+    def restore_entry_for_rollback(self, entry: object) -> None:
+        self.restored_entries.append(entry)
 
     def entry_for_directory(
         self,
@@ -536,16 +541,35 @@ async def test_delete_user_override_restores_running_builtin_and_preserves_state
                 }
             return {"success": True}
 
-        monkeypatch.setattr(module, "get_user_plugin_exec_root", lambda: exec_root)
-        monkeypatch.setattr(module, "get_plugin_state_root", lambda: tmp_path / "state" / "plugins")
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (exec_root, builtin_config.parent.parent))
+        monkeypatch.setattr(
+            uninstall_module, "get_user_plugin_exec_root", lambda: exec_root
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "get_plugin_state_root",
+            lambda: tmp_path / "state" / "plugins",
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "PLUGIN_CONFIG_ROOTS",
+            (exec_root, builtin_config.parent.parent),
+        )
         monkeypatch.setattr(module.PluginLifecycleService, "stop_plugin", stop_plugin)
         monkeypatch.setattr(module.PluginLifecycleService, "start_plugin", start_plugin)
-        monkeypatch.setattr(module.plugin_registry_service, "refresh_registry", refresh_registry)
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
+            "refresh_registry",
+            refresh_registry,
+        )
         install_source_manager = _FakeInstallSourceManager(package_id="")
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-        monkeypatch.setattr(module, "_stage_orphaned_package_profile_sync", lambda _path: None)
-        monkeypatch.setattr(module, "_mark_install_source_removed_sync", lambda _path: None)
+        monkeypatch.setattr(
+            uninstall_module, "get_install_source_manager", lambda: install_source_manager
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "_stage_orphaned_package_profile_sync",
+            lambda _path, *, manager=None: None,
+        )
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda _event: None)
 
         response = await module.PluginLifecycleService().delete_plugin("study_companion")
@@ -553,6 +577,9 @@ async def test_delete_user_override_restores_running_builtin_and_preserves_state
         assert response["success"] is True
         assert response["restored_builtin"] is True
         assert response["restored_builtin_started"] is not start_fails
+        assert response["preference_action"] == "preserved"
+        assert response["filesystem_rollback"] == "not_needed"
+        assert response["cleanup_pending"] is False
         restart_error = response["restored_builtin_restart_error"]
         if start_fails:
             assert restart_error == {
@@ -622,20 +649,38 @@ async def test_delete_user_override_preserves_disabled_preference_for_restored_b
                 }
             return {"success": True}
 
-        monkeypatch.setattr(module, "get_user_plugin_exec_root", lambda: exec_root)
-        monkeypatch.setattr(module, "get_plugin_state_root", lambda: tmp_path / "state")
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (exec_root, builtin_config.parent.parent))
-        monkeypatch.setattr(module.plugin_registry_service, "refresh_registry", refresh_registry)
+        monkeypatch.setattr(
+            uninstall_module, "get_user_plugin_exec_root", lambda: exec_root
+        )
+        monkeypatch.setattr(
+            uninstall_module, "get_plugin_state_root", lambda: tmp_path / "state"
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "PLUGIN_CONFIG_ROOTS",
+            (exec_root, builtin_config.parent.parent),
+        )
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
+            "refresh_registry",
+            refresh_registry,
+        )
         install_source_manager = _FakeInstallSourceManager(package_id="")
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-        monkeypatch.setattr(module, "_stage_orphaned_package_profile_sync", lambda _path: None)
-        monkeypatch.setattr(module, "_mark_install_source_removed_sync", lambda _path: None)
+        monkeypatch.setattr(
+            uninstall_module, "get_install_source_manager", lambda: install_source_manager
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "_stage_orphaned_package_profile_sync",
+            lambda _path, *, manager=None: None,
+        )
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda _event: None)
 
         response = await module.PluginLifecycleService().delete_plugin("study_companion")
 
         assert response["restored_builtin"] is True
         assert response["restored_builtin_started"] is False
+        assert response["preference_action"] == "preserved"
         assert _isolate_runtime_overrides == {
             "study_companion": {"enabled": False, "auto_start": False},
         }
@@ -662,7 +707,6 @@ async def test_delete_manual_plugin_fails_before_runtime_or_filesystem_mutation(
     )
     manager = _FakeInstallSourceManager(package_id="", channel="manual")
     runtime_checks: list[str] = []
-    delete_calls: list[Path] = []
 
     monkeypatch.setattr(
         module,
@@ -674,16 +718,11 @@ async def test_delete_manual_plugin_fails_before_runtime_or_filesystem_mutation(
         "_resolve_plugin_config_path_sync",
         lambda _plugin_id, _meta: plugin_dir / "plugin.toml",
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: manager)
+    monkeypatch.setattr(uninstall_module, "get_install_source_manager", lambda: manager)
     monkeypatch.setattr(
         module,
         "_plugin_is_running_sync",
         lambda plugin_id: runtime_checks.append(plugin_id) or True,
-    )
-    monkeypatch.setattr(
-        module,
-        "_delete_plugin_directory_sync",
-        lambda path: delete_calls.append(path) or True,
     )
 
     with pytest.raises(ServerDomainError) as captured:
@@ -692,8 +731,8 @@ async def test_delete_manual_plugin_fails_before_runtime_or_filesystem_mutation(
     assert captured.value.code == "PLUGIN_MANUAL_NOT_MANAGED"
     assert captured.value.status_code == 409
     assert captured.value.details["plugin_id"] == "manual_plugin"
+    assert captured.value.details["stage"] == "ownership"
     assert runtime_checks == []
-    assert delete_calls == []
     assert manager.marked_removed == []
     assert plugin_dir.is_dir()
 
@@ -721,7 +760,6 @@ async def test_delete_reloads_install_source_before_ownership_gate(
 
     manager.load = reload_stale_snapshot  # type: ignore[attr-defined]
     runtime_checks: list[str] = []
-    delete_calls: list[Path] = []
 
     monkeypatch.setattr(
         module,
@@ -733,16 +771,11 @@ async def test_delete_reloads_install_source_before_ownership_gate(
         "_resolve_plugin_config_path_sync",
         lambda _plugin_id, _meta: config_path,
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: manager)
+    monkeypatch.setattr(uninstall_module, "get_install_source_manager", lambda: manager)
     monkeypatch.setattr(
         module,
         "_plugin_is_running_sync",
         lambda plugin_id: runtime_checks.append(plugin_id) or False,
-    )
-    monkeypatch.setattr(
-        module,
-        "_delete_plugin_directory_sync",
-        lambda path: delete_calls.append(path) or True,
     )
 
     with pytest.raises(ServerDomainError) as captured:
@@ -751,7 +784,6 @@ async def test_delete_reloads_install_source_before_ownership_gate(
     assert captured.value.code == "PLUGIN_MANUAL_NOT_MANAGED"
     assert load_calls == 1
     assert runtime_checks == []
-    assert delete_calls == []
     assert plugin_dir.is_dir()
 
 
@@ -797,10 +829,15 @@ async def test_delete_runtime_alias_uses_declared_id_for_managed_ownership(
         async def _refresh_registry() -> dict[str, object]:
             return {"success": True}
 
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (root,))
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: manager)
+        monkeypatch.setattr(uninstall_module, "PLUGIN_CONFIG_ROOTS", (root,))
         monkeypatch.setattr(
-            module.plugin_registry_service,
+            uninstall_module,
+            "get_user_package_profiles_root",
+            lambda: tmp_path / "profiles",
+        )
+        monkeypatch.setattr(uninstall_module, "get_install_source_manager", lambda: manager)
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
             "refresh_registry",
             _refresh_registry,
         )
@@ -810,6 +847,8 @@ async def test_delete_runtime_alias_uses_declared_id_for_managed_ownership(
 
         assert response["success"] is True
         assert response["plugin_id"] == "demo_1"
+        assert response["deleted_from_disk"] is True
+        assert response["preference_action"] == "cleared"
         assert plugin_dir.exists() is False
         assert manager.marked_removed == [plugin_dir]
     finally:
@@ -834,18 +873,22 @@ def test_delete_path_guard_rejects_builtin_and_state_roots(
     exec_root = tmp_path / "exec"
     builtin_root = tmp_path / "builtin"
     state_root = tmp_path / "plugins"
-    monkeypatch.setattr(module, "get_user_plugin_exec_root", lambda: exec_root)
-    monkeypatch.setattr(module, "get_plugin_state_root", lambda: state_root)
-    monkeypatch.setattr(module, "BUILTIN_PLUGIN_CONFIG_ROOT", builtin_root)
-    monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (exec_root, builtin_root))
+    monkeypatch.setattr(uninstall_module, "get_user_plugin_exec_root", lambda: exec_root)
+    monkeypatch.setattr(uninstall_module, "get_plugin_state_root", lambda: state_root)
+    monkeypatch.setattr(uninstall_module, "BUILTIN_PLUGIN_CONFIG_ROOT", builtin_root)
+    monkeypatch.setattr(
+        uninstall_module, "PLUGIN_CONFIG_ROOTS", (exec_root, builtin_root)
+    )
 
-    assert module._path_within_plugin_roots_sync(exec_root / "demo") is True
-    assert module._path_within_plugin_roots_sync(builtin_root / "demo") is False
-    assert module._path_within_plugin_roots_sync(state_root / "demo") is False
+    assert uninstall_module._path_within_plugin_roots_sync(exec_root / "demo") is True
+    assert uninstall_module._path_within_plugin_roots_sync(builtin_root / "demo") is False
+    assert uninstall_module._path_within_plugin_roots_sync(state_root / "demo") is False
 
-    monkeypatch.setattr(module, "get_user_plugin_exec_root", lambda: state_root)
-    monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (state_root, builtin_root))
-    assert module._path_within_plugin_roots_sync(state_root / "demo") is False
+    monkeypatch.setattr(uninstall_module, "get_user_plugin_exec_root", lambda: state_root)
+    monkeypatch.setattr(
+        uninstall_module, "PLUGIN_CONFIG_ROOTS", (state_root, builtin_root)
+    )
+    assert uninstall_module._path_within_plugin_roots_sync(state_root / "demo") is False
 
 
 @pytest.mark.plugin_unit
@@ -2503,11 +2546,19 @@ async def test_delete_plugin_removes_directory_and_metadata(
             refresh_calls.append("refresh")
             return {"success": True}
 
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
-        monkeypatch.setattr(module.plugin_registry_service, "refresh_registry", _refresh_registry)
+        monkeypatch.setattr(uninstall_module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
+            "refresh_registry",
+            _refresh_registry,
+        )
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: events.append(dict(event)))
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-        monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+        monkeypatch.setattr(
+            uninstall_module, "get_install_source_manager", lambda: install_source_manager
+        )
+        monkeypatch.setattr(
+            uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+        )
 
         service = module.PluginLifecycleService()
         response = await service.delete_plugin("demo_plugin")
@@ -2515,6 +2566,8 @@ async def test_delete_plugin_removes_directory_and_metadata(
         assert response["success"] is True
         assert response["plugin_id"] == "demo_plugin"
         assert response["deleted_from_disk"] is True
+        assert response["preference_action"] == "cleared"
+        assert response["runtime_restart"] == "not_needed"
         assert refresh_calls == ["refresh"]
         assert plugin_dir.exists() is False
         assert profile_dir.exists() is False
@@ -2540,7 +2593,7 @@ async def test_delete_plugin_removes_directory_and_metadata(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
-async def test_delete_plugin_restores_profile_and_restarts_after_directory_failure(
+async def test_delete_plugin_restores_profile_and_restarts_after_code_staging_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2570,30 +2623,44 @@ async def test_delete_plugin_restores_profile_and_restarts_after_directory_failu
 
         async def _stop_plugin(self, plugin_id: str, **_kwargs: object) -> dict[str, object]:
             assert plugin_id == "running_plugin"
+            with module.state.acquire_plugin_hosts_write_lock():
+                module.state.plugin_hosts.pop(plugin_id, None)
             return {"success": True}
 
         async def _start_plugin(self, plugin_id: str, **_kwargs: object) -> dict[str, object]:
             restart_calls.append(plugin_id)
             return {"success": True}
 
-        def _fail_directory_delete(path: Path) -> bool:
+        def _fail_code_staging(path: Path) -> object:
             assert path == plugin_dir
             raise PermissionError("plugin is in use")
 
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-        monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+        monkeypatch.setattr(uninstall_module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
+        monkeypatch.setattr(
+            uninstall_module, "get_install_source_manager", lambda: install_source_manager
+        )
+        monkeypatch.setattr(
+            uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+        )
         monkeypatch.setattr(module.PluginLifecycleService, "stop_plugin", _stop_plugin)
         monkeypatch.setattr(module.PluginLifecycleService, "start_plugin", _start_plugin)
-        monkeypatch.setattr(module, "_delete_plugin_directory_sync", _fail_directory_delete)
+        monkeypatch.setattr(
+            uninstall_module, "_stage_plugin_code_sync", _fail_code_staging
+        )
 
-        with pytest.raises(ServerDomainError, match="Failed to delete plugin"):
+        with pytest.raises(ServerDomainError, match="Failed to delete plugin") as captured:
             await module.PluginLifecycleService().delete_plugin("running_plugin")
 
+        assert captured.value.details["stage"] == "stage_code"
+        assert captured.value.details["filesystem_rollback"] == "completed"
+        assert captured.value.details["runtime_restart"] == "succeeded"
         assert profile_dir.is_dir()
         assert (profile_dir / "settings.toml").is_file()
+        assert plugin_dir.is_dir()
+        assert config_path.is_file()
         assert restart_calls == ["running_plugin"]
         assert install_source_manager.marked_removed == []
+        assert install_source_manager.restored_entries == []
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()
@@ -2617,10 +2684,14 @@ def test_delete_keeps_profile_shared_by_another_bundle_plugin(
         package_id="shared_bundle",
         active_package_ids=("shared_bundle",),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is None
     assert profile_dir.is_dir()
@@ -2637,15 +2708,19 @@ def test_delete_uses_plugin_directory_name_for_legacy_empty_package_id(
     profile_dir = profiles_root / plugin_dir.name
     profile_dir.mkdir(parents=True)
     install_source_manager = _FakeInstallSourceManager(package_id="")
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
     assert staged_profile.original_dir == profile_dir
     assert profile_dir.exists() is False
-    assert module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
+    assert uninstall_module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
     assert staged_profile.staged_dir.exists() is False
 
 
@@ -2666,13 +2741,15 @@ def test_delete_legacy_empty_profile_dir_uses_explicit_config_root_sibling(
     )
     monkeypatch.setenv("PLUGIN_CONFIG_ROOT", str(custom_exec_root))
     monkeypatch.delenv("PACKAGE_PROFILES_ROOT", raising=False)
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
     assert staged_profile.original_dir == profile_dir.resolve()
-    module._restore_staged_package_profile_sync(staged_profile)
+    uninstall_module._restore_staged_package_profile_sync(staged_profile)
     assert (profile_dir / "settings.toml").is_file()
 
 
@@ -2700,10 +2777,14 @@ def test_delete_skips_legacy_inference_when_another_legacy_row_is_installed(
         active_directory_names=("legacy_bundle_sibling",),
         active_channels=("imported",),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
     assert (profile_dir / "sibling_config.toml").is_file()
 
 
@@ -2732,10 +2813,14 @@ def test_delete_skips_cleanup_when_a_sibling_row_lacks_a_package_id(
         active_directory_names=("shared_b",),
         active_channels=("imported",),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
     assert (profile_dir / "sibling_config.toml").is_file()
 
 
@@ -2755,10 +2840,14 @@ def test_delete_still_cleans_legacy_profile_when_other_rows_record_package_ids(
         active_directory_names=("some_other_plugin",),
         active_channels=("imported",),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
     assert profile_dir.exists() is False
@@ -2774,10 +2863,14 @@ def test_delete_does_not_infer_profile_ownership_for_manual_plugin(
     profile_dir = profiles_root / plugin_dir.name
     profile_dir.mkdir(parents=True)
     install_source_manager = _FakeInstallSourceManager(package_id="", channel="manual")
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
     assert profile_dir.is_dir()
 
 
@@ -2794,45 +2887,15 @@ def test_delete_does_not_infer_profile_ownership_for_new_profileless_package(
         package_id="profileless_package",
         profile_installed=False,
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
-
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
-    assert profile_dir.is_dir()
-
-
-@pytest.mark.plugin_unit
-@pytest.mark.asyncio
-async def test_delete_plugin_serializes_profile_ownership_transactions(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    started = asyncio.Event()
-    release = asyncio.Event()
-    calls: list[str] = []
-
-    async def _blocked_delete(_self: object, plugin_id: str) -> dict[str, object]:
-        calls.append(plugin_id)
-        if len(calls) == 1:
-            started.set()
-            await release.wait()
-        return {"plugin_id": plugin_id}
-
     monkeypatch.setattr(
-        module.PluginLifecycleService,
-        "_delete_plugin_unlocked",
-        _blocked_delete,
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
     )
-    service = module.PluginLifecycleService()
-    first = asyncio.create_task(service.delete_plugin("first"))
-    await started.wait()
-    second = asyncio.create_task(service.delete_plugin("second"))
-    await asyncio.sleep(0)
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert calls == ["first"]
-    release.set()
-    assert await first == {"plugin_id": "first"}
-    assert await second == {"plugin_id": "second"}
-    assert calls == ["first", "second"]
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert profile_dir.is_dir()
 
 
 @pytest.mark.plugin_unit
@@ -2853,10 +2916,14 @@ def test_delete_keeps_profile_shared_by_same_named_plugin_in_another_root(
         active_root_ids=("builtin",),
         active_directory_names=(plugin_dir.name,),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
     assert profile_dir.is_dir()
 
 
@@ -2876,13 +2943,17 @@ def test_delete_does_not_treat_manual_plugin_as_package_profile_owner(
         active_profile_dirs=(str(profile_dir),),
         active_channels=("manual",),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
-    assert module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
+    assert uninstall_module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
     assert profile_dir.exists() is False
 
 
@@ -2899,13 +2970,17 @@ def test_delete_removes_profile_from_recorded_custom_root(
         package_id="custom_package",
         profile_dir=str(profile_dir),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
-    assert module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
+    assert uninstall_module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
     assert profile_dir.exists() is False
 
 
@@ -2924,17 +2999,19 @@ def test_delete_removes_recorded_profile_after_profile_root_changes(
         profile_dir=str(profile_dir),
         profile_installed=True,
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
     monkeypatch.setattr(
-        module,
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module,
         "get_user_package_profiles_root",
         lambda: current_profiles_root,
     )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
-    assert module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
+    assert uninstall_module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
     assert profile_dir.exists() is False
 
 
@@ -2954,11 +3031,15 @@ def test_delete_preserves_recorded_profile_under_plugin_state_root(
         profile_dir=str(profile_dir),
         profile_installed=True,
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: tmp_path / "profiles")
-    monkeypatch.setattr(module, "get_plugin_state_root", lambda: state_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: tmp_path / "profiles"
+    )
+    monkeypatch.setattr(uninstall_module, "get_plugin_state_root", lambda: state_root)
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is None
     assert state_file.read_bytes() == b"persistent legacy state"
@@ -2981,12 +3062,16 @@ def test_delete_preserves_recorded_profile_under_builtin_root(
         profile_dir=str(profile_dir),
         profile_installed=True,
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: tmp_path / "profiles")
-    monkeypatch.setattr(module, "get_plugin_state_root", lambda: tmp_path / "state")
-    monkeypatch.setattr(module, "BUILTIN_PLUGIN_CONFIG_ROOT", builtin_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: tmp_path / "profiles"
+    )
+    monkeypatch.setattr(uninstall_module, "get_plugin_state_root", lambda: tmp_path / "state")
+    monkeypatch.setattr(uninstall_module, "BUILTIN_PLUGIN_CONFIG_ROOT", builtin_root)
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is None
     assert builtin_manifest.read_bytes() == b"immutable builtin"
@@ -3012,10 +3097,14 @@ def test_delete_refuses_symlinked_recorded_profile(
         return path == profile_link or original_is_symlink(path)
 
     monkeypatch.setattr(Path, "is_symlink", _is_symlink)
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
     assert install_source_manager.marked_removed == []
 
 
@@ -3039,10 +3128,14 @@ def test_delete_refuses_recorded_profile_below_symlinked_ancestor(
         return path == symlinked_ancestor or original_is_symlink(path)
 
     monkeypatch.setattr(Path, "is_symlink", _is_symlink)
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    assert module._stage_orphaned_package_profile_sync(plugin_dir) is None
+    assert uninstall_module._stage_orphaned_package_profile_sync(plugin_dir) is None
     assert install_source_manager.marked_removed == []
 @pytest.mark.plugin_unit
 def test_delete_removes_profile_not_shared_at_a_different_custom_root(
@@ -3061,13 +3154,17 @@ def test_delete_removes_profile_not_shared_at_a_different_custom_root(
         active_package_ids=("shared_package",),
         active_profile_dirs=(str(other_profile_dir),),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is not None
-    assert module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
+    assert uninstall_module._finalize_staged_package_profile_sync(staged_profile) == profile_dir
     assert profile_dir.exists() is False
     assert other_profile_dir.is_dir()
 
@@ -3083,12 +3180,16 @@ def test_delete_ignores_install_source_listing_failure(
     profile_dir.mkdir(parents=True)
     install_source_manager = _FakeInstallSourceManager(
         package_id="demo_package",
-        list_entries_error=module.InstallSourceError("lock_read_failed"),
+        list_entries_error=uninstall_module.InstallSourceError("lock_read_failed"),
     )
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
-    staged_profile = module._stage_orphaned_package_profile_sync(plugin_dir)
+    staged_profile = uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert staged_profile is None
     assert profile_dir.is_dir()
@@ -3105,18 +3206,22 @@ def test_delete_propagates_profile_staging_failure_for_retry(
     profile_dir = profiles_root / "demo_package"
     profile_dir.mkdir(parents=True)
     install_source_manager = _FakeInstallSourceManager(package_id="demo_package")
-    monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
-    monkeypatch.setattr(module, "get_user_package_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(
+        uninstall_module, "get_install_source_manager", lambda: install_source_manager
+    )
+    monkeypatch.setattr(
+        uninstall_module, "get_user_package_profiles_root", lambda: profiles_root
+    )
 
     def _fail_to_stage(self: Path, target: Path) -> Path:
         assert self == profile_dir
         assert target.name.startswith(".demo_package.deleting-")
         raise PermissionError("profile is in use")
 
-    monkeypatch.setattr(module.Path, "replace", _fail_to_stage)
+    monkeypatch.setattr(uninstall_module.Path, "replace", _fail_to_stage)
 
     with pytest.raises(PermissionError, match="profile is in use"):
-        module._stage_orphaned_package_profile_sync(plugin_dir)
+        uninstall_module._stage_orphaned_package_profile_sync(plugin_dir)
 
     assert install_source_manager.marked_removed == []
     assert profile_dir.is_dir()
@@ -3131,19 +3236,19 @@ def test_deferred_profile_cleanup_is_persisted_and_retried(
     staged_dir = tmp_path / "profiles" / ".demo_package.deleting-0123456789abcdef0123456789abcdef"
     staged_dir.mkdir(parents=True)
     (staged_dir / "config.toml").write_text("value = true\n", encoding="utf-8")
-    staged_profile = module._StagedPackageProfile(
+    staged_profile = uninstall_module._StagedPackageProfile(
         original_dir=tmp_path / "profiles" / "demo_package",
         staged_dir=staged_dir,
     )
     monkeypatch.setattr(
-        module,
+        uninstall_module,
         "_deferred_profile_cleanup_record_path_sync",
         lambda: record_path,
     )
 
-    assert module._record_deferred_profile_cleanup_sync(staged_profile) is True
+    assert uninstall_module._record_deferred_profile_cleanup_sync(staged_profile) is True
     assert record_path.is_file()
-    assert module._retry_deferred_profile_cleanup_sync() == 1
+    assert uninstall_module.retry_deferred_profile_cleanup_sync() == 1
     assert staged_dir.exists() is False
     assert record_path.exists() is False
 
@@ -3160,18 +3265,18 @@ def test_deferred_profile_cleanup_retries_dotted_package_ids(
     )
     staged_dir.mkdir(parents=True)
     (staged_dir / "config.toml").write_text("value = true\n", encoding="utf-8")
-    staged_profile = module._StagedPackageProfile(
+    staged_profile = uninstall_module._StagedPackageProfile(
         original_dir=tmp_path / "profiles" / "com.example.demo",
         staged_dir=staged_dir,
     )
     monkeypatch.setattr(
-        module,
+        uninstall_module,
         "_deferred_profile_cleanup_record_path_sync",
         lambda: record_path,
     )
 
-    assert module._record_deferred_profile_cleanup_sync(staged_profile) is True
-    assert module._retry_deferred_profile_cleanup_sync() == 1
+    assert uninstall_module._record_deferred_profile_cleanup_sync(staged_profile) is True
+    assert uninstall_module.retry_deferred_profile_cleanup_sync() == 1
     assert staged_dir.exists() is False
 
 
@@ -3185,22 +3290,22 @@ def test_deferred_profile_cleanup_migrates_legacy_record(
     staged_dir = tmp_path / "profiles" / (".demo.deleting-" + "a" * 32)
     staged_dir.mkdir(parents=True)
     legacy_record_path.parent.mkdir(parents=True)
-    module._save_deferred_profile_cleanup_paths_sync(
+    uninstall_module._save_deferred_profile_cleanup_paths_sync(
         legacy_record_path,
         [str(staged_dir)],
     )
     monkeypatch.setattr(
-        module,
+        uninstall_module,
         "_deferred_profile_cleanup_record_path_sync",
         lambda: record_path,
     )
     monkeypatch.setattr(
-        module,
+        uninstall_module,
         "_legacy_deferred_profile_cleanup_record_path_sync",
         lambda: legacy_record_path,
     )
 
-    assert module._retry_deferred_profile_cleanup_sync() == 1
+    assert uninstall_module.retry_deferred_profile_cleanup_sync() == 1
     assert staged_dir.exists() is False
     assert legacy_record_path.exists() is False
     assert record_path.exists() is False
@@ -3214,19 +3319,19 @@ def test_unreadable_deferred_cleanup_record_is_never_overwritten(
     """A record we could not parse still names staging dirs nobody else tracks."""
     record_path = tmp_path / "package_profile_cleanup.json"
     record_path.write_text("{ not json", encoding="utf-8")
-    staged_profile = module._StagedPackageProfile(
+    staged_profile = uninstall_module._StagedPackageProfile(
         original_dir=tmp_path / "profiles" / "demo_package",
         staged_dir=tmp_path / "profiles" / (".demo_package.deleting-" + "a" * 32),
     )
     monkeypatch.setattr(
-        module,
+        uninstall_module,
         "_deferred_profile_cleanup_record_path_sync",
         lambda: record_path,
     )
 
-    assert module._load_deferred_profile_cleanup_paths_sync(record_path) is None
-    assert module._record_deferred_profile_cleanup_sync(staged_profile) is False
-    assert module._retry_deferred_profile_cleanup_sync() == 0
+    assert uninstall_module._load_deferred_profile_cleanup_paths_sync(record_path) is None
+    assert uninstall_module._record_deferred_profile_cleanup_sync(staged_profile) is False
+    assert uninstall_module.retry_deferred_profile_cleanup_sync() == 0
     assert record_path.read_text(encoding="utf-8") == "{ not json"
 
 
@@ -3241,16 +3346,16 @@ def test_deferred_cleanup_recording_swallows_non_oserror(
         raise RuntimeError("plugin config root unavailable")
 
     monkeypatch.setattr(
-        module,
+        uninstall_module,
         "_deferred_profile_cleanup_record_path_sync",
         _raise_runtime_error,
     )
-    staged_profile = module._StagedPackageProfile(
+    staged_profile = uninstall_module._StagedPackageProfile(
         original_dir=tmp_path / "profiles" / "demo_package",
         staged_dir=tmp_path / "profiles" / (".demo_package.deleting-" + "a" * 32),
     )
 
-    assert module._record_deferred_profile_cleanup_sync(staged_profile) is False
+    assert uninstall_module._record_deferred_profile_cleanup_sync(staged_profile) is False
 
 
 @pytest.mark.plugin_unit
@@ -3299,12 +3404,18 @@ async def test_delete_plugin_stops_running_host_before_removing(
             stop_calls.append(plugin_id)
             return await original_stop_plugin(self, plugin_id)
 
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
+        monkeypatch.setattr(uninstall_module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
         monkeypatch.setattr(module.PluginLifecycleService, "stop_plugin", _tracked_stop)
-        monkeypatch.setattr(module.plugin_registry_service, "refresh_registry", _refresh_registry)
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
+            "refresh_registry",
+            _refresh_registry,
+        )
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
         install_source_manager = _FakeInstallSourceManager(package_id="")
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
+        monkeypatch.setattr(
+            uninstall_module, "get_install_source_manager", lambda: install_source_manager
+        )
 
         service = module.PluginLifecycleService()
         response = await service.delete_plugin("running_plugin")
@@ -3369,11 +3480,17 @@ async def test_delete_plugin_clears_runtime_override(
         async def _refresh_registry() -> dict[str, object]:
             return {"success": True}
 
-        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
-        monkeypatch.setattr(module.plugin_registry_service, "refresh_registry", _refresh_registry)
+        monkeypatch.setattr(uninstall_module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
+            "refresh_registry",
+            _refresh_registry,
+        )
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
         install_source_manager = _FakeInstallSourceManager(package_id="")
-        monkeypatch.setattr(module, "get_install_source_manager", lambda: install_source_manager)
+        monkeypatch.setattr(
+            uninstall_module, "get_install_source_manager", lambda: install_source_manager
+        )
 
         service = module.PluginLifecycleService()
         await service.delete_plugin("demo_plugin")

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -14,6 +14,7 @@ from plugin._types.exceptions import PluginLifecycleError
 from plugin.core import registry as registry_module
 from plugin.server.application.plugins import query_service as query_module
 from plugin.server.application.plugins import lifecycle_service as module
+from plugin.server.application.plugins import operation_lock as operation_lock_module
 import plugin.server.application.plugins.installation_transactions.uninstall as uninstall_module
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure import runtime_overrides as runtime_overrides_module
@@ -73,6 +74,66 @@ class _CaptureLogger:
         for arg in args:
             rendered = rendered.replace("{}", str(arg), 1)
         self.errors.append(rendered)
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["start", "stop"])
+async def test_runtime_mutations_wait_for_plugin_operation_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    plugin_id = "serialized_plugin"
+    host = _FakeProcessHost(
+        plugin_id=plugin_id,
+        entry_point="tests.fake:Plugin",
+        config_path=tmp_path / plugin_id / "plugin.toml",
+    )
+    hosts_backup = dict(module.state.plugin_hosts)
+    second_acquire_attempted = asyncio.Event()
+    original_acquire = operation_lock_module._PROCESS_LOCK.acquire
+    acquire_calls = 0
+
+    async def _tracked_acquire() -> None:
+        nonlocal acquire_calls
+        acquire_calls += 1
+        if acquire_calls == 2:
+            second_acquire_attempted.set()
+        await original_acquire()
+
+    async def _clear_tools(_plugin_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        operation_lock_module._PROCESS_LOCK,
+        "acquire",
+        _tracked_acquire,
+    )
+    monkeypatch.setattr(module, "clear_plugin_llm_tools", _clear_tools)
+
+    try:
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts[plugin_id] = host
+
+        service = module.PluginLifecycleService()
+        async with operation_lock_module.plugin_operation_lock.hold():
+            if operation == "start":
+                task = asyncio.create_task(
+                    service.start_plugin(plugin_id, refresh_registry=False)
+                )
+            else:
+                task = asyncio.create_task(service.stop_plugin(plugin_id))
+            await asyncio.wait_for(second_acquire_attempted.wait(), timeout=5)
+            assert task.done() is False
+
+        response = await asyncio.wait_for(task, timeout=5)
+        assert response["success"] is True
+    finally:
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
 
 
 class _FakeInstallSourceManager:

--- a/plugin/tests/unit/server/test_uninstall_transaction.py
+++ b/plugin/tests/unit/server/test_uninstall_transaction.py
@@ -755,13 +755,18 @@ async def test_uninstall_rollback_keeps_newer_concurrent_preference(
     )
 
     task = asyncio.create_task(uninstall_plugin("demo"))
-    await asyncio.to_thread(commit_entered.wait)
-    runtime_overrides_module.set_runtime_override("demo", True)
-    release_commit.set()
+    entered = False
+    try:
+        entered = await asyncio.to_thread(commit_entered.wait, 5)
+        if entered:
+            runtime_overrides_module.set_runtime_override("demo", True)
+    finally:
+        release_commit.set()
 
     with pytest.raises(UninstallPluginError) as captured:
         await task
 
+    assert entered is True
     assert captured.value.filesystem_rollback == "completed"
     assert "preference_rollback" not in _details_of(captured.value)
     assert _isolate_runtime_overrides == {"demo": True}
@@ -914,7 +919,12 @@ async def test_uninstall_committed_code_cleanup_failure_is_pending(
     transaction_dirs = list(backup_root.iterdir())
     assert len(transaction_dirs) == 1
     assert (transaction_dirs[0] / "committed.json").is_file()
-    assert (transaction_dirs[0] / "demo" / "plugin.toml").is_file()
+    assert (
+        transaction_dirs[0]
+        / uninstall_module._CODE_PAYLOAD_DIR_NAME
+        / "demo"
+        / "plugin.toml"
+    ).is_file()
 
     assert uninstall_module.retry_deferred_plugin_code_cleanup_sync() == 1
     assert backup_root.exists() is False
@@ -952,6 +962,25 @@ def test_committed_code_cleanup_keeps_marker_after_partial_payload_failure(
 
 
 @pytest.mark.plugin_unit
+def test_code_marker_cannot_collide_with_valid_plugin_directory_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    harness = _Harness(tmp_path, plugin_names=("committed.json",))
+    harness.install(monkeypatch)
+    plugin_dir = harness.exec_root / "committed.json"
+
+    staged = uninstall_module._stage_plugin_code_sync(plugin_dir)
+    committed = uninstall_module._commit_staged_plugin_code_sync(staged)
+
+    assert staged.staged_dir.is_dir()
+    assert staged.staged_dir.name == "committed.json"
+    assert committed.marker_path.is_file()
+    assert committed.marker_path != staged.staged_dir
+    assert uninstall_module._finalize_committed_plugin_code_sync(committed) is True
+
+
+@pytest.mark.plugin_unit
 def test_deferred_code_cleanup_refuses_unmarked_backup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -959,7 +988,7 @@ def test_deferred_code_cleanup_refuses_unmarked_backup(
     harness = _Harness(tmp_path)
     harness.install(monkeypatch)
     transaction_dir = harness.exec_root / ".uninstall-backups" / ("a" * 32)
-    staged_dir = transaction_dir / "demo"
+    staged_dir = transaction_dir / uninstall_module._CODE_PAYLOAD_DIR_NAME / "demo"
     staged_dir.mkdir(parents=True)
     (staged_dir / "plugin.toml").write_text(
         "[plugin]\nid='demo'\n",

--- a/plugin/tests/unit/server/test_uninstall_transaction.py
+++ b/plugin/tests/unit/server/test_uninstall_transaction.py
@@ -600,6 +600,35 @@ async def test_uninstall_ignores_unrelated_registry_scan_failure(
 
 
 @pytest.mark.plugin_unit
+def test_registry_failure_path_disambiguates_runtime_alias_declared_id(
+    tmp_path: Path,
+) -> None:
+    target_config = tmp_path / "user" / "demo" / "plugin.toml"
+    builtin_config = tmp_path / "builtin" / "demo" / "plugin.toml"
+    target = uninstall_module._RegistryRefreshTarget(
+        runtime_plugin_id="demo_1",
+        declared_plugin_id="demo",
+        config_paths=(target_config, builtin_config),
+    )
+
+    assert uninstall_module._registry_failure_matches_target(
+        {
+            "plugin_id": "demo",
+            "config_path": str(tmp_path / "other" / "demo" / "plugin.toml"),
+        },
+        target=target,
+    ) is False
+    assert uninstall_module._registry_failure_matches_target(
+        {"plugin_id": "different", "config_path": str(builtin_config)},
+        target=target,
+    ) is True
+    assert uninstall_module._registry_failure_matches_target(
+        {"plugin_id": "demo"},
+        target=target,
+    ) is True
+
+
+@pytest.mark.plugin_unit
 @pytest.mark.asyncio
 async def test_uninstall_restores_then_propagates_system_exit(
     monkeypatch: pytest.MonkeyPatch,
@@ -849,6 +878,37 @@ async def test_uninstall_committed_code_cleanup_failure_is_pending(
 
     assert uninstall_module.retry_deferred_plugin_code_cleanup_sync() == 1
     assert backup_root.exists() is False
+
+
+@pytest.mark.plugin_unit
+def test_committed_code_cleanup_keeps_marker_after_partial_payload_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    staged = uninstall_module._stage_plugin_code_sync(harness.plugin_dir)
+    committed = uninstall_module._commit_staged_plugin_code_sync(staged)
+    real_rmtree = uninstall_module.shutil.rmtree
+    failed_once = False
+
+    def _partially_remove_then_fail(path: Path) -> None:
+        nonlocal failed_once
+        if Path(path) == staged.staged_dir and not failed_once:
+            failed_once = True
+            (staged.staged_dir / "plugin.toml").unlink()
+            raise OSError("staged payload locked")
+        real_rmtree(path)
+
+    monkeypatch.setattr(uninstall_module.shutil, "rmtree", _partially_remove_then_fail)
+
+    with pytest.raises(OSError, match="staged payload locked"):
+        uninstall_module._finalize_committed_plugin_code_sync(committed)
+
+    assert committed.marker_path.is_file()
+    assert staged.staged_dir.is_dir()
+    assert uninstall_module.retry_deferred_plugin_code_cleanup_sync() == 1
+    assert committed.marker_path.parent.exists() is False
 
 
 @pytest.mark.plugin_unit

--- a/plugin/tests/unit/server/test_uninstall_transaction.py
+++ b/plugin/tests/unit/server/test_uninstall_transaction.py
@@ -1,0 +1,1066 @@
+"""Deterministic fault-injection tests for the uninstall transaction."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from plugin.server.application.install_source.manager import InstallSourceError
+from plugin.server.application.install_source.models import LockEntry
+from plugin.server.application.plugins import lifecycle_service as lifecycle_module
+from plugin.server.application.plugins import operation_lock as operation_lock_module
+import plugin.server.application.plugins.installation_transactions.uninstall as uninstall_module
+from plugin.server.application.plugins.installation_transactions.uninstall import (
+    UninstallPluginError,
+    uninstall_plugin,
+)
+from plugin.server.domain.errors import ServerDomainError
+from plugin.server.infrastructure import runtime_overrides as runtime_overrides_module
+
+
+@pytest.fixture(autouse=True)
+def _isolate_operation_file_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Never let unit tests contend with a running user's Core process."""
+
+    monkeypatch.setenv(
+        "NEKO_PLUGIN_OPERATION_LOCK_PATH",
+        str(tmp_path / "operation.lock"),
+    )
+
+
+def _entry(
+    *,
+    plugin_id: str = "demo",
+    directory_name: str = "demo",
+    channel: str = "imported",
+) -> LockEntry:
+    return LockEntry(
+        root_id="user",  # type: ignore[arg-type]
+        directory_name=directory_name,
+        plugin_id=plugin_id,
+        channel=channel,  # type: ignore[arg-type]
+        reason="user_requested",
+        installed_at="2026-08-29T00:00:00.000000Z",
+        updated_at="2026-08-29T00:00:00.000000Z",
+        last_seen_at="2026-08-29T00:00:00.000000Z",
+    )
+
+
+class _FakeManager:
+    """Minimal install-source manager double keyed by directory name."""
+
+    def __init__(
+        self,
+        plugin_names: tuple[str, ...] = ("demo",),
+        *,
+        mark_removed_error: Exception | None = None,
+    ) -> None:
+        self.plugin_names = tuple(plugin_names)
+        self.is_degraded = False
+        self.mark_removed_error = mark_removed_error
+        self.marked_removed: list[Path] = []
+        self.restored_entries: list[LockEntry] = []
+        self.load_calls = 0
+        self.entries = {
+            name: _entry(plugin_id=name, directory_name=name) for name in plugin_names
+        }
+
+    def load(self) -> None:
+        self.load_calls += 1
+
+    def entry_for_directory(
+        self,
+        directory_path: Path,
+        *,
+        include_removed: bool = False,
+    ) -> LockEntry | None:
+        entry = self.entries.get(directory_path.name)
+        if entry is None or (entry.removed and not include_removed):
+            return None
+        return entry
+
+    def list_entries(self) -> list[LockEntry]:
+        return [entry for entry in self.entries.values() if not entry.removed]
+
+    def mark_removed(self, *, directory_path: Path) -> None:
+        if self.mark_removed_error is not None:
+            raise self.mark_removed_error
+        self.marked_removed.append(directory_path)
+        entry = self.entries[directory_path.name]
+        self.entries[directory_path.name] = replace(
+            entry,
+            removed=True,
+            removed_at="2026-08-30T00:00:00.000000Z",
+        )
+
+    def restore_entry_for_rollback(self, entry: LockEntry) -> None:
+        self.restored_entries.append(entry)
+        self.entries[entry.directory_name] = entry
+
+
+class _Harness:
+    """Build managed user plugins with isolated roots, fakes and a run log."""
+
+    def __init__(
+        self, tmp_path: Path, *, plugin_names: tuple[str, ...] = ("demo",)
+    ) -> None:
+        self.tmp_path = tmp_path
+        self.plugin_names = plugin_names
+        self.exec_root = tmp_path / "exec"
+        self.builtin_root = tmp_path / "builtin"
+        self.state_root = tmp_path / "state" / "plugins"
+        self.profiles_root = tmp_path / "profiles"
+        self.exec_root.mkdir(parents=True)
+        self.builtin_root.mkdir(parents=True)
+        for name in plugin_names:
+            self.make_plugin(name)
+        self.config_dir = tmp_path / "persistent" / "config" / "demo"
+        self.config_dir.mkdir(parents=True)
+        self.config_file = self.config_dir / "settings.toml"
+        self.config_file.write_text("value = 1\n", encoding="utf-8")
+        self.data_file = self.state_root / "demo" / "data" / "data.db"
+        self.data_file.parent.mkdir(parents=True)
+        self.data_file.write_bytes(b"persistent-data")
+        self.cache_file = tmp_path / "persistent" / "cache" / "demo" / "blob"
+        self.cache_file.parent.mkdir(parents=True)
+        self.cache_file.write_bytes(b"cached-blob")
+        self.manager = _FakeManager(plugin_names)
+        self.running: set[str] = set()
+        self.stop_calls: list[str] = []
+        self.start_calls: list[str] = []
+        self.refresh_calls = 0
+        self.refresh_error: Exception | None = None
+        self.refresh_result: dict[str, object] = {"success": True}
+        self.stop_error: Exception | None = None
+        self.builtin_after_refresh = False
+        self.log: list[str] = []
+
+    def make_plugin(self, name: str) -> None:
+        plugin_dir = self.exec_root / name
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.toml").write_text(
+            f"[plugin]\nid='{name}'\n", encoding="utf-8"
+        )
+
+    @property
+    def plugin_dir(self) -> Path:
+        return self.exec_root / "demo"
+
+    @property
+    def config_path(self) -> Path:
+        return self.plugin_dir / "plugin.toml"
+
+    @property
+    def builtin_config(self) -> Path:
+        return self.builtin_root / "demo" / "plugin.toml"
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            uninstall_module, "get_user_plugin_exec_root", lambda: self.exec_root
+        )
+        monkeypatch.setattr(
+            uninstall_module, "get_plugin_state_root", lambda: self.state_root
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "get_user_package_profiles_root",
+            lambda: self.profiles_root,
+        )
+        monkeypatch.setattr(
+            uninstall_module, "BUILTIN_PLUGIN_CONFIG_ROOT", self.builtin_root
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "PLUGIN_CONFIG_ROOTS",
+            (self.exec_root, self.builtin_root),
+        )
+        monkeypatch.setattr(
+            uninstall_module,
+            "get_install_source_manager",
+            lambda: self.manager,
+        )
+        monkeypatch.setattr(
+            lifecycle_module,
+            "_get_plugin_meta_sync",
+            self._get_plugin_meta_sync,
+        )
+        monkeypatch.setattr(
+            lifecycle_module,
+            "_plugin_is_running_sync",
+            self._plugin_is_running_sync,
+        )
+        monkeypatch.setattr(
+            uninstall_module.plugin_registry_service,
+            "refresh_registry",
+            self._refresh_registry,
+        )
+        monkeypatch.setattr(
+            lifecycle_module.PluginLifecycleService,
+            "stop_plugin",
+            self._stop_plugin,
+        )
+        monkeypatch.setattr(
+            lifecycle_module.PluginLifecycleService,
+            "start_plugin",
+            self._start_plugin,
+        )
+
+    def _get_plugin_meta_sync(self, plugin_id: str) -> dict[str, object]:
+        source = (
+            "builtin"
+            if self.builtin_after_refresh and self.refresh_calls > 0
+            else "user"
+        )
+        return {
+            "id": plugin_id,
+            "config_path": str(self.exec_root / plugin_id / "plugin.toml"),
+            "effective_source": source,
+        }
+
+    def _plugin_is_running_sync(self, plugin_id: str) -> bool:
+        return plugin_id in self.running
+
+    async def _refresh_registry(self) -> dict[str, object]:
+        self.refresh_calls += 1
+        self.log.append("refresh")
+        if self.refresh_error is not None:
+            raise self.refresh_error
+        return dict(self.refresh_result)
+
+    async def _stop_plugin(
+        self, plugin_id: str, **_kwargs: object
+    ) -> dict[str, object]:
+        self.log.append(f"stop:{plugin_id}")
+        if self.stop_error is not None:
+            raise self.stop_error
+        self.stop_calls.append(plugin_id)
+        self.running.discard(plugin_id)
+        return {"success": True}
+
+    async def _start_plugin(
+        self, plugin_id: str, **_kwargs: object
+    ) -> dict[str, object]:
+        self.start_calls.append(plugin_id)
+        self.running.add(plugin_id)
+        return {"success": True}
+
+    def persistent_hashes(self) -> dict[Path, str]:
+        return {
+            path: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in (self.config_file, self.data_file, self.cache_file)
+        }
+
+
+def _package_entry_fakes(
+    monkeypatch: pytest.MonkeyPatch, harness: _Harness, package_id: str = "demo_package"
+) -> None:
+    """Make the fake manager describe one package-owned profile for demo."""
+
+    def _entry_for_directory(
+        self: _FakeManager, directory_path: Path, *, include_removed: bool = False
+    ) -> SimpleNamespace:
+        del include_removed
+        return SimpleNamespace(
+            package_id=package_id,
+            plugin_id=directory_path.name,
+            profile_dir="",
+            profile_installed=None,
+            channel="imported",
+            root_id="user",
+            directory_name=directory_path.name,
+            removed=False,
+        )
+
+    def _list_entries(
+        self: _FakeManager, include_removed: bool = False
+    ) -> list[SimpleNamespace]:
+        del include_removed
+        return [_entry_for_directory(self, Path(name)) for name in self.plugin_names]
+
+    monkeypatch.setattr(
+        type(harness.manager), "entry_for_directory", _entry_for_directory
+    )
+    monkeypatch.setattr(type(harness.manager), "list_entries", _list_entries)
+
+
+def _details_of(exc: BaseException) -> dict[str, object]:
+    assert isinstance(exc, UninstallPluginError)
+    return exc.details
+
+
+def _signal_second_operation_lock_acquire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> asyncio.Event:
+    """Signal once the second transaction has actually attempted the lock."""
+    second_acquire_attempted = asyncio.Event()
+    original_acquire = operation_lock_module._PROCESS_LOCK.acquire
+    acquire_calls = 0
+
+    async def _tracked_acquire() -> None:
+        nonlocal acquire_calls
+        acquire_calls += 1
+        if acquire_calls == 2:
+            second_acquire_attempted.set()
+        await original_acquire()
+
+    monkeypatch.setattr(
+        operation_lock_module._PROCESS_LOCK,
+        "acquire",
+        _tracked_acquire,
+    )
+    return second_acquire_attempted
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_success_reports_commit_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.running.add("demo")
+    harness.install(monkeypatch)
+    runtime_overrides_module.set_runtime_override("demo", False)
+
+    result = await uninstall_plugin("demo")
+
+    assert result.deleted_from_disk is True
+    assert result.plugin_dir == harness.plugin_dir
+    assert result.deleted_profile_dir is None
+    assert result.restored_builtin is False
+    assert result.preference_action == "cleared"
+    assert result.filesystem_rollback == "not_needed"
+    assert result.runtime_restart == "not_needed"
+    assert result.cleanup_pending is False
+    assert harness.manager.load_calls == 1
+    assert harness.stop_calls == ["demo"]
+    assert harness.start_calls == []
+    assert harness.manager.marked_removed == [harness.plugin_dir]
+    assert harness.refresh_calls == 1
+    assert harness.plugin_dir.exists() is False
+    assert not (harness.exec_root / ".uninstall-backups").exists()
+    assert _isolate_runtime_overrides == {}
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_stop_failure_keeps_original_runtime_and_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.running.add("demo")
+    harness.stop_error = ServerDomainError(
+        code="PLUGIN_STOP_FAILED",
+        message="stop failed",
+        status_code=500,
+    )
+    harness.install(monkeypatch)
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.code == "PLUGIN_STOP_FAILED"
+    assert captured.value.stage == "stop"
+    assert captured.value.filesystem_rollback == "not_needed"
+    # The original runtime was never stopped, so it is still up.
+    assert captured.value.runtime_restart == "succeeded"
+    assert harness.manager.marked_removed == []
+    assert harness.refresh_calls == 0
+    assert harness.plugin_dir.is_dir()
+    assert harness.config_path.is_file()
+    assert _isolate_runtime_overrides == {}
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_profile_staging_failure_keeps_code_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+
+    def _fail_stage(plugin_dir: Path, *, manager: object = None) -> None:
+        del plugin_dir, manager
+        raise PermissionError("profile is in use")
+
+    monkeypatch.setattr(
+        uninstall_module, "_stage_orphaned_package_profile_sync", _fail_stage
+    )
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "stage_profile"
+    assert captured.value.filesystem_rollback == "not_needed"
+    assert captured.value.runtime_restart == "not_needed"
+    assert harness.plugin_dir.is_dir()
+    assert harness.manager.marked_removed == []
+    assert harness.manager.restored_entries == []
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_code_staging_failure_restores_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    profile_dir = harness.profiles_root / "demo_package"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "settings.toml").write_text("value = 1\n", encoding="utf-8")
+    _package_entry_fakes(monkeypatch, harness)
+
+    def _fail_code_stage(plugin_dir: Path) -> None:
+        del plugin_dir
+        raise PermissionError("code is in use")
+
+    monkeypatch.setattr(uninstall_module, "_stage_plugin_code_sync", _fail_code_stage)
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "stage_code"
+    # The profile was already staged, so the rollback genuinely restored it.
+    assert captured.value.filesystem_rollback == "completed"
+    assert captured.value.runtime_restart == "not_needed"
+    assert profile_dir.is_dir()
+    assert (profile_dir / "settings.toml").is_file()
+    assert harness.plugin_dir.is_dir()
+    assert harness.manager.marked_removed == []
+    assert harness.manager.restored_entries == []
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_source_update_failure_restores_code_and_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    profile_dir = harness.profiles_root / "demo_package"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "settings.toml").write_text("value = 1\n", encoding="utf-8")
+    _package_entry_fakes(monkeypatch, harness)
+    harness.manager.mark_removed_error = InstallSourceError(
+        "LOCK_WRITE_FAILED",
+        "lock write failed",
+    )
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "update_source"
+    assert captured.value.filesystem_rollback == "completed"
+    assert captured.value.runtime_restart == "not_needed"
+    assert harness.plugin_dir.is_dir()
+    assert harness.config_path.is_file()
+    assert profile_dir.is_dir()
+    assert harness.manager.marked_removed == []
+    # The soft-delete was attempted, so rollback best-effort restores the row.
+    assert harness.manager.restored_entries == [
+        harness.manager.entry_for_directory(harness.plugin_dir)
+    ]
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_source_write_then_raise_restores_exact_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    """A source write that persists and then raises must restore the exact row."""
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    source_entry = harness.manager.entry_for_directory(harness.plugin_dir)
+    assert source_entry is not None
+
+    real_mark_removed = type(harness.manager).mark_removed
+
+    def _mark_then_raise(self: _FakeManager, *, directory_path: Path) -> None:
+        real_mark_removed(self, directory_path=directory_path)
+        written_entry = self.entry_for_directory(
+            directory_path,
+            include_removed=True,
+        )
+        assert written_entry is not None and written_entry.removed is True
+        raise InstallSourceError("SAVE_CRASHED", "crashed after write")
+
+    monkeypatch.setattr(type(harness.manager), "mark_removed", _mark_then_raise)
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "update_source"
+    assert captured.value.filesystem_rollback == "completed"
+    assert harness.manager.marked_removed == [harness.plugin_dir]
+    assert harness.manager.restored_entries == [source_entry]
+    assert harness.manager.entry_for_directory(harness.plugin_dir) == source_entry
+    assert harness.plugin_dir.is_dir()
+    assert harness.config_path.is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_registry_refresh_failure_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    harness.refresh_error = RuntimeError("scan crashed")
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "refresh_and_preferences"
+    assert captured.value.filesystem_rollback == "completed"
+    assert captured.value.runtime_restart == "not_needed"
+    # One failing refresh in the stage and one best-effort refresh in rollback.
+    assert harness.refresh_calls == 2
+    assert harness.manager.restored_entries == [
+        harness.manager.entry_for_directory(harness.plugin_dir)
+    ]
+    assert harness.plugin_dir.is_dir()
+    assert harness.config_path.is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_registry_reported_failure_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    harness.refresh_result = {
+        "success": False,
+        "failed": [{"plugin_id": "demo", "error": "scan failed"}],
+    }
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "refresh_and_preferences"
+    assert captured.value.filesystem_rollback == "completed"
+    assert harness.refresh_calls == 2
+    assert harness.manager.entry_for_directory(harness.plugin_dir) is not None
+    assert harness.plugin_dir.is_dir()
+    assert harness.config_path.is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_ignores_unrelated_registry_scan_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    unrelated_config = harness.exec_root / "broken" / "plugin.toml"
+    harness.refresh_result = {
+        "success": False,
+        "failed": [
+            {
+                "plugin_id": "broken",
+                "config_path": str(unrelated_config),
+                "error": "invalid manifest",
+            }
+        ],
+    }
+
+    result = await uninstall_plugin("demo")
+
+    assert result.deleted_from_disk is True
+    assert result.restored_builtin is False
+    assert result.preference_action == "cleared"
+    assert harness.refresh_calls == 1
+    assert harness.manager.entry_for_directory(harness.plugin_dir) is None
+    assert harness.plugin_dir.exists() is False
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_restores_then_propagates_system_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    refresh_calls = 0
+
+    async def _interrupt_once() -> dict[str, object]:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        if refresh_calls == 1:
+            raise SystemExit(17)
+        return {"success": True, "failed": []}
+
+    monkeypatch.setattr(
+        uninstall_module.plugin_registry_service,
+        "refresh_registry",
+        _interrupt_once,
+    )
+
+    with pytest.raises(SystemExit) as captured:
+        # Run the preserved transaction body in this task.  ``asyncio`` treats
+        # SystemExit raised by a child Task as an event-loop shutdown signal,
+        # which would bypass pytest's local exception assertion.
+        await uninstall_plugin.__wrapped__("demo")
+
+    assert captured.value.code == 17
+    assert refresh_calls == 2
+    assert harness.manager.entry_for_directory(harness.plugin_dir) is not None
+    assert harness.plugin_dir.is_dir()
+    assert harness.config_path.is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_preference_clear_failure_restores_preference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    runtime_overrides_module.set_runtime_override("demo", True, auto_start=True)
+
+    real_clear = uninstall_module.clear_runtime_override
+
+    def _clear_then_fail(plugin_id: str) -> None:
+        real_clear(plugin_id)
+        assert runtime_overrides_module.get_runtime_override(plugin_id) is None
+        raise OSError("override disk full")
+
+    monkeypatch.setattr(uninstall_module, "clear_runtime_override", _clear_then_fail)
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "refresh_and_preferences"
+    assert captured.value.filesystem_rollback == "completed"
+    # The pre-commit preference restore ran successfully, so no extra detail.
+    assert "preference_rollback" not in _details_of(captured.value)
+    assert _isolate_runtime_overrides == {"demo": {"enabled": True, "auto_start": True}}
+    assert harness.plugin_dir.is_dir()
+    assert harness.manager.restored_entries != []
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_rollback_restores_running_runtime_and_reports_separately(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.running.add("demo")
+    harness.install(monkeypatch)
+    harness.refresh_error = RuntimeError("scan crashed")
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.filesystem_rollback == "completed"
+    assert captured.value.runtime_restart == "succeeded"
+    assert harness.start_calls == ["demo"]
+    assert harness.plugin_dir.is_dir()
+    assert harness.manager.restored_entries != []
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_rollback_does_not_start_plugin_that_was_not_running(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    harness.refresh_error = RuntimeError("scan crashed")
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.filesystem_rollback == "completed"
+    assert captured.value.runtime_restart == "not_needed"
+    assert harness.stop_calls == []
+    assert harness.start_calls == []
+
+
+def _patch_builtin_restore(monkeypatch: pytest.MonkeyPatch, harness: _Harness) -> None:
+    """Make the harness flip demo to builtin source after refresh."""
+
+    harness.builtin_after_refresh = True
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_restore_builtin_keeps_preferences(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    runtime_overrides_module.set_runtime_override("demo", False, auto_start=False)
+    _patch_builtin_restore(monkeypatch, harness)
+
+    result = await uninstall_plugin("demo")
+
+    assert result.restored_builtin is True
+    assert result.preference_action == "preserved"
+    assert result.runtime_restart == "not_needed"
+    assert _isolate_runtime_overrides == {
+        "demo": {"enabled": False, "auto_start": False}
+    }
+    assert harness.plugin_dir.exists() is False
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_builtin_runtime_restore_failure_is_not_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.running.add("demo")
+    harness.install(monkeypatch)
+    _patch_builtin_restore(monkeypatch, harness)
+
+    async def _fail_start(_self: object, plugin_id: str, **_kwargs: object) -> None:
+        del plugin_id
+        raise ServerDomainError(
+            code="PLUGIN_START_FAILED",
+            message="builtin start failed",
+            status_code=500,
+        )
+
+    monkeypatch.setattr(
+        lifecycle_module.PluginLifecycleService, "start_plugin", _fail_start
+    )
+
+    result = await uninstall_plugin("demo")
+
+    assert result.filesystem_rollback == "not_needed"
+    assert result.runtime_restart == "failed"
+    assert result.cleanup_pending is False
+    assert result.runtime_restart_error == {
+        "code": "PLUGIN_BUILTIN_RESTORE_START_FAILED",
+        "message": "builtin start failed",
+        "error_type": "ServerDomainError",
+    }
+    assert harness.plugin_dir.exists() is False
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_committed_code_cleanup_failure_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+
+    real_finalize = uninstall_module._finalize_committed_plugin_code_sync
+    finalize_calls = 0
+
+    def _fail_finalize_once(
+        committed: uninstall_module._CommittedPluginCodeCleanup,
+    ) -> bool:
+        nonlocal finalize_calls
+        finalize_calls += 1
+        if finalize_calls == 1:
+            raise OSError("staged tree locked")
+        return real_finalize(committed)
+
+    monkeypatch.setattr(
+        uninstall_module,
+        "_finalize_committed_plugin_code_sync",
+        _fail_finalize_once,
+    )
+
+    result = await uninstall_plugin("demo")
+
+    assert result.deleted_from_disk is True
+    assert result.cleanup_pending is True
+    assert result.filesystem_rollback == "not_needed"
+    backup_root = harness.exec_root / ".uninstall-backups"
+    transaction_dirs = list(backup_root.iterdir())
+    assert len(transaction_dirs) == 1
+    assert (transaction_dirs[0] / "committed.json").is_file()
+    assert (transaction_dirs[0] / "demo" / "plugin.toml").is_file()
+
+    assert uninstall_module.retry_deferred_plugin_code_cleanup_sync() == 1
+    assert backup_root.exists() is False
+
+
+@pytest.mark.plugin_unit
+def test_deferred_code_cleanup_refuses_unmarked_backup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    transaction_dir = harness.exec_root / ".uninstall-backups" / ("a" * 32)
+    staged_dir = transaction_dir / "demo"
+    staged_dir.mkdir(parents=True)
+    (staged_dir / "plugin.toml").write_text(
+        "[plugin]\nid='demo'\n",
+        encoding="utf-8",
+    )
+
+    assert uninstall_module.retry_deferred_plugin_code_cleanup_sync() == 0
+    assert (staged_dir / "plugin.toml").is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_startup_cleanup_retries_profile_and_committed_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        lifecycle_module,
+        "retry_deferred_profile_cleanup_sync",
+        lambda: calls.append("profile") or 2,
+    )
+    monkeypatch.setattr(
+        lifecycle_module,
+        "retry_deferred_plugin_code_cleanup_sync",
+        lambda: calls.append("code") or 3,
+    )
+
+    cleaned = await lifecycle_module.PluginLifecycleService().retry_deferred_profile_cleanup()
+
+    assert cleaned == 2
+    assert calls == ["profile", "code"]
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_committed_profile_cleanup_failure_is_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    profile_dir = harness.profiles_root / "demo_package"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "settings.toml").write_text("value = 1\n", encoding="utf-8")
+    _package_entry_fakes(monkeypatch, harness)
+
+    def _fail_finalize(staged_profile: object) -> Path | None:
+        del staged_profile
+        raise OSError("profile tree locked")
+
+    monkeypatch.setattr(
+        uninstall_module, "_finalize_staged_package_profile_sync", _fail_finalize
+    )
+    record_path = tmp_path / "persistent" / "package_profile_cleanup.json"
+    monkeypatch.setattr(
+        uninstall_module,
+        "_deferred_profile_cleanup_record_path_sync",
+        lambda: record_path,
+    )
+
+    result = await uninstall_plugin("demo")
+
+    assert result.deleted_from_disk is True
+    assert result.deleted_profile_dir is None
+    assert result.cleanup_pending is True
+    assert result.filesystem_rollback == "not_needed"
+    assert record_path.is_file()
+    staged = [
+        path
+        for path in harness.profiles_root.iterdir()
+        if path.name.startswith(".demo_package.deleting-")
+    ]
+    assert len(staged) == 1
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_never_touches_config_data_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    hashes_before = harness.persistent_hashes()
+
+    result = await uninstall_plugin("demo")
+
+    assert result.deleted_from_disk is True
+    assert harness.persistent_hashes() == hashes_before
+    assert harness.config_file.is_file()
+    assert harness.data_file.is_file()
+    assert harness.cache_file.is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_serializes_concurrent_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path, plugin_names=("demo", "beta"))
+    harness.running.add("demo")
+    harness.install(monkeypatch)
+    second_acquire_attempted = _signal_second_operation_lock_acquire(monkeypatch)
+    demo_refresh_entered = asyncio.Event()
+    release_demo_refresh = asyncio.Event()
+    original_refresh = harness._refresh_registry
+
+    async def _gated_refresh() -> dict[str, object]:
+        result = await original_refresh()
+        if "demo" in harness.stop_calls and not demo_refresh_entered.is_set():
+            demo_refresh_entered.set()
+            await release_demo_refresh.wait()
+        return result
+
+    monkeypatch.setattr(
+        uninstall_module.plugin_registry_service, "refresh_registry", _gated_refresh
+    )
+
+    demo_task = asyncio.create_task(uninstall_plugin("demo"))
+    await demo_refresh_entered.wait()
+    beta_task = asyncio.create_task(uninstall_plugin("beta"))
+    await second_acquire_attempted.wait()
+
+    assert "stop:beta" not in harness.log
+    release_demo_refresh.set()
+    demo_result = await demo_task
+    beta_result = await beta_task
+
+    assert demo_result.deleted_from_disk is True
+    assert beta_result.deleted_from_disk is True
+    # demo was running, beta was not: only demo stops, and beta's transaction
+    # could not even reach its stop stage until demo's refresh gate opened.
+    assert harness.log == ["stop:demo", "refresh", "refresh"]
+    assert (harness.exec_root / "demo").exists() is False
+    assert (harness.exec_root / "beta").exists() is False
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_cancelled_waiter_propagates_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    """Cancelling a lock waiter aborts only the waiter; the holder finishes."""
+    harness = _Harness(tmp_path, plugin_names=("demo", "beta"))
+    harness.running.add("demo")
+    harness.install(monkeypatch)
+    second_acquire_attempted = _signal_second_operation_lock_acquire(monkeypatch)
+    demo_refresh_entered = asyncio.Event()
+    release_demo_refresh = asyncio.Event()
+    original_refresh = harness._refresh_registry
+
+    async def _gated_refresh() -> dict[str, object]:
+        result = await original_refresh()
+        if "demo" in harness.stop_calls and not demo_refresh_entered.is_set():
+            demo_refresh_entered.set()
+            await release_demo_refresh.wait()
+        return result
+
+    monkeypatch.setattr(
+        uninstall_module.plugin_registry_service, "refresh_registry", _gated_refresh
+    )
+
+    demo_task = asyncio.create_task(uninstall_plugin("demo"))
+    await demo_refresh_entered.wait()
+    beta_task = asyncio.create_task(uninstall_plugin("beta"))
+    await second_acquire_attempted.wait()
+
+    beta_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await beta_task
+
+    # The waiting transaction never mutated beta's files.
+    assert "stop:beta" not in harness.log
+    assert (harness.exec_root / "beta" / "plugin.toml").is_file()
+
+    release_demo_refresh.set()
+    demo_result = await demo_task
+    assert demo_result.deleted_from_disk is True
+    assert (harness.exec_root / "demo").exists() is False
+    assert (harness.exec_root / "beta" / "plugin.toml").is_file()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_delete_plugin_cancellation_finishes_event_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Once acquired, cancellation waits for mutation and lifecycle event."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    mutation_finished = asyncio.Event()
+    events: list[dict[str, object]] = []
+
+    async def _gated_uninstall(plugin_id: str) -> SimpleNamespace:
+        entered.set()
+        await release.wait()
+        mutation_finished.set()
+        return SimpleNamespace(
+            plugin_id=plugin_id,
+            plugin_dir=tmp_path / plugin_id,
+            deleted_from_disk=True,
+            deleted_profile_dir=None,
+            restored_builtin=False,
+            preference_action="cleared",
+            filesystem_rollback="not_needed",
+            runtime_restart="not_needed",
+            cleanup_pending=False,
+            runtime_restart_error=None,
+        )
+
+    monkeypatch.setattr(lifecycle_module, "uninstall_plugin", _gated_uninstall)
+    monkeypatch.setattr(
+        lifecycle_module,
+        "_emit_lifecycle_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    task = asyncio.create_task(
+        lifecycle_module.PluginLifecycleService().delete_plugin("demo")
+    )
+    await entered.wait()
+    task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert mutation_finished.is_set()
+    assert [event["event_type"] for event in events] == ["plugin_deleted"]

--- a/plugin/tests/unit/server/test_uninstall_transaction.py
+++ b/plugin/tests/unit/server/test_uninstall_transaction.py
@@ -670,6 +670,38 @@ async def test_uninstall_preference_clear_failure_restores_preference(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
+async def test_uninstall_commit_failure_restores_auto_start_only_preference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    _isolate_runtime_overrides["demo"] = {"auto_start": True}
+    runtime_overrides_module.reset_cache_for_testing()
+
+    def _fail_commit(_staged: object) -> None:
+        raise OSError("marker write failed")
+
+    monkeypatch.setattr(
+        uninstall_module,
+        "_commit_staged_plugin_code_sync",
+        _fail_commit,
+    )
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await uninstall_plugin("demo")
+
+    assert captured.value.stage == "refresh_and_preferences"
+    assert captured.value.filesystem_rollback == "completed"
+    assert "preference_rollback" not in _details_of(captured.value)
+    assert _isolate_runtime_overrides == {"demo": {"auto_start": True}}
+    assert harness.manager.entry_for_directory(harness.plugin_dir) is not None
+    assert harness.plugin_dir.is_dir()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
 async def test_uninstall_rollback_restores_running_runtime_and_reports_separately(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/plugin/tests/unit/server/test_uninstall_transaction.py
+++ b/plugin/tests/unit/server/test_uninstall_transaction.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import replace
 import hashlib
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -725,6 +726,45 @@ async def test_uninstall_commit_failure_restores_auto_start_only_preference(
     assert captured.value.filesystem_rollback == "completed"
     assert "preference_rollback" not in _details_of(captured.value)
     assert _isolate_runtime_overrides == {"demo": {"auto_start": True}}
+    assert harness.manager.entry_for_directory(harness.plugin_dir) is not None
+    assert harness.plugin_dir.is_dir()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_uninstall_rollback_keeps_newer_concurrent_preference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    harness = _Harness(tmp_path)
+    harness.install(monkeypatch)
+    runtime_overrides_module.set_runtime_override("demo", False)
+    commit_entered = threading.Event()
+    release_commit = threading.Event()
+
+    def _fail_commit_after_concurrent_write(_staged: object) -> None:
+        commit_entered.set()
+        release_commit.wait()
+        raise OSError("marker write failed")
+
+    monkeypatch.setattr(
+        uninstall_module,
+        "_commit_staged_plugin_code_sync",
+        _fail_commit_after_concurrent_write,
+    )
+
+    task = asyncio.create_task(uninstall_plugin("demo"))
+    await asyncio.to_thread(commit_entered.wait)
+    runtime_overrides_module.set_runtime_override("demo", True)
+    release_commit.set()
+
+    with pytest.raises(UninstallPluginError) as captured:
+        await task
+
+    assert captured.value.filesystem_rollback == "completed"
+    assert "preference_rollback" not in _details_of(captured.value)
+    assert _isolate_runtime_overrides == {"demo": True}
     assert harness.manager.entry_for_directory(harness.plugin_dir) is not None
     assert harness.plugin_dir.is_dir()
 


### PR DESCRIPTION
## Summary

- Add the narrow uninstall_plugin(plugin_id) installation transaction and structured result/error types.
- Stage installer-owned package profiles and plugin code before the explicit commit point, with reverse-order pre-commit compensation.
- Keep filesystem rollback, runtime restart, and post-commit cleanup outcomes separate.
- Reduce PluginLifecycleService.delete_plugin() to the operation boundary, error mapping, lifecycle events, and compatibility response.

## PR3 hard scope

Included:

- Exact imported/market ownership enforcement using the existing install-source model.
- Same-filesystem code rename staging and rollback before commit.
- Existing shared/legacy profile ownership behavior and symlink/root safety checks.
- Explicit source update, registry refresh, preference, cancellation, and rollback ordering.
- Transaction-owned committed cleanup markers and narrowly scoped startup retry.
- Removal of lifecycle file-transaction helpers replaced by this transaction.

Explicitly excluded:

- PR4 replacement-interface migration or replacement behavior changes.
- Registry/CAS/JSONL/schema or candidate-model redesign.
- Managed/adoption behavior, multiple user candidates, or runtime ID conflict policy changes.
- A general rollback framework or arbitrary cleanup queue.
- New product behavior, production dependencies, or config/data/cache deletion.

## Compatibility

- Preserves runtime aliases and top-level manifest ID fallback.
- Preserves exact imported/market ownership and legacy-profile behavior.
- Preserves manifestless and existing lifecycle response compatibility.
- Restoring a builtin candidate preserves enabled/auto-start preference; removing the last candidate clears it.
- An unrelated plugin scan failure does not block the target uninstall.

## Validation

- PR3 unit regression: 140 passed, 1 skipped.
- Runtime override/install-source adjacent tests: 15 passed.
- Ruff on all five scope files: passed.
- git diff --check: passed.
- Deterministic concurrency tests use events/controlled lock acquisition; no asyncio.sleep(0).
- Clean merge-tree check against current upstream/main (4298d5ba): passed.

Baseline: merged PR #3001 at 13a6298a. Current upstream/main changes after that baseline do not overlap this PR's plugin files.

Refs #2994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增事务性插件卸载，支持安全移除插件、配置、代码及运行时数据。
  * 卸载失败时自动回滚；清理失败会记录为待处理任务并支持后续重试。
  * 卸载结果提供回滚、运行时重启及清理状态等信息。
  * 支持完整保存与恢复运行时偏好设置。

* **Bug 修复**
  * 改进内置插件恢复、路径安全校验及共享配置处理。
  * 增强插件启停、重启和并发卸载场景的可靠性。
  * 优化运行时偏好恢复，避免覆盖更新后的设置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->