### PR TITLE
perf(startup): 把约 0.5s 的无谓开销从端口 bind 之前挪走

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -39,7 +39,6 @@ from .character_fields import (  # noqa: F401
 from .network import (  # noqa: F401
     json,
     os,
-    platform,
     uuid,
     _read_port_overrides,
     _PORT_FILE_OVERRIDES,

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -36,6 +36,12 @@ from .character_fields import (  # noqa: F401
     LEGACY_FLAT_TO_RESERVED,
 )
 
+# `config` 是老单体模块的兼容门面，历史上 `from config import platform` 是能用的，
+# 而外部插件不在本仓能 grep 的范围内（codex）。所以名字留着——但直接在这里 import，
+# 不再从 config.network 转出：那边已经改用 sys.platform，转出会让它多一个纯为兼容
+# 而存在的未使用导入。
+import platform  # noqa: F401 - 兼容门面：外部可能 `from config import platform`
+
 from .network import (  # noqa: F401
     json,
     os,

--- a/config/network.py
+++ b/config/network.py
@@ -17,7 +17,6 @@
 
 import json
 import os
-import platform  # noqa: F401 - config/__init__.py 再导出它
 import sys
 import uuid
 

--- a/config/network.py
+++ b/config/network.py
@@ -17,7 +17,8 @@
 
 import json
 import os
-import platform
+import platform  # noqa: F401 - config/__init__.py 再导出它
+import sys
 import uuid
 
 from .application import logger
@@ -25,13 +26,17 @@ from .application import logger
 # 从 Electron userData 目录读取端口覆盖配置（由前端端口设置窗口写入）
 def _read_port_overrides() -> dict:
     try:
-        system = platform.system()
-        if system == "Windows":
+        # 用 sys.platform 而不是 platform.system()：后者在 Windows 上会走
+        # platform.uname() -> win32_ver() -> _syscmd_ver()，**spawn 一个
+        # `cmd /c ver` 子进程**。实测首调 54 ms，杀软介入时观测到 224 ms。
+        # 这个模块被 config 包顶层 import，坐在 launcher 启动链的最前面。
+        # sys.platform 是解释器常量，零成本，三分支判据完全等价。
+        if sys.platform == "win32":
             appdata = os.environ.get("APPDATA") or os.path.join(
                 os.path.expanduser("~"), "AppData", "Roaming"
             )
             base = os.path.join(appdata, "N.E.K.O")
-        elif system == "Darwin":
+        elif sys.platform == "darwin":
             base = os.path.join(os.path.expanduser("~"), "Library", "Application Support", "N.E.K.O")
         else:
             base = os.path.join(

--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -78,6 +78,7 @@ ban-topic regex vs. negative-keyword scan
 from __future__ import annotations
 
 import re
+import threading
 import unicodedata
 from typing import List, Tuple
 
@@ -1888,11 +1889,45 @@ _PATTERNS_RAW: List[Tuple[str, str, str]] = [
 ]
 
 
-# 编译期一次性 compile，运行时直接复用。
-DIRECTIVE_PATTERNS: List[Tuple[str, str, "re.Pattern[str]"]] = [
-    (locale, kind, re.compile(raw, re.IGNORECASE | re.UNICODE))
-    for locale, kind, raw in _PATTERNS_RAW
-]
+# 惰性 compile，不在 import 时做。
+#
+# 这 21 条模板里有 4 条各约 51 KB 正则源码，合计 209 KB；模块级 compile 实测
+# 294-298 ms。而这个模块坐在 memory_server 的 eager 导入链上
+# （app/__init__.py -> app/runtime_bindings.py -> memory.user_directives），
+# memory_server 又是 merged 模式下第一个被 import 的 app 模块。uvicorn 先
+# await lifespan.startup() 再 create_server()，所以这段时间全花在**端口还不存在**
+# 的阶段——用户那边是 connection-refused，不是"慢"。
+#
+# 真正需要它的是用户开口之后的指令抽取。改成首次访问时才编译，并在
+# utils/module_warmup.py 的预热表里登记，服务 ready 之后由后台线程提前编好，
+# 首次真实抽取也不用等——与那几个 LLM SDK 的处理同构。
+_DIRECTIVE_PATTERNS_CACHE: List[Tuple[str, str, "re.Pattern[str]"]] | None = None
+_DIRECTIVE_PATTERNS_LOCK = threading.Lock()
+
+
+def _directive_patterns() -> List[Tuple[str, str, "re.Pattern[str]"]]:
+    global _DIRECTIVE_PATTERNS_CACHE
+
+    cached = _DIRECTIVE_PATTERNS_CACHE
+    if cached is None:
+        with _DIRECTIVE_PATTERNS_LOCK:
+            if _DIRECTIVE_PATTERNS_CACHE is None:
+                # 整列表建好再赋值：别的线程要么看到 None、要么看到完整的一份，
+                # 不会读到编译到一半的列表。
+                _DIRECTIVE_PATTERNS_CACHE = [
+                    (locale, kind, re.compile(raw, re.IGNORECASE | re.UNICODE))
+                    for locale, kind, raw in _PATTERNS_RAW
+                ]
+            cached = _DIRECTIVE_PATTERNS_CACHE
+    return cached
+
+
+def __getattr__(name: str) -> object:
+    # DIRECTIVE_PATTERNS 是这个模块的公开名字（测试和外部都按名字取），保持可用；
+    # 只是取它的那一刻才付编译代价。PEP 562 对 `from ... import X` 同样生效。
+    if name == "DIRECTIVE_PATTERNS":
+        return _directive_patterns()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def extract_directives(text: str) -> List[Tuple[str, str, str]]:
@@ -1917,7 +1952,7 @@ def extract_directives(text: str) -> List[Tuple[str, str, str]]:
     # 过滤器就只看得到第一条那个**不重叠**的区间，于是 ``股票就`` 逃过一劫（codex P2）。
     out: List[Tuple[str, str, str]] = []
     spans: List[Tuple[int, int]] = []
-    for locale, kind, pat in DIRECTIVE_PATTERNS:
+    for locale, kind, pat in _directive_patterns():
         # 同上：不手写 startswith("zh")，走公共的 fallback-family 判定。
         zh_family = prompt_locale_fallback_key(locale) == "zh"
         # ⚠️ 不能直接 finditer：日文守卫否掉一条命中之后，那整段区间已经被消费掉了，

--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -2921,3 +2921,16 @@ def scan_negative_keywords(message: str, lang: str = "zh") -> bool:
         if kw.lower() in lower:
             return True
     return False
+
+
+# `from ... import *` 不经过 __getattr__。没有 __all__ 时 Python 直接枚举模块全局量，
+# 于是 DIRECTIVE_PATTERNS 改成惰性之后会从通配导入里**静默消失**，下游再用就是
+# NameError（codex）。声明 __all__ 把它显式列回去：有 __all__ 时 import * 逐名
+# getattr，惰性访问器照常触发。
+#
+# 其余名字按"此刻实际存在的公开全局量"原样算出来，而不是手写一张清单——这个模块
+# 没有 __all__ 时的历史行为就是"所有不以下划线开头的模块级名字"，手写会顺手收窄
+# 通配面，而收窄了谁也不会发现。必须留在文件末尾，globals() 才是全的。
+__all__ = sorted(
+    {name for name in globals() if not name.startswith("_")} | {"DIRECTIVE_PATTERNS"}
+)

--- a/launcher_core/runtime.py
+++ b/launcher_core/runtime.py
@@ -1885,10 +1885,26 @@ def apply_port_strategy() -> bool | str:
     existing_owners_by_key: dict[str, list] = {}
     reserved: set[int] = set()
 
-    # 预先查询 Hyper-V 保留端口范围，避免重复子进程调用
-    excluded_ranges = get_hyperv_excluded_ranges()
-    if excluded_ranges:
-        print(f"[Launcher] Detected {len(excluded_ranges)} Hyper-V/WSL excluded port range(s)", flush=True)
+    # Hyper-V/WSL 保留端口范围只有端口**已经**绑不上时才用得到，而查询它要
+    # spawn 一个 `netsh interface ipv4 show excludedportrange` 子进程——本机实测
+    # 122 / 49 / 50 ms。原来它无条件跑在所有 bind 探测**之前**，也就是每一次正常
+    # 启动都白付一次子进程，而正常启动恰恰是没有端口冲突、结果用不上的那种。
+    #
+    # 改成用到时再查。仍然只查一次（结果缓存在闭包里），原来那句"避免重复子进程
+    # 调用"照旧成立；那行 Detected 日志跟着挪到真的查过之后，免得报一个没查过的
+    # 数字。
+    _excluded_ranges_cache: list[list[tuple[int, int]]] = []
+
+    def _excluded_ranges() -> list[tuple[int, int]]:
+        if not _excluded_ranges_cache:
+            ranges = get_hyperv_excluded_ranges()
+            _excluded_ranges_cache.append(ranges)
+            if ranges:
+                print(
+                    f"[Launcher] Detected {len(ranges)} Hyper-V/WSL excluded port range(s)",
+                    flush=True,
+                )
+        return _excluded_ranges_cache[0]
 
     for key in ("MEMORY_SERVER_PORT", "TOOL_SERVER_PORT", "MAIN_SERVER_PORT"):
         preferred = int(DEFAULT_PORTS[key])
@@ -1898,7 +1914,7 @@ def apply_port_strategy() -> bool | str:
             continue
 
         # 端口不可绑定，识别具体原因（同时获取 owners 避免重复查询）
-        reason, owners = _classify_port_conflict(preferred, excluded_ranges)
+        reason, owners = _classify_port_conflict(preferred, _excluded_ranges())
 
         if reason == "neko":
             # Defer the decision until all three public ports are inspected.

--- a/scripts/check_startup_import_lazy.py
+++ b/scripts/check_startup_import_lazy.py
@@ -317,10 +317,11 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
     reported_symbols: set[tuple[int, int, str]] = set()
     for stmt in _iter_module_scope_stmts(tree.body):
         found: list[tuple[str, str]] = []  # (banned key, import text)
-        # (qualified name, home, text, lineno, col) —— 位置取**读取点自身**，不是
+        # (qualified name, home, text, lineno, col, whole_stmt) —— 位置取**读取点
+        # 自身**，不是
         # 外层语句：一个嵌在模块作用域 if/try/class 里的读取，会被外层容器和内层
         # 语句各走一遍，按语句定位就会报两条。
-        symbols: list[tuple[str, str, str, int, int]] = []
+        symbols: list[tuple[str, str, str, int, int, bool]] = []
         if isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 key = _banned_key(alias.name)
@@ -362,6 +363,7 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                                     f"from {stmt.module} import *",
                                     stmt.lineno,
                                     stmt.col_offset,
+                                    True,
                                 )
                             )
                         continue
@@ -374,6 +376,7 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                                 f"from {stmt.module} import {alias.name}",
                                 stmt.lineno,
                                 stmt.col_offset,
+                                True,
                             )
                         )
         # 属性读法：`import ... as d` + 模块作用域的 `d.DIRECTIVE_PATTERNS`。
