### PR TITLE
fix(card-drop): capture PNGTuber forge references safely

### DIFF
--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -436,6 +436,24 @@ async def set_card_drop_active_character(request: Request, payload: dict):
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
     if not isinstance(payload, dict):
         return {"ok": True}
+    revision_alias = next(
+        (alias for alias in ("modelRevision", "model_revision") if alias in payload),
+        None,
+    )
+    if revision_alias is not None:
+        try:
+            incoming_revision = max(0, int(payload.get(revision_alias) or 0))
+        except (TypeError, ValueError):
+            incoming_revision = 0
+        try:
+            current_revision = max(
+                0, int(_card_drop_active_character.get("modelRevision") or 0)
+            )
+        except (TypeError, ValueError):
+            current_revision = 0
+        if incoming_revision < current_revision:
+            return {"ok": False, "stale": True}
+        _card_drop_active_character["modelRevision"] = incoming_revision
     name_changed = False
     if "name" in payload:
         next_name = str(payload.get("name") or "")

--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -431,18 +431,45 @@ def _active_character_cors_headers(request: Request) -> dict[str, str] | None:
 
 @app.post("/api/card-drop/active-character")
 async def set_card_drop_active_character(request: Request, payload: dict):
-    """Apply supplied fields, dropping avatar payloads that belong to a prior name."""
+    """Apply fields and invalidate images when character/model identity changes."""
     if not _card_drop_mutation_origin_allowed(request):
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
     if not isinstance(payload, dict):
         return {"ok": True}
+    name_changed = False
     if "name" in payload:
         next_name = str(payload.get("name") or "")
-        if next_name != _card_drop_active_character.get("name", ""):
-            for avatar_field in ("dataUrl", "characterReferenceDataUrl"):
-                if avatar_field not in payload:
-                    _card_drop_active_character.pop(avatar_field, None)
+        name_changed = next_name != _card_drop_active_character.get("name", "")
         _card_drop_active_character["name"] = next_name
+
+    identity_changed = name_changed
+    model_type_supplied = "modelType" in payload or "model_type" in payload
+    model_key_supplied = "modelKey" in payload or "model_key" in payload
+    for stored_field, aliases in (
+        ("modelType", ("modelType", "model_type")),
+        ("modelKey", ("modelKey", "model_key")),
+    ):
+        supplied_alias = next((alias for alias in aliases if alias in payload), None)
+        if supplied_alias is None:
+            continue
+        next_value = str(payload.get(supplied_alias) or "")
+        if next_value != _card_drop_active_character.get(stored_field, ""):
+            identity_changed = True
+        _card_drop_active_character[stored_field] = next_value
+
+    if name_changed:
+        if not model_type_supplied:
+            _card_drop_active_character.pop("modelType", None)
+        if not model_key_supplied:
+            _card_drop_active_character.pop("modelKey", None)
+    elif model_type_supplied and identity_changed and not model_key_supplied:
+        # A type-only transition must not leave the prior model's key attached.
+        _card_drop_active_character.pop("modelKey", None)
+
+    if identity_changed:
+        for avatar_field in ("dataUrl", "characterReferenceDataUrl"):
+            if avatar_field not in payload:
+                _card_drop_active_character.pop(avatar_field, None)
     if "dataUrl" in payload:
         _card_drop_active_character["dataUrl"] = str(payload.get("dataUrl") or "")
     if "characterReferenceDataUrl" in payload:
