### PR TITLE
修复 VRM 点歌跳舞时被待机动作提前打断的问题，并同步适配网页端和 Electron Pet

### DIFF
--- a/static/jukebox/jukebox-loader.js
+++ b/static/jukebox/jukebox-loader.js
@@ -162,6 +162,9 @@
           state.isPlaying = true;
         } catch (error) {
           console.error('[Jukebox]', translate('Jukebox.vmdPlayFailed', 'VMD 播放失败'), error);
+          if (playRequestId === state.playRequestId) {
+            await facade.restoreIdleAnimation();
+          }
         } finally {
           finishNativeAnimationPlayback(state, playRequestId);
         }
@@ -191,7 +194,8 @@
           motionRuntimeHeld = holdResult === false ? false : await holdResult;
           if (playRequestId !== state.playRequestId) {
             if (motionRuntimeHeld) {
-              await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
+              // stop/new play 已经决定后续姿势；旧请求这里只解锁，不能再抢着恢复。
+              await releaseNekoMotionPlayback({ token: playRequestId, resume: false });
             }
             return;
           }
@@ -199,11 +203,16 @@
           var played = await window.vrmManager.playVRMAAnimation(vrmaPath, {
             loop: false,
             fadeInDuration: 0.5,
-            fadeOutDuration: 0.5
+            fadeOutDuration: 0.5,
+            shouldStart: function() {
+              return playRequestId === state.playRequestId;
+            }
           });
           if (played !== true || playRequestId !== state.playRequestId) {
             if (motionRuntimeHeld) {
               await releaseOwnedNekoMotionPlayback(state, { token: playRequestId, resume: true });
+            } else if (playRequestId === state.playRequestId) {
+              await facade.restoreIdleAnimation();
             }
             return;
           }
@@ -214,6 +223,8 @@
           console.error('[Jukebox] VRMA 播放失败:', error);
           if (motionRuntimeHeld) {
             await releaseOwnedNekoMotionPlayback(state, { token: playRequestId, resume: true });
+          } else if (playRequestId === state.playRequestId) {
+            await facade.restoreIdleAnimation();
           }
         } finally {
           finishNativeAnimationPlayback(state, playRequestId);
@@ -223,16 +234,28 @@
       stopVMD: function(skipIdleRestore) {
         var state = facade.State;
         var pendingRequestId = state.pendingAnimationRequestId;
+        var cancelledPendingRequest = false;
         if (pendingRequestId !== null) {
           // isVMDPlaying 只在真正起播后才会置位；等待 loadAnimation 或
           // holdExternalPlayback 时也必须能被停止。只有当前世代仍属于这条
           // 在途请求时才推进，避免旧 finally 误取消后来接手的新请求。
           if (pendingRequestId === state.playRequestId) {
             state.playRequestId += 1;
+            cancelledPendingRequest = true;
           }
           state.pendingAnimationRequestId = null;
         }
-        if (!state.isVMDPlaying) return;
+        if (!state.isVMDPlaying) {
+          if (cancelledPendingRequest && facade.getModelType() === 'vrm' &&
+              window.vrmManager && typeof window.vrmManager.stopVRMAAnimation === 'function') {
+            // 底层 stop 会推进 VRMA 自己的加载世代，和 shouldStart 组成双重取消闸门。
+            window.vrmManager.stopVRMAAnimation();
+          }
+          if (cancelledPendingRequest && !skipIdleRestore) {
+            facade.restoreIdleAnimation();
+          }
+          return;
+        }
 
         var modelType = facade.getModelType();
         if (modelType === 'vrm') {

--- a/static/jukebox/jukebox-loader.js
+++ b/static/jukebox/jukebox-loader.js
@@ -52,6 +52,22 @@
     });
   }
 
+  function beginNativeAnimationPlayback(facade) {
+    var state = facade.State;
+    // 先终止上一段动画（也会作废它仍在途的加载），再给新请求取号；否则
+    // stopVMD 推进世代时会把刚创建的这条请求一起误伤。
+    facade.stopVMD(true);
+    state.playRequestId += 1;
+    state.pendingAnimationRequestId = state.playRequestId;
+    return state.playRequestId;
+  }
+
+  function finishNativeAnimationPlayback(state, requestId) {
+    if (state.pendingAnimationRequestId === requestId) {
+      state.pendingAnimationRequestId = null;
+    }
+  }
+
   function ensureNativeJukeboxFacade() {
     if (window.Jukebox) return;
 
@@ -63,7 +79,8 @@
         isVMDPlaying: false,
         isPaused: false,
         savedIdleAnimationUrl: null,
-        playRequestId: 0
+        playRequestId: 0,
+        pendingAnimationRequestId: null
       },
 
       toggle: function() {
@@ -96,14 +113,12 @@
         }
 
         var state = facade.State;
-        state.playRequestId += 1;
-        var playRequestId = state.playRequestId;
+        if (!state.savedIdleAnimationUrl && window.mmdManager.currentAnimationUrl) {
+          state.savedIdleAnimationUrl = window.mmdManager.currentAnimationUrl;
+        }
+        var playRequestId = beginNativeAnimationPlayback(facade);
 
         try {
-          if (!state.savedIdleAnimationUrl && window.mmdManager.currentAnimationUrl) {
-            state.savedIdleAnimationUrl = window.mmdManager.currentAnimationUrl;
-          }
-          facade.stopVMD(true);
           if (typeof window.mmdManager.loadAnimation === 'function') {
             await window.mmdManager.loadAnimation(vmdPath);
           }
@@ -118,6 +133,8 @@
           state.isPlaying = true;
         } catch (error) {
           console.error('[Jukebox]', translate('Jukebox.vmdPlayFailed', 'VMD 播放失败'), error);
+        } finally {
+          finishNativeAnimationPlayback(state, playRequestId);
         }
       },
 
@@ -129,12 +146,10 @@
         }
 
         var state = facade.State;