@@ -387,14 +390,21 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                 continue
             hit = _banned_symbol_read(dotted, aliases)
             if hit is not None:
-                symbols.append((hit[0], hit[1], dotted, node.lineno, node.col_offset))
+                symbols.append(
+                    (hit[0], hit[1], dotted, node.lineno, node.col_offset, False)
+                )
         # noqa on any line of a multiline import suppresses the statement.
         end_lineno = getattr(stmt, "end_lineno", None) or stmt.lineno
         stmt_suppressed = any(
             ln in suppressed for ln in range(stmt.lineno, end_lineno + 1)
         )
-        for qualified, home, text, lineno, col in symbols:
-            if stmt_suppressed or lineno in suppressed:
+        for qualified, home, text, lineno, col, whole_stmt in symbols:
+            # 整条语句的 noqa 范围只给 import 语句用——多行 import 上 noqa 写在哪一行
+            # 都该算数。属性读取不能用它：一个 FunctionDef 的范围**覆盖整个函数体**，
+            # 于是函数体里随便一句 noqa 就能压掉装饰器/默认参数里的 import 期读取；
+            # if 语句同理，体里的 noqa 会压掉判断表达式里的读取（CodeRabbit）。
+            # 那些只认读取点自己那一行。
+            if lineno in suppressed or (whole_stmt and stmt_suppressed):
                 continue
             if (lineno, col, qualified) in reported_symbols:
                 continue

--- a/scripts/check_startup_import_lazy.py
+++ b/scripts/check_startup_import_lazy.py
@@ -218,9 +218,88 @@ def _noqa_lines(source: str) -> set[int]:
     return lines
 
 
