### PR TITLE
修复 MMD 热重载期间 UI 隐藏/恢复竞态导致模型加载后不可见的问题，并补充回归测试

### DIFF
--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1560,6 +1560,10 @@ I.mod = window.appInterpage;
             console.error('[Model] 模型热切换失败:', error);
             if (activeMmdLoadingSessionId) {
                 window.MMDLoadingOverlay?.fail(activeMmdLoadingSessionId, { detail: error?.message || String(error) });
+                var failedMmdCanvas = document.getElementById('mmd-canvas');
+                if (isMMDLoadingSessionActive(failedMmdCanvas, activeMmdLoadingSessionId)) {
+                    clearMMDCanvasLoadingSession(failedMmdCanvas);
+                }
                 if (mmdRequestSessionId === activeMmdLoadingSessionId) {
                     mmdRequestSessionId = '';
                 }

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -282,6 +282,7 @@ I.mod = window.appInterpage;
     var modelManagerOverlapRefreshTimer = 0;
     var mainUIHideOwners = Object.create(null);
     var deferredMainUIShowAfterModelReload = null;
+    var activeMMDReloadCanvasSessionId = '';
 
     function getMainUIHideOwner(options) {
         return String((options && (options.owner || options.reason)) || 'legacy-main-ui');
@@ -1218,6 +1219,7 @@ I.mod = window.appInterpage;
                         // 先隐藏 canvas，避免旧帧或加载中的模型透过半透明 overlay 露出。
                         markMMDCanvasLoadingSession(mmdCanvasShow, loadingSessionId);
                     }
+                    activeMMDReloadCanvasSessionId = loadingSessionId;
                     mmdRequestSessionId = loadingSessionId;
                     activeMmdLoadingSessionId = loadingSessionId;
                     window.MMDLoadingOverlay?.begin(loadingSessionId, { stage: 'engine' });
@@ -1300,6 +1302,7 @@ I.mod = window.appInterpage;
                         if (mmdRequestSessionId === loadingSessionId && isMMDLoadingSessionActive(mmdCanvasReady, loadingSessionId)) {
                             window.MMDLoadingOverlay?.end(loadingSessionId);
                             restoreMMDCanvasForLoadingSession(mmdCanvasReady, loadingSessionId);
+                            activeMMDReloadCanvasSessionId = '';
                             mmdRequestSessionId = '';
                             activeMmdLoadingSessionId = '';
                         }
@@ -1560,6 +1563,9 @@ I.mod = window.appInterpage;
                 if (mmdRequestSessionId === activeMmdLoadingSessionId) {
                     mmdRequestSessionId = '';
                 }
+                if (activeMMDReloadCanvasSessionId === activeMmdLoadingSessionId) {
+                    activeMMDReloadCanvasSessionId = '';
+                }
                 activeMmdLoadingSessionId = '';
             }
             // 回滚提前写入的 config，防止残留错误的模型类型
