### PR TITLE
refactor(plugin): narrow plugin replacement boundary

### DIFF
--- a/docs/ja/plugins/safe-local-upgrades.md
+++ b/docs/ja/plugins/safe-local-upgrades.md
@@ -95,7 +95,7 @@ previous_ids = ["old_plugin_id"] # 任意の旧 identity 衝突 guard
 | 責務 | 正規実装 |
 | --- | --- |
 | Plan 分類と confirmation token | `plugin/server/application/plugin_cli/install_plan.py` |
-| Transaction、backup、restore、restart | `plugin/server/application/plugins/upgrade_support.py` |
+| Transaction、backup、restore、restart | `plugin/server/application/plugins/installation_transactions/replace.py` |
 | Install orchestration と path policy | `plugin/server/application/plugin_cli/service.py` |
 | HTTP request/response model | `plugin/server/routes/plugin_cli.py` |
 | Plugin Manager の確認と結果表示 | `frontend/plugin-manager/src/composables/usePackageManager.ts` |

--- a/docs/plugins/safe-local-upgrades.md
+++ b/docs/plugins/safe-local-upgrades.md
@@ -103,7 +103,7 @@ Both endpoints require administrator authorization. User-facing errors must not 
 | Responsibility | Canonical implementation |
 | --- | --- |
 | Plan classification and confirmation token | `plugin/server/application/plugin_cli/install_plan.py` |
-| Transaction, backup, restore, and restart | `plugin/server/application/plugins/upgrade_support.py` |
+| Transaction, backup, restore, and restart | `plugin/server/application/plugins/installation_transactions/replace.py` |
 | Install orchestration and path policy | `plugin/server/application/plugin_cli/service.py` |
 | HTTP request/response models | `plugin/server/routes/plugin_cli.py` |
 | Plugin Manager confirmation and result messages | `frontend/plugin-manager/src/composables/usePackageManager.ts` |

--- a/docs/zh-CN/plugins/safe-local-upgrades.md
+++ b/docs/zh-CN/plugins/safe-local-upgrades.md
@@ -103,7 +103,7 @@ previous_ids = ["old_plugin_id"] # 可选的旧身份冲突保护
 | 职责 | 权威实现 |
 | --- | --- |
 | 安装计划分类与确认令牌 | `plugin/server/application/plugin_cli/install_plan.py` |
-| 事务、备份、恢复和重启 | `plugin/server/application/plugins/upgrade_support.py` |
+| 事务、备份、恢复和重启 | `plugin/server/application/plugins/installation_transactions/replace.py` |
 | 安装编排与路径策略 | `plugin/server/application/plugin_cli/service.py` |
 | HTTP 请求与响应模型 | `plugin/server/routes/plugin_cli.py` |
 | 插件管理器确认流程与结果提示 | `frontend/plugin-manager/src/composables/usePackageManager.ts` |

--- a/plugin/server/application/plugin_cli/service.py
+++ b/plugin/server/application/plugin_cli/service.py
@@ -38,7 +38,10 @@ from plugin.server.application.plugin_cli.install_plan import (
     build_install_plan,
     is_manifestless_state_directory,
 )
