### PR TITLE
修复自定义触摸区域触发的表情延迟恢复误清除新表情的问题，完善同表情接管及模型卸载时的定时器清理，并补充回归测试

### DIFF
--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -128,6 +128,8 @@ class Live2DManager {
         this._transientExpressionGeneration = 0;
         this._transientExpressionTask = null;
         this._activeTransientExpression = false;
+        this._touchSetExpressionRestoreGeneration = 0;
+        this._touchSetExpressionRestoreState = null;
         this.isEmotionChanging = false;
         this.dragEnabled = false;
         this.isFocusing = false;

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -1499,12 +1499,22 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
     const isIdleEmotion = typeof emotion === 'string' && emotion.toLowerCase() === 'idle';
     const willApplyNewExpression = !!targetExpressionFile;
     const shouldPreserveExistingExpression = isIdleEmotion && !willApplyNewExpression;
+    const touchSetOwnsCurrentExpression = typeof this._isTouchSetExpressionRestoreCurrent === 'function'
+        && this._isTouchSetExpressionRestoreCurrent();
+    const shouldReplaceTouchSetExpression = touchSetOwnsCurrentExpression && !shouldPreserveExistingExpression;
+    if (shouldReplaceTouchSetExpression && typeof this._cancelTouchSetExpressionRestore === 'function') {
+        this._cancelTouchSetExpressionRestore();
+    }
     const emotionModel = this.currentModel;
     const shouldAttemptMotion = typeof this.hasActiveActionMotion !== 'function'
         || !this.hasActiveActionMotion(emotionModel);
     
-    // 相同表情保持不变，只尝试触发新的动作；动作槽忙时 playMotion 会直接拒绝。
-    if (this.currentEmotion === emotion && this.currentExpressionFile === targetExpressionFile) {
+    // 相同表情通常保持不变；若当前由 TouchSet 临时表情占用，则必须重放正常情感表情以接管表情槽。
+    if (
+        !shouldReplaceTouchSetExpression
+        && this.currentEmotion === emotion
+        && this.currentExpressionFile === targetExpressionFile
+    ) {
         this.isEmotionChanging = true;
         try {
             // 相同情绪且相同表情，保留原有的50%概率随机播放动作机制

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -3822,6 +3822,10 @@ Live2DManager.prototype.cleanupEventListeners = function () {
     this._clickEffectAction = null;
     this._currentClickEffectId = null;
 
+    if (typeof this._cancelTouchSetExpressionRestore === 'function') {
+        this._cancelTouchSetExpressionRestore();
+    }
+
     // 清理页面卸载监听器（如果存在）
     if (this._unloadListener) {
         window.removeEventListener('beforeunload', this._unloadListener);
@@ -4382,6 +4386,26 @@ Live2DManager.prototype.setupHitAreaInteraction = function(model) {
     console.log(`[HitArea] HitArea 交互已设置 : ${window.live2dManager.modelName}`);
 };
 
+Live2DManager.prototype._cancelTouchSetExpressionRestore = function() {
+    this._touchSetExpressionRestoreGeneration = (this._touchSetExpressionRestoreGeneration || 0) + 1;
+    const restoreState = this._touchSetExpressionRestoreState;
+    if (restoreState?.timer) {
+        clearTimeout(restoreState.timer);
+    }
+    this._touchSetExpressionRestoreState = null;
+    return this._touchSetExpressionRestoreGeneration;
+};
+
+Live2DManager.prototype._isTouchSetExpressionRestoreCurrent = function() {
+    const restoreState = this._touchSetExpressionRestoreState;
+    return !!(
+        restoreState
+        && restoreState.generation === this._touchSetExpressionRestoreGeneration
+        && restoreState.model === this.currentModel
+        && restoreState.expressionGeneration === this._transientExpressionGeneration
+    );
+};
+
 /**
  * 根据 touchSet 配置播放 HitArea 对应的动画
  * @param {string} hitAreaId - HitArea ID
@@ -4601,7 +4625,10 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
             } else {
                 console.log(`[TouchSet] 尝试播放表情: ${faceInfo.File}`);
                 try {
-                    const expressionResult = await this.playExpression(randomExpressionName, faceInfo.File);
+                    const touchExpressionModel = this.currentModel;
+                    const expressionTask = this.playExpression(randomExpressionName, faceInfo.File);
+                    const touchExpressionGeneration = this._transientExpressionGeneration;
+                    const expressionResult = await expressionTask;
                     if (expressionResult !== false) {
                         triggerLog.expressions.push({
                             name: randomExpressionName,
@@ -4619,16 +4646,38 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
                         console.warn(`[TouchSet] 表情播放返回失败: ${randomExpressionName}`);
                     }
 
-                    clearTimeout(this.expressionTimer);
-                    const holdingTime = Number.isFinite(faceHoldingTime) && faceHoldingTime > 0 ? faceHoldingTime : 3000;
-                    this.expressionTimer = setTimeout(async () => {
-                        if (typeof this.clearExpression === 'function') {
-                            try {
-                                await this.clearExpression();
-                                console.log(`[TouchSet] 临时表情清除，准备恢复常驻状态`);
-                            } catch (_) {}
-                        }
-                    }, holdingTime);
+                    if (
+                        expressionResult !== false
+                        && this.currentModel === touchExpressionModel
+                        && this._transientExpressionGeneration === touchExpressionGeneration
+                    ) {
+                        const holdingTime = Number.isFinite(faceHoldingTime) && faceHoldingTime > 0 ? faceHoldingTime : 3000;
+                        const restoreGeneration = this._cancelTouchSetExpressionRestore();
+                        const restoreState = {
+                            generation: restoreGeneration,
+                            model: touchExpressionModel,
+                            expressionGeneration: touchExpressionGeneration,
+                            timer: null
+                        };
+                        this._touchSetExpressionRestoreState = restoreState;
+                        restoreState.timer = setTimeout(async () => {
+                            if (this._touchSetExpressionRestoreState !== restoreState) {
+                                return;
+                            }
+                            const shouldRestore = this._isTouchSetExpressionRestoreCurrent();
+                            this._touchSetExpressionRestoreState = null;
+                            if (!shouldRestore) {
+                                console.log('[TouchSet] 临时表情已被新的表情接管，跳过恢复');
+                                return;
+                            }
+                            if (typeof this.clearExpression === 'function') {
+                                try {
+                                    await this.clearExpression();
+                                    console.log(`[TouchSet] 临时表情清除，准备恢复常驻状态`);
+                                } catch (_) {}
+                            }
+                        }, holdingTime);
+                    }
                 } catch (e) {
                     triggerLog.failedExpressions.push({
                         name: randomExpressionName,

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -161,6 +161,9 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     this._activeMotionParamIds = null;
     this._actionMotionRequestPendingModel = null;
     this._simpleMotionActive = false;
+    if (typeof this._cancelTouchSetExpressionRestore === 'function') {
+        this._cancelTouchSetExpressionRestore();
+    }
     this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
     this._transientExpressionTask = null;
     this._activeTransientExpression = false;

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -206,3 +206,22 @@ def test_live2d_touch_set_prefers_motion_and_uses_expression_as_fallback():
     assert motion_branch < expression_fallback
     assert "triggerLog.motions.push({" in touch_set_animation
     assert "fallbackFor: 'motion'" in touch_set_animation
+
+
+def test_live2d_touch_set_only_restores_the_expression_it_started():
+    source = _live2d_source()
+    emotion_source = (PROJECT_ROOT / "static/live2d/live2d-emotion.js").read_text(encoding="utf-8")
+    cancel_restore = _js_block(source, "Live2DManager.prototype._cancelTouchSetExpressionRestore")
+    current_restore = _js_block(source, "Live2DManager.prototype._isTouchSetExpressionRestoreCurrent")
+    touch_set_animation = _js_block(source, "Live2DManager.prototype._playTouchSetAnimation")
+    set_emotion = _js_block(emotion_source, "Live2DManager.prototype.setEmotion")
+
+    assert "clearTimeout(restoreState.timer);" in cancel_restore
+    assert "restoreState.model === this.currentModel" in current_restore
+    assert "restoreState.expressionGeneration === this._transientExpressionGeneration" in current_restore
+    assert "const touchExpressionGeneration = this._transientExpressionGeneration;" in touch_set_animation
+    assert "const shouldRestore = this._isTouchSetExpressionRestoreCurrent();" in touch_set_animation
+    assert "this._touchSetExpressionRestoreState = null;" in touch_set_animation
+    assert "this.expressionTimer" not in touch_set_animation
+    assert "const shouldReplaceTouchSetExpression = touchSetOwnsCurrentExpression" in set_emotion
+    assert "!shouldReplaceTouchSetExpression" in set_emotion

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -75,6 +75,47 @@ def _extract_js_function(source: str, name: str) -> str:
     raise AssertionError(f"unterminated JavaScript function: {name}")
 
 
+def test_set_emotion_reclaims_expression_owned_by_touch_set():
+    script = _manager_harness(
+        """
+        (async () => {
+          const manager = new context.Live2DManager();
+          manager.currentModel = {};
+          manager.currentEmotion = 'happy';
+          manager.currentExpressionFile = 'expressions/happy.exp3.json';
+          manager.emotionMapping = {
+            expressions: { happy: ['expressions/happy.exp3.json'] },
+            motions: {}
+          };
+          manager.fileReferences = { Expressions: [], Motions: {} };
+          manager.getRandomElement = values => values[0];
+          manager.hasActiveActionMotion = () => true;
+          manager._cancelSmoothReset = () => {};
+          manager._isTouchSetExpressionRestoreCurrent = () => true;
+
+          let restoreCancelled = false;
+          let replayedExpression = null;
+          manager._cancelTouchSetExpressionRestore = () => { restoreCancelled = true; };
+          manager.playExpression = async (emotion, file) => {
+            replayedExpression = { emotion, file };
+            return true;
+          };
+          manager.applyPersistentExpressionsNative = async () => true;
+
+          await manager.setEmotion('happy');
+
+          assert.strictEqual(restoreCancelled, true);
+          assert.deepStrictEqual(replayedExpression, {
+            emotion: 'happy',
+            file: 'expressions/happy.exp3.json'
+          });
+        })().catch(error => { console.error(error); process.exitCode = 1; });
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
 def test_parameter_editor_mode_suppresses_idle_and_saved_parameter_overlay():
     model_source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
     editor_source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复自定义触摸区域触发的表情延迟恢复误清除新表情的问题

## 测试 / Testing

手动触发自定义触摸区域表情进行测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 优化触摸动作临时表情的恢复机制，避免覆盖更新后的情绪表情。
  * 切换情绪时可正确接管当前表情，减少表情恢复异常。
  * 移除模型或清理交互时，会取消待处理的表情恢复任务。

* **测试**
  * 新增触摸动作表情恢复及情绪切换场景的验证，确保表情状态切换更可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->