@@ -1603,6 +1609,7 @@ I.mod = window.appInterpage;
         } finally {
             // Clear in-flight flag
             window._modelReloadInFlight = false;
+            activeMMDReloadCanvasSessionId = '';
             if (reloadSucceeded) {
                 window._lastModelReloadKey = reloadKey;
                 window._lastModelReloadAt = Date.now();
@@ -1957,8 +1964,8 @@ I.mod = window.appInterpage;
                 // 热重载期间再次收到 hide/show 是模型管理窗口生命周期的正常竞态。
                 // 此时只隐藏 Canvas，不清除会话 ID；否则重载收尾无法结束 overlay
                 // 和恢复 Canvas，最终会留下已加载但不可见的 MMD 模型。
-                var preserveMMDLoadingSession = window._modelReloadInFlight === true
-                    && !!mmdCanvas.dataset.mmdLoadingSessionId;
+                var preserveMMDLoadingSession = !!activeMMDReloadCanvasSessionId
+                    && mmdCanvas.dataset.mmdLoadingSessionId === activeMMDReloadCanvasSessionId;
                 if (preserveMMDLoadingSession) {
                     mmdCanvas.style.visibility = 'hidden';
                     mmdCanvas.style.pointerEvents = 'none';

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -281,6 +281,7 @@ I.mod = window.appInterpage;
     var modelManagerOverlapHidden = false;
     var modelManagerOverlapRefreshTimer = 0;
     var mainUIHideOwners = Object.create(null);
+    var deferredMainUIShowAfterModelReload = null;
 
     function getMainUIHideOwner(options) {
         return String((options && (options.owner || options.reason)) || 'legacy-main-ui');
@@ -1618,6 +1619,12 @@ I.mod = window.appInterpage;
             if (I.isMainUIHiddenByModelManager()) {
                 console.log('[Model] 主界面处于模型管理隐藏状态，模型重载完成后重新隐藏 UI');
                 I.handleHideMainUI({ preserveHiddenState: true });
+                deferredMainUIShowAfterModelReload = null;
+            } else if (deferredMainUIShowAfterModelReload) {
+                var deferredShowOptions = deferredMainUIShowAfterModelReload;
+                deferredMainUIShowAfterModelReload = null;
+                console.log('[Model] 执行热重载期间延后的主界面恢复');
+                I.handleShowMainUI(deferredShowOptions);
             }
 
             // Process any queued reload request
@@ -1947,7 +1954,17 @@ I.mod = window.appInterpage;
 
             var mmdCanvas = document.getElementById('mmd-canvas');
             if (mmdCanvas) {
-                clearMMDCanvasLoadingSession(mmdCanvas);
+                // 热重载期间再次收到 hide/show 是模型管理窗口生命周期的正常竞态。
+                // 此时只隐藏 Canvas，不清除会话 ID；否则重载收尾无法结束 overlay
+                // 和恢复 Canvas，最终会留下已加载但不可见的 MMD 模型。
+                var preserveMMDLoadingSession = window._modelReloadInFlight === true
+                    && !!mmdCanvas.dataset.mmdLoadingSessionId;
+                if (preserveMMDLoadingSession) {
+                    mmdCanvas.style.visibility = 'hidden';
+                    mmdCanvas.style.pointerEvents = 'none';
+                } else {
+                    clearMMDCanvasLoadingSession(mmdCanvas);
+                }
             }
 
             // Pause render loops to save resources
@@ -2022,6 +2039,7 @@ I.mod = window.appInterpage;
         // 错误地恢复旧模型类型的容器，导致需要切换两次才能成功。
         if (window._modelReloadInFlight) {
             console.log('[UI] 模型重载进行中，跳过显示主界面（避免覆盖正在切换的容器）');
+            deferredMainUIShowAfterModelReload = Object.assign({}, options);
             return;
         }
         console.log('[UI] 显示主界面并恢复渲染');

--- a/tests/frontend/test_mmd_hot_reload_visibility_race.py
+++ b/tests/frontend/test_mmd_hot_reload_visibility_race.py
@@ -14,8 +14,7 @@ INTERPAGE_SCRIPT = (
 )
 
 
-@pytest.mark.frontend
-def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
+def _set_up_mmd_reload_page(page: Page):
     page.set_content(
         """
         <div id="live2d-container"><canvas id="live2d-canvas"></canvas></div>
@@ -84,6 +83,11 @@ def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
     )
     page.add_script_tag(path=str(INTERPAGE_SCRIPT))
 
+
+@pytest.mark.frontend
+def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
+    _set_up_mmd_reload_page(page)
+
     result = page.evaluate(
         """
         async () => {
@@ -132,6 +136,59 @@ def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
         "reloadSucceeded": True,
         "rendering": True,
         "containerHidden": False,
+        "containerDisplay": "block",
+        "canvasVisibility": "visible",
+        "canvasPointerEvents": "auto",
+        "finalCanvasSession": "",
+    }
+
+
+@pytest.mark.frontend
+def test_failed_mmd_hot_reload_clears_session_before_deferred_show(page: Page):
+    _set_up_mmd_reload_page(page)
+
+    result = page.evaluate(
+        """
+        async () => {
+            const interpage = window.__appInterpageParts;
+            window.__overlayFailed = false;
+            window.MMDLoadingOverlay.fail = () => { window.__overlayFailed = true; };
+            window.mmdManager.loadModel = () => new Promise((resolve, reject) => {
+                window.__failMmdLoad = () => reject(new Error('expected MMD load failure'));
+            });
+
+            interpage.handleHideMainUI();
+            const reloadPromise = interpage.handleModelReload('TestMMD');
+            while (typeof window.__failMmdLoad !== 'function') {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+
+            interpage.handleHideMainUI();
+            interpage.handleShowMainUI();
+            window.__failMmdLoad();
+            await reloadPromise;
+
+            const container = document.getElementById('mmd-container');
+            const canvas = document.getElementById('mmd-canvas');
+            return {
+                overlayFailed: window.__overlayFailed,
+                reloadSucceeded: window._lastModelReloadResult,
+                mainUIHiddenByModelManager: document.body.classList.contains(
+                    'neko-main-ui-hidden-by-model-manager'
+                ),
+                containerDisplay: getComputedStyle(container).display,
+                canvasVisibility: canvas.style.visibility,
+                canvasPointerEvents: canvas.style.pointerEvents,
+                finalCanvasSession: canvas.dataset.mmdLoadingSessionId || ''
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "overlayFailed": True,
+        "reloadSucceeded": False,
+        "mainUIHiddenByModelManager": False,
         "containerDisplay": "block",
         "canvasVisibility": "visible",
         "canvasPointerEvents": "auto",

--- a/tests/frontend/test_mmd_hot_reload_visibility_race.py
+++ b/tests/frontend/test_mmd_hot_reload_visibility_race.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+INTERPAGE_SCRIPT = (
+    PROJECT_ROOT
+    / "static"
+    / "app"
+    / "app-interpage"
+    / "bootstrap-resources-and-model-reload.js"
+)
+
+
+@pytest.mark.frontend
+def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
+    page.set_content(
+        """
+        <div id="live2d-container"><canvas id="live2d-canvas"></canvas></div>
+        <div id="vrm-container"><canvas id="vrm-canvas"></canvas></div>
+        <div id="mmd-container"><canvas id="mmd-canvas"></canvas></div>
+        """
+    )
+    page.evaluate(
+        """
+        () => {
+            window.appState = {};
+            window.lanlan_config = {
+                lanlan_name: 'TestMMD',
+                model_type: 'live3d',
+                live3d_sub_type: 'mmd'
+            };
+            window.showStatusToast = () => {};
+            window.__overlayEnded = false;
+            window.MMDLoadingOverlay = {
+                begin() {},
+                update() {},
+                end() { window.__overlayEnded = true; },
+                fail() {}
+            };
+            window._createMMDLoadingSessionId = () => 'mmd-visibility-race';
+            window._waitForMMDRenderFrame = async () => {};
+
+            window.mmdManager = {
+                _shouldRender: true,
+                currentModel: null,
+                enablePhysics: true,
+                pauseRendering() { this._shouldRender = false; },
+                resumeRendering() { this._shouldRender = true; },
+                loadModel() {
+                    return new Promise((resolve) => {
+                        window.__finishMmdLoad = () => {
+                            this.currentModel = { mesh: { visible: true } };
+                            resolve({ name: 'Loaded MMD' });
+                        };
+                    });
+                },
+                applySettings() {}
+            };
+
+            window.fetch = async (url) => {
+                if (String(url).includes('/api/config/page_config')) {
+                    return {
+                        json: async () => ({
+                            success: true,
+                            model_path: '/static/mmd/Miku/Miku.pmx',
+                            model_type: 'live3d',
+                            live3d_sub_type: 'mmd'
+                        })
+                    };
+                }
+                if (String(url).includes('/mmd_settings')) {
+                    return { json: async () => ({ success: true, settings: {} }) };
+                }
+                if (String(url) === '/api/characters') {
+                    return { ok: true, json: async () => ({ '猫娘': { TestMMD: {} } }) };
+                }
+                throw new Error(`Unexpected request: ${url}`);
+            };
+        }
+        """
+    )
+    page.add_script_tag(path=str(INTERPAGE_SCRIPT))
+
+    result = page.evaluate(
+        """
+        async () => {
+            const interpage = window.__appInterpageParts;
+
+            // The manager page already owns visibility before the reload starts.
+            interpage.handleHideMainUI();
+            const reloadPromise = interpage.handleModelReload('TestMMD');
+            while (typeof window.__finishMmdLoad !== 'function') {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+
+            // Reproduce the observed lifecycle pulse while loadModel is pending.
+            interpage.handleHideMainUI();
+            const canvasDuringLoad = document.getElementById('mmd-canvas');
+            const sessionAfterSecondHide = canvasDuringLoad.dataset.mmdLoadingSessionId || '';
+            interpage.handleShowMainUI();
+
+            window.__finishMmdLoad();
+            await reloadPromise;
+
+            const container = document.getElementById('mmd-container');
+            const canvas = document.getElementById('mmd-canvas');
+            return {
+                sessionAfterSecondHide,
+                overlayEnded: window.__overlayEnded,
+                reloadSucceeded: window._lastModelReloadResult,
+                rendering: window.mmdManager._shouldRender,
+                containerHidden: container.classList.contains('hidden'),
+                containerDisplay: container.style.display,
+                canvasVisibility: canvas.style.visibility,
+                canvasPointerEvents: canvas.style.pointerEvents,
+                finalCanvasSession: canvas.dataset.mmdLoadingSessionId || ''
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "sessionAfterSecondHide": "mmd-visibility-race",
+        "overlayEnded": True,
+        "reloadSucceeded": True,
+        "rendering": True,
+        "containerHidden": False,
+        "containerDisplay": "block",
+        "canvasVisibility": "visible",
+        "canvasPointerEvents": "auto",
+        "finalCanvasSession": "",
+    }

--- a/tests/frontend/test_mmd_hot_reload_visibility_race.py
+++ b/tests/frontend/test_mmd_hot_reload_visibility_race.py
@@ -108,12 +108,15 @@ def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
             const container = document.getElementById('mmd-container');
             const canvas = document.getElementById('mmd-canvas');
             return {
+                mainUIHiddenByModelManager: document.body.classList.contains(
+                    'neko-main-ui-hidden-by-model-manager'
+                ),
                 sessionAfterSecondHide,
                 overlayEnded: window.__overlayEnded,
                 reloadSucceeded: window._lastModelReloadResult,
                 rendering: window.mmdManager._shouldRender,
                 containerHidden: container.classList.contains('hidden'),
-                containerDisplay: container.style.display,
+                containerDisplay: getComputedStyle(container).display,
                 canvasVisibility: canvas.style.visibility,
                 canvasPointerEvents: canvas.style.pointerEvents,
                 finalCanvasSession: canvas.dataset.mmdLoadingSessionId || ''
@@ -123,6 +126,7 @@ def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
     )
 
     assert result == {
+        "mainUIHiddenByModelManager": False,
         "sessionAfterSecondHide": "mmd-visibility-race",
         "overlayEnded": True,
         "reloadSucceeded": True,
@@ -132,4 +136,48 @@ def test_mmd_hot_reload_survives_hide_show_during_model_loading(page: Page):
         "canvasVisibility": "visible",
         "canvasPointerEvents": "auto",
         "finalCanvasSession": "",
+    }
+
+
+@pytest.mark.frontend
+def test_non_mmd_reload_does_not_preserve_stale_mmd_loading_session(page: Page):
+    page.set_content(
+        """
+        <div id="live2d-container"><canvas id="live2d-canvas"></canvas></div>
+        <div id="vrm-container"><canvas id="vrm-canvas"></canvas></div>
+        <div id="mmd-container"><canvas id="mmd-canvas"></canvas></div>
+        """
+    )
+    page.evaluate(
+        """
+        () => {
+            window.appState = {};
+            window.lanlan_config = { model_type: 'pngtuber' };
+        }
+        """
+    )
+    page.add_script_tag(path=str(INTERPAGE_SCRIPT))
+
+    result = page.evaluate(
+        """
+        () => {
+            const canvas = document.getElementById('mmd-canvas');
+            canvas.dataset.mmdLoadingSessionId = 'stale-mmd-session';
+            window._modelReloadInFlight = true;
+
+            window.__appInterpageParts.handleHideMainUI();
+
+            return {
+                finalCanvasSession: canvas.dataset.mmdLoadingSessionId || '',
+                canvasVisibility: canvas.style.visibility,
+                canvasPointerEvents: canvas.style.pointerEvents
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "finalCanvasSession": "",
+        "canvasVisibility": "hidden",
+        "canvasPointerEvents": "none",
     }


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 MMD 热重载期间 UI 隐藏/恢复竞态导致模型加载后不可见的问题

## 测试 / Testing

确认不会再次复现


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复模型热重载期间快速隐藏或显示主界面可能导致加载中断、界面无法恢复的问题。
  * 优化模型加载完成后的界面、画布与加载状态恢复，避免界面不可见或加载状态残留。
  * 修复模型加载失败时加载状态未清理、延迟显示异常的问题。
  * 修复非模型热重载场景下过期加载状态未清除的问题，确保画布正确隐藏并禁用交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->