-        state.playRequestId += 1;
-        var playRequestId = state.playRequestId;
+        var playRequestId = beginNativeAnimationPlayback(facade);
         var motionRuntimeHeld = false;
 
         try {
-          facade.stopVMD(true);
           var holdResult = holdNekoMotionPlayback(playRequestId);
           motionRuntimeHeld = holdResult === false ? false : await holdResult;
           if (playRequestId !== state.playRequestId) {
@@ -162,11 +177,23 @@
           if (motionRuntimeHeld) {
             await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
           }
+        } finally {
+          finishNativeAnimationPlayback(state, playRequestId);
         }
       },
 
       stopVMD: function(skipIdleRestore) {
         var state = facade.State;
+        var pendingRequestId = state.pendingAnimationRequestId;
+        if (pendingRequestId !== null) {
+          // isVMDPlaying 只在真正起播后才会置位；等待 loadAnimation 或
+          // holdExternalPlayback 时也必须能被停止。只有当前世代仍属于这条
+          // 在途请求时才推进，避免旧 finally 误取消后来接手的新请求。
+          if (pendingRequestId === state.playRequestId) {
+            state.playRequestId += 1;
+          }
+          state.pendingAnimationRequestId = null;
+        }
         if (!state.isVMDPlaying) return;
 
         var modelType = facade.getModelType();

--- a/static/jukebox/jukebox-loader.js
+++ b/static/jukebox/jukebox-loader.js
@@ -16,6 +16,42 @@
     return value.replace(/\.vrma(?=[?#]|$)/i, '.vrma.gz');
   }
 
+  function holdNekoMotionPlayback(token) {
+    var runtime = window.NekoMotion;
+    if (!runtime || typeof runtime.holdExternalPlayback !== 'function') return false;
+    var holdRequest;
+    try {
+      holdRequest = runtime.holdExternalPlayback('jukebox', { token: token });
+    } catch (error) {
+      console.warn('[Jukebox] VRM 动作运行时占用失败，继续使用底层播放器:', error);
+      return false;
+    }
+    return Promise.resolve(holdRequest).then(function(held) {
+      return held === true;
+    }).catch(function(error) {
+      console.warn('[Jukebox] VRM 动作运行时占用失败，继续使用底层播放器:', error);
+      return false;
+    });
+  }
+
+  function releaseNekoMotionPlayback(options) {
+    var runtime = window.NekoMotion;
+    if (!runtime || typeof runtime.releaseExternalPlayback !== 'function') return false;
+    var releaseRequest;
+    try {
+      releaseRequest = runtime.releaseExternalPlayback('jukebox', options || {});
+    } catch (error) {
+      console.warn('[Jukebox] VRM 动作运行时释放失败，回退直接恢复待机:', error);
+      return false;
+    }
+    return Promise.resolve(releaseRequest).then(function(released) {
+      return released === true;
+    }).catch(function(error) {
+      console.warn('[Jukebox] VRM 动作运行时释放失败，回退直接恢复待机:', error);
+      return false;
+    });
+  }
+
   function ensureNativeJukeboxFacade() {
     if (window.Jukebox) return;
 
@@ -95,20 +131,37 @@
         var state = facade.State;
         state.playRequestId += 1;
         var playRequestId = state.playRequestId;
+        var motionRuntimeHeld = false;
 
         try {
           facade.stopVMD(true);
+          var holdResult = holdNekoMotionPlayback(playRequestId);
+          motionRuntimeHeld = holdResult === false ? false : await holdResult;
+          if (playRequestId !== state.playRequestId) {
+            if (motionRuntimeHeld) {
+              await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
+            }
+            return;
+          }
           var played = await window.vrmManager.playVRMAAnimation(vrmaPath, {
             loop: false,
             fadeInDuration: 0.5,
             fadeOutDuration: 0.5
           });
-          if (played !== true || playRequestId !== state.playRequestId) return;
+          if (played !== true || playRequestId !== state.playRequestId) {
+            if (motionRuntimeHeld) {
+              await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
+            }
+            return;
+          }
           state.isVMDPlaying = true;
           state.isPaused = false;
           state.isPlaying = true;
         } catch (error) {
           console.error('[Jukebox] VRMA 播放失败:', error);
+          if (motionRuntimeHeld) {
+            await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
+          }
         }
       },
 
@@ -143,6 +196,13 @@
 
         if (modelType === 'vrm' && window.vrmManager && typeof window.vrmManager.playVRMAAnimation === 'function') {
           try {
+            var releaseResult = releaseNekoMotionPlayback({
+              resume: true,
+              scheduleNext: true
+            });
+            var motionRuntimeRestored = releaseResult === false ? false : await releaseResult;
+            if (restoreRequestId !== state.playRequestId) return;
+            if (motionRuntimeRestored) return;
             var vrmIdleList = window.lanlan_config && window.lanlan_config.vrmIdleAnimations;
             var vrmIdleUrl = Array.isArray(vrmIdleList) && vrmIdleList.length > 0 ? vrmIdleList[0] : null;
             if (!vrmIdleUrl) {

--- a/static/jukebox/jukebox-loader.js
+++ b/static/jukebox/jukebox-loader.js
@@ -182,14 +182,8 @@
         var motionRuntimeHeld = false;
 
         try {
-          if (state.vrmMotionRuntimeToken !== null) {
-            var previousRelease = releaseOwnedNekoMotionPlayback(state, {
-              resume: false,
-              scheduleNext: false
-            });
-            if (previousRelease !== false) await previousRelease;
-            if (playRequestId !== state.playRequestId) return;
-          }
+          // 同一个 owner 的新 token 会在运行时内原子替换旧 token。先释放再占用会在
+          // 冷启动时等待完整初始化，让接班舞蹈落后于已经开始的音频。
           var holdResult = holdNekoMotionPlayback(playRequestId);
           motionRuntimeHeld = holdResult === false ? false : await holdResult;
           if (playRequestId !== state.playRequestId) {

--- a/static/jukebox/jukebox-loader.js
+++ b/static/jukebox/jukebox-loader.js
@@ -52,6 +52,26 @@
     });
   }
 
+  function releaseOwnedNekoMotionPlayback(state, options) {
+    var releaseOptions = Object.assign({}, options || {});
+    if (!Object.prototype.hasOwnProperty.call(releaseOptions, 'token') &&
+        state.vrmMotionRuntimeToken !== null) {
+      releaseOptions.token = state.vrmMotionRuntimeToken;
+    }
+    var releaseToken = Object.prototype.hasOwnProperty.call(releaseOptions, 'token')
+      ? releaseOptions.token
+      : null;
+    var releaseResult = releaseNekoMotionPlayback(releaseOptions);
+    if (releaseResult === false) return false;
+    return Promise.resolve(releaseResult).then(function(released) {
+      if (released === true && releaseToken !== null &&
+          state.vrmMotionRuntimeToken === releaseToken) {
+        state.vrmMotionRuntimeToken = null;
+      }
+      return released === true;
+    });
+  }
+
   function beginNativeAnimationPlayback(facade) {
     var state = facade.State;
     // 先终止上一段动画（也会作废它仍在途的加载），再给新请求取号；否则
@@ -80,7 +100,8 @@
         isPaused: false,
         savedIdleAnimationUrl: null,
         playRequestId: 0,
-        pendingAnimationRequestId: null
+        pendingAnimationRequestId: null,
+        vrmMotionRuntimeToken: null
       },
 
       toggle: function() {
@@ -119,6 +140,14 @@
         var playRequestId = beginNativeAnimationPlayback(facade);
 
         try {
+          if (state.vrmMotionRuntimeToken !== null) {
+            var releaseResult = releaseOwnedNekoMotionPlayback(state, {
+              resume: false,
+              scheduleNext: false
+            });
+            if (releaseResult !== false) await releaseResult;
+            if (playRequestId !== state.playRequestId) return;
+          }
           if (typeof window.mmdManager.loadAnimation === 'function') {
             await window.mmdManager.loadAnimation(vmdPath);
           }
@@ -150,6 +179,14 @@
         var motionRuntimeHeld = false;
 
         try {
+          if (state.vrmMotionRuntimeToken !== null) {
+            var previousRelease = releaseOwnedNekoMotionPlayback(state, {
+              resume: false,
+              scheduleNext: false
+            });
+            if (previousRelease !== false) await previousRelease;
+            if (playRequestId !== state.playRequestId) return;
+          }
           var holdResult = holdNekoMotionPlayback(playRequestId);
           motionRuntimeHeld = holdResult === false ? false : await holdResult;
           if (playRequestId !== state.playRequestId) {
@@ -158,6 +195,7 @@
             }
             return;
           }
+          if (motionRuntimeHeld) state.vrmMotionRuntimeToken = playRequestId;
           var played = await window.vrmManager.playVRMAAnimation(vrmaPath, {
             loop: false,
             fadeInDuration: 0.5,
@@ -165,7 +203,7 @@
           });
           if (played !== true || playRequestId !== state.playRequestId) {
             if (motionRuntimeHeld) {
-              await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
+              await releaseOwnedNekoMotionPlayback(state, { token: playRequestId, resume: true });
             }
             return;
           }
@@ -175,7 +213,7 @@
         } catch (error) {
           console.error('[Jukebox] VRMA 播放失败:', error);
           if (motionRuntimeHeld) {
-            await releaseNekoMotionPlayback({ token: playRequestId, resume: true });
+            await releaseOwnedNekoMotionPlayback(state, { token: playRequestId, resume: true });
           }
         } finally {
           finishNativeAnimationPlayback(state, playRequestId);
@@ -220,15 +258,23 @@
         state.playRequestId += 1;
         var restoreRequestId = state.playRequestId;
         var modelType = facade.getModelType();
+        var canResumeVrm = modelType === 'vrm' && window.vrmManager &&
+          typeof window.vrmManager.playVRMAAnimation === 'function';
+        var heldRuntimeToken = state.vrmMotionRuntimeToken;
+        var motionRuntimeRestored = false;
 
-        if (modelType === 'vrm' && window.vrmManager && typeof window.vrmManager.playVRMAAnimation === 'function') {
+        if (heldRuntimeToken !== null) {
+          var releaseResult = releaseOwnedNekoMotionPlayback(state, {
+            token: heldRuntimeToken,
+            resume: !!canResumeVrm,
+            scheduleNext: !!canResumeVrm
+          });
+          motionRuntimeRestored = releaseResult === false ? false : await releaseResult;
+          if (restoreRequestId !== state.playRequestId) return;
+        }
+
+        if (canResumeVrm) {
           try {
-            var releaseResult = releaseNekoMotionPlayback({
-              resume: true,
-              scheduleNext: true
-            });
-            var motionRuntimeRestored = releaseResult === false ? false : await releaseResult;
-            if (restoreRequestId !== state.playRequestId) return;
             if (motionRuntimeRestored) return;
             var vrmIdleList = window.lanlan_config && window.lanlan_config.vrmIdleAnimations;
             var vrmIdleUrl = Array.isArray(vrmIdleList) && vrmIdleList.length > 0 ? vrmIdleList[0] : null;
@@ -250,6 +296,8 @@
           }
           return;
         }
+
+        if (modelType === 'vrm') return;
 
         if (!window.mmdManager) return;
 

--- a/static/jukebox/jukebox/core.js
+++ b/static/jukebox/jukebox/core.js
@@ -137,6 +137,9 @@ Object.assign(window.Jukebox, {
     // 「欠着一次待机恢复」：stopVMD(true) 把舞蹈停掉却跳过恢复时置真，
     // 由真正接上动画或真正回到静止的那一方清账。见 transport.js 的 settleIdleRestore。
     idleRestorePending: false,
+    // 记录实际取得的 NekoMotion owner token；模型热切换不会刷新页面，释放时不能
+    // 依赖当前 modelType 判断这段占用最初属于谁。
+    vrmMotionRuntimeToken: null,
     controlOwnerChannel: null,
     controlOwnerHeartbeatTimer: null,
     // 拥有者是否已经能真的执行指令（曲库拉完、播放器建好）。宣告归属要尽早，

--- a/static/jukebox/jukebox/transport.js
+++ b/static/jukebox/jukebox/transport.js
@@ -1469,6 +1469,9 @@ Object.assign(window.Jukebox, {
     const nextSong = Jukebox.getNextSongToPlay(endedSong);
     rollback.markAdvanced();
     const nextAction = nextSong ? Jukebox.getActionForModel(nextSong) : null;
+    // 自动续播也是一条独立播放请求：先作废旧歌曲仍在加载的动作。没有接班动作时
+    // stopVMD(false) 可能再推进一次世代来保护异步待机恢复，下面会取它的最终值。
+    if (nextSong) Jukebox.State.playRequestId += 1;
     Jukebox.stopVMD(!!nextAction);
     Jukebox.State.isPlaying = false;
     Jukebox.State.isPaused = false;
@@ -1477,6 +1480,8 @@ Object.assign(window.Jukebox, {
     Jukebox.updateStoppedStatus();
 
     if (nextSong) {
+      // 旧歌曲与接班歌曲不能复用 runtime hold token，否则旧请求收尾时会误释放
+      // 接班者；若上面的待机恢复又推进了世代，以推进后的值为准。
       const requestId = Jukebox.State.playRequestId;
       const scheduledMode = Jukebox.State.playbackMode;
       const fromQueue = scheduledMode === 'random';

--- a/static/jukebox/jukebox/transport.js
+++ b/static/jukebox/jukebox/transport.js
@@ -1880,14 +1880,8 @@ Object.assign(window.Jukebox, {
       Jukebox.stopVMD(true); // 停止之前的舞蹈动画
       const playRequestId = Jukebox.State.playRequestId;
       motionRuntimeToken = playRequestId;
-      if (Jukebox.State.vrmMotionRuntimeToken !== null) {
-        const previousRelease = Jukebox.releaseVrmMotionRuntime({
-          resume: false,
-          scheduleNext: false
-        });
-        if (previousRelease !== false) await previousRelease;
-        if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;
-      }
+      // 同一个 owner 的新 token 会在运行时内原子替换旧 token。先释放再占用会在
+      // 冷启动时等待完整初始化，让接班舞蹈落后于已经开始的音频。
       const holdResult = Jukebox.holdVrmMotionRuntime(playRequestId);
       motionRuntimeHeld = holdResult === false ? false : await holdResult;
       if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;

--- a/static/jukebox/jukebox/transport.js
+++ b/static/jukebox/jukebox/transport.js
@@ -1764,6 +1764,15 @@ Object.assign(window.Jukebox, {
 
       Jukebox.stopVMD(true); // skipIdleRestore = true
 
+      if (Jukebox.State.vrmMotionRuntimeToken !== null) {
+        const releaseResult = Jukebox.releaseVrmMotionRuntime({
+          resume: false,
+          scheduleNext: false
+        });
+        if (releaseResult !== false) await releaseResult;
+        if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;
+      }
+
       await window.mmdManager.loadAnimation(vmdPath);
       if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;
       window.mmdManager.playAnimation('dance');
@@ -1800,7 +1809,10 @@ Object.assign(window.Jukebox, {
         }
         return false;
       }
-      if (held === true) Jukebox.State.idleRestorePending = true;
+      if (held === true) {
+        Jukebox.State.idleRestorePending = true;
+        Jukebox.State.vrmMotionRuntimeToken = requestId;
+      }
       return held === true;
     }).catch(function(error) {
       console.warn('[Jukebox] VRM 动作运行时占用失败，继续使用底层播放器:', error);
@@ -1811,14 +1823,26 @@ Object.assign(window.Jukebox, {
   releaseVrmMotionRuntime: function(options = {}) {
     const runtime = window.NekoMotion;
     if (!runtime || typeof runtime.releaseExternalPlayback !== 'function') return false;
+    const releaseOptions = { ...options };
+    if (!Object.prototype.hasOwnProperty.call(releaseOptions, 'token') &&
+        Jukebox.State.vrmMotionRuntimeToken !== null) {
+      releaseOptions.token = Jukebox.State.vrmMotionRuntimeToken;
+    }
+    const releaseToken = Object.prototype.hasOwnProperty.call(releaseOptions, 'token')
+      ? releaseOptions.token
+      : null;
     let releaseRequest;
     try {
-      releaseRequest = runtime.releaseExternalPlayback('jukebox', options);
+      releaseRequest = runtime.releaseExternalPlayback('jukebox', releaseOptions);
     } catch (error) {
       console.warn('[Jukebox] VRM 动作运行时释放失败，回退直接恢复待机:', error);
       return false;
     }
     return Promise.resolve(releaseRequest).then(function(released) {
+      if (released === true && releaseToken !== null &&
+          Jukebox.State.vrmMotionRuntimeToken === releaseToken) {
+        Jukebox.State.vrmMotionRuntimeToken = null;
+      }
       return released === true;
     }).catch(function(error) {
       console.warn('[Jukebox] VRM 动作运行时释放失败，回退直接恢复待机:', error);
@@ -1851,6 +1875,14 @@ Object.assign(window.Jukebox, {
       Jukebox.stopVMD(true); // 停止之前的舞蹈动画
       const playRequestId = Jukebox.State.playRequestId;
       motionRuntimeToken = playRequestId;
+      if (Jukebox.State.vrmMotionRuntimeToken !== null) {
+        const previousRelease = Jukebox.releaseVrmMotionRuntime({
+          resume: false,
+          scheduleNext: false
+        });
+        if (previousRelease !== false) await previousRelease;
+        if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;
+      }
       const holdResult = Jukebox.holdVrmMotionRuntime(playRequestId);
       motionRuntimeHeld = holdResult === false ? false : await holdResult;
       if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;
@@ -2271,17 +2303,29 @@ Object.assign(window.Jukebox, {
       return;
     }
 
-    // VRM 模式：恢复 VRM 待机动画
     var modelType = Jukebox.getModelType();
-    if (modelType === 'vrm' && window.vrmManager) {
+    var canResumeVrm = modelType === 'vrm' && !!window.vrmManager;
+    var heldRuntimeToken = Jukebox.State.vrmMotionRuntimeToken;
+    const restoreRequestId = (heldRuntimeToken !== null || canResumeVrm)
+      ? ++Jukebox.State.playRequestId
+      : Jukebox.State.playRequestId;
+    var motionRuntimeRestored = false;
+
+    // 模型切换是同页热切换。即使当前已经是 MMD/Live2D，仍需释放先前 VRM
+    // 舞蹈取得的 token；此时只解锁，不唤起旧 VRM 的待机动作。
+    if (heldRuntimeToken !== null) {
+      const releaseResult = Jukebox.releaseVrmMotionRuntime({
+        token: heldRuntimeToken,
+        resume: canResumeVrm,
+        scheduleNext: canResumeVrm
+      });
+      motionRuntimeRestored = releaseResult === false ? false : await releaseResult;
+      if (restoreRequestId !== Jukebox.State.playRequestId) return;
+    }
+
+    // VRM 模式：恢复 VRM 待机动画
+    if (canResumeVrm) {
       try {
-        const restoreRequestId = ++Jukebox.State.playRequestId;
-        const releaseResult = Jukebox.releaseVrmMotionRuntime({
-          resume: true,
-          scheduleNext: true
-        });
-        const motionRuntimeRestored = releaseResult === false ? false : await releaseResult;
-        if (restoreRequestId !== Jukebox.State.playRequestId) return;
         if (motionRuntimeRestored === true) {
           console.log('[Jukebox] VRM 待机动画已由动作运行时恢复');
           return;
@@ -2307,9 +2351,9 @@ Object.assign(window.Jukebox, {
       return;
     }
 
-    if (!window.mmdManager) return;
+    if (modelType === 'vrm') return;
 
-    const restoreRequestId = Jukebox.State.playRequestId;
+    if (!window.mmdManager) return;
 
     let idleUrl = Jukebox.State.savedIdleAnimationUrl;
 

--- a/static/jukebox/jukebox/transport.js
+++ b/static/jukebox/jukebox/transport.js
@@ -1778,6 +1778,54 @@ Object.assign(window.Jukebox, {
     }
   },
 
+  holdVrmMotionRuntime: function(requestId) {
+    const runtime = window.NekoMotion;
+    if (!runtime || typeof runtime.holdExternalPlayback !== 'function') return false;
+    let holdRequest;
+    try {
+      holdRequest = runtime.holdExternalPlayback('jukebox', { token: requestId });
+    } catch (error) {
+      console.warn('[Jukebox] VRM 动作运行时占用失败，继续使用底层播放器:', error);
+      return false;
+    }
+    return Promise.resolve(holdRequest).then(async function(held) {
+      if (!Jukebox.isPlaybackRequestCurrent(requestId)) {
+        // 旧加载请求晚到时，只能释放自己的 token。若新歌已经接管，同 owner
+        // 的 token 已被替换，这次释放会成为无操作，不会误恢复待机。
+        if (held === true && typeof runtime.releaseExternalPlayback === 'function') {
+          await runtime.releaseExternalPlayback('jukebox', {
+            token: requestId,
+            resume: true
+          });
+        }
+        return false;
+      }
+      if (held === true) Jukebox.State.idleRestorePending = true;
+      return held === true;
+    }).catch(function(error) {
+      console.warn('[Jukebox] VRM 动作运行时占用失败，继续使用底层播放器:', error);
+      return false;
+    });
+  },
+
+  releaseVrmMotionRuntime: function(options = {}) {
+    const runtime = window.NekoMotion;
+    if (!runtime || typeof runtime.releaseExternalPlayback !== 'function') return false;
+    let releaseRequest;
+    try {
+      releaseRequest = runtime.releaseExternalPlayback('jukebox', options);
+    } catch (error) {
+      console.warn('[Jukebox] VRM 动作运行时释放失败，回退直接恢复待机:', error);
+      return false;
+    }
+    return Promise.resolve(releaseRequest).then(function(released) {
+      return released === true;
+    }).catch(function(error) {
+      console.warn('[Jukebox] VRM 动作运行时释放失败，回退直接恢复待机:', error);
+      return false;
+    });
+  },
+
   // 播放 VRMA 动画（VRM 模型）
   playVRMA: async function(vrmaPath, options = {}) {
     const requestId = options.requestId;
@@ -1795,11 +1843,29 @@ Object.assign(window.Jukebox, {
       return false;
     }
 
+    let motionRuntimeToken = null;
+    let motionRuntimeHeld = false;
     try {
       console.log('[Jukebox] 播放 VRMA 动画:', vrmaPath);
 
       Jukebox.stopVMD(true); // 停止之前的舞蹈动画
       const playRequestId = Jukebox.State.playRequestId;
+      motionRuntimeToken = playRequestId;
+      const holdResult = Jukebox.holdVrmMotionRuntime(playRequestId);
+      motionRuntimeHeld = holdResult === false ? false : await holdResult;
+      if (!Jukebox.isPlaybackRequestCurrent(requestId)) return false;
+
+      const releaseFailedStart = async function() {
+        if (!motionRuntimeHeld) return false;
+        const released = await Jukebox.releaseVrmMotionRuntime({
+          token: playRequestId,
+          resume: true
+        });
+        if (released === true && Jukebox.isPlaybackRequestCurrent(requestId)) {
+          Jukebox.State.idleRestorePending = false;
+        }
+        return released;
+      };
 
       // 使用 VRMManager 播放 VRMA（manager 内部会确保 animation 模块已初始化）
       const animationStarted = await window.vrmManager.playVRMAAnimation(vrmaPath, {
@@ -1808,13 +1874,30 @@ Object.assign(window.Jukebox, {
         fadeOutDuration: 0.5,
         shouldStart: () => Jukebox.isPlaybackRequestCurrent(requestId)
       });
-      if (animationStarted !== true) return false;
-      if (playRequestId !== Jukebox.State.playRequestId || !Jukebox.isPlaybackRequestCurrent(requestId)) return false;
+      if (animationStarted !== true) {
+        await releaseFailedStart();
+        return false;
+      }
+      if (playRequestId !== Jukebox.State.playRequestId || !Jukebox.isPlaybackRequestCurrent(requestId)) {
+        await releaseFailedStart();
+        return false;
+      }
       Jukebox.State.isVMDPlaying = true;
       console.log('[Jukebox] VRMA 动画已播放:', vrmaPath);
       return true;
     } catch (error) {
       console.error('[Jukebox] VRMA 播放失败:', error);
+      // playVRMA 可能在 holdExternalPlayback 之后的加载/解析阶段失败。对应 token
+      // 仍属于本请求时释放它，避免待机轮换被永久暂停。
+      if (motionRuntimeHeld) {
+        const released = await Jukebox.releaseVrmMotionRuntime({
+          token: motionRuntimeToken,
+          resume: true
+        });
+        if (released === true && Jukebox.isPlaybackRequestCurrent(requestId)) {
+          Jukebox.State.idleRestorePending = false;
+        }
+      }
       return false;
     }
   },
@@ -2192,13 +2275,23 @@ Object.assign(window.Jukebox, {
     var modelType = Jukebox.getModelType();
     if (modelType === 'vrm' && window.vrmManager) {
       try {
+        const restoreRequestId = ++Jukebox.State.playRequestId;
+        const releaseResult = Jukebox.releaseVrmMotionRuntime({
+          resume: true,
+          scheduleNext: true
+        });
+        const motionRuntimeRestored = releaseResult === false ? false : await releaseResult;
+        if (restoreRequestId !== Jukebox.State.playRequestId) return;
+        if (motionRuntimeRestored === true) {
+          console.log('[Jukebox] VRM 待机动画已由动作运行时恢复');
+          return;
+        }
         var vrmIdleList = window.lanlan_config?.vrmIdleAnimations;
         var vrmIdleUrl = (Array.isArray(vrmIdleList) && vrmIdleList.length > 0) ? vrmIdleList[0] : null;
         if (!vrmIdleUrl) {
           vrmIdleUrl = window.lanlan_config?.vrmIdleAnimation || '/static/vrm/animation/wait03.vrma.gz';
         }
         vrmIdleUrl = normalizeJukeboxBundledVrmIdleUrl(vrmIdleUrl);
-        const restoreRequestId = ++Jukebox.State.playRequestId;
         await window.vrmManager.playVRMAAnimation(vrmIdleUrl, {
           loop: true,
           isIdle: true,

--- a/static/vrm/motion/player.js
+++ b/static/vrm/motion/player.js
@@ -737,8 +737,10 @@
             const settings = options || {};
             const ownerKey = String(owner || 'external');
             if (!this.externalPlaybackOwners.has(ownerKey)) return false;
-            if (Object.prototype.hasOwnProperty.call(settings, 'token')
-                && this.externalPlaybackOwners.get(ownerKey) !== settings.token) {
+            const hasToken = Object.prototype.hasOwnProperty.call(settings, 'token');
+            const heldToken = this.externalPlaybackOwners.get(ownerKey);
+            if ((hasToken && heldToken !== settings.token)
+                || (!hasToken && heldToken !== null)) {
                 return false;
             }
 

--- a/static/vrm/motion/player.js
+++ b/static/vrm/motion/player.js
@@ -829,6 +829,10 @@
 
         async _resumeBase(generation, seed, scheduleNext) {
             if (generation !== this.queueGeneration) return false;
+            if (this.externalPlaybackOwners.size > 0) {
+                this.metrics.externalPlaybackBlocks += 1;
+                return false;
+            }
             if (this.state.posture !== 'stand' && this.state.poseAsset) {
                 this.state.phase = 'pose';
                 const played = await this._playAsset(this.state.poseAsset, generation, {

--- a/static/vrm/motion/player.js
+++ b/static/vrm/motion/player.js
@@ -1072,6 +1072,9 @@
             const seed = context && context.seed || Date.now();
             this.sequence += 1;
             const task = async () => {
+                // hold/cancel 会替换 this.queue，但旧 Promise 已排进微任务队列的 task
+                // 仍可能晚到；必须在写 busy 前先验世代，避免把已清零的状态重新置真。
+                if (generation !== this.queueGeneration) return false;
                 this.busy = true;
                 let succeeded = true;
                 for (let index = 0; index < items.length; index += 1) {

--- a/static/vrm/motion/player.js
+++ b/static/vrm/motion/player.js
@@ -148,6 +148,11 @@
             this.idleActivityVersion = 0;
             this.idleScheduleSequence = 0;
             this.lastIdleDelayMs = 0;
+            // 外部功能（目前是点歌台）直接占用同一个 VRMA mixer 时，语义动作运行时
+            // 必须暂停待机轮换和对话动作，否则仍保持 rest 状态的旧定时器会在
+            // 18-38 秒后把正在播放的整曲舞蹈覆盖掉。Map 中的 token 用来防止旧的
+            // 异步播放请求在新请求接管后误释放占用。
+            this.externalPlaybackOwners = new Map();
             this.busy = false;
             this.sequence = 0;
             this.lastByIntent = new Map();
@@ -165,6 +170,9 @@
                 restEntries: 0,
                 idleSchedules: 0,
                 idleSwitches: 0,
+                externalPlaybackHolds: 0,
+                externalPlaybackReleases: 0,
+                externalPlaybackBlocks: 0,
                 heldAfterAction: 0,
                 cancelled: 0
             };
@@ -640,7 +648,8 @@
 
         _scheduleIdleSwitch(generation, seed, mode, allowBusy) {
             this._clearIdleSwitch();
-            if (generation !== this.queueGeneration || (!allowBusy && this.busy)
+            if (this.externalPlaybackOwners.size > 0
+                || generation !== this.queueGeneration || (!allowBusy && this.busy)
                 || this.state.posture !== 'stand' || this.state.phase !== 'rest'
                 || !this.state.restAsset) return false;
 
@@ -667,6 +676,7 @@
                 this.idleSwitchTimer = null;
                 if (generation !== this.queueGeneration
                     || activityVersion !== this.idleActivityVersion
+                    || this.externalPlaybackOwners.size > 0
                     || this.busy || this.state.posture !== 'stand'
                     || this.state.phase !== 'rest') return;
                 this.metrics.idleSwitches += 1;
@@ -700,9 +710,67 @@
             );
         }
 
+        holdExternalPlayback(owner, options) {
+            const settings = options || {};
+            const ownerKey = String(owner || 'external');
+            const token = Object.prototype.hasOwnProperty.call(settings, 'token')
+                ? settings.token : null;
+
+            this.externalPlaybackOwners.set(ownerKey, token);
+            this.idleActivityVersion += 1;
+            this._clearIdleSwitch();
+            this.queueGeneration += 1;
+            this._releaseWaiters();
+            this.queue = Promise.resolve();
+            this.busy = false;
+            this.state.phase = 'external';
+            this.state.currentAsset = null;
+            this.metrics.externalPlaybackHolds += 1;
+            emit('neko-motion-playback', {
+                status: 'external-held',
+                owner: ownerKey
+            });
+            return true;
+        }
+
+        async releaseExternalPlayback(owner, options) {
+            const settings = options || {};
+            const ownerKey = String(owner || 'external');
+            if (!this.externalPlaybackOwners.has(ownerKey)) return false;
+            if (Object.prototype.hasOwnProperty.call(settings, 'token')
+                && this.externalPlaybackOwners.get(ownerKey) !== settings.token) {
+                return false;
+            }
+
+            this.externalPlaybackOwners.delete(ownerKey);
+            this.metrics.externalPlaybackReleases += 1;
+            if (this.externalPlaybackOwners.size > 0) return true;
+
+            this.queueGeneration += 1;
+            this._releaseWaiters();
+            this.queue = Promise.resolve();
+            this.busy = false;
+            const generation = this.queueGeneration;
+            if (settings.resume === false) {
+                this.state.phase = 'boot';
+                this.state.currentAsset = null;
+                return true;
+            }
+
+            return this._resumeBase(
+                generation,
+                'external-release:' + ownerKey,
+                settings.scheduleNext !== false
+            );
+        }
+
         async enterRest(options) {
             const settings = options || {};
             this._clearIdleSwitch();
+            if (this.externalPlaybackOwners.size > 0) {
+                this.metrics.externalPlaybackBlocks += 1;
+                return false;
+            }
             if (settings.idleActivityVersion === undefined) {
                 this.idleActivityVersion += 1;
             } else if (settings.idleActivityVersion !== this.idleActivityVersion) {
@@ -994,6 +1062,10 @@
         }
 
         enqueuePlan(plan, context) {
+            if (this.externalPlaybackOwners.size > 0) {
+                this.metrics.externalPlaybackBlocks += 1;
+                return Promise.resolve(false);
+            }
             const items = Array.isArray(plan) ? plan.slice(0, 3) : [];
             if (!items.length) return Promise.resolve(false);
             const generation = this.queueGeneration || this.beginPlan();
@@ -1031,6 +1103,10 @@
         }
 
         playPlan(plan, context) {
+            if (this.externalPlaybackOwners.size > 0) {
+                this.metrics.externalPlaybackBlocks += 1;
+                return Promise.resolve(false);
+            }
             this.beginPlan();
             return this.enqueuePlan(plan, context);
         }
@@ -1076,6 +1152,7 @@
                 poseAsset: this.state.poseAsset && this.state.poseAsset.id || null,
                 poseStyle: this.state.poseStyle,
                 busy: this.busy,
+                externalPlaybackOwners: Array.from(this.externalPlaybackOwners.keys()),
                 assets: this.assets.length,
                 cachedAssets: 0,
                 idleTimerPending: !!this.idleSwitchTimer,

--- a/static/vrm/motion/runtime.js
+++ b/static/vrm/motion/runtime.js
@@ -53,6 +53,10 @@
     let lastCasualTalkAt = 0;
     let selectedMode = configuredMode();
     let readyPromise = null;
+    let runtimeReady = false;
+    // 外部播放可能在冷启动初始化完成前到达。先同步记账，让调用方无需等待
+    // semantics/persona/idle 加载；player 一创建就补记，并跳过初始化待机。
+    const externalPlaybackOwners = new Map();
     let activeCharacterProfile = null;
     let ownsPlayback = false;
     const emotionState = {
@@ -411,16 +415,20 @@
             });
             core = new window.NekoMotionCore(semantics);
             player = new window.NekoMotionPlayer();
+            externalPlaybackOwners.forEach(function (token, owner) {
+                player.holdExternalPlayback(owner, { token: token });
+            });
             await player.load();
             syncSavedRestAnimations();
             core.registerActionCards(player.assets);
             await resolveCharacterProfile();
             if (refreshMode() !== 'vrm') {
                 releasePlaybackOwnership();
+                runtimeReady = true;
                 return true;
             }
             acquirePlaybackOwnership();
-            if (vrmReady()) {
+            if (vrmReady() && externalPlaybackOwners.size === 0) {
                 await player.enterRest({
                     profile: characterProfile(),
                     seed: 'initialize',
@@ -428,10 +436,12 @@
                     reselect: true
                 });
             }
+            runtimeReady = true;
             console.info('[NekoMotion] runtime ready; one playback owner, no prompt injection and no model call');
             return true;
         })().catch(function (error) {
             console.error('[NekoMotion] initialization failed:', error);
+            runtimeReady = false;
             releasePlaybackOwnership();
             readyPromise = null;
             return false;
@@ -1254,13 +1264,42 @@
             }, options || {}));
         },
         holdExternalPlayback: async function (owner, options) {
-            await requireInitialized();
-            return player.holdExternalPlayback(owner, options || {});
+            const settings = options || {};
+            const ownerKey = String(owner || 'external');
+            const token = Object.prototype.hasOwnProperty.call(settings, 'token')
+                ? settings.token : null;
+            externalPlaybackOwners.set(ownerKey, token);
+            if (player) player.holdExternalPlayback(ownerKey, settings);
+            if (!runtimeReady) void initialize();
+            return true;
         },
         releaseExternalPlayback: async function (owner, options) {
-            await requireInitialized();
-            syncSavedRestAnimations();
-            return player.releaseExternalPlayback(owner, options || {});
+            const settings = options || {};
+            const ownerKey = String(owner || 'external');
+            if (!externalPlaybackOwners.has(ownerKey)) return false;
+            if (Object.prototype.hasOwnProperty.call(settings, 'token')
+                && externalPlaybackOwners.get(ownerKey) !== settings.token) {
+                return false;
+            }
+            externalPlaybackOwners.delete(ownerKey);
+            const pendingInitialization = !runtimeReady ? readyPromise : null;
+            if (player) {
+                syncSavedRestAnimations();
+                const released = await player.releaseExternalPlayback(ownerKey, Object.assign({}, settings, {
+                    // 初始化尚未完成时不从半成品 player 恢复；initialize 会在无 owner 时
+                    // 统一进入待机，避免冷启动 release 和初始化 idle 互相抢占。
+                    resume: runtimeReady ? settings.resume : false
+                }));
+                if (released !== true) return false;
+            } else if (!pendingInitialization) {
+                return false;
+            }
+            if (pendingInitialization) {
+                // hold 是乐观且立即成功的；若后台初始化最终失败，必须把失败传给调用方，
+                // 让点歌台回退到底层 VRM 待机恢复，不能把“已删除 owner”误报成“已恢复”。
+                return await pendingInitialization === true;
+            }
+            return true;
         },
         stats: function () {
             refreshMode();

--- a/static/vrm/motion/runtime.js
+++ b/static/vrm/motion/runtime.js
@@ -1,8 +1,9 @@
 (function () {
     'use strict';
 
-    // Ownership is acquired only after the catalog is ready. A failed startup
-    // must not leave the official idle controller permanently disabled.
+    // A cold external hold acquires ownership before the catalog is ready so
+    // the official idle scheduler cannot race the jukebox. Failed startup must
+    // hand ownership back after the last external owner releases it.
     window.__nekoMotionOwnsVrmPlayback = false;
 
     const SEMANTICS_URL = '/static/vrm/motion/semantics.json';
@@ -442,7 +443,12 @@
         })().catch(function (error) {
             console.error('[NekoMotion] initialization failed:', error);
             runtimeReady = false;
-            releasePlaybackOwnership();
+            if (player && typeof player.cancel === 'function') {
+                player.cancel('initialization_failed', { resume: false });
+            }
+            core = null;
+            player = null;
+            if (externalPlaybackOwners.size === 0) releasePlaybackOwnership();
             readyPromise = null;
             return false;
         });
@@ -1269,6 +1275,7 @@
             const token = Object.prototype.hasOwnProperty.call(settings, 'token')
                 ? settings.token : null;
             externalPlaybackOwners.set(ownerKey, token);
+            if (refreshMode() === 'vrm') acquirePlaybackOwnership();
             if (player) player.holdExternalPlayback(ownerKey, settings);
             if (!runtimeReady) void initialize();
             return true;
@@ -1292,12 +1299,19 @@
                 }));
                 if (released !== true) return false;
             } else if (!pendingInitialization) {
+                if (externalPlaybackOwners.size === 0) releasePlaybackOwnership();
                 return false;
             }
             if (pendingInitialization) {
                 // hold 是乐观且立即成功的；若后台初始化最终失败，必须把失败传给调用方，
                 // 让点歌台回退到底层 VRM 待机恢复，不能把“已删除 owner”误报成“已恢复”。
-                return await pendingInitialization === true;
+                const initialized = await pendingInitialization === true;
+                if (!initialized && externalPlaybackOwners.size === 0) releasePlaybackOwnership();
+                return initialized;
+            }
+            if (!runtimeReady) {
+                if (externalPlaybackOwners.size === 0) releasePlaybackOwnership();
+                return false;
             }
             return true;
         },

--- a/static/vrm/motion/runtime.js
+++ b/static/vrm/motion/runtime.js
@@ -1299,18 +1299,22 @@
                 }));
                 if (released !== true) return false;
             } else if (!pendingInitialization) {
-                if (externalPlaybackOwners.size === 0) releasePlaybackOwnership();
+                if (externalPlaybackOwners.size > 0) return true;
+                releasePlaybackOwnership();
                 return false;
             }
             if (pendingInitialization) {
                 // hold 是乐观且立即成功的；若后台初始化最终失败，必须把失败传给调用方，
-                // 让点歌台回退到底层 VRM 待机恢复，不能把“已删除 owner”误报成“已恢复”。
+                // 最后一个 owner 释放时让点歌台回退到底层 VRM 待机恢复；其他 owner
+                // 仍持有播放权时则保持成功，避免其中一个调用方提前恢复待机。
                 const initialized = await pendingInitialization === true;
-                if (!initialized && externalPlaybackOwners.size === 0) releasePlaybackOwnership();
-                return initialized;
+                if (initialized || externalPlaybackOwners.size > 0) return true;
+                releasePlaybackOwnership();
+                return false;
             }
             if (!runtimeReady) {
-                if (externalPlaybackOwners.size === 0) releasePlaybackOwnership();
+                if (externalPlaybackOwners.size > 0) return true;
+                releasePlaybackOwnership();
                 return false;
             }
             return true;

--- a/static/vrm/motion/runtime.js
+++ b/static/vrm/motion/runtime.js
@@ -1284,8 +1284,10 @@
             const settings = options || {};
             const ownerKey = String(owner || 'external');
             if (!externalPlaybackOwners.has(ownerKey)) return false;
-            if (Object.prototype.hasOwnProperty.call(settings, 'token')
-                && externalPlaybackOwners.get(ownerKey) !== settings.token) {
+            const hasToken = Object.prototype.hasOwnProperty.call(settings, 'token');
+            const heldToken = externalPlaybackOwners.get(ownerKey);
+            if ((hasToken && heldToken !== settings.token)
+                || (!hasToken && heldToken !== null)) {
                 return false;
             }
             externalPlaybackOwners.delete(ownerKey);
@@ -1308,7 +1310,18 @@
                 // 最后一个 owner 释放时让点歌台回退到底层 VRM 待机恢复；其他 owner
                 // 仍持有播放权时则保持成功，避免其中一个调用方提前恢复待机。
                 const initialized = await pendingInitialization === true;
-                if (initialized || externalPlaybackOwners.size > 0) return true;
+                if (externalPlaybackOwners.size > 0) return true;
+                if (initialized) {
+                    if (settings.resume === false) {
+                        // 初始化可能在 owner 删除后短暂进入了语义待机；无恢复释放必须
+                        // 清掉该状态并交还官方待机调度，不能遗留全局播放所有权。
+                        if (player && typeof player.cancel === 'function') {
+                            player.cancel('external_release_without_resume', { resume: false });
+                        }
+                        releasePlaybackOwnership();
+                    }
+                    return true;
+                }
                 releasePlaybackOwnership();
                 return false;
             }
@@ -1316,6 +1329,9 @@
                 if (externalPlaybackOwners.size > 0) return true;
                 releasePlaybackOwnership();
                 return false;
+            }
+            if (externalPlaybackOwners.size === 0 && settings.resume === false) {
+                releasePlaybackOwnership();
             }
             return true;
         },

--- a/static/vrm/motion/runtime.js
+++ b/static/vrm/motion/runtime.js
@@ -1253,6 +1253,15 @@
                 force: true
             }, options || {}));
         },
+        holdExternalPlayback: async function (owner, options) {
+            await requireInitialized();
+            return player.holdExternalPlayback(owner, options || {});
+        },
+        releaseExternalPlayback: async function (owner, options) {
+            await requireInitialized();
+            syncSavedRestAnimations();
+            return player.releaseExternalPlayback(owner, options || {});
+        },
         stats: function () {
             refreshMode();
             return {

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -314,6 +314,127 @@ def test_jukebox_vrm_dance_holds_motion_runtime_until_stop_in_web_and_pet(mock_p
 
 
 @pytest.mark.frontend
+def test_jukebox_vrma_replacement_atomically_replaces_runtime_token(mock_page: Page):
+    mock_page.set_content(
+        """
+        <script>
+          window.__nekoJukeboxToggle = function() {};
+          window.t = (key, fallback) => fallback || key;
+        </script>
+        """
+    )
+    mock_page.add_script_tag(content=JUKEBOX_LOADER_SCRIPT)
+
+    native_result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          let finishRelease = null;
+          window.lanlan_config = { model_type: 'live3d', live3d_sub_type: 'vrm' };
+          window.NekoMotion = {
+            holdExternalPlayback: async (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return true;
+            },
+            releaseExternalPlayback: (owner, options) => {
+              calls.push(`release:${owner}:${options.token}:${options.resume}`);
+              return new Promise((resolve) => { finishRelease = resolve; });
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            },
+            stopVRMAAnimation: () => calls.push('stop')
+          };
+
+          await window.Jukebox.playVRMA('/first.vrma');
+          const replacement = window.Jukebox.playVRMA('/second.vrma');
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const callsBeforeAnyRelease = calls.slice();
+          const blockedOnRelease = finishRelease !== null;
+          if (finishRelease) finishRelease(true);
+          await replacement;
+          return {
+            callsBeforeAnyRelease,
+            blockedOnRelease,
+            token: window.Jukebox.State.vrmMotionRuntimeToken
+          };
+        }
+        """
+    )
+    assert native_result == {
+        "callsBeforeAnyRelease": [
+            "hold:jukebox:1",
+            "play:/first.vrma",
+            "stop",
+            "hold:jukebox:2",
+            "play:/second.vrma",
+        ],
+        "blockedOnRelease": False,
+        "token": 2,
+    }
+
+    setup_jukebox_page(mock_page)
+    web_result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          let finishRelease = null;
+          const J = window.Jukebox;
+          J.getModelType = () => 'vrm';
+          window.NekoMotion = {
+            holdExternalPlayback: async (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return true;
+            },
+            releaseExternalPlayback: (owner, options) => {
+              calls.push(`release:${owner}:${options.token}:${options.resume}`);
+              return new Promise((resolve) => { finishRelease = resolve; });
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            },
+            stopVRMAAnimation: () => calls.push('stop')
+          };
+
+          await J.playVRMA('/first.vrma', { requestId: J.State.playRequestId });
+          J.State.playRequestId += 1;
+          const requestId = J.State.playRequestId;
+          const replacement = J.playVRMA('/second.vrma', { requestId });
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const callsBeforeAnyRelease = calls.slice();
+          const blockedOnRelease = finishRelease !== null;
+          if (finishRelease) finishRelease(true);
+          const started = await replacement;
+          return {
+            callsBeforeAnyRelease,
+            blockedOnRelease,
+            started,
+            token: J.State.vrmMotionRuntimeToken
+          };
+        }
+        """
+    )
+    assert web_result == {
+        "callsBeforeAnyRelease": [
+            "hold:jukebox:0",
+            "play:/first.vrma",
+            "stop",
+            "hold:jukebox:1",
+            "play:/second.vrma",
+        ],
+        "blockedOnRelease": False,
+        "started": True,
+        "token": 1,
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_native_stop_cancels_vrma_while_runtime_hold_is_pending(mock_page: Page):
     mock_page.set_content(
         """

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -3642,7 +3642,7 @@ def test_jukebox_audio_end_queued_next_respects_request_generation(mock_page: Pa
     assert result == {
         "played": [],
         "currentSong": None,
-        "playRequestId": 8,
+        "playRequestId": 9,
     }
 
 
@@ -5083,6 +5083,49 @@ def test_jukebox_auto_advance_restores_idle_when_the_successor_animation_fails(m
     assert result["advanced"] == "song2"
     # 接班动画没起来 -> 待机必须接回去。
     assert result["idleRestored"] is True
+
+
+@pytest.mark.frontend
+def test_jukebox_auto_advance_allocates_a_fresh_playback_request(mock_page: Page):
+    """A successor must not share the ended track's VRMA hold token."""
+    setup_headless_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          await J.ensureRuntime({ headless: true });
+          J.State.playbackMode = 'sequence';
+          J.State.currentSong = J.State.songs[0];
+          J.State.isPlaying = true;
+          J.State.isVMDPlaying = false;
+          J.State.playRequestId = 73;
+
+          let successorRequestId = null;
+          const originalPlaySong = J.playSong;
+          J.playSong = async (songId, options = {}) => {
+            successorRequestId = options.requestId;
+            return J.State.songs.find(song => song.id === songId) || null;
+          };
+          try {
+            J.handleAudioEnded(J.getPlayer());
+            await new Promise(resolve => setTimeout(resolve, 20));
+          } finally {
+            J.playSong = originalPlaySong;
+          }
+
+          return {
+            successorRequestId,
+            currentRequestId: J.State.playRequestId
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "successorRequestId": 74,
+        "currentRequestId": 74,
+    }
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -211,6 +211,109 @@ def test_jukebox_loader_native_mode_keeps_animation_facade(mock_page: Page):
 
 
 @pytest.mark.frontend
+def test_jukebox_vrm_dance_holds_motion_runtime_until_stop_in_web_and_pet(mock_page: Page):
+    mock_page.set_content(
+        """
+        <script>
+          window.__nekoJukeboxToggle = function() {};
+          window.t = (key, fallback) => fallback || key;
+        </script>
+        """
+    )
+    mock_page.add_script_tag(content=JUKEBOX_LOADER_SCRIPT)
+
+    native_calls = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          window.lanlan_config = { model_type: 'live3d', live3d_sub_type: 'vrm' };
+          window.NekoMotion = {
+            holdExternalPlayback: async (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return true;
+            },
+            releaseExternalPlayback: async (owner, options) => {
+              calls.push(`release:${owner}:${options.resume}`);
+              return true;
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            },
+            stopVRMAAnimation: () => calls.push('stop')
+          };
+
+          await window.Jukebox.playVRMA('/dance.vrma');
+          window.Jukebox.stopVMD(false);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          delete window.NekoMotion;
+          return calls;
+        }
+        """
+    )
+    assert native_calls == [
+        "hold:jukebox:1",
+        "play:/dance.vrma",
+        "stop",
+        "release:jukebox:true",
+    ]
+
+    setup_jukebox_page(mock_page)
+    web_result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          const J = window.Jukebox;
+          J.getModelType = () => 'vrm';
+          window.NekoMotion = {
+            holdExternalPlayback: async (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return true;
+            },
+            releaseExternalPlayback: async (owner, options) => {
+              calls.push(`release:${owner}:${options.resume}`);
+              return true;
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            },
+            stopVRMAAnimation: () => calls.push('stop')
+          };
+
+          const started = await J.playVRMA('/dance.vrma', { requestId: J.State.playRequestId });
+          const debtWhileDancing = J.State.idleRestorePending;
+          J.stopVMD(false);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const result = {
+            started,
+            debtWhileDancing,
+            debtAfterStop: J.State.idleRestorePending,
+            calls
+          };
+          delete window.NekoMotion;
+          return result;
+        }
+        """
+    )
+    assert web_result == {
+        "started": True,
+        "debtWhileDancing": True,
+        "debtAfterStop": False,
+        "calls": [
+            "hold:jukebox:0",
+            "play:/dance.vrma",
+            "stop",
+            "release:jukebox:true",
+        ],
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_loader_normalizes_legacy_bundled_vrm_idle(mock_page: Page):
     mock_page.set_content(
         """
@@ -452,7 +555,7 @@ def test_jukebox_loader_fetches_all_parts_sequentially(mock_page: Page):
 
     assert loaded_parts == [part.name for part in JUKEBOX_PARTS]
     assert result == {
-        "keyCount": 203,
+        "keyCount": 205,
         "hasLoadSongs": True,
         "hasManager": True,
         "hasScriptTag": True,

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -384,6 +384,109 @@ def test_jukebox_native_stop_cancels_vrma_while_runtime_hold_is_pending(mock_pag
 
 
 @pytest.mark.frontend
+def test_jukebox_vrm_hold_releases_after_model_switch_or_manager_unload(mock_page: Page):
+    mock_page.set_content(
+        """
+        <script>
+          window.__nekoJukeboxToggle = function() {};
+          window.t = (key, fallback) => fallback || key;
+        </script>
+        """
+    )
+    mock_page.add_script_tag(content=JUKEBOX_LOADER_SCRIPT)
+
+    native_result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          window.lanlan_config = { model_type: 'live3d', live3d_sub_type: 'vrm' };
+          window.NekoMotion = {
+            holdExternalPlayback: async (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return true;
+            },
+            releaseExternalPlayback: async (owner, options) => {
+              calls.push(`release:${owner}:${options.token}:${options.resume}:${options.scheduleNext}`);
+              return true;
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            }
+          };
+
+          await window.Jukebox.playVRMA('/dance.vrma');
+          delete window.vrmManager;
+          window.Jukebox.stopVMD(false);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          const token = window.Jukebox.State.vrmMotionRuntimeToken;
+          delete window.NekoMotion;
+          return { calls, token };
+        }
+        """
+    )
+    assert native_result == {
+        "calls": [
+            "hold:jukebox:1",
+            "play:/dance.vrma",
+            "release:jukebox:1:false:false",
+        ],
+        "token": None,
+    }
+
+    setup_jukebox_page(mock_page)
+    web_result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          const J = window.Jukebox;
+          J.getModelType = () => 'vrm';
+          window.NekoMotion = {
+            holdExternalPlayback: async (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return true;
+            },
+            releaseExternalPlayback: async (owner, options) => {
+              calls.push(`release:${owner}:${options.token}:${options.resume}:${options.scheduleNext}`);
+              return true;
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            }
+          };
+          window.mmdManager = {
+            animationModule: { stop: () => calls.push('mmd-stop') }
+          };
+
+          await J.playVRMA('/dance.vrma', { requestId: J.State.playRequestId });
+          J.getModelType = () => 'mmd';
+          J.stopVMD(false);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          const token = J.State.vrmMotionRuntimeToken;
+          delete window.NekoMotion;
+          return { calls, token };
+        }
+        """
+    )
+    assert web_result == {
+        "calls": [
+            "hold:jukebox:0",
+            "play:/dance.vrma",
+            "mmd-stop",
+            "release:jukebox:0:false:false",
+        ],
+        "token": None,
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_loader_normalizes_legacy_bundled_vrm_idle(mock_page: Page):
     mock_page.set_content(
         """

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -342,8 +342,8 @@ def test_jukebox_native_stop_cancels_vrma_while_runtime_hold_is_pending(mock_pag
             }
           };
           window.vrmManager = {
-            playVRMAAnimation: async (url) => {
-              calls.push('play:' + url);
+            playVRMAAnimation: async (url, options) => {
+              calls.push((options && options.isIdle ? 'idle:' : 'play:') + url);
               return true;
             },
             stopVRMAAnimation: () => calls.push('stop')
@@ -373,14 +373,113 @@ def test_jukebox_native_stop_cancels_vrma_while_runtime_hold_is_pending(mock_pag
     assert result == {
         "calls": [
             "hold:jukebox:1",
-            "release:jukebox:1:true",
+            "stop",
+            "idle:/static/vrm/animation/wait03.vrma.gz",
+            "release:jukebox:1:false",
         ],
         "requestDuringHold": 1,
-        "requestAfterStop": 2,
+        "requestAfterStop": 3,
         "pendingRequest": None,
         "isVMDPlaying": False,
         "isPlaying": False,
     }
+
+
+@pytest.mark.frontend
+def test_jukebox_native_stop_cancels_pending_vrma_load_and_restores_idle(mock_page: Page):
+    mock_page.set_content(
+        """
+        <script>
+          window.__nekoJukeboxToggle = function() {};
+          window.t = (key, fallback) => fallback || key;
+        </script>
+        """
+    )
+    mock_page.add_script_tag(content=JUKEBOX_LOADER_SCRIPT)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          let finishDance;
+          let danceShouldStart;
+          window.lanlan_config = { model_type: 'live3d', live3d_sub_type: 'vrm' };
+          window.vrmManager = {
+            playVRMAAnimation: (url, options) => {
+              if (options.isIdle) {
+                calls.push('idle:' + url);
+                return Promise.resolve(true);
+              }
+              calls.push('dance:' + url);
+              danceShouldStart = options.shouldStart;
+              return new Promise((resolve) => {
+                finishDance = () => resolve(danceShouldStart());
+              });
+            },
+            stopVRMAAnimation: () => calls.push('stop')
+          };
+
+          const pendingPlay = window.Jukebox.playVRMA('/loading.vrma');
+          window.Jukebox.stopVMD(false);
+          const guardAfterStop = danceShouldStart();
+          finishDance();
+          await pendingPlay;
+
+          return {
+            calls,
+            guardAfterStop,
+            isVMDPlaying: window.Jukebox.State.isVMDPlaying,
+            pendingRequest: window.Jukebox.State.pendingAnimationRequestId
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "calls": [
+            "dance:/loading.vrma",
+            "stop",
+            "idle:/static/vrm/animation/wait03.vrma.gz",
+        ],
+        "guardAfterStop": False,
+        "isVMDPlaying": False,
+        "pendingRequest": None,
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_native_vrma_failure_without_runtime_restores_idle(mock_page: Page):
+    mock_page.set_content(
+        """
+        <script>
+          window.__nekoJukeboxToggle = function() {};
+          window.t = (key, fallback) => fallback || key;
+        </script>
+        """
+    )
+    mock_page.add_script_tag(content=JUKEBOX_LOADER_SCRIPT)
+
+    calls = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          window.lanlan_config = { model_type: 'live3d', live3d_sub_type: 'vrm' };
+          window.vrmManager = {
+            playVRMAAnimation: async (url, options) => {
+              calls.push((options.isIdle ? 'idle:' : 'dance:') + url);
+              return options.isIdle === true;
+            }
+          };
+          await window.Jukebox.playVRMA('/broken.vrma');
+          return calls;
+        }
+        """
+    )
+
+    assert calls == [
+        "dance:/broken.vrma",
+        "idle:/static/vrm/animation/wait03.vrma.gz",
+    ]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -314,6 +314,76 @@ def test_jukebox_vrm_dance_holds_motion_runtime_until_stop_in_web_and_pet(mock_p
 
 
 @pytest.mark.frontend
+def test_jukebox_native_stop_cancels_vrma_while_runtime_hold_is_pending(mock_page: Page):
+    mock_page.set_content(
+        """
+        <script>
+          window.__nekoJukeboxToggle = function() {};
+          window.t = (key, fallback) => fallback || key;
+        </script>
+        """
+    )
+    mock_page.add_script_tag(content=JUKEBOX_LOADER_SCRIPT)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const calls = [];
+          let resolveHold;
+          window.lanlan_config = { model_type: 'live3d', live3d_sub_type: 'vrm' };
+          window.NekoMotion = {
+            holdExternalPlayback: (owner, options) => {
+              calls.push(`hold:${owner}:${options.token}`);
+              return new Promise((resolve) => { resolveHold = resolve; });
+            },
+            releaseExternalPlayback: async (owner, options) => {
+              calls.push(`release:${owner}:${options.token}:${options.resume}`);
+              return true;
+            }
+          };
+          window.vrmManager = {
+            playVRMAAnimation: async (url) => {
+              calls.push('play:' + url);
+              return true;
+            },
+            stopVRMAAnimation: () => calls.push('stop')
+          };
+
+          const pendingPlay = window.Jukebox.playVRMA('/late.vrma');
+          const requestDuringHold = window.Jukebox.State.playRequestId;
+          window.Jukebox.stopVMD(false);
+          const requestAfterStop = window.Jukebox.State.playRequestId;
+          resolveHold(true);
+          await pendingPlay;
+
+          const state = window.Jukebox.State;
+          delete window.NekoMotion;
+          return {
+            calls,
+            requestDuringHold,
+            requestAfterStop,
+            pendingRequest: state.pendingAnimationRequestId,
+            isVMDPlaying: state.isVMDPlaying,
+            isPlaying: state.isPlaying
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "calls": [
+            "hold:jukebox:1",
+            "release:jukebox:1:true",
+        ],
+        "requestDuringHold": 1,
+        "requestAfterStop": 2,
+        "pendingRequest": None,
+        "isVMDPlaying": False,
+        "isPlaying": False,
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_loader_normalizes_legacy_bundled_vrm_idle(mock_page: Page):
     mock_page.set_content(
         """

--- a/tests/frontend/vrm_motion_player.test.cjs
+++ b/tests/frontend/vrm_motion_player.test.cjs
@@ -298,6 +298,28 @@ async function waitForLoadStart(predicate, message) {
         poseStyle: null
     });
 
+    const heldCancelPlayer = new global.NekoMotionPlayer();
+    let heldCancelResumeCount = 0;
+    heldCancelPlayer._playAsset = async function () {
+        heldCancelResumeCount += 1;
+        return true;
+    };
+    heldCancelPlayer.state.posture = 'lie';
+    heldCancelPlayer.state.phase = 'pose';
+    heldCancelPlayer.state.poseAsset = { id: 'held-pose', mode: 'loop' };
+    heldCancelPlayer.state.poseStyle = 'side';
+    heldCancelPlayer.holdExternalPlayback('jukebox', { token: 91 });
+    heldCancelPlayer.cancel('assistant_speech_cancel', { resume: true });
+    await Promise.resolve();
+    assert.equal(heldCancelResumeCount, 0, 'cancel recovery must not replace held external playback');
+    assert.equal(heldCancelPlayer.state.phase, 'external');
+    assert.equal(await heldCancelPlayer.releaseExternalPlayback('jukebox', {
+        token: 91,
+        resume: true,
+        scheduleNext: false
+    }), true);
+    assert.equal(heldCancelResumeCount, 1, 'the saved pose may resume after the final external release');
+
     const staleCatalogPlayer = new global.NekoMotionPlayer();
     const staleCatalogAsset = { id: 'stale-catalog', m: 'wave', i: 2 };
     let finishCatalogLoad;

--- a/tests/frontend/vrm_motion_player.test.cjs
+++ b/tests/frontend/vrm_motion_player.test.cjs
@@ -299,9 +299,9 @@ async function waitForLoadStart(predicate, message) {
     });
 
     const heldCancelPlayer = new global.NekoMotionPlayer();
-    let heldCancelResumeCount = 0;
-    heldCancelPlayer._playAsset = async function () {
-        heldCancelResumeCount += 1;
+    const heldCancelResumeAssets = [];
+    heldCancelPlayer._playAsset = async function (asset) {
+        heldCancelResumeAssets.push(asset.id);
         return true;
     };
     heldCancelPlayer.state.posture = 'lie';
@@ -311,14 +311,18 @@ async function waitForLoadStart(predicate, message) {
     heldCancelPlayer.holdExternalPlayback('jukebox', { token: 91 });
     heldCancelPlayer.cancel('assistant_speech_cancel', { resume: true });
     await Promise.resolve();
-    assert.equal(heldCancelResumeCount, 0, 'cancel recovery must not replace held external playback');
+    assert.equal(heldCancelResumeAssets.length, 0, 'cancel recovery must not replace held external playback');
     assert.equal(heldCancelPlayer.state.phase, 'external');
     assert.equal(await heldCancelPlayer.releaseExternalPlayback('jukebox', {
         token: 91,
         resume: true,
         scheduleNext: false
     }), true);
-    assert.equal(heldCancelResumeCount, 1, 'the saved pose may resume after the final external release');
+    assert.deepEqual(
+        heldCancelResumeAssets,
+        ['held-pose'],
+        'the saved pose may resume after the final external release'
+    );
 
     const staleCatalogPlayer = new global.NekoMotionPlayer();
     const staleCatalogAsset = { id: 'stale-catalog', m: 'wave', i: 2 };
@@ -517,6 +521,12 @@ async function waitForLoadStart(predicate, message) {
     // A newer song reuses the same owner but replaces its token. The stale
     // loader must not release the newer dance when it finally settles.
     scheduledRestPlayer.holdExternalPlayback('jukebox', { token: 42 });
+    assert.equal(
+        await scheduledRestPlayer.releaseExternalPlayback('jukebox', { resume: true }),
+        false,
+        'a tokenized hold must not be released without its token'
+    );
+    assert.equal(scheduledRestPlayer.externalPlaybackOwners.get('jukebox'), 42);
     assert.equal(
         await scheduledRestPlayer.releaseExternalPlayback('jukebox', {
             token: 41,

--- a/tests/frontend/vrm_motion_player.test.cjs
+++ b/tests/frontend/vrm_motion_player.test.cjs
@@ -480,7 +480,44 @@ async function waitForLoadStart(predicate, message) {
         true
     );
     assert.notEqual(scheduledRestPlayer.idleSwitchTimer, null);
-    scheduledRestPlayer._clearIdleSwitch();
+    const generationBeforeExternalPlayback = scheduledRestPlayer.queueGeneration;
+    assert.equal(
+        scheduledRestPlayer.holdExternalPlayback('jukebox', { token: 41 }),
+        true
+    );
+    assert.equal(scheduledRestPlayer.idleSwitchTimer, null);
+    assert.equal(scheduledRestPlayer.state.phase, 'external');
+    assert.equal(scheduledRestPlayer.queueGeneration, generationBeforeExternalPlayback + 1);
+    assert.equal(scheduledRestPlayer.resumeIdleCountdown('while-dancing'), false);
+    assert.equal(await scheduledRestPlayer.enterRest({ force: true }), false);
+    assert.equal(await scheduledRestPlayer.playPlan([{ intent: 'wave' }]), false);
+
+    // A newer song reuses the same owner but replaces its token. The stale
+    // loader must not release the newer dance when it finally settles.
+    scheduledRestPlayer.holdExternalPlayback('jukebox', { token: 42 });
+    assert.equal(
+        await scheduledRestPlayer.releaseExternalPlayback('jukebox', {
+            token: 41,
+            resume: true
+        }),
+        false
+    );
+    let externalResume = null;
+    scheduledRestPlayer._resumeBase = async function (generation, seed, scheduleNext) {
+        externalResume = { generation, seed, scheduleNext };
+        return true;
+    };
+    assert.equal(
+        await scheduledRestPlayer.releaseExternalPlayback('jukebox', {
+            token: 42,
+            resume: true,
+            scheduleNext: true
+        }),
+        true
+    );
+    assert.equal(scheduledRestPlayer.externalPlaybackOwners.size, 0);
+    assert.equal(externalResume.seed, 'external-release:jukebox');
+    assert.equal(externalResume.scheduleNext, true);
 
     savedCatalogPlayer.assets = [{
         id: 'saved-motion-pack',

--- a/tests/frontend/vrm_motion_player.test.cjs
+++ b/tests/frontend/vrm_motion_player.test.cjs
@@ -519,6 +519,18 @@ async function waitForLoadStart(predicate, message) {
     assert.equal(externalResume.seed, 'external-release:jukebox');
     assert.equal(externalResume.scheduleNext, true);
 
+    const staleQueuePlayer = new global.NekoMotionPlayer();
+    const staleFirst = staleQueuePlayer.enqueuePlan([{ intent: 'wave' }], { seed: 'first' });
+    const staleSecond = staleQueuePlayer.enqueuePlan([{ intent: 'nod' }], { seed: 'second' });
+    staleQueuePlayer.holdExternalPlayback('jukebox', { token: 51 });
+    assert.deepEqual(await Promise.all([staleFirst, staleSecond]), [false, false]);
+    assert.equal(staleQueuePlayer.busy, false);
+    assert.equal(await staleQueuePlayer.releaseExternalPlayback('jukebox', {
+        token: 51,
+        resume: false
+    }), true);
+    assert.equal(staleQueuePlayer.busy, false);
+
     savedCatalogPlayer.assets = [{
         id: 'saved-motion-pack',
         m: 'idle',

--- a/tests/frontend/vrm_motion_policy.test.cjs
+++ b/tests/frontend/vrm_motion_policy.test.cjs
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 const zlib = require('node:zlib');
 
 const fileRoot = path.resolve(__dirname, '..', '..');
@@ -169,7 +170,7 @@ assert.equal(runtimeSource.includes('.slice(0, 1000)'), false);
 assert.match(runtimeSource, /fetchWithTimeout\(SEMANTICS_URL/);
 assert.match(runtimeSource, /fetchWithTimeout\('\/api\/characters\/character\/'/);
 assert.match(runtimeSource, /async function requireInitialized\(\)/);
-assert.equal((runtimeSource.match(/await requireInitialized\(\)/g) || []).length, 7);
+assert.equal((runtimeSource.match(/await requireInitialized\(\)/g) || []).length, 5);
 assert.match(runtimeSource, /processUnseenStagesDirect\(turn\)/);
 assert.match(runtimeSource, /turn\.cancelled = true/);
 assert.match(runtimeSource, /played = await player\.playPlan\(plan, context\)/);
@@ -348,6 +349,22 @@ assert.match(
     runtimeSource,
     /releaseExternalPlayback:\s*async function[\s\S]*player\.releaseExternalPlayback/
 );
+const externalHoldBlock = sliceBetween(
+    runtimeSource,
+    'holdExternalPlayback: async function',
+    'releaseExternalPlayback: async function',
+    'external hold API'
+);
+assert.ok(
+    externalHoldBlock.indexOf('externalPlaybackOwners.set(')
+        < externalHoldBlock.indexOf('void initialize()'),
+    'a cold external hold must be recorded synchronously before initialization starts'
+);
+assert.equal(externalHoldBlock.includes('await requireInitialized()'), false);
+assert.match(
+    runtimeSource,
+    /if \(vrmReady\(\) && externalPlaybackOwners\.size === 0\) \{\s*await player\.enterRest/
+);
 
 const modelManagerSource = fs.readFileSync(
     path.join(root, 'static/js/model_manager/page-controller.js'),
@@ -379,4 +396,136 @@ assert.match(modelManagerSource, /cancel\('model_manager_stop', \{ resume: false
 assert.match(modelManagerSource, /normalizeBundledVrmAnimationUrl/);
 assert.match(modelManagerTemplate, /static\/vrm\/motion\/player\.js/);
 
-console.log('VRM motion policy and source integrity: OK (75 gzip assets)');
+function createRuntimeHarness(fetchImplementation) {
+    const calls = [];
+    const players = [];
+    const listeners = new Map();
+    class FakeMotionCore {
+        registerActionCards() {}
+        stats() { return {}; }
+    }
+    class FakeMotionPlayer {
+        constructor() {
+            this.assets = [];
+            this.owners = new Map();
+            players.push(this);
+        }
+        holdExternalPlayback(owner, options) {
+            this.owners.set(owner, options.token);
+            calls.push(['hold', owner, options.token]);
+            return true;
+        }
+        async releaseExternalPlayback(owner, options) {
+            if (!this.owners.has(owner) || this.owners.get(owner) !== options.token) return false;
+            this.owners.delete(owner);
+            calls.push(['release', owner, options.token, options.resume]);
+            return true;
+        }
+        async load() { return this; }
+        async enterRest() {
+            calls.push(['rest']);
+            return true;
+        }
+        setSavedRestAnimations() { return 0; }
+        setProfile() {}
+        cancel() { return true; }
+        stats() { return {}; }
+    }
+    const context = {
+        AbortController,
+        clearInterval: function () {},
+        clearTimeout,
+        console: {
+            debug: function () {},
+            error: function () {},
+            info: function () {},
+            log: function () {},
+            warn: function () {}
+        },
+        document: { documentElement: { lang: 'zh-CN' } },
+        fetch: fetchImplementation,
+        navigator: { language: 'zh-CN' },
+        setInterval: function () { return 1; },
+        setTimeout,
+        CustomEvent: class CustomEvent {
+            constructor(type, options) {
+                this.type = type;
+                this.detail = options && options.detail;
+            }
+        }
+    };
+    context.window = context;
+    context.lanlan_config = { model_type: 'live2d' };
+    context.NekoMotionCore = FakeMotionCore;
+    context.NekoMotionPlayer = FakeMotionPlayer;
+    context.NekoMotionText = { extractClosedStages: function () { return []; } };
+    context.vrmManager = {
+        currentModel: { vrm: {} },
+        playVRMAAnimation: async function () { return true; }
+    };
+    context.addEventListener = function (name, listener) { listeners.set(name, listener); };
+    context.removeEventListener = function (name) { listeners.delete(name); };
+    context.dispatchEvent = function () { return true; };
+    vm.runInNewContext(runtimeSource, context, { filename: 'runtime.js' });
+    return { calls, context, players };
+}
+
+async function flushMicrotasks(count = 12) {
+    for (let index = 0; index < count; index += 1) await Promise.resolve();
+}
+
+async function verifyColdExternalPlaybackOwnership() {
+    let resolveSemantics;
+    const semanticsResponse = new Promise(function (resolve) {
+        resolveSemantics = function () {
+            resolve({ ok: true, json: async function () { return {}; } });
+        };
+    });
+    const harness = createRuntimeHarness(function () { return semanticsResponse; });
+    harness.context.lanlan_config.model_type = 'vrm';
+
+    let holdSettled = false;
+    const holdResult = harness.context.NekoMotion.holdExternalPlayback('jukebox', { token: 71 })
+        .then(function (held) {
+            holdSettled = true;
+            return held;
+        });
+    await flushMicrotasks(2);
+    assert.equal(holdSettled, true, 'a cold external hold must not wait for runtime initialization');
+    assert.equal(await holdResult, true);
+    assert.equal(harness.players.length, 0, 'the hold should resolve while semantics are still loading');
+
+    resolveSemantics();
+    await flushMicrotasks();
+    assert.equal(harness.players.length, 1);
+    assert.deepEqual(harness.calls, [['hold', 'jukebox', 71]]);
+    assert.equal(
+        await harness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 71, resume: true }),
+        true
+    );
+    assert.deepEqual(harness.calls, [
+        ['hold', 'jukebox', 71],
+        ['release', 'jukebox', 71, true]
+    ]);
+
+    const failedHarness = createRuntimeHarness(async function () {
+        throw new Error('semantics unavailable');
+    });
+    failedHarness.context.lanlan_config.model_type = 'vrm';
+    assert.equal(
+        await failedHarness.context.NekoMotion.holdExternalPlayback('jukebox', { token: 72 }),
+        true
+    );
+    assert.equal(
+        await failedHarness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 72, resume: true }),
+        false,
+        'a failed background initialization must leave idle restoration to the caller'
+    );
+}
+
+verifyColdExternalPlaybackOwnership().then(function () {
+    console.log('VRM motion policy and source integrity: OK (75 gzip assets)');
+}).catch(function (error) {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/frontend/vrm_motion_policy.test.cjs
+++ b/tests/frontend/vrm_motion_policy.test.cjs
@@ -169,7 +169,7 @@ assert.equal(runtimeSource.includes('.slice(0, 1000)'), false);
 assert.match(runtimeSource, /fetchWithTimeout\(SEMANTICS_URL/);
 assert.match(runtimeSource, /fetchWithTimeout\('\/api\/characters\/character\/'/);
 assert.match(runtimeSource, /async function requireInitialized\(\)/);
-assert.equal((runtimeSource.match(/await requireInitialized\(\)/g) || []).length, 5);
+assert.equal((runtimeSource.match(/await requireInitialized\(\)/g) || []).length, 7);
 assert.match(runtimeSource, /processUnseenStagesDirect\(turn\)/);
 assert.match(runtimeSource, /turn\.cancelled = true/);
 assert.match(runtimeSource, /played = await player\.playPlan\(plan, context\)/);
@@ -340,6 +340,14 @@ assert.match(runtimeSource, /function stopMaintenanceTimers\(\)/);
 assert.match(runtimeSource, /window\.addEventListener\('pagehide'/);
 assert.match(runtimeSource, /window\.addEventListener\('pageshow'/);
 assert.match(runtimeSource, /bindMotionLifecycleBridge\(\);\s*startMaintenanceTimers\(\)/);
+assert.match(
+    runtimeSource,
+    /holdExternalPlayback:\s*async function[\s\S]*player\.holdExternalPlayback/
+);
+assert.match(
+    runtimeSource,
+    /releaseExternalPlayback:\s*async function[\s\S]*player\.releaseExternalPlayback/
+);
 
 const modelManagerSource = fs.readFileSync(
     path.join(root, 'static/js/model_manager/page-controller.js'),

--- a/tests/frontend/vrm_motion_policy.test.cjs
+++ b/tests/frontend/vrm_motion_policy.test.cjs
@@ -511,6 +511,19 @@ async function verifyColdExternalPlaybackOwnership() {
         ['official-stop'],
         ['hold', 'jukebox', 71]
     ]);
+    const originalRelease = harness.players[0].releaseExternalPlayback.bind(harness.players[0]);
+    let forwardedMissingTokenRelease = 0;
+    harness.players[0].releaseExternalPlayback = async function (owner, options) {
+        forwardedMissingTokenRelease += 1;
+        return originalRelease(owner, options);
+    };
+    assert.equal(
+        await harness.context.NekoMotion.releaseExternalPlayback('jukebox', { resume: true }),
+        false,
+        'the runtime must reject a tokenless release of a tokenized owner'
+    );
+    assert.equal(forwardedMissingTokenRelease, 0, 'a rejected release must not reach the player');
+    harness.players[0].releaseExternalPlayback = originalRelease;
     assert.equal(
         await harness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 71, resume: true }),
         true
@@ -519,6 +532,22 @@ async function verifyColdExternalPlaybackOwnership() {
         ['official-stop'],
         ['hold', 'jukebox', 71],
         ['release', 'jukebox', 71, true]
+    ]);
+
+    harness.context.lanlan_config.vrmIdleAnimations = ['/ready-idle.vrma'];
+    assert.equal(
+        await harness.context.NekoMotion.holdExternalPlayback('jukebox', { token: 74 }),
+        true
+    );
+    assert.equal(
+        await harness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 74, resume: false }),
+        true
+    );
+    assert.equal(harness.context.__nekoMotionOwnsVrmPlayback, false);
+    assert.deepEqual(harness.calls.slice(-3), [
+        ['hold', 'jukebox', 74],
+        ['release', 'jukebox', 74, false],
+        ['official-start', '/ready-idle.vrma']
     ]);
 
     const failedHarness = createRuntimeHarness(async function () {

--- a/tests/frontend/vrm_motion_policy.test.cjs
+++ b/tests/frontend/vrm_motion_policy.test.cjs
@@ -528,10 +528,10 @@ async function verifyColdExternalPlaybackOwnership() {
         model_type: 'vrm',
         vrmIdleAnimations: ['/idle-a.vrma', '/idle-b.vrma']
     };
-    assert.equal(
-        await failedHarness.context.NekoMotion.holdExternalPlayback('jukebox', { token: 72 }),
-        true
-    );
+    const failedJukeboxHold = failedHarness.context.NekoMotion.holdExternalPlayback('jukebox', { token: 72 });
+    const failedPreviewHold = failedHarness.context.NekoMotion.holdExternalPlayback('preview', { token: 73 });
+    assert.equal(await failedJukeboxHold, true);
+    assert.equal(await failedPreviewHold, true);
     await flushMicrotasks();
     assert.equal(failedHarness.players.length, 1, 'the failure must happen after player assignment');
     assert.equal(failedHarness.context.NekoMotion.stats().ready, false);
@@ -543,6 +543,17 @@ async function verifyColdExternalPlaybackOwnership() {
     );
     assert.equal(
         await failedHarness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 72, resume: true }),
+        true,
+        'a failed runtime must stay held while another external owner remains'
+    );
+    assert.equal(failedHarness.context.__nekoMotionOwnsVrmPlayback, true);
+    assert.equal(
+        failedHarness.calls.some(function (entry) { return entry[0] === 'official-start'; }),
+        false,
+        'releasing one owner must not restart official idle for the remaining owner'
+    );
+    assert.equal(
+        await failedHarness.context.NekoMotion.releaseExternalPlayback('preview', { token: 73, resume: true }),
         false,
         'a failed background initialization must leave idle restoration to the caller'
     );

--- a/tests/frontend/vrm_motion_policy.test.cjs
+++ b/tests/frontend/vrm_motion_policy.test.cjs
@@ -396,7 +396,7 @@ assert.match(modelManagerSource, /cancel\('model_manager_stop', \{ resume: false
 assert.match(modelManagerSource, /normalizeBundledVrmAnimationUrl/);
 assert.match(modelManagerTemplate, /static\/vrm\/motion\/player\.js/);
 
-function createRuntimeHarness(fetchImplementation) {
+function createRuntimeHarness(fetchImplementation, options = {}) {
     const calls = [];
     const players = [];
     const listeners = new Map();
@@ -421,7 +421,10 @@ function createRuntimeHarness(fetchImplementation) {
             calls.push(['release', owner, options.token, options.resume]);
             return true;
         }
-        async load() { return this; }
+        async load() {
+            if (options.failPlayerLoad === true) throw new Error('manifest unavailable');
+            return this;
+        }
         async enterRest() {
             calls.push(['rest']);
             return true;
@@ -459,6 +462,10 @@ function createRuntimeHarness(fetchImplementation) {
     context.NekoMotionCore = FakeMotionCore;
     context.NekoMotionPlayer = FakeMotionPlayer;
     context.NekoMotionText = { extractClosedStages: function () { return []; } };
+    context._stopVrmIdleRotation = function () { calls.push(['official-stop']); };
+    context._startVrmIdleRotation = function (urls) {
+        calls.push(['official-start', Array.isArray(urls) ? urls.join('|') : '']);
+    };
     context.vrmManager = {
         currentModel: { vrm: {} },
         playVRMAAnimation: async function () { return true; }
@@ -494,33 +501,55 @@ async function verifyColdExternalPlaybackOwnership() {
     assert.equal(holdSettled, true, 'a cold external hold must not wait for runtime initialization');
     assert.equal(await holdResult, true);
     assert.equal(harness.players.length, 0, 'the hold should resolve while semantics are still loading');
+    assert.deepEqual(harness.calls, [['official-stop']]);
+    assert.equal(harness.context.__nekoMotionOwnsVrmPlayback, true);
 
     resolveSemantics();
     await flushMicrotasks();
     assert.equal(harness.players.length, 1);
-    assert.deepEqual(harness.calls, [['hold', 'jukebox', 71]]);
+    assert.deepEqual(harness.calls, [
+        ['official-stop'],
+        ['hold', 'jukebox', 71]
+    ]);
     assert.equal(
         await harness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 71, resume: true }),
         true
     );
     assert.deepEqual(harness.calls, [
+        ['official-stop'],
         ['hold', 'jukebox', 71],
         ['release', 'jukebox', 71, true]
     ]);
 
     const failedHarness = createRuntimeHarness(async function () {
-        throw new Error('semantics unavailable');
-    });
-    failedHarness.context.lanlan_config.model_type = 'vrm';
+        return { ok: true, json: async function () { return {}; } };
+    }, { failPlayerLoad: true });
+    failedHarness.context.lanlan_config = {
+        model_type: 'vrm',
+        vrmIdleAnimations: ['/idle-a.vrma', '/idle-b.vrma']
+    };
     assert.equal(
         await failedHarness.context.NekoMotion.holdExternalPlayback('jukebox', { token: 72 }),
         true
+    );
+    await flushMicrotasks();
+    assert.equal(failedHarness.players.length, 1, 'the failure must happen after player assignment');
+    assert.equal(failedHarness.context.NekoMotion.stats().ready, false);
+    assert.equal(failedHarness.context.__nekoMotionOwnsVrmPlayback, true);
+    assert.equal(
+        failedHarness.calls.some(function (entry) { return entry[0] === 'official-start'; }),
+        false,
+        'official idle must stay stopped while the external dance still owns playback'
     );
     assert.equal(
         await failedHarness.context.NekoMotion.releaseExternalPlayback('jukebox', { token: 72, resume: true }),
         false,
         'a failed background initialization must leave idle restoration to the caller'
     );
+    assert.equal(failedHarness.context.__nekoMotionOwnsVrmPlayback, false);
+    assert.deepEqual(failedHarness.calls.slice(-1), [
+        ['official-start', '/idle-a.vrma|/idle-b.vrma']
+    ]);
 }
 
 verifyColdExternalPlaybackOwnership().then(function () {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 VRM 点歌跳舞时被待机动作提前打断的问题

## 测试 / Testing

手动测试确认已经修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 播放 VRM 动画时可暂时接管待机动作，避免状态冲突。
  * 动画结束、停止或失败后自动释放控制并恢复待机动作。
  * 自动连续播放可正确衔接下一首动画。

* **错误修复**
  * 改善快速切换、停止播放及模型切换时的请求管理。
  * 优化加载取消、播放失败和初始化异常后的资源清理，提升稳定性。

* **测试**
  * 增加动画占用释放、连续切换、失败恢复及待机恢复场景覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->