@@ -481,6 +508,9 @@ async def get_card_drop_active_character(
     payload: dict[str, str] = {"name": name}
     if master_name:
         payload["master_name"] = master_name
+    if not used_fallback:
+        payload["modelType"] = _card_drop_active_character.get("modelType", "")
+        payload["modelKey"] = _card_drop_active_character.get("modelKey", "")
     if include_avatar and not used_fallback:
         payload["dataUrl"] = _card_drop_active_character.get("dataUrl", "")
         payload["characterReferenceDataUrl"] = _card_drop_active_character.get(

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -1274,6 +1274,11 @@
         const trigger = options.trigger || null;
         const manualCrop = options.manualCrop === true;
 
+        if (pngtuberModelLoading && getCurrentModelType() === 'pngtuber') {
+            pendingAutoCapture = true;
+            return;
+        }
+
         if (isCapturing) {
             if (showCard) {
                 setPreviewVisible(true, trigger);
@@ -1465,6 +1470,10 @@
 
     function handleModelLoading() {
         pngtuberModelLoading = true;
+        if (autoCaptureTimer) {
+            clearTimeout(autoCaptureTimer);
+            autoCaptureTimer = null;
+        }
         advanceCardDropModelRevision();
         invalidateCachedPreview();
         syncAvatarToCardDrop('', { scheduleReference: false });
@@ -1499,6 +1508,10 @@
         window.addEventListener('pngtuber-model-loaded', function () {
             pngtuberModelLoading = false;
             handleModelLoaded('pngtuber-model-loaded');
+        });
+
+        window.addEventListener('pngtuber-model-load-finished', function () {
+            pngtuberModelLoading = false;
         });
     }
 

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -1505,6 +1505,7 @@
         window.addEventListener('pngtuber-model-loading', function (event) {
             const loadToken = Number(event?.detail?.loadToken) || 0;
             if (loadToken < pngtuberModelLoadToken) return;
+            if (loadToken === pngtuberModelLoadToken && pngtuberModelLoading) return;
             pngtuberModelLoadToken = loadToken;
             handleModelLoading();
         });

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -447,8 +447,9 @@
     }
 
     function ensureCharacterReferenceRetryCacheKey(cacheKey) {
-        if (characterReferenceRetryCacheKey === cacheKey) return;
-        characterReferenceRetryCacheKey = cacheKey || '';
+        var revisionCacheKey = (cacheKey || '') + ':' + cardDropModelRevision;
+        if (characterReferenceRetryCacheKey === revisionCacheKey) return;
+        characterReferenceRetryCacheKey = revisionCacheKey;
         characterReferenceRetryAttempts = 0;
         if (characterReferenceRetryTimer) {
             clearTimeout(characterReferenceRetryTimer);

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -24,6 +24,7 @@
     let lastScheduledCacheKey = '';
     let cardDropModelRevision = Date.now();
     let pngtuberModelLoading = false;
+    let pngtuberModelLoadToken = 0;
     // 多窗口模式：由 IPC 从 Pet 窗口注入的头像（/chat 页面无本地模型）
     let externalAvatarDataUrl = '';
     let externalAvatarModelType = '';
@@ -1501,16 +1502,23 @@
             handleModelLoaded('mmd-model-loaded');
         });
 
-        window.addEventListener('pngtuber-model-loading', function () {
+        window.addEventListener('pngtuber-model-loading', function (event) {
+            const loadToken = Number(event?.detail?.loadToken) || 0;
+            if (loadToken < pngtuberModelLoadToken) return;
+            pngtuberModelLoadToken = loadToken;
             handleModelLoading();
         });
 
-        window.addEventListener('pngtuber-model-loaded', function () {
+        window.addEventListener('pngtuber-model-loaded', function (event) {
+            const loadToken = Number(event?.detail?.loadToken) || 0;
+            if (loadToken !== pngtuberModelLoadToken) return;
             pngtuberModelLoading = false;
             handleModelLoaded('pngtuber-model-loaded');
         });
 
-        window.addEventListener('pngtuber-model-load-finished', function () {
+        window.addEventListener('pngtuber-model-load-finished', function (event) {
+            const loadToken = Number(event?.detail?.loadToken) || 0;
+            if (loadToken !== pngtuberModelLoadToken) return;
             pngtuberModelLoading = false;
         });
     }

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -83,7 +83,12 @@
             var raw = localStorage.getItem(key);
             if (!raw) return null;
             var parsed = JSON.parse(raw);
-            if (parsed && parsed.dataUrl) return parsed;
+            if (
+                parsed
+                && parsed.dataUrl
+                && parsed.cacheKey
+                && parsed.cacheKey === getCurrentModelCacheKey()
+            ) return parsed;
         } catch (_) { /* 损坏数据 — 忽略 */ }
         return null;
     }
@@ -116,6 +121,7 @@
 
     function normalizeModelLabel(modelType) {
         const type = String(modelType || '').toLowerCase();
+        if (type === 'pngtuber') return 'PNGTuber';
         if (type === 'vrm') return 'VRM';
         if (type === 'mmd') return 'MMD';
         return 'Live2D';
@@ -326,6 +332,7 @@
             return window.avatarPortrait.normalizeModelType();
         }
         const modelType = String(window.lanlan_config?.model_type || '').toLowerCase();
+        if (modelType === 'pngtuber') return 'pngtuber';
         if (modelType === 'live3d') {
             const subType = String(window.lanlan_config?.live3d_sub_type || '').toLowerCase();
             if (subType === 'mmd') return 'mmd';
@@ -338,9 +345,19 @@
 
     function getCurrentModelCacheKey() {
         const modelType = getCurrentModelType();
+        if (modelType === 'pngtuber') {
+            const config = window.pngtuberManager?.config || window.lanlan_config?.pngtuber || {};
+            return 'pngtuber:' + String(
+                config.layered_metadata ||
+                config.idle_image ||
+                config.talking_image ||
+                ''
+            );
+        }
         if (modelType === 'vrm') {
             return 'vrm:' + String(
                 window.vrmManager?.currentModel?.url ||
+                window.vrmModel ||
                 window.lanlan_config?.vrm ||
                 ''
             );
@@ -358,6 +375,14 @@
             window.cubism4Model ||
             ''
         );
+    }
+
+    function appendCardDropModelIdentity(body) {
+        const modelType = getCurrentModelType();
+        const modelKey = getCurrentModelCacheKey();
+        if (modelType) body.modelType = modelType;
+        if (modelKey && !modelKey.endsWith(':')) body.modelKey = modelKey;
+        return body;
     }
 
     function hasUsableCachedPreview() {
@@ -405,7 +430,9 @@
     function postCharacterReferenceToCardDrop(characterReferenceDataUrl) {
         if (!characterReferenceDataUrl) return Promise.resolve(false);
         var _nekoName = getActiveLanlanName();
-        var referenceBody = { characterReferenceDataUrl: characterReferenceDataUrl };
+        var referenceBody = appendCardDropModelIdentity({
+            characterReferenceDataUrl: characterReferenceDataUrl
+        });
         if (_nekoName) referenceBody.name = _nekoName;
         return fetch('/api/card-drop/active-character', {
             method: 'POST',
@@ -641,6 +668,7 @@
         var body = {};
         if (dataUrl) body.dataUrl = dataUrl;
         if (_nekoName) body.name = _nekoName;
+        appendCardDropModelIdentity(body);
         fetch('/api/card-drop/active-character', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -675,7 +703,7 @@
         }));
     }
 
-    /** 仅清内存，让 scheduleAutoCapture 不被跳过；localStorage 按角色隔离，无需清除 */
+    /** 仅清内存，让 scheduleAutoCapture 不被跳过；持久化缓存会按角色 + 模型 key 校验 */
     function invalidateCachedPreview() {
         cachedPreview = null;
         lastScheduledCacheKey = '';
@@ -1363,6 +1391,10 @@
         window.addEventListener('mmd-model-loaded', function () {
             handleModelLoaded('mmd-model-loaded');
         });
+
+        window.addEventListener('pngtuber-model-loaded', function () {
+            handleModelLoaded('pngtuber-model-loaded');
+        });
     }
 
     function handleOutsidePointer(event) {
@@ -1591,7 +1623,7 @@
     /**
      * 多窗口模式：由 preload / IPC 调用，设置从 Pet 窗口获取的头像
      * @param {string} dataUrl - base64 data URL
-     * @param {string} [modelType] - 'live2d' | 'vrm' | 'mmd'
+     * @param {string} [modelType] - 'live2d' | 'vrm' | 'mmd' | 'pngtuber'
      */
     mod.setExternalAvatar = function setExternalAvatar(dataUrl, modelType) {
         externalAvatarDataUrl = dataUrl || '';

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -403,14 +403,18 @@
     function appendCardDropModelIdentity(body) {
         const modelType = getCurrentModelType();
         const modelKey = getCurrentModelCacheKey();
-        // Electron follower windows can receive the avatar/type without the model
-        // path. Keep their avatar/name sync, but leave authoritative identity to Pet.
-        if (modelType && modelKey && !modelKey.endsWith(':')) {
+        if (modelType) {
             body.modelType = modelType;
-            body.modelKey = modelKey;
+            body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';
             body.modelRevision = cardDropModelRevision;
         }
         return body;
+    }
+
+    function isCardDropIdentityFollowerWindow() {
+        const pathname = String(window.location?.pathname || '');
+        return window.__NEKO_MULTI_WINDOW__ === true
+            && /^\/chat(?:_full)?(?:\/|$)/.test(pathname);
     }
 
     function advanceCardDropModelRevision() {
@@ -720,7 +724,9 @@
         var body = {};
         if (dataUrl) body.dataUrl = dataUrl;
         if (_nekoName) body.name = _nekoName;
-        appendCardDropModelIdentity(body);
+        // Electron chat windows mirror Pet's avatar but do not own its model path.
+        // They may update avatar/name fields, while Pet remains identity authority.
+        if (!isCardDropIdentityFollowerWindow()) appendCardDropModelIdentity(body);
         fetch('/api/card-drop/active-character', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -16,6 +16,7 @@
     let cachedCharacterReference = null;
     let pendingCharacterReference = null;
     let pendingCharacterReferenceCacheKey = '';
+    let pendingCharacterReferenceRevision = 0;
     let characterReferenceRetryTimer = null;
     let characterReferenceRetryAttempts = 0;
     let characterReferenceRetryCacheKey = '';
@@ -440,6 +441,7 @@
         return !!(
             cachedCharacterReference &&
             cachedCharacterReference.cacheKey === cacheKey &&
+            cachedCharacterReference.modelRevision === cardDropModelRevision &&
             isRasterImageDataUrl(cachedCharacterReference.dataUrl)
         );
     }
@@ -454,12 +456,14 @@
         }
     }
 
-    function postCharacterReferenceToCardDrop(characterReferenceDataUrl) {
+    function postCharacterReferenceToCardDrop(characterReferenceDataUrl, captureRevision) {
         if (!characterReferenceDataUrl) return Promise.resolve(false);
+        if (captureRevision !== cardDropModelRevision) return Promise.resolve(false);
         var _nekoName = getActiveLanlanName();
         var referenceBody = appendCardDropModelIdentity({
             characterReferenceDataUrl: characterReferenceDataUrl
         });
+        referenceBody.modelRevision = captureRevision;
         if (_nekoName) referenceBody.name = _nekoName;
         return fetch('/api/card-drop/active-character', {
             method: 'POST',
@@ -504,15 +508,16 @@
         var modelCacheKey = getCurrentModelCacheKey();
         if (!modelCacheKey || modelCacheKey.endsWith(':')) return Promise.resolve(false);
         var cacheKey = getCharacterReferenceCacheKey();
+        var captureRevision = cardDropModelRevision;
         ensureCharacterReferenceRetryCacheKey(cacheKey);
         characterReferenceRetryAttempts += 1;
-        return captureCharacterReferenceDataUrl()
+        return captureCharacterReferenceDataUrl(captureRevision)
             .then(function (characterReferenceDataUrl) {
                 if (!characterReferenceDataUrl) {
                     queueCharacterReferenceRetry(reason || 'empty-capture');
                     return false;
                 }
-                return postCharacterReferenceToCardDrop(characterReferenceDataUrl)
+                return postCharacterReferenceToCardDrop(characterReferenceDataUrl, captureRevision)
                     .then(function (posted) {
                         if (posted) {
                             characterReferenceRetryAttempts = 0;
@@ -540,13 +545,14 @@
         }, hasUsableCachedCharacterReference() ? 0 : 240);
     }
 
-    function rememberCharacterReferenceResult(result, cacheKey) {
+    function rememberCharacterReferenceResult(result, cacheKey, captureRevision) {
         var dataUrl = result && result.dataUrl ? result.dataUrl : '';
         if (isRasterImageDataUrl(dataUrl)) {
             cachedCharacterReference = {
                 cacheKey: cacheKey,
                 dataUrl: dataUrl,
                 modelType: result.modelType || getCurrentModelType(),
+                modelRevision: captureRevision,
                 capturedAt: Date.now()
             };
             return dataUrl;
@@ -630,18 +636,23 @@
         });
     }
 
-    function captureCharacterReferenceDataUrl() {
+    function captureCharacterReferenceDataUrl(captureRevision) {
         var cacheKey = getCharacterReferenceCacheKey();
+        captureRevision = Number.isFinite(captureRevision)
+            ? captureRevision
+            : cardDropModelRevision;
         if (
             cachedCharacterReference &&
             cachedCharacterReference.cacheKey === cacheKey &&
+            cachedCharacterReference.modelRevision === captureRevision &&
             isRasterImageDataUrl(cachedCharacterReference.dataUrl)
         ) {
             return Promise.resolve(cachedCharacterReference.dataUrl);
         }
         if (
             pendingCharacterReference &&
-            pendingCharacterReferenceCacheKey === cacheKey
+            pendingCharacterReferenceCacheKey === cacheKey &&
+            pendingCharacterReferenceRevision === captureRevision
         ) {
             return pendingCharacterReference;
         }
@@ -663,7 +674,8 @@
             })
             .then(function (result) {
                 if (getCharacterReferenceCacheKey() !== cacheKey) return '';
-                return rememberCharacterReferenceResult(result, cacheKey);
+                if (cardDropModelRevision !== captureRevision) return '';
+                return rememberCharacterReferenceResult(result, cacheKey, captureRevision);
             })
             .catch(function (err) {
                 console.warn('[chat-avatar] card-drop character reference capture failed:', err);
@@ -673,10 +685,12 @@
                 if (pendingCharacterReference === capturePromise) {
                     pendingCharacterReference = null;
                     pendingCharacterReferenceCacheKey = '';
+                    pendingCharacterReferenceRevision = 0;
                 }
             });
         pendingCharacterReference = capturePromise;
         pendingCharacterReferenceCacheKey = cacheKey;
+        pendingCharacterReferenceRevision = captureRevision;
         return capturePromise;
     }
 
@@ -705,8 +719,12 @@
         scheduleCharacterReferenceSync('avatar-sync');
     }
 
-    function applyPreviewResult(result, cacheKey) {
-        if (!cacheKey || cacheKey !== getCurrentModelCacheKey()) {
+    function applyPreviewResult(result, cacheKey, captureRevision) {
+        if (
+            !cacheKey ||
+            cacheKey !== getCurrentModelCacheKey() ||
+            captureRevision !== cardDropModelRevision
+        ) {
             pendingAutoCapture = true;
             return false;
         }
@@ -901,6 +919,7 @@
             var currentSourceHeight = sourceHeight;
             var currentModelType = options.modelType || getCurrentModelType();
             var currentCacheKey = options.cacheKey || getCurrentModelCacheKey();
+            var currentModelRevision = options.modelRevision || cardDropModelRevision;
             var recaptureFn = typeof options.recaptureFn === 'function' ? options.recaptureFn : null;
             var displayW, displayH, scaleRatio;
             var crop = { x: 0, y: 0, size: 0 };
@@ -962,6 +981,7 @@
                 currentSourceHeight = next.sourceHeight || currentSourceHeight || 640;
                 currentModelType = next.modelType || currentModelType || getCurrentModelType();
                 currentCacheKey = next.cacheKey || currentCacheKey || getCurrentModelCacheKey();
+                currentModelRevision = next.modelRevision || currentModelRevision;
                 drag = null;
                 img.src = currentSourceDataUrl;
                 initLayout();
@@ -1073,7 +1093,8 @@
                         },
                         sourceDataUrl: currentSourceDataUrl,
                         modelType: currentModelType,
-                        cacheKey: currentCacheKey
+                        cacheKey: currentCacheKey,
+                        modelRevision: currentModelRevision
                     });
                 } else {
                     resolve(null);
@@ -1256,6 +1277,7 @@
         const token = ++activeCaptureToken;
         activeCaptureCardVisible = showCard;
         const cacheKey = getCurrentModelCacheKey();
+        const captureRevision = cardDropModelRevision;
         const prevCachedPreview = cachedPreview ? Object.assign({}, cachedPreview) : null;
         if (showCard) {
             setPreviewVisible(true, trigger);
@@ -1269,6 +1291,10 @@
         try {
             const result = await captureAvatarPreview({ includeSourceDataUrl: manualCrop });
             if (token !== activeCaptureToken) return;
+            if (captureRevision !== cardDropModelRevision) {
+                pendingAutoCapture = true;
+                return;
+            }
 
             if (manualCrop && result.sourceDataUrl) {
                 setLoadingState(false);
@@ -1279,7 +1305,11 @@
 
                 async function recaptureCropperSource() {
                     var freshCacheKey = getCurrentModelCacheKey();
+                    var freshRevision = cardDropModelRevision;
                     var fresh = await captureAvatarPreview({ includeSourceDataUrl: true });
+                    if (freshRevision !== cardDropModelRevision) {
+                        throw new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
+                    }
                     if (!fresh || !fresh.sourceDataUrl) {
                         throw new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
                     }
@@ -1290,13 +1320,15 @@
                         sourceWidth: dims.w,
                         sourceHeight: dims.h,
                         modelType: fresh.modelType || getCurrentModelType(),
-                        cacheKey: freshCacheKey || getCurrentModelCacheKey()
+                        cacheKey: freshCacheKey || getCurrentModelCacheKey(),
+                        modelRevision: freshRevision
                     };
                 }
 
                 var userCrop = await openAvatarCropper(result.sourceDataUrl, defRect, srcDims.w, srcDims.h, {
                     modelType: result.modelType || getCurrentModelType(),
                     cacheKey: cacheKey,
+                    modelRevision: captureRevision,
                     recaptureFn: recaptureCropperSource
                 });
                 if (token !== activeCaptureToken) return;
@@ -1305,7 +1337,8 @@
                     var croppedDataUrl = await cropSourceToAvatar(userCrop.sourceDataUrl, userCrop.cropRect);
                     applyPreviewResult(
                         { dataUrl: croppedDataUrl, modelType: userCrop.modelType || result.modelType },
-                        userCrop.cacheKey || cacheKey
+                        userCrop.cacheKey || cacheKey,
+                        userCrop.modelRevision || captureRevision
                     );
                 } else {
                     if (prevCachedPreview) {
@@ -1321,7 +1354,7 @@
                     setPreviewNote(translateLabel('chat.avatarPreviewCropCancelled', '已取消手动裁剪，保持原头像不变。'));
                 }
             } else {
-                applyPreviewResult(result, cacheKey);
+                applyPreviewResult(result, cacheKey, captureRevision);
             }
         } catch (error) {
             if (token !== activeCaptureToken) return;

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -23,6 +23,7 @@
     let autoCaptureTimer = null;
     let lastScheduledCacheKey = '';
     let cardDropModelRevision = Date.now();
+    let pngtuberModelLoading = false;
     // 多窗口模式：由 IPC 从 Pet 窗口注入的头像（/chat 页面无本地模型）
     let externalAvatarDataUrl = '';
     let externalAvatarModelType = '';
@@ -413,8 +414,7 @@
 
     function isCardDropIdentityFollowerWindow() {
         const pathname = String(window.location?.pathname || '');
-        return window.__NEKO_MULTI_WINDOW__ === true
-            && /^\/chat(?:_full)?(?:\/|$)/.test(pathname);
+        return /^\/chat(?:_full)?(?:\/|$)/.test(pathname);
     }
 
     function advanceCardDropModelRevision() {
@@ -652,6 +652,9 @@
     }
 
     function captureCharacterReferenceDataUrl(captureRevision) {
+        if (pngtuberModelLoading && getCurrentModelType() === 'pngtuber') {
+            return Promise.resolve('');
+        }
         var cacheKey = getCharacterReferenceCacheKey();
         captureRevision = Number.isFinite(captureRevision)
             ? captureRevision
@@ -718,29 +721,33 @@
      * 上一次同步过来的猫娘名覆盖掉。当 dataUrl 暂不可用但 name 仍有效时，
      * 仍然走一次 name-only 同步。
      */
-    function syncAvatarToCardDrop(dataUrl) {
+    function syncAvatarToCardDrop(dataUrl, options = {}) {
+        // /chat and /chat_full mirror an owner page and never host model runtimes.
+        // Keeping them read-only avoids late follower writes reverting Pet state.
+        if (isCardDropIdentityFollowerWindow()) return;
         var _nekoName = getActiveLanlanName();
         if (!dataUrl && !_nekoName) return;
         var body = {};
         if (dataUrl) body.dataUrl = dataUrl;
         if (_nekoName) body.name = _nekoName;
-        // Electron chat windows mirror Pet's avatar but do not own its model path.
-        // They may update avatar/name fields, while Pet remains identity authority.
-        if (!isCardDropIdentityFollowerWindow()) appendCardDropModelIdentity(body);
+        appendCardDropModelIdentity(body);
         fetch('/api/card-drop/active-character', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)
         }).catch(function () { /* 本地角色快照同步失败时静默 */ });
 
-        scheduleCharacterReferenceSync('avatar-sync');
+        if (options.scheduleReference !== false) {
+            scheduleCharacterReferenceSync('avatar-sync');
+        }
     }
 
     function applyPreviewResult(result, cacheKey, captureRevision) {
         if (
             !cacheKey ||
             cacheKey !== getCurrentModelCacheKey() ||
-            captureRevision !== cardDropModelRevision
+            captureRevision !== cardDropModelRevision ||
+            (pngtuberModelLoading && getCurrentModelType() === 'pngtuber')
         ) {
             pendingAutoCapture = true;
             return false;
@@ -1401,6 +1408,10 @@
     }
 
     function scheduleAutoCapture(reason) {
+        if (pngtuberModelLoading && getCurrentModelType() === 'pngtuber') {
+            pendingAutoCapture = true;
+            return;
+        }
         const cacheKey = getCurrentModelCacheKey();
         if (!cacheKey || cacheKey.endsWith(':')) {
             return;
@@ -1452,6 +1463,13 @@
         scheduleAutoCapture(reason);
     }
 
+    function handleModelLoading() {
+        pngtuberModelLoading = true;
+        advanceCardDropModelRevision();
+        invalidateCachedPreview();
+        syncAvatarToCardDrop('', { scheduleReference: false });
+    }
+
     function bindModelLoadListeners() {
         const previousOnModelLoaded = window.live2dManager && typeof window.live2dManager.onModelLoaded === 'function'
             ? window.live2dManager.onModelLoaded
@@ -1474,7 +1492,12 @@
             handleModelLoaded('mmd-model-loaded');
         });
 
+        window.addEventListener('pngtuber-model-loading', function () {
+            handleModelLoading();
+        });
+
         window.addEventListener('pngtuber-model-loaded', function () {
+            pngtuberModelLoading = false;
             handleModelLoaded('pngtuber-model-loaded');
         });
     }

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -403,9 +403,13 @@
     function appendCardDropModelIdentity(body) {
         const modelType = getCurrentModelType();
         const modelKey = getCurrentModelCacheKey();
-        if (modelType) body.modelType = modelType;
-        if (modelType) body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';
-        body.modelRevision = cardDropModelRevision;
+        // Electron follower windows can receive the avatar/type without the model
+        // path. Keep their avatar/name sync, but leave authoritative identity to Pet.
+        if (modelType && modelKey && !modelKey.endsWith(':')) {
+            body.modelType = modelType;
+            body.modelKey = modelKey;
+            body.modelRevision = cardDropModelRevision;
+        }
         return body;
     }
 

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -402,9 +402,11 @@
         return String(value || '');
     }
 
-    function appendCardDropModelIdentity(body) {
-        const modelType = getCurrentModelType();
-        const modelKey = getCurrentModelCacheKey();
+    function appendCardDropModelIdentity(body, options = {}) {
+        const modelType = options.modelType || getCurrentModelType();
+        const modelKey = Object.prototype.hasOwnProperty.call(options, 'modelKey')
+            ? String(options.modelKey || '')
+            : getCurrentModelCacheKey();
         if (modelType) {
             body.modelType = modelType;
             body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';
@@ -731,7 +733,7 @@
         var body = {};
         if (dataUrl) body.dataUrl = dataUrl;
         if (_nekoName) body.name = _nekoName;
-        appendCardDropModelIdentity(body);
+        appendCardDropModelIdentity(body, options);
         fetch('/api/card-drop/active-character', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -1371,7 +1373,11 @@
                         userCrop.modelRevision || captureRevision
                     );
                 } else {
-                    if (prevCachedPreview) {
+                    if (captureRevision !== cardDropModelRevision) {
+                        cachedPreview = null;
+                        pendingAutoCapture = true;
+                        setPreviewImage('');
+                    } else if (prevCachedPreview) {
                         cachedPreview = prevCachedPreview;
                         setPreviewImage(prevCachedPreview.dataUrl);
                         setPreviewStatus(
@@ -1477,7 +1483,11 @@
         }
         advanceCardDropModelRevision();
         invalidateCachedPreview();
-        syncAvatarToCardDrop('', { scheduleReference: false });
+        syncAvatarToCardDrop('', {
+            scheduleReference: false,
+            modelType: 'pngtuber',
+            modelKey: ''
+        });
     }
 
     function bindModelLoadListeners() {

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -679,6 +679,10 @@
     }
 
     function applyPreviewResult(result, cacheKey) {
+        if (!cacheKey || cacheKey !== getCurrentModelCacheKey()) {
+            pendingAutoCapture = true;
+            return false;
+        }
         cachedPreview = {
             cacheKey,
             dataUrl: result.dataUrl,
@@ -1638,9 +1642,10 @@
                 modelType: externalAvatarModelType || getCurrentModelType(),
                 capturedAt: Date.now()
             };
-            saveToStorage(cachedPreview);
-            syncAvatarToCardDrop(cachedPreview.dataUrl);
-        }
+        saveToStorage(cachedPreview);
+        syncAvatarToCardDrop(cachedPreview.dataUrl);
+        return true;
+    }
 
         // 如果弹窗已打开且本地没有本窗口可采集的模型，就直接把 IPC 数据显示出来。
         const card = S.dom && S.dom.chatAvatarPreviewCard;

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -477,7 +477,13 @@
                 );
                 return false;
             }
-            return true;
+            return response.json()
+                .then(function (payload) {
+                    return !(payload && (payload.ok === false || payload.stale === true));
+                })
+                .catch(function () {
+                    return true;
+                });
         }).catch(function (err) {
             console.warn('[chat-avatar] card-drop character reference sync failed:', err);
             return false;

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -1483,6 +1483,7 @@
         }
         advanceCardDropModelRevision();
         invalidateCachedPreview();
+        setPreviewImage('');
         syncAvatarToCardDrop('', {
             scheduleReference: false,
             modelType: 'pngtuber',

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -1642,10 +1642,9 @@
                 modelType: externalAvatarModelType || getCurrentModelType(),
                 capturedAt: Date.now()
             };
-        saveToStorage(cachedPreview);
-        syncAvatarToCardDrop(cachedPreview.dataUrl);
-        return true;
-    }
+            saveToStorage(cachedPreview);
+            syncAvatarToCardDrop(cachedPreview.dataUrl);
+        }
 
         // 如果弹窗已打开且本地没有本窗口可采集的模型，就直接把 IPC 数据显示出来。
         const card = S.dom && S.dom.chatAvatarPreviewCard;

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -21,6 +21,7 @@
     let characterReferenceRetryCacheKey = '';
     let autoCaptureTimer = null;
     let lastScheduledCacheKey = '';
+    let cardDropModelRevision = Date.now();
     // 多窗口模式：由 IPC 从 Pet 窗口注入的头像（/chat 页面无本地模型）
     let externalAvatarDataUrl = '';
     let externalAvatarModelType = '';
@@ -403,7 +404,12 @@
         const modelKey = getCurrentModelCacheKey();
         if (modelType) body.modelType = modelType;
         if (modelType) body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';
+        body.modelRevision = cardDropModelRevision;
         return body;
+    }
+
+    function advanceCardDropModelRevision() {
+        cardDropModelRevision = Math.max(cardDropModelRevision + 1, Date.now());
     }
 
     function hasUsableCachedPreview() {
@@ -1381,6 +1387,7 @@
     }
 
     function handleModelLoaded(reason) {
+        advanceCardDropModelRevision();
         var newCacheKey = getCurrentModelCacheKey();
         if (cachedPreview && cachedPreview.dataUrl && cachedPreview.cacheKey === newCacheKey) {
             // 不同猫娘可能复用同一模型/cache key；即使头像无需重抓，也要把当前名称

--- a/static/app/app-chat-avatar.js
+++ b/static/app/app-chat-avatar.js
@@ -347,12 +347,15 @@
         const modelType = getCurrentModelType();
         if (modelType === 'pngtuber') {
             const config = window.pngtuberManager?.config || window.lanlan_config?.pngtuber || {};
-            return 'pngtuber:' + String(
-                config.layered_metadata ||
-                config.idle_image ||
-                config.talking_image ||
-                ''
-            );
+            const identity = {
+                layeredMetadata: normalizeModelIdentityPart(config.layered_metadata),
+                idleImage: normalizeModelIdentityPart(config.idle_image),
+                talkingImage: normalizeModelIdentityPart(config.talking_image)
+            };
+            if (!identity.layeredMetadata && !identity.idleImage && !identity.talkingImage) {
+                return 'pngtuber:';
+            }
+            return 'pngtuber:' + JSON.stringify(identity);
         }
         if (modelType === 'vrm') {
             return 'vrm:' + String(
@@ -377,11 +380,29 @@
         );
     }
 
+    function normalizeModelIdentityPart(value) {
+        if (value === undefined || value === null) return '';
+        if (value && typeof value === 'object') {
+            try {
+                return JSON.stringify(value, function (_key, nestedValue) {
+                    if (!nestedValue || typeof nestedValue !== 'object' || Array.isArray(nestedValue)) {
+                        return nestedValue;
+                    }
+                    return Object.keys(nestedValue).sort().reduce(function (sorted, key) {
+                        sorted[key] = nestedValue[key];
+                        return sorted;
+                    }, {});
+                });
+            } catch (_) {}
+        }
+        return String(value || '');
+    }
+
     function appendCardDropModelIdentity(body) {
         const modelType = getCurrentModelType();
         const modelKey = getCurrentModelCacheKey();
         if (modelType) body.modelType = modelType;
-        if (modelKey && !modelKey.endsWith(':')) body.modelKey = modelKey;
+        if (modelType) body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';
         return body;
     }
 

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -1718,13 +1718,6 @@
                 return { manager, drawable, canvas: drawable };
             },
             async prepare(ctx) {
-                await new Promise((resolve) => {
-                    if (typeof global.requestAnimationFrame === 'function') {
-                        global.requestAnimationFrame(() => resolve());
-                    } else {
-                        resolve();
-                    }
-                });
                 ctx.drawable = getPNGTuberCaptureDrawable(ctx.manager, { allowHidden: true }) || ctx.drawable;
                 if (ctx.drawable) {
                     await waitForPNGTuberDrawable(ctx.drawable);

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -78,9 +78,14 @@
 
     function getPNGTuberDrawableSize(drawable) {
         if (!drawable) return { width: 0, height: 0 };
+        const isImage = isPNGTuberImageElement(drawable);
         return {
-            width: finiteOr(drawable.width, 0) || finiteOr(drawable.naturalWidth, 0) || finiteOr(drawable.clientWidth, 0),
-            height: finiteOr(drawable.height, 0) || finiteOr(drawable.naturalHeight, 0) || finiteOr(drawable.clientHeight, 0)
+            width: isImage
+                ? finiteOr(drawable.naturalWidth, 0) || finiteOr(drawable.width, 0) || finiteOr(drawable.clientWidth, 0)
+                : finiteOr(drawable.width, 0) || finiteOr(drawable.clientWidth, 0),
+            height: isImage
+                ? finiteOr(drawable.naturalHeight, 0) || finiteOr(drawable.height, 0) || finiteOr(drawable.clientHeight, 0)
+                : finiteOr(drawable.height, 0) || finiteOr(drawable.clientHeight, 0)
         };
     }
 
@@ -128,6 +133,11 @@
         // The model manager temporarily hides the desktop avatar while it covers the
         // main window. Community forging still needs an off-screen snapshot of the
         // loaded model, so visibility must not be a prerequisite for capture.
+        // Preserve a still-loading image as well: prepare() owns waiting for its
+        // load/error event before dimensions are required.
+        if (isPNGTuberImageElement(manager?.image)) return manager.image;
+        const loadingImage = candidates.find(isPNGTuberImageElement);
+        if (loadingImage) return loadingImage;
         if (isReadyPNGTuberDrawable(manager?.image)) return manager.image;
         return candidates.find(isReadyPNGTuberDrawable) || null;
     }

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -29,6 +29,8 @@
         cropMode: 'headshot'
     });
     const PNGTUBER_IMAGE_LOAD_TIMEOUT_MS = 15000;
+    const PNGTUBER_SOURCE_MAX_EDGE = 2048;
+    const VISIBILITY_ANALYSIS_MAX_EDGE = 256;
 
     function clamp(value, min, max) {
         return Math.min(max, Math.max(min, value));
@@ -652,9 +654,15 @@
         const safeWidth = Math.max(1, Math.min(width, canvas.width - x));
         const safeHeight = Math.max(1, Math.min(height, canvas.height - y));
 
+        const analysisScale = Math.min(
+            1,
+            VISIBILITY_ANALYSIS_MAX_EDGE / Math.max(safeWidth, safeHeight)
+        );
+        const analysisWidth = Math.max(1, Math.round(safeWidth * analysisScale));
+        const analysisHeight = Math.max(1, Math.round(safeHeight * analysisScale));
         const analysisCanvas = document.createElement('canvas');
-        analysisCanvas.width = safeWidth;
-        analysisCanvas.height = safeHeight;
+        analysisCanvas.width = analysisWidth;
+        analysisCanvas.height = analysisHeight;
 
         let ctx = null;
         try {
@@ -674,22 +682,22 @@
                 safeHeight,
                 0,
                 0,
-                safeWidth,
-                safeHeight
+                analysisWidth,
+                analysisHeight
             );
-            imageData = ctx.getImageData(0, 0, safeWidth, safeHeight).data;
+            imageData = ctx.getImageData(0, 0, analysisWidth, analysisHeight).data;
         } catch (_) {
             return true;
         }
 
-        const stepX = Math.max(1, Math.floor(safeWidth / 18));
-        const stepY = Math.max(1, Math.floor(safeHeight / 18));
+        const stepX = Math.max(1, Math.floor(analysisWidth / 18));
+        const stepY = Math.max(1, Math.floor(analysisHeight / 18));
         let visibleCount = 0;
         let sampleCount = 0;
 
-        for (let py = 0; py < safeHeight; py += stepY) {
-            for (let px = 0; px < safeWidth; px += stepX) {
-                const idx = (py * safeWidth + px) * 4;
+        for (let py = 0; py < analysisHeight; py += stepY) {
+            for (let px = 0; px < analysisWidth; px += stepX) {
+                const idx = (py * analysisWidth + px) * 4;
                 const alpha = imageData[idx + 3];
                 const r = imageData[idx];
                 const g = imageData[idx + 1];
@@ -1773,11 +1781,17 @@
                 if (!drawable || !size.width || !size.height) {
                     throw createError('PNGTuber 画面尚未就绪，无法提取头像');
                 }
-                const canvas = createOutputCanvas(size.width, size.height);
+                const sourceScale = Math.min(
+                    1,
+                    PNGTUBER_SOURCE_MAX_EDGE / Math.max(size.width, size.height)
+                );
+                const sourceWidth = Math.max(1, Math.round(size.width * sourceScale));
+                const sourceHeight = Math.max(1, Math.round(size.height * sourceScale));
+                const canvas = createOutputCanvas(sourceWidth, sourceHeight);
                 const context = canvas.getContext('2d');
                 if (!context) throw createError('无法创建 PNGTuber 导出画布');
                 try {
-                    context.drawImage(drawable, 0, 0, size.width, size.height);
+                    context.drawImage(drawable, 0, 0, sourceWidth, sourceHeight);
                 } catch (error) {
                     throw createCanvasExportError(error);
                 }
@@ -1786,8 +1800,8 @@
                 }
                 return {
                     canvas,
-                    cropRectCss: { x: 0, y: 0, width: size.width, height: size.height },
-                    cropRectPixels: { x: 0, y: 0, width: size.width, height: size.height },
+                    cropRectCss: { x: 0, y: 0, width: sourceWidth, height: sourceHeight },
+                    cropRectPixels: { x: 0, y: 0, width: sourceWidth, height: sourceHeight },
                     sourceCanvas: canvas,
                     modelType: 'pngtuber'
                 };

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -656,10 +656,10 @@
         const safeWidth = Math.max(1, Math.min(width, canvas.width - x));
         const safeHeight = Math.max(1, Math.min(height, canvas.height - y));
 
-        const analysisScale = Math.min(
-            1,
-            VISIBILITY_ANALYSIS_MAX_EDGE / Math.max(safeWidth, safeHeight)
-        );
+        const requireAny = options.requireAny === true;
+        const analysisScale = requireAny
+            ? 1
+            : Math.min(1, VISIBILITY_ANALYSIS_MAX_EDGE / Math.max(safeWidth, safeHeight));
         const analysisWidth = Math.max(1, Math.round(safeWidth * analysisScale));
         const analysisHeight = Math.max(1, Math.round(safeHeight * analysisScale));
         const analysisCanvas = document.createElement('canvas');
@@ -692,7 +692,6 @@
             return true;
         }
 
-        const requireAny = options.requireAny === true;
         const stepX = requireAny ? 1 : Math.max(1, Math.floor(analysisWidth / 18));
         const stepY = requireAny ? 1 : Math.max(1, Math.floor(analysisHeight / 18));
         let visibleCount = 0;

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -138,10 +138,12 @@
         // loaded model, so visibility must not be a prerequisite for capture.
         // Preserve a still-loading image as well: prepare() owns waiting for its
         // load/error event before dimensions are required.
+        if (!isPNGTuberImageElement(manager?.image) && isReadyPNGTuberDrawable(manager?.image)) {
+            return manager.image;
+        }
         if (isPNGTuberImageElement(manager?.image)) return manager.image;
         const loadingImage = candidates.find(isPNGTuberImageElement);
         if (loadingImage) return loadingImage;
-        if (isReadyPNGTuberDrawable(manager?.image)) return manager.image;
         return candidates.find(isReadyPNGTuberDrawable) || null;
     }
 
@@ -1772,26 +1774,45 @@
                     assertPNGTuberDrawableIsExportable(ctx.drawable);
                 }
             },
-            renderSource(ctx) {
+            renderSource(ctx, options = {}) {
                 const layeredSnapshot = typeof ctx.manager.renderLayeredSnapshotCanvas === 'function'
-                    ? ctx.manager.renderLayeredSnapshotCanvas()
+                    ? ctx.manager.renderLayeredSnapshotCanvas(undefined, undefined, {
+                        maxEdge: PNGTUBER_SOURCE_MAX_EDGE
+                    })
                     : null;
                 const drawable = layeredSnapshot || ctx.drawable;
                 const size = getPNGTuberDrawableSize(drawable);
                 if (!drawable || !size.width || !size.height) {
                     throw createError('PNGTuber 画面尚未就绪，无法提取头像');
                 }
+                const containPortrait = options.cropMode === 'portrait';
+                const padding = containPortrait ? clamp(finiteOr(options.padding, 0), 0, 0.45) : 0;
+                const contentRatio = 1 - (padding * 2);
+                const desiredWidth = containPortrait
+                    ? Math.max(1, finiteOr(options.width, DEFAULTS.width))
+                    : size.width;
+                const desiredHeight = containPortrait
+                    ? Math.max(1, finiteOr(options.height, DEFAULTS.height))
+                    : size.height;
                 const sourceScale = Math.min(
                     1,
-                    PNGTUBER_SOURCE_MAX_EDGE / Math.max(size.width, size.height)
+                    PNGTUBER_SOURCE_MAX_EDGE / Math.max(desiredWidth, desiredHeight)
                 );
-                const sourceWidth = Math.max(1, Math.round(size.width * sourceScale));
-                const sourceHeight = Math.max(1, Math.round(size.height * sourceScale));
+                const sourceWidth = Math.max(1, Math.round(desiredWidth * sourceScale));
+                const sourceHeight = Math.max(1, Math.round(desiredHeight * sourceScale));
                 const canvas = createOutputCanvas(sourceWidth, sourceHeight);
                 const context = canvas.getContext('2d');
                 if (!context) throw createError('无法创建 PNGTuber 导出画布');
+                const drawableScale = Math.min(
+                    (sourceWidth * contentRatio) / size.width,
+                    (sourceHeight * contentRatio) / size.height
+                );
+                const drawWidth = size.width * drawableScale;
+                const drawHeight = size.height * drawableScale;
+                const drawX = (sourceWidth - drawWidth) * 0.5;
+                const drawY = (sourceHeight - drawHeight) * 0.5;
                 try {
-                    context.drawImage(drawable, 0, 0, sourceWidth, sourceHeight);
+                    context.drawImage(drawable, drawX, drawY, drawWidth, drawHeight);
                 } catch (error) {
                     throw createCanvasExportError(error);
                 }

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -1,6 +1,6 @@
 /**
  * Avatar Portrait
- * 从当前已加载的 Live2D / VRM / MMD 模型中提取头像裁剪图。
+ * 从当前已加载的 Live2D / VRM / MMD / PNGTuber 模型中提取头像裁剪图。
  *
  * 设计目标：
  * 1. 不重建模型，不侵入现有渲染循环
@@ -59,6 +59,7 @@
 
     function normalizeModelType(modelType) {
         const raw = String(modelType || global.lanlan_config?.model_type || '').toLowerCase();
+        if (raw === 'pngtuber') return 'pngtuber';
         if (raw === 'vrm') return 'vrm';
         if (raw === 'mmd') return 'mmd';
         if (raw === 'live2d') return 'live2d';
@@ -73,6 +74,102 @@
         if (global.vrmManager?.currentModel?.vrm?.scene) return 'vrm';
         if (global.live2dManager?.getCurrentModel?.()) return 'live2d';
         return 'live2d';
+    }
+
+    function getPNGTuberDrawableSize(drawable) {
+        if (!drawable) return { width: 0, height: 0 };
+        return {
+            width: finiteOr(drawable.width, 0) || finiteOr(drawable.naturalWidth, 0) || finiteOr(drawable.clientWidth, 0),
+            height: finiteOr(drawable.height, 0) || finiteOr(drawable.naturalHeight, 0) || finiteOr(drawable.clientHeight, 0)
+        };
+    }
+
+    function isPNGTuberImageElement(drawable) {
+        return !!drawable && (
+            String(drawable.tagName || '').toLowerCase() === 'img'
+            || (typeof global.HTMLImageElement !== 'undefined' && drawable instanceof global.HTMLImageElement)
+        );
+    }
+
+    function isVisiblePNGTuberDrawable(drawable) {
+        if (!drawable) return false;
+        const size = getPNGTuberDrawableSize(drawable);
+        if (!size.width || !size.height) return false;
+        if (drawable.hidden || drawable.classList?.contains?.('hidden')) return false;
+        if (drawable.style?.display === 'none') return false;
+        if (typeof global.getComputedStyle === 'function') {
+            const style = global.getComputedStyle(drawable);
+            if (style.display === 'none' || style.visibility === 'hidden') return false;
+        }
+        return true;
+    }
+
+    function isReadyPNGTuberDrawable(drawable) {
+        if (!drawable) return false;
+        const size = getPNGTuberDrawableSize(drawable);
+        return !!(size.width && size.height);
+    }
+
+    function getPNGTuberCaptureDrawable(manager, options = {}) {
+        const allowHidden = options.allowHidden === true;
+        if (manager && typeof manager.ensureContainer === 'function') {
+            try {
+                manager.ensureContainer();
+            } catch (_) {}
+        }
+        if (isVisiblePNGTuberDrawable(manager?.image)) return manager.image;
+        const container = global.document?.getElementById?.('pngtuber-container');
+        const drawables = container?.querySelectorAll?.('canvas.pngtuber-layered-canvas, img.pngtuber-image');
+        const candidates = Array.from(drawables || []);
+        const visibleDrawable = candidates.find(isVisiblePNGTuberDrawable);
+        if (visibleDrawable) return visibleDrawable;
+        if (!allowHidden) return null;
+
+        // The model manager temporarily hides the desktop avatar while it covers the
+        // main window. Community forging still needs an off-screen snapshot of the
+        // loaded model, so visibility must not be a prerequisite for capture.
+        if (isReadyPNGTuberDrawable(manager?.image)) return manager.image;
+        return candidates.find(isReadyPNGTuberDrawable) || null;
+    }
+
+    function waitForPNGTuberDrawable(drawable) {
+        if (!isPNGTuberImageElement(drawable)) return Promise.resolve();
+        if (drawable.complete) {
+            if (drawable.naturalWidth > 0 && drawable.naturalHeight > 0) {
+                return Promise.resolve();
+            }
+            return Promise.reject(createError('PNGTuber 图片加载失败'));
+        }
+        return new Promise((resolve, reject) => {
+            const cleanup = () => {
+                drawable.removeEventListener?.('load', onLoad);
+                drawable.removeEventListener?.('error', onError);
+            };
+            const onLoad = () => {
+                cleanup();
+                resolve();
+            };
+            const onError = () => {
+                cleanup();
+                reject(createError('PNGTuber 图片加载失败'));
+            };
+            drawable.addEventListener?.('load', onLoad, { once: true });
+            drawable.addEventListener?.('error', onError, { once: true });
+        });
+    }
+
+    function assertPNGTuberDrawableIsExportable(drawable) {
+        if (!isPNGTuberImageElement(drawable)) return;
+        const src = String(drawable.currentSrc || drawable.src || '').trim();
+        if (!src || !global.location?.href) return;
+        try {
+            const resolved = new URL(src, global.location.href);
+            if (/^https?:$/.test(resolved.protocol) && resolved.origin !== global.location.origin) {
+                throw createError('远程 PNGTuber 图片未启用同源访问，无法导出头像');
+            }
+        } catch (error) {
+            if (String(error?.message || '').startsWith('[avatar-portrait]')) throw error;
+        }
     }
 
     function getCanvasMetrics(canvas) {
@@ -1608,8 +1705,66 @@
         };
     }
 
+    function getPNGTuberAdapter() {
+        return {
+            type: 'pngtuber',
+            getContext() {
+                const manager = global.pngtuberManager;
+                const drawable = getPNGTuberCaptureDrawable(manager, { allowHidden: true });
+                const canRenderLayeredSnapshot = typeof manager?.renderLayeredSnapshotCanvas === 'function';
+                if (!manager || (!drawable && !canRenderLayeredSnapshot)) {
+                    throw createError('当前没有可用的 PNGTuber 模型');
+                }
+                return { manager, drawable, canvas: drawable };
+            },
+            async prepare(ctx) {
+                await new Promise((resolve) => {
+                    if (typeof global.requestAnimationFrame === 'function') {
+                        global.requestAnimationFrame(() => resolve());
+                    } else {
+                        resolve();
+                    }
+                });
+                ctx.drawable = getPNGTuberCaptureDrawable(ctx.manager, { allowHidden: true }) || ctx.drawable;
+                if (ctx.drawable) {
+                    await waitForPNGTuberDrawable(ctx.drawable);
+                    assertPNGTuberDrawableIsExportable(ctx.drawable);
+                }
+            },
+            renderSource(ctx) {
+                const layeredSnapshot = typeof ctx.manager.renderLayeredSnapshotCanvas === 'function'
+                    ? ctx.manager.renderLayeredSnapshotCanvas()
+                    : null;
+                const drawable = layeredSnapshot || ctx.drawable;
+                const size = getPNGTuberDrawableSize(drawable);
+                if (!drawable || !size.width || !size.height) {
+                    throw createError('PNGTuber 画面尚未就绪，无法提取头像');
+                }
+                const canvas = createOutputCanvas(size.width, size.height);
+                const context = canvas.getContext('2d');
+                if (!context) throw createError('无法创建 PNGTuber 导出画布');
+                try {
+                    context.drawImage(drawable, 0, 0, size.width, size.height);
+                } catch (error) {
+                    throw createCanvasExportError(error);
+                }
+                if (!hasVisiblePixelsInCanvas(canvas)) {
+                    throw createError('PNGTuber 画面尚未就绪，无法提取头像');
+                }
+                return {
+                    canvas,
+                    cropRectCss: { x: 0, y: 0, width: size.width, height: size.height },
+                    cropRectPixels: { x: 0, y: 0, width: size.width, height: size.height },
+                    sourceCanvas: canvas,
+                    modelType: 'pngtuber'
+                };
+            }
+        };
+    }
+
     function getAdapter(modelType) {
         const normalizedType = normalizeModelType(modelType);
+        if (normalizedType === 'pngtuber') return getPNGTuberAdapter();
         if (normalizedType === 'vrm') return getVrmAdapter();
         if (normalizedType === 'mmd') return getMmdAdapter();
         return getLive2DAdapter();
@@ -1619,7 +1774,7 @@
         const finalOptions = { ...DEFAULTS, ...options };
         const adapter = getAdapter(finalOptions.modelType);
         const context = adapter.getContext();
-        adapter.prepare(context);
+        await adapter.prepare(context);
 
         if (typeof adapter.renderSource === 'function') {
             const renderedSource = adapter.renderSource(context, finalOptions);

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -202,20 +202,6 @@
         });
     }
 
-    function assertPNGTuberDrawableIsExportable(drawable) {
-        if (!isPNGTuberImageElement(drawable)) return;
-        const src = String(drawable.currentSrc || drawable.src || '').trim();
-        if (!src || !global.location?.href) return;
-        try {
-            const resolved = new URL(src, global.location.href);
-            if (/^https?:$/.test(resolved.protocol) && resolved.origin !== global.location.origin) {
-                throw createError('远程 PNGTuber 图片未启用同源访问，无法导出头像');
-            }
-        } catch (error) {
-            if (String(error?.message || '').startsWith('[avatar-portrait]')) throw error;
-        }
-    }
-
     function getCanvasMetrics(canvas) {
         const rect = canvas?.getBoundingClientRect?.();
         const cssWidth = finiteOr(rect?.width, 0) || finiteOr(canvas?.clientWidth, 0) || finiteOr(canvas?.width, 0) || 1;
@@ -1782,7 +1768,6 @@
                 ctx.drawable = getPNGTuberCaptureDrawable(ctx.manager, { allowHidden: true }) || ctx.drawable;
                 if (ctx.drawable) {
                     await waitForPNGTuberDrawable(ctx.drawable);
-                    assertPNGTuberDrawableIsExportable(ctx.drawable);
                 }
             },
             renderSource(ctx, options = {}) {

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -647,7 +647,7 @@
         };
     }
 
-    function hasVisiblePixelsInCrop(canvas, rect) {
+    function hasVisiblePixelsInCrop(canvas, rect, options = {}) {
         if (!canvas || !rect) return false;
         const width = Math.max(1, Math.min(canvas.width, Math.round(rect.width)));
         const height = Math.max(1, Math.min(canvas.height, Math.round(rect.height)));
@@ -692,8 +692,9 @@
             return true;
         }
 
-        const stepX = Math.max(1, Math.floor(analysisWidth / 18));
-        const stepY = Math.max(1, Math.floor(analysisHeight / 18));
+        const requireAny = options.requireAny === true;
+        const stepX = requireAny ? 1 : Math.max(1, Math.floor(analysisWidth / 18));
+        const stepY = requireAny ? 1 : Math.max(1, Math.floor(analysisHeight / 18));
         let visibleCount = 0;
         let sampleCount = 0;
 
@@ -707,11 +708,12 @@
                 sampleCount += 1;
                 if (alpha > 8 && (r < 250 || g < 250 || b < 250 || alpha > 24)) {
                     visibleCount += 1;
+                    if (requireAny) return true;
                 }
             }
         }
 
-        return sampleCount > 0 && (visibleCount / sampleCount) >= 0.03;
+        return !requireAny && sampleCount > 0 && (visibleCount / sampleCount) >= 0.03;
     }
 
     function hasVisiblePixelsInCanvas(canvas) {
@@ -722,6 +724,16 @@
             width: canvas.width,
             height: canvas.height
         });
+    }
+
+    function hasAnyVisiblePixelInCanvas(canvas) {
+        if (!canvas) return false;
+        return hasVisiblePixelsInCrop(canvas, {
+            x: 0,
+            y: 0,
+            width: canvas.width,
+            height: canvas.height
+        }, { requireAny: true });
     }
 
     function createOutputCanvas(width, height) {
@@ -1816,7 +1828,7 @@
                 } catch (error) {
                     throw createCanvasExportError(error);
                 }
-                if (!hasVisiblePixelsInCanvas(canvas)) {
+                if (!hasAnyVisiblePixelInCanvas(canvas)) {
                     throw createError('PNGTuber 画面尚未就绪，无法提取头像');
                 }
                 return {

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -28,6 +28,7 @@
         // 'portrait' - 立绘模式（全身或大半身）
         cropMode: 'headshot'
     });
+    const PNGTUBER_IMAGE_LOAD_TIMEOUT_MS = 15000;
 
     function clamp(value, min, max) {
         return Math.min(max, Math.max(min, value));
@@ -151,20 +152,49 @@
             return Promise.reject(createError('PNGTuber 图片加载失败'));
         }
         return new Promise((resolve, reject) => {
+            let settled = false;
+            let timeoutId = null;
             const cleanup = () => {
                 drawable.removeEventListener?.('load', onLoad);
                 drawable.removeEventListener?.('error', onError);
+                if (timeoutId !== null) {
+                    (global.clearTimeout || clearTimeout)(timeoutId);
+                    timeoutId = null;
+                }
             };
             const onLoad = () => {
+                if (settled) return;
+                settled = true;
                 cleanup();
-                resolve();
+                if (drawable.naturalWidth > 0 && drawable.naturalHeight > 0) {
+                    resolve();
+                } else {
+                    reject(createError('PNGTuber 图片加载失败'));
+                }
             };
             const onError = () => {
+                if (settled) return;
+                settled = true;
                 cleanup();
                 reject(createError('PNGTuber 图片加载失败'));
             };
+            const onTimeout = () => {
+                if (settled) return;
+                settled = true;
+                timeoutId = null;
+                cleanup();
+                reject(createError('PNGTuber 图片加载超时'));
+            };
             drawable.addEventListener?.('load', onLoad, { once: true });
             drawable.addEventListener?.('error', onError, { once: true });
+            timeoutId = (global.setTimeout || setTimeout)(onTimeout, PNGTUBER_IMAGE_LOAD_TIMEOUT_MS);
+
+            // Avoid missing a load/error event fired between the initial complete
+            // check and listener registration.
+            if (drawable.complete) {
+                if (drawable.naturalWidth > 0 && drawable.naturalHeight > 0) onLoad();
+                else onError();
+            }
         });
     }
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3604,6 +3604,7 @@
             this.clearEmotion({ render: false });
             this._modelManagerUseCurrentPlacement = false;
             this.config = normalizeConfig(config || {});
+            window.dispatchEvent(new CustomEvent('pngtuber-model-loading'));
             await this.setupLayeredAdapter();
             this.ensureContainer();
             this.preloadImages();

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -64,7 +64,7 @@
 
     function assignImageSource(image, src) {
         if (!image) return;
-        if (/^https?:\/\//i.test(String(src || ''))) {
+        if (/^(?:https?:)?\/\//i.test(String(src || ''))) {
             image.crossOrigin = 'anonymous';
         } else {
             image.removeAttribute?.('crossorigin');
@@ -237,6 +237,8 @@
             this._lastPngtuberPointerX = null;
             this._lastPngtuberPointerY = null;
             this._renderingPaused = false;
+            this._loadGeneration = 0;
+            this._latestLifecycleLoadToken = 0;
         }
 
         setMouseTrackingEnabled(enabled) {
@@ -874,7 +876,12 @@
             }
         }
 
-        async setupLayeredAdapter() {
+        async setupLayeredAdapter(options = {}) {
+            const config = options.config || this.config;
+            const isCurrentLoad = typeof options.isCurrentLoad === 'function'
+                ? options.isCurrentLoad
+                : () => true;
+            if (!isCurrentLoad()) return false;
             this.clearLayeredTimers();
             this.detachLayeredHotkeys();
             this.detachLayeredPlayEvent();
@@ -897,23 +904,29 @@
             this.layeredPointer = { x: 0, y: 0, targetX: 0, targetY: 0, active: false, at: 0, lastTime: 0 };
             this.layeredAssetVisibility = new Map();
             this.layeredAssetActionActive = false;
-            if (!this.isLayeredConfigured()) return false;
+            if (config.adapter !== 'layered_canvas_v1' || !config.layered_metadata) return false;
             try {
-                const response = await fetch(this.config.layered_metadata, { cache: 'no-cache' });
+                const response = await fetch(config.layered_metadata, { cache: 'no-cache' });
+                if (!isCurrentLoad()) return false;
                 if (!response.ok) throw new Error(`metadata ${response.status}`);
                 const metadata = await response.json();
+                if (!isCurrentLoad()) return false;
                 const layers = Array.isArray(metadata.layers) ? metadata.layers : [];
                 if (metadata.runtime !== 'layered_canvas' || layers.length === 0) {
                     throw new Error('metadata is not layered_canvas');
                 }
+                const layeredImages = new Map();
                 await Promise.all(layers.map(async (layer, index) => {
-                    const src = resolveSiblingAsset(this.config.layered_metadata, layer.image);
+                    const src = resolveSiblingAsset(config.layered_metadata, layer.image);
                     if (!src) return;
                     const img = await loadImageElement(src);
-                    this.layeredImages.set(index, img);
+                    if (!isCurrentLoad()) return;
+                    layeredImages.set(index, img);
                     layer._imageIndex = index;
                 }));
-                if (this.layeredImages.size === 0) throw new Error('no layer images loaded');
+                if (!isCurrentLoad()) return false;
+                if (layeredImages.size === 0) throw new Error('no layer images loaded');
+                this.layeredImages = layeredImages;
                 this.layeredMetadata = metadata;
                 this.layeredStateIndex = 0;
                 this.initializeLayeredToggleState(layers);
@@ -958,6 +971,7 @@
                 this.attachLayeredPointerTracking();
                 return true;
             } catch (error) {
+                if (!isCurrentLoad()) return false;
                 console.warn('[PNGTuber] layered adapter disabled, falling back to image mode:', error);
                 this.layeredMetadata = null;
                 this.layeredImages = new Map();
@@ -3611,15 +3625,24 @@
         }
 
         async load(config, options = {}) {
+            const loadToken = Number(options.loadToken) || 0;
+            if (loadToken && loadToken < this._latestLifecycleLoadToken) return false;
+            if (loadToken) this._latestLifecycleLoadToken = loadToken;
+            const loadGeneration = ++this._loadGeneration;
+            const isCurrentLoad = () => (
+                loadGeneration === this._loadGeneration
+                && (!loadToken || loadToken === this._latestLifecycleLoadToken)
+            );
             this.detachDragListeners();
             this.clearEmotion({ render: false });
             this._modelManagerUseCurrentPlacement = false;
-            this.config = normalizeConfig(config || {});
-            const loadToken = Number(options.loadToken) || 0;
+            const normalizedConfig = normalizeConfig(config || {});
+            this.config = normalizedConfig;
             window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
                 detail: { loadToken }
             }));
-            await this.setupLayeredAdapter();
+            await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad });
+            if (!isCurrentLoad()) return false;
             this.ensureContainer();
             this.preloadImages();
             this.attachSpeechListeners();
@@ -4772,12 +4795,17 @@
 
     async function loadPNGTuberAvatar(config) {
         const loadToken = ++pngtuberLoadSequence;
+        window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
+            detail: { loadToken }
+        }));
         try {
             await hideOtherAvatarRuntimesForPNGTuber();
+            if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager || null;
             if (!window.pngtuberManager) {
                 window.pngtuberManager = new PNGTuberManager();
             }
-            await window.pngtuberManager.load(config || {}, { loadToken });
+            const loaded = await window.pngtuberManager.load(config || {}, { loadToken });
+            if (!loaded || loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
             if (document.body?.classList.contains('model-manager-page')
                 && window._modelManagerCurrentAvatarType
                 && window._modelManagerCurrentAvatarType !== 'pngtuber') {
@@ -4785,8 +4813,10 @@
                 return window.pngtuberManager;
             }
             await hideOtherAvatarRuntimesForPNGTuber();
+            if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
             window.pngtuberManager.show();
             await hideOtherAvatarRuntimesForPNGTuber();
+            if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
             window.dispatchEvent(new CustomEvent('pngtuber-model-loaded', {
                 detail: { loadToken }
             }));

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -34,6 +34,7 @@
     const PNGTUBER_BREATHING_IDLE_FPS = 20;
     const PNGTUBER_ANIMATION_IDLE_FPS = 30;
     const PNGTUBER_FULL_RATE_HOLD_MS = 900;
+    let pngtuberLoadSequence = 0;
 
     function clampNumber(value, min, max, fallback) {
         const parsed = Number(value);
@@ -61,6 +62,16 @@
         return path;
     }
 
+    function assignImageSource(image, src) {
+        if (!image) return;
+        if (/^https?:\/\//i.test(String(src || ''))) {
+            image.crossOrigin = 'anonymous';
+        } else {
+            image.removeAttribute?.('crossorigin');
+        }
+        image.src = src;
+    }
+
     function isPNGTuberPlusLayerVisible(showTalk, showBlink, speaking, blinking) {
         const value = (Number(showTalk) || 0)
             + ((Number(showBlink) || 0) * 3)
@@ -82,7 +93,7 @@
             const img = new Image();
             img.onload = () => resolve(img);
             img.onerror = reject;
-            img.src = src;
+            assignImageSource(img, src);
         });
     }
 
@@ -378,7 +389,7 @@
                 if (!src || seen.has(src)) return;
                 seen.add(src);
                 const img = new Image();
-                img.src = src;
+                assignImageSource(img, src);
             });
         }
 
@@ -2519,7 +2530,7 @@
             }
             const nextSrc = src || this.config.drag_image || this.config.idle_image || DEFAULT_PLACEHOLDER;
             if (this.image && nextSrc && this.image.getAttribute('src') !== nextSrc) {
-                this.image.src = nextSrc;
+                assignImageSource(this.image, nextSrc);
             }
             this.applyTransform();
             this.updateLockIconPosition();
@@ -3599,12 +3610,15 @@
             }, delayMs);
         }
 
-        async load(config) {
+        async load(config, options = {}) {
             this.detachDragListeners();
             this.clearEmotion({ render: false });
             this._modelManagerUseCurrentPlacement = false;
             this.config = normalizeConfig(config || {});
-            window.dispatchEvent(new CustomEvent('pngtuber-model-loading'));
+            const loadToken = Number(options.loadToken) || 0;
+            window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
+                detail: { loadToken }
+            }));
             await this.setupLayeredAdapter();
             this.ensureContainer();
             this.preloadImages();
@@ -3734,7 +3748,7 @@
             }
             const nextSrc = this.stateToSrc(this.state);
             if (this.image && this.image.getAttribute('src') !== nextSrc) {
-                this.image.src = nextSrc;
+                assignImageSource(this.image, nextSrc);
             }
             this.applyTransform();
             this.updateLockIconPosition();
@@ -4757,12 +4771,13 @@
     }
 
     async function loadPNGTuberAvatar(config) {
+        const loadToken = ++pngtuberLoadSequence;
         try {
             await hideOtherAvatarRuntimesForPNGTuber();
             if (!window.pngtuberManager) {
                 window.pngtuberManager = new PNGTuberManager();
             }
-            await window.pngtuberManager.load(config || {});
+            await window.pngtuberManager.load(config || {}, { loadToken });
             if (document.body?.classList.contains('model-manager-page')
                 && window._modelManagerCurrentAvatarType
                 && window._modelManagerCurrentAvatarType !== 'pngtuber') {
@@ -4772,10 +4787,14 @@
             await hideOtherAvatarRuntimesForPNGTuber();
             window.pngtuberManager.show();
             await hideOtherAvatarRuntimesForPNGTuber();
-            window.dispatchEvent(new CustomEvent('pngtuber-model-loaded'));
+            window.dispatchEvent(new CustomEvent('pngtuber-model-loaded', {
+                detail: { loadToken }
+            }));
             return window.pngtuberManager;
         } finally {
-            window.dispatchEvent(new CustomEvent('pngtuber-model-load-finished'));
+            window.dispatchEvent(new CustomEvent('pngtuber-model-load-finished', {
+                detail: { loadToken }
+            }));
         }
     }
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -4757,22 +4757,26 @@
     }
 
     async function loadPNGTuberAvatar(config) {
-        await hideOtherAvatarRuntimesForPNGTuber();
-        if (!window.pngtuberManager) {
-            window.pngtuberManager = new PNGTuberManager();
-        }
-        await window.pngtuberManager.load(config || {});
-        if (document.body?.classList.contains('model-manager-page')
-            && window._modelManagerCurrentAvatarType
-            && window._modelManagerCurrentAvatarType !== 'pngtuber') {
-            window.pngtuberManager.hide();
+        try {
+            await hideOtherAvatarRuntimesForPNGTuber();
+            if (!window.pngtuberManager) {
+                window.pngtuberManager = new PNGTuberManager();
+            }
+            await window.pngtuberManager.load(config || {});
+            if (document.body?.classList.contains('model-manager-page')
+                && window._modelManagerCurrentAvatarType
+                && window._modelManagerCurrentAvatarType !== 'pngtuber') {
+                window.pngtuberManager.hide();
+                return window.pngtuberManager;
+            }
+            await hideOtherAvatarRuntimesForPNGTuber();
+            window.pngtuberManager.show();
+            await hideOtherAvatarRuntimesForPNGTuber();
+            window.dispatchEvent(new CustomEvent('pngtuber-model-loaded'));
             return window.pngtuberManager;
+        } finally {
+            window.dispatchEvent(new CustomEvent('pngtuber-model-load-finished'));
         }
-        await hideOtherAvatarRuntimesForPNGTuber();
-        window.pngtuberManager.show();
-        await hideOtherAvatarRuntimesForPNGTuber();
-        window.dispatchEvent(new CustomEvent('pngtuber-model-loaded'));
-        return window.pngtuberManager;
     }
 
     function playPNGTuberAnimation(target, options = {}) {

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2401,15 +2401,25 @@
                 || (Number(a.order || 0) - Number(b.order || 0));
         }
 
-        renderLayeredSnapshotCanvas(stateName = this.state || 'idle', timestamp = performance.now()) {
+        renderLayeredSnapshotCanvas(
+            stateName = this.state || 'idle',
+            timestamp = performance.now(),
+            options = {}
+        ) {
             if (!this.isLayeredActive()) return null;
+            const logicalWidth = Math.max(1, Math.round(Number(this.layeredCanvasLogicalWidth) || 1));
+            const logicalHeight = Math.max(1, Math.round(Number(this.layeredCanvasLogicalHeight) || 1));
+            const maxEdge = Math.max(0, Number(options.maxEdge) || 0);
+            const snapshotScale = maxEdge > 0
+                ? Math.min(1, maxEdge / Math.max(logicalWidth, logicalHeight))
+                : 1;
             const canvas = document.createElement('canvas');
-            canvas.width = Math.max(1, Math.round(Number(this.layeredCanvasLogicalWidth) || 1));
-            canvas.height = Math.max(1, Math.round(Number(this.layeredCanvasLogicalHeight) || 1));
+            canvas.width = Math.max(1, Math.round(logicalWidth * snapshotScale));
+            canvas.height = Math.max(1, Math.round(logicalHeight * snapshotScale));
             const drawn = this.drawLayeredState(stateName, timestamp, {
                 canvas,
-                scaleX: 1,
-                scaleY: 1
+                scaleX: canvas.width / logicalWidth,
+                scaleY: canvas.height / logicalHeight
             });
             return drawn ? canvas : null;
         }

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -96,6 +96,40 @@ vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.
   assert.equal(result.sourceCanvas.height, 1800);
   assert.equal(result.dataUrl, 'data:image/png;base64,AAAA');
 
+  const highResolutionImage = {{
+    tagName: 'IMG', width: 320, height: 480, clientWidth: 320, clientHeight: 480,
+    naturalWidth: 1600, naturalHeight: 2400, complete: true, hidden: false,
+    style: {{ display: '' }}, classList: {{ contains: () => false }},
+    currentSrc: '/user_pngtuber/high-resolution.png',
+  }};
+  window.pngtuberManager = {{ image: highResolutionImage, ensureContainer() {{}} }};
+  const intrinsicResult = await window.avatarPortrait.capture({{
+    modelType: 'pngtuber', width: 768, height: 1024,
+  }});
+  assert.equal(intrinsicResult.sourceCanvas.width, 1600);
+  assert.equal(intrinsicResult.sourceCanvas.height, 2400);
+
+  const loadingImage = {{
+    tagName: 'IMG', width: 0, height: 0, clientWidth: 0, clientHeight: 0,
+    naturalWidth: 0, naturalHeight: 0, complete: false, hidden: false,
+    style: {{ display: '' }}, classList: {{ contains: () => false }},
+    currentSrc: '/user_pngtuber/loading.png',
+    addEventListener(type, callback) {{
+      if (type !== 'load') return;
+      setTimeout(() => {{
+        this.complete = true;
+        this.naturalWidth = 900;
+        this.naturalHeight = 1200;
+        callback();
+      }}, 0);
+    }},
+    removeEventListener() {{}},
+  }};
+  window.pngtuberManager = {{ image: loadingImage, ensureContainer() {{}} }};
+  const loadedResult = await window.avatarPortrait.capture({{ modelType: 'pngtuber' }});
+  assert.equal(loadedResult.sourceCanvas.width, 900);
+  assert.equal(loadedResult.sourceCanvas.height, 1200);
+
   window.pngtuberManager = {{
     image: runtimeCanvas,
     ensureContainer() {{}},

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -117,6 +117,15 @@ vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.
   assert.equal(intrinsicResult.sourceCanvas.width, 1365);
   assert.equal(intrinsicResult.sourceCanvas.height, 2048);
 
+  const remoteCorsImage = Object.assign({{}}, highResolutionImage, {{
+    currentSrc: 'https://assets.example.test/avatar.png',
+  }});
+  window.pngtuberManager = {{ image: remoteCorsImage, ensureContainer() {{}} }};
+  const remoteResult = await window.avatarPortrait.capture({{
+    modelType: 'pngtuber', width: 512, height: 512,
+  }});
+  assert.equal(remoteResult.modelType, 'pngtuber');
+
   const loadingImage = {{
     tagName: 'IMG', width: 0, height: 0, clientWidth: 0, clientHeight: 0,
     naturalWidth: 0, naturalHeight: 0, complete: false, hidden: false,

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -130,6 +130,28 @@ vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.
   assert.equal(loadedResult.sourceCanvas.width, 900);
   assert.equal(loadedResult.sourceCanvas.height, 1200);
 
+  const stalledImage = {{
+    tagName: 'IMG', width: 0, height: 0, clientWidth: 0, clientHeight: 0,
+    naturalWidth: 0, naturalHeight: 0, complete: false, hidden: false,
+    style: {{ display: '' }}, classList: {{ contains: () => false }},
+    currentSrc: '/user_pngtuber/stalled.png',
+    addEventListener() {{}},
+    removeEventListener() {{}},
+  }};
+  window.pngtuberManager = {{ image: stalledImage, ensureContainer() {{}} }};
+  window.setTimeout = (callback, delay) => {{
+    assert.equal(delay, 15000);
+    Promise.resolve().then(callback);
+    return 1;
+  }};
+  window.clearTimeout = () => {{}};
+  await assert.rejects(
+    () => window.avatarPortrait.capture({{ modelType: 'pngtuber' }}),
+    /PNGTuber 图片加载超时/,
+  );
+  delete window.setTimeout;
+  delete window.clearTimeout;
+
   window.pngtuberManager = {{
     image: runtimeCanvas,
     ensureContainer() {{}},

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -78,7 +78,10 @@ const window = {{
   pngtuberManager: {{
     image: runtimeCanvas,
     ensureContainer() {{}},
-    renderLayeredSnapshotCanvas: () => layeredSnapshot,
+    renderLayeredSnapshotCanvas: (_state, _timestamp, options) => {{
+      assert.equal(options.maxEdge, 2048);
+      return layeredSnapshot;
+    }},
   }},
 }};
 const context = {{ window, document, console, URL, Promise, Array, setTimeout, clearTimeout }};
@@ -129,6 +132,39 @@ vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.
   const loadedResult = await window.avatarPortrait.capture({{ modelType: 'pngtuber' }});
   assert.equal(loadedResult.sourceCanvas.width, 900);
   assert.equal(loadedResult.sourceCanvas.height, 1200);
+
+  const squarePortrait = {{
+    tagName: 'IMG', width: 512, height: 512, clientWidth: 512, clientHeight: 512,
+    naturalWidth: 512, naturalHeight: 512, complete: true, hidden: false,
+    style: {{ display: '' }}, classList: {{ contains: () => false }},
+    currentSrc: '/user_pngtuber/square.png', hasVisiblePixels: true,
+  }};
+  window.pngtuberManager = {{ image: squarePortrait, ensureContainer() {{}} }};
+  const portraitResult = await window.avatarPortrait.capture({{
+    modelType: 'pngtuber', width: 768, height: 1024, cropMode: 'portrait', padding: 0.08,
+  }});
+  assert.equal(portraitResult.sourceCanvas.width / portraitResult.sourceCanvas.height, 0.75);
+  assert.equal(portraitResult.cropRectPixels.width, portraitResult.sourceCanvas.width);
+  assert.equal(portraitResult.cropRectPixels.height, portraitResult.sourceCanvas.height);
+  assert.ok(portraitResult.sourceCanvas.drawCalls[0][1] > 0);
+  assert.ok(portraitResult.sourceCanvas.drawCalls[0][2] > 0);
+
+  const hiddenLayeredCanvas = new FakeCanvas(800, 1200);
+  hiddenLayeredCanvas.hidden = true;
+  hiddenLayeredCanvas.style.display = 'none';
+  const emptyCompanionImage = {{
+    tagName: 'IMG', width: 0, height: 0, clientWidth: 0, clientHeight: 0,
+    naturalWidth: 0, naturalHeight: 0, complete: true, hidden: true,
+    style: {{ display: 'none' }}, classList: {{ contains: () => false }},
+  }};
+  document.getElementById = () => ({{
+    querySelectorAll: () => [emptyCompanionImage, hiddenLayeredCanvas],
+  }});
+  window.pngtuberManager = {{ image: hiddenLayeredCanvas, ensureContainer() {{}} }};
+  const hiddenLayeredResult = await window.avatarPortrait.capture({{ modelType: 'pngtuber' }});
+  assert.equal(hiddenLayeredResult.sourceCanvas.width, 800);
+  assert.equal(hiddenLayeredResult.sourceCanvas.height, 1200);
+  document.getElementById = () => null;
 
   const stalledImage = {{
     tagName: 'IMG', width: 0, height: 0, clientWidth: 0, clientHeight: 0,

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -34,6 +34,7 @@ class FakeCanvas {{
     this.classList = {{ contains: () => false }};
     this.drawCalls = [];
     this.hasVisiblePixels = hasVisiblePixels;
+    this.sparseVisiblePixel = false;
   }}
   getContext() {{
     return {{
@@ -42,13 +43,15 @@ class FakeCanvas {{
       drawImage: (source, ...args) => {{
         this.drawCalls.push([source, ...args]);
         this.hasVisiblePixels = source?.hasVisiblePixels !== false;
+        this.sparseVisiblePixel = source?.sparseVisiblePixel === true;
       }},
       getImageData: () => ({{
         data: new Proxy({{}}, {{
           get: (_target, key) => {{
             const index = Number(key);
             if (!Number.isInteger(index)) return undefined;
-            return this.hasVisiblePixels && index % 4 === 3 ? 255 : 0;
+            if (!this.hasVisiblePixels || index % 4 !== 3) return 0;
+            return !this.sparseVisiblePixel || index === 3 ? 255 : 0;
           }},
         }}),
       }}),
@@ -148,6 +151,13 @@ vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.
   assert.equal(portraitResult.cropRectPixels.height, portraitResult.sourceCanvas.height);
   assert.ok(portraitResult.sourceCanvas.drawCalls[0][1] > 0);
   assert.ok(portraitResult.sourceCanvas.drawCalls[0][2] > 0);
+
+  const sparsePortrait = Object.assign({{}}, squarePortrait, {{
+    currentSrc: '/user_pngtuber/sparse.png', sparseVisiblePixel: true,
+  }});
+  window.pngtuberManager = {{ image: sparsePortrait, ensureContainer() {{}} }};
+  const sparseResult = await window.avatarPortrait.capture({{ modelType: 'pngtuber' }});
+  assert.equal(sparseResult.modelType, 'pngtuber');
 
   const hiddenLayeredCanvas = new FakeCanvas(800, 1200);
   hiddenLayeredCanvas.hidden = true;

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -1,0 +1,122 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+AVATAR_PORTRAIT_PATH = PROJECT_ROOT / "static" / "avatar" / "avatar-portrait.js"
+
+
+@pytest.mark.unit
+def test_avatar_portrait_captures_pngtuber_layered_snapshot():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+
+    source = AVATAR_PORTRAIT_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+class FakeCanvas {{
+  constructor(width = 1, height = 1, hasVisiblePixels = true) {{
+    this.tagName = 'CANVAS';
+    this.width = width;
+    this.height = height;
+    this.clientWidth = width;
+    this.clientHeight = height;
+    this.hidden = false;
+    this.style = {{ display: '' }};
+    this.classList = {{ contains: () => false }};
+    this.drawCalls = [];
+    this.hasVisiblePixels = hasVisiblePixels;
+  }}
+  getContext() {{
+    return {{
+      save() {{}}, restore() {{}}, beginPath() {{}}, rect() {{}}, clip() {{}},
+      arc() {{}}, arcTo() {{}}, moveTo() {{}}, closePath() {{}}, fillRect() {{}},
+      drawImage: (source, ...args) => {{
+        this.drawCalls.push([source, ...args]);
+        this.hasVisiblePixels = source?.hasVisiblePixels !== false;
+      }},
+      getImageData: () => ({{
+        data: new Proxy({{}}, {{
+          get: (_target, key) => {{
+            const index = Number(key);
+            if (!Number.isInteger(index)) return undefined;
+            return this.hasVisiblePixels && index % 4 === 3 ? 255 : 0;
+          }},
+        }}),
+      }}),
+    }};
+  }}
+  getBoundingClientRect() {{ return {{ width: this.width, height: this.height }}; }}
+  toDataURL() {{ return 'data:image/png;base64,AAAA'; }}
+}}
+
+const runtimeCanvas = new FakeCanvas(512, 512);
+runtimeCanvas.hidden = true;
+runtimeCanvas.style.display = 'none';
+const layeredSnapshot = new FakeCanvas(1200, 1800);
+const document = {{
+  createElement: (tag) => tag === 'canvas' ? new FakeCanvas() : null,
+  getElementById: () => null,
+}};
+const window = {{
+  document,
+  location: {{ href: 'http://127.0.0.1:48911/', origin: 'http://127.0.0.1:48911' }},
+  lanlan_config: {{ model_type: 'pngtuber' }},
+  requestAnimationFrame: (callback) => callback(),
+  getComputedStyle: (drawable) => ({{
+    display: drawable.style.display || '',
+    visibility: drawable.hidden ? 'hidden' : 'visible',
+  }}),
+  pngtuberManager: {{
+    image: runtimeCanvas,
+    ensureContainer() {{}},
+    renderLayeredSnapshotCanvas: () => layeredSnapshot,
+  }},
+}};
+const context = {{ window, document, console, URL, Promise, Array, setTimeout, clearTimeout }};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.js' }});
+
+(async () => {{
+  assert.equal(window.avatarPortrait.normalizeModelType(), 'pngtuber');
+  const result = await window.avatarPortrait.capture({{
+    modelType: 'pngtuber', width: 768, height: 1024, includeDataUrl: true,
+  }});
+  assert.equal(result.modelType, 'pngtuber');
+  assert.equal(result.canvas.width, 768);
+  assert.equal(result.canvas.height, 1024);
+  assert.equal(result.sourceCanvas.width, 1200);
+  assert.equal(result.sourceCanvas.height, 1800);
+  assert.equal(result.dataUrl, 'data:image/png;base64,AAAA');
+
+  window.pngtuberManager = {{
+    image: runtimeCanvas,
+    ensureContainer() {{}},
+    renderLayeredSnapshotCanvas: () => new FakeCanvas(1200, 1800, false),
+  }};
+  await assert.rejects(
+    () => window.avatarPortrait.capture({{ modelType: 'pngtuber' }}),
+    /PNGTuber 画面尚未就绪/,
+  );
+
+  const brokenImage = {{
+    tagName: 'IMG', width: 512, height: 512, clientWidth: 512, clientHeight: 512,
+    naturalWidth: 0, naturalHeight: 0, complete: true, hidden: false,
+    style: {{ display: '' }}, classList: {{ contains: () => false }},
+  }};
+  window.pngtuberManager = {{ image: brokenImage, ensureContainer() {{}} }};
+  await assert.rejects(
+    () => window.avatarPortrait.capture({{ modelType: 'pngtuber' }}),
+    /PNGTuber 图片加载失败/,
+  );
+}})().catch((error) => {{ console.error(error); process.exit(1); }});
+"""
+
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -18,6 +18,8 @@ def test_avatar_portrait_captures_pngtuber_layered_snapshot():
         pytest.skip("node is not installed")
 
     source = AVATAR_PORTRAIT_PATH.read_text(encoding="utf-8")
+    assert "const analysisScale = requireAny" in source
+    assert "? 1" in source
     script = f"""
 const assert = require('node:assert/strict');
 const vm = require('node:vm');

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -106,8 +106,8 @@ vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'avatar-portrait.
   const intrinsicResult = await window.avatarPortrait.capture({{
     modelType: 'pngtuber', width: 768, height: 1024,
   }});
-  assert.equal(intrinsicResult.sourceCanvas.width, 1600);
-  assert.equal(intrinsicResult.sourceCanvas.height, 2400);
+  assert.equal(intrinsicResult.sourceCanvas.width, 1365);
+  assert.equal(intrinsicResult.sourceCanvas.height, 2048);
 
   const loadingImage = {{
     tagName: 'IMG', width: 0, height: 0, clientWidth: 0, clientHeight: 0,

--- a/tests/unit/test_avatar_portrait_pngtuber.py
+++ b/tests/unit/test_avatar_portrait_pngtuber.py
@@ -70,7 +70,7 @@ const window = {{
   document,
   location: {{ href: 'http://127.0.0.1:48911/', origin: 'http://127.0.0.1:48911' }},
   lanlan_config: {{ model_type: 'pngtuber' }},
-  requestAnimationFrame: (callback) => callback(),
+  requestAnimationFrame: () => {{ throw new Error('capture must not depend on animation frames'); }},
   getComputedStyle: (drawable) => ({{
     display: drawable.style.display || '',
     visibility: drawable.hidden ? 'hidden' : 'visible',

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -91,6 +91,7 @@ def test_same_cache_key_reload_invalidates_inflight_capture_revision():
     assert "if (captureRevision !== cardDropModelRevision)" in avatar_capture_block
     assert "pendingCharacterReferenceRevision === captureRevision" in reference_capture_block
     assert "if (cardDropModelRevision !== captureRevision) return '';" in reference_capture_block
+    assert "(cacheKey || '') + ':' + cardDropModelRevision" in source
 
 
 @pytest.mark.unit

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -71,17 +71,37 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
 
 
 @pytest.mark.unit
-def test_electron_chat_follower_does_not_publish_model_identity():
+def test_chat_follower_does_not_mutate_card_drop_snapshot():
     source = _read(APP_CHAT_AVATAR_PATH)
-    sync_block = source.split("function syncAvatarToCardDrop(dataUrl)", 1)[1].split(
+    sync_block = source.split("function syncAvatarToCardDrop(dataUrl, options = {})", 1)[1].split(
         "function applyPreviewResult",
         1,
     )[0]
 
     assert "function isCardDropIdentityFollowerWindow()" in source
-    assert "window.__NEKO_MULTI_WINDOW__ === true" in source
     assert "/^\\/chat(?:_full)?(?:\\/|$)/.test(pathname)" in source
-    assert "if (!isCardDropIdentityFollowerWindow()) appendCardDropModelIdentity(body);" in sync_block
+    assert "if (isCardDropIdentityFollowerWindow()) return;" in sync_block
+    assert sync_block.index("if (isCardDropIdentityFollowerWindow()) return;") < sync_block.index(
+        "fetch('/api/card-drop/active-character'"
+    )
+
+
+@pytest.mark.unit
+def test_pngtuber_loading_invalidates_snapshot_without_early_reference_capture():
+    source = _read(APP_CHAT_AVATAR_PATH)
+    loading_block = source.split("function handleModelLoading()", 1)[1].split(
+        "function bindModelLoadListeners()",
+        1,
+    )[0]
+
+    assert "window.addEventListener('pngtuber-model-loading'" in source
+    assert "let pngtuberModelLoading = false;" in source
+    assert "pngtuberModelLoading = true;" in loading_block
+    assert "advanceCardDropModelRevision();" in loading_block
+    assert "invalidateCachedPreview();" in loading_block
+    assert "syncAvatarToCardDrop('', { scheduleReference: false });" in loading_block
+    assert "pngtuberModelLoading = false;" in source
+    assert "pngtuberModelLoading && getCurrentModelType() === 'pngtuber'" in source
 
 
 @pytest.mark.unit

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -54,7 +54,8 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "return 'pngtuber:' + JSON.stringify(identity);" in source
     assert "window.vrmManager?.currentModel?.url" in source
     assert "window.vrmModel" in source
-    assert "function appendCardDropModelIdentity(body)" in source
+    assert "function appendCardDropModelIdentity(body, options = {})" in source
+    assert "Object.prototype.hasOwnProperty.call(options, 'modelKey')" in source
     assert "if (modelType)" in source
     assert "body.modelType = modelType;" in source
     assert "body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';" in source
@@ -101,7 +102,9 @@ def test_pngtuber_loading_invalidates_snapshot_without_early_reference_capture()
     assert "autoCaptureTimer = null;" in loading_block
     assert "advanceCardDropModelRevision();" in loading_block
     assert "invalidateCachedPreview();" in loading_block
-    assert "syncAvatarToCardDrop('', { scheduleReference: false });" in loading_block
+    assert "modelType: 'pngtuber'" in loading_block
+    assert "modelKey: ''" in loading_block
+    assert "syncAvatarToCardDrop('', {" in loading_block
     assert "pngtuberModelLoading = false;" in source
     assert "pngtuberModelLoading && getCurrentModelType() === 'pngtuber'" in source
     render_block = source.split("async function renderAvatarPreview(options = {})", 1)[1].split(
@@ -152,6 +155,27 @@ def test_same_cache_key_reload_invalidates_inflight_capture_revision():
     assert "pendingCharacterReferenceRevision === captureRevision" in reference_capture_block
     assert "if (cardDropModelRevision !== captureRevision) return '';" in reference_capture_block
     assert "(cacheKey || '') + ':' + cardDropModelRevision" in source
+
+
+@pytest.mark.unit
+def test_manual_crop_cancel_does_not_restore_preview_from_old_model_revision():
+    source = _read(APP_CHAT_AVATAR_PATH)
+    capture_block = source.split("async function renderAvatarPreview(options = {})", 1)[1].split(
+        "function scheduleAutoCapture",
+        1,
+    )[0]
+    cancel_block = capture_block.split("                } else {", 1)[1].split(
+        "                    setPreviewNote(",
+        1,
+    )[0]
+
+    assert "if (captureRevision !== cardDropModelRevision)" in cancel_block
+    assert "cachedPreview = null;" in cancel_block
+    assert "pendingAutoCapture = true;" in cancel_block
+    assert "} else if (prevCachedPreview) {" in cancel_block
+    assert cancel_block.index("if (captureRevision !== cardDropModelRevision)") < cancel_block.index(
+        "cachedPreview = prevCachedPreview;"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -53,6 +53,8 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "function appendCardDropModelIdentity(body)" in source
     assert "body.modelType = modelType;" in source
     assert "body.modelKey = modelKey;" in source
+    assert "cacheKey !== getCurrentModelCacheKey()" in source
+    assert "pendingAutoCapture = true;" in source
     assert "window.addEventListener('pngtuber-model-loaded'" in source
 
 

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -123,6 +123,8 @@ def test_card_drop_character_reference_http_failures_remain_retryable():
     assert ".then(function (response)" in post_block
     assert "if (!response.ok)" in post_block
     assert "response.status" in post_block
+    assert "response.json()" in post_block
+    assert "payload.ok === false || payload.stale === true" in post_block
     assert "return false;" in post_block
 
 

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -55,9 +55,9 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "window.vrmManager?.currentModel?.url" in source
     assert "window.vrmModel" in source
     assert "function appendCardDropModelIdentity(body)" in source
-    assert "if (modelType && modelKey && !modelKey.endsWith(':'))" in source
+    assert "if (modelType)" in source
     assert "body.modelType = modelType;" in source
-    assert "body.modelKey = modelKey;" in source
+    assert "body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';" in source
     assert "let cardDropModelRevision = Date.now();" in source
     assert "body.modelRevision = cardDropModelRevision;" in source
     assert "function advanceCardDropModelRevision()" in source
@@ -68,6 +68,20 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "applyPreviewResult(result, cacheKey, captureRevision);" in source
     assert "pendingAutoCapture = true;" in source
     assert "window.addEventListener('pngtuber-model-loaded'" in source
+
+
+@pytest.mark.unit
+def test_electron_chat_follower_does_not_publish_model_identity():
+    source = _read(APP_CHAT_AVATAR_PATH)
+    sync_block = source.split("function syncAvatarToCardDrop(dataUrl)", 1)[1].split(
+        "function applyPreviewResult",
+        1,
+    )[0]
+
+    assert "function isCardDropIdentityFollowerWindow()" in source
+    assert "window.__NEKO_MULTI_WINDOW__ === true" in source
+    assert "/^\\/chat(?:_full)?(?:\\/|$)/.test(pathname)" in source
+    assert "if (!isCardDropIdentityFollowerWindow()) appendCardDropModelIdentity(body);" in sync_block
 
 
 @pytest.mark.unit

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -55,8 +55,9 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "window.vrmManager?.currentModel?.url" in source
     assert "window.vrmModel" in source
     assert "function appendCardDropModelIdentity(body)" in source
+    assert "if (modelType && modelKey && !modelKey.endsWith(':'))" in source
     assert "body.modelType = modelType;" in source
-    assert "body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';" in source
+    assert "body.modelKey = modelKey;" in source
     assert "let cardDropModelRevision = Date.now();" in source
     assert "body.modelRevision = cardDropModelRevision;" in source
     assert "function advanceCardDropModelRevision()" in source

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -114,6 +114,21 @@ def test_pngtuber_loading_invalidates_snapshot_without_early_reference_capture()
 
 
 @pytest.mark.unit
+def test_pngtuber_loading_state_ignores_stale_lifecycle_events():
+    source = _read(APP_CHAT_AVATAR_PATH)
+    listeners = source.split("function bindModelLoadListeners()", 1)[1].split(
+        "function handleOutsidePointer",
+        1,
+    )[0]
+
+    assert "let pngtuberModelLoadToken = 0;" in source
+    assert "pngtuber-model-loading', function (event)" in listeners
+    assert "if (loadToken < pngtuberModelLoadToken) return;" in listeners
+    assert "pngtuberModelLoadToken = loadToken;" in listeners
+    assert listeners.count("if (loadToken !== pngtuberModelLoadToken) return;") == 2
+
+
+@pytest.mark.unit
 def test_same_cache_key_reload_invalidates_inflight_capture_revision():
     source = _read(APP_CHAT_AVATAR_PATH)
     model_loaded_block = source.split("function handleModelLoaded(reason)", 1)[1].split(

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -97,11 +97,20 @@ def test_pngtuber_loading_invalidates_snapshot_without_early_reference_capture()
     assert "window.addEventListener('pngtuber-model-loading'" in source
     assert "let pngtuberModelLoading = false;" in source
     assert "pngtuberModelLoading = true;" in loading_block
+    assert "clearTimeout(autoCaptureTimer);" in loading_block
+    assert "autoCaptureTimer = null;" in loading_block
     assert "advanceCardDropModelRevision();" in loading_block
     assert "invalidateCachedPreview();" in loading_block
     assert "syncAvatarToCardDrop('', { scheduleReference: false });" in loading_block
     assert "pngtuberModelLoading = false;" in source
     assert "pngtuberModelLoading && getCurrentModelType() === 'pngtuber'" in source
+    render_block = source.split("async function renderAvatarPreview(options = {})", 1)[1].split(
+        "function scheduleAutoCapture",
+        1,
+    )[0]
+    assert "if (pngtuberModelLoading && getCurrentModelType() === 'pngtuber')" in render_block
+    assert "pendingAutoCapture = true;" in render_block
+    assert "window.addEventListener('pngtuber-model-load-finished'" in source
 
 
 @pytest.mark.unit

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -124,6 +124,7 @@ def test_pngtuber_loading_state_ignores_stale_lifecycle_events():
     assert "let pngtuberModelLoadToken = 0;" in source
     assert "pngtuber-model-loading', function (event)" in listeners
     assert "if (loadToken < pngtuberModelLoadToken) return;" in listeners
+    assert "if (loadToken === pngtuberModelLoadToken && pngtuberModelLoading) return;" in listeners
     assert "pngtuberModelLoadToken = loadToken;" in listeners
     assert listeners.count("if (loadToken !== pngtuberModelLoadToken) return;") == 2
 

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -25,7 +25,7 @@ def test_card_drop_character_reference_retries_independently_of_avatar_cache():
     assert "function syncCharacterReferenceToCardDrop(reason)" in source
     assert "function queueCharacterReferenceRetry(reason)" in source
     assert "characterReferenceRetryAttempts >= CHARACTER_REFERENCE_RETRY_LIMIT" in source
-    assert "postCharacterReferenceToCardDrop(characterReferenceDataUrl)" in source
+    assert "postCharacterReferenceToCardDrop(characterReferenceDataUrl, captureRevision)" in source
     assert "scheduleCharacterReferenceSync('avatar-sync');" in source
     assert (
         "if (hasUsableCachedPreview()) {\n"
@@ -62,8 +62,35 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "function advanceCardDropModelRevision()" in source
     assert "cardDropModelRevision = Math.max(cardDropModelRevision + 1, Date.now());" in source
     assert "cacheKey !== getCurrentModelCacheKey()" in source
+    assert "captureRevision !== cardDropModelRevision" in source
+    assert "const captureRevision = cardDropModelRevision;" in source
+    assert "applyPreviewResult(result, cacheKey, captureRevision);" in source
     assert "pendingAutoCapture = true;" in source
     assert "window.addEventListener('pngtuber-model-loaded'" in source
+
+
+@pytest.mark.unit
+def test_same_cache_key_reload_invalidates_inflight_capture_revision():
+    source = _read(APP_CHAT_AVATAR_PATH)
+    model_loaded_block = source.split("function handleModelLoaded(reason)", 1)[1].split(
+        "function bindModelLoadListeners()",
+        1,
+    )[0]
+    avatar_capture_block = source.split("async function renderAvatarPreview", 1)[1].split(
+        "function scheduleAutoCapture",
+        1,
+    )[0]
+    reference_capture_block = source.split(
+        "function captureCharacterReferenceDataUrl(captureRevision)", 1
+    )[1].split("/**\n     * 把当前头像", 1)[0]
+
+    assert model_loaded_block.index("advanceCardDropModelRevision();") < model_loaded_block.index(
+        "var newCacheKey = getCurrentModelCacheKey();"
+    )
+    assert "const captureRevision = cardDropModelRevision;" in avatar_capture_block
+    assert "if (captureRevision !== cardDropModelRevision)" in avatar_capture_block
+    assert "pendingCharacterReferenceRevision === captureRevision" in reference_capture_block
+    assert "if (cardDropModelRevision !== captureRevision) return '';" in reference_capture_block
 
 
 @pytest.mark.unit
@@ -100,16 +127,19 @@ def test_card_drop_character_reference_http_failures_remain_retryable():
 
 
 @pytest.mark.unit
-def test_character_reference_pending_capture_is_bound_to_its_cache_key():
+def test_character_reference_pending_capture_is_bound_to_model_revision():
     source = _read(APP_CHAT_AVATAR_PATH)
-    capture_block = source.split("function captureCharacterReferenceDataUrl()", 1)[1].split(
+    capture_block = source.split(
+        "function captureCharacterReferenceDataUrl(captureRevision)", 1
+    )[1].split(
         "/**\n     * 把当前头像",
         1,
     )[0]
     matching_pending_guard = (
         "if (\n"
         "            pendingCharacterReference &&\n"
-        "            pendingCharacterReferenceCacheKey === cacheKey\n"
+        "            pendingCharacterReferenceCacheKey === cacheKey &&\n"
+        "            pendingCharacterReferenceRevision === captureRevision\n"
         "        ) {\n"
         "            return pendingCharacterReference;\n"
         "        }"
@@ -117,7 +147,8 @@ def test_character_reference_pending_capture_is_bound_to_its_cache_key():
     stale_result_guard = (
         ".then(function (result) {\n"
         "                if (getCharacterReferenceCacheKey() !== cacheKey) return '';\n"
-        "                return rememberCharacterReferenceResult(result, cacheKey);\n"
+        "                if (cardDropModelRevision !== captureRevision) return '';\n"
+        "                return rememberCharacterReferenceResult(result, cacheKey, captureRevision);\n"
         "            })"
     )
     pending_capture_binding = (
@@ -125,14 +156,19 @@ def test_character_reference_pending_capture_is_bound_to_its_cache_key():
         "                if (pendingCharacterReference === capturePromise) {\n"
         "                    pendingCharacterReference = null;\n"
         "                    pendingCharacterReferenceCacheKey = '';\n"
+        "                    pendingCharacterReferenceRevision = 0;\n"
         "                }\n"
         "            });\n"
         "        pendingCharacterReference = capturePromise;\n"
         "        pendingCharacterReferenceCacheKey = cacheKey;\n"
+        "        pendingCharacterReferenceRevision = captureRevision;\n"
         "        return capturePromise;"
     )
 
     assert "let pendingCharacterReferenceCacheKey = '';" in source
+    assert "let pendingCharacterReferenceRevision = 0;" in source
+    assert "cachedCharacterReference.modelRevision === captureRevision" in capture_block
+    assert "referenceBody.modelRevision = captureRevision;" in source
     assert matching_pending_guard in capture_block
     assert stale_result_guard in capture_block
     assert pending_capture_binding in capture_block

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -102,6 +102,7 @@ def test_pngtuber_loading_invalidates_snapshot_without_early_reference_capture()
     assert "autoCaptureTimer = null;" in loading_block
     assert "advanceCardDropModelRevision();" in loading_block
     assert "invalidateCachedPreview();" in loading_block
+    assert "setPreviewImage('');" in loading_block
     assert "modelType: 'pngtuber'" in loading_block
     assert "modelKey: ''" in loading_block
     assert "syncAvatarToCardDrop('', {" in loading_block

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -48,11 +48,15 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "if (modelType === 'pngtuber') return 'pngtuber';" in source
     assert "config.layered_metadata" in source
     assert "config.idle_image" in source
+    assert "config.talking_image" in source
+    assert "function normalizeModelIdentityPart(value)" in source
+    assert "Object.keys(nestedValue).sort()" in source
+    assert "return 'pngtuber:' + JSON.stringify(identity);" in source
     assert "window.vrmManager?.currentModel?.url" in source
     assert "window.vrmModel" in source
     assert "function appendCardDropModelIdentity(body)" in source
     assert "body.modelType = modelType;" in source
-    assert "body.modelKey = modelKey;" in source
+    assert "body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';" in source
     assert "cacheKey !== getCurrentModelCacheKey()" in source
     assert "pendingAutoCapture = true;" in source
     assert "window.addEventListener('pngtuber-model-loaded'" in source

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -42,6 +42,21 @@ def test_card_drop_character_reference_retries_independently_of_avatar_cache():
 
 
 @pytest.mark.unit
+def test_card_drop_snapshot_is_bound_to_current_model_identity():
+    source = _read(APP_CHAT_AVATAR_PATH)
+
+    assert "if (modelType === 'pngtuber') return 'pngtuber';" in source
+    assert "config.layered_metadata" in source
+    assert "config.idle_image" in source
+    assert "window.vrmManager?.currentModel?.url" in source
+    assert "window.vrmModel" in source
+    assert "function appendCardDropModelIdentity(body)" in source
+    assert "body.modelType = modelType;" in source
+    assert "body.modelKey = modelKey;" in source
+    assert "window.addEventListener('pngtuber-model-loaded'" in source
+
+
+@pytest.mark.unit
 def test_card_drop_name_sync_does_not_wait_for_avatar_capture():
     source = _read(APP_CHAT_AVATAR_PATH)
     model_loaded_block = source.split("function handleModelLoaded(reason)", 1)[1].split(

--- a/tests/unit/test_card_drop_character_reference_static.py
+++ b/tests/unit/test_card_drop_character_reference_static.py
@@ -57,6 +57,10 @@ def test_card_drop_snapshot_is_bound_to_current_model_identity():
     assert "function appendCardDropModelIdentity(body)" in source
     assert "body.modelType = modelType;" in source
     assert "body.modelKey = modelKey && !modelKey.endsWith(':') ? modelKey : '';" in source
+    assert "let cardDropModelRevision = Date.now();" in source
+    assert "body.modelRevision = cardDropModelRevision;" in source
+    assert "function advanceCardDropModelRevision()" in source
+    assert "cardDropModelRevision = Math.max(cardDropModelRevision + 1, Date.now());" in source
     assert "cacheKey !== getCurrentModelCacheKey()" in source
     assert "pendingAutoCapture = true;" in source
     assert "window.addEventListener('pngtuber-model-loaded'" in source

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -223,6 +223,45 @@ async def test_main_active_character_type_only_change_clears_prior_model_key(
 
 
 @pytest.mark.asyncio
+async def test_main_active_character_rejects_stale_model_revision_before_mutation(
+    monkeypatch,
+):
+    from app.main_server import web_app
+
+    snapshot = {
+        "name": "N.E.K.O",
+        "modelType": "pngtuber",
+        "modelKey": "pngtuber:new-model",
+        "modelRevision": 200,
+        "dataUrl": "new-avatar",
+        "characterReferenceDataUrl": "new-reference",
+    }
+    monkeypatch.setattr(web_app, "_card_drop_active_character", snapshot)
+
+    response = await web_app.set_card_drop_active_character(
+        _main_server_request(),
+        {
+            "name": "N.E.K.O",
+            "modelType": "live2d",
+            "modelKey": "live2d:old-model",
+            "modelRevision": 100,
+            "dataUrl": "old-avatar",
+            "characterReferenceDataUrl": "old-reference",
+        },
+    )
+
+    assert response == {"ok": False, "stale": True}
+    assert snapshot == {
+        "name": "N.E.K.O",
+        "modelType": "pngtuber",
+        "modelKey": "pngtuber:new-model",
+        "modelRevision": 200,
+        "dataUrl": "new-avatar",
+        "characterReferenceDataUrl": "new-reference",
+    }
+
+
+@pytest.mark.asyncio
 async def test_main_active_character_get_exposes_model_identity(monkeypatch):
     from app.main_server import web_app
 

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -165,6 +165,88 @@ async def test_main_active_character_name_change_clears_only_stale_avatar_fields
 
 
 @pytest.mark.asyncio
+async def test_main_active_character_model_change_clears_stale_images_for_same_name(
+    monkeypatch,
+):
+    from app.main_server import web_app
+
+    snapshot = {
+        "name": "N.E.K.O",
+        "modelType": "live2d",
+        "modelKey": "live2d:/models/old/model.json",
+        "dataUrl": "old-avatar",
+        "characterReferenceDataUrl": "old-reference",
+    }
+    monkeypatch.setattr(web_app, "_card_drop_active_character", snapshot)
+
+    response = await web_app.set_card_drop_active_character(
+        _main_server_request(),
+        {
+            "name": "N.E.K.O",
+            "modelType": "pngtuber",
+            "modelKey": "pngtuber:/user_pngtuber/new/idle.png",
+            "dataUrl": "new-avatar",
+        },
+    )
+
+    assert response == {"ok": True}
+    assert snapshot == {
+        "name": "N.E.K.O",
+        "modelType": "pngtuber",
+        "modelKey": "pngtuber:/user_pngtuber/new/idle.png",
+        "dataUrl": "new-avatar",
+    }
+
+
+@pytest.mark.asyncio
+async def test_main_active_character_type_only_change_clears_prior_model_key(
+    monkeypatch,
+):
+    from app.main_server import web_app
+
+    snapshot = {
+        "name": "N.E.K.O",
+        "modelType": "live2d",
+        "modelKey": "live2d:/models/old/model.json",
+        "dataUrl": "old-avatar",
+        "characterReferenceDataUrl": "old-reference",
+    }
+    monkeypatch.setattr(web_app, "_card_drop_active_character", snapshot)
+
+    response = await web_app.set_card_drop_active_character(
+        _main_server_request(),
+        {"name": "N.E.K.O", "modelType": "vrm"},
+    )
+
+    assert response == {"ok": True}
+    assert snapshot == {"name": "N.E.K.O", "modelType": "vrm"}
+
+
+@pytest.mark.asyncio
+async def test_main_active_character_get_exposes_model_identity(monkeypatch):
+    from app.main_server import web_app
+
+    monkeypatch.setattr(
+        web_app,
+        "_card_drop_active_character",
+        {
+            "name": "N.E.K.O",
+            "modelType": "pngtuber",
+            "modelKey": "pngtuber:/user_pngtuber/neko/idle.png",
+        },
+    )
+
+    response = await web_app.get_card_drop_active_character(
+        _main_server_request(),
+        include_avatar=False,
+    )
+    payload = json.loads(response.body.decode("utf-8"))
+
+    assert payload["modelType"] == "pngtuber"
+    assert payload["modelKey"] == "pngtuber:/user_pngtuber/neko/idle.png"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "origin",
     ["https://evil.example", "https://community.example"],

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1062,9 +1062,11 @@ def test_layered_pngtuber_can_render_full_resolution_snapshot_without_resizing_r
     assert "document.createElement('canvas')" in snapshot_block
     assert "Number(this.layeredCanvasLogicalWidth)" in snapshot_block
     assert "Number(this.layeredCanvasLogicalHeight)" in snapshot_block
+    assert "Number(options.maxEdge)" in snapshot_block
+    assert "maxEdge / Math.max(logicalWidth, logicalHeight)" in snapshot_block
     assert "this.drawLayeredState(stateName, timestamp, {" in snapshot_block
-    assert "scaleX: 1" in snapshot_block
-    assert "scaleY: 1" in snapshot_block
+    assert "scaleX: canvas.width / logicalWidth" in snapshot_block
+    assert "scaleY: canvas.height / logicalHeight" in snapshot_block
     assert "return drawn ? canvas : null;" in snapshot_block
     assert "this.canvasElement =" not in snapshot_block
     assert "renderTarget?.canvas || this.canvasElement" in draw_block

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1077,12 +1077,12 @@ def test_layered_pngtuber_can_render_full_resolution_snapshot_without_resizing_r
 def test_pngtuber_load_announces_identity_change_before_async_setup():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     load_block = source[
-        source.index("        async load(config) {"):
+        source.index("        async load(config, options = {}) {"):
         source.index("        stateToSrc(state)")
     ]
 
     config_assignment = "this.config = normalizeConfig(config || {});"
-    loading_event = "window.dispatchEvent(new CustomEvent('pngtuber-model-loading'));"
+    loading_event = "window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {"
     async_setup = "await this.setupLayeredAdapter();"
     assert load_block.index(config_assignment) < load_block.index(loading_event)
     assert load_block.index(loading_event) < load_block.index(async_setup)
@@ -1097,7 +1097,39 @@ def test_pngtuber_loader_finishes_loading_state_on_every_exit():
 
     assert "try {" in loader_block
     assert "} finally {" in loader_block
-    assert "window.dispatchEvent(new CustomEvent('pngtuber-model-load-finished'));" in loader_block
+    assert "window.dispatchEvent(new CustomEvent('pngtuber-model-load-finished', {" in loader_block
+
+
+def test_pngtuber_loader_binds_lifecycle_events_to_one_load_token():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    load_block = source[
+        source.index("        async load(config, options = {}) {"):
+        source.index("        stateToSrc(state)")
+    ]
+    loader_block = source[
+        source.index("    async function loadPNGTuberAvatar(config) {"):
+        source.index("    function playPNGTuberAnimation")
+    ]
+
+    assert "let pngtuberLoadSequence = 0;" in source
+    assert "const loadToken = ++pngtuberLoadSequence;" in loader_block
+    assert "await window.pngtuberManager.load(config || {}, { loadToken });" in loader_block
+    assert "const loadToken = Number(options.loadToken) || 0;" in load_block
+    assert load_block.count("detail: { loadToken }") == 1
+    assert loader_block.count("detail: { loadToken }") == 2
+
+
+def test_pngtuber_remote_images_enable_anonymous_cors_before_loading():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    assign_block = source[
+        source.index("    function assignImageSource(image, src) {"):
+        source.index("    function isPNGTuberPlusLayerVisible")
+    ]
+
+    assert "image.crossOrigin = 'anonymous';" in assign_block
+    assert assign_block.index("image.crossOrigin = 'anonymous';") < assign_block.index("image.src = src;")
+    assert "assignImageSource(img, src);" in source
+    assert "assignImageSource(this.image, nextSrc);" in source
 
 
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1021,7 +1021,7 @@ def test_layered_pngtuber_motion_requires_explicit_runtime_feature_flags():
 def test_layered_pngtuber_caps_render_resolution_without_changing_logical_coordinates():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     setup_block = source[
-        source.index("        async setupLayeredAdapter()"):
+        source.index("        async setupLayeredAdapter(options = {})"):
         source.index("        hasBlinkLayers()")
     ]
     pointer_block = source[
@@ -1081,9 +1081,9 @@ def test_pngtuber_load_announces_identity_change_before_async_setup():
         source.index("        stateToSrc(state)")
     ]
 
-    config_assignment = "this.config = normalizeConfig(config || {});"
+    config_assignment = "this.config = normalizedConfig;"
     loading_event = "window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {"
-    async_setup = "await this.setupLayeredAdapter();"
+    async_setup = "await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad });"
     assert load_block.index(config_assignment) < load_block.index(loading_event)
     assert load_block.index(loading_event) < load_block.index(async_setup)
 
@@ -1115,8 +1115,11 @@ def test_pngtuber_loader_binds_lifecycle_events_to_one_load_token():
     assert "const loadToken = ++pngtuberLoadSequence;" in loader_block
     assert "await window.pngtuberManager.load(config || {}, { loadToken });" in loader_block
     assert "const loadToken = Number(options.loadToken) || 0;" in load_block
+    assert "if (!isCurrentLoad()) return false;" in load_block
+    assert loader_block.count("if (loadToken !== pngtuberLoadSequence)") == 3
+    assert "if (!loaded || loadToken !== pngtuberLoadSequence)" in loader_block
     assert load_block.count("detail: { loadToken }") == 1
-    assert loader_block.count("detail: { loadToken }") == 2
+    assert loader_block.count("detail: { loadToken }") == 3
 
 
 def test_pngtuber_remote_images_enable_anonymous_cors_before_loading():
@@ -1126,10 +1129,75 @@ def test_pngtuber_remote_images_enable_anonymous_cors_before_loading():
         source.index("    function isPNGTuberPlusLayerVisible")
     ]
 
+    assert "/^(?:https?:)?\\/\\//i.test" in assign_block
     assert "image.crossOrigin = 'anonymous';" in assign_block
     assert assign_block.index("image.crossOrigin = 'anonymous';") < assign_block.index("image.src = src;")
     assert "assignImageSource(img, src);" in source
     assert "assignImageSource(this.image, nextSrc);" in source
+
+
+def test_pngtuber_older_overlapping_load_cannot_resume_over_latest_model():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for PNGTuber overlapping load tests")
+
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const events = [];
+const window = {{
+  location: {{ pathname: '/' }},
+  innerWidth: 1280,
+  innerHeight: 720,
+  lanlan_config: {{ model_type: 'pngtuber' }},
+  dispatchEvent(event) {{ events.push(event); }},
+}};
+const document = {{
+  body: {{ classList: {{ contains() {{ return false; }} }} }},
+  getElementById() {{ return null; }},
+  querySelectorAll() {{ return []; }},
+}};
+class CustomEvent {{
+  constructor(type, options = {{}}) {{ this.type = type; this.detail = options.detail; }}
+}}
+const context = {{ console, CustomEvent, document, window }};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
+
+const manager = new window.PNGTuberManager();
+const pendingSetups = [];
+manager.detachDragListeners = () => {{}};
+manager.clearEmotion = () => {{}};
+manager.setupLayeredAdapter = (options) => new Promise((resolve) => {{
+  pendingSetups.push({{ options, resolve }});
+}});
+manager.ensureContainer = () => {{}};
+manager.preloadImages = () => {{}};
+manager.attachSpeechListeners = () => {{}};
+manager.attachDragListeners = () => {{}};
+manager.setState = () => {{}};
+manager.applyTransform = () => {{}};
+manager.syncGlobalConfig = () => {{}};
+manager.setupHTMLLockIcon = () => {{}};
+
+(async () => {{
+  const older = manager.load({{ idle_image: 'older.png' }}, {{ loadToken: 1 }});
+  const newer = manager.load({{ idle_image: 'newer.png' }}, {{ loadToken: 2 }});
+  assert.equal(pendingSetups.length, 2);
+
+  pendingSetups[1].resolve(false);
+  assert.equal(await newer, true);
+  assert.equal(manager.config.idle_image, 'newer.png');
+
+  pendingSetups[0].resolve(false);
+  assert.equal(await older, false);
+  assert.equal(manager.config.idle_image, 'newer.png');
+  assert.equal(events.filter((event) => event.type === 'pngtuber-model-loading').length, 2);
+}})().catch((error) => {{ console.error(error); process.exit(1); }});
+"""
+
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
 
 
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():
@@ -1140,7 +1208,7 @@ def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():
     ]
     handler_block = source[
         source.index("        handleLayeredHotkey(event) {"):
-        source.index("        async setupLayeredAdapter()")
+        source.index("        async setupLayeredAdapter(options = {})")
     ]
     cycle_hotkey_block = source[
         source.index("        isLayeredCycleHotkey(event) {"):
@@ -1186,7 +1254,7 @@ def test_layered_pngtuber_alt_two_toggles_imported_asset_action():
     ]
     handler_block = source[
         source.index("        handleLayeredHotkey(event) {"):
-        source.index("        async setupLayeredAdapter()")
+        source.index("        async setupLayeredAdapter(options = {})")
     ]
     asset_hotkey_block = source[
         source.index("        isLayeredAssetActionHotkey(event) {"):

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1088,6 +1088,18 @@ def test_pngtuber_load_announces_identity_change_before_async_setup():
     assert load_block.index(loading_event) < load_block.index(async_setup)
 
 
+def test_pngtuber_loader_finishes_loading_state_on_every_exit():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    loader_block = source[
+        source.index("    async function loadPNGTuberAvatar(config) {"):
+        source.index("    function playPNGTuberAnimation")
+    ]
+
+    assert "try {" in loader_block
+    assert "} finally {" in loader_block
+    assert "window.dispatchEvent(new CustomEvent('pngtuber-model-load-finished'));" in loader_block
+
+
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     attach_block = source[

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1074,6 +1074,20 @@ def test_layered_pngtuber_can_render_full_resolution_snapshot_without_resizing_r
     assert "renderTarget?.scaleY ?? this.layeredCanvasScaleY" in draw_block
 
 
+def test_pngtuber_load_announces_identity_change_before_async_setup():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    load_block = source[
+        source.index("        async load(config) {"):
+        source.index("        stateToSrc(state)")
+    ]
+
+    config_assignment = "this.config = normalizeConfig(config || {});"
+    loading_event = "window.dispatchEvent(new CustomEvent('pngtuber-model-loading'));"
+    async_setup = "await this.setupLayeredAdapter();"
+    assert load_block.index(config_assignment) < load_block.index(loading_event)
+    assert load_block.index(loading_event) < load_block.index(async_setup)
+
+
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     attach_block = source[


### PR DESCRIPTION
## Summary

- add a PNGTuber adapter to the existing `avatarPortrait.capture()` pipeline, including layered-canvas snapshots and loaded models that are temporarily hidden by the desktop layout
- bind avatar/reference caches and active-character snapshots to a generic `modelType` / `modelKey`, with reliable VRM and PNGTuber model identity detection
- invalidate stale avatar and character-reference images immediately when the active character name or model identity changes
- keep Live2D, VRM, MMD, and PNGTuber on the same active-character endpoint and downstream forge reference contract; no model-specific forge route or pipeline is introduced

This is the N.E.K.O desktop half of the fix. The Verse-side identity checks remain a separate companion change.

## 回归报告

### 改动与必要性

社区铸造原先依赖 `avatarPortrait.capture()` 生成角色外形参考图，但 PNGTuber 没有对应适配器；同时头像和参考图缓存没有绑定当前模型身份，同名角色切换 Live2D、VRM 或 PNGTuber 后可能继续使用旧模型图片。本改动在现有采集入口内补充 PNGTuber 取帧，并为所有模型统一附加 `modelType` / `modelKey` 身份。

### 改动前后行为

- 改动前：Live2D/VRM 能进入现有捕获入口，PNGTuber 无法生成社区铸造参考图；缓存主要按角色保存，同名切模可能命中旧图。
- 改动后：PNGTuber 通过相同的 `avatarPortrait.capture()` 输出标准 PNG data URL；Live2D、VRM、MMD、PNGTuber 均通过相同 active-character endpoint 同步。角色名或模型身份变化时，未随更新显式提供的旧头像和参考图会立即失效并重新采集。

### 潜在回归与控制

- PNGTuber 图片尚未加载、为空或跨域不可导出时会明确拒绝捕获，不会上传损坏图片。
- `prepare()` 现在被统一 `await`；原有同步 Live2D/VRM/MMD adapter 返回值仍可由 `await` 兼容。
- 模型身份不完整时不会复用持久化缓存，可能触发一次额外采集，这是为了避免把旧模型图片用于铸造。
- 定向测试覆盖普通 PNG、分层 canvas、隐藏模型、损坏图片、同名切模失效、CORS 和现有 PNGTuber 合同；Electron IPC 仍使用同一公共捕获入口。

## Validation

- `uv run pytest -q tests/unit/test_avatar_portrait_pngtuber.py tests/unit/test_card_drop_character_reference_static.py tests/unit/test_card_drop_session_facts.py tests/unit/test_pngtuber_static_contracts.py` — 110 passed
- `node --check static/app/app-chat-avatar.js`
- `node --check static/avatar/avatar-portrait.js`
- `uv run python -m py_compile app/main_server/web_app.py tests/unit/test_avatar_portrait_pngtuber.py`
- `uv build` — wheel and source distribution built successfully
- local Docker forge exercised the existing async forge/image/claim path with a PNGTuber reference; the external image generation request and claim both returned HTTP 200

## Scope

- no OAuth/account-mismatch test bypass is included
- no API keys or local provider overrides are included
- N.E.K.O.-PC was reviewed read-only; its character-reference IPC bridge already delegates to `avatarPortrait.capture()`, so no Electron repository change is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持 PNGTuber 模型的聊天头像预览、分层渲染与肖像捕获。
  * 活动角色信息新增模型类型、标识及修订号，并拒绝过期数据。
  * 多窗口跟随模式支持头像与名称同步。

* **问题修复**
  * 模型切换时自动使旧缓存及进行中的捕获结果失效。
  * 改善模型加载、图片加载、隐藏图层及高分辨率捕获处理。
  * 更换模型或角色名称后自动清理失效的头像与参考图数据。

* **测试**
  * 新增 PNGTuber 捕获、模型身份绑定及并发竞态测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->