### PR TITLE
test(jukebox): drop the guard that fabricated a global the app does not have

### DIFF
--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -7156,13 +7156,17 @@ def test_jukebox_targetless_previous_leaves_the_music_playing(mock_page: Page):
 
 @pytest.mark.frontend
 def test_jukebox_close_tears_down_when_only_the_panel_was_used(mock_page: Page):
-    """The preserve-on-close branch must not fire without a headless request.
+    """A hand-driven panel must tear down on close, not be kept alive.
 
-    hasHeadlessRuntime() keys on State.headlessRuntimeRequested precisely to
-    tell "the AI asked for a runtime" apart from "the user opened the panel and
-    played something".  Without that key, closing a panel that was only ever
-    driven by hand would preserve a runtime nobody asked to keep alive: the
-    music would go on playing with no UI, and the parts would never unload.
+    Only ensureRuntime() sets isRuntimeReady, and the panel path in open() never
+    calls it -- so a session the user drove by hand reaches close() with the
+    runtime not ready, and the preserve branch must not fire.  Preserving it
+    would leave music playing with no UI and the parts never unloading.
+
+    Deliberately does NOT fabricate isRuntimeReady: an earlier version of this
+    test set it to true so that hasHeadlessRuntime()'s headlessRuntimeRequested
+    check would be reached, and thereby claimed coverage of a state the app
+    cannot produce -- every caller that sets isRuntimeReady also sets the flag.
     """
     setup_headless_jukebox_page(mock_page)
 
@@ -7182,13 +7186,14 @@ def test_jukebox_close_tears_down_when_only_the_panel_was_used(mock_page: Page):
           J.State.container = wrapper;
           J.State.styleElement = style;
           J.State.isOpen = true;
-          J.State.isRuntimeReady = true;
           J.initPlayer({ headless: false });
           await J.playSong('song1');
 
           const before = {
-            // 全程没有任何 headless 指令，这个标志必须还是假的。
+            // 全程没有任何 headless 指令，也没人调过 ensureRuntime：这就是
+            // 「用户自己开面板放歌」的真实状态。
             headlessRuntimeRequested: J.State.headlessRuntimeRequested,
+            isRuntimeReady: J.State.isRuntimeReady,
             playing: J.State.isPlaying
           };
 
@@ -7213,8 +7218,12 @@ def test_jukebox_close_tears_down_when_only_the_panel_was_used(mock_page: Page):
         """
     )
 
-    assert result["before"] == {"headlessRuntimeRequested": False, "playing": True}
-    # 没人请求过无头运行时：关闭就该停播、彻底拆除、通知卸载分片。
+    assert result["before"] == {
+        "headlessRuntimeRequested": False,
+        "isRuntimeReady": False,
+        "playing": True,
+    }
+    # 手动开的面板：关闭就该停播、彻底拆除、通知卸载分片。
     assert result["stopped"] == 1, result
     assert result["fullCloseEvents"] == 1, result
     assert result["isPlaying"] is False

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -7206,7 +7206,8 @@ def test_jukebox_close_tears_down_when_only_the_panel_was_used(mock_page: Page):
             fullCloseEvents,
             isPlaying: J.State.isPlaying,
             currentSong: J.State.currentSong && J.State.currentSong.id,