-from plugin.server.application.plugins import upgrade_support
+from plugin.server.application.plugins.installation_transactions import (
+    replace as replacement_transaction,
+)
+from plugin.server.application.plugins import source_switch
 from plugin.server.application.plugins.installation_transactions.manual_takeover import (
     is_manual_takeover_entry,
     local_manual_takeover_confirmation_token,
@@ -210,7 +213,7 @@ def _classify_package_error(exc: Exception) -> str | None:
 
 
 def _replacement_error_details(
-    exc: upgrade_support.ReplacePluginError,
+    exc: replacement_transaction.ReplacePluginError,
 ) -> dict[str, object]:
     details: dict[str, object] = {
         "stage": exc.stage,
@@ -538,23 +541,10 @@ class PluginCliService:
                 )
             return install_result
 
-        async def validate_new() -> None:
-            plugin_id = self._read_installed_plugin_toml_id(target_dir)
-            if plugin_id != plan.plugin_id or target_dir.name != plan.directory_name:
-                raise ValueError("installed plugin identity does not match the upgrade plan")
-
-        async def start(plugin_id: str) -> None:
-            await upgrade_support.start_plugin_after_replace(plugin_id, strict=True)
-
         try:
-            result = await upgrade_support.replace_plugin(
+            result = await replacement_transaction.replace_plugin(
                 layout=resolve_plugin_layout(plan.plugin_id, target_dir),
                 install_new=install_new,
-                validate_new=validate_new,
-                is_running=upgrade_support.plugin_is_running,
-                stop=upgrade_support.stop_plugin_for_replace,
-                start=start,
-                cleanup_backup=upgrade_support.remove_directory,
                 additional_targets=(
                     (profile_dir,)
                     if manual_manager is None or manual_package_has_profiles
@@ -578,7 +568,7 @@ class PluginCliService:
                     else None
                 ),
             )
-        except upgrade_support.ReplacePluginError as exc:
+        except replacement_transaction.ReplacePluginError as exc:
             source_restored = True
             if manual_entry is not None and source_write_attempted:
                 try:
@@ -767,9 +757,6 @@ class PluginCliService:
                 config_path=target_dir / "plugin.toml",
             )
 
-        async def start(plugin_id: str) -> None:
-            await upgrade_support.start_plugin_after_replace(plugin_id, strict=True)
-
         try:
             switched = await switch_builtin_source(
                 SourceSwitchRequest(
@@ -787,9 +774,9 @@ class PluginCliService:
                 clear_user_source=clear_user_source,
                 refresh_registry=refresh_registry,
                 validate_promoted_source=validate_promoted_source,
-                is_running=upgrade_support.plugin_is_running,
-                stop=upgrade_support.stop_plugin_for_replace,
-                start=start,
+                is_running=source_switch.plugin_is_running_for_source_switch,
+                stop=source_switch.stop_plugin_for_source_switch,
+                start=source_switch.start_plugin_for_source_switch,
             )
         finally:
             await asyncio.to_thread(self._cleanup_builtin_override_staging_sync, staged)

--- a/plugin/server/application/plugins/installation_transactions/__init__.py
+++ b/plugin/server/application/plugins/installation_transactions/__init__.py
@@ -10,6 +10,7 @@ from .ownership import (
     can_neko_uninstall,
     require_uninstall_ownership,
 )
+from .replace import ReplacePluginError, ReplacePluginResult, replace_plugin
 from .uninstall import (
     UninstallPluginError,
     UninstallPluginResult,
@@ -22,6 +23,8 @@ __all__ = [
     "UninstallOwnershipError",
     "UninstallPluginError",
     "UninstallPluginResult",
+    "ReplacePluginError",
+    "ReplacePluginResult",
     "can_neko_uninstall",
     "is_manual_takeover_entry",
     "local_manual_takeover_confirmation_token",
@@ -29,5 +32,6 @@ __all__ = [
     "require_uninstall_ownership",
     "retry_deferred_plugin_code_cleanup_sync",
     "retry_deferred_profile_cleanup_sync",
+    "replace_plugin",
     "uninstall_plugin",
 ]

--- a/plugin/server/application/plugins/installation_transactions/replace.py
+++ b/plugin/server/application/plugins/installation_transactions/replace.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import shutil
 import stat
+import tomllib
 
 from plugin import settings
 from plugin.core.plugin_layout import PluginLayout
@@ -16,7 +17,7 @@ from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure.config_paths import ensure_plugin_layout_runtime_config
 from plugin.settings import get_plugin_state_root
 
-logger = get_logger("server.application.plugins.upgrade_support")
+logger = get_logger("server.application.plugins.installation_transactions.replace")
 
 _MANIFEST_ADJACENT_PROFILE_NAMES = {
     "profiles.toml": "profiles.toml",
@@ -40,7 +41,7 @@ class ReplacePluginError(RuntimeError):
         self.cause = cause
 
 
-async def plugin_is_running(plugin_id: str) -> bool:
+async def _plugin_is_running(plugin_id: str) -> bool:
     if not plugin_id:
         return False
     try:
@@ -56,7 +57,7 @@ async def plugin_is_running(plugin_id: str) -> bool:
         raise
 
 
-async def stop_plugin_for_replace(plugin_id: str) -> None:
+async def _stop_plugin(plugin_id: str) -> None:
     if not plugin_id:
         return
     from plugin.server.application.plugins.lifecycle_service import PluginLifecycleService
@@ -69,29 +70,21 @@ async def stop_plugin_for_replace(plugin_id: str) -> None:
         raise
 
 
-async def start_plugin_after_replace(plugin_id: str, *, strict: bool) -> bool:
+async def _start_plugin(plugin_id: str) -> None:
     if not plugin_id:
-        return False
+        return
     from plugin.server.application.plugins.lifecycle_service import PluginLifecycleService
 
     try:
         await PluginLifecycleService().start_plugin(plugin_id)
-        return True
+        return
     except Exception as exc:
         logger.error(
             "lifecycle restart failed plugin_id={} err_type={}",
             plugin_id,
             type(exc).__name__,
         )
-        if strict:
-            raise
-        return False
-
-
-# Market keeps the established names until its Day 3 adapter switches to the
-# shared replace transaction.
-stop_plugin_for_upgrade = stop_plugin_for_replace
-start_plugin_after_upgrade = start_plugin_after_replace
+        raise
 
 
 def backup_path_for(target_dir: Path, *, backup_root: Path | None = None) -> Path:
@@ -111,6 +104,26 @@ async def remove_directory(target_dir: Path) -> None:
     if not target_dir.exists():
         return
     await asyncio.to_thread(shutil.rmtree, target_dir)
+
+
+def _validate_installed_identity(layout: PluginLayout) -> None:
+    manifest_path = layout.installed_dir / "plugin.toml"
+    if manifest_path.resolve(strict=False) != layout.manifest_path.resolve(strict=False):
+        raise ValueError("plugin layout manifest does not belong to the replacement target")
+    try:
+        data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"installed plugin.toml not found: {manifest_path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"installed plugin.toml is invalid TOML: {manifest_path}") from exc
+    plugin_table = data.get("plugin")
+    if not isinstance(plugin_table, dict):
+        raise ValueError(f"installed plugin.toml missing [plugin] table: {manifest_path}")
+    installed_plugin_id = plugin_table.get("id")
+    if not isinstance(installed_plugin_id, str) or not installed_plugin_id.strip():
+        raise ValueError(f"installed plugin.toml missing [plugin].id: {manifest_path}")
+    if installed_plugin_id.strip() != layout.plugin_id:
+        raise ValueError("installed plugin identity does not match the replacement target")
 
 
 async def merge_directory_contents(source_dir: Path, target_dir: Path) -> None:
@@ -173,7 +186,6 @@ async def run_rollback(
     target_dir: Path,
     backup_dir: Path,
     restart: bool,
-    start: Callable[[str], Awaitable[None]],
 ) -> bool:
     restored = True
     try:
@@ -187,7 +199,7 @@ async def run_rollback(
         )
     if restart:
         try:
-            await start(plugin_id)
+            await _start_plugin(plugin_id)
         except Exception as exc:
             restored = False
             logger.error(
@@ -308,15 +320,11 @@ async def replace_plugin(
     *,
     layout: PluginLayout,
     install_new: Callable[[], Awaitable[dict[str, object]]],
-    validate_new: Callable[[], Awaitable[None]],
-    is_running: Callable[[str], Awaitable[bool]],
-    stop: Callable[[str], Awaitable[None]],
-    start: Callable[[str], Awaitable[None]],
-    cleanup_backup: Callable[[Path], Awaitable[None]],
     additional_targets: tuple[Path, ...] = (),
     preserve_targets: tuple[Path, ...] = (),
     initialize_runtime_config: bool = True,
     validate_backup: Callable[[Path], Awaitable[None]] | None = None,
+    validate_channel_specific: Callable[[], Awaitable[None]] | None = None,
     on_rollback_start: Callable[[], None] | None = None,
 ) -> ReplacePluginResult:
     plugin_id = layout.plugin_id
@@ -338,9 +346,9 @@ async def replace_plugin(
             ensure_plugin_layout_runtime_config,
             layout,
         )
-    was_running = await is_running(plugin_id)
+    was_running = await _plugin_is_running(plugin_id)
     if was_running:
-        await stop(plugin_id)
+        await _stop_plugin(plugin_id)
 
     preexisting_targets = frozenset(target for target in targets if target.exists())
     backups: dict[Path, Path] = {}
@@ -365,7 +373,7 @@ async def replace_plugin(
         )
         if was_running:
             try:
-                await start(plugin_id)
+                await _start_plugin(plugin_id)
             except Exception as restart_exc:
                 recovered = False
                 logger.error(
@@ -385,7 +393,9 @@ async def replace_plugin(
         stage = "install"
         install_result = await install_new()
         stage = "validate"
-        await validate_new()
+        await asyncio.to_thread(_validate_installed_identity, layout)
+        if validate_channel_specific is not None:
+            await validate_channel_specific()
         stage = "preserve"
         for target in preserve_targets:
             backup = backups.get(target)
@@ -396,11 +406,11 @@ async def replace_plugin(
         await asyncio.to_thread(_evict_replaced_plugin_modules, plugin_id)
         if was_running:
             stage = "restart"
-            await start(plugin_id)
+            await _start_plugin(plugin_id)
         stage = "cleanup"
         for backup in backups.values():
             try:
-                await cleanup_backup(backup)
+                await remove_directory(backup)
             except Exception as exc:  # cleanup must not roll back a valid replacement
                 logger.warning(
                     "plugin backup cleanup failed plugin_id={} err_type={}",
@@ -432,7 +442,7 @@ async def replace_plugin(
             )
         if was_running:
             try:
-                await start(plugin_id)
+                await _start_plugin(plugin_id)
             except Exception as restart_exc:
                 restored = False
                 logger.error(

--- a/plugin/server/application/plugins/source_switch.py
+++ b/plugin/server/application/plugins/source_switch.py
@@ -9,11 +9,57 @@ from typing import Any
 
 from plugin.core.state import state
 from plugin.logging_config import get_logger
+from plugin.server.domain.errors import ServerDomainError
 
 logger = get_logger("server.application.plugins.source_switch")
 
 AsyncNoArg = Callable[[], Awaitable[Any]]
 AsyncPluginAction = Callable[[str], Awaitable[Any]]
+
+
+async def plugin_is_running_for_source_switch(plugin_id: str) -> bool:
+    if not plugin_id:
+        return False
+    from plugin.server.application.plugins.lifecycle_service import _plugin_is_running_sync
+
+    try:
+        return await asyncio.to_thread(_plugin_is_running_sync, plugin_id)
+    except Exception as exc:  # pragma: no cover - defensive host-registry boundary
+        logger.warning(
+            "lifecycle running-state probe failed plugin_id={} err_type={}",
+            plugin_id,
+            type(exc).__name__,
+        )
+        raise
+
+
+async def stop_plugin_for_source_switch(plugin_id: str) -> None:
+    if not plugin_id:
+        return
+    from plugin.server.application.plugins.lifecycle_service import PluginLifecycleService
+
+    try:
+        await PluginLifecycleService().stop_plugin(plugin_id)
+    except ServerDomainError as exc:
+        if getattr(exc, "code", None) == "PLUGIN_NOT_RUNNING":
+            return
+        raise
+
+
+async def start_plugin_for_source_switch(plugin_id: str) -> None:
+    if not plugin_id:
+        return
+    from plugin.server.application.plugins.lifecycle_service import PluginLifecycleService
+
+    try:
+        await PluginLifecycleService().start_plugin(plugin_id)
+    except Exception as exc:
+        logger.error(
+            "lifecycle restart failed plugin_id={} err_type={}",
+            plugin_id,
+            type(exc).__name__,
+        )
+        raise
 
 
 @dataclass(frozen=True, slots=True)

--- a/plugin/server/routes/market_bridge.py
+++ b/plugin/server/routes/market_bridge.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from collections.abc import Awaitable, Callable
 import dataclasses
 import hashlib
 import hmac
@@ -31,10 +32,11 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import BaseModel, Field, field_validator
 
 from plugin.logging_config import get_logger
-from plugin.core.plugin_layout import resolve_plugin_layout
+from plugin.core.plugin_layout import PluginLayout, resolve_plugin_layout
 from plugin.neko_plugin_cli.public import inspect_package
 from plugin.server.application.install_source import (
     InstallSourceError,
+    InstallSourceManager,
     LockEntry,
     SourceDetailMarket,
     classify_plugin_path,
@@ -44,19 +46,14 @@ from plugin.server.application.install_source.scanner import PluginDirectoryScan
 from plugin.server.application.plugin_cli import PluginCliService
 from plugin.server.application.plugin_cli.paths import PluginCliPathPolicy
 from plugin.server.application.plugins.operation_lock import serialized_plugin_operation
-from plugin.server.application.plugins.installation_transactions.manual_takeover import (
+from plugin.server.application.plugins.installation_transactions import (
+    ReplacePluginError,
+    ReplacePluginResult,
     is_manual_takeover_entry,
     manual_takeover_snapshot_sha256,
+    replace_plugin,
 )
 from plugin.server.application.plugins.source_switch import SourceSwitchError
-from plugin.server.application.plugins.upgrade_support import (
-    ReplacePluginError,
-    plugin_is_running,
-    remove_directory,
-    replace_plugin,
-    start_plugin_after_upgrade,
-    stop_plugin_for_upgrade,
-)
 from plugin.server.domain.errors import ServerDomainError
 from plugin.settings import (
     MARKET_API_URL,
@@ -3491,16 +3488,21 @@ async def _do_install(
 @serialized_plugin_operation
 async def _replace_market_plugin_transaction(
     *,
-    manager: Any,
+    manager: InstallSourceManager,
     expected_plugin_id: str,
     original_entry: LockEntry,
     original_entry_fingerprint: tuple[object, ...],
     installed_package_id: str,
     plugin_dir: Path,
-    replace_kwargs: dict[str, Any],
+    layout: PluginLayout,
+    install_new: Callable[[], Awaitable[dict[str, object]]],
+    additional_targets: tuple[Path, ...] = (),
+    preserve_targets: tuple[Path, ...] = (),
+    validate_channel_specific: Callable[[], Awaitable[None]] | None = None,
+    on_rollback_start: Callable[[], None] | None = None,
     manual_snapshot_sha256: str = "",
-    rollback_install_source: Any | None = None,
-) -> Any:
+    rollback_install_source: Callable[[], Awaitable[None]] | None = None,
+) -> ReplacePluginResult:
     """Revalidate and replace under the shared plugin filesystem lock."""
     reload_install_source = getattr(manager, "load", None)
     if callable(reload_install_source):
@@ -3537,6 +3539,7 @@ async def _replace_market_plugin_transaction(
                 message="manual plugin changed after takeover confirmation",
                 http_status=409,
             )
+
         async def validate_manual_backup(backup_dir: Path) -> None:
             staged_snapshot = await asyncio.to_thread(
                 manual_takeover_snapshot_sha256,
@@ -3553,12 +3556,18 @@ async def _replace_market_plugin_transaction(
                     status_code=409,
                 )
 
-        replace_kwargs = {
-            **replace_kwargs,
-            "validate_backup": validate_manual_backup,
-        }
+    else:
+        validate_manual_backup = None
     try:
-        return await replace_plugin(**replace_kwargs)
+        return await replace_plugin(
+            layout=layout,
+            install_new=install_new,
+            additional_targets=additional_targets,
+            preserve_targets=preserve_targets,
+            validate_backup=validate_manual_backup,
+            validate_channel_specific=validate_channel_specific,
+            on_rollback_start=on_rollback_start,
+        )
     except ReplacePluginError:
         if rollback_install_source is not None:
             await rollback_install_source()
@@ -3811,20 +3820,8 @@ async def _do_upgrade(
                     restore_exc,
                 )
 
-        async def validate_new() -> None:
-            actual_plugin_id = await asyncio.to_thread(
-                _read_plugin_toml_id,
-                plugin_dir / "plugin.toml",
-            )
-            if actual_plugin_id and actual_plugin_id != installed_plugin_id:
-                raise ValueError(
-                    "installed plugin identity does not match the Market replacement target"
-                )
+        async def validate_channel_specific() -> None:
             if continues_builtin_override:
-                if actual_plugin_id != installed_plugin_id:
-                    raise ValueError(
-                        "installed plugin identity does not match the builtin override target"
-                    )
                 from plugin.server.application.plugins.lifecycle_service import (
                     plugin_registry_service,
                 )
@@ -3833,9 +3830,6 @@ async def _do_upgrade(
                     plugin_id=installed_plugin_id,
                     config_path=plugin_dir / "plugin.toml",
                 )
-
-        async def start(plugin_id: str) -> None:
-            await start_plugin_after_upgrade(plugin_id, strict=True)
 
         def mark_rollback_running() -> None:
             _set_task_stage(
@@ -3872,24 +3866,18 @@ async def _do_upgrade(
                 original_entry_fingerprint=entry_fingerprint,
                 installed_package_id=installed_package_id,
                 plugin_dir=plugin_dir,
+                layout=resolve_plugin_layout(installed_plugin_id, plugin_dir),
+                install_new=install_new,
+                additional_targets=(
+                    (profile_dir,)
+                    if not manual_takeover or manual_package_has_profiles
+                    else ()
+                ),
+                preserve_targets=(() if manual_takeover else (profile_dir,)),
+                validate_channel_specific=validate_channel_specific,
+                on_rollback_start=mark_rollback_running,
                 manual_snapshot_sha256=manual_snapshot_sha256,
                 rollback_install_source=rollback_install_source,
-                replace_kwargs={
-                    "layout": resolve_plugin_layout(installed_plugin_id, plugin_dir),
-                    "install_new": install_new,
-                    "validate_new": validate_new,
-                    "is_running": plugin_is_running,
-                    "stop": stop_plugin_for_upgrade,
-                    "start": start,
-                    "cleanup_backup": _async_remove_dir,
-                    "additional_targets": (
-                        (profile_dir,)
-                        if not manual_takeover or manual_package_has_profiles
-                        else ()
-                    ),
-                    "preserve_targets": (() if manual_takeover else (profile_dir,)),
-                    "on_rollback_start": mark_rollback_running,
-                },
             )
         except ReplacePluginError as exc:
             rollback_ok = exc.rollback_status == "completed" and source_restored
@@ -4067,13 +4055,6 @@ def _post_install_payload_check(
         )
 
 
-async def _async_remove_dir(target_dir: Path) -> None:
-    """Async best-effort rmtree for backup cleanup."""
-
-    try:
-        await remove_directory(target_dir)
-    except Exception as exc:  # pragma: no cover - platform-specific cleanup failure
-        logger.warning("backup cleanup failed for {}: {}", target_dir, exc)
 def _utc_iso_now() -> str:
     """Current UTC time in ISO 8601 with microsecond precision and ``Z`` suffix."""
 

--- a/plugin/tests/integration/test_market_bridge_e2e.py
+++ b/plugin/tests/integration/test_market_bridge_e2e.py
@@ -45,6 +45,9 @@ from plugin.server.application.install_source.scanner import (
     PluginDirectoryScanner,
 )
 from plugin.server.application.install_source.models import SourceDetailMarket
+from plugin.server.application.plugins.installation_transactions import (
+    replace as replacement_transaction,
+)
 from plugin.neko_plugin_cli.public import build_plugin
 
 
@@ -1730,6 +1733,8 @@ async def test_proxy_verification_cancellation_removes_temporary_package(
     verifier_started = threading.Event()
     release_verifier = threading.Event()
     verifier_finished = threading.Event()
+    cancellation_wait_started = asyncio.Event()
+    wait_for_verification = market_bridge_module._wait_for_verification_task
 
     def blocking_verifier(path: Path, expected_hash: str) -> str:
         with path.open("rb"):
@@ -1738,7 +1743,16 @@ async def test_proxy_verification_cancellation_removes_temporary_package(
         verifier_finished.set()
         return "passed"
 
+    async def observe_cancellation_wait(verification_task: asyncio.Task[Any]) -> None:
+        cancellation_wait_started.set()
+        await wait_for_verification(verification_task)
+
     monkeypatch.setattr(market_bridge_module, "_verify_sha256_file", blocking_verifier)
+    monkeypatch.setattr(
+        market_bridge_module,
+        "_wait_for_verification_task",
+        observe_cancellation_wait,
+    )
 
     verification = asyncio.create_task(
         market_bridge_module._verify_downloaded_package_with_fallback(
@@ -1750,7 +1764,7 @@ async def test_proxy_verification_cancellation_removes_temporary_package(
     )
     assert await asyncio.to_thread(verifier_started.wait, 1)
     verification.cancel()
-    await asyncio.sleep(0)
+    await asyncio.wait_for(cancellation_wait_started.wait(), timeout=1)
 
     assert package_path.exists()
     assert not verification.done()
@@ -1780,6 +1794,8 @@ async def test_direct_verification_cancellation_removes_temporary_package(
     verifier_started = threading.Event()
     release_verifier = threading.Event()
     verifier_finished = threading.Event()
+    cancellation_wait_started = asyncio.Event()
+    wait_for_verification = market_bridge_module._wait_for_verification_task
 
     def verify_or_block(path: Path, expected_hash: str) -> str:
         if path == proxy_path:
@@ -1794,8 +1810,17 @@ async def test_direct_verification_cancellation_removes_temporary_package(
         assert url == direct_url
         return direct_path
 
+    async def observe_cancellation_wait(verification_task: asyncio.Task[Any]) -> None:
+        cancellation_wait_started.set()
+        await wait_for_verification(verification_task)
+
     monkeypatch.setattr(market_bridge_module, "_verify_sha256_file", verify_or_block)
     monkeypatch.setattr(market_bridge_module, "_download_package_once", download_direct)
+    monkeypatch.setattr(
+        market_bridge_module,
+        "_wait_for_verification_task",
+        observe_cancellation_wait,
+    )
 
     verification = asyncio.create_task(
         market_bridge_module._verify_downloaded_package_with_fallback(
@@ -1807,7 +1832,7 @@ async def test_direct_verification_cancellation_removes_temporary_package(
     )
     assert await asyncio.to_thread(verifier_started.wait, 1)
     verification.cancel()
-    await asyncio.sleep(0)
+    await asyncio.wait_for(cancellation_wait_started.wait(), timeout=1)
 
     assert direct_path.exists()
     assert not verification.done()
@@ -4606,8 +4631,6 @@ async def test_upgrade_lifecycle_uses_installed_plugin_id_not_market_id(
         )
         assert (await _wait_task(resp.json()["task_id"]))["status"] == "completed"
 
-    from plugin.server.routes import market_bridge as market_bridge_module
-
     async def fake_is_running(target: str) -> bool:
         calls.append(("is_running", target))
         return True
@@ -4615,13 +4638,12 @@ async def test_upgrade_lifecycle_uses_installed_plugin_id_not_market_id(
     async def fake_stop(target: str) -> None:
         calls.append(("stop", target))
 
-    async def fake_start(target: str, *, strict: bool) -> bool:
+    async def fake_start(target: str) -> None:
         calls.append(("start", target))
-        return strict
 
-    monkeypatch.setattr(market_bridge_module, "plugin_is_running", fake_is_running)
-    monkeypatch.setattr(market_bridge_module, "stop_plugin_for_upgrade", fake_stop)
-    monkeypatch.setattr(market_bridge_module, "start_plugin_after_upgrade", fake_start)
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", fake_is_running)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", fake_stop)
+    monkeypatch.setattr(replacement_transaction, "_start_plugin", fake_start)
 
     with _serve_bytes(
         filename=f"{plugin_id}-2.0.0.neko-plugin", content=v2_zip,

--- a/plugin/tests/unit/server/test_market_bridge_safe_upgrade.py
+++ b/plugin/tests/unit/server/test_market_bridge_safe_upgrade.py
@@ -9,13 +9,19 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 
+from plugin.core.plugin_layout import resolve_plugin_layout
 from plugin.server.application.install_source import InstallSourceManager
 from plugin.server.application.install_source.scanner import PluginDirectoryScanner
+from plugin.server.application.plugins.installation_transactions import (
+    replace as replacement_transaction,
+)
 from plugin.server.routes import market_bridge
+from plugin.server.application.plugins import operation_lock
 from plugin.server.application.plugins.operation_lock import serialized_plugin_operation
 
 
 pytestmark = pytest.mark.plugin_unit
+DEMO_MANIFEST_V2 = '[plugin]\nid = "demo"\nversion = "2.0.0"\n'
 
 
 def _payload(plugin_id: str = "demo") -> SimpleNamespace:
@@ -756,7 +762,19 @@ async def test_market_upgrade_holds_operation_lock_for_entire_replacement(
 
     entered = asyncio.Event()
     release = asyncio.Event()
+    second_waiting_for_lock = asyncio.Event()
     calls: list[dict[str, Any]] = []
+    acquire_attempts = 0
+    original_acquire = operation_lock._PROCESS_LOCK.acquire
+
+    async def observed_acquire() -> None:
+        nonlocal acquire_attempts
+        acquire_attempts += 1
+        if acquire_attempts == 2:
+            second_waiting_for_lock.set()
+        await original_acquire()
+
+    monkeypatch.setattr(operation_lock._PROCESS_LOCK, "acquire", observed_acquire)
 
     async def blocked_replace(**kwargs: Any) -> SimpleNamespace:
         calls.append(kwargs)
@@ -774,7 +792,7 @@ async def test_market_upgrade_holds_operation_lock_for_entire_replacement(
     first = asyncio.create_task(market_bridge._do_upgrade({}, _payload(), {}))
     await entered.wait()
     second = asyncio.create_task(market_bridge._do_upgrade({}, _payload(), {}))
-    await asyncio.sleep(0)
+    await asyncio.wait_for(second_waiting_for_lock.wait(), timeout=1)
     assert len(calls) == 1
 
     release.set()
@@ -951,6 +969,11 @@ async def test_market_upgrade_rejects_stale_lock_snapshot(
 
     manager = ReloadingManager()
 
+    async def install_new() -> dict[str, object]:
+        return {}
+
+    plugin_dir = tmp_path / "plugins" / "demo"
+
     with pytest.raises(market_bridge._TaskError) as exc_info:
         await market_bridge._replace_market_plugin_transaction(
             manager=manager,
@@ -958,8 +981,9 @@ async def test_market_upgrade_rejects_stale_lock_snapshot(
             original_entry=first_entry,
             original_entry_fingerprint=market_bridge._market_entry_fingerprint(first_entry),
             installed_package_id="demo",
-            plugin_dir=tmp_path / "plugins" / "demo",
-            replace_kwargs={"layout": object()},
+            plugin_dir=plugin_dir,
+            layout=resolve_plugin_layout("demo", plugin_dir),
+            install_new=install_new,
         )
 
     assert exc_info.value.code == "plugin_upgrade_plan_changed"
@@ -969,6 +993,7 @@ async def test_market_upgrade_rejects_stale_lock_snapshot(
 @pytest.mark.asyncio
 async def test_market_manual_takeover_revalidates_backup_after_stop(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     plugin_dir = tmp_path / "plugins" / "demo"
     plugin_dir.mkdir(parents=True)
@@ -994,9 +1019,6 @@ async def test_market_manual_takeover_revalidates_backup_after_stop(
         install_called = True
         return {}
 
-    async def validate_new() -> None:
-        return None
-
     async def is_running(_plugin_id: str) -> bool:
         return True
 
@@ -1006,13 +1028,14 @@ async def test_market_manual_takeover_revalidates_backup_after_stop(
     async def start(_plugin_id: str) -> None:
         return None
 
-    async def cleanup_backup(backup_dir: Path) -> None:
-        shutil.rmtree(backup_dir)
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", is_running)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", stop)
+    monkeypatch.setattr(replacement_transaction, "_start_plugin", start)
 
-    layout = SimpleNamespace(
-        plugin_id="demo",
-        installed_dir=plugin_dir,
-        data_dir=tmp_path / "runtime_data" / "plugins" / "demo",
+    layout = resolve_plugin_layout(
+        "demo",
+        plugin_dir,
+        storage_root=tmp_path / "runtime_data",
     )
     with pytest.raises(market_bridge.ReplacePluginError) as exc_info:
         await market_bridge._replace_market_plugin_transaction(
@@ -1022,17 +1045,9 @@ async def test_market_manual_takeover_revalidates_backup_after_stop(
             original_entry_fingerprint=market_bridge._market_entry_fingerprint(entry),
             installed_package_id="demo",
             plugin_dir=plugin_dir,
+            layout=layout,
+            install_new=install_new,
             manual_snapshot_sha256=expected_snapshot,
-            replace_kwargs={
-                "layout": layout,
-                "install_new": install_new,
-                "validate_new": validate_new,
-                "is_running": is_running,
-                "stop": stop,
-                "start": start,
-                "cleanup_backup": cleanup_backup,
-                "initialize_runtime_config": False,
-            },
         )
 
     assert isinstance(exc_info.value.cause, market_bridge.ServerDomainError)
@@ -1121,7 +1136,11 @@ async def test_market_upgrade_rolls_back_plugin_profile_with_plugin_directory(
         plugins_root=plugins_root,
         profiles_root=profiles_root,
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda url, task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda path: None)
@@ -1133,7 +1152,7 @@ async def test_market_upgrade_rolls_back_plugin_profile_with_plugin_directory(
             shutil.rmtree(profile_dir)
         plugin_dir.mkdir(parents=True)
         profile_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.toml").write_text("version = '2.0.0'\n", encoding="utf-8")
+        (plugin_dir / "plugin.toml").write_text(DEMO_MANIFEST_V2, encoding="utf-8")
         (profile_dir / "default.toml").write_text("version = 2\n", encoding="utf-8")
         raise RuntimeError("install failed after promotion")
 
@@ -1155,8 +1174,6 @@ async def test_market_upgrade_exposes_rollback_while_files_are_being_restored(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from plugin.server.application.plugins import upgrade_support
-
     plugins_root = tmp_path / "plugins"
     profiles_root = tmp_path / "profiles"
     plugin_dir = plugins_root / "demo"
@@ -1166,7 +1183,11 @@ async def test_market_upgrade_exposes_rollback_while_files_are_being_restored(
     package_path.write_bytes(b"package")
 
     _configure_paths(monkeypatch, plugins_root=plugins_root, profiles_root=profiles_root)
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda _url, _task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda _path: None)
@@ -1180,14 +1201,18 @@ async def test_market_upgrade_exposes_rollback_while_files_are_being_restored(
 
     rollback_started = asyncio.Event()
     allow_rollback = asyncio.Event()
-    remove_directory = upgrade_support.remove_directory
+    remove_directory = replacement_transaction.remove_directory
 
     async def pause_during_rollback(path: Path) -> None:
         rollback_started.set()
         await allow_rollback.wait()
         await remove_directory(path)
 
-    monkeypatch.setattr(upgrade_support, "remove_directory", pause_during_rollback)
+    monkeypatch.setattr(
+        replacement_transaction,
+        "remove_directory",
+        pause_during_rollback,
+    )
 
     task: dict[str, Any] = {}
     operation = asyncio.create_task(market_bridge._do_upgrade(task, _payload(), {}))
@@ -1220,7 +1245,11 @@ async def test_market_upgrade_preserves_install_source_error_after_rollback(
     package_path.write_bytes(b"package")
 
     _configure_paths(monkeypatch, plugins_root=plugins_root, profiles_root=profiles_root)
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda _url, _task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda _path: None)
@@ -1266,7 +1295,11 @@ async def test_market_upgrade_preserves_existing_profile_files_on_success(
         plugins_root=plugins_root,
         profiles_root=profiles_root,
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda url, task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda path: None)
@@ -1274,7 +1307,7 @@ async def test_market_upgrade_preserves_existing_profile_files_on_success(
     async def install_new(**kwargs: Any) -> dict[str, object]:
         plugin_dir.mkdir(parents=True)
         profile_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.toml").write_text("version = '2.0.0'\n", encoding="utf-8")
+        (plugin_dir / "plugin.toml").write_text(DEMO_MANIFEST_V2, encoding="utf-8")
         (profile_dir / "default.toml").write_text("package_value = true\n", encoding="utf-8")
         (profile_dir / "new.toml").write_text("new = true\n", encoding="utf-8")
         return {"operation": "upgrade"}
@@ -1287,7 +1320,7 @@ async def test_market_upgrade_preserves_existing_profile_files_on_success(
 
     await market_bridge._do_upgrade({}, _payload(), {})
 
-    assert (plugin_dir / "plugin.toml").read_text(encoding="utf-8") == "version = '2.0.0'\n"
+    assert (plugin_dir / "plugin.toml").read_text(encoding="utf-8") == DEMO_MANIFEST_V2
     assert (profile_dir / "default.toml").read_text(encoding="utf-8") == "user_value = true\n"
     assert (profile_dir / "custom.toml").read_text(encoding="utf-8") == "custom = true\n"
     assert (profile_dir / "new.toml").read_text(encoding="utf-8") == "new = true\n"
@@ -1323,7 +1356,11 @@ async def test_market_upgrade_uses_package_id_for_profile_backup(
             find_active_market_entry=lambda _plugin_id: _entry(plugin_id, package_id)
         ),
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda url, task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda path: None)
@@ -1339,7 +1376,7 @@ async def test_market_upgrade_uses_package_id_for_profile_backup(
             raise FileExistsError(profile_dir)
         plugin_dir.mkdir(parents=True)
         profile_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.toml").write_text("version = '2.0.0'\n", encoding="utf-8")
+        (plugin_dir / "plugin.toml").write_text(DEMO_MANIFEST_V2, encoding="utf-8")
         (profile_dir / "new.toml").write_text("new = true\n", encoding="utf-8")
         return {"operation": "upgrade"}
 
@@ -1380,7 +1417,11 @@ async def test_market_upgrade_rejects_legacy_rename_despite_stale_incoming_profi
         "get_install_source_manager",
         lambda: SimpleNamespace(find_active_market_entry=lambda _plugin_id: _entry("demo", "")),
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda _url, _task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda _path: None)
@@ -1438,7 +1479,11 @@ async def test_market_upgrade_blocks_package_id_change_and_preserves_old_profile
             find_active_market_entry=lambda _plugin_id: _entry("demo", "old-package")
         ),
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
     monkeypatch.setattr(market_bridge, "_download_package", lambda _url, _task: _async_value(package_path))
     monkeypatch.setattr(market_bridge, "_verify_sha256_file", lambda *args, **kwargs: "passed")
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda _path: None)
@@ -1519,10 +1564,14 @@ async def test_market_restart_failure_restores_previous_install_source_entry(
             profile_names=["payload/profiles/default.toml"],
         ),
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda _plugin_id: _async_true())
     monkeypatch.setattr(
-        market_bridge,
-        "stop_plugin_for_upgrade",
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_true(),
+    )
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_stop_plugin",
         lambda _plugin_id: _async_none(),
     )
     monkeypatch.setattr(
@@ -1536,7 +1585,7 @@ async def test_market_restart_failure_restores_previous_install_source_entry(
     async def install_new(**_kwargs: Any) -> dict[str, object]:
         plugin_dir.mkdir(parents=True)
         profile_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.toml").write_text("version = '2.0.0'\n", encoding="utf-8")
+        (plugin_dir / "plugin.toml").write_text(DEMO_MANIFEST_V2, encoding="utf-8")
         (profile_dir / "generated.toml").write_text(
             "replacement = true\n",
             encoding="utf-8",
@@ -1547,19 +1596,19 @@ async def test_market_restart_failure_restores_previous_install_source_entry(
 
     start_calls = 0
 
-    async def fail_new_start(_plugin_id: str, *, strict: bool) -> bool:
+    async def fail_new_start(_plugin_id: str) -> None:
         nonlocal start_calls
         start_calls += 1
         if start_calls == 1:
             raise RuntimeError("replacement start failed")
-        return True
+        return None
 
     monkeypatch.setattr(
         market_bridge,
         "_cli_service",
         SimpleNamespace(upload_and_install=install_new),
     )
-    monkeypatch.setattr(market_bridge, "start_plugin_after_upgrade", fail_new_start)
+    monkeypatch.setattr(replacement_transaction, "_start_plugin", fail_new_start)
 
     payload = _payload()
     if original_channel == "manual":
@@ -1599,12 +1648,20 @@ async def test_market_backup_failure_reports_incomplete_when_old_plugin_cannot_r
         plugins_root=plugins_root,
         profiles_root=profiles_root,
     )
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda plugin_id: _async_true())
-    monkeypatch.setattr(market_bridge, "stop_plugin_for_upgrade", lambda plugin_id: _async_none())
     monkeypatch.setattr(
-        market_bridge,
-        "start_plugin_after_upgrade",
-        lambda plugin_id, strict: _async_raise(RuntimeError("old plugin restart failed")),
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda plugin_id: _async_true(),
+    )
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_stop_plugin",
+        lambda plugin_id: _async_none(),
+    )
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_start_plugin",
+        lambda plugin_id: _async_raise(RuntimeError("old plugin restart failed")),
     )
     package_path = tmp_path / "demo.neko-plugin"
     package_path.write_bytes(b"package")
@@ -1716,7 +1773,11 @@ async def test_stopped_builtin_override_upgrade_validates_runtime_and_rolls_back
         lambda *_args, **_kwargs: _async_value((package_path, "passed")),
     )
     monkeypatch.setattr(market_bridge, "_cleanup_download_file", lambda _path: None)
-    monkeypatch.setattr(market_bridge, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
 
     captured_override: dict[str, Any] = {}
 

--- a/plugin/tests/unit/server/test_plugin_cli_builtin_override.py
+++ b/plugin/tests/unit/server/test_plugin_cli_builtin_override.py
@@ -16,7 +16,7 @@ from plugin.server.application.install_source import (
     PluginDirectoryScanner,
     set_global_manager,
 )
-from plugin.server.application.plugins import source_switch, upgrade_support
+from plugin.server.application.plugins import source_switch
 from plugin.server.application.plugins.source_switch import SourceSwitchError
 from plugin.server.domain.errors import ServerDomainError
 from plugin.core.state import state
@@ -390,11 +390,11 @@ async def test_disabled_builtin_override_with_invalid_entry_rolls_back(
         _ = strict
 
     monkeypatch.setattr(lifecycle_service.plugin_registry_service, "refresh_registry", refresh_registry)
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", is_running)
-    monkeypatch.setattr(upgrade_support, "stop_plugin_for_replace", no_op)
+    monkeypatch.setattr(source_switch, "plugin_is_running_for_source_switch", is_running)
+    monkeypatch.setattr(source_switch, "stop_plugin_for_source_switch", no_op)
     monkeypatch.setattr(
-        upgrade_support,
-        "start_plugin_after_replace",
+        source_switch,
+        "start_plugin_for_source_switch",
         no_op,
     )
 
@@ -508,9 +508,9 @@ async def test_market_builtin_override_switches_or_restores_without_touching_sta
             raise RuntimeError("market start failed")
 
     monkeypatch.setattr(lifecycle_service.plugin_registry_service, "refresh_registry", refresh_registry)
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", is_running)
-    monkeypatch.setattr(upgrade_support, "stop_plugin_for_replace", stop)
-    monkeypatch.setattr(upgrade_support, "start_plugin_after_replace", lambda pid, strict: start(pid))
+    monkeypatch.setattr(source_switch, "plugin_is_running_for_source_switch", is_running)
+    monkeypatch.setattr(source_switch, "stop_plugin_for_source_switch", stop)
+    monkeypatch.setattr(source_switch, "start_plugin_for_source_switch", start)
 
     try:
         service = PluginCliService()
@@ -750,8 +750,8 @@ async def test_market_builtin_override_rejects_read_only_lock_before_staging_or_
     async def stop(_plugin_id: str) -> None:
         runtime_calls.append("stop")
 
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", is_running)
-    monkeypatch.setattr(upgrade_support, "stop_plugin_for_replace", stop)
+    monkeypatch.setattr(source_switch, "plugin_is_running_for_source_switch", is_running)
+    monkeypatch.setattr(source_switch, "stop_plugin_for_source_switch", stop)
     service = PluginCliService()
 
     def stage_override(**_kwargs: object) -> None:

--- a/plugin/tests/unit/server/test_plugin_cli_safe_upgrade.py
+++ b/plugin/tests/unit/server/test_plugin_cli_safe_upgrade.py
@@ -15,11 +15,29 @@ from plugin.server.application.plugin_cli.service import (
     _replacement_error_details,
 )
 from plugin.server.application.install_source.models import LockEntry
-from plugin.server.application.plugins import upgrade_support
-from plugin.server.application.plugins.upgrade_support import ReplacePluginError, replace_plugin
+from plugin.server.application.plugins.installation_transactions import (
+    ReplacePluginError,
+    replace_plugin,
+)
+from plugin.server.application.plugins.installation_transactions import (
+    replace as replacement_transaction,
+)
 from plugin.server.domain.errors import ServerDomainError
 
 pytestmark = pytest.mark.plugin_unit
+
+
+@pytest.fixture(autouse=True)
+def _default_replacement_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def not_running(_plugin_id: str) -> bool:
+        return False
+
+    async def no_op(_plugin_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", not_running)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", no_op)
+    monkeypatch.setattr(replacement_transaction, "_start_plugin", no_op)
 
 
 class _ManualTakeoverManager:
@@ -133,6 +151,7 @@ def test_hash_mismatch_reason_survives_upgrade_rollback() -> None:
 @pytest.mark.parametrize("failure_stage", ["install", "validate", "restart"])
 async def test_safe_upgrade_restores_old_directory_after_each_failure(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     failure_stage: str,
 ) -> None:
     target = tmp_path / "demo"
@@ -186,18 +205,15 @@ async def test_safe_upgrade_restores_old_directory_after_each_failure(
         if failure_stage == "restart" and start_attempts == 1:
             raise RuntimeError("restart failed")
 
-    async def cleanup_backup(path: Path) -> None:
-        calls.append(f"cleanup:{path.name}")
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", is_running)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", stop)
+    monkeypatch.setattr(replacement_transaction, "_start_plugin", start)
 
     with pytest.raises(ReplacePluginError, match=failure_stage):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target, storage_root=storage_root),
             install_new=install_new,
-            validate_new=validate_new,
-            is_running=is_running,
-            stop=stop,
-            start=start,
-            cleanup_backup=cleanup_backup,
+            validate_channel_specific=validate_new,
             additional_targets=(profile,),
         )
 
@@ -212,7 +228,10 @@ async def test_safe_upgrade_restores_old_directory_after_each_failure(
 
 
 @pytest.mark.asyncio
-async def test_safe_upgrade_replaces_plugin_and_cleans_backup_on_success(tmp_path: Path) -> None:
+async def test_safe_upgrade_replaces_plugin_and_cleans_backup_on_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     target = tmp_path / "demo"
     target.mkdir()
     (target / "plugin.toml").write_text(
@@ -233,14 +252,27 @@ async def test_safe_upgrade_replaces_plugin_and_cleans_backup_on_success(tmp_pat
         calls.append(f"cleanup:{path.name}")
         shutil.rmtree(path)
 
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_true(),
+    )
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_stop_plugin",
+        lambda plugin_id: _record(calls, f"stop:{plugin_id}"),
+    )
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_start_plugin",
+        lambda plugin_id: _record(calls, f"start:{plugin_id}"),
+    )
+    monkeypatch.setattr(replacement_transaction, "remove_directory", cleanup_backup)
+
     result = await replace_plugin(
         layout=resolve_plugin_layout("demo", target),
         install_new=install_new,
-        validate_new=lambda: _async_none(),
-        is_running=lambda _plugin_id: _async_true(),
-        stop=lambda plugin_id: _record(calls, f"stop:{plugin_id}"),
-        start=lambda plugin_id: _record(calls, f"start:{plugin_id}"),
-        cleanup_backup=cleanup_backup,
+        validate_channel_specific=lambda: _async_none(),
     )
 
     assert result.restarted is True
@@ -262,7 +294,7 @@ async def test_rollback_keeps_targets_that_were_not_backed_up(tmp_path: Path) ->
     profile.mkdir(parents=True)
     (profile / "default.toml").write_text("user_value = true\n", encoding="utf-8")
 
-    restored = await upgrade_support._rollback_targets(
+    restored = await replacement_transaction._rollback_targets(
         targets=(target, profile),
         backups={target: backup},
         preexisting_targets=frozenset({target, profile}),
@@ -275,7 +307,10 @@ async def test_rollback_keeps_targets_that_were_not_backed_up(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_safe_upgrade_removes_profile_created_by_failed_install(tmp_path: Path) -> None:
+async def test_safe_upgrade_removes_profile_created_by_failed_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     target = tmp_path / "demo"
     target.mkdir()
     (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
@@ -283,7 +318,10 @@ async def test_safe_upgrade_removes_profile_created_by_failed_install(tmp_path: 
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(
+            '[plugin]\nid = "demo"\nversion = 2\n',
+            encoding="utf-8",
+        )
         profile.mkdir(parents=True)
         (profile / "default.toml").write_text("new_value = true\n", encoding="utf-8")
         return {"ok": True}
@@ -291,15 +329,17 @@ async def test_safe_upgrade_removes_profile_created_by_failed_install(tmp_path: 
     async def validate_new() -> None:
         raise RuntimeError("validation failed")
 
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_true(),
+    )
+
     with pytest.raises(ReplacePluginError, match="validate"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=install_new,
-            validate_new=validate_new,
-            is_running=lambda _plugin_id: _async_true(),
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=lambda _path: _async_none(),
+            validate_channel_specific=validate_new,
             additional_targets=(profile,),
         )
 
@@ -415,7 +455,11 @@ async def test_service_replaces_with_new_same_or_old_version_without_touching_us
         "get_install_source_manager",
         lambda: _managed_manager(),
     )
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
 
     service = PluginCliService()
     plan = await service.plan_install(package=str(package_path))
@@ -476,7 +520,7 @@ async def test_service_rejects_changed_target_before_stopping(
     async def unexpected_stop(plugin_id: str) -> None:
         stop_calls.append(plugin_id)
 
-    monkeypatch.setattr(upgrade_support, "stop_plugin_for_replace", unexpected_stop)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", unexpected_stop)
     with pytest.raises(ServerDomainError) as exc_info:
         await service.install(
             package=str(package_path),
@@ -536,7 +580,7 @@ async def test_service_rejects_unsafe_upgrade_plan_paths_before_backup(
         return object()
 
     monkeypatch.setattr(service, "plan_install", unsafe_plan_install)
-    monkeypatch.setattr(upgrade_support, "replace_plugin", unexpected_upgrade)
+    monkeypatch.setattr(replacement_transaction, "replace_plugin", unexpected_upgrade)
 
     with pytest.raises(ValueError, match=field):
         await service.install(
@@ -584,7 +628,7 @@ async def test_service_backs_up_profile_by_package_id_during_upgrade(
     async def not_running(_plugin_id: str) -> bool:
         return False
 
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", not_running)
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", not_running)
 
     service = PluginCliService()
     plan = await service.plan_install(package=str(package_path))
@@ -637,7 +681,7 @@ async def test_service_uses_custom_profile_root_with_recorded_package_identity(
     async def not_running(_plugin_id: str) -> bool:
         return False
 
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", not_running)
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", not_running)
 
     service = PluginCliService()
     plan = await service.plan_install(
@@ -795,7 +839,11 @@ async def test_local_package_manual_takeover_requires_bound_plan_and_records_imp
     monkeypatch.setattr(plugin_settings, "USER_PLUGIN_PACKAGES_ROOT", packages_root)
     monkeypatch.setattr(plugin_settings, "USER_PACKAGE_PROFILES_ROOT", profiles_root)
     monkeypatch.setattr(service_module, "get_install_source_manager", lambda: manager)
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
 
     service = PluginCliService()
     plan = await service.plan_install(package=str(package_path))
@@ -930,16 +978,20 @@ async def test_local_manual_takeover_revalidates_backup_after_stop(
         tmp_path / "profiles",
     )
     monkeypatch.setattr(service_module, "get_install_source_manager", lambda: manager)
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", lambda _plugin_id: _async_true())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_true(),
+    )
 
     async def mutate_while_stopping(_plugin_id: str) -> None:
         sentinel.write_text("edited_during_stop = true\n", encoding="utf-8")
 
-    monkeypatch.setattr(upgrade_support, "stop_plugin_for_replace", mutate_while_stopping)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", mutate_while_stopping)
     monkeypatch.setattr(
-        upgrade_support,
-        "start_plugin_after_replace",
-        lambda _plugin_id, *, strict: _async_true(),
+        replacement_transaction,
+        "_start_plugin",
+        lambda _plugin_id: _async_none(),
     )
 
     service = PluginCliService()
@@ -982,7 +1034,11 @@ async def test_local_package_takes_over_exact_manual_slot_alongside_builtin(
     monkeypatch.setattr(plugin_settings, "USER_PLUGIN_PACKAGES_ROOT", packages_root)
     monkeypatch.setattr(plugin_settings, "USER_PACKAGE_PROFILES_ROOT", tmp_path / "profiles")
     monkeypatch.setattr(service_module, "get_install_source_manager", lambda: manager)
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", lambda _plugin_id: _async_false())
+    monkeypatch.setattr(
+        replacement_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_false(),
+    )
 
     service = PluginCliService()
     plan = await service.plan_install(package=str(package_path))
@@ -1033,13 +1089,12 @@ async def test_failed_local_manual_takeover_restores_directory_and_lock_entry(
     async def stop(_plugin_id: str) -> None:
         return None
 
-    async def fail_start(_plugin_id: str, *, strict: bool) -> bool:
-        assert strict is True
+    async def fail_start(_plugin_id: str) -> None:
         raise RuntimeError("restart failed")
 
-    monkeypatch.setattr(upgrade_support, "plugin_is_running", running)
-    monkeypatch.setattr(upgrade_support, "stop_plugin_for_replace", stop)
-    monkeypatch.setattr(upgrade_support, "start_plugin_after_replace", fail_start)
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", running)
+    monkeypatch.setattr(replacement_transaction, "_stop_plugin", stop)
+    monkeypatch.setattr(replacement_transaction, "_start_plugin", fail_start)
 
     service = PluginCliService()
     plan = await service.plan_install(package=str(package_path))

--- a/plugin/tests/unit/server/test_plugin_replacement_boundary.py
+++ b/plugin/tests/unit/server/test_plugin_replacement_boundary.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+import textwrap
+
+import pytest
+
+from plugin.core.plugin_layout import resolve_plugin_layout
+from plugin.server.application.plugin_cli import service as plugin_cli_service
+from plugin.server.application.plugins import operation_lock
+from plugin.server.application.plugins.installation_transactions import (
+    replace as replacement_transaction,
+)
+from plugin.server.routes import market_bridge
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def _replacement_call_keywords(function: object) -> set[str | None]:
+    source = textwrap.dedent(inspect.getsource(function))
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "replace_plugin"
+            or isinstance(node.func, ast.Attribute)
+            and node.func.attr == "replace_plugin"
+        )
+    ]
+    assert len(calls) == 1
+    return {keyword.arg for keyword in calls[0].keywords}
+
+
+def test_replacement_callers_share_one_narrow_typed_transaction() -> None:
+    assert (
+        plugin_cli_service.replacement_transaction.replace_plugin
+        is replacement_transaction.replace_plugin
+    )
+    assert market_bridge.replace_plugin is replacement_transaction.replace_plugin
+
+    transaction_parameters = inspect.signature(
+        replacement_transaction.replace_plugin
+    ).parameters
+    assert set(transaction_parameters) == {
+        "layout",
+        "install_new",
+        "additional_targets",
+        "preserve_targets",
+        "initialize_runtime_config",
+        "validate_backup",
+        "validate_channel_specific",
+        "on_rollback_start",
+    }
+
+    cli_keywords = _replacement_call_keywords(plugin_cli_service.PluginCliService.install)
+    market_keywords = _replacement_call_keywords(
+        market_bridge._replace_market_plugin_transaction.__wrapped__
+    )
+    constant_dependencies = {"is_running", "stop", "start", "cleanup_backup"}
+    assert cli_keywords.isdisjoint(constant_dependencies)
+    assert market_keywords.isdisjoint(constant_dependencies)
+    assert None not in market_keywords
+    assert "replace_kwargs" not in inspect.signature(
+        market_bridge._replace_market_plugin_transaction
+    ).parameters
+
+
+@pytest.mark.asyncio
+async def test_market_channel_validation_runs_inside_operation_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = tmp_path / "plugins" / "demo"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.toml").write_text(
+        '[plugin]\nid = "demo"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    entry = market_bridge.LockEntry(
+        root_id="user",
+        directory_name="demo",
+        plugin_id="demo",
+        package_id="demo",
+        channel="market",
+        reason="user_requested",
+        installed_at="2026-08-31T00:00:00.000000Z",
+        updated_at="2026-08-31T00:00:00.000000Z",
+        last_seen_at="2026-08-31T00:00:00.000000Z",
+    )
+    manager = type(
+        "Manager",
+        (),
+        {"find_active_user_entry": lambda self, _plugin_id: entry},
+    )()
+
+    async def not_running(_plugin_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr(replacement_transaction, "_plugin_is_running", not_running)
+
+    async def install_new() -> dict[str, object]:
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.toml").write_text(
+            '[plugin]\nid = "demo"\nversion = "2.0.0"\n',
+            encoding="utf-8",
+        )
+        return {"installed": True}
+
+    lock_states: list[bool] = []
+
+    async def validate_channel_specific() -> None:
+        lock_states.append(operation_lock._operation_lock_is_held_by_current_task())
+
+    result = await market_bridge._replace_market_plugin_transaction(
+        manager=manager,  # type: ignore[arg-type]
+        expected_plugin_id="demo",
+        original_entry=entry,
+        original_entry_fingerprint=market_bridge._market_entry_fingerprint(entry),
+        installed_package_id="demo",
+        plugin_dir=plugin_dir,
+        layout=resolve_plugin_layout(
+            "demo",
+            plugin_dir,
+            storage_root=tmp_path / "runtime-data",
+        ),
+        install_new=install_new,
+        validate_channel_specific=validate_channel_specific,
+    )
+
+    assert result.install_result == {"installed": True}
+    assert lock_states == [True]

--- a/plugin/tests/unit/server/test_plugin_replacement_transaction.py
+++ b/plugin/tests/unit/server/test_plugin_replacement_transaction.py
@@ -6,17 +6,36 @@ import pytest
 
 from plugin.core import host as host_module
 from plugin.core.plugin_layout import resolve_plugin_layout
-from plugin.server.application.plugins import upgrade_support
-from plugin.server.application.plugins.upgrade_support import (
+from plugin.server.application.plugins.installation_transactions import (
     ReplacePluginError,
-    plugin_is_running,
     replace_plugin,
+)
+from plugin.server.application.plugins.installation_transactions import (
+    replace as replace_transaction,
+)
+from plugin.server.application.plugins.installation_transactions.replace import (
+    _plugin_is_running as plugin_is_running,
     remove_directory,
     run_rollback,
 )
 from plugin.server.infrastructure.config_profiles import load_profiles_cfg_from_file
 
 pytestmark = pytest.mark.plugin_unit
+OLD_PLUGIN_MANIFEST = '[plugin]\nid = "demo"\nversion = 1\n'
+NEW_PLUGIN_MANIFEST = '[plugin]\nid = "demo"\nversion = 2\n'
+
+
+@pytest.fixture(autouse=True)
+def _default_replacement_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def not_running(_plugin_id: str) -> bool:
+        return False
+
+    async def no_op(_plugin_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", not_running)
+    monkeypatch.setattr(replace_transaction, "_stop_plugin", no_op)
+    monkeypatch.setattr(replace_transaction, "_start_plugin", no_op)
 
 
 async def _async_none() -> None:
@@ -37,7 +56,7 @@ async def _record(events: list[str], value: str) -> None:
 
 def test_legacy_profile_case_variants_cannot_share_one_canonical_target() -> None:
     with pytest.raises(OSError, match="multiple legacy profile paths map to profiles.toml"):
-        upgrade_support._canonical_profile_sources(
+        replace_transaction._canonical_profile_sources(
             [Path("profiles.toml"), Path("Profiles.toml")]
         )
 
@@ -48,7 +67,7 @@ async def test_replace_plugin_replaces_only_payload_and_preserves_external_user_
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     (target / "vendor").mkdir()
     (target / "vendor" / "dependency.txt").write_text("old", encoding="utf-8")
 
@@ -65,7 +84,7 @@ async def test_replace_plugin_replaces_only_payload_and_preserves_external_user_
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         (target / "vendor").mkdir()
         (target / "vendor" / "dependency.txt").write_text("new", encoding="utf-8")
         return {"installed": True}
@@ -73,14 +92,10 @@ async def test_replace_plugin_replaces_only_payload_and_preserves_external_user_
     result = await replace_plugin(
         layout=resolve_plugin_layout("demo", target, storage_root=storage_root),
         install_new=install_new,
-        validate_new=_async_none,
-        is_running=lambda _plugin_id: _async_false(),
-        stop=lambda _plugin_id: _async_none(),
-        start=lambda _plugin_id: _async_none(),
-        cleanup_backup=remove_directory,
+        validate_channel_specific=_async_none,
     )
 
-    assert (target / "plugin.toml").read_text(encoding="utf-8") == "version = 2\n"
+    assert (target / "plugin.toml").read_text(encoding="utf-8") == NEW_PLUGIN_MANIFEST
     assert (target / "vendor" / "dependency.txt").read_text(encoding="utf-8") == "new"
     for path, content in expected_state.items():
         assert path.read_text(encoding="utf-8") == content
@@ -93,30 +108,109 @@ async def test_replace_plugin_invalidates_module_cache_before_restart(
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     events: list[str] = []
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         return {"installed": True}
 
     def evict(plugin_id: str) -> None:
         events.append(f"evict:{plugin_id}")
 
     monkeypatch.setattr(host_module, "evict_cached_plugin_modules", evict)
+    monkeypatch.setattr(
+        replace_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_true(),
+    )
+    monkeypatch.setattr(
+        replace_transaction,
+        "_stop_plugin",
+        lambda plugin_id: _record(events, f"stop:{plugin_id}"),
+    )
+    monkeypatch.setattr(
+        replace_transaction,
+        "_start_plugin",
+        lambda plugin_id: _record(events, f"start:{plugin_id}"),
+    )
 
     await replace_plugin(
         layout=resolve_plugin_layout("demo", target),
         install_new=install_new,
-        validate_new=_async_none,
-        is_running=lambda _plugin_id: _async_true(),
-        stop=lambda plugin_id: _record(events, f"stop:{plugin_id}"),
-        start=lambda plugin_id: _record(events, f"start:{plugin_id}"),
-        cleanup_backup=remove_directory,
+        validate_channel_specific=_async_none,
     )
 
     assert events == ["stop:demo", "evict:demo", "start:demo"]
+
+
+@pytest.mark.asyncio
+async def test_replace_plugin_rejects_shared_identity_mismatch_before_channel_validation(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "plugins" / "demo"
+    target.mkdir(parents=True)
+    (target / "plugin.toml").write_text(
+        '[plugin]\nid = "demo"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    channel_validation_called = False
+
+    async def install_new() -> dict[str, object]:
+        target.mkdir()
+        (target / "plugin.toml").write_text(
+            '[plugin]\nid = "other"\nversion = "2.0.0"\n',
+            encoding="utf-8",
+        )
+        return {"installed": True}
+
+    async def validate_channel_specific() -> None:
+        nonlocal channel_validation_called
+        channel_validation_called = True
+
+    with pytest.raises(ReplacePluginError) as exc_info:
+        await replace_plugin(
+            layout=resolve_plugin_layout("demo", target),
+            install_new=install_new,
+            validate_channel_specific=validate_channel_specific,
+        )
+
+    assert exc_info.value.stage == "validate"
+    assert exc_info.value.rollback_status == "completed"
+    assert channel_validation_called is False
+    assert 'id = "demo"' in (target / "plugin.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_replace_plugin_rolls_back_new_payload_missing_plugin_table(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "plugins" / "demo"
+    target.mkdir(parents=True)
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
+    channel_validation_called = False
+
+    async def install_new() -> dict[str, object]:
+        target.mkdir()
+        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        return {"installed": True}
+
+    async def validate_channel_specific() -> None:
+        nonlocal channel_validation_called
+        channel_validation_called = True
+
+    with pytest.raises(ReplacePluginError) as exc_info:
+        await replace_plugin(
+            layout=resolve_plugin_layout("demo", target),
+            install_new=install_new,
+            validate_channel_specific=validate_channel_specific,
+        )
+
+    assert exc_info.value.stage == "validate"
+    assert exc_info.value.rollback_status == "completed"
+    assert channel_validation_called is False
+    assert (target / "plugin.toml").read_text(encoding="utf-8") == OLD_PLUGIN_MANIFEST
 
 
 @pytest.mark.asyncio
@@ -126,13 +220,13 @@ async def test_replace_plugin_invalidates_new_cache_before_rollback_restart(
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     events: list[str] = []
     start_attempts = 0
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         return {"installed": True}
 
     async def start(plugin_id: str) -> None:
@@ -146,16 +240,23 @@ async def test_replace_plugin_invalidates_new_cache_before_rollback_restart(
         events.append(f"evict:{plugin_id}")
 
     monkeypatch.setattr(host_module, "evict_cached_plugin_modules", evict)
+    monkeypatch.setattr(
+        replace_transaction,
+        "_plugin_is_running",
+        lambda _plugin_id: _async_true(),
+    )
+    monkeypatch.setattr(
+        replace_transaction,
+        "_stop_plugin",
+        lambda plugin_id: _record(events, f"stop:{plugin_id}"),
+    )
+    monkeypatch.setattr(replace_transaction, "_start_plugin", start)
 
     with pytest.raises(ReplacePluginError, match="restart"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=install_new,
-            validate_new=_async_none,
-            is_running=lambda _plugin_id: _async_true(),
-            stop=lambda plugin_id: _record(events, f"stop:{plugin_id}"),
-            start=start,
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
         )
 
     assert events == [
@@ -165,7 +266,7 @@ async def test_replace_plugin_invalidates_new_cache_before_rollback_restart(
         "evict:demo",
         "start:demo",
     ]
-    assert (target / "plugin.toml").read_text(encoding="utf-8") == "version = 1\n"
+    assert (target / "plugin.toml").read_text(encoding="utf-8") == OLD_PLUGIN_MANIFEST
 
 
 @pytest.mark.asyncio
@@ -174,7 +275,7 @@ async def test_replace_plugin_preserves_manifest_adjacent_user_profiles(
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     (target / "profiles.toml").write_text(
         "[config_profiles]\nactive = 'dev'\n",
         encoding="utf-8",
@@ -187,20 +288,16 @@ async def test_replace_plugin_preserves_manifest_adjacent_user_profiles(
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         return {"installed": True}
 
     await replace_plugin(
         layout=resolve_plugin_layout("demo", target),
         install_new=install_new,
-        validate_new=_async_none,
-        is_running=lambda _plugin_id: _async_false(),
-        stop=lambda _plugin_id: _async_none(),
-        start=lambda _plugin_id: _async_none(),
-        cleanup_backup=remove_directory,
+        validate_channel_specific=_async_none,
     )
 
-    assert (target / "plugin.toml").read_text(encoding="utf-8") == "version = 2\n"
+    assert (target / "plugin.toml").read_text(encoding="utf-8") == NEW_PLUGIN_MANIFEST
     assert (target / "profiles.toml").read_text(encoding="utf-8") == (
         "[config_profiles]\nactive = 'dev'\n"
     )
@@ -215,7 +312,7 @@ async def test_replace_plugin_canonicalizes_legacy_profile_path_case_for_reader(
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     (target / "Profiles.toml").write_text(
         "[config_profiles]\nactive = 'dev'\n[config_profiles.files]\ndev = 'profiles/dev.toml'\n",
         encoding="utf-8",
@@ -228,17 +325,13 @@ async def test_replace_plugin_canonicalizes_legacy_profile_path_case_for_reader(
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         return {"installed": True}
 
     await replace_plugin(
         layout=resolve_plugin_layout("demo", target),
         install_new=install_new,
-        validate_new=_async_none,
-        is_running=lambda _plugin_id: _async_false(),
-        stop=lambda _plugin_id: _async_none(),
-        start=lambda _plugin_id: _async_none(),
-        cleanup_backup=remove_directory,
+        validate_channel_specific=_async_none,
     )
 
     restored_names = {path.name for path in target.iterdir()}
@@ -256,7 +349,7 @@ async def test_replace_plugin_rejects_duplicate_casefolded_profile_paths(
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     (target / "profiles.toml").write_text("canonical\n", encoding="utf-8")
     (target / "Profiles.toml").write_text("variant\n", encoding="utf-8")
     variants = [
@@ -269,23 +362,19 @@ async def test_replace_plugin_rejects_duplicate_casefolded_profile_paths(
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         return {"installed": True}
 
     with pytest.raises(ReplacePluginError) as exc_info:
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=install_new,
-            validate_new=_async_none,
-            is_running=lambda _plugin_id: _async_false(),
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
         )
 
     assert exc_info.value.stage == "preserve"
     assert exc_info.value.rollback_status == "completed"
-    assert (target / "plugin.toml").read_text(encoding="utf-8") == "version = 1\n"
+    assert (target / "plugin.toml").read_text(encoding="utf-8") == OLD_PLUGIN_MANIFEST
 
 
 @pytest.mark.asyncio
@@ -300,7 +389,7 @@ async def test_replace_plugin_rejects_manifest_adjacent_profile_symlinks(
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     link_target = tmp_path / f"external-{relative_path.replace('.', '-')}"
     if link_target_exists:
         if relative_path == "profiles":
@@ -316,23 +405,19 @@ async def test_replace_plugin_rejects_manifest_adjacent_profile_symlinks(
 
     async def install_new() -> dict[str, object]:
         target.mkdir()
-        (target / "plugin.toml").write_text("version = 2\n", encoding="utf-8")
+        (target / "plugin.toml").write_text(NEW_PLUGIN_MANIFEST, encoding="utf-8")
         return {"installed": True}
 
     with pytest.raises(ReplacePluginError) as exc_info:
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=install_new,
-            validate_new=_async_none,
-            is_running=lambda _plugin_id: _async_false(),
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
         )
 
     assert exc_info.value.stage == "preserve"
     assert exc_info.value.rollback_status == "completed"
-    assert (target / "plugin.toml").read_text(encoding="utf-8") == "version = 1\n"
+    assert (target / "plugin.toml").read_text(encoding="utf-8") == OLD_PLUGIN_MANIFEST
     assert profile_path.is_symlink()
 
 
@@ -369,11 +454,7 @@ async def test_replace_plugin_initializes_runtime_config_from_old_payload_before
     await replace_plugin(
         layout=resolve_plugin_layout("demo", target, storage_root=storage_root),
         install_new=install_new,
-        validate_new=_async_none,
-        is_running=lambda _plugin_id: _async_false(),
-        stop=lambda _plugin_id: _async_none(),
-        start=lambda _plugin_id: _async_none(),
-        cleanup_backup=remove_directory,
+        validate_channel_specific=_async_none,
     )
 
     runtime_config = storage_root / "plugins" / "demo" / "config" / "plugin.toml"
@@ -383,6 +464,7 @@ async def test_replace_plugin_initializes_runtime_config_from_old_payload_before
 @pytest.mark.asyncio
 async def test_replace_plugin_rejects_invalid_preserve_target_before_side_effects(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     target = tmp_path / "plugins" / "demo"
     target.mkdir(parents=True)
@@ -397,18 +479,13 @@ async def test_replace_plugin_rejects_invalid_preserve_target_before_side_effect
         events.append(f"running:{plugin_id}")
         return True
 
-    async def stop(plugin_id: str) -> None:
-        events.append(f"stop:{plugin_id}")
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
 
     with pytest.raises(ValueError, match="preserve targets"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target, storage_root=storage_root),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=is_running,
-            stop=stop,
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             preserve_targets=(tmp_path / "not-a-replacement-target",),
         )
 
@@ -420,6 +497,7 @@ async def test_replace_plugin_rejects_invalid_preserve_target_before_side_effect
 @pytest.mark.parametrize("target_kind", ["duplicate", "nested"])
 async def test_replace_plugin_rejects_overlapping_targets_before_side_effects(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     target_kind: str,
 ) -> None:
     target = tmp_path / "plugins" / "demo"
@@ -435,15 +513,13 @@ async def test_replace_plugin_rejects_overlapping_targets_before_side_effects(
         events.append(f"running:{plugin_id}")
         return False
 
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
+
     with pytest.raises(ValueError, match="distinct and non-overlapping"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target, storage_root=tmp_path / "state"),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=is_running,
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             additional_targets=(additional_target,),
         )
 
@@ -463,21 +539,19 @@ async def test_replace_plugin_rejects_persistent_state_target_before_side_effect
     state_db.parent.mkdir()
     state_db.write_bytes(b"state")
     events: list[str] = []
-    monkeypatch.setattr(upgrade_support, "get_plugin_state_root", lambda: state_root)
+    monkeypatch.setattr(replace_transaction, "get_plugin_state_root", lambda: state_root)
 
     async def is_running(plugin_id: str) -> bool:
         events.append(f"running:{plugin_id}")
         return False
 
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
+
     with pytest.raises(ValueError, match="persistent state paths"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target, storage_root=tmp_path),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=is_running,
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
         )
 
     assert events == []
@@ -491,7 +565,7 @@ async def test_replace_plugin_uses_layout_state_root_for_custom_storage(
 ) -> None:
     target = tmp_path / "installed" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     storage_root = tmp_path / "custom-state"
     plugin_state = storage_root / "plugins" / "demo"
     state_db = plugin_state / "data" / "study.db"
@@ -499,7 +573,7 @@ async def test_replace_plugin_uses_layout_state_root_for_custom_storage(
     state_db.write_bytes(b"state")
     events: list[str] = []
     monkeypatch.setattr(
-        upgrade_support,
+        replace_transaction,
         "get_plugin_state_root",
         lambda: tmp_path / "unrelated-global-state",
     )
@@ -508,15 +582,13 @@ async def test_replace_plugin_uses_layout_state_root_for_custom_storage(
         events.append(f"running:{plugin_id}")
         return False
 
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
+
     with pytest.raises(ValueError, match="persistent state paths"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target, storage_root=storage_root),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=is_running,
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             additional_targets=(plugin_state,),
         )
 
@@ -532,28 +604,26 @@ async def test_replace_plugin_rejects_target_containing_persistent_state_before_
 ) -> None:
     target = tmp_path / "exec" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     profile_ancestor = tmp_path / "managed"
     state_root = profile_ancestor / "plugins"
     state_db = state_root / "study_companion" / "data" / "study.db"
     state_db.parent.mkdir(parents=True)
     state_db.write_bytes(b"state")
     events: list[str] = []
-    monkeypatch.setattr(upgrade_support, "get_plugin_state_root", lambda: state_root)
+    monkeypatch.setattr(replace_transaction, "get_plugin_state_root", lambda: state_root)
 
     async def is_running(plugin_id: str) -> bool:
         events.append(f"running:{plugin_id}")
         return False
 
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
+
     with pytest.raises(ValueError, match="persistent state paths"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=is_running,
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             additional_targets=(profile_ancestor,),
         )
 
@@ -571,7 +641,7 @@ async def test_replace_plugin_rejects_builtin_root_overlap_before_side_effects(
 ) -> None:
     target = tmp_path / "user-plugins" / "demo"
     target.mkdir(parents=True)
-    (target / "plugin.toml").write_text("version = 1\n", encoding="utf-8")
+    (target / "plugin.toml").write_text(OLD_PLUGIN_MANIFEST, encoding="utf-8")
     builtin_root = tmp_path / "runtime" / "plugin" / "plugins"
     builtin_plugin = builtin_root / "demo"
     builtin_plugin.mkdir(parents=True)
@@ -583,21 +653,23 @@ async def test_replace_plugin_rejects_builtin_root_overlap_before_side_effects(
         "ancestor": builtin_root.parent,
     }[overlap]
     events: list[str] = []
-    monkeypatch.setattr(upgrade_support.settings, "BUILTIN_PLUGIN_CONFIG_ROOT", builtin_root)
+    monkeypatch.setattr(
+        replace_transaction.settings,
+        "BUILTIN_PLUGIN_CONFIG_ROOT",
+        builtin_root,
+    )
 
     async def is_running(plugin_id: str) -> bool:
         events.append(f"running:{plugin_id}")
         return False
 
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
+
     with pytest.raises(ValueError, match="immutable builtin plugin paths"):
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=is_running,
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             additional_targets=(forbidden_target,),
         )
 
@@ -607,7 +679,10 @@ async def test_replace_plugin_rejects_builtin_root_overlap_before_side_effects(
 
 
 @pytest.mark.asyncio
-async def test_run_rollback_removes_new_directory_restores_backup_and_restarts(tmp_path: Path) -> None:
+async def test_run_rollback_removes_new_directory_restores_backup_and_restarts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     target = tmp_path / "demo"
     backup = tmp_path / "demo.bak"
     target.mkdir()
@@ -619,12 +694,13 @@ async def test_run_rollback_removes_new_directory_restores_backup_and_restarts(t
     async def start(plugin_id: str) -> None:
         restarted.append(plugin_id)
 
+    monkeypatch.setattr(replace_transaction, "_start_plugin", start)
+
     restored = await run_rollback(
         plugin_id="demo",
         target_dir=target,
         backup_dir=backup,
         restart=True,
-        start=start,
     )
 
     assert restored is True
@@ -668,16 +744,16 @@ async def test_backup_failure_restarts_running_plugin_without_installing(
         raise PermissionError(destination)
 
     monkeypatch.setattr(Path, "rename", fail_rename)
+    monkeypatch.setattr(replace_transaction, "_plugin_is_running", is_running)
+    monkeypatch.setattr(replace_transaction, "_stop_plugin", stop)
+    monkeypatch.setattr(replace_transaction, "_start_plugin", start)
+    monkeypatch.setattr(replace_transaction, "remove_directory", cleanup_backup)
 
     with pytest.raises(ReplacePluginError) as exc_info:
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=install_new,
-            validate_new=validate_new,
-            is_running=is_running,
-            stop=stop,
-            start=start,
-            cleanup_backup=cleanup_backup,
+            validate_channel_specific=validate_new,
         )
 
     assert exc_info.value.stage == "backup"
@@ -712,11 +788,7 @@ async def test_backup_failure_rolls_back_when_rollback_observer_fails(
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=lambda: _async_none(),  # type: ignore[arg-type]
-            validate_new=_async_none,
-            is_running=lambda _plugin_id: _async_false(),
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             additional_targets=(additional_target,),
             on_rollback_start=fail_observer,
         )
@@ -747,11 +819,7 @@ async def test_install_failure_rolls_back_when_rollback_observer_fails(
         await replace_plugin(
             layout=resolve_plugin_layout("demo", target),
             install_new=fail_install,
-            validate_new=_async_none,
-            is_running=lambda _plugin_id: _async_false(),
-            stop=lambda _plugin_id: _async_none(),
-            start=lambda _plugin_id: _async_none(),
-            cleanup_backup=remove_directory,
+            validate_channel_specific=_async_none,
             on_rollback_start=fail_observer,
         )
 
@@ -780,8 +848,6 @@ async def test_remove_directory_propagates_cleanup_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from plugin.server.application.plugins import upgrade_support
-
     target = tmp_path / "demo"
     target.mkdir()
     ignore_values: list[bool] = []
@@ -792,7 +858,11 @@ async def test_remove_directory_propagates_cleanup_failure(
         if not ignore_errors:
             raise PermissionError("cleanup denied")
 
-    monkeypatch.setattr(upgrade_support.shutil, "rmtree", fail_unless_errors_are_suppressed)
+    monkeypatch.setattr(
+        replace_transaction.shutil,
+        "rmtree",
+        fail_unless_errors_are_suppressed,
+    )
 
     with pytest.raises(PermissionError, match="cleanup denied"):
         await remove_directory(target)


### PR DESCRIPTION
## Summary

Part of #2994, PR4 only: narrow the already-verified plugin replacement transaction boundary without changing product behavior.

## PR4 hard scope

- Move the replacement file transaction from plugin/server/application/plugins/upgrade_support.py into plugin/server/application/plugins/installation_transactions/replace.py.
- Internalize the invariant lifecycle dependencies: running-state probe, stop, strict restart, module cache invalidation, and default backup cleanup.
- Centralize the shared installed plugin identity validation used by both Plugin CLI and Market.
- Keep Plugin CLI callers limited to the changing install, validation, additional-target, and preserve-target inputs.
- Replace the Market dict[str, Any] plus kwargs adapter with an explicit, fully typed call.
- Migrate both callers and the existing replacement regression suite.
- Delete upgrade_support.py after migration, with no compatibility or re-export layer.
- Keep Market channel-specific validation inside the serialized operation lock.

## Behavior retained

- Manifestless existing plugins and legacy profile handling.
- Manifest-adjacent profile migration and restoration.
- additional_targets and preserve_targets.
- Manual takeover snapshot confirmation and rollback of both directories and LockEntry.
- Builtin override and existing source-switch behavior.
- Runtime config initialization timing.
- Module cache invalidation and restoration of the previous running state after failure.
- Successful replacement remains committed when backup cleanup fails.
- Persistent config/data/cache/state isolation.
- Builtin-root, symlink, overlapping-path, and case-normalization guards.
- Legacy Market rename normalization, response fields, and error mappings.

The incoming replacement payload must prove its identity with a valid [plugin].id. A missing [plugin] table now fails during validation and restores the previous installation; manifestless compatibility remains limited to the pre-replacement installed directory.

## Verification

- Backend replacement, Plugin CLI, Market, operation-lock, builtin-override, and adjacent E2E regression suite: 219 passed, 5 skipped.
- Replacement-focused suite: 26 passed, 4 skipped.
- Ruff on every changed Python file: passed.
- Plugin Manager installer regression: 16 passed.
- TypeScript type check: passed.
- Locale consistency: 717 keys across 8 locales, passed.
- git diff --check db69f186: passed.
- Production references to upgrade_support: zero.
- Frontend and locale copy changes: zero diff.

Manual QA covered running-plugin upgrade/reinstall, configuration and profile preservation, persistent plugin data, restart behavior, invalid package rejection, and uninstall using beginner_demo, NEKO Live, and the War Thunder plugin. A real builtin-to-Market override was intentionally not exercised; the automated builtin override regression suite passed.

## Explicit exclusions

- No package-management facade, Coordinator, or wide replacement request object.
- No new install mode, storage format, dependency, or product behavior.
- No Registry/CAS/JSONL/schema, managed/adoption, or multi-user candidate work.
- No runtime ID conflict or automatic rename policy changes.
- No PR3 uninstall transaction behavior changes.
- No source-switch, Market task-system, or generic rollback-framework refactor.
- No frontend error-copy or locale behavior changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 统一插件升级、重装与替换流程，提升操作一致性和可靠性。
  - 增强安装包校验，确保插件身份、清单格式及渠道信息正确。
  - 优化失败回滚、备份清理及插件停止与重启处理。

- **文档**
  - 更新中文、日文维护文档中的实现路径说明。

- **测试**
  - 扩展替换、回滚、锁定及内置插件覆盖场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->