### PR TITLE
fix(i18n): 递增 LOCALE_VERSION，修复 main 上的语言包缓存守卫红灯

### DIFF
--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -33,7 +33,7 @@
     // errors.* 文案；递增版本让 Electron、Docker 等长期缓存重新拉取包含完整新 key
     // 的语言包 —— 不递增的话，缓存住旧语言包的客户端会继续把 errors.TURN_IMAGES_TRIMMED
     // 这类 key 当字面量渲染出来，正好是本次改动想修掉的那个症状。
-    const LOCALE_VERSION = '2026-08-31-openfang-removal';
+    const LOCALE_VERSION = '2026-09-01-day2-arc-menu-guide';
     function initDecorativeImageDragGuard() {
         const markImage = (img) => {
             if (!(img instanceof HTMLImageElement)) return;

--- a/tests/unit/test_locale_cache_bust_contract.py
+++ b/tests/unit/test_locale_cache_bust_contract.py
@@ -127,6 +127,7 @@ RETIRED_LOCALE_VERSIONS = frozenset(
         "2026-08-16-voice-identity-one-click",
         "2026-08-29-turn-image-budget-notices",
         "2026-08-29-repetition-insights",
+        "2026-08-31-openfang-removal",
     }
 )
 
@@ -139,7 +140,7 @@ RETIRED_LOCALE_VERSIONS = frozenset(
 #
 # 数组也按下标展开，所以往 badminton.lines.* 这类台词数组里追加一条同样会打红：
 # 陈旧缓存下那一条会取到 undefined，症状和缺 key 是一类。
-LOCALE_KEY_SIGNATURE = "5d972c2838f04947abfe96c6d04455d803fd375895fe013f1c669a62f19b48c7"
+LOCALE_KEY_SIGNATURE = "37f9351216645eaedb0a02797c90d5555bad3b1f28737387007b196db25ee621"
 
 _BUMP_INSTRUCTIONS = (
     "static/locales 的 key 结构变了。请在 static/i18n-i18next.js 里把 LOCALE_VERSION "


### PR DESCRIPTION
## 现状

`main` 的 `Unit Tests` 从 #3021 合并起就一直红，失败的是
`tests/unit/test_locale_cache_bust_contract.py::test_locale_key_signature_pins_the_shipped_key_set`。

#3021 往 8 个语言包各加了一个 key（tutorial 的 `toolWheelRotation`），但没有递增
`static/i18n-i18next.js` 里的 `LOCALE_VERSION`。

## 守卫红得对

语言包是带 `?v=${LOCALE_VERSION}` 取的。版本不变 → URL 不变 → 缓存住旧包的客户端
拿不到新 key，界面会把 key 本身当文案渲染出来。这正是这条守卫存在的理由，它的红灯
文案里也写清了修法。

## 改动

按红灯文案的三步：

| | 旧 | 新 |
|---|---|---|
| `LOCALE_VERSION` | `2026-08-31-openfang-removal` | `2026-09-01-day2-arc-menu-guide` |
| `RETIRED_LOCALE_VERSIONS` | — | 追加 `2026-08-31-openfang-removal` |
| `LOCALE_KEY_SIGNATURE` | `5d972c28…9a62f19b48c7` | `37f93512…b196db25ee621` |

没有碰任何语言包内容。

## 验证

- `tests/unit/test_locale_cache_bust_contract.py` — **5 passed**
- 变异验证：把 `LOCALE_VERSION` 改回旧值，`test_locale_version_is_not_a_value_that_already_shipped` 会红。确认旧值是真的退役了，而不是只把指纹刷绿——后者正是这条守卫文档里点名的那个洞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新本地化资源的缓存版本标识，确保用户能够获取最新的语言包内容。
  * 优化语言包版本管理，避免浏览器继续使用已过期的本地缓存。
* **测试**
  * 更新本地化资源校验规则，确保语言包结构与版本信息保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->