-            songCount: J.State.songs.length
+            songCount: J.State.songs.length,
+            playerDestroyed: window.__lastAPlayer.destroyed === true
           };
         }
         """
@@ -7219,3 +7220,6 @@ def test_jukebox_close_tears_down_when_only_the_panel_was_used(mock_page: Page):
     assert result["isPlaying"] is False
     assert result["currentSong"] is None
     assert result["songCount"] == 0
+    # 这条不能省：上面几项在「只 stopPlayback、不 prepareForUnload」的回归下全都
+    # 照样成立，播放器却还活着。要证明走的是彻底拆除那条分支，只能看它死没死。
+    assert result["playerDestroyed"] is True

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -3498,63 +3498,6 @@ def test_jukebox_fuzzy_distance_stays_linear_in_candidate_length(mock_page: Page
 
 
 @pytest.mark.frontend
-def test_jukebox_close_preserves_playback_started_on_a_shared_player(mock_page: Page):
-    """#4: closing the panel must not stop playback started on a shared player.
-
-    Reusing ``music_ui``'s player creates no headless host, which used to make
-    hasHeadlessRuntime() permanently false.
-    """
-    setup_headless_jukebox_page(mock_page)
-
-    result = mock_page.evaluate(
-        """
-        async () => {
-          const J = window.Jukebox;
-          const shared = new window.APlayer({ volume: 1, audio: [] });
-          window.music_ui = { getMusicPlayerInstance: () => shared };
-
-          await J.executeControl({ action: 'play', query: 'Song 1', headless: true });
-          const startedOnShared = J.getPlayer() === shared;
-
-          let fullCloseEvents = 0;
-          window.addEventListener('neko:jukebox-full-close', () => { fullCloseEvents += 1; });
-
-          const wrapper = document.createElement('div');
-          wrapper.className = 'jukebox-wrapper';
-          wrapper.innerHTML = '<div class="jukebox-container"></div>';
-          document.body.appendChild(wrapper);
-          J.State.container = wrapper;
-          J.State.isOpen = true;
-
-          let stopped = 0;
-          const originalStop = J.stopPlayback;
-          J.stopPlayback = function(...args) { stopped += 1; return originalStop.apply(this, args); };
-          J.close();
-          J.stopPlayback = originalStop;
-
-          return {
-            startedOnShared,
-            stopped,
-            fullCloseEvents,
-            sharedDestroyed: shared.destroyed === true,
-            currentSong: J.State.currentSong && J.State.currentSong.id,
-            isRuntimeReady: J.State.isRuntimeReady
-          };
-        }
-        """
-    )
-
-    assert result == {
-        "startedOnShared": True,
-        "stopped": 0,
-        "fullCloseEvents": 0,
-        "sharedDestroyed": False,
-        "currentSong": "song1",
-        "isRuntimeReady": True,
-    }
-
-
-@pytest.mark.frontend
 def test_jukebox_close_preserves_playback_when_panel_opened_first(mock_page: Page):
     """#4, second half: panel opened first, then the control API reuses its player.
 
@@ -7209,3 +7152,70 @@ def test_jukebox_targetless_previous_leaves_the_music_playing(mock_page: Page):
     assert result["afterPlaying"] is True, result
     assert result["afterSong"] == "song1"
     assert result["audioPaused"] is False, result
