### PR TITLE
fix(plugin): 插件生命周期归属改成显式声明，根绝「静默把全量扫描放回启动路径」

### DIFF
--- a/plugin/server/http_app.py
+++ b/plugin/server/http_app.py
@@ -129,7 +129,10 @@ def _include_optional_router(
 
 @asynccontextmanager
 async def plugin_server_lifespan(app: FastAPI) -> AsyncIterator[None]:
-    _ = app
+    # 谁负责插件生命周期，由**建这个 app 的人**说了算，见
+    # build_plugin_server_app 的 manage_lifecycle。默认 False：没人明说就不起，
+    # 这个方向的错误是「独立服务器里插件不自启」——看得见、也没人受伤。
+    manage_lifecycle = bool(getattr(app.state, "manage_plugin_lifecycle", False))
 
     if _can_register_faulthandler_signal():
         try:
@@ -175,9 +178,15 @@ async def plugin_server_lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     heartbeat_task = asyncio.create_task(_heartbeat(), name="server-heartbeat")
 
-    # When embedded inside agent_server, lifecycle is managed externally
-    # via the user_plugin_enabled flag — do NOT auto-start here.
-    if not _EMBEDDED_BY_AGENT:
+    # 内嵌进 agent_server 时，生命周期由外部按 user_plugin_enabled 开关管理，
+    # 这里绝不能自动起——起了就是把整轮插件元数据扫描拉回端口 bind 之前。
+    #
+    # 以前这个判断读的是模块级的 _EMBEDDED_BY_AGENT，也就是**import 那一刻**的
+    # NEKO_PLUGIN_HOSTED_BY_AGENT。它今天恰好是对的，只因为 agent_server 在第一次
+    # import 这个模块之前先设了环境变量——两件相隔很远、谁都没保证的事。任何人在
+    # 那之前先 import 到 plugin.server.http_app，这个常量就冻成 False，全量扫描
+    # **静默**回到启动路径，没有任何东西会红。
+    if manage_lifecycle:
         await lifecycle_startup()
 
     # Install-source lock subsystem: tracks plugin provenance (builtin/manual/
@@ -224,12 +233,29 @@ async def plugin_server_lifespan(app: FastAPI) -> AsyncIterator[None]:
                 type(exc).__name__,
                 str(exc),
             )
-        if not _EMBEDDED_BY_AGENT:
+        if manage_lifecycle:
             await lifecycle_shutdown()
 
 
-def build_plugin_server_app(title: str = "N.E.K.O User Plugin Server") -> FastAPI:
+def build_plugin_server_app(
+    title: str = "N.E.K.O User Plugin Server",
+    *,
+    manage_lifecycle: bool = False,
+) -> FastAPI:
+    """Build the plugin HTTP app.
+
+    ``manage_lifecycle`` says whether this app owns the plugin lifecycle — the
+    full metadata refresh plus autostart. Only the standalone entry point does;
+    when embedded in agent_server the lifecycle is driven externally by the
+    ``user_plugin_enabled`` flag.
+
+    It defaults to ``False`` on purpose. Getting it wrong in that direction means
+    "plugins do not autostart in the standalone server", which is visible the
+    moment anyone looks. The other direction puts a full plugin scan back on the
+    startup path before any port binds, and nothing reports it.
+    """
     app = FastAPI(title=title, lifespan=plugin_server_lifespan)
+    app.state.manage_plugin_lifecycle = manage_lifecycle
 
     @app.get("/api_key", include_in_schema=False)
     async def redirect_model_settings(request: Request) -> RedirectResponse:

--- a/plugin/tests/unit/server/test_plugin_lifecycle_ownership.py
+++ b/plugin/tests/unit/server/test_plugin_lifecycle_ownership.py
@@ -1,0 +1,236 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Who owns the plugin lifecycle must be stated, not inferred from the environment.
+
+Starting the lifecycle runs a full plugin metadata refresh plus autostart. Inside
+agent_server that must not happen during the app's lifespan, because uvicorn
+awaits ``lifespan.startup()`` before it creates the listening socket — the cost
+would land while the port does not exist yet, and the user sees a refused
+connection rather than a slow one.
+
+That was previously decided by a module-level constant read from
+``NEKO_PLUGIN_HOSTED_BY_AGENT`` at **import** time, and it was correct only
+because agent_server happens to set the variable before anything first imports
+this module. Two distant facts with nothing enforcing the order between them: an
+earlier import from anywhere freezes the constant to False and silently puts the
+scan back on the startup path.
+
+These guards pin the replacement: an explicit argument, a fail-safe default, and
+no dependence on the environment.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@pytest.fixture
+def _neutralised_lifespan(monkeypatch: pytest.MonkeyPatch):
+    """Stub the parts of the lifespan that touch the real machine."""
+    from plugin.server.application import install_source
+    from plugin.server.routes import market_bridge
+
+    monkeypatch.setattr(
+        install_source, "build_install_source_manager",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stubbed out")),
+    )
+    monkeypatch.setattr(market_bridge, "write_bridge_token_file", lambda *a, **k: None)
+
+
+async def _run_lifespan(module, app) -> None:
+    async with module.plugin_server_lifespan(app):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("env_value", "label"),
+    [(None, "unset"), ("true", "true"), ("false", "false")],
+    ids=["env-unset", "env-true", "env-false"],
+)
+async def test_the_default_app_never_starts_the_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    _neutralised_lifespan: None,
+    env_value: str | None,
+    label: str,
+) -> None:
+    """No explicit claim means no lifecycle, whatever the environment says.
+
+    Parametrised over the environment variable precisely because the point of the
+    change is that it no longer participates. A single-value test would pass just
+    as well against the old import-time constant.
+
+    Mutation: default ``manage_lifecycle`` to True, or read the env at the call.
+    """
+    from plugin.server import http_app as module
+
+    if env_value is None:
+        monkeypatch.delenv("NEKO_PLUGIN_HOSTED_BY_AGENT", raising=False)
+    else:
+        monkeypatch.setenv("NEKO_PLUGIN_HOSTED_BY_AGENT", env_value)
+
+    started: list[int] = []
+
+    # 必须是 async 的：生产代码 `await lifecycle_startup()`。同步 stub 只会在
+    # 那条路**真的被执行**时才炸——第一版就是同步的，而这条用例正因为路径没走
+    # 到才绿，等于什么都没证明。
+    async def _start() -> None:
+        started.append(1)
+
+    async def _stop() -> None:
+        started.append(2)
+
+    monkeypatch.setattr(module, "lifecycle_startup", _start)
+    monkeypatch.setattr(module, "lifecycle_shutdown", _stop)
+
+    app = module.build_plugin_server_app()
+    await _run_lifespan(module, app)
+
+    assert started == [], (
+        f"env={label} 时默认 app 仍然起了插件生命周期——全量扫描回到端口 bind 之前"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_app_that_claims_ownership_does_start_the_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    _neutralised_lifespan: None,
+) -> None:
+    """The fail-safe default must not turn into "never starts at all".
+
+    Without this the whole rule could be satisfied by deleting the call, and the
+    standalone server would silently stop loading plugins.
+
+    Mutation: ignore ``manage_lifecycle`` and never start.
+    """
+    from plugin.server import http_app as module
+
+    monkeypatch.delenv("NEKO_PLUGIN_HOSTED_BY_AGENT", raising=False)
+
+    calls: list[str] = []
+
+    async def _start() -> None:
+        calls.append("start")
+
+    async def _stop() -> None:
+        calls.append("stop")
+
+    monkeypatch.setattr(module, "lifecycle_startup", _start)
+    monkeypatch.setattr(module, "lifecycle_shutdown", _stop)
+
+    app = module.build_plugin_server_app(manage_lifecycle=True)
+    await _run_lifespan(module, app)
+
+    assert calls == ["start", "stop"], f"认领了所有权却没有起/停生命周期：{calls}"
+
+
+def _build_call_keywords(source: str) -> dict[str, list[ast.keyword]]:
+    """Every ``build_plugin_server_app(...)`` call in a file, by keyword name."""
+    tree = ast.parse(source)
+    found: dict[str, list[ast.keyword]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name != "build_plugin_server_app":
+            continue
+        found.setdefault("calls", []).extend(node.keywords)
+        found.setdefault("nodes", []).append(node)
+    return found
+
+
+def test_only_the_standalone_entry_point_claims_the_lifecycle() -> None:
+    """Testing the predicate is not testing the call sites.
+
+    The flag being correct proves nothing about who passes it. There are exactly
+    two constructors of this app, and they must disagree: the standalone entry
+    owns the lifecycle because nothing else would start it, and the embedded one
+    does not because agent_server drives it from ``user_plugin_enabled``.
+
+    Mutation: pass ``manage_lifecycle=True`` from the embedded call site, or drop
+    it from the standalone one.
+    """
+    standalone = (REPO_ROOT / "plugin" / "user_plugin_server.py").read_text(
+        encoding="utf-8"
+    )
+    embedded = (REPO_ROOT / "app" / "agent_server" / "plugin_host.py").read_text(
+        encoding="utf-8"
+    )
+
+    standalone_kw = _build_call_keywords(standalone)
+    assert standalone_kw.get("nodes"), "独立入口不再构造插件 app 了？"
+    claimed = [
+        kw for kw in standalone_kw["calls"]
+        if kw.arg == "manage_lifecycle" and getattr(kw.value, "value", None) is True
+    ]
+    assert claimed, (
+        "独立入口没有显式认领生命周期——独立跑的时候没有别人会起它，插件会静默不加载"
+    )
+
+    embedded_kw = _build_call_keywords(embedded)
+    assert embedded_kw.get("nodes"), "内嵌路径不再构造插件 app 了？"
+    over_claimed = [
+        kw for kw in embedded_kw["calls"]
+        if kw.arg == "manage_lifecycle" and getattr(kw.value, "value", None) is True
+    ]
+    assert not over_claimed, (
+        "内嵌路径认领了生命周期——那会把整轮插件扫描拉回 agent_server 的启动路径，"
+        "而 uvicorn 是先跑完 lifespan 才 bind 端口的"
+    )
+
+
+def test_the_lifecycle_decision_no_longer_reads_the_environment() -> None:
+    """The import-time constant must not creep back onto the decision.
+
+    ``_EMBEDDED_BY_AGENT`` still exists and is still fine for choosing a logger
+    namespace — getting *that* wrong only misfiles log lines. What must never
+    return is its use around ``lifecycle_startup`` / ``lifecycle_shutdown``,
+    because that is the one place where an import-order accident is silent and
+    expensive.
+
+    Mutation: guard either lifecycle call with ``_EMBEDDED_BY_AGENT`` again.
+    """
+    source = (REPO_ROOT / "plugin" / "server" / "http_app.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        names = {
+            sub.id for sub in ast.walk(node.test) if isinstance(sub, ast.Name)
+        }
+        if "_EMBEDDED_BY_AGENT" not in names:
+            continue
+        called = {
+            sub.func.id
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+        }
+        if called & {"lifecycle_startup", "lifecycle_shutdown"}:
+            offenders.append(node.lineno)
+
+    assert not offenders, (
+        f"生命周期的起/停又被 _EMBEDDED_BY_AGENT 决定了（行 {offenders}）——"
+        "那是 import 时刻的环境变量，顺序一变就静默把全量扫描放回启动路径"
+    )

--- a/plugin/user_plugin_server.py
+++ b/plugin/user_plugin_server.py
@@ -198,7 +198,9 @@ _disable_windows_plugin_zmq_when_tornado_missing()
 from plugin.server.http_app import build_plugin_server_app  # noqa: E402
 
 
-app = build_plugin_server_app()
+# 独立跑的时候没有别人管生命周期，所以这里显式认领。内嵌进 agent_server 的那条
+# 路径（app/agent_server/plugin_host.py）不认领，由 user_plugin_enabled 开关驱动。
+app = build_plugin_server_app(manage_lifecycle=True)
 
 
 def _can_register_faulthandler_signal() -> bool:


### PR DESCRIPTION
## 现状：一个只靠巧合成立的不变量

起插件生命周期 = 跑**一整轮插件元数据刷新 + 自启动**。内嵌进 `agent_server` 时这件事绝不能发生在 app 的 lifespan 里 —— uvicorn 是先 `await lifespan.startup()` 再 `create_server()`，那段时间**端口还不存在**，用户看到的是 connection-refused 而不是「慢」。

今天它确实没发生。但依据是：

```
app/agent_server/api_runtime.py:696   os.environ["NEKO_PLUGIN_HOSTED_BY_AGENT"] = "true"
plugin/server/http_app.py:44          _EMBEDDED_BY_AGENT = os.getenv(...)   ← import 那一刻
plugin/server/http_app.py:180         if not _EMBEDDED_BY_AGENT: await lifecycle_startup()
```

**两件相隔很远、中间没有任何东西保证顺序的事。** 只要有人在设 env 之前先 import 到 `plugin.server.http_app`，那个模块级常量就冻成 `False`，全量扫描**静默**回到启动路径 —— 不报错、不变红、只是每次启动慢几秒。

## 改法：三层一起，才叫根绝

| | |
|---|---|
| **① 去掉 import 顺序依赖** | 判断不再来自模块级常量 |
| **② 去掉全局 env 依赖** | 显式参数 `build_plugin_server_app(manage_lifecycle=…)`，承重判断读闭包不读进程环境 |
| **③ 反转默认的失败方向** | 默认 `False`。没人明说就不起 |

③ 是最关键的一层。今天「没信息 ⇒ 不是内嵌 ⇒ **起** lifecycle」，最坏结果是启动悄悄变慢。反过来之后，将来任何疏漏的最坏结果是「独立服务器里插件不自启」—— **看得见、有人会立刻报**。

两个调用点各自表态：

- `plugin/user_plugin_server.py` → `manage_lifecycle=True`（独立跑没别人会起它）
- `app/agent_server/plugin_host.py` → 不传（由 `user_plugin_enabled` 开关驱动）

`_EMBEDDED_BY_AGENT` **保留** —— 它还在决定 logger 命名空间，那处搞错了只是日志归错类。承重的两处不再碰它。

## 守卫

`plugin/tests/unit/server/test_plugin_lifecycle_ownership.py`，六条：

- **默认不起 lifecycle**，对环境变量 `unset` / `true` / `false` 三种取值各验一次。参数化不是凑数：**单值用例对旧的 import 期常量同样会绿**，证明不了环境变量已经不参与。
- 显式认领时要**真的**起和停 —— 否则整条规则可以靠「把调用删掉」满足，而独立服务器会静默不加载插件。
- **两个调用点必须一个认领、一个不认领。** 谓词对不等于调用点传对了，这是本轮反复出现的洞。
- 起停判断**不得再由 `_EMBEDDED_BY_AGENT` 决定**（AST 断言，允许它继续用于 logger）。

**五条变异全杀**：默认翻 True / 判断改回读环境 / 忽略参数永不起 / 独立入口不再认领 / 内嵌调用点认领。

## 一个值得记的过程细节

守卫第一版的 stub 是**同步**的，而生产代码是 `await lifecycle_startup()`。「默认不起」那条**照样绿** —— 正因为那条路根本没被执行。改成 async stub 之后，「显式认领」那条立刻红出 `TypeError`。

同步 stub 在这里等于什么都没证明：它只在被真正调用时才会暴露自己是错的，而那恰好是「不该调用」的用例永远不会到达的地方。

## 验证

- `plugin/tests/unit/server` — **742 passed / 3 skipped**
- `scripts/check_docstring_no_cjk.py --base origin/main` — rc=0
- ruff clean

## 与在途 PR 的关系

与 #3020（`plugin/server/application/`、`messaging/`、`routes/`）和 #3028（`config/`、`launcher_core/`、`utils/`）**零文件重叠**，已核实。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 插件服务器现在通过显式配置管理启动与关闭生命周期，默认不会自动接管。
  * 独立运行的插件服务器会明确管理自身生命周期；嵌入式运行模式继续由宿主服务控制。
  * 更新了相关使用说明，明确区分独立服务器与嵌入式服务器的运行方式。

* **测试**
  * 增加生命周期所有权测试，覆盖默认配置、独立运行和嵌入式运行场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->