### PR TITLE
fix(memory): 禁令块收敛到 next-session；人称代词不参与硬闸 + 召回打标方向修正

### DIFF
--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -78,6 +78,7 @@ ban-topic regex vs. negative-keyword scan
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import List, Tuple
 
 from config.prompts._locale import normalize_prompt_locale, prompt_locale_fallback_key
@@ -585,6 +586,14 @@ _ZH_TRAILING_FILLERS = (
 # 就内联在 'zh' 这一项里，繁中用户照样命中。开一个 'zh-TW' 键反而会造出
 # "同一批词分两处维护、改一边忘另一边"的漂移面——这个模块为此吃过四次亏
 # （见 _ZH_NEG 那段"派生不手抄"的注释）。
+# ⚠️ **人称代词与指代词是同一维，不是两维**。判据（"单独拿出来指代什么"）对
+# ``我`` / ``me`` / ``我们`` 的答案与对 ``这个`` 的完全一样：它们指向说话现场的
+# 参与者，不指向任何话题内容。而危害比指代词那批**更大** —— ``别再提我了`` /
+# ``stop talking about me`` 恰恰是这功能最自然的用法之一，抽出来的 term 就是
+# ``me``，实测让三条最普通的英文主动搭话草稿（"Hey, let me know how the build
+# went!" 等）3/3 全被 drop，词边界在这里救不了场（``me`` 本身就是完整的词）。
+# 那正是这张表当初为 ``it`` → ``favorite`` 建立时要挡的同一类 P1，而 TTL 递增
+# 之后中招代价从 3 天变成最长 30 天。
 _SEMANTICALLY_EMPTY_TERMS_BY_LOCALE: dict[str, frozenset[str]] = {  # noqa: PROMPT_ZH_TW  # 判据词表非渲染模板，繁体字形内联在 zh 项
     "zh": frozenset({
         "这个", "這個", "那个", "那個", "这些", "這些", "那些",
@@ -595,31 +604,66 @@ _SEMANTICALLY_EMPTY_TERMS_BY_LOCALE: dict[str, frozenset[str]] = {  # noqa: PROM
         "这样的事", "這樣的事", "这类事", "這類事",
         "刚才的事", "剛才的事", "刚刚的事", "剛剛的事",
         "这一切", "這一切", "那一切",
+        # 人称 / 反身 / 领属。单字的（我 / 你 / 他）够不到 _TERM_MIN_LEN=2，
+        # 抽取侧本来就存不下，不列进来当噪音。
+        "我们", "我們", "咱们", "咱們", "你们", "你們",
+        "他们", "他們", "她们", "她們", "它们", "它們",
+        "自己", "我自己", "你自己", "他自己", "她自己", "自个儿", "自個兒",
+        "我的", "你的", "他的", "她的", "我们的", "我們的", "你们的", "你們的",
     }),
     "en": frozenset({
         "this", "that", "these", "those", "it", "them",
         "this thing", "that thing", "this topic", "that topic",
         "this stuff", "that stuff", "this one", "that one",
         "the topic", "the subject", "anything", "everything", "all this",
+        # 人称 / 反身 / 领属（"i" 是单字符，够不到 _TERM_MIN_LEN）
+        "me", "you", "we", "us", "him", "her", "he", "she",
+        "my", "your", "our", "his", "hers", "its", "their", "theirs",
+        "mine", "yours", "ours",
+        "myself", "yourself", "yourselves", "ourselves",
+        "himself", "herself", "itself", "themselves", "oneself",
     }),
     "ja": frozenset({
         "これ", "それ", "あれ", "この話", "その話", "あの話",
         "この件", "その件", "あの件", "こんな話", "そんな話",
         "この話題", "その話題",
+        # 人称 / 反身。単漢字（私 / 僕 / 君 / 俺）は _TERM_MIN_LEN に届かない。
+        "わたし", "あたし", "ぼく", "おれ", "あなた", "きみ", "おまえ", "お前",
+        "自分", "自分自身", "私たち", "僕たち", "俺たち", "わたしたち",
+        "あなたたち", "君たち", "私自身",
     }),
     "ko": frozenset({
         "이거", "그거", "저거", "이것", "그것", "저것",
         "이 얘기", "그 얘기", "이 이야기", "그 이야기",
         "이 일", "그 일", "이 주제", "그 주제",
+        # 인칭 / 재귀
+        "우리", "우리들", "저희", "너희", "당신", "그들", "그녀",
+        "자기", "자신", "자기자신", "제가", "저는",
     }),
     "ru": frozenset({
         "это", "то", "этом", "этому", "об этом", "эту тему", "эта тема",
+        # Личные / возвратные / притяжательные
+        "мы", "вы", "он", "она", "они", "оно",
+        "меня", "тебя", "нас", "вас", "его", "её", "ее", "их",
+        "мне", "тебе", "нам", "вам", "себя", "себе",
+        "мой", "твой", "наш", "ваш", "свой", "моя", "твоя", "наша", "ваша",
     }),
     "es": frozenset({
         "esto", "eso", "aquello", "este tema", "ese tema", "esta cosa",
+        # Personales / reflexivos / posesivos
+        "yo", "tú", "tu", "él", "el", "ella", "ellos", "ellas",
+        "nosotros", "nosotras", "vosotros", "vosotras", "usted", "ustedes",
+        "mí", "mi", "ti", "te", "nos", "su", "sus",
+        "mío", "mía", "tuyo", "tuya", "suyo", "suya",
+        "mí mismo", "sí mismo", "ti mismo",
     }),
     "pt": frozenset({
         "isso", "isto", "aquilo", "esse tema", "este tema", "essa coisa",
+        # Pessoais / reflexivos / possessivos
+        "eu", "tu", "ele", "ela", "eles", "elas", "nós", "vós",
+        "você", "vocês", "mim", "ti", "si", "me", "te", "nos", "vos",
+        "meu", "minha", "teu", "tua", "seu", "sua", "nosso", "nossa",
+        "dele", "dela", "si mesmo", "mim mesmo",
     }),
 }
 
@@ -628,8 +672,11 @@ _SEMANTICALLY_EMPTY_TERMS_BY_LOCALE: dict[str, frozenset[str]] = {  # noqa: PROM
 # 不存在同形歧义 —— 它们在任何一种语言里都是纯指代词，没有哪个是别的语言的
 # 实义内容词。（``_TRIM_TRAIL_TOKENS_BY_LOCALE`` 必须分表是因为 ``唄`` 那类
 # 同码位歧义，这里没有那个问题。）
+# ⚠️ 建集时就 NFC 归一，别只归一查询侧：源码字面量本身可能以分解形式存进文件
+# （编辑器 / 剪贴板差异），那样查询侧再怎么归一也对不上。两侧同一形式才闭合。
 _SEMANTICALLY_EMPTY_TERMS = frozenset(
-    t for terms in _SEMANTICALLY_EMPTY_TERMS_BY_LOCALE.values() for t in terms
+    unicodedata.normalize("NFC", t)
+    for terms in _SEMANTICALLY_EMPTY_TERMS_BY_LOCALE.values() for t in terms
 )
 
 
@@ -639,8 +686,16 @@ def is_semantically_empty_term(term: str) -> bool:
     Consumers use this to decide whether a directive term is specific enough to
     hard-block output on. It is deliberately NOT applied at extraction time —
     see the table's comment for why the two sides differ.
+
+    ⚠️ NFC first. Accented Spanish/Portuguese entries (``él`` / ``mí`` / ``você``)
+    can reach the store decomposed (``e`` + combining acute) from an IME or a
+    pasted string, which is a different codepoint sequence from the composed
+    form written in the table above — the lookup would silently miss and the
+    pronoun would go back to hard-blocking every draft. The proactive gate
+    normalizes for the same reason (``generation._normalize_for_match``); this
+    predicate has to agree with it or the two disagree on the same term.
     """
-    return term.strip().casefold() in _SEMANTICALLY_EMPTY_TERMS
+    return unicodedata.normalize("NFC", term.strip()).casefold() in _SEMANTICALLY_EMPTY_TERMS
 
 # 话题里允许出现的**一个单位**。四条 zh 模板共用一份，别再各写各的。
 #

--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -680,12 +680,47 @@ _SEMANTICALLY_EMPTY_TERMS = frozenset(
 )
 
 
+def term_needs_case_sensitive_match(term: str) -> bool:
+    """Whether a term must be matched case-sensitively: a name spelled like a pronoun.
+
+    English writes ``the US`` / the films ``Us`` and ``Her`` with capitals and
+    the pronouns ``us`` / ``her`` without, so case is the one local signal that
+    separates the two. Same criterion ``_trim_term`` already uses to keep
+    ``Never Please`` intact while still stripping a trailing ``please``.
+
+    ⚠️ **Only for terms that actually collide with the table.** Widening this to
+    "any capitalized term" costs far more than it buys: ``Work`` (an IME
+    capitalizing the first letter, or just a sentence-initial capture) would
+    then stop matching ``work`` / ``WORK`` in a draft, a fresh miss on the
+    ordinary path — while the collision this exists for is confined to terms
+    whose casefold is in ``_SEMANTICALLY_EMPTY_TERMS``. Pinned by
+    ``test_matcher_is_case_insensitive``.
+
+    Complementary to ``is_semantically_empty_term`` — for a term whose casefold
+    is in the table, exactly one of the two is true (lowercase → exempt from the
+    hard gate, capitalized → gated but matched case-sensitively). Terms outside
+    the table get False from both and follow the ordinary path.
+    """
+    normalized = unicodedata.normalize("NFC", term.strip())
+    if not any(ch.isupper() for ch in normalized):
+        return False
+    return normalized.casefold() in _SEMANTICALLY_EMPTY_TERMS
+
+
 def is_semantically_empty_term(term: str) -> bool:
     """Whether a term is a bare referent that means nothing outside its own turn.
 
     Consumers use this to decide whether a directive term is specific enough to
     hard-block output on. It is deliberately NOT applied at extraction time —
     see the table's comment for why the two sides differ.
+
+    ⚠️ Capitalized terms are never exempt. ``stop talking about US`` (the
+    country) and the films ``Us`` / ``Her`` all yield terms whose casefold lands
+    on a pronoun in the table; exempting them means the hard gate skips a topic
+    the user explicitly banned, which is strictly worse than before the pronoun
+    entries existed. The proactive gate pairs this with a case-sensitive match
+    for such terms, so ``US`` no longer matches the ``us`` in "Want us to…" —
+    fixing only this half would silence proactive chat wholesale instead.
 
     ⚠️ NFC first. Accented Spanish/Portuguese entries (``él`` / ``mí`` / ``você``)
     can reach the store decomposed (``e`` + combining acute) from an IME or a
@@ -695,7 +730,10 @@ def is_semantically_empty_term(term: str) -> bool:
     normalizes for the same reason (``generation._normalize_for_match``); this
     predicate has to agree with it or the two disagree on the same term.
     """
-    return unicodedata.normalize("NFC", term.strip()).casefold() in _SEMANTICALLY_EMPTY_TERMS
+    normalized = unicodedata.normalize("NFC", term.strip())
+    if any(ch.isupper() for ch in normalized):
+        return False
+    return normalized.casefold() in _SEMANTICALLY_EMPTY_TERMS
 
 # 话题里允许出现的**一个单位**。四条 zh 模板共用一份，别再各写各的。
 #

--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -69,13 +69,13 @@ _CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
     # 「最坏情况渲染块 ≤ 本预算」，改大上面两个常量任一个都会红。
     "user_directives": 2000,
 }
+# ⚠️ 这张表只作用于 ``prime_context`` 那条回落路径，而那条只有
+# ``lifetime in {"current_session", "session_family"}`` 才走得到。纯
+# ``next_session`` 的 source（如 ``user_directives``）登记在这里是死配置，
+# 会让人误以为它还会经 realtime instructions 下发 —— 别加。
 _CONTEXT_APPEND_BARE_PRIME_SOURCES = frozenset({
     "game.realtime_context",
     "game.postgame",
-    # 这段文本**本身就是**一段 system prompt（"[用户最近明确表示过不想聊…]"），
-    # 再给它拼一个 ``system: `` 角色前缀是冗余的——它会被原样送进 realtime 的
-    # instructions。与上面两个同样用 role='system' 的 source 同理。
-    "user_directives",
 })
 
 

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -238,13 +238,21 @@ class NotifyMixin:
         return prompt
 
     async def _inject_pending_user_directives(self) -> None:
-        """Push freshly recorded ban-topic directives into the LIVE session.
+        """Carry freshly recorded ban-topic directives into the NEXT session.
 
-        ``_build_initial_prompt`` runs once per session, so a directive recorded
-        at turn N would otherwise not reach the prompt until the next session
-        rebuild — up to ``SESSION_TURN_THRESHOLD`` user turns away. The user
-        meanwhile said "stop bringing X up" and watches the character keep doing
-        it. This closes that window to the next turn.
+        ``_build_initial_prompt`` reads the directive store once per session,
+        and for a hot swap that read happens during background warm-up
+        (``lifecycle._background_prepare_pending_session``) — a full user turn
+        before the swap actually lands, because the final swap waits for the
+        next turn-end (``turn.py`` step 4). A directive recorded inside that
+        gap misses the very session it was about to configure: the new session
+        starts with a fresh ``_conversation_history`` (the user's original
+        words are gone with the old one) and a system prompt that predates the
+        directive, so nothing carries it for up to another archive cycle.
+
+        Writing it into the next-session cache closes exactly that gap. It is
+        deliberately NOT injected into the live session — see the ``lifetime``
+        comment below.
 
         Called from both user-utterance entry points (text and voice), right
         after the plugin-bus publish that drives the recording sink.
@@ -281,39 +289,35 @@ class NotifyMixin:
         block = block.strip()
         if not block:
             return
-        # ⚠️⚠️ **只有文字会话能接收当前会话的注入**，语音（realtime）不行。
+        # ⚠️ lifetime='next_session'：**只**写 next-session 缓存，不进当前会话。
+        # 两条路径（文字 / 语音）在这里收敛到同一个值，不按会话类型分叉。
         #
-        # ``append_context`` 对没有 ``_conversation_history`` 的会话回落到
-        # ``prime_context(text, skipped=True)``，而 realtime 那条路在 Gemini 上
-        # 会 ``send_client_content(turn_complete=True)`` **另开一个 user turn**，
-        # 同时置 ``_skip_until_next_response``——本轮所有 output_transcription
-        # 与 audio delta 被整段吞掉。用户刚说完"以后别再提加班"，角色一个音都
-        # 不发。既有的 prime_context 调用点都在热切换期间（用户不在说话），
-        # 把它放进用户回合正中间是本条改动第一次，Gemini Live 下每次说禁令句
-        # 必中 —— 恰好坏在这个功能最该起作用的那一刻。
+        # 当前会话不需要它。``_conversation_history`` 在会话生命周期内是
+        # append-only（唯一会砍它的是复读恢复，见 omni_offline_client/
+        # _streaming.py 那处 reset），所以用户那句"别再提 X"的原话一直待在
+        # 上下文里，模型每一轮都看得见；而会话开头 ``_build_initial_prompt``
+        # 已经注入过**全量**活跃列表，本轮的真实增量只有刚抽到的那一条 ——
+        # 恰恰是模型从原话里已经知道的那条。跨会话才是真缺口（新会话不继承
+        # 旧 history），而那正是这份缓存管的事。
         #
-        # 所以语音侧只写 next-session 缓存：下次会话建立时随缓存进 prompt。
-        # 这不比改动前更差（改动前也是等下次重建时 ``_build_initial_prompt``
-        # 读盘），而且顺带保住了热切换竞态那一半——预热跑完才落盘的指令，
-        # 靠这份缓存仍能赶上那次 swap。
-        # 判据用的就是 ``_append_context_to_targets`` 自己的那条：有没有
-        # ``_conversation_history``（只有 OmniOfflineClient 有）。
-        session = getattr(self, "session", None)
-        is_text_session = isinstance(
-            getattr(session, "_conversation_history", None), list
-        )
-        # lifetime='session_family'：既进当前会话，也写进 next-session 缓存。
-        # 后者不是冗余保险，是**热切换竞态**的唯一解——预热
-        # （lifecycle._background_prepare_pending_session）已经跑过
-        # _build_initial_prompt 之后才落盘的指令，会整个错过那次 swap，而下一
-        # 次重建最长要再等一个完整周期。代价是新会话里这段文本会和 system
-        # prompt 里的那段重复一次（内容一致、不矛盾，且缓存被消费后即止）。
-        lifetime = "session_family" if is_text_session else "next_session"
+        # 而写进当前会话是有代价的：``append_context`` 把 role='system' 渲染成
+        # ``HumanMessage("system: ...")``，**以用户消息的形态**落进 history。
+        # 别的 source（游戏结果 / 主动搭话素材）带的是模型不知道的新信息，这条
+        # 带的却是模型刚看过的用户原话的复述 —— 模型很容易顺着回一句"好的我
+        # 不会再提了"，而用户这一轮真正想聊的往往是后半句。
+        #
+        # 语音（realtime）侧本来就收不了：``append_context`` 对没有
+        # ``_conversation_history`` 的会话回落到 ``prime_context``，而 Gemini
+        # 那条路会 ``send_client_content(turn_complete=True)`` 另开一个 user
+        # turn 并置 ``_skip_until_next_response`` —— 本轮所有
+        # output_transcription 与 audio delta 被整段吞掉，用户刚说完禁令句、
+        # 角色一个音都不发，恰好坏在这功能最该起作用的那一刻。
+        lifetime = "next_session"
         try:
             # request_id 让 append_context 的去重生效：用户**重复说**同一条指令
             # （E 那半按 hit_count 递增 TTL，整个设计就预期他会重复）同样会置待
-            # 注入标记。不给 id 的话每次都原样再追加一份：文字侧堆进 history 还会
-            # 被算进归档 token 预算、提前触发热切换，语音侧堆进 next-session 缓存。
+            # 注入标记。不给 id 的话每次都原样再追加一份到 next-session 缓存，
+            # 下个会话开头就会连着看到同一段禁令块好几遍。
             #
             # ⚠️ 去重窗口是 **120 秒**（`_CONTEXT_APPEND_DEDUP_TTL_SECONDS`，
             # append_context 的既有契约），不是永久 —— 别把这里读成"同一组 term

--- a/main_logic/core/streaming.py
+++ b/main_logic/core/streaming.py
@@ -612,8 +612,10 @@ class StreamingMixin:
                     )
 
                     # 上面那次 dispatch 会同步跑完 ban-topic 抽取 + 落盘；若本
-                    # 轮真抽到了新指令，立刻把禁令块推进当前会话，别等下一次
-                    # session 重建（最长 ~10 轮）。语音路径在
+                    # 轮真抽到了新指令，把禁令块写进 next-session 缓存，赶上正在
+                    # 预热的那次热切换（预热已定稿 prompt、swap 还要等下一个
+                    # turn-end，中间落盘的指令否则整个错过）。当前会话不写：原话
+                    # 还在 _conversation_history 里，模型看得见。语音路径在
                     # handle_input_transcript 有对偶的一处。
                     await self._inject_pending_user_directives()
 

--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -1296,9 +1296,12 @@ class TurnMixin:
                 self._publish_user_utterance_to_plugin_bus(transcript, is_voice_source=True)
 
                 # 与文本路径（_process_stream_data_internal）对偶：dispatch 已
-                # 同步跑完 ban-topic 抽取 + 落盘，本轮真抽到新指令就立刻推进
-                # 当前会话。realtime 侧走 prime_context → session.update，是
-                # 中途改 instructions 的既有通道。
+                # 同步跑完 ban-topic 抽取 + 落盘，本轮真抽到新指令就把禁令块写进
+                # next-session 缓存，赶上正在预热的那次热切换。
+                # ⚠️ **不**碰当前会话，realtime 尤其不能：那条路会回落到
+                # prime_context，而它在 Gemini 上会另开一个 user turn 并吞掉本轮
+                # 全部音频与转写。判据写在 _inject_pending_user_directives 的
+                # lifetime 注释里。
                 await self._inject_pending_user_directives()
 
                 # Mini-game 邀请关键词兜底：与文本路径

--- a/main_logic/proactive_chat/generation.py
+++ b/main_logic/proactive_chat/generation.py
@@ -216,7 +216,13 @@ def _proactive_directive_hits(lanlan_name: str, draft: str) -> list[str]:
         return []
     # 延迟 import：memory 层在偏窄的 entrypoint 下未必加载，与本函数其余
     # 部分对 memory 的取用方式一致。
-    from memory.script_fold import fold_script
+    # ⚠️ import **和**调用都必须在 try 内。docstring 承诺 "Never raises"，而这个
+    # 延迟 import 的理由恰恰是"memory 层未必加载"—— 它自己举的那个场景正是会抛
+    # 的场景，放在 try 外等于契约在唯一相关的情况下不成立（上面那次
+    # get_active_terms 已经护住了，唯独这里漏了）。
+    def _no_fold(text: str) -> str:
+        return text
+
     # ⚠️ 繁简折叠两侧都做。用户换个输入法说"别再提遊戲"，落盘 term 是繁体，
     # 而角色按 locale 输出简体"游戏"——不折的话逐字不等、直接漏杀，用户明确
     # 禁掉的话题照样被推到脸上。项目里 memory.script_fold 就是为这条造的
@@ -224,7 +230,17 @@ def _proactive_directive_hits(lanlan_name: str, draft: str) -> list[str]:
     # 分词各走各的"的覆辙。
     # ⚠️ 还要 Unicode 归一：西 / 葡的重音字母可能以分解形式（e + 组合重音符）
     # 落盘，与合成形式（é）逐字节不等，重音 term 会静默永不命中（codex）。
-    folded = _normalize_for_match(fold_script(draft)).casefold()
+    try:
+        from memory.script_fold import fold_script
+        folded = _normalize_for_match(fold_script(draft)).casefold()
+    except Exception as exc:  # pragma: no cover - defensive
+        # ⚠️ 降级成**不折叠继续匹配**，不是放弃整道闸。折叠只解决跨字形
+        # （遊戲/游戏）那一档，丢了它仍能拦住同字形的绝大多数命中；而直接
+        # return [] 会把用户明确禁掉的话题原样推到脸上 —— 两者严格可比，
+        # 降级那侧在任何输入上都不比放弃更差。
+        logger.debug("[UserDirectives] script fold unavailable: %s", exc)
+        fold_script = _no_fold
+        folded = _normalize_for_match(draft).casefold()
     # ⚠️ 纯指代词（``这个`` / ``this`` / ``それ``）只走软约束，不参与硬拦截。
     # 抽取侧是会存下它们的（"别再讲这个了"），而且那个行为被既有测试成片钉着，
     # 不该由这条改动顺手动；但拿汉语最高频的词去做子串匹配，等于让主动搭话在

--- a/main_logic/proactive_chat/generation.py
+++ b/main_logic/proactive_chat/generation.py
@@ -38,6 +38,7 @@ from config import (
 )
 from config.prompts.prompts_directives import (
     is_semantically_empty_term,
+    term_needs_case_sensitive_match,
     render_format_fix_instruction,
     render_regen_avoid_instruction,
 )
@@ -158,14 +159,24 @@ def _normalize_for_match(text: str) -> str:
     return unicodedata.normalize("NFC", text)
 
 
-def _directive_term_in_draft(term: str, draft_folded: str) -> bool:
-    """Whether ``term`` occurs in an already-casefolded draft.
+def _directive_term_in_draft(
+    term: str, draft_folded: str, *, fold_case: bool = True,
+) -> bool:
+    """Whether ``term`` occurs in a draft the caller already normalized.
 
     Latin/Cyrillic/Greek terms match only when not glued to another letter of
     the same family; CJK/kana/hangul are written without spaces and can only
     be matched as substrings.
+
+    ⚠️ ``fold_case`` must agree with how the caller prepared ``draft_folded``:
+    True expects a casefolded draft, False expects one that kept its case. A
+    capitalized term (``US``, ``Us``, ``Her``) is a proper name, and matching it
+    case-insensitively would fire on every ordinary ``us`` / ``her`` in the
+    draft — the pronoun-silencing P1 all over again. See
+    ``term_needs_case_sensitive_match``.
     """
-    folded_term = _normalize_for_match(term).casefold()
+    normalized_term = _normalize_for_match(term)
+    folded_term = normalized_term.casefold() if fold_case else normalized_term
     if not folded_term:
         return False
     if _BOUNDARYLESS_SCRIPT_RE.search(folded_term):
@@ -246,12 +257,24 @@ def _proactive_directive_hits(lanlan_name: str, draft: str) -> list[str]:
     # 不该由这条改动顺手动；但拿汉语最高频的词去做子串匹配，等于让主动搭话在
     # 这条指令的整个生命周期里（递增 TTL 后最长 30 天）全面静默，而用户今天
     # 没有界面能看到、更别说删掉它。判据与危害都在消费侧，就在消费侧收口。
-    return [
-        t for t in terms
-        if t
-        and not is_semantically_empty_term(t)
-        and _directive_term_in_draft(fold_script(t), folded)
-    ]
+    # ⚠️ 保留大小写的那一份草稿，专给专名 term 用（``US`` / ``Us`` / ``Her``）。
+    # 它们在表里的小写形态是代词，casefold 之后会命中草稿里每一个普通的
+    # ``us`` / ``her``；反过来若把它们当代词豁免，用户明确 ban 掉的话题就直接
+    # 放行了。两条路都是 P1，所以判据落在 term 自己的大小写上，两侧配套。
+    cased = _normalize_for_match(fold_script(draft))
+    hits: list[str] = []
+    for t in terms:
+        if not t or is_semantically_empty_term(t):
+            continue
+        folded_t = fold_script(t)
+        case_sensitive = term_needs_case_sensitive_match(folded_t)
+        if _directive_term_in_draft(
+            folded_t,
+            cased if case_sensitive else folded,
+            fold_case=not case_sensitive,
+        ):
+            hits.append(t)
+    return hits
 
 
 def _merge_regen_avoid_terms(*term_groups: Any) -> list[str]:

--- a/memory/hybrid_recall.py
+++ b/memory/hybrid_recall.py
@@ -1003,22 +1003,27 @@ def _tag_tier(
             # 条目正是该被召回的东西。加上 ``disputation > 0`` 这一维，过滤
             # 的语义才真正等于那句 docstring：**有人反驳过，且反驳压过了确认**。
             #
-            # 没有 disputation 的行不盖 score 键 → 回落到"不按分过滤"，与本次
-            # 改动之前的行为一致。
+            # 没有 disputation 的行**原样不动**：真实数据里 reflections.json 就
+            # 没有 score 键，不动 = 没有键 = 回落到"不按分过滤"，正是想要的。
+            #
+            # ⚠️ 这里曾经写的是 ``d.pop('score', None)``，方向恰好反了。改动前
+            # ``_tag_tier`` 根本不碰这个键，所以"与改动之前一致"要求的是**不碰**
+            # 而不是删：盘上真带着 ``score: -5.0`` 的陈旧行（下面那条注释自己
+            # 承认这种行存在），原样走 ``_hard_filter`` 会被丢掉，pop 之后反而
+            # **活了下来** —— 与"只会多丢行、不会多留行"的单调性主张正相反。
+            # 实测 ``{"id":"stale_neg","status":"confirmed","score":-5.0}``：
+            # 直接过 _hard_filter 得 []，先过 _tag_tier 再过则得 ['stale_neg']。
             try:
                 if float(d.get('disputation', 0.0) or 0.0) > 0.0:
                     # ⚠️ 覆盖式赋值，不是 setdefault：行里若真带了 ``score``，
                     # 那是历史遗留 / 手工编辑的陈旧快照，衰减早已算不准。
                     # 唯一权威是现算值。
                     d['score'] = evidence_score(d, now)
-                else:
-                    d.pop('score', None)
             except Exception as exc:
                 # 单行字段类型坏掉（``reinforcement: "abc"``）不该让整池挂掉；
                 # 与本函数的 non-dict 跳过、``_hard_filter`` 的 per-entry
-                # try/except 同一策略。删掉 score 键 → 回落到"不按分过滤"，
-                # 与本次改动之前的行为一致（fail-open，不误杀）。
-                d.pop('score', None)
+                # try/except 同一策略。这里同样**不删** score 键：算不出现值时
+                # 保留盘上原值，是最接近"本函数没跑过"的状态。
                 logger.debug(
                     "[hybrid_recall] _tag_tier: score unavailable for "
                     "reflection id=%r: %s: %s",

--- a/tests/unit/test_hybrid_recall.py
+++ b/tests/unit/test_hybrid_recall.py
@@ -380,6 +380,43 @@ class TestHybridRecallE2E(unittest.IsolatedAsyncioTestCase):
         tagged = _tag_tier(rows, "reflection")
         self.assertLess(tagged[0]["score"], 0.0)
 
+    async def test_tagging_only_ever_drops_rows_never_resurrects_one(self):
+        """``_tag_tier`` must be monotone against a bare ``_hard_filter``."""
+        # ⚠️ 这条钉的是**方向**。``disputation <= 0`` 那支一度写的是
+        # ``d.pop('score', None)``，理由是"回落到不按分过滤，与改动前一致"——
+        # 但改动前 _tag_tier 根本不碰这个键，所以"一致"要求的是不碰而不是删：
+        # 盘上带着陈旧 ``score: -5.0`` 的行原样会被 _hard_filter 丢掉，pop 之后
+        # 反而活了下来，与那句单调性注释正相反。
+        # 只断言 stale_neg 被丢是不够的（把 pop 换成任何别的写法都能过），
+        # 用集合包含关系直接编码"只减不增"。
+        from memory.recall import MemoryRecallReranker
+
+        def _rows():
+            return [
+                {"id": "stale_neg", "text": "陈旧负分", "status": "confirmed",
+                 "score": -5.0},
+                {"id": "silent", "text": "用户没接话", "status": "confirmed",
+                 "reinforcement": -0.2, "disputation": 0.0},
+                {"id": "disputed", "text": "被反驳过", "status": "confirmed",
+                 "reinforcement": 0.0, "disputation": 3.0,
+                 "disp_last_signal_at": datetime.now().isoformat()},
+            ]
+
+        baseline = {
+            r["id"] for r in MemoryRecallReranker._hard_filter(_rows())
+        }
+        tagged = {
+            r["id"] for r in MemoryRecallReranker._hard_filter(
+                _tag_tier(_rows(), "reflection")
+            )
+        }
+        # 前提：裸过滤本来就丢 stale_neg（否则这条测不到任何东西）
+        self.assertNotIn("stale_neg", baseline)
+        self.assertLessEqual(tagged, baseline)
+        # 而"沉默"那类（rein 负、disp=0）必须仍然活着 —— 单调性不能靠一刀切
+        # 多杀来满足，那会把实测 17.8% 的活跃 reflection 一起抹掉。
+        self.assertIn("silent", tagged)
+
     async def test_hard_filter_drops_suppressed(self):
         facts = [
             {"id": "ok", "text": "博士养了只猫", "score": 1.0},

--- a/tests/unit/test_proactive_user_directives.py
+++ b/tests/unit/test_proactive_user_directives.py
@@ -24,6 +24,7 @@ import pytest
 
 import memory.anti_repeat as anti_repeat_module
 import memory.user_directives as user_directives_module
+from config.prompts.prompts_directives import extract_directives
 from main_logic.proactive_chat.contracts import PROACTIVE_REASON_PASS_USER_DIRECTIVE
 from main_logic.proactive_chat.generation import (
     _append_directives_section,
@@ -170,6 +171,79 @@ def test_bare_referents_never_hard_block(monkeypatch, term, draft):
     # 能看到、更别说删掉它。所以判据落在消费侧：软约束照旧注入，硬拦截跳过。
     _install_directives(monkeypatch, [term])
     assert _proactive_directive_hits("Neko", draft) == []
+
+
+@pytest.mark.parametrize("utterance,draft", [
+    ("stop talking about me", "Hey, let me know how the build went!"),
+    ("stop talking about us", "Want us to pick a movie tonight?"),
+    ("以后别提我们了", "我们要不要一起看个电影？"),
+    ("别再说你自己了", "你自己最近还好吗？"),
+    ("别再提自己了", "自己一个人别硬扛啊。"),
+])
+def test_pronoun_directives_never_silence_ordinary_drafts(
+    monkeypatch, utterance, draft,
+):
+    """Personal pronouns are the same axis as demonstratives, and hurt more.
+
+    "别再提我了" / "stop talking about me" is one of the most natural ways to
+    use this feature, and the term it yields is ``me`` — which matches three
+    out of three perfectly ordinary English drafts. Word boundaries do not
+    save it: ``me`` *is* a whole word. That is the identical P1 this table was
+    first built for (``it`` matching ``favorite``), and with the escalating
+    TTL the blast radius went from 3 days to 30.
+    """  # noqa: DOCSTRING_CJK  # 引的是用户实际会说的那句话
+    # ⚠️ 前提断言：这条测试的意义全在"抽取侧确实会产出这个 term"上。抽取行为
+    # 哪天变了（正则收紧 / 长度门变化），没有这句的话测试会静默变成空转绿。
+    hits = extract_directives(utterance)
+    assert hits, f"{utterance!r} 不再被抽成 ban_topic，本测试的前提已失效"
+    terms = [t for _, _, t in hits]
+    _install_directives(monkeypatch, terms)
+
+    assert _proactive_directive_hits("Neko", draft) == []
+
+
+def test_pronoun_skip_does_not_disarm_the_gate_for_content_terms(monkeypatch):
+    """Control: the same drafts must still be blocked by a real content term."""
+    # 没有这条对照，上面那组只要"硬闸整个失效"就会全绿 —— 变异实测过这个方向。
+    _install_directives(monkeypatch, ["加班"])
+    assert _proactive_directive_hits("Neko", "我们今天还要加班吗？") == ["加班"]
+
+
+def test_accented_pronoun_is_matched_regardless_of_unicode_form(monkeypatch):
+    """A decomposed accented pronoun must still be recognised as empty."""
+    # ⚠️ ``is_semantically_empty_term`` 走 NFC 归一，否则 IME / 粘贴来的分解形式
+    # （e + 组合重音符）与表里的合成形式逐码位不等，查表静默落空，这个西语代词
+    # 会退回去硬拦截每一条草稿 —— 正是上面那条 P1 的重演，只是换了触发条件。
+    import unicodedata
+
+    decomposed = unicodedata.normalize("NFD", "él")
+    assert decomposed != "él", "前提：两种 Unicode 形式确实不同"
+    _install_directives(monkeypatch, [decomposed])
+
+    assert _proactive_directive_hits("Neko", "él dijo algo interesante") == []
+
+
+def test_hits_degrade_but_still_block_when_script_fold_is_unavailable(
+    monkeypatch,
+):
+    """``Never raises`` must hold in the very case the lazy import cites."""
+    # ⚠️ ``from memory.script_fold import fold_script`` 的理由写的就是"memory 层
+    # 在偏窄的 entrypoint 下未必加载"，而它一度落在 try 之外 —— 契约在它自己举的
+    # 那个场景下不成立。降级方向也钉住：不折叠**继续匹配**，不是放弃整道闸，
+    # 所以同字形的 ``加班`` 仍然拦得住。
+    _install_directives(monkeypatch, ["加班"])
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _boom_on_script_fold(name, *args, **kwargs):
+        if name == "memory.script_fold":
+            raise ImportError("simulated narrow entrypoint")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _boom_on_script_fold)
+
+    assert _proactive_directive_hits("Neko", "今天又加班到很晚吧？") == ["加班"]
 
 
 def test_bare_referent_does_not_mask_a_real_term_in_the_same_list(monkeypatch):

--- a/tests/unit/test_proactive_user_directives.py
+++ b/tests/unit/test_proactive_user_directives.py
@@ -24,7 +24,11 @@ import pytest
 
 import memory.anti_repeat as anti_repeat_module
 import memory.user_directives as user_directives_module
-from config.prompts.prompts_directives import extract_directives
+from config.prompts.prompts_directives import (
+    extract_directives,
+    is_semantically_empty_term,
+    term_needs_case_sensitive_match,
+)
 from main_logic.proactive_chat.contracts import PROACTIVE_REASON_PASS_USER_DIRECTIVE
 from main_logic.proactive_chat.generation import (
     _append_directives_section,
@@ -200,6 +204,74 @@ def test_pronoun_directives_never_silence_ordinary_drafts(
     _install_directives(monkeypatch, terms)
 
     assert _proactive_directive_hits("Neko", draft) == []
+
+
+@pytest.mark.parametrize("term,blocked_draft,ignored_draft", [
+    # 国名 vs 代词
+    ("US", "The US economy is wild these days.", "Want us to pick a movie?"),
+    # 电影《我们》/《她》
+    ("Us", "Want to watch Us tonight?", "Want us to pick a movie?"),
+    ("Her", "Her is still my favorite film.", "Did you ask her about it?"),
+    # #3013 R4：IT 行业 vs 代词 it
+    ("IT", "The IT department replied.", "How is it going for you?"),
+])
+def test_capitalized_terms_are_names_not_pronouns(
+    monkeypatch, term, blocked_draft, ignored_draft,
+):
+    """A capitalized term is a proper name: still gated, but matched case-sensitively.
+
+    Both halves are load-bearing and neither works alone:
+
+    - exempting it (case-folding down onto the pronoun table) silently drops
+      the hard gate for a topic the user explicitly banned — strictly worse
+      than before the pronoun entries existed;
+    - gating it while still matching case-insensitively fires on every
+      ordinary ``us`` / ``her`` / ``it`` in the draft, which is the
+      proactive-silence P1 the table was built to prevent.
+    """
+    _install_directives(monkeypatch, [term])
+    assert _proactive_directive_hits("Neko", blocked_draft) == [term]
+    assert _proactive_directive_hits("Neko", ignored_draft) == []
+
+
+@pytest.mark.parametrize("term", ["us", "her", "me", "it", "this"])
+def test_lowercase_pronouns_stay_exempt(monkeypatch, term):
+    """Control for the rule above: the lowercase spelling is still the pronoun."""
+    # 没有这条，把"含大写才豁免"写反（变成"只豁免大写"）也能让上面那组全绿。
+    _install_directives(monkeypatch, [term])
+    assert _proactive_directive_hits(
+        "Neko", "Want us to pick a movie, or should I ask her about it?",
+    ) == []
+
+
+@pytest.mark.parametrize("term,exempt,case_sensitive", [
+    # 撞表 + 全小写 → 豁免硬闸
+    ("us", True, False),
+    ("it", True, False),
+    ("me", True, False),
+    # 撞表 + 含大写 → 不豁免，且必须大小写敏感
+    ("US", False, True),
+    ("Us", False, True),
+    ("IT", False, True),
+    # 不撞表 → 两者都 False，走普通的大小写不敏感路径
+    ("work", False, False),
+    ("Work", False, False),
+    ("加班", False, False),
+])
+def test_exemption_and_case_sensitivity_are_complementary(
+    term, exempt, case_sensitive,
+):
+    """For any term, at most one of the two rules applies — never both.
+
+    The pair has to stay complementary or one of two P1s comes back: exempting
+    a capitalized name silently drops the ban, and case-folding it back down
+    fires on every ordinary pronoun in the draft. Note the third group — the
+    case-sensitive rule must NOT widen to "any capitalized term", or an
+    IME-capitalized ``Work`` stops matching ``work``.
+    """
+    assert is_semantically_empty_term(term) is exempt
+    assert term_needs_case_sensitive_match(term) is case_sensitive
+    assert not (exempt and case_sensitive)
 
 
 def test_pronoun_skip_does_not_disarm_the_gate_for_content_terms(monkeypatch):

--- a/tests/unit/test_user_directives_midsession_inject.py
+++ b/tests/unit/test_user_directives_midsession_inject.py
@@ -1,12 +1,21 @@
 # -*- coding: utf-8 -*-
-"""Contract for pushing fresh ban-topic directives into the LIVE session.
+"""Contract for carrying fresh ban-topic directives into the NEXT session.
 
-``_build_initial_prompt`` runs once per session, so a directive recorded at
-turn N would otherwise not reach the model's prompt until the next session
-rebuild — which in normal chatting is up to ``SESSION_TURN_THRESHOLD`` user
-turns away. In between, the user has said "stop bringing X up" and watches the
-character keep bringing X up. ``_inject_pending_user_directives`` closes that
-window to the next turn.
+``_build_initial_prompt`` reads the directive store once per session, and for a
+hot swap that read happens during background warm-up — a full user turn before
+the swap lands. A directive recorded inside that gap misses the very session it
+was about to configure: the new session starts with a fresh
+``_conversation_history`` and a system prompt that predates it, so nothing
+carries it for up to another archive cycle.
+``_inject_pending_user_directives`` closes exactly that gap by writing the
+next-session cache.
+
+⚠️ It deliberately does NOT inject into the live session, for either session
+shape. Inside a session the user's original words stay in
+``_conversation_history`` (append-only), and the session-opening prompt already
+carried the full active list — so a live injection is redundant there, while
+still costing the awkward ``HumanMessage("system: ...")`` shape. See
+``test_directive_block_only_targets_the_next_session``.
 
 Layering note: ``memory`` (L3) cannot import ``main_logic`` (L4), so the sink
 only persists and raises a flag; the injection itself lives in L4. These tests
@@ -72,36 +81,66 @@ async def test_injects_when_a_directive_was_just_recorded(monkeypatch):
     kwargs = mgr.append_context.await_args.kwargs
     assert "加班" in kwargs["text"]
     assert kwargs["audience"] == "model"
-    # session_family：既进当前会话，也写进 next-session 缓存。后者是**热切换
-    # 竞态**的唯一解——预热已经跑过 _build_initial_prompt 之后才落盘的指令，
-    # 会整个错过那次 swap。降成 current_session 的话这条会红。
-    assert kwargs["lifetime"] == "session_family"
     # when_ready：会话还没建好时排队，不丢。
     assert kwargs["timing"] == "when_ready"
     # request_id 让 append_context 的去重生效（同一组 term 只注入一次）
     assert kwargs.get("request_id")
 
 
+@pytest.mark.parametrize("text_session", [True, False], ids=["text", "voice"])
 @pytest.mark.asyncio
-async def test_voice_session_never_touches_the_live_turn(monkeypatch):
-    """⚠️⚠️ Realtime sessions must NOT receive a current-session injection."""
-    # ``append_context`` 对没有 _conversation_history 的会话回落到
-    # ``prime_context(skipped=True)``，而那条路在 Gemini 上会
-    # ``send_client_content(turn_complete=True)`` 另开一个 user turn 并置
-    # _skip_until_next_response —— 本轮所有 transcript 与 audio 被整段吞掉。
-    # 用户刚说完"以后别再提加班"，角色一个音都不发，恰好坏在这个功能最该起
-    # 作用的那一刻（对抗审查用真 Gemini 客户端 A/B 实测复现）。
-    # 语音侧只写 next-session 缓存：不比改动前差（那时也是等下次重建读盘），
-    # 且仍能赶上热切换。
+async def test_directive_block_only_targets_the_next_session(
+    monkeypatch, text_session,
+):
+    """⚠️⚠️ Neither session shape may receive a current-session injection.
+
+    Two independent reasons land on the same value, which is why this is one
+    parametrized invariant rather than a per-shape branch:
+
+    - **text**: redundant. ``_conversation_history`` is append-only within a
+      session, so the user's own "stop bringing X up" stays in context for
+      every later turn, and the session-opening ``_build_initial_prompt``
+      already injected the full active list — the only delta this turn is the
+      term the model just read in the raw utterance. What a live injection
+      *does* add is shape risk: ``append_context`` renders ``role='system'``
+      as ``HumanMessage("system: ...")``, i.e. it arrives looking like another
+      user message that merely restates what the user just said.
+    - **voice**: harmful. ``append_context`` falls back to
+      ``prime_context(skipped=True)`` for sessions with no
+      ``_conversation_history``, and on Gemini that path issues
+      ``send_client_content(turn_complete=True)``, opening a second user turn
+      and setting ``_skip_until_next_response`` — the whole turn's transcript
+      and audio get swallowed. The user finishes saying "stop mentioning
+      overtime" and the character makes no sound at all (reproduced A/B
+      against a real Gemini client during adversarial review).
+
+    Raising this to ``current_session`` / ``session_family`` re-opens the
+    voice failure outright, so the guard covers both ids.
+    """
     _install(monkeypatch, pending=True)
-    mgr = _Manager(text_session=False)
+    mgr = _Manager(text_session=text_session)
 
     await mgr._inject_pending_user_directives()
 
     kwargs = mgr.append_context.await_args.kwargs
     assert kwargs["lifetime"] == "next_session", (
-        "realtime 会话拿到 current_session/session_family 会让 Gemini 吞掉整轮回复"
+        "current_session/session_family 会让 Gemini 吞掉整轮回复，"
+        "文字侧则是重复模型刚读过的原话"
     )
+
+
+def test_directive_source_is_not_registered_for_bare_prime():
+    """``user_directives`` must stay out of the bare-prime table (dead config).
+
+    That table only affects the ``prime_context`` fallback, which is reachable
+    only for ``lifetime in {"current_session", "session_family"}``. With the
+    source pinned to ``next_session`` above, an entry here would never be read
+    — and would suggest to the next reader that the block still goes out via
+    realtime instructions.
+    """
+    from main_logic.core._shared import _CONTEXT_APPEND_BARE_PRIME_SOURCES
+
+    assert "user_directives" not in _CONTEXT_APPEND_BARE_PRIME_SOURCES
 
 
 @pytest.mark.asyncio
@@ -109,8 +148,8 @@ async def test_repeat_of_the_same_directive_reuses_one_request_id(monkeypatch):
     """Saying the same thing twice must not append two identical blocks."""
     # E 那半按 hit_count 递增 TTL，整个设计就预期用户会重复说同一条；而
     # ``record`` 的刷新分支同样会置待注入标记。不给稳定 request_id 的话，
-    # 每次都原样再追加一份：文字侧堆进 history 还会被算进归档 token 预算、
-    # 提前触发热切换，语音侧堆进 next-session 缓存。
+    # 每次都原样再追加一份到 next-session 缓存，下个会话开头会连着看到同一段
+    # 禁令块好几遍。
     _install(monkeypatch, pending=True)
     mgr = _Manager()
 


### PR DESCRIPTION
承接 #3011 的收尾：一条是复核后发现前提不成立的自纠，四条来自该 PR 的 review。

## 回归报告

### 1. 禁令块只写 next-session，不再注入当前会话

**现状**：#3011 给 ban-topic 指令加了会话中途注入，`lifetime` 按会话类型分叉（文字 `session_family` / 语音 `next_session`）。理由写的是「原话已被 `compress_history` 抹掉，模型在会话内看不见」。

**复核后这条前提不成立**：`compress_history` 压的是 `memory/recent.py` 的跨会话备忘录，根本不碰 `_conversation_history`；而后者在会话生命周期内是 append-only（唯一会砍它的是复读恢复）。用户那句「别再提 X」的原话一直待在上下文里，模型每一轮都看得见。

**真缺口在热切换的预热与 swap 之间**（`turn.py` 那段 1→4 步）：

1. 轮次/token 阈值达到 → `is_preparing_new_session`
2. 10s 后某个 turn-end → `_background_prepare_pending_session`，内部跑 `_build_initial_prompt`，**禁令快照在此定稿**
3. 预热完成，置 `warmed_up_event`
4. **再下一个 turn-end** 才 `_perform_final_swap_sequence`

3 与 4 之间隔着至少一整个用户轮。在那一轮里落盘的指令错过它本该配置的那次 swap：新会话 `_conversation_history` 全新（原话随旧会话一起没了），system prompt 又早于该指令，于是要再等一个完整归档周期才补上。next-session 缓存堵的正是这一段，而这一半本来就在做。

**改成什么**：`lifetime` 无条件 `next_session`，删掉 `is_text_session` 分叉。顺带撤掉 `_CONTEXT_APPEND_BARE_PRIME_SOURCES` 里的 `user_directives`（那张表只作用于 `prime_context` 回落路径，只有 `current_session`/`session_family` 才走得到，现在是死配置）。

**回归风险**：文字会话里「用户中途说禁令 → 本会话立刻多一块结构化提醒」没有了。按上面的分析这个效果本就≈零（原话在 history 里，会话开头又已注入过全量活跃列表，本轮真实增量只有模型刚从原话读到的那一条）。唯一真受影响的场景是复读恢复砍 history 之后，但那时注入块也会被一起丢掉（即 #3013 的 R3），两种方案一样坏。语音侧行为完全不变。

**收益**：去掉一处形态风险 —— `append_context` 把 `role='system'` 渲染成 `HumanMessage("system: ...")`，以用户消息的形态落进 history，带的又是对用户刚说过的话的复述，模型很容易顺着回一句「好的我不会再提了」，而用户这轮真正想聊的往往是后半句。同时每次说禁令不再往 history 塞一块（token 与归档预算都省），并少一个需要维护的分叉判据。

`_CONTEXT_APPEND_SOURCE_MAX_TOKENS` 的 2000 预算**保留**：它在 `_normalize_context_text_for_source` 生效，与 lifetime 无关，而「截断后 request_id 按完整 term 集合算、被截掉的禁令永远补不回来」这条在 next-session 缓存上同样成立。

### 2. 人称代词不参与禁令硬闸（P1）

**现状**：`_SEMANTICALLY_EMPTY_TERMS_BY_LOCALE` 只收了指代词（`this`/`it`/`这个`），没收人称代词。

**实测**：`extract_directives("stop talking about me")` → term `me`，长度 2 过 `_normalize_term`，而 `is_semantically_empty_term("me")` 为 False，于是主动搭话出口硬闸拿 `me` 去匹配：三条最普通的英文草稿（`Hey, let me know how the build went!` / `You told me you'd rest tonight.` / `Want me to put on some music?`）**3/3 全被 drop**。词边界救不了场，`me` 本身就是完整的词。控制组 `overtime` 0/3，不是无脑全中。中文侧同款轻一档：`以后别提我们了` → `我们`、`别再说你自己了` → `你自己`，各命中 1/3。

**改成什么**：七个 locale 对偶补齐人称/反身/领属代词。判据与表里现有那批完全一致 ——「单独拿出来指代什么」：人称代词指向说话现场的参与者，不指向任何话题内容。单字符的（`我`/`你`/`i`/`私`）够不到 `_TERM_MIN_LEN=2`，抽取侧本就存不下，不列进来当噪音。

配套修 `is_semantically_empty_term` 的 Unicode 归一：补进带重音的 `él`/`mí`/`você` 之后，IME 或粘贴来的分解形式（`e` + 组合重音符）与表里的合成形式逐码位不等，查表会静默落空、该代词退回去硬拦截每一条草稿。查询侧与建集侧都做 NFC。

**回归风险**：只放大「跳过硬拦截」的集合，软约束（prompt 注入）不变，方向与既有单调性一致。风险是真想 ban 掉「提到我」的用户拿不到硬拦截 —— 但那本来就是软约束该管的事，且这批词在任何语言里都不是实义内容词。

**收益**：堵掉的正是这张表当初为 `it` → `favorite` 建立时要挡的同一类 P1，而触发句式（`别再提我了` / `stop talking about me`）是这功能最自然的用法之一。TTL 递增之后中招代价从 3 天变成最长 30 天，用户今天还没有界面能删。

### 3. `_tag_tier` 里 `d.pop('score', None)` 的方向反了

**现状**：`disputation <= 0` 那支删掉 `score` 键，注释说「回落到不按分过滤，与改动前一致」。

**但改动前 `_tag_tier` 根本不碰这个键**，所以「一致」要求的是不碰而不是删。三行 A/B 实测：

| | 结果 |
|---|---|
| 裸 `_hard_filter` | `['silent', 'disputed']` |
| 旧代码（有 pop） | `['stale_neg', 'silent']` ← 陈旧负分**活了下来** |
| 现在 | `['silent']` |

盘上带 `score: -5.0` 的陈旧行原样会被 `_hard_filter` 丢掉，pop 之后反而放行 —— 与「只会多丢行、不会多留行」的单调性主张正相反。`except` 分支同理：算不出现值时保留盘上原值，才最接近「本函数没跑过」。

**回归风险**：低。当前没有任何 writer 往 `reflections.json` 写 `score`，改前改后对真实数据都是 no-op。

**收益**：注释与代码对齐；将来真有 writer 落 score 时不会静默放行负分行。同时钉住「沉默那类（rein 负、disp=0）必须仍然活着」—— 单调性不能靠一刀切多杀来满足，那会把实测 17.8% 的活跃 reflection 一起抹掉。

### 4. `_proactive_directive_hits` 的 "Never raises" 在自己举的场景下不成立

**现状**：`from memory.script_fold import fold_script` 及其调用落在 try 之外，而这个延迟 import 的理由写的正是「memory 层在偏窄的 entrypoint 下未必加载」—— 它自己举的那个场景正是会抛的场景。

**改成什么**：纳入 try，并降级成**不折叠继续匹配**而非 `return []`。折叠只解决跨字形（`遊戲`/`游戏`）那一档，丢了它仍能拦住同字形的绝大多数命中；而放弃整道闸会把用户明确禁掉的话题原样推到脸上，两者严格可比，降级那侧在任何输入上都不比放弃更差。顺带删掉一行遗留的重复 `folded` 计算 —— 它在 try 之外，会把降级结果覆盖回去。

**回归风险**：无行为变化（正常路径 import 必成功）。

**收益**：契约成立；异常路径不再让整个主动搭话流程抛出。

### 5. 两处调用点注释与实现不符

`turn.py` 说「realtime 侧走 `prime_context` → `session.update`」，而实现恰恰刻意绕开那条路（它在 Gemini 上会另开 user turn 并吞掉整轮音频与转写，是 #3011 判定的 P1）。`streaming.py` 说「立刻把禁令块推进当前会话」，那是本 PR 第 1 条改掉的行为。两处都改成描述实际语义。

**回归风险**：纯注释，无。**收益**：防止后来者按注释「修回去」，尤其前一条描述的正是必须绕开的那条通路。

## 验证

| 项 | 结果 |
|---|---|
| directive / recall / proactive / context_append / notify 相关套件 | 3823 passed, 4 skipped |
| `check_docstring_no_cjk --base origin/main` | exit=0 |
| `check_module_layering` | exit=0 |
| `check_prompt_zh_tw` | exit=0 |

新增/改写 5 条守卫，每条都做了变异验证：

- `test_directive_block_only_targets_the_next_session`（参数化 text/voice）— 变异 `lifetime`→`session_family`：两个 id 都红
- `test_directive_source_is_not_registered_for_bare_prime` — 把 `user_directives` 加回该表：红
- `test_pronoun_directives_never_silence_ordinary_drafts` — 端到端从用户真实说法出发（抽取 → 判空 → 匹配），带前提断言防抽取行为变更后空转变绿
- `test_accented_pronoun_is_matched_regardless_of_unicode_form` — 变异掉 NFC：红
- `test_hits_degrade_but_still_block_when_script_fold_is_unavailable` — import 挪回 try 外：红；降级改成 `return []`：也红（两个方向都钉）
- `test_tagging_only_ever_drops_rows_never_resurrects_one` — 用集合包含关系直接编码单调性；把 pop 加回去：红

⚠️ 一次**变异存活**值得记录：只从 `en` 项删 `me` 时测试仍全绿 —— 因为 `pt` 项也有它，而消费侧按并集匹配。从所有 locale 删掉才红。测试钉的是并集这个真不变量，是变异设计错了，不是测试假。

另外补一条对照 `test_pronoun_skip_does_not_disarm_the_gate_for_content_terms`：没有它的话，「硬闸整个失效」也能让上面那组代词测试全绿。

### 6. 拼写撞代词的专名走大小写敏感匹配（review 追加，`fe304f9f6`）

**现状**：greptile P1 与 codex P2 从两个角度报了同一条 —— `stop talking about US`（国名）抽出 term `US`，casefold 成 `us` 撞进上面新加的代词表，硬闸直接跳过；电影《Us》《Her》同理。

**这是本 PR 的自伤**：改动前 `us` / `her` 不在表里，硬闸拦得住；补进人称代词之后反而放行，对这批 term 严格比改动前差。

**改成什么**：两处同时改 —— `is_semantically_empty_term` 含大写一律不豁免；出口闸对这类 term 用**保留大小写**的草稿匹配（`Us` 命中 "Want to watch Us?"，不命中 "Want us to pick a movie?"）。只改前者的话 draft 侧仍 casefold，`US` 会命中英文里每一个 `us`，等于把「主动搭话全静默」那个 P1 原样造回来。

⚠️ **判据中途收窄过一次**：第一版写的是「任何含大写的 term 都走大小写敏感」，既有测试 `test_matcher_is_case_insensitive` 当场变红 —— 而它是对的，输入法自动首字母大写产出的 `Work` 会因此不再命中草稿里的 `work` / `WORK`，那是比要修的问题更常见的新漏杀。最终判据是**撞表**：只有 casefold 之后落进 `_SEMANTICALLY_EMPTY_TERMS` 的大写 term 才需要大小写敏感，表外的（`Work` / `加班`）行为不变。

**回归风险**：低且方向明确。表外 term 完全不受影响（由既有的 `test_matcher_is_case_insensitive` 钉住）；表内大写 term 从「被豁免」变成「被大小写敏感地拦截」，是恢复改动前的拦截能力。残留代价是句首大写的真代词（如俄语 `Это`）会走硬闸，但大小写敏感把打击面限制在草稿也大写的位置，远小于原先的全静默。

**收益**：堵住自伤；顺带把 #3013 的 **R4**（IT 行业的 `IT` vs 代词 `it`）一并修掉 —— 同一个冲突、同一条判据，没有理由只修一半。

追加守卫：`test_capitalized_terms_are_names_not_pronouns`（US / Us / Her / IT 四组，每组都断言「该拦的拦住 + 该放的放过」两侧）、`test_lowercase_pronouns_stay_exempt`（对照，防把规则写反成「只豁免大写」）、`test_exemption_and_case_sensitivity_are_complementary`（三组九例钉两条规则互补，**第三组专门钉住不许放宽到任何大写 term**）。变异：去掉「含大写不豁免」→ 7 条红；放宽到「任何含大写」→ 2 条红，其中一条正是既有的 `test_matcher_is_case_insensitive`，说明新守卫与既有契约同向。

## 不在本 PR 范围

#3013 的 **R1 / R2 / R3 / R5** 仍然未动（附带素材绕过出口闸、短路路由不过禁令、复读恢复丢注入块、next-session 缓存堆陈旧快照）。**R4 已在上面第 6 条随手修掉**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化禁用主题识别，避免人称、反身及所有格代词误拦截正常内容。
  - 支持不同 Unicode 重音形式，提升多语言匹配准确性。
  - 新增会话中的指令将在下一会话生效，避免影响当前对话。
  - 提升主动回复在部分功能不可用时的稳定性。
  - 修复记忆评分处理，避免错误恢复已过滤的旧记录或丢失有效评分。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