+
+
+@pytest.mark.frontend
+def test_jukebox_close_tears_down_when_only_the_panel_was_used(mock_page: Page):
+    """The preserve-on-close branch must not fire without a headless request.
+
+    hasHeadlessRuntime() keys on State.headlessRuntimeRequested precisely to
+    tell "the AI asked for a runtime" apart from "the user opened the panel and
+    played something".  Without that key, closing a panel that was only ever
+    driven by hand would preserve a runtime nobody asked to keep alive: the
+    music would go on playing with no UI, and the parts would never unload.
+    """
+    setup_headless_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          await J.loadSongData();
+
+          // 纯面板使用：建面板、建面板播放器、用户自己点了一首。
+          const wrapper = document.createElement('div');
+          wrapper.className = 'jukebox-wrapper';
+          wrapper.innerHTML = '<div class="jukebox-container"></div>';
+          document.body.appendChild(wrapper);
+          const style = document.createElement('style');
+          document.head.appendChild(style);
+          J.State.container = wrapper;
+          J.State.styleElement = style;
+          J.State.isOpen = true;
+          J.State.isRuntimeReady = true;
+          J.initPlayer({ headless: false });
+          await J.playSong('song1');
+
+          const before = {
+            // 全程没有任何 headless 指令，这个标志必须还是假的。
+            headlessRuntimeRequested: J.State.headlessRuntimeRequested,
+            playing: J.State.isPlaying
+          };
+
+          let fullCloseEvents = 0;
+          window.addEventListener('neko:jukebox-full-close', () => { fullCloseEvents += 1; });
+          let stopped = 0;
+          const originalStop = J.stopPlayback;
+          J.stopPlayback = function(...args) { stopped += 1; return originalStop.apply(this, args); };
+          J.close();
+          J.stopPlayback = originalStop;
+
+          return {
+            before,
+            stopped,
+            fullCloseEvents,
+            isPlaying: J.State.isPlaying,
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            songCount: J.State.songs.length
+          };
+        }
+        """
+    )
+
+    assert result["before"] == {"headlessRuntimeRequested": False, "playing": True}
+    # 没人请求过无头运行时：关闭就该停播、彻底拆除、通知卸载分片。
+    assert result["stopped"] == 1, result
+    assert result["fullCloseEvents"] == 1, result
+    assert result["isPlaying"] is False
+    assert result["currentSong"] is None
+    assert result["songCount"] == 0


### PR DESCRIPTION
Follow-up to #2293, which merged before this landed.

## What

`test_jukebox_close_preserves_playback_started_on_a_shared_player` assigned `window.music_ui` itself and then asserted the jukebox behaved correctly when reusing that object's player:

```js
const shared = new window.APlayer({ volume: 1, audio: [] });
window.music_ui = { getMusicPlayerInstance: () => shared };
```

Nothing in the application ever assigns `window.music_ui`. A repo-wide search over `.js/.ts/.html/.json`, build output included, finds no assignment at all — so the branch it exercised (`getPlayer`/`initPlayer` in `static/jukebox/jukebox/transport.js` probing `window.music_ui.getMusicPlayerInstance`) has never run outside that test. The guard could only ever pass, and it documented a capability that does not exist.

## Why this is not a loss of coverage

Every assertion it made is covered by a test of a configuration that is actually reachable:

| assertion | covered by |
| --- | --- |
| `stopped == 0` | `..._when_panel_opened_first` |
| `currentSong` / `playerDestroyed` | both siblings |
| `fullCloseEvents == 0` | `..._preserves_headless_runtime` |
| `isRuntimeReady == True` | `..._preserves_headless_runtime` |
| `startedOnShared` | the fabricated global only |

Confirmed by mutation rather than by reading: reverting `hasHeadlessRuntime` to require a runtime host, and forcing `close()` to always `stopPlayback`, both still turn the suite red.

## The second test, and a claim I had to withdraw

I originally added `test_jukebox_close_tears_down_when_only_the_panel_was_used` on the grounds that `hasHeadlessRuntime`'s check on `State.headlessRuntimeRequested` was pinned by nothing. Codex and Greptile both pointed out that my test only reached that check because it set `State.isRuntimeReady` itself — the same fabrication this PR exists to remove. They are right, and the claim was wrong.

The state is unreachable. `isRuntimeReady` is assigned in exactly one place, `ensureRuntime` (`transport.js:102`), and every caller sets the headless flag with it: `executeControl`'s three call sites all pass `headless: command.headless !== false`, nothing in the repository ever sends `headless: false`, and the loader's `ensureRuntime` facade has no callers at all. The panel path in `open()` calls `loadSongs()` and `initPlayer()` and never touches either. So `isRuntimeReady && !headlessRuntimeRequested` cannot occur, and that check cannot be pinned — with the fabrication removed, its mutant survives, as it should.

The test is kept, on a claim that holds. Driving the real hand-driven flow — panel open, panel player, user-selected song, close — it is the **only** test that kills `hasHeadlessRuntime() -> true`: the standalone teardown tests are saved by the `!__NEKO_JUKEBOX_STANDALONE__` term and never exercise "runtime not ready". It also kills the always-preserve mutant and the stopPlayback-without-`prepareForUnload` mutant, the latter after CodeRabbit pointed out the assertions could not distinguish that regression until `playerDestroyed` was added.

Its docstring records why `isRuntimeReady` must not be set there, so the fabrication does not grow back.

## Not touched

The dead probe itself stays. It predates #2293, and its direction is wrong independently of whether it works: `static/jukebox/music_ui.js` is built-in host code that *serves* plugins — it exports `window.MusicPluginAPI`, dispatches `music-ui-ready` so plugins can register domains, and is listed as a required host asset in `main_routers/pages_router.py:130`. The optional pieces are `plugin/plugins/music_pusher` and `netease_music`, and they own no player. So the jukebox reaching into `music_ui` inverts the dependency, and `grep -ic jukebox static/jukebox/music_ui.js` returns 0 — there is no reciprocal path. Whether the two should share a player at all, and in which direction, is a design question for its own change.

## Test plan

```
uv run --no-sync python -m pytest tests/frontend/test_jukebox_playback_modes.py \
        tests/unit/test_jukebox_control_contract.py -q
uv run --no-sync python scripts/check_docstring_no_cjk.py --base origin/main
```

159 passed. Mutation results above.

## 回归报告 / Regression Report

Test-only change: one guard removed as fiction, one added for a real uncovered invariant. No production code touched, so no runtime behaviour changes. The risk of removing a test is losing coverage, and that was checked by mutation in both directions — the invariants the removed test named are still killed by the remaining tests, and the newly added one kills a mutant that previously survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **问题修复**
  - 修复独立使用点唱台时关闭面板后仍可能继续播放的问题。
  - 关闭点唱台后会停止播放，清空当前歌曲与曲库，并正确销毁播放器。
  - 完成关闭流程后会触发完整的卸载通知。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