+def _iter_eager_nodes(node: ast.AST) -> Iterator[ast.AST]:
+    """Walk one module-scope statement without entering deferred bodies.
+
+    ``ast.walk`` descends into nested function bodies, and a read in there is
+    precisely the sanctioned lazy form this rule exists to steer people toward —
+    flagging it would make the guard fight its own advice. Decorators, default
+    arguments and annotations do run at import time, so those stay in the walk.
+    """
+    stack: list[ast.AST] = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            stack.extend(current.decorator_list)
+            stack.extend(ast.iter_child_nodes(current.args))
+            if current.returns is not None:
+                stack.append(current.returns)
+            continue
+        if isinstance(current, ast.Lambda):
+            stack.extend(ast.iter_child_nodes(current.args))
+            continue
+        stack.extend(ast.iter_child_nodes(current))
+
+
+def _module_alias_map(body: list[ast.stmt]) -> dict[str, str]:
+    """Names bound at module scope -> the module path each one stands for.
+
+    Needed because the expensive read can be spelled through an alias:
+    ``import config.prompts.prompts_directives as directives`` followed by
+    ``directives.DIRECTIVE_PATTERNS``. Only module-scope bindings count; a name
+    rebound inside a function cannot put anything on the import chain.
+    """
+    aliases: dict[str, str] = {}
+    for stmt in _iter_module_scope_stmts(body):
+        if isinstance(stmt, ast.Import):
+            for alias in stmt.names:
+                if alias.asname:
+                    aliases[alias.asname] = alias.name
+                else:
+                    # ``import a.b.c`` binds only ``a``; the rest is spelled out
+                    # again at the use site, so the head maps to itself.
+                    head = alias.name.split(".")[0]
+                    aliases.setdefault(head, head)
+        elif isinstance(stmt, ast.ImportFrom) and stmt.module and stmt.level == 0:
+            for alias in stmt.names:
+                aliases[alias.asname or alias.name] = f"{stmt.module}.{alias.name}"
+    return aliases
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    """``a.b.c`` as a string, or None when the root is not a bare name."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return None
+    parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _banned_symbol_read(dotted: str, aliases: dict[str, str]) -> tuple[str, str] | None:
+    """Resolve ``directives.DIRECTIVE_PATTERNS`` to a BANNED_SYMBOLS hit."""
+    parts = dotted.split(".")
+    if len(parts) < 2:
+        return None
+    head, middle, symbol = parts[0], parts[1:-1], parts[-1]
+    target = aliases.get(head)
+    if target is None:
+        # 头名字不是本模块 import 进来的，解析不出模块路径——不猜。
+        return None
+    module = ".".join([target, *middle])
+    home = BANNED_SYMBOLS.get((module, symbol))
+    if home is None:
+        return None
+    return module + "." + symbol, home
+
+
 def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, int, str]]:
     violations: list[tuple[int, int, str]] = []
     suppressed = _noqa_lines(source)
+    aliases = _module_alias_map(tree.body)
     for stmt in _iter_module_scope_stmts(tree.body):
         found: list[tuple[str, str]] = []  # (banned key, import text)
         symbols: list[tuple[str, str, str]] = []  # (qualified name, home, import text)
@@ -242,9 +321,13 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                     alias_key = _banned_key(f"{stmt.module}.{alias.name}")
                     if alias_key is not None:
                         found.append((alias_key, f"from {stmt.module} import {alias.name}"))
-            if stmt.module:
+            if stmt.module and stmt.level == 0:
                 # 精确 (模块, 符号) 对，不做前缀匹配：同一个模块里的其它名字都是
                 # 合法导入，宽一点就会把 main 打红。
+                #
+                # level == 0 一起卡住：相对导入的 stmt.module 是**相对**路径，
+                # 拿它去比绝对的 (模块, 符号) 对会误判——`from ...a.b import X`
+                # 解析出来的根本是另一个模块（CodeRabbit）。
                 for alias in stmt.names:
                     home = BANNED_SYMBOLS.get((stmt.module, alias.name))
                     if home is not None:
@@ -255,14 +338,28 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                                 f"from {stmt.module} import {alias.name}",
                             )
                         )
+        # 属性读法：`import ... as d` + 模块作用域的 `d.DIRECTIVE_PATTERNS`。
+        # 只认 from-import 的话，这条等价写法可以完全绕过闸门，而它触发的是同一个
+        # __getattr__、付的是同一份代价（CodeRabbit）。只看 Load，不看赋值目标。
+        for node in _iter_eager_nodes(stmt):
+            if not isinstance(node, ast.Attribute) or not isinstance(node.ctx, ast.Load):
+                continue
+            dotted = _dotted_name(node)
+            if dotted is None:
+                continue
+            hit = _banned_symbol_read(dotted, aliases)
+            if hit is not None:
+                symbols.append((hit[0], hit[1], dotted))
         # noqa on any line of a multiline import suppresses the statement.
         end_lineno = getattr(stmt, "end_lineno", None) or stmt.lineno
         stmt_suppressed = any(
             ln in suppressed for ln in range(stmt.lineno, end_lineno + 1)
         )
+        seen_symbols: set[str] = set()
         for qualified, home, text in symbols:
-            if stmt_suppressed:
+            if stmt_suppressed or qualified in seen_symbols:
                 continue
+            seen_symbols.add(qualified)
             violations.append(
                 (
                     stmt.lineno,

--- a/scripts/check_startup_import_lazy.py
+++ b/scripts/check_startup_import_lazy.py
@@ -137,6 +137,22 @@ BANNED_MODULES: dict[str, str] = {
 }
 
 
+# (module, symbol) -> where its sanctioned lazy home is.
+#
+# BANNED_MODULES 只认模块名，看不见符号。但同一类回归也可以由一个**符号**造成：
+# 一个模块本身很轻，却导出一个求值时才昂贵的惰性名字，任何人在模块作用域取它就
+# 把代价搬回了启动链——而 import 那个模块仍然是合法且必要的（同一个文件里还有别的
+# 轻量名字要用），所以整模块封禁会把 main 打红，只能按符号封。
+BANNED_SYMBOLS: dict[tuple[str, str], str] = {
+    # 21 条封禁话题模板的 compile，实测 294-298 ms。模块 __getattr__ 里惰性求值，
+    # 预热在 utils/module_warmup.py 的表里。模块作用域取这个名字 = 回到 bind 之前。
+    ("config.prompts.prompts_directives", "DIRECTIVE_PATTERNS"): (
+        "evaluated on first access via the module __getattr__; warmed in "
+        "utils/module_warmup.py"
+    ),
+}
+
+
 def _banned_key(module_name: str | None) -> str | None:
     if not module_name:
         return None
@@ -207,6 +223,7 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
     suppressed = _noqa_lines(source)
     for stmt in _iter_module_scope_stmts(tree.body):
         found: list[tuple[str, str]] = []  # (banned key, import text)
+        symbols: list[tuple[str, str, str]] = []  # (qualified name, home, import text)
         if isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 key = _banned_key(alias.name)
@@ -225,10 +242,40 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                     alias_key = _banned_key(f"{stmt.module}.{alias.name}")
                     if alias_key is not None:
                         found.append((alias_key, f"from {stmt.module} import {alias.name}"))
+            if stmt.module:
+                # 精确 (模块, 符号) 对，不做前缀匹配：同一个模块里的其它名字都是
+                # 合法导入，宽一点就会把 main 打红。
+                for alias in stmt.names:
+                    home = BANNED_SYMBOLS.get((stmt.module, alias.name))
+                    if home is not None:
+                        symbols.append(
+                            (
+                                f"{stmt.module}.{alias.name}",
+                                home,
+                                f"from {stmt.module} import {alias.name}",
+                            )
+                        )
         # noqa on any line of a multiline import suppresses the statement.
         end_lineno = getattr(stmt, "end_lineno", None) or stmt.lineno
+        stmt_suppressed = any(
+            ln in suppressed for ln in range(stmt.lineno, end_lineno + 1)
+        )
+        for qualified, home, text in symbols:
+            if stmt_suppressed:
+                continue
+            violations.append(
+                (
+                    stmt.lineno,
+                    stmt.col_offset + 1,
+                    f"`{text}` at module scope forces `{qualified}` to be "
+                    f"evaluated at import time, which puts its cost back on the "
+                    f"startup chain before any port binds. Import the module and "
+                    f"read the name inside the function that needs it, or call "
+                    f"the accessor that wraps it. Sanctioned home: {home}.",
+                )
+            )
         for key, text in found:
-            if any(ln in suppressed for ln in range(stmt.lineno, end_lineno + 1)):
+            if stmt_suppressed:
                 continue
             violations.append(
                 (

--- a/scripts/check_startup_import_lazy.py
+++ b/scripts/check_startup_import_lazy.py
@@ -347,6 +347,24 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                 # 拿它去比绝对的 (模块, 符号) 对会误判——`from ...a.b import X`
                 # 解析出来的根本是另一个模块（CodeRabbit）。
                 for alias in stmt.names:
+                    if alias.name == "*":
+                        # 通配导入会把 __all__ 里每个名字都 getattr 一遍，惰性访问器
+                        # 照常触发。而 __all__ 恰恰是为了让惰性名字重新出现在通配面里
+                        # 才加的，等于亲手给这条规则开了个口子——按字面名 "*" 去查表
+                        # 永远查不中（codex）。当成"把这个模块的每个被禁符号都导了"。
+                        for (module, symbol), star_home in BANNED_SYMBOLS.items():
+                            if module != stmt.module:
+                                continue
+                            symbols.append(
+                                (
+                                    f"{module}.{symbol}",
+                                    star_home,
+                                    f"from {stmt.module} import *",
+                                    stmt.lineno,
+                                    stmt.col_offset,
+                                )
+                            )
+                        continue
                     home = BANNED_SYMBOLS.get((stmt.module, alias.name))
                     if home is not None:
                         symbols.append(

--- a/scripts/check_startup_import_lazy.py
+++ b/scripts/check_startup_import_lazy.py
@@ -239,6 +239,19 @@ def _iter_eager_nodes(node: ast.AST) -> Iterator[ast.AST]:
         if isinstance(current, ast.Lambda):
             stack.extend(ast.iter_child_nodes(current.args))
             continue
+        if isinstance(current, ast.If) and _is_type_checking_if(current):
+            # 和 _iter_module_scope_stmts 保持一致：TYPE_CHECKING 的 body 不在运行时
+            # 执行，else 分支执行。外层迭代器把这个 If **节点本身**照常 yield 出来
+            # （它先 yield 再决定要不要下降），所以这里不跳的话，走查会一头扎进那段
+            # 不执行的代码，把零代价的写法报成启动期访问——共享闸门上的误报
+            # （codex）。
+            #
+            # test 不用走：_is_type_checking_if 只认裸 `TYPE_CHECKING` 或
+            # `typing.TYPE_CHECKING`，两者都不可能含被禁读取，所以走它是构造上
+            # 不可达的死代码。普通 if 的 test 会执行、也确实可能藏读取，那条路
+            # 不走这个分支，照常整棵走。
+            stack.extend(current.orelse)
+            continue
         stack.extend(ast.iter_child_nodes(current))
 
 
@@ -300,9 +313,14 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
     violations: list[tuple[int, int, str]] = []
     suppressed = _noqa_lines(source)
     aliases = _module_alias_map(tree.body)
+    # 全文件去重：同一个读取点会被外层容器和内层语句各遍历一次。
+    reported_symbols: set[tuple[int, int, str]] = set()
     for stmt in _iter_module_scope_stmts(tree.body):
         found: list[tuple[str, str]] = []  # (banned key, import text)
-        symbols: list[tuple[str, str, str]] = []  # (qualified name, home, import text)
+        # (qualified name, home, text, lineno, col) —— 位置取**读取点自身**，不是
+        # 外层语句：一个嵌在模块作用域 if/try/class 里的读取，会被外层容器和内层
+        # 语句各走一遍，按语句定位就会报两条。
+        symbols: list[tuple[str, str, str, int, int]] = []
         if isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 key = _banned_key(alias.name)
@@ -336,6 +354,8 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                                 f"{stmt.module}.{alias.name}",
                                 home,
                                 f"from {stmt.module} import {alias.name}",
+                                stmt.lineno,
+                                stmt.col_offset,
                             )
                         )
         # 属性读法：`import ... as d` + 模块作用域的 `d.DIRECTIVE_PATTERNS`。
@@ -349,21 +369,22 @@ def check_source(path: Path, source: str, tree: ast.Module) -> list[tuple[int, i
                 continue
             hit = _banned_symbol_read(dotted, aliases)
             if hit is not None:
-                symbols.append((hit[0], hit[1], dotted))
+                symbols.append((hit[0], hit[1], dotted, node.lineno, node.col_offset))
         # noqa on any line of a multiline import suppresses the statement.
         end_lineno = getattr(stmt, "end_lineno", None) or stmt.lineno
         stmt_suppressed = any(
             ln in suppressed for ln in range(stmt.lineno, end_lineno + 1)
         )
-        seen_symbols: set[str] = set()
-        for qualified, home, text in symbols:
-            if stmt_suppressed or qualified in seen_symbols:
+        for qualified, home, text, lineno, col in symbols:
+            if stmt_suppressed or lineno in suppressed:
                 continue
-            seen_symbols.add(qualified)
+            if (lineno, col, qualified) in reported_symbols:
+                continue
+            reported_symbols.add((lineno, col, qualified))
             violations.append(
                 (
-                    stmt.lineno,
-                    stmt.col_offset + 1,
+                    lineno,
+                    col + 1,
                     f"`{text}` at module scope forces `{qualified}` to be "
                     f"evaluated at import time, which puts its cost back on the "
                     f"startup chain before any port binds. Import the module and "

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -132,3 +132,55 @@ def test_warmup_touches_the_attribute_not_just_the_import(
     touched.clear()
     module_warmup._warm_one("neko_fake_warm_target")
     assert touched == [], f"无属性条目不该访问任何属性，却碰了 {touched}"
+
+
+def _check(source: str):
+    """Run the startup-chain gate over one snippet of source."""
+    import ast
+
+    from scripts.check_startup_import_lazy import check_source
+
+    return check_source(Path("app/fake_module.py"), source, ast.parse(source))
+
+
+@pytest.mark.unit
+def test_the_startup_gate_catches_a_module_scope_import_of_the_lazy_symbol() -> None:
+    """The gate knew module names; this symbol needed it to know names too.
+
+    ``check_startup_import_lazy`` bans heavy *modules* from the startup import
+    chain. This change created the same class of regression in a shape the gate
+    could not see: a cheap module exporting one name whose *evaluation* costs
+    294 ms. Importing that name at module scope puts the cost straight back
+    before the port binds, and nothing would have gone red.
+
+    Banning the whole module is not an option -- both production importers of
+    ``config.prompts.prompts_directives`` legitimately pull other, cheap names
+    from it, so a module-level ban would fail main immediately.
+
+    Mutation: drop the ``BANNED_SYMBOLS`` lookup, or make it a prefix match.
+    """
+    offending = "from config.prompts.prompts_directives import DIRECTIVE_PATTERNS\n"
+    violations = _check(offending)
+    assert len(violations) == 1, f"gate missed the module-scope import: {violations}"
+    assert "DIRECTIVE_PATTERNS" in violations[0][2]
+
+    # 同一个模块里的其它名字必须放行——生产的两处 importer 就是这么用的，规则一宽
+    # 就会立刻把 main 打红。
+    innocent = "from config.prompts.prompts_directives import extract_directives\n"
+    assert _check(innocent) == [], "规则太宽，合法的轻量导入被打红了"
+
+    # 函数体内的导入正是被认可的惰性写法。
+    lazy = (
+        "def f():\n"
+        "    from config.prompts.prompts_directives import DIRECTIVE_PATTERNS\n"
+        "    return DIRECTIVE_PATTERNS\n"
+    )
+    assert _check(lazy) == [], "函数内导入被误判——那是这条规则要引导人去写的形式"
+
+    # 逃生阀照旧生效。
+    escaped = (
+        "from config.prompts.prompts_directives import (  # noqa: STARTUP_LAZY_IMPORT\n"
+        "    DIRECTIVE_PATTERNS,\n"
+        ")\n"
+    )
+    assert _check(escaped) == [], "noqa 逃生阀对符号规则失效了"

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -184,3 +184,64 @@ def test_the_startup_gate_catches_a_module_scope_import_of_the_lazy_symbol() -> 
         ")\n"
     )
     assert _check(escaped) == [], "noqa 逃生阀对符号规则失效了"
+
+
+@pytest.mark.unit
+def test_the_startup_gate_is_not_bypassed_by_an_aliased_attribute_read() -> None:
+    """A from-import ban that only sees from-imports is a ban with a doorway.
+
+    ``import ... as d`` followed by a module-scope ``d.DIRECTIVE_PATTERNS`` runs
+    the same module ``__getattr__`` and pays the same 294 ms, but it is an
+    ``ast.Attribute`` read rather than an import alias, so the first version of
+    this rule never saw it (CodeRabbit). A guard whose bypass can be named in one
+    line does not guard anything.
+
+    Mutation: drop the ``ast.Attribute`` walk, or stop resolving aliases.
+    """
+    aliased = (
+        "import config.prompts.prompts_directives as directives\n"
+        "PATTERNS = directives.DIRECTIVE_PATTERNS\n"
+    )
+    violations = _check(aliased)
+    assert len(violations) == 1, f"别名属性读法绕过了闸门：{violations}"
+    assert "DIRECTIVE_PATTERNS" in violations[0][2]
+
+    # 不带 as 的写法：`import a.b.c` 只绑定 `a`，使用点把全路径又拼了一遍。
+    spelled_out = (
+        "import config.prompts.prompts_directives\n"
+        "PATTERNS = config.prompts.prompts_directives.DIRECTIVE_PATTERNS\n"
+    )
+    assert len(_check(spelled_out)) == 1, "全路径属性读法没被认出来"
+
+    # 函数体内读它正是被引导的写法，必须放行。
+    lazy = (
+        "import config.prompts.prompts_directives as directives\n"
+        "def f():\n"
+        "    return directives.DIRECTIVE_PATTERNS\n"
+    )
+    assert _check(lazy) == [], "函数内属性读被误判"
+
+    # 同名符号挂在别的模块上，不该命中——规则是 (模块, 符号) 对，不是符号名。
+    lookalike = (
+        "import some.other.module as d\n"
+        "PATTERNS = d.DIRECTIVE_PATTERNS\n"
+    )
+    assert _check(lookalike) == [], "只按符号名匹配了，模块没参与判断"
+
+
+@pytest.mark.unit
+def test_the_startup_gate_does_not_fire_on_a_relative_import() -> None:
+    """A relative import's ``stmt.module`` is a relative path, not an absolute one.
+
+    ``from ...config.prompts.prompts_directives import X`` parses with
+    ``module == "config.prompts.prompts_directives"`` and ``level == 3``, but it
+    resolves to an entirely different module. Matching it against the absolute
+    ``BANNED_SYMBOLS`` key would be a false positive on a shared gate that every
+    PR runs (CodeRabbit).
+
+    Mutation: drop the ``stmt.level == 0`` condition.
+    """
+    relative = (
+        "from ...config.prompts.prompts_directives import DIRECTIVE_PATTERNS\n"
+    )
+    assert _check(relative) == [], "相对导入被当成绝对路径匹配了——共享闸门上的误报"

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -340,3 +340,32 @@ def test_the_startup_gate_does_not_fire_inside_type_checking() -> None:
         "    pass\n"
     )
     assert len(_check(in_the_test)) == 1, "if 判断表达式里的访问被漏掉了"
+
+
+@pytest.mark.unit
+def test_the_startup_gate_catches_a_wildcard_import_of_the_lazy_module() -> None:
+    """Adding ``__all__`` handed the rule a doorway it had to be taught about.
+
+    Declaring ``__all__`` is what put the lazy name back into ``from ... import *``
+    -- which also means a wildcard import now ``getattr``s it and compiles the
+    regexes on the pre-bind path. The rule looked up the literal alias name
+    ``"*"`` in ``BANNED_SYMBOLS``, which never matches, so the fix for one finding
+    opened a bypass for the guard added for another (codex).
+
+    Mutation: drop the ``"*"`` branch.
+    """
+    wildcard = "from config.prompts.prompts_directives import *\n"
+    violations = _check(wildcard)
+    assert len(violations) == 1, f"通配导入绕过了闸门：{violations}"
+    assert "DIRECTIVE_PATTERNS" in violations[0][2]
+
+    # 函数体内的通配导入是语法错误，所以没有对应的放行用例；换一个方向：别的模块
+    # 的通配导入不该命中。
+    other = "from some.other.module import *\n"
+    assert _check(other) == [], "任何通配导入都被打红了"
+
+    # 逃生阀对通配这条同样要管用。
+    escaped = (
+        "from config.prompts.prompts_directives import *  # noqa: STARTUP_LAZY_IMPORT\n"
+    )
+    assert _check(escaped) == [], "noqa 对通配规则失效"

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -12,18 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""封禁话题模板必须惰性编译，且预热表要真的把它编出来。
+"""Ban-topic templates must compile lazily, and the warmup must really compile them.
 
-这两条守的是同一件事的两头。``config/prompts/prompts_directives`` 里那 21 条
-模板有 4 条各约 51 KB 正则源码，编译实测 294-298 ms；而这个模块坐在
-memory_server 的 eager 导入链上（``app/__init__.py`` -> ``app/runtime_bindings``
--> ``memory.user_directives``），memory_server 又是 merged 模式下第一个被 import
-的 app 模块。uvicorn 先 ``await lifespan.startup()`` 再 ``create_server()``，所以
-这段时间花在**端口还不存在**的阶段——用户那边是 connection-refused。
+These two guards cover the two ends of one change. Four of the 21 templates in
+``config/prompts/prompts_directives`` carry roughly 51 KB of regex source each;
+compiling the set measures 294-298 ms. That module sits on memory_server's eager
+import chain (``app/__init__.py`` -> ``app/runtime_bindings`` ->
+``memory.user_directives``), and memory_server is the first app module imported
+in merged mode. uvicorn awaits ``lifespan.startup()`` before ``create_server()``,
+so the time is spent while the port does not exist yet -- the user sees
+connection-refused, not slowness.
 
-把编译挪到首次访问，代价就转嫁给第一次指令抽取了；所以第二条守卫盯预热：
-``MAIN_SERVER_WARMUP`` 里那条 ``"模块:属性"`` 必须真的被求值，否则这个改动只是
-把 300 ms 从启动搬到了用户第一句话上，而且搬得悄无声息。
+Making the compile lazy on its own would just move the cost onto the first
+directive extraction, so the second guard watches the warmup: the
+``"module:attribute"`` entry in ``MAIN_SERVER_WARMUP`` has to actually be
+evaluated. Otherwise this change silently relocates 300 ms from startup to the
+user's first sentence.
 """
 
 from __future__ import annotations
@@ -42,11 +46,13 @@ _WARMUP_ENTRY = "config.prompts.prompts_directives:DIRECTIVE_PATTERNS"
 
 @pytest.mark.unit
 def test_directive_patterns_are_not_compiled_at_import_time() -> None:
-    """import 这个模块不许触发那 294 ms。
+    """Importing the module must not trigger the 294 ms compile.
 
-    起子进程来问，不在本进程里判：模块级状态跨用例存活，同一个 pytest session
-    里只要有任何一条用例先碰过 ``DIRECTIVE_PATTERNS``，缓存就已经填好了，本进程
-    里的断言会永远为真——那就是一条永远绿的假守卫。
+    Asked in a subprocess rather than judged in-process, deliberately.
+    Module-level state outlives a test, so if any earlier case in the same
+    pytest session has already touched ``DIRECTIVE_PATTERNS`` the cache is
+    filled and an in-process assertion would be true forever -- a guard that
+    can never fail.
     """
     probe = (
         "import config.prompts.prompts_directives as D;"
@@ -79,7 +85,11 @@ def test_directive_patterns_are_not_compiled_at_import_time() -> None:
 
 @pytest.mark.unit
 def test_warmup_entry_for_directive_patterns_is_registered() -> None:
-    """预热表里必须有这一条，否则第一次指令抽取要现编 294 ms。"""
+    """The warmup table must carry this entry.
+
+    Without it the first directive extraction compiles the 294 ms of regex
+    inline, on a user turn.
+    """
     from utils.module_warmup import MAIN_SERVER_WARMUP
 
     assert _WARMUP_ENTRY in MAIN_SERVER_WARMUP, (
@@ -92,13 +102,14 @@ def test_warmup_entry_for_directive_patterns_is_registered() -> None:
 def test_warmup_touches_the_attribute_not_just_the_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``"模块:属性"`` 这种条目必须真的取一次属性。
+    """A ``"module:attribute"`` entry must actually read the attribute.
 
-    只 import 是不够的，而且恰恰对这条毫无作用：被预热的模块此刻早就在
-    ``sys.modules`` 里了（memory_server 的导入链把它拉进来的），
-    ``import_module`` 直接命中缓存返回，一行代码都不会执行——贵的是那次属性求值。
+    Importing alone is not enough, and for this entry it does nothing at all:
+    the module is already in ``sys.modules`` by then, dragged in by
+    memory_server's import chain, so ``import_module`` is a cache hit that runs
+    no code. The expensive part is the attribute evaluation.
 
-    变异：把 ``_warm_one`` 里的 ``getattr`` 去掉，这条必须红。
+    Mutation: drop the ``getattr`` in ``_warm_one``; this must go red.
     """
     from utils import module_warmup
 

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -369,3 +369,48 @@ def test_the_startup_gate_catches_a_wildcard_import_of_the_lazy_module() -> None
         "from config.prompts.prompts_directives import *  # noqa: STARTUP_LAZY_IMPORT\n"
     )
     assert _check(escaped) == [], "noqa 对通配规则失效"
+
+
+@pytest.mark.unit
+def test_a_nested_noqa_cannot_suppress_an_import_time_read() -> None:
+    """The statement line range is the wrong scope for an expression read.
+
+    A ``FunctionDef``'s range covers the whole body, so a ``noqa`` anywhere
+    inside it was suppressing reads in the decorator and default arguments --
+    which do run at import time. An ``if`` had the same problem: a ``noqa`` in
+    the body suppressed a read in the test expression (CodeRabbit).
+
+    The full-statement range is still right for imports, where a ``noqa`` on any
+    line of a multi-line import should count.
+
+    Mutation: go back to one shared suppression scope for both kinds.
+    """
+    decorated = (
+        "import config.prompts.prompts_directives as d\n"
+        "@deco(d.DIRECTIVE_PATTERNS)\n"
+        "def f():\n"
+        "    x = 1  # noqa: STARTUP_LAZY_IMPORT\n"
+    )
+    assert len(_check(decorated)) == 1, "函数体里的 noqa 压掉了装饰器里的 import 期读取"
+
+    in_if_test = (
+        "import config.prompts.prompts_directives as d\n"
+        "if d.DIRECTIVE_PATTERNS:\n"
+        "    pass  # noqa: STARTUP_LAZY_IMPORT\n"
+    )
+    assert len(_check(in_if_test)) == 1, "if 体里的 noqa 压掉了判断表达式里的读取"
+
+    # 写在读取那一行的 noqa 必须照常生效——否则这条规则就没有逃生阀了。
+    on_the_line = (
+        "import config.prompts.prompts_directives as d\n"
+        "P = d.DIRECTIVE_PATTERNS  # noqa: STARTUP_LAZY_IMPORT\n"
+    )
+    assert _check(on_the_line) == [], "读取点自己那行的 noqa 失效了"
+
+    # 多行 import 仍然整条语句范围生效。
+    multiline = (
+        "from config.prompts.prompts_directives import (  # noqa: STARTUP_LAZY_IMPORT\n"
+        "    DIRECTIVE_PATTERNS,\n"
+        ")\n"
+    )
+    assert _check(multiline) == [], "多行 import 的 noqa 范围被收窄了"

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""封禁话题模板必须惰性编译，且预热表要真的把它编出来。
+
+这两条守的是同一件事的两头。``config/prompts/prompts_directives`` 里那 21 条
+模板有 4 条各约 51 KB 正则源码，编译实测 294-298 ms；而这个模块坐在
+memory_server 的 eager 导入链上（``app/__init__.py`` -> ``app/runtime_bindings``
+-> ``memory.user_directives``），memory_server 又是 merged 模式下第一个被 import
+的 app 模块。uvicorn 先 ``await lifespan.startup()`` 再 ``create_server()``，所以
+这段时间花在**端口还不存在**的阶段——用户那边是 connection-refused。
+
+把编译挪到首次访问，代价就转嫁给第一次指令抽取了；所以第二条守卫盯预热：
+``MAIN_SERVER_WARMUP`` 里那条 ``"模块:属性"`` 必须真的被求值，否则这个改动只是
+把 300 ms 从启动搬到了用户第一句话上，而且搬得悄无声息。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_WARMUP_ENTRY = "config.prompts.prompts_directives:DIRECTIVE_PATTERNS"
+
+
+@pytest.mark.unit
+def test_directive_patterns_are_not_compiled_at_import_time() -> None:
+    """import 这个模块不许触发那 294 ms。
+
+    起子进程来问，不在本进程里判：模块级状态跨用例存活，同一个 pytest session
+    里只要有任何一条用例先碰过 ``DIRECTIVE_PATTERNS``，缓存就已经填好了，本进程
+    里的断言会永远为真——那就是一条永远绿的假守卫。
+    """
+    probe = (
+        "import config.prompts.prompts_directives as D;"
+        "print('CACHE=%s' % (D._DIRECTIVE_PATTERNS_CACHE is None));"
+        "n = len(D.DIRECTIVE_PATTERNS);"
+        "print('AFTER=%s' % (D._DIRECTIVE_PATTERNS_CACHE is not None));"
+        "print('COUNT=%d' % n);"
+        "print('RAW=%d' % len(D._PATTERNS_RAW))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    out = result.stdout
+
+    assert "CACHE=True" in out, (
+        "import 完就已经编译好了——那 294 ms 又回到了端口 bind 之前的启动路径上"
+    )
+    assert "AFTER=True" in out, "取过 DIRECTIVE_PATTERNS 之后缓存仍是空的"
+
+    # 惰性不能顺手改变模板集合：条数必须和原始表一一对应。少一条就是少一条封禁
+    # 规则，而那种缺失在功能测试里只表现为"这句没被拦住"，很难归因。
+    count = next(line for line in out.splitlines() if line.startswith("COUNT="))
+    raw = next(line for line in out.splitlines() if line.startswith("RAW="))
+    assert count.split("=")[1] == raw.split("=")[1], (
+        f"编译出来的模板数和 _PATTERNS_RAW 对不上：{count} vs {raw}"
+    )
+
+
+@pytest.mark.unit
+def test_warmup_entry_for_directive_patterns_is_registered() -> None:
+    """预热表里必须有这一条，否则第一次指令抽取要现编 294 ms。"""
+    from utils.module_warmup import MAIN_SERVER_WARMUP
+
+    assert _WARMUP_ENTRY in MAIN_SERVER_WARMUP, (
+        "DIRECTIVE_PATTERNS 改成惰性之后没登记预热：启动是快了，代价原样落到"
+        "用户第一句话上"
+    )
+
+
+@pytest.mark.unit
+def test_warmup_touches_the_attribute_not_just_the_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``"模块:属性"`` 这种条目必须真的取一次属性。
+
+    只 import 是不够的，而且恰恰对这条毫无作用：被预热的模块此刻早就在
+    ``sys.modules`` 里了（memory_server 的导入链把它拉进来的），
+    ``import_module`` 直接命中缓存返回，一行代码都不会执行——贵的是那次属性求值。
+
+    变异：把 ``_warm_one`` 里的 ``getattr`` 去掉，这条必须红。
+    """
+    from utils import module_warmup
+
+    touched: list[str] = []
+
+    class _Recording(types.ModuleType):
+        def __getattr__(self, name: str) -> object:
+            touched.append(name)
+            return object()
+
+    fake = _Recording("neko_fake_warm_target")
+    monkeypatch.setitem(sys.modules, "neko_fake_warm_target", fake)
+
+    module_warmup._warm_one("neko_fake_warm_target:LAZY_THING")
+    assert touched == ["LAZY_THING"], (
+        f"带属性的预热条目没有真的求值，只是 import 了一遍：touched={touched}"
+    )
+
+    # 不带冒号的条目保持原样：只 import，不去乱碰属性。
+    touched.clear()
+    module_warmup._warm_one("neko_fake_warm_target")
+    assert touched == [], f"无属性条目不该访问任何属性，却碰了 {touched}"

--- a/tests/unit/test_startup_lazy_directive_patterns.py
+++ b/tests/unit/test_startup_lazy_directive_patterns.py
@@ -245,3 +245,98 @@ def test_the_startup_gate_does_not_fire_on_a_relative_import() -> None:
         "from ...config.prompts.prompts_directives import DIRECTIVE_PATTERNS\n"
     )
     assert _check(relative) == [], "相对导入被当成绝对路径匹配了——共享闸门上的误报"
+
+
+@pytest.mark.unit
+def test_the_lazy_symbol_still_survives_a_wildcard_import() -> None:
+    """``import *`` does not consult ``__getattr__``, so the name needs ``__all__``.
+
+    With no ``__all__``, Python builds a wildcard import by enumerating module
+    globals. ``DIRECTIVE_PATTERNS`` used to be a global; once it became lazy it
+    silently vanished from ``from ... import *``, and a downstream consumer would
+    get a ``NameError`` at the point of use rather than at import (codex).
+
+    Declaring ``__all__`` fixes it because Python then iterates that list and
+    ``getattr``s each name, which does reach ``__getattr__``. The list is computed
+    from the module's actual public globals rather than hand-written, so declaring
+    it cannot quietly narrow the wildcard surface that already existed.
+
+    Run in a subprocess: a wildcard import here would compile the patterns and
+    fill the cache for the rest of the session, which is exactly what the
+    laziness guard above needs to observe as empty.
+
+    Mutation: delete the ``__all__`` block.
+    """
+    probe = (
+        "import config.prompts.prompts_directives as D;"
+        "print('LAZY=%s' % (D._DIRECTIVE_PATTERNS_CACHE is None));"
+        "ns = {};"
+        "exec('from config.prompts.prompts_directives import *', ns);"
+        "print('WILDCARD=%s' % ('DIRECTIVE_PATTERNS' in ns));"
+        "print('SIBLING=%s' % ('extract_directives' in ns));"
+        "print('SAME=%s' % (ns.get('DIRECTIVE_PATTERNS') is D.DIRECTIVE_PATTERNS))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    out = result.stdout
+
+    # 声明 __all__ 不能把惰性弄没了——它只是一张名字表，不该触发求值。
+    assert "LAZY=True" in out, "加了 __all__ 之后 import 期就编译了"
+    assert "WILDCARD=True" in out, (
+        "通配导入里没有 DIRECTIVE_PATTERNS——下游 `import *` 的消费者会在用到时才 NameError"
+    )
+    assert "SIBLING=True" in out, "声明 __all__ 顺手把通配面收窄了"
+    assert "SAME=True" in out, "通配拿到的不是同一个对象"
+
+
+@pytest.mark.unit
+def test_the_startup_gate_does_not_fire_inside_type_checking() -> None:
+    """A read under ``if TYPE_CHECKING:`` costs nothing at runtime.
+
+    ``_iter_module_scope_stmts`` already excludes that branch — but it yields the
+    ``If`` node itself before deciding not to descend, so an unconditional child
+    walk lands right back inside the body it just excluded (codex). On a gate
+    every PR runs, that is a false positive on code with no runtime cost, which
+    is worse than a miss.
+
+    Mutation: drop the ``TYPE_CHECKING`` skip in ``_iter_eager_nodes``.
+    """
+    type_checking_only = (
+        "from typing import TYPE_CHECKING\n"
+        "import config.prompts.prompts_directives as d\n"
+        "if TYPE_CHECKING:\n"
+        "    P = d.DIRECTIVE_PATTERNS\n"
+    )
+    assert _check(type_checking_only) == [], "TYPE_CHECKING 分支被当成运行时访问了"
+
+    # 但真会执行的模块作用域分支必须照抓——别把豁免开得比 TYPE_CHECKING 还宽。
+    really_runs = (
+        "import config.prompts.prompts_directives as d\n"
+        "if True:\n"
+        "    P = d.DIRECTIVE_PATTERNS\n"
+    )
+    assert len(_check(really_runs)) == 1, "会执行的 if 分支里的访问被漏掉了"
+
+    # TYPE_CHECKING 的 else 分支是会执行的，同样要抓。
+    else_branch = (
+        "from typing import TYPE_CHECKING\n"
+        "import config.prompts.prompts_directives as d\n"
+        "if TYPE_CHECKING:\n"
+        "    pass\n"
+        "else:\n"
+        "    P = d.DIRECTIVE_PATTERNS\n"
+    )
+    assert len(_check(else_branch)) == 1, "TYPE_CHECKING 的 else 分支被一起豁免了"
+
+    # if 的判断表达式一定执行，而且它是唯一只能从 If 节点本身看到的位置——body 里的
+    # 语句外层迭代器会单独 yield 一遍，test 不会。跳过 If 时把 test 一起丢掉，这里就
+    # 漏了。
+    in_the_test = (
+        "import config.prompts.prompts_directives as d\n"
+        "if d.DIRECTIVE_PATTERNS:\n"
+        "    pass\n"
+    )
+    assert len(_check(in_the_test)) == 1, "if 判断表达式里的访问被漏掉了"

--- a/utils/doubao_tts.py
+++ b/utils/doubao_tts.py
@@ -22,7 +22,14 @@ import uuid
 from collections.abc import Iterable
 from typing import Any
 
-import httpx
+# httpx 不在模块顶层 import。
+#
+# 这个模块只有一个函数用 httpx，却因为 DOUBAO_VOICE_STORAGE_KEY 这个字符串
+# 常量被 utils/config_manager 引用，而坐在 launcher 的启动导入链上。httpx
+# 会 eager import 自己的 CLI（httpx._main -> rich + pygments + click），实测
+# 整包 108 ms、其中 CLI 占 74-85 ms——而进程启动到端口 bind 之间一次 HTTP
+# 都不发。改成用到时再 import，与 utils/llm_client.py 对那几个 LLM SDK 的
+# 处理同构（见 scripts/check_startup_import_lazy.py 的说明）。
 
 DOUBAO_TTS_DEFAULT_BASE_URL = "https://openspeech.bytedance.com"
 DOUBAO_TTS_DEFAULT_RESOURCE_ID = "seed-icl-2.0"
@@ -206,6 +213,9 @@ class DoubaoVoiceCloneClient:
             "display_name": display_name or speaker_id,
         }
         headers = doubao_voice_clone_headers(self.api_key)
+        # 放在 try 之前：下面的 except 子句也要认得 httpx.TimeoutException。
+        import httpx
+
         try:
             async with httpx.AsyncClient(timeout=60) as client:
                 resp = await client.post(

--- a/utils/module_warmup.py
+++ b/utils/module_warmup.py
@@ -78,10 +78,11 @@ _warmup_started = False
 def _warm_one(name: str) -> None:
     """Warm one entry: ``"module"``, or ``"module:attribute"``.
 
-    带属性的形式是给**惰性求值**的重家伙准备的（比如一批正则的 compile）。那种
-    模块通常早就在 ``sys.modules`` 里了——它是被别的东西顺路 import 进来的，只是
-    真正贵的那部分被推迟到了首次取值。对它们光 ``import_module`` 会直接命中缓存
-    返回，一行代码都不执行，预热等于没做。所以属性要真的取一次。
+    The attribute form is for lazily-evaluated heavyweights -- a batch of regex
+    compilations, say. Such a module is usually in ``sys.modules`` already,
+    dragged in by something else, with only the expensive part deferred to first
+    access; importing it again is a cache hit that runs no code, so warming it
+    would do nothing. The attribute has to actually be read.
     """
     module_name, _, attr = name.partition(":")
     module = importlib.import_module(module_name)

--- a/utils/module_warmup.py
+++ b/utils/module_warmup.py
@@ -64,10 +64,29 @@ MAIN_SERVER_WARMUP: tuple[str, ...] = (
     "pyncm_async",
     "bs4",
     "bilibili_api",
+    # 21 条封禁话题模板的 compile（其中 4 条各约 51 KB 正则源码），实测
+    # 294-298 ms。原来在 config/prompts/prompts_directives 模块级做，坐在
+    # memory_server 的 eager 导入链上、也就是端口 bind 之前。改惰性之后在
+    # 这里预热，首次指令抽取不用等。
+    "config.prompts.prompts_directives:DIRECTIVE_PATTERNS",
 )
 
 _warmup_lock = threading.Lock()
 _warmup_started = False
+
+
+def _warm_one(name: str) -> None:
+    """Warm one entry: ``"module"``, or ``"module:attribute"``.
+
+    带属性的形式是给**惰性求值**的重家伙准备的（比如一批正则的 compile）。那种
+    模块通常早就在 ``sys.modules`` 里了——它是被别的东西顺路 import 进来的，只是
+    真正贵的那部分被推迟到了首次取值。对它们光 ``import_module`` 会直接命中缓存
+    返回，一行代码都不执行，预热等于没做。所以属性要真的取一次。
+    """
+    module_name, _, attr = name.partition(":")
+    module = importlib.import_module(module_name)
+    if attr:
+        getattr(module, attr)
 
 
 def start_background_warmup(modules, *, label: str = "server") -> bool:
@@ -94,7 +113,7 @@ def start_background_warmup(modules, *, label: str = "server") -> bool:
         for name in module_list:
             start = time.monotonic()
             try:
-                importlib.import_module(name)
+                _warm_one(name)
                 loaded += 1
                 logger.debug(
                     "[warmup:%s] %s (%.0f ms)",


### PR DESCRIPTION
## 为什么这些毫秒特别贵

从装好的 uvicorn 源码核实：`server.py:97` 先 `await self.lifespan.startup()`，`:136` 才 `loop.create_server()`。**所以启动路径上每一毫秒都花在 socket 还不存在的阶段**——用户那边是 connection-refused，不是"慢"。

而 merged 模式下 main / memory / agent 是**同进程三线程**，任何一条上的阻塞连坐另外两条。

## 四处纯浪费

| # | 是什么 | 实测 |
|---|---|---|
| 1 | **httpx 被一个字符串常量拖上启动链**。`utils/config_manager` 只为取 `DOUBAO_VOICE_STORAGE_KEY = "__DOUBAO_TTS__"` 而 import `utils.doubao_tts`，后者顶层 `import httpx`；httpx 又 eager import 自己的 CLI（rich + pygments + click）。**启动到 bind 之间一次 HTTP 都不发。** | 108 ms（CLI 占 74–85） |
| 2 | **`platform.system()` 在 Windows 上 spawn `cmd /c ver`**。`config/network.py` 被 `config` 包顶层 import，坐在 launcher 链最前面 | 54 ms（杀软介入时观测到 224） |
| 3 | **netsh 子进程无条件跑**。`get_hyperv_excluded_ranges()` 在所有 bind 探测**之前**查一次，而它唯一的消费者只在端口已经绑不上时才跑 | 122 / 49 / 50 ms |
| 4 | **21 条封禁话题模板在模块级 compile**（其中 4 条各约 51 KB 正则源码）。`prompts_directives` 坐在 memory_server 的 eager 导入链上，而 memory_server 是第一个被 import 的 app 模块 | 294–298 ms |

## 改法

1、2、3 是直接的：httpx 改成用到时再 import（该模块只有一个函数用它）；`sys.platform` 替掉 `platform.system()`（三分支判据等价，`import platform` 保留因为 `config/__init__.py` 把它当符号再导出）；netsh 改成用到时才查、仍只查一次。

**4 需要说明一句。** 只改成惰性的话，294 ms 不是消失了，是搬到用户第一句话上了。所以同时登记进 `utils/module_warmup` 的预热表——服务 ready 之后由后台线程编好，首次指令抽取也不用等。为此给预热表加了 `"模块:属性"` 形式：被预热的惰性对象往往早就在 `sys.modules` 里，光 `import_module` 一次什么都不会发生。

公开名 `DIRECTIVE_PATTERNS` 用 PEP 562 `__getattr__` 保持可用，`from ... import DIRECTIVE_PATTERNS` 也照常（7 处测试调用点无需改动）。

## 实测

min of N，同机同解释器，source 模式：

```
launcher_core.runtime 导入链      299 ms -> 152 ms
三个 server 模块串行 import      1994 ms -> 1715 ms   (memory 969 -> 592)
netsh 子进程                    50-122 ms -> 0        (正常启动路径上不再发生)
```

结构上也核对过：改后 launcher 链里 `httpx` 不再进 `sys.modules`，`platform._uname_cache` 不再被填（即 `cmd /c ver` 不再 spawn）。

## 守卫

`tests/unit/test_startup_lazy_directive_patterns.py`，3 条：

- **惰性编译用子进程问，不在本进程里判。** 模块级状态跨用例存活，同一个 pytest session 里只要有任何一条用例先碰过 `DIRECTIVE_PATTERNS`，本进程里的断言就永远为真——那是一条永远绿的假守卫。
- 顺带钉住"编译出的模板数 == `_PATTERNS_RAW` 条数"：惰性不能顺手改变模板集合，而那种缺失在功能测试里只表现为"这句没被拦住"，很难归因。
- 预热条目必须在表里，且 `"模块:属性"` 必须**真的求值**（只 import 对它毫无作用）。

三条变异全部被杀：改回 eager compile / 去掉 `getattr` / 删掉预热表项。

## 验证

- `scripts/check_startup_import_lazy.py` — rc=0
- `tests/unit -k "port or network or directive or warmup or launcher or doubao or startup"` — **1655 passed / 15 skipped**
- `tests/unit/test_user_directives.py` + `test_ban_topic_regex_zh_tw.py` — **2166 passed / 3 skipped**

## 不在本 PR 范围内

- `awarmup_region_check()` 的 GeoIP 网络探测，走免费路由的用户最多等 **5 秒**，三个 server 各一次（并发，不叠加）。这是有意的"拿到区域结论再放开会话准入"，改它是产品判断不是性能清理。
- `templates/index.html` 有 **178 个 parser-blocking `<script src>`、defer=0、async=0、12.86 MiB**。前端首屏，后端怎么改都动不了，需要单独的 bundle 闸门。
- 防回归的 CI 闸门。现有的 `scripts/check_startup_import_lazy.py` 是**白名单**——只认已经改成惰性的那几个 SDK，新加一个重依赖它抓不到。补一个导入图棘轮是下一步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **性能优化**
  - 优化应用启动流程，减少不必要的初始化、依赖加载及系统查询。
  - 指令模板改为首次使用时加载并缓存，并支持后台预热。
  - 语音复刻相关依赖改为按需加载，降低启动开销。
  - 优化端口策略检测，仅在需要时执行。

- **稳定性改进**
  - 增强并发初始化安全性，确保缓存状态完整可用。
  - 保持跨平台端口配置、语音复刻请求及现有兼容性行为。
  - 改进启动检查，提升导入场景下的规则识别准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->