### PR TITLE
fix(music): stabilize proactive candidate fallback cards

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -7351,6 +7351,31 @@ describe('App', () => {
     );
   });
 
+  it('gives compact history link cards a bounded readable width', () => {
+    expect(compactChatStyles).toContain('--compact-export-history-edge-gutter: 12px;');
+    expect(compactChatStyles).toContain('--compact-export-history-viewport-gutter: 24px;');
+    expect(compactChatStyles).toContain('--compact-export-history-shadow-gutter-right: 32px;');
+    expect(compactChatStyles).toContain('--compact-export-history-shadow-gutter-left: 12px;');
+    expect(compactChatStyles).toContain('--compact-export-link-card-min-inline-size: 170px;');
+    expect(compactChatStyles).toContain('--compact-export-link-bubble-chrome-inline-size: 23px;');
+    expect(compactChatStyles).toContain('--compact-export-link-row-reserve-inline-size: 48px;');
+    expect(compactChatStyles).toMatch(
+      /--compact-export-link-history-min-inline-size:\s*calc\([\s\S]*?var\(--compact-export-link-card-min-inline-size\)[\s\S]*?var\(--compact-export-link-bubble-chrome-inline-size\)[\s\S]*?var\(--compact-export-link-row-reserve-inline-size\)[\s\S]*?var\(--compact-export-history-shadow-gutter-left\) \+ var\(--compact-export-history-shadow-gutter-right\)[\s\S]*?\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-history-anchor:has\(\.compact-export-history-content > \.message-block-link\)\s*\{[\s\S]*?max\(var\(--compact-export-history-inline-size\), var\(--compact-export-link-history-min-inline-size\)\)[\s\S]*?var\(--compact-export-history-max-inline-size\)/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-history-bubble:has\(> \.compact-export-history-content > \.message-block-link\)\s*\{[\s\S]*?width: calc\(100% - var\(--compact-export-link-row-reserve-inline-size\)\);[\s\S]*?min-width: min\(/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-history-content > \.message-block-link\s*\{[\s\S]*?width: 100%;[\s\S]*?max-width: 100%;[\s\S]*?min-width: 0;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-history-content > \.message-block-link \.message-link-copy\s*\{[\s\S]*?min-width: 0;[\s\S]*?overflow-wrap: anywhere;/,
+    );
+  });
+
   it('keeps compact composer text legible over both light and dark backdrops', () => {
     expect(compactChatStyles).toMatch(
       /\.compact-chat-surface-frame\[data-compact-chat-state="input"\] \.composer-input\s*\{[\s\S]*?color: #2f526b;[\s\S]*?caret-color: #167fbd;[\s\S]*?0 1px 1px rgba\(255, 255, 255, 0\.94\),[\s\S]*?0 0 4px rgba\(255, 255, 255, 0\.72\);/,

--- a/frontend/react-neko-chat/src/MessageBlockView.tsx
+++ b/frontend/react-neko-chat/src/MessageBlockView.tsx
@@ -15,8 +15,22 @@ type MessageBlockViewProps = {
   onAction?: (message: ChatMessage, action: MessageAction) => void;
 };
 
+const MUSIC_COVER_PLACEHOLDER_URL = '/static/assets/music/music-cover-placeholder.png';
+
 function handleImageLoadError(event: SyntheticEvent<HTMLImageElement>, url: string) {
   swapImageToMemeLoadFailedSticker(event.currentTarget, url);
+}
+
+function handleLinkThumbnailLoadError(
+  event: SyntheticEvent<HTMLImageElement>,
+  messageId: ChatMessage['id'],
+) {
+  if (typeof messageId !== 'string' || !messageId.startsWith('music-')) return;
+
+  const image = event.currentTarget;
+  const placeholderUrl = new URL(MUSIC_COVER_PLACEHOLDER_URL, window.location.href).href;
+  if (image.src === placeholderUrl) return;
+  image.src = MUSIC_COVER_PLACEHOLDER_URL;
 }
 
 export function isGuideMessage(message: ChatMessage) {
@@ -75,7 +89,13 @@ export default function MessageBlockView({
       >
         {block.thumbnailUrl ? (
           <div className="message-link-thumb">
-            <img src={block.thumbnailUrl} alt="" loading="lazy" />
+            <img
+              key={block.thumbnailUrl}
+              src={block.thumbnailUrl}
+              alt=""
+              loading="lazy"
+              onError={(event) => handleLinkThumbnailLoadError(event, message.id)}
+            />
           </div>
         ) : null}
         <div className="message-link-copy">

--- a/frontend/react-neko-chat/src/MessageList.test.tsx
+++ b/frontend/react-neko-chat/src/MessageList.test.tsx
@@ -89,6 +89,95 @@ describe('MessageList image fallback', () => {
   });
 });
 
+describe('MessageList music cover fallback', () => {
+  const placeholderUrl = '/static/assets/music/music-cover-placeholder.png';
+
+  it('replaces a failed music thumbnail with the local placeholder without looping', () => {
+    const musicMessage = parseChatMessage({
+      id: 'music-cover-1',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:03',
+      createdAt: 4,
+      blocks: [{
+        type: 'link',
+        url: 'https://music.example/track',
+        title: 'Track',
+        thumbnailUrl: 'https://music.example/cover.jpg',
+      }],
+      status: 'sent',
+    });
+    const { container } = render(<MessageList messages={[musicMessage]} />);
+    const img = container.querySelector<HTMLImageElement>('.message-link-thumb img');
+
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://music.example/cover.jpg');
+
+    fireEvent.error(img as HTMLImageElement);
+    expect(img).toHaveAttribute('src', placeholderUrl);
+
+    fireEvent.error(img as HTMLImageElement);
+    expect(img).toHaveAttribute('src', placeholderUrl);
+  });
+
+  it('does not replace a failed thumbnail on a regular link message', () => {
+    const linkMessage = parseChatMessage({
+      id: 'link-cover-1',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:04',
+      createdAt: 5,
+      blocks: [{
+        type: 'link',
+        url: 'https://example.com/article',
+        title: 'Article',
+        thumbnailUrl: 'https://example.com/thumbnail.jpg',
+      }],
+      status: 'sent',
+    });
+    const { container } = render(<MessageList messages={[linkMessage]} />);
+    const img = container.querySelector<HTMLImageElement>('.message-link-thumb img');
+
+    fireEvent.error(img as HTMLImageElement);
+
+    expect(img).toHaveAttribute('src', 'https://example.com/thumbnail.jpg');
+  });
+
+  it('remounts the thumbnail when a reused music card switches candidates', () => {
+    const firstCandidate = parseChatMessage({
+      id: 'music-cover-2',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:05',
+      createdAt: 6,
+      blocks: [{
+        type: 'link',
+        url: 'https://music.example/first',
+        title: 'First',
+        thumbnailUrl: 'https://music.example/first.jpg',
+      }],
+      status: 'sent',
+    });
+    const secondCandidate = parseChatMessage({
+      ...firstCandidate,
+      blocks: [{
+        type: 'link',
+        url: 'https://music.example/second',
+        title: 'Second',
+        thumbnailUrl: 'https://music.example/second.jpg',
+      }],
+    });
+    const { container, rerender } = render(<MessageList messages={[firstCandidate]} />);
+    const firstImage = container.querySelector<HTMLImageElement>('.message-link-thumb img');
+
+    rerender(<MessageList messages={[secondCandidate]} />);
+    const secondImage = container.querySelector<HTMLImageElement>('.message-link-thumb img');
+
+    expect(secondImage).not.toBe(firstImage);
+    expect(secondImage).toHaveAttribute('src', 'https://music.example/second.jpg');
+  });
+});
+
 describe('plugin system bubble', () => {
   const pluginMessage = parseChatMessage({
     id: 'plugin-1',

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2969,8 +2969,8 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   position: fixed;
   --compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
   --compact-export-surface-center-inline-position: calc(
-    var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) +
-      (var(--compact-export-surface-width) / 2)
+    var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw))
+      + (var(--compact-export-surface-width) / 2)
   );
   --compact-export-layout-inline-size: 100vw;
   --compact-export-history-edge-gutter: 12px;
@@ -3003,10 +3003,10 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   --compact-export-link-row-reserve-inline-size: 48px;
   /* 170px card + bubble chrome + row reserve + 44px shadow gutters. */
   --compact-export-link-history-min-inline-size: calc(
-    var(--compact-export-link-card-min-inline-size) +
-      var(--compact-export-link-bubble-chrome-inline-size) +
-      var(--compact-export-link-row-reserve-inline-size) +
-      var(--compact-export-history-shadow-gutter-left) + var(--compact-export-history-shadow-gutter-right)
+    var(--compact-export-link-card-min-inline-size)
+      + var(--compact-export-link-bubble-chrome-inline-size)
+      + var(--compact-export-link-row-reserve-inline-size)
+      + var(--compact-export-history-shadow-gutter-left) + var(--compact-export-history-shadow-gutter-right)
   );
   --compact-export-history-inline-size: min(
     calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
@@ -3017,9 +3017,9 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     calc((var(--compact-export-history-active-inline-size) / 2) + var(--compact-export-history-edge-gutter)),
     var(--compact-export-surface-center-inline-position),
     calc(
-      var(--compact-export-layout-inline-size) -
-        (var(--compact-export-history-active-inline-size) / 2) -
-        var(--compact-export-history-edge-gutter)
+      var(--compact-export-layout-inline-size)
+        - (var(--compact-export-history-active-inline-size) / 2)
+        - var(--compact-export-history-edge-gutter)
     )
   );
   --compact-export-history-bubble-max-ratio: 86%;
@@ -3475,8 +3475,8 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   width: calc(100% - var(--compact-export-link-row-reserve-inline-size));
   min-width: min(
     calc(
-      var(--compact-export-link-card-min-inline-size) +
-        var(--compact-export-link-bubble-chrome-inline-size)
+      var(--compact-export-link-card-min-inline-size)
+        + var(--compact-export-link-bubble-chrome-inline-size)
     ),
     calc(100% - var(--compact-export-link-row-reserve-inline-size))
   );

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2968,7 +2968,12 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-export-history-anchor {
   position: fixed;
   --compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
-  left: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
+  --compact-export-surface-center-inline-position: calc(
+    var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) +
+      (var(--compact-export-surface-width) / 2)
+  );
+  --compact-export-layout-inline-size: 100vw;
+  --compact-export-history-edge-gutter: 12px;
   bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 2px);
   /* Geometry-critical: derive collapse compensation from control metrics; do not animate layout properties here. */
   --compact-export-controls-padding-y: clamp(4px, calc(var(--compact-export-surface-width) * 0.0116), 6px);
@@ -2993,9 +2998,29 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   --compact-export-history-shadow-gutter-right: 32px;
   --compact-export-history-shadow-gutter-left: 12px;
   --compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));
+  --compact-export-link-card-min-inline-size: 170px;
+  --compact-export-link-bubble-chrome-inline-size: 23px;
+  --compact-export-link-row-reserve-inline-size: 48px;
+  /* 170px card + bubble chrome + row reserve + 44px shadow gutters. */
+  --compact-export-link-history-min-inline-size: calc(
+    var(--compact-export-link-card-min-inline-size) +
+      var(--compact-export-link-bubble-chrome-inline-size) +
+      var(--compact-export-link-row-reserve-inline-size) +
+      var(--compact-export-history-shadow-gutter-left) + var(--compact-export-history-shadow-gutter-right)
+  );
   --compact-export-history-inline-size: min(
     calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
     var(--compact-export-history-max-inline-size)
+  );
+  --compact-export-history-active-inline-size: var(--compact-export-history-inline-size);
+  --compact-export-history-center-inline-position: clamp(
+    calc((var(--compact-export-history-active-inline-size) / 2) + var(--compact-export-history-edge-gutter)),
+    var(--compact-export-surface-center-inline-position),
+    calc(
+      var(--compact-export-layout-inline-size) -
+        (var(--compact-export-history-active-inline-size) / 2) -
+        var(--compact-export-history-edge-gutter)
+    )
   );
   --compact-export-history-bubble-max-ratio: 86%;
   --compact-export-history-system-bubble-max-ratio: 94%;
@@ -3007,7 +3032,8 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     max(var(--compact-export-history-region-height), var(--compact-export-preview-min-height)),
     var(--compact-export-preview-max-height)
   );
-  width: var(--compact-export-history-inline-size);
+  left: var(--compact-export-history-center-inline-position);
+  width: var(--compact-export-history-active-inline-size);
   /* 与 JS getCompactHistorySlotMaxHeight 对齐：高度上限只受屏幕(78vh)约束、不再挂对话条宽度，
      否则窄宽+高屏时 JS 允许的 slot 高 > CSS anchor 高，hit region 会被裁出死区(Codex P2)。 */
   max-height: var(--compact-export-preview-max-height);
@@ -3035,6 +3061,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   --compact-export-history-max-inline-size: calc(
     var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)
   );
+  --compact-export-layout-inline-size: var(--compact-desktop-workarea-width, 1440px);
   --compact-export-preview-max-height: min(
     calc(var(--compact-export-surface-width) * 1.46),
     calc(var(--compact-desktop-workarea-height, 900px) * 0.78)
@@ -3432,6 +3459,38 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   min-width: 0;
   font-size: 0.92rem;
   line-height: 1.48;
+}
+
+/* Preserve a readable card at the 180px compact-surface minimum without
+   changing the surface itself. The active width and center are both capped,
+   so a link card also remains inside the viewport/workarea near either edge. */
+.compact-export-history-anchor:has(.compact-export-history-content > .message-block-link) {
+  --compact-export-history-active-inline-size: min(
+    max(var(--compact-export-history-inline-size), var(--compact-export-link-history-min-inline-size)),
+    var(--compact-export-history-max-inline-size)
+  );
+}
+
+.compact-export-history-bubble:has(> .compact-export-history-content > .message-block-link) {
+  width: calc(100% - var(--compact-export-link-row-reserve-inline-size));
+  min-width: min(
+    calc(
+      var(--compact-export-link-card-min-inline-size) +
+        var(--compact-export-link-bubble-chrome-inline-size)
+    ),
+    calc(100% - var(--compact-export-link-row-reserve-inline-size))
+  );
+}
+
+.compact-export-history-content > .message-block-link {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.compact-export-history-content > .message-block-link .message-link-copy {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .compact-export-history-controls,

--- a/static/app/app-proactive.js
+++ b/static/app/app-proactive.js
@@ -24,6 +24,8 @@
     const NEW_USER_ICEBREAKER_STORAGE_KEY = 'neko.new_user_icebreaker.v1';
     const NEW_USER_ICEBREAKER_BLOCKING_WINDOW_MS = 2 * 60 * 60 * 1000;
     const MEME_LOAD_FAILED_STICKER_URL = '/static/icons/meme-image-load-failed-sticker.png';
+    const MUSIC_CANDIDATE_FALLBACK_BUDGET_MS = 10000;
+    const MUSIC_CANDIDATE_ATTEMPT_TIMEOUT_MS = 3000;
 
     function isMusicOccupiedNow() {
         if (typeof window.isMusicOccupied === 'function') return window.isMusicOccupied();
@@ -1433,6 +1435,9 @@
                     console.log('主动搭话已发送:', result.message, result.source_mode ? '(来源: ' + result.source_mode + ')' : '');
 
                     var dispatchedTrackUrl = null;
+                    var proactiveMusicCardScopeId = 'proactive:' + (
+                        result.turn_id || (Date.now() + '-' + Math.random().toString(36).slice(2, 8))
+                    );
 
                     // 如果模式包含音乐信号，按顺序尝试音轨；候选 URL 或媒体自身
                     // 的错误（包括加载超时）才回退，播放器/调度错误结束本轮推荐。
@@ -1465,8 +1470,10 @@
                                 if (!unknownTrack || unknownTrack === 'music.unknownTrack') unknownTrack = 'Unknown Track';
                                 if (!unknownArtist || unknownArtist === 'music.unknownArtist') unknownArtist = 'Unknown Artist';
 
+                                var proactiveMusicFallbackDeadlineAt = Date.now() + MUSIC_CANDIDATE_FALLBACK_BUDGET_MS;
                                 for (var musicIndex = 0; musicIndex < musicLinks.length; musicIndex++) {
                                     var musicLink = musicLinks[musicIndex];
+                                    var hasNextMusicCandidate = musicIndex < musicLinks.length - 1;
                                     var track = {
                                         name: musicLink.title || unknownTrack,
                                         artist: musicLink.artist || unknownArtist,
@@ -1476,7 +1483,17 @@
                                     console.log('[ProactiveChat] 尝试音乐候选 ' + (musicIndex + 1) + '/' + musicLinks.length + ':', track);
                                     var dispatchResult;
                                     if (typeof window.dispatchMusicPlayDetailed === 'function') {
-                                        dispatchResult = await window.dispatchMusicPlayDetailed(track, { source: 'proactive' });
+                                        dispatchResult = await window.dispatchMusicPlayDetailed(track, {
+                                            source: 'proactive',
+                                            cardScopeId: proactiveMusicCardScopeId,
+                                            hasNextCandidate: hasNextMusicCandidate,
+                                            fallbackDeadlineAt: hasNextMusicCandidate
+                                                ? proactiveMusicFallbackDeadlineAt
+                                                : undefined,
+                                            candidateTimeoutMs: hasNextMusicCandidate
+                                                ? MUSIC_CANDIDATE_ATTEMPT_TIMEOUT_MS
+                                                : undefined
+                                        });
                                     } else {
                                         var legacyAccepted = await window.dispatchMusicPlay(track, { source: 'proactive' });
                                         dispatchResult = {

--- a/static/app/app-proactive.js
+++ b/static/app/app-proactive.js
@@ -1471,47 +1471,62 @@
                                 if (!unknownArtist || unknownArtist === 'music.unknownArtist') unknownArtist = 'Unknown Artist';
 
                                 var proactiveMusicFallbackDeadlineAt = Date.now() + MUSIC_CANDIDATE_FALLBACK_BUDGET_MS;
-                                for (var musicIndex = 0; musicIndex < musicLinks.length; musicIndex++) {
-                                    var musicLink = musicLinks[musicIndex];
-                                    var hasNextMusicCandidate = musicIndex < musicLinks.length - 1;
-                                    var track = {
-                                        name: musicLink.title || unknownTrack,
-                                        artist: musicLink.artist || unknownArtist,
-                                        url: musicLink.url,
-                                        cover: musicLink.cover
-                                    };
-                                    console.log('[ProactiveChat] 尝试音乐候选 ' + (musicIndex + 1) + '/' + musicLinks.length + ':', track);
-                                    var dispatchResult;
-                                    if (typeof window.dispatchMusicPlayDetailed === 'function') {
-                                        dispatchResult = await window.dispatchMusicPlayDetailed(track, {
-                                            source: 'proactive',
-                                            cardScopeId: proactiveMusicCardScopeId,
-                                            hasNextCandidate: hasNextMusicCandidate,
-                                            fallbackDeadlineAt: hasNextMusicCandidate
-                                                ? proactiveMusicFallbackDeadlineAt
-                                                : undefined,
-                                            candidateTimeoutMs: hasNextMusicCandidate
-                                                ? MUSIC_CANDIDATE_ATTEMPT_TIMEOUT_MS
-                                                : undefined
-                                        });
-                                    } else {
-                                        var legacyAccepted = await window.dispatchMusicPlay(track, { source: 'proactive' });
-                                        dispatchResult = {
-                                            ok: legacyAccepted === true,
-                                            reason: legacyAccepted === true ? '' : 'player_error',
-                                            canTryNextCandidate: false
+                                var lastAttemptedMusicTrack = null;
+                                try {
+                                    for (var musicIndex = 0; musicIndex < musicLinks.length; musicIndex++) {
+                                        var musicLink = musicLinks[musicIndex];
+                                        var hasNextMusicCandidate = musicIndex < musicLinks.length - 1;
+                                        var track = {
+                                            name: musicLink.title || unknownTrack,
+                                            artist: musicLink.artist || unknownArtist,
+                                            url: musicLink.url,
+                                            cover: musicLink.cover
                                         };
-                                    }
+                                        lastAttemptedMusicTrack = track;
+                                        console.log('[ProactiveChat] 尝试音乐候选 ' + (musicIndex + 1) + '/' + musicLinks.length + ':', track);
+                                        var dispatchResult;
+                                        if (typeof window.dispatchMusicPlayDetailed === 'function') {
+                                            dispatchResult = await window.dispatchMusicPlayDetailed(track, {
+                                                source: 'proactive',
+                                                cardScopeId: proactiveMusicCardScopeId,
+                                                hasNextCandidate: hasNextMusicCandidate,
+                                                fallbackDeadlineAt: hasNextMusicCandidate
+                                                    ? proactiveMusicFallbackDeadlineAt
+                                                    : undefined,
+                                                candidateTimeoutMs: hasNextMusicCandidate
+                                                    ? MUSIC_CANDIDATE_ATTEMPT_TIMEOUT_MS
+                                                    : undefined
+                                            });
+                                        } else {
+                                            var legacyAccepted = await window.dispatchMusicPlay(track, { source: 'proactive' });
+                                            dispatchResult = {
+                                                ok: legacyAccepted === true,
+                                                reason: legacyAccepted === true ? '' : 'player_error',
+                                                canTryNextCandidate: false
+                                            };
+                                        }
 
-                                    if (dispatchResult.ok === true) {
-                                        dispatchedTrackUrl = musicLink.url;
-                                        break;
+                                        if (dispatchResult.ok === true) {
+                                            dispatchedTrackUrl = musicLink.url;
+                                            break;
+                                        }
+                                        if (dispatchResult.canTryNextCandidate !== true) {
+                                            console.warn('[ProactiveChat] 音乐派发因非候选错误停止:', dispatchResult.reason, musicLink.url);
+                                            break;
+                                        }
+                                        console.warn('[ProactiveChat] 音乐候选不可用，尝试下一条:', dispatchResult.reason, musicLink.url);
                                     }
-                                    if (dispatchResult.canTryNextCandidate !== true) {
-                                        console.warn('[ProactiveChat] 音乐派发因非候选错误停止:', dispatchResult.reason, musicLink.url);
-                                        break;
+                                } finally {
+                                    if (
+                                        !dispatchedTrackUrl
+                                        && lastAttemptedMusicTrack
+                                        && typeof window.finalizeMusicCandidateCardFailure === 'function'
+                                    ) {
+                                        window.finalizeMusicCandidateCardFailure(lastAttemptedMusicTrack, {
+                                            source: 'proactive',
+                                            cardScopeId: proactiveMusicCardScopeId
+                                        });
                                     }
-                                    console.warn('[ProactiveChat] 音乐候选不可用，尝试下一条:', dispatchResult.reason, musicLink.url);
                                 }
                             }
                         }

--- a/static/jukebox/music_ui.js
+++ b/static/jukebox/music_ui.js
@@ -122,6 +122,8 @@
     let currentMusicOwnerStartedAt = 0;
     let localPlayer = null;
     let musicCardMessageId = null;
+    let musicCardScopeKey = '';
+    let musicCardState = '';
     let aplayerLoadPromise = null;
     let latestMusicRequestToken = 0;
     let currentMusicPlaybackContext = { source: '' };
@@ -168,6 +170,8 @@
             lifecycleStartedAt: getMusicLifecycleTimestamp(),
             mediaReady: false,
             source: typeof options.source === 'string' ? options.source.slice(0, 16) : '',
+            hasNextCandidate: options.hasNextCandidate === true,
+            failureUiHandled: false,
             url: String(track.url || ''),
             track: {
                 name: String(track.name || '').slice(0, 120),
@@ -1616,7 +1620,8 @@
 
         let prefix = '❓';
         let text = musicT('music.unknownState', 'Unknown state');
-        if (state === 'playing') { prefix = '🎵'; text = musicT('music.playing', 'Playing'); }
+        if (state === 'loading') { prefix = '⏳'; text = musicT('music.loading', 'Loading'); }
+        else if (state === 'playing') { prefix = '🎵'; text = musicT('music.playing', 'Playing'); }
         else if (state === 'paused') { prefix = '⏸'; text = musicT('music.paused', 'Paused'); }
         else if (state === 'ended') { prefix = '✅'; text = musicT('music.ended', 'Ended'); }
         else if (state === 'error') { prefix = '❌'; text = musicT('music.playError', 'Playback failed'); }
@@ -1633,10 +1638,7 @@
                 thumbnailUrl: getMusicCoverUrl(track?.cover)
             }]
         });
-
-        if (state === 'error') {
-            musicCardMessageId = null;
-        }
+        musicCardState = state;
     };
 
     // --- 状态追踪：用于 5 秒去重 与 进度条清理 ---
@@ -1907,11 +1909,41 @@
         'media_error'
     ].includes(reason);
 
+    const shouldDeferCandidateFailureUi = (options, reason) => (
+        options
+        && options.hasNextCandidate === true
+        && canTryNextMusicCandidate(reason)
+    );
+
+    const getMusicCardScopeKey = (playbackOptions) => {
+        const options = playbackOptions || {};
+        if (options.cardScopeId === undefined || options.cardScopeId === null || options.cardScopeId === '') {
+            return '';
+        }
+        return String(options.source || 'music') + ':' + String(options.cardScopeId).slice(0, 160);
+    };
+
+    const getCandidateMediaReadyTimeoutMs = (playbackOptions) => {
+        const options = playbackOptions || {};
+        if (options.hasNextCandidate !== true) return MUSIC_MEDIA_LOAD_TIMEOUT_MS;
+
+        const deadlineAt = Number(options.fallbackDeadlineAt);
+        const remainingMs = Number.isFinite(deadlineAt) && deadlineAt > 0
+            ? Math.max(1, deadlineAt - Date.now())
+            : MUSIC_MEDIA_LOAD_TIMEOUT_MS;
+        const requestedTimeoutMs = Number(options.candidateTimeoutMs);
+        const attemptTimeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0
+            ? requestedTimeoutMs
+            : MUSIC_MEDIA_LOAD_TIMEOUT_MS;
+        return Math.min(MUSIC_MEDIA_LOAD_TIMEOUT_MS, remainingMs, attemptTimeoutMs);
+    };
+
     const waitForMusicMediaReady = (
         player,
         token,
         expectedUrl,
-        enforceRecommendationLimit
+        enforceRecommendationLimit,
+        timeoutMs = MUSIC_MEDIA_LOAD_TIMEOUT_MS
     ) => new Promise((resolve) => {
         const audio = player && player.audio;
         if (!audio) {
@@ -1985,7 +2017,11 @@
         audio.addEventListener('loadedmetadata', onMetadata);
         audio.addEventListener('canplay', onCanPlay);
         audio.addEventListener('error', onError);
-        timeoutId = window.setTimeout(() => finish(false, 'load_timeout'), MUSIC_MEDIA_LOAD_TIMEOUT_MS);
+        const effectiveTimeoutMs = Math.max(
+            1,
+            Math.min(MUSIC_MEDIA_LOAD_TIMEOUT_MS, Number(timeoutMs) || MUSIC_MEDIA_LOAD_TIMEOUT_MS)
+        );
+        timeoutId = window.setTimeout(() => finish(false, 'load_timeout'), effectiveTimeoutMs);
 
         if (!audio.error && audio.readyState >= 1) {
             window.queueMicrotask(() => validateDuration('already_ready'));
@@ -2200,6 +2236,8 @@
         }
         currentPlayingTrack = null;
         musicCardMessageId = null;
+        musicCardScopeKey = '';
+        musicCardState = '';
 
         // 跨窗口协调：通知其他窗口本地音乐已停
         stopMusicHeartbeat();
@@ -2365,6 +2403,12 @@
         // 被覆盖之前用旧值更新，否则旧卡片会被改写成新曲目信息。
         const previousTrackForCard = currentPlayingTrack;
         const previousCardId = musicCardMessageId;
+        const requestedCardScopeKey = getMusicCardScopeKey(playbackOptions);
+        const reuseScopedMusicCard = Boolean(
+            previousCardId
+            && requestedCardScopeKey
+            && requestedCardScopeKey === musicCardScopeKey
+        );
 
         // --- 2. 原地更新 UI 文本与音乐状态图标 (始终执行) ---
         const playbackIdForRequest = createMusicPlaybackId(trackInfo, currentToken);
@@ -2397,7 +2441,7 @@
             if (host && typeof host.appendMessage === 'function') {
                 // 切歌时，先把上一首的卡片标记为"已结束"，避免覆盖 musicCardMessageId
                 // 之后旧卡片永远停在"播放中"。注意要用旧 id + 旧 track。
-                if (previousCardId) {
+                if (previousCardId && !reuseScopedMusicCard && !['ended', 'error'].includes(musicCardState)) {
                     try {
                         // 镜像到所有窗口：follower 也要把上一首标成已播完
                         mirrorHostUpdate(host, previousCardId, {
@@ -2412,39 +2456,46 @@
                         });
                     } catch (_) { /* ignore */ }
                 }
-                let assistantName = '';
-                if (window.lanlan_config && window.lanlan_config.lanlan_name) assistantName = window.lanlan_config.lanlan_name;
-                else if (window._currentCatgirl) assistantName = window._currentCatgirl;
-                else if (window.currentCatgirl) assistantName = window.currentCatgirl;
-                assistantName = assistantName || 'Neko';
-                let avatarUrl = '';
-                if (window.appChatAvatar && typeof window.appChatAvatar.getCurrentAvatarDataUrl === 'function') {
-                    avatarUrl = window.appChatAvatar.getCurrentAvatarDataUrl() || '';
+                if (reuseScopedMusicCard) {
+                    updateMusicCard('loading', trackInfo);
+                    musicCardScopeKey = requestedCardScopeKey;
+                } else {
+                    let assistantName = '';
+                    if (window.lanlan_config && window.lanlan_config.lanlan_name) assistantName = window.lanlan_config.lanlan_name;
+                    else if (window._currentCatgirl) assistantName = window._currentCatgirl;
+                    else if (window.currentCatgirl) assistantName = window.currentCatgirl;
+                    assistantName = assistantName || 'Neko';
+                    let avatarUrl = '';
+                    if (window.appChatAvatar && typeof window.appChatAvatar.getCurrentAvatarDataUrl === 'function') {
+                        avatarUrl = window.appChatAvatar.getCurrentAvatarDataUrl() || '';
+                    }
+                    const now = new Date();
+                    const timeStr = now.getHours().toString().padStart(2, '0') + ':' + now.getMinutes().toString().padStart(2, '0');
+                    const msgId = 'music-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+                    musicCardMessageId = msgId;
+                    musicCardScopeKey = requestedCardScopeKey;
+                    musicCardState = 'loading';
+                    // 镜像到所有窗口：leader 本地 append + 广播给 follower，
+                    // 保证 chat.html 里也能出现音乐卡片（见本文件 chat mirror 段的注释）
+                    mirrorHostAppend(host, {
+                        id: msgId,
+                        role: 'assistant',
+                        author: assistantName,
+                        time: timeStr,
+                        createdAt: Date.now(),
+                        avatarLabel: assistantName.trim().slice(0, 1).toUpperCase(),
+                        avatarUrl: avatarUrl || undefined,
+                        blocks: [{
+                            type: 'link',
+                            url: trackInfo.url || '#',
+                            title: trackInfo.name || musicT('music.unknownTrack', 'Unknown Track'),
+                            description: trackInfo.artist || musicT('music.unknownArtist', 'Unknown Artist'),
+                            siteName: '⏳ ' + musicT('music.loading', 'Loading'),
+                            thumbnailUrl: displayCoverUrl
+                        }],
+                        status: 'sent'
+                    });
                 }
-                const now = new Date();
-                const timeStr = now.getHours().toString().padStart(2, '0') + ':' + now.getMinutes().toString().padStart(2, '0');
-                const msgId = 'music-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
-                musicCardMessageId = msgId;
-                // 镜像到所有窗口：leader 本地 append + 广播给 follower，
-                // 保证 chat.html 里也能出现音乐卡片（见本文件 chat mirror 段的注释）
-                mirrorHostAppend(host, {
-                    id: msgId,
-                    role: 'assistant',
-                    author: assistantName,
-                    time: timeStr,
-                    createdAt: Date.now(),
-                    avatarLabel: assistantName.trim().slice(0, 1).toUpperCase(),
-                    avatarUrl: avatarUrl || undefined,
-                    blocks: [{
-                        type: 'link',
-                        url: trackInfo.url || '#',
-                        title: trackInfo.name || musicT('music.unknownTrack', 'Unknown Track'),
-                        description: trackInfo.artist || musicT('music.unknownArtist', 'Unknown Artist'),
-                        siteName: '⏳ ' + musicT('music.loading', 'Loading'),
-                        thumbnailUrl: displayCoverUrl
-                    }],
-                    status: 'sent'
-                });
             }
         }
         if (timeTotal) timeTotal.textContent = '00:00';
@@ -2526,6 +2577,7 @@
                     const playbackState = boundPlayer.audio && boundPlayer.audio.ended ? 'ended' : 'paused';
                     const reportContext = getOwnedMusicPlaybackReportContext(boundPlayer, playbackState);
                     if (!reportContext) return;
+                    if (!reportContext.mediaReady && reportContext.hasNextCandidate) return;
                     updatePlayBtnState(false);
                     const tokenAtEvent = boundPlayer._latestToken;
                     if (autoDestroyTimer) clearTimeout(autoDestroyTimer);
@@ -2599,6 +2651,15 @@
                         console.error('[Music UI] APlayer error:', err);
                         playbackStartedAt = 0;
                         boundPlayer._loadError = true;
+
+                        // 仍处于首轮媒体加载、并且后面确有候选时，当前错误只驱动
+                        // 内部回退。候选一旦就绪，后续流错误仍必须正常反馈给用户。
+                        if (
+                            !reportContext.mediaReady
+                            && shouldDeferCandidateFailureUi(reportContext, 'media_error')
+                        ) return;
+                        if (reportContext.failureUiHandled) return;
+                        reportContext.failureUiHandled = true;
 
                         let errorDetail = musicT('music.playError', 'Playback failed');
                         if (err && err.message) errorDetail = err.message;
@@ -2899,7 +2960,8 @@
                 localPlayer,
                 currentToken,
                 trackInfo.url,
-                playbackOptions.source === 'proactive'
+                playbackOptions.source === 'proactive',
+                getCandidateMediaReadyTimeoutMs(playbackOptions)
             );
 
             // 执行播放
@@ -2920,20 +2982,24 @@
             if (currentToken !== latestMusicRequestToken) return musicPlayResult(false, 'superseded');
             if (!mediaResult.ok) {
                 localPlayer._loadError = true;
-                if (mediaResult.reason === 'track_too_long') {
-                    showErrorToast('music.trackTooLong', 'This track is too long for music recommendations');
-                } else if (mediaResult.reason === 'load_timeout') {
-                    showErrorToast('music.loadTimeout', 'Music loading timed out');
+                const deferFailureUi = shouldDeferCandidateFailureUi(playbackOptions, mediaResult.reason);
+                if (!playbackReportContext.failureUiHandled && !deferFailureUi) {
+                    playbackReportContext.failureUiHandled = true;
+                    if (mediaResult.reason === 'track_too_long') {
+                        showErrorToast('music.trackTooLong', 'This track is too long for music recommendations');
+                    } else if (mediaResult.reason === 'load_timeout') {
+                        showErrorToast('music.loadTimeout', 'Music loading timed out');
+                    }
+                    setMusicBarVisualState(musicBar, 'error');
+                    reportMusicPlaybackState(
+                        'error',
+                        null,
+                        playbackReportContext,
+                        mediaResult.reason
+                    );
+                    updateMusicCard('error', currentPlayingTrack);
+                    emitBarState();
                 }
-                setMusicBarVisualState(musicBar, 'error');
-                reportMusicPlaybackState(
-                    'error',
-                    null,
-                    playbackReportContext,
-                    mediaResult.reason
-                );
-                updateMusicCard('error', currentPlayingTrack);
-                emitBarState();
                 return musicPlayResult(
                     false,
                     mediaResult.reason,
@@ -3022,14 +3088,16 @@
 
         if (trackInfo.url && isUnsupportedMusicStream(trackInfo.url)) {
             console.warn('[Music UI] 不支持直接播放 HLS 音频流:', trackInfo.url);
-            showErrorToast('music.playError', 'This audio stream is not supported');
+            if (!shouldDeferCandidateFailureUi(playbackOptions, 'unsupported_stream')) {
+                showErrorToast('music.playError', 'This audio stream is not supported');
+            }
             releasePending();
             return musicPlayResult(false, 'unsupported_stream', true);
         }
 
         if (!trackInfo.url || !isSafeUrl(trackInfo.url)) {
             console.warn('[Music UI] 音频 URL 未通过安全校验:', trackInfo.url);
-            if (window.showStatusToast) {
+            if (!shouldDeferCandidateFailureUi(playbackOptions, 'unsafe_url') && window.showStatusToast) {
                 var domain = extractHostname(trackInfo.url) || musicT('music.unknownSource', 'Unknown source');
                 var msg = musicT('music.unsafeSource', 'Blocked unsafe audio source: {{domain}}', { domain: domain });
                 window.showStatusToast(msg, 5000);

--- a/static/jukebox/music_ui.js
+++ b/static/jukebox/music_ui.js
@@ -3403,6 +3403,7 @@
     // 推荐频率限流：最近是否刚派发过 proactive 推荐
     window.isMusicRecommendRateLimited = isMusicRecommendRateLimited;
     window.markProactiveMusicRecommended = markProactiveMusicRecommended;
+    window.finalizeMusicCandidateCardFailure = finalizeScopedMusicCardFailure;
 
     // 派发就绪事件，通知提前加载的插件可以开始注册域名了
     window.dispatchEvent(new CustomEvent('music-ui-ready'));

--- a/static/jukebox/music_ui.js
+++ b/static/jukebox/music_ui.js
@@ -1923,6 +1923,21 @@
         return String(options.source || 'music') + ':' + String(options.cardScopeId).slice(0, 160);
     };
 
+    const finalizeScopedMusicCardFailure = (track, playbackOptions) => {
+        const requestedScopeKey = getMusicCardScopeKey(playbackOptions);
+        if (
+            !musicCardMessageId
+            || !requestedScopeKey
+            || requestedScopeKey !== musicCardScopeKey
+        ) return false;
+
+        updateMusicCard('error', track);
+        musicCardMessageId = null;
+        musicCardScopeKey = '';
+        musicCardState = '';
+        return true;
+    };
+
     const getCandidateMediaReadyTimeoutMs = (playbackOptions) => {
         const options = playbackOptions || {};
         if (options.hasNextCandidate !== true) return MUSIC_MEDIA_LOAD_TIMEOUT_MS;
@@ -2138,7 +2153,12 @@
     };
 
 
-    const destroyMusicPlayer = (removeDOM = true, fullTeardown = false, updateToken = false) => {
+    const destroyMusicPlayer = (
+        removeDOM = true,
+        fullTeardown = false,
+        updateToken = false,
+        preserveMusicCard = false
+    ) => {
         // 播放器销毁即结束当前曲目生命周期，清起播时间戳，避免残留到下一首
         playbackStartedAt = 0;
         const destroyedPlaybackId = getCurrentMusicPlaybackId();
@@ -2235,9 +2255,11 @@
             updateMusicCard('ended', currentPlayingTrack);
         }
         currentPlayingTrack = null;
-        musicCardMessageId = null;
-        musicCardScopeKey = '';
-        musicCardState = '';
+        if (!preserveMusicCard || fullTeardown) {
+            musicCardMessageId = null;
+            musicCardScopeKey = '';
+            musicCardState = '';
+        }
 
         // 跨窗口协调：通知其他窗口本地音乐已停
         stopMusicHeartbeat();
@@ -3090,6 +3112,7 @@
             console.warn('[Music UI] 不支持直接播放 HLS 音频流:', trackInfo.url);
             if (!shouldDeferCandidateFailureUi(playbackOptions, 'unsupported_stream')) {
                 showErrorToast('music.playError', 'This audio stream is not supported');
+                finalizeScopedMusicCardFailure(trackInfo, playbackOptions);
             }
             releasePending();
             return musicPlayResult(false, 'unsupported_stream', true);
@@ -3101,6 +3124,9 @@
                 var domain = extractHostname(trackInfo.url) || musicT('music.unknownSource', 'Unknown source');
                 var msg = musicT('music.unsafeSource', 'Blocked unsafe audio source: {{domain}}', { domain: domain });
                 window.showStatusToast(msg, 5000);
+            }
+            if (!shouldDeferCandidateFailureUi(playbackOptions, 'unsafe_url')) {
+                finalizeScopedMusicCardFailure(trackInfo, playbackOptions);
             }
             releasePending();
             return musicPlayResult(false, 'unsafe_url', true);
@@ -3202,7 +3228,12 @@
             await loadAPlayerLibrary();
             const result = await executePlay(trackInfo, currentToken, shouldAutoPlay, playbackOptions);
             if (!result.ok && currentToken === latestMusicRequestToken) {
-                destroyMusicPlayer(true, false, true);
+                destroyMusicPlayer(
+                    true,
+                    false,
+                    true,
+                    shouldDeferCandidateFailureUi(playbackOptions, result.reason)
+                );
             }
             if (result.ok && shouldAutoPlay) showNowPlayingToast(trackInfo.name);
             return result;

--- a/static/jukebox/music_ui.js
+++ b/static/jukebox/music_ui.js
@@ -212,6 +212,15 @@
         } catch (_) { /* best-effort playback awareness */ }
     }
 
+    function reportMusicPlaybackFailureIfNeeded(playbackContext, failureReason, deferFailureUi) {
+        if (!playbackContext || playbackContext.lastReportedState === 'error') return;
+        if (
+            deferFailureUi
+            && !['playing', 'paused'].includes(playbackContext.lastReportedState)
+        ) return;
+        reportMusicPlaybackState('error', null, playbackContext, failureReason);
+    }
+
     function getOwnedMusicPlaybackReportContext(player, state) {
         const context = player && player._musicPlaybackReportContext;
         const audio = player && player.audio;
@@ -1615,8 +1624,11 @@
 
     // --- 更新 React 聊天窗口音乐卡片 ---
     const updateMusicCard = (state, track) => {
+        if (!musicCardMessageId) return;
+        musicCardState = state;
+
         const host = window.reactChatWindowHost;
-        if (!host || typeof host.updateMessage !== 'function' || !musicCardMessageId) return;
+        if (!host || typeof host.updateMessage !== 'function') return;
 
         let prefix = '❓';
         let text = musicT('music.unknownState', 'Unknown state');
@@ -1638,7 +1650,6 @@
                 thumbnailUrl: getMusicCoverUrl(track?.cover)
             }]
         });
-        musicCardState = state;
     };
 
     // --- 状态追踪：用于 5 秒去重 与 进度条清理 ---
@@ -2250,8 +2261,12 @@
             }
             clearManagedListeners();
         }
-        // 手动关闭时更新卡片状态为"已结束"，必须在清空 musicCardMessageId 之前
-        if (fullTeardown && musicCardMessageId) {
+        // 完整销毁只结束非终态卡片；播放失败必须保留 error，不能被延迟销毁改写。
+        if (
+            fullTeardown
+            && musicCardMessageId
+            && !['error', 'ended'].includes(musicCardState)
+        ) {
             updateMusicCard('ended', currentPlayingTrack);
         }
         currentPlayingTrack = null;
@@ -2676,10 +2691,16 @@
 
                         // 仍处于首轮媒体加载、并且后面确有候选时，当前错误只驱动
                         // 内部回退。候选一旦就绪，后续流错误仍必须正常反馈给用户。
-                        if (
+                        const deferFailureUi = (
                             !reportContext.mediaReady
                             && shouldDeferCandidateFailureUi(reportContext, 'media_error')
-                        ) return;
+                        );
+                        reportMusicPlaybackFailureIfNeeded(
+                            reportContext,
+                            'media_error',
+                            deferFailureUi
+                        );
+                        if (deferFailureUi) return;
                         if (reportContext.failureUiHandled) return;
                         reportContext.failureUiHandled = true;
 
@@ -2689,8 +2710,6 @@
                         showErrorToast('music.playError', errorDetail);
                         updatePlayBtnState(false);
                         setMusicBarVisualState(musicBar, 'error');
-                        reportMusicPlaybackState('error', null, reportContext, 'media_error');
-
                         if (autoDestroyTimer) clearTimeout(autoDestroyTimer);
                         autoDestroyTimer = setTimeout(() => {
                             if (localPlayer === boundPlayer && boundPlayer._latestToken === tokenAtEvent) {
@@ -3005,6 +3024,11 @@
             if (!mediaResult.ok) {
                 localPlayer._loadError = true;
                 const deferFailureUi = shouldDeferCandidateFailureUi(playbackOptions, mediaResult.reason);
+                reportMusicPlaybackFailureIfNeeded(
+                    playbackReportContext,
+                    mediaResult.reason,
+                    deferFailureUi
+                );
                 if (!playbackReportContext.failureUiHandled && !deferFailureUi) {
                     playbackReportContext.failureUiHandled = true;
                     if (mediaResult.reason === 'track_too_long') {
@@ -3013,12 +3037,6 @@
                         showErrorToast('music.loadTimeout', 'Music loading timed out');
                     }
                     setMusicBarVisualState(musicBar, 'error');
-                    reportMusicPlaybackState(
-                        'error',
-                        null,
-                        playbackReportContext,
-                        mediaResult.reason
-                    );
                     updateMusicCard('error', currentPlayingTrack);
                     emitBarState();
                 }
@@ -3037,12 +3055,7 @@
         } catch (err) {
             if (currentToken !== latestMusicRequestToken) return musicPlayResult(false, 'superseded');
             console.error('[Music UI] 播放器处理异常:', err);
-            reportMusicPlaybackState(
-                'error',
-                null,
-                playbackReportContext,
-                'player_error'
-            );
+            reportMusicPlaybackFailureIfNeeded(playbackReportContext, 'player_error', false);
             updateMusicCard('error', currentPlayingTrack);
             destroyMusicPlayer(true, false, true);
             showErrorToast('music.playError', 'Music playback failed to load');

--- a/tests/unit/test_music_playback_static.py
+++ b/tests/unit/test_music_playback_static.py
@@ -250,6 +250,9 @@ def test_music_candidate_fallback_preserves_and_finalizes_only_the_matching_card
     destroy_source = source.split("const destroyMusicPlayer = (", 1)[1].split(
         "const getMusicPlayerInstance", 1
     )[0]
+    update_card_source = source.split("const updateMusicCard = (state, track) => {", 1)[1].split(
+        "// --- 状态追踪", 1
+    )[0]
 
     assert "String(options.source || 'music') + ':' + String(options.cardScopeId)" in scoped_card_source
     assert "requestedScopeKey !== musicCardScopeKey" in scoped_card_source
@@ -258,6 +261,13 @@ def test_music_candidate_fallback_preserves_and_finalizes_only_the_matching_card
     assert "musicCardScopeKey = ''" in scoped_card_source
     assert "preserveMusicCard = false" in destroy_source
     assert "if (!preserveMusicCard || fullTeardown)" in destroy_source
+    assert "!['error', 'ended'].includes(musicCardState)" in destroy_source
+    assert destroy_source.index("!['error', 'ended'].includes(musicCardState)") < destroy_source.index(
+        "updateMusicCard('ended', currentPlayingTrack)"
+    )
+    assert update_card_source.index("musicCardState = state;") < update_card_source.index(
+        "const host = window.reactChatWindowHost;"
+    )
     assert "shouldDeferCandidateFailureUi(playbackOptions, result.reason)" in source
     assert "window.finalizeMusicCandidateCardFailure = finalizeScopedMusicCardFailure" in source
 
@@ -363,9 +373,34 @@ def test_music_player_reports_confirmed_state_to_backend():
     assert "reportMusicPlaybackState('playing', null, reportContext)" in player_source
     assert "reportMusicPlaybackState('ended', null, reportContext)" in player_source
     assert (
-        "reportMusicPlaybackState('error', null, reportContext, 'media_error')"
+        "function reportMusicPlaybackFailureIfNeeded(playbackContext, failureReason, deferFailureUi)"
         in player_source
     )
+    failure_helper = player_source.split(
+        "function reportMusicPlaybackFailureIfNeeded", 1
+    )[1].split("function getOwnedMusicPlaybackReportContext", 1)[0]
+    assert "playbackContext.lastReportedState === 'error'" in failure_helper
+    assert "!['playing', 'paused'].includes(playbackContext.lastReportedState)" in failure_helper
+    assert "reportMusicPlaybackState('error', null, playbackContext, failureReason)" in failure_helper
+    media_failure_source = player_source.split(
+        "const mediaResult = await mediaReadyPromise;", 1
+    )[1].split("playbackReportContext.mediaReady = true;", 1)[0]
+    media_report = media_failure_source.index("reportMusicPlaybackFailureIfNeeded(")
+    media_ui_gate = media_failure_source.index(
+        "if (!playbackReportContext.failureUiHandled && !deferFailureUi)"
+    )
+    assert media_report < media_ui_gate
+    assert "reportMusicPlaybackState(" not in media_failure_source
+
+    error_handler = player_source.split(
+        "boundPlayer.on('error', (err) => {", 1
+    )[1].split("// 进度条与播放按钮点击", 1)[0]
+    delayed_error_handler = error_handler.split("setTimeout(() => {", 1)[1]
+    error_report = delayed_error_handler.index("reportMusicPlaybackFailureIfNeeded(")
+    deferred_return = delayed_error_handler.index("if (deferFailureUi) return;")
+    error_ui_gate = delayed_error_handler.index("if (reportContext.failureUiHandled) return;")
+    assert error_report < deferred_return < error_ui_gate
+    assert "reportMusicPlaybackState(" not in delayed_error_handler
     assert "mediaResult.reason" in player_source
     assert "'player_error'" in player_source
     assert "localPlayer === boundPlayer && boundPlayer._latestToken === tokenAtEvent" in player_source

--- a/tests/unit/test_music_playback_static.py
+++ b/tests/unit/test_music_playback_static.py
@@ -209,18 +209,57 @@ def test_exact_http_allowlist_is_carried_without_enabling_http_proxy():
     assert "pluginHttpUrls" not in proxy_source
 
 
-def test_proactive_music_only_retries_candidate_specific_failures():
+def test_proactive_music_reuses_one_card_scope_and_only_shortens_intermediate_attempts():
     source = PROACTIVE_UI_PATH.read_text(encoding="utf-8")
+    player_source = MUSIC_UI_PATH.read_text(encoding="utf-8")
+    candidate_loop = source.split("var proactiveMusicFallbackDeadlineAt", 1)[1].split(
+        "// 【重构】统一处理链接", 1
+    )[0]
 
-    assert "for (var musicIndex = 0; musicIndex < musicLinks.length; musicIndex++)" in source
-    assert "window.dispatchMusicPlayDetailed(track, { source: 'proactive' })" in source
-    assert "if (dispatchResult.ok === true)" in source
-    assert "if (dispatchResult.canTryNextCandidate !== true)" in source
-    assert "音乐派发因非候选错误停止" in source
-    assert "音乐候选不可用，尝试下一条" in source
+    assert "const MUSIC_CANDIDATE_FALLBACK_BUDGET_MS = 10000" in source
+    assert "const MUSIC_CANDIDATE_ATTEMPT_TIMEOUT_MS = 3000" in source
+    assert "const MUSIC_MEDIA_LOAD_TIMEOUT_MS = 10000" in player_source
+    assert "var proactiveMusicCardScopeId = 'proactive:'" in source
+    assert "for (var musicIndex = 0; musicIndex < musicLinks.length; musicIndex++)" in candidate_loop
+    assert "var hasNextMusicCandidate = musicIndex < musicLinks.length - 1" in candidate_loop
+    assert "dispatchResult = await window.dispatchMusicPlayDetailed(track, {" in candidate_loop
+    assert "cardScopeId: proactiveMusicCardScopeId" in candidate_loop
+    assert "hasNextCandidate: hasNextMusicCandidate" in candidate_loop
+    assert "fallbackDeadlineAt: hasNextMusicCandidate" in candidate_loop
+    assert "? proactiveMusicFallbackDeadlineAt" in candidate_loop
+    assert "candidateTimeoutMs: hasNextMusicCandidate" in candidate_loop
+    assert "? MUSIC_CANDIDATE_ATTEMPT_TIMEOUT_MS" in candidate_loop
+    assert "if (dispatchResult.ok === true)" in candidate_loop
+    assert "if (dispatchResult.canTryNextCandidate !== true)" in candidate_loop
+    assert "音乐派发因非候选错误停止" in candidate_loop
+    assert "音乐候选不可用，尝试下一条" in candidate_loop
+    assert "finally {" in candidate_loop
+    assert "!dispatchedTrackUrl" in candidate_loop
+    assert "window.finalizeMusicCandidateCardFailure(lastAttemptedMusicTrack, {" in candidate_loop
+    assert "cardScopeId: proactiveMusicCardScopeId" in candidate_loop
     assert "musicLinks = normalizedLinks.filter" in source
     assert "name: musicLink.title || '未知曲目'" not in source
     assert "artist: musicLink.artist || '未知艺术家'" not in source
+
+
+def test_music_candidate_fallback_preserves_and_finalizes_only_the_matching_card_scope():
+    source = MUSIC_UI_PATH.read_text(encoding="utf-8")
+    scoped_card_source = source.split("const getMusicCardScopeKey", 1)[1].split(
+        "const getCandidateMediaReadyTimeoutMs", 1
+    )[0]
+    destroy_source = source.split("const destroyMusicPlayer = (", 1)[1].split(
+        "const getMusicPlayerInstance", 1
+    )[0]
+
+    assert "String(options.source || 'music') + ':' + String(options.cardScopeId)" in scoped_card_source
+    assert "requestedScopeKey !== musicCardScopeKey" in scoped_card_source
+    assert "updateMusicCard('error', track)" in scoped_card_source
+    assert "musicCardMessageId = null" in scoped_card_source
+    assert "musicCardScopeKey = ''" in scoped_card_source
+    assert "preserveMusicCard = false" in destroy_source
+    assert "if (!preserveMusicCard || fullTeardown)" in destroy_source
+    assert "shouldDeferCandidateFailureUi(playbackOptions, result.reason)" in source
+    assert "window.finalizeMusicCandidateCardFailure = finalizeScopedMusicCardFailure" in source
 
 
 def test_proactive_request_rechecks_music_state_before_search():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -833,6 +833,9 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
         ".compact-export-history-anchor:has(.compact-export-history-content > .message-block-link) {",
         ".compact-export-history-bubble:has(> .compact-export-history-content > .message-block-link)",
     )
+    active_inline_size_marker = "--compact-export-history-active-inline-size:"
+    assert active_inline_size_marker in link_anchor_block
+    active_inline_size = link_anchor_block.split(active_inline_size_marker, 1)[1].split(";", 1)[0]
 
     assert "--compact-export-history-width-ratio:" in anchor_block
     assert "--compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));" in anchor_block
@@ -840,12 +843,12 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
     assert "--compact-export-history-active-inline-size: var(--compact-export-history-inline-size);" in anchor_block
     assert "width: var(--compact-export-history-active-inline-size);" in anchor_block
-    assert "--compact-export-history-active-inline-size: min(" in link_anchor_block
+    assert "min(" in active_inline_size
     assert (
         "max(var(--compact-export-history-inline-size), var(--compact-export-link-history-min-inline-size))"
-        in link_anchor_block
+        in active_inline_size
     )
-    assert "var(--compact-export-history-max-inline-size)" in link_anchor_block
+    assert "var(--compact-export-history-max-inline-size)" in active_inline_size
     assert "--compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));" in anchor_block
     assert "--compact-export-preview-min-height: 360px;" in anchor_block
     assert "--compact-export-preview-max-height: 78vh;" in anchor_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -828,12 +828,24 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
         ".compact-export-preview-message.is-system .compact-export-preview-bubble {",
         ".compact-export-preview-meta",
     )
+    link_anchor_block = css_block(
+        styles,
+        ".compact-export-history-anchor:has(.compact-export-history-content > .message-block-link) {",
+        ".compact-export-history-bubble:has(> .compact-export-history-content > .message-block-link)",
+    )
 
     assert "--compact-export-history-width-ratio:" in anchor_block
     assert "--compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));" in anchor_block
     assert "--compact-export-history-inline-size: min(" in anchor_block
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
-    assert "width: var(--compact-export-history-inline-size);" in anchor_block
+    assert "--compact-export-history-active-inline-size: var(--compact-export-history-inline-size);" in anchor_block
+    assert "width: var(--compact-export-history-active-inline-size);" in anchor_block
+    assert "--compact-export-history-active-inline-size: min(" in link_anchor_block
+    assert (
+        "max(var(--compact-export-history-inline-size), var(--compact-export-link-history-min-inline-size))"
+        in link_anchor_block
+    )
+    assert "var(--compact-export-history-max-inline-size)" in link_anchor_block
     assert "--compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));" in anchor_block
     assert "--compact-export-preview-min-height: 360px;" in anchor_block
     assert "--compact-export-preview-max-height: 78vh;" in anchor_block


### PR DESCRIPTION
## 改动概述 / Summary

- 主动音乐推荐的候选回退复用同一张卡片，中间候选失败时保留卡片身份，仅在整条候选链结束后结算最终失败。
- 音乐封面 URL 合法但实际加载失败时回退到默认占位图。
- 含链接卡片的 compact history 按需扩宽，并同时受视口或 Electron workArea 上限约束；长标题、描述和连续 URL 可以换行。
- 保留全局 10000ms 媒体加载超时；短等待只由已有候选回退预算控制。
- 这是对 #2799 中仍然有效部分的重新实现；没有带入已被 #2836 删除的点歌链路、app-websocket 候选队列或 main_logic 失败幂等代码。

## 回归报告 / Regression Report

### 改动前

1. 主动推荐的多个候选依次失败时会丢失音乐卡片复用 ID，产生多张失败卡片和重复失败反馈。
2. 封面地址通过预检但返回 403 或 404 时会显示破损图片。
3. compact history 内的链接卡片可能被压缩到不可读宽度。
4. 旧 #2799 还包含已经没有落点的对话点歌代码和全局 3 秒加载超时，无法安全按原样合并。

### 改动后

1. 同一候选链始终复用同一张卡片；中间失败不结算，成功候选原地接管，全部失败时只显示一次最终错误。
2. 图片元素真实加载失败后切换占位封面，并避免重复 onError。
3. 链接卡片历史区域按内容扩到 285px 目标宽度，同时在屏幕两侧保留约 12px 边距。
4. 慢网和大音频仍使用全局 10000ms 超时，只有后续仍有候选时才受 fallback deadline 限制。

### 潜在回归点

- 主动音乐候选的作用域切换、卡片复用和最终失败结算。
- APlayer 媒体错误、等待超时及旧候选迟到事件。
- 封面加载失败后的占位图切换。
- compact history 在窄窗口和左右屏幕边缘的布局。

## 不拆分理由 / Why Not Split

不适用。PR 仅修改 7 个文件，未超过 20 个文件上限；这些改动共同维护主动音乐卡片从候选选择、媒体加载到紧凑历史展示的同一条用户可见链路。

## 测试 / Testing

- uv run pytest tests/unit/test_music_playback_static.py
  - 18 passed
- npm test -- src/App.test.tsx src/MessageList.test.tsx
  - 2 files passed，266 tests passed
- node --check static/app/app-proactive.js
- node --check static/jukebox/music_ui.js
- git diff --check
- 人工候选链验证
  - 连续推送 3 个失败音频候选，只保留 1 张卡片，最终失败只结算一次
- 人工 compact 卡片验证
  - 438px 视口、180px 紧凑栏
  - 左贴边 anchor 12.0..297.0，右贴边 140.6..425.6
  - anchor 285.0px、bubble 193.0px、link 171.4px
  - 长标题、描述和连续 URL 均无横向溢出

Supersedes #2799 based on the current-main review by @wehos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 音乐播放失败时会自动尝试其他候选曲目，减少播放中断。
  * 候选曲目切换期间保留同一音乐卡片，全部失败后再显示错误状态。
  * 音乐链接缩略图加载失败时自动显示封面占位图。

* **问题修复**
  * 优化紧凑导出历史中的链接卡片宽度、换行和布局，提升小屏及桌面环境下的可读性。
  * 修复音乐候选切换时缩略图未正确更新的问题。
  * 改进音乐播放失败状态处理，避免重复提示并确保最终失败状态正确显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->