### PR TITLE
fix(tts): Qwen 实时 TTS 换成不带日期后缀的滚动模型名

### DIFF
--- a/main_logic/tts_client/workers/qwen.py
+++ b/main_logic/tts_client/workers/qwen.py
@@ -38,7 +38,7 @@ from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Main")
 
-_QWEN_REALTIME_TTS_MODEL = "qwen3-tts-flash-realtime-2025-11-27"
+_QWEN_REALTIME_TTS_MODEL = "qwen3-tts-flash-realtime"
 _DASHSCOPE_DEFAULT_REALTIME_WS_URL = "wss://dashscope.aliyuncs.com/api-ws/v1/realtime"
 
 def _resolve_qwen_realtime_tts_url() -> str:
@@ -59,7 +59,7 @@ def _resolve_qwen_realtime_tts_url() -> str:
 def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
     """
     Qwen realtime TTS worker (for default voices)
-    Uses Aliyun's realtime TTS API (qwen3-tts-flash-2025-09-18)
+    Uses Aliyun's realtime TTS API (qwen3-tts-flash-realtime)
     
     Args:
         request_queue: multiprocess request queue receiving (speech_id, text) tuples

--- a/scripts/probe_qwen_tts.py
+++ b/scripts/probe_qwen_tts.py
@@ -45,7 +45,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 from utils.config_manager import get_config_manager
 
-TTS_URL = "wss://dashscope.aliyuncs.com/api-ws/v1/realtime?model=qwen3-tts-flash-realtime-2025-11-27"
+TTS_URL = "wss://dashscope.aliyuncs.com/api-ws/v1/realtime?model=qwen3-tts-flash-realtime"
 
 
 async def run(args: argparse.Namespace, log: logging.Logger) -> int:


### PR DESCRIPTION
阿里云已公告下线 `qwen3-tts-flash-realtime-2025-11-27` 这个带日期的快照。它不是边缘配置，而是 qwen / qwen_intl 用户在没有克隆音色时默认发声路径上唯一会被用到的模型名，快照一停这条路径就整体没声音。

## 回归报告

### 改动

- `main_logic/tts_client/workers/qwen.py:41` — `_QWEN_REALTIME_TTS_MODEL` 由 `qwen3-tts-flash-realtime-2025-11-27` 改为不带日期后缀的 `qwen3-tts-flash-realtime`。
- `scripts/probe_qwen_tts.py:48` — 探针脚本 WS URL 里同样硬编码的那份同步改掉。
- `main_logic/tts_client/workers/qwen.py:62` — 一句更陈旧的 docstring（还写着 `qwen3-tts-flash-2025-09-18`）对齐到现在真正在用的模型名。

### 理由 / 必要性

`_resolve_qwen_realtime_tts_url()` 的模型选择是：configured_model 只在 `startswith("qwen3-tts")` 时才被采用，否则回落到硬编码常量。而 `DEFAULT_TTS_MODEL` 是 `qwen3-omni-flash-realtime`（omni 实时对话模型，不是 TTS 模型，前缀 gate 正是拦它的），`config/api_providers.json` 里 qwen / qwen_intl 也没给 `tts_default_model` 覆盖值。所以默认配置下**永远**落到硬编码常量，从不读配置值。这个常量就是下线目标。

触发面见 `main_logic/tts_client/__init__.py:397-408`：`core_api_type` 为 `qwen` / `qwen_intl` 且无自定义克隆音色（用 Momo 等免费预设音色）时一律走这个 worker。有克隆音色的走 CosyVoice，不受影响。

改成滚动别名而不是钉新快照，是为了以后阿里云轮换快照时不用再跟着改代码。别名目前仍在官方实时语音合成文档的模型列表里。

### 前后行为

WS URL 从 `...?model=qwen3-tts-flash-realtime-2025-11-27` 变为 `...?model=qwen3-tts-flash-realtime`。协议、端点、`session.update` 载荷、音色参数、采样率、重采样链路全部不变，只有 query 里的模型名一个 token 变化。

### 潜在回归

滚动别名的语义是上游可随时把它指到新底座，音色映射、音质、首包延迟都可能在我们不知情时漂移；我们钉死用 `Momo` 等免费预设音色，若别名换底座后音色 ID 变了会是静默失败（连得上、发得出、声音不对）。合并前建议用探针实测一次：`uv run python scripts/probe_qwen_tts.py --text "测试一下声音" --voice Momo --save-audio probe.wav -v`。

另一个方向的风险是 0：即便别名当天出问题，也不比留着一个确定要下线的快照更差。

`tests/unit/test_gemini_realtime_voice_routing.py` 和 `test_mimo_tts_worker.py` 里还有三处旧串，是 fixture 里随手填的字符串（测的是 vllm_omni 路由，不对模型名做断言），本 PR 未改动，不影响。

### 验证

`uv run pytest tests/unit/test_openai_compatible_tts.py tests/unit/test_qwen_intl_tts_routing.py tests/unit/test_tts_language_hint.py` → 89 passed。

`uv run python scripts/check_docstring_no_cjk.py --base origin/main` → exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **更新**
  * Qwen 实时语音合成现使用不带日期后缀的默认模型标识。
  * 相关模型名称与连接配置已保持一致，提升服务调用兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->