### PR TITLE
feat(plugin): 支持声明式安装元数据与 Market fresh install 刷新

### DIFF
--- a/plugin/config/schema.py
+++ b/plugin/config/schema.py
@@ -7,9 +7,10 @@
 from __future__ import annotations
 
 import math
+import re
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, StrictBool, StrictStr, field_validator, model_validator
 from plugin._types.plugin_types import (
     PluginType,
     SUPPORTED_PLUGIN_TYPES,
@@ -19,6 +20,7 @@ from plugin._types.plugin_types import (
 )
 
 _PLUGIN_RUNTIME_TIMEOUT_MAX = 300.0
+_PLUGIN_INSTALL_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 class PluginAuthorSchema(BaseModel):
@@ -56,6 +58,96 @@ class PluginConfigProfilesSchema(BaseModel):
 class PluginSafetySchema(BaseModel):
     """插件安全配置 Schema"""
     sync_call_in_handler: Optional[Literal["warn", "reject"]] = None
+
+
+class PluginInstallKindSchema(BaseModel):
+    """One host-managed install action declared by a plugin manifest."""
+
+    model_config = {"extra": "forbid"}
+
+    entry_id: StrictStr
+    label: StrictStr
+    queued_message: StrictStr
+    entry_timeout: float
+
+    @field_validator("entry_id")
+    @classmethod
+    def validate_entry_id(cls, value: str) -> str:
+        if not value or value.strip() != value:
+            raise ValueError("entry_id must be non-empty and unpadded")
+        return value
+
+    @field_validator("label")
+    @classmethod
+    def validate_label(cls, value: str) -> str:
+        if not value or value.strip() != value:
+            raise ValueError("label must be non-empty and unpadded")
+        return value
+
+    @field_validator("queued_message")
+    @classmethod
+    def validate_queued_message(cls, value: str) -> str:
+        if not value or value.strip() != value:
+            raise ValueError("queued_message must be non-empty and unpadded")
+        return value
+
+    @field_validator("entry_timeout", mode="before")
+    @classmethod
+    def validate_entry_timeout(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("entry_timeout must be a finite number greater than zero")
+        try:
+            timeout = float(value)
+        except (OverflowError, ValueError) as exc:
+            raise ValueError(
+                "entry_timeout must be a finite number greater than zero"
+            ) from exc
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("entry_timeout must be a finite number greater than zero")
+        return timeout
+
+
+class PluginInstallSchema(BaseModel):
+    """Declarative install capabilities under ``[plugin.install]``."""
+
+    model_config = {"extra": "forbid"}
+
+    enabled: StrictBool
+    ui_i18n_dir: Optional[StrictStr] = None
+    tutorial_enabled: StrictBool = False
+    kinds: Dict[str, PluginInstallKindSchema] = Field(default_factory=dict)
+
+    @field_validator("kinds")
+    @classmethod
+    def validate_kind_names(
+        cls,
+        value: Dict[str, PluginInstallKindSchema],
+    ) -> Dict[str, PluginInstallKindSchema]:
+        for kind in value:
+            if not _PLUGIN_INSTALL_KIND_PATTERN.fullmatch(kind):
+                raise ValueError(
+                    "install kinds must match ^[a-z][a-z0-9_]*$ without normalization"
+                )
+        return value
+
+    @field_validator("ui_i18n_dir")
+    @classmethod
+    def validate_i18n_path_string(cls, value: str | None) -> str | None:
+        if value is not None and (not value or value.strip() != value):
+            raise ValueError("ui_i18n_dir must be non-empty and unpadded")
+        return value
+
+    @model_validator(mode="after")
+    def validate_disabled_contract(self) -> "PluginInstallSchema":
+        if self.enabled:
+            return self
+        if self.kinds:
+            raise ValueError("disabled plugin install declarations must not define kinds")
+        if self.tutorial_enabled:
+            raise ValueError("disabled plugin install declarations must not enable tutorials")
+        if self.ui_i18n_dir is not None:
+            raise ValueError("disabled plugin install declarations must not define ui_i18n_dir")
+        return self
 
 
 class PluginDependencySchema(BaseModel):
@@ -96,6 +188,7 @@ class PluginSectionSchema(BaseModel):
     store: Optional[PluginStoreSchema] = None
     config_profiles: Optional[PluginConfigProfilesSchema] = None
     safety: Optional[PluginSafetySchema] = None
+    install: Optional[PluginInstallSchema] = None
     dependencies: Optional[List[PluginDependencySchema]] = None
 
     @model_validator(mode="before")
@@ -451,6 +544,8 @@ __all__ = [
     "PluginAuthorSchema",
     "PluginSdkSchema",
     "PluginStoreSchema",
+    "PluginInstallKindSchema",
+    "PluginInstallSchema",
     "PluginConfigProfilesSchema",
     "PluginDependencySchema",
     "PluginType",

--- a/plugin/neko_plugin_cli/commands/validate_cmd.py
+++ b/plugin/neko_plugin_cli/commands/validate_cmd.py
@@ -6,7 +6,8 @@ import ast
 import json
 import math
 import re
-from pathlib import Path
+import stat
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from plugin.core.python_dependencies import (
     collect_project_python_requirements,
@@ -166,6 +167,7 @@ def _check_plugin_toml_schema(
         "ui",
         "store",
         "host",
+        "install",
         "safety",
         "config_profiles",
         "dependency",
@@ -196,6 +198,7 @@ def _check_plugin_toml_schema(
     _check_sdk_table(plugin_table.get("sdk"), issues)
     _check_store_table(plugin_table.get("store"), issues)
     _check_i18n_table(plugin_dir, plugin_table.get("i18n"), issues)
+    _check_install_table(plugin_dir, plugin_table.get("install"), issues)
     _check_safety_table(plugin_table.get("safety"), issues)
     _check_config_profiles_table(plugin_table.get("config_profiles"), issues)
     _check_dependency_tables(plugin_table.get("dependency"), issues)
@@ -215,6 +218,11 @@ def _check_plugin_toml_schema(
 def _warn_unknown_keys(table: dict[str, object], allowed: set[str], label: str, issues: list[tuple[str, str]]) -> None:
     for key in sorted(set(table) - allowed):
         issues.append(("warning", f"{label}.{key} is not a recognized plugin.toml field"))
+
+
+def _error_unknown_keys(table: dict[str, object], allowed: set[str], label: str, issues: list[tuple[str, str]]) -> None:
+    for key in sorted(set(table) - allowed):
+        issues.append(("error", f"{label}.{key} is not a recognized plugin.toml field"))
 
 
 def _require_string(
@@ -413,6 +421,153 @@ def _check_i18n_table(plugin_dir: Path, value: object, issues: list[tuple[str, s
             issues.append(("error", "[plugin.i18n].locales_dir must be a non-empty string"))
         elif not (plugin_dir / locales_dir).is_dir():
             issues.append(("warning", f"[plugin.i18n].locales_dir does not exist: {locales_dir}"))
+
+
+def _check_install_table(
+    plugin_dir: Path,
+    value: object,
+    issues: list[tuple[str, str]],
+) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        issues.append(("error", "[plugin.install] must be a table"))
+        return
+
+    _error_unknown_keys(
+        value,
+        {"enabled", "ui_i18n_dir", "tutorial_enabled", "kinds"},
+        "[plugin.install]",
+        issues,
+    )
+    enabled = value.get("enabled")
+    if not isinstance(enabled, bool):
+        issues.append(("error", "[plugin.install].enabled must be a boolean"))
+
+    tutorial_enabled = value.get("tutorial_enabled", False)
+    if not isinstance(tutorial_enabled, bool):
+        issues.append(("error", "[plugin.install].tutorial_enabled must be a boolean"))
+
+    kinds = value.get("kinds", {})
+    if not isinstance(kinds, dict):
+        issues.append(("error", "[plugin.install].kinds must be a table"))
+        kinds = {}
+    else:
+        for kind, declaration in kinds.items():
+            label = f"[plugin.install.kinds.{kind}]"
+            if not isinstance(kind, str) or not re.fullmatch(r"[a-z][a-z0-9_]*", kind):
+                issues.append(
+                    (
+                        "error",
+                        f"[plugin.install].kinds key {kind!r} must match ^[a-z][a-z0-9_]*$",
+                    )
+                )
+            if not isinstance(declaration, dict):
+                issues.append(("error", f"{label} must be a table"))
+                continue
+            _error_unknown_keys(
+                declaration,
+                {"entry_id", "label", "queued_message", "entry_timeout"},
+                label,
+                issues,
+            )
+            for field in ("entry_id", "label", "queued_message"):
+                field_value = declaration.get(field)
+                field_label = f"{label}.{field}"
+                if not isinstance(field_value, str) or not field_value:
+                    issues.append(("error", f"{field_label} must be a non-empty string"))
+                elif field_value.strip() != field_value:
+                    issues.append(
+                        ("error", f"{field_label} must not contain leading/trailing whitespace")
+                    )
+            timeout = declaration.get("entry_timeout")
+            timeout_is_valid = not isinstance(timeout, bool) and isinstance(
+                timeout,
+                (int, float),
+            )
+            if timeout_is_valid:
+                try:
+                    timeout_number = float(timeout)
+                except (OverflowError, ValueError):
+                    timeout_is_valid = False
+                else:
+                    timeout_is_valid = math.isfinite(timeout_number) and timeout_number > 0
+            if not timeout_is_valid:
+                issues.append(
+                    (
+                        "error",
+                        f"{label}.entry_timeout must be a finite number greater than zero",
+                    )
+                )
+
+    ui_i18n_dir = value.get("ui_i18n_dir")
+    if ui_i18n_dir is not None:
+        _check_install_i18n_dir(plugin_dir, ui_i18n_dir, issues)
+
+    if enabled is False:
+        if kinds:
+            issues.append(("error", "disabled [plugin.install] must not define install kinds"))
+        if tutorial_enabled is True:
+            issues.append(("error", "disabled [plugin.install] must not enable tutorials"))
+        if ui_i18n_dir is not None:
+            issues.append(("error", "disabled [plugin.install] must not define ui_i18n_dir"))
+
+
+def _check_install_i18n_dir(
+    plugin_dir: Path,
+    value: object,
+    issues: list[tuple[str, str]],
+) -> None:
+    label = "[plugin.install].ui_i18n_dir"
+    if not isinstance(value, str) or not value or value.strip() != value:
+        issues.append(("error", f"{label} must be a non-empty relative path"))
+        return
+
+    relative = Path(value)
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or ".." in posix_path.parts
+        or ".." in windows_path.parts
+    ):
+        issues.append(("error", f"{label} must stay within the plugin directory"))
+        return
+
+    try:
+        plugin_root = plugin_dir.resolve(strict=True)
+        candidate = (plugin_root / relative).resolve(strict=True)
+        candidate.relative_to(plugin_root)
+    except (FileNotFoundError, OSError, RuntimeError, ValueError):
+        issues.append(
+            (
+                "error",
+                f"{label} must resolve to an existing directory inside the plugin directory",
+            )
+        )
+        return
+
+    current = plugin_root
+    for part in relative.parts:
+        current = current / part
+        try:
+            metadata = current.lstat()
+        except OSError:
+            break
+        file_attributes = getattr(metadata, "st_file_attributes", 0)
+        reparse_attribute = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+        if current.is_symlink() or bool(file_attributes & reparse_attribute):
+            try:
+                current.resolve(strict=True).relative_to(plugin_root)
+            except (FileNotFoundError, OSError, RuntimeError, ValueError):
+                issues.append(
+                    ("error", f"{label} must not escape through a link or reparse point")
+                )
+                return
+
+    if not candidate.is_dir():
+        issues.append(("error", f"{label} must point to an existing directory"))
 
 
 def _check_safety_table(value: object, issues: list[tuple[str, str]]) -> None:

--- a/plugin/server/application/plugin_cli/service.py
+++ b/plugin/server/application/plugin_cli/service.py
@@ -42,6 +42,7 @@ from plugin.server.application.plugins.installation_transactions import (
     replace as replacement_transaction,
 )
 from plugin.server.application.plugins import source_switch
+from plugin.server.application.plugins.registry_service import PluginRegistryService
 from plugin.server.application.plugins.installation_transactions.manual_takeover import (
     is_manual_takeover_entry,
     local_manual_takeover_confirmation_token,
@@ -79,6 +80,34 @@ _UPLOAD_MAX_BYTES = 500 * 1024 * 1024
 _UPLOAD_COPY_CHUNK_BYTES = 1024 * 1024
 
 logger = get_logger("server.application.plugin_cli")
+plugin_registry_service = PluginRegistryService()
+
+
+async def _refresh_committed_market_install(plugin_id: str) -> str | None:
+    """Refresh a fresh Market install without rolling back committed files.
+
+    The source row is the commit point. Cancellation after it must wait for the
+    one refresh already in flight, then propagate to the caller; refresh failure
+    is surfaced as a warning while the committed installation remains intact.
+    """
+
+    try:
+        # upload_and_install is wrapped by serialized_plugin_operation, which
+        # shields the complete locked operation and waits for it before
+        # propagating caller cancellation. Await directly here so no orphan
+        # refresh task is created.
+        await plugin_registry_service.refresh_plugin(plugin_id, force=True)
+    except Exception as exc:  # noqa: BLE001 - committed install stays successful.
+        logger.warning(
+            "post-commit Market plugin refresh failed: plugin_id={}",
+            plugin_id,
+            exc_info=True,
+        )
+        return (
+            f"plugin '{plugin_id}' was installed, but its registry refresh failed "
+            f"({type(exc).__name__}: {exc}); refresh plugins or restart N.E.K.O"
+        )
+    return None
 
 _PACKAGE_ERROR_PATTERNS = (
     (
@@ -1253,6 +1282,12 @@ class PluginCliService:
                     package_id=str(unpack_result.get("package_id") or ""),
                     profile_dir=str(unpack_result.get("profile_dir") or ""),
                 )
+                if install_mode == "install":
+                    refresh_warning = await _refresh_committed_market_install(
+                        package_plugin_id
+                    )
+                    if refresh_warning is not None:
+                        warnings.append(refresh_warning)
                 return self._compose_install_result(
                     saved=saved,
                     unpack_result=unpack_result,
@@ -1343,6 +1378,12 @@ class PluginCliService:
                     profile_dir=str(unpack_result.get("profile_dir") or ""),
                 )
             warnings.extend(ism_warnings)
+            if install_mode == "install":
+                refresh_warning = await _refresh_committed_market_install(
+                    package_plugin_id
+                )
+                if refresh_warning is not None:
+                    warnings.append(refresh_warning)
 
             install_dict: dict[str, Any] = {
                 "channel": entry.channel,

--- a/plugin/server/install_registry.py
+++ b/plugin/server/install_registry.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import importlib.util
+import tomllib
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 import threading
 from types import MappingProxyType
 
+from plugin.config.schema import PluginInstallSchema
+from plugin.core.state import state
 from plugin.logging_config import get_logger
 
 
@@ -27,11 +30,21 @@ class InstallPluginRegistration:
     install_kinds: Mapping[str, InstallKindRegistration]
     ui_i18n_dir: Path | None = None
     tutorial_enabled: bool = False
+    config_path: Path | None = None
+    effective_source: str | None = None
+
+
+@dataclass(frozen=True)
+class _SelectedPluginState:
+    config_path: str
+    entry_ids: frozenset[str]
+    runtime_load_state: str | None
+    effective_source: str | None
 
 
 _install_plugin_registry: dict[str, InstallPluginRegistration] = {}
 _tutorial_migration_hooks: dict[str, list[Callable[[Path], None]]] | list[Callable[[Path], None]] = {}
-_builtin_install_registry_lock = threading.RLock()
+_registry_lock = threading.RLock()
 
 
 def normalize_registered_plugin_id(plugin_id: str) -> str:
@@ -48,6 +61,8 @@ def register_install_plugin(
     ui_i18n_dir: Path | str | None = None,
     tutorial_enabled: bool = False,
 ) -> None:
+    """Register the legacy in-process install API used by third-party plugins."""
+
     normalized_plugin_id = normalize_registered_plugin_id(plugin_id)
     normalized_kinds: dict[str, InstallKindRegistration] = {}
     for raw_kind, registration in install_kinds.items():
@@ -60,11 +75,175 @@ def register_install_plugin(
             raise ValueError(f"install entry_id for kind {normalized_kind!r} must not be empty")
         normalized_kinds[normalized_kind] = registration
 
-    _install_plugin_registry[normalized_plugin_id] = InstallPluginRegistration(
+    registration = InstallPluginRegistration(
         plugin_id=normalized_plugin_id,
         install_kinds=MappingProxyType(normalized_kinds),
         ui_i18n_dir=Path(ui_i18n_dir).resolve() if ui_i18n_dir is not None else None,
         tutorial_enabled=bool(tutorial_enabled),
+    )
+    with _registry_lock:
+        _install_plugin_registry[normalized_plugin_id] = registration
+
+
+def _selected_plugin_state(plugin_id: str) -> _SelectedPluginState | None:
+    with state.acquire_plugins_read_lock():
+        raw_meta = state.plugins.get(plugin_id)
+        if not isinstance(raw_meta, dict):
+            return None
+        config_path = raw_meta.get("config_path")
+        if not isinstance(config_path, str) or not config_path:
+            return None
+        entries_preview = raw_meta.get("entries_preview")
+        entries = entries_preview if isinstance(entries_preview, list) else []
+        entry_ids = frozenset(
+            entry_id
+            for item in entries
+            if isinstance(item, dict)
+            for entry_id in (item.get("id"),)
+            if isinstance(entry_id, str) and entry_id
+        )
+        runtime_load_state = raw_meta.get("runtime_load_state")
+        effective_source = raw_meta.get("effective_source")
+        return _SelectedPluginState(
+            config_path=config_path,
+            entry_ids=entry_ids,
+            runtime_load_state=(
+                runtime_load_state if isinstance(runtime_load_state, str) else None
+            ),
+            effective_source=(
+                effective_source if isinstance(effective_source, str) else None
+            ),
+        )
+
+
+def _load_selected_manifest(config_path: Path) -> tuple[dict[str, object], bool]:
+    resolved = config_path.resolve(strict=True)
+    if resolved.name != "plugin.toml" or not resolved.is_file():
+        raise ValueError("selected plugin config_path must point to plugin.toml")
+    with resolved.open("rb") as file_obj:
+        manifest = tomllib.load(file_obj)
+    plugin_table = manifest.get("plugin")
+    if not isinstance(plugin_table, dict):
+        raise ValueError("selected plugin manifest has no [plugin] table")
+    return plugin_table, "install" in plugin_table
+
+
+def _resolve_i18n_dir(plugin_root: Path, relative_value: str | None) -> Path | None:
+    if relative_value is None:
+        return None
+    if not relative_value or relative_value.strip() != relative_value:
+        raise ValueError("ui_i18n_dir must be non-empty and unpadded")
+    relative = Path(relative_value)
+    posix_path = PurePosixPath(relative_value)
+    windows_path = PureWindowsPath(relative_value)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or ".." in posix_path.parts
+        or ".." in windows_path.parts
+    ):
+        raise ValueError("ui_i18n_dir must stay within the selected plugin root")
+    resolved_root = plugin_root.resolve(strict=True)
+    resolved = (resolved_root / relative).resolve(strict=True)
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError("ui_i18n_dir escapes the selected plugin root") from exc
+    if not resolved.is_dir():
+        raise ValueError("ui_i18n_dir must point to an existing directory")
+    return resolved
+
+
+def _validate_entry_ids(
+    install_kinds: Mapping[str, InstallKindRegistration],
+    selected: _SelectedPluginState,
+) -> None:
+    missing = sorted(
+        registration.entry_id
+        for registration in install_kinds.values()
+        if registration.entry_id not in selected.entry_ids
+    )
+    if missing:
+        raise ValueError(
+            "install declaration references entries absent from selected metadata: "
+            + ", ".join(missing)
+        )
+
+
+def _explicit_registration(
+    plugin_id: str,
+    *,
+    config_path: Path,
+    selected: _SelectedPluginState,
+    install_table: object,
+) -> InstallPluginRegistration | None:
+    declaration = PluginInstallSchema.model_validate(install_table)
+    if not declaration.enabled:
+        return None
+    kinds = MappingProxyType(
+        {
+            kind: InstallKindRegistration(
+                entry_id=spec.entry_id,
+                label=spec.label,
+                queued_message=spec.queued_message,
+                entry_timeout=spec.entry_timeout,
+            )
+            for kind, spec in declaration.kinds.items()
+        }
+    )
+    _validate_entry_ids(kinds, selected)
+    return InstallPluginRegistration(
+        plugin_id=plugin_id,
+        install_kinds=kinds,
+        ui_i18n_dir=_resolve_i18n_dir(
+            config_path.parent,
+            declaration.ui_i18n_dir,
+        ),
+        tutorial_enabled=declaration.tutorial_enabled,
+        config_path=config_path,
+        effective_source=selected.effective_source,
+    )
+
+
+def _dynamic_registration(
+    plugin_id: str,
+    *,
+    config_path: Path,
+    selected: _SelectedPluginState,
+) -> InstallPluginRegistration | None:
+    with _registry_lock:
+        registration = _install_plugin_registry.get(plugin_id)
+    if registration is None:
+        return None
+    return InstallPluginRegistration(
+        plugin_id=registration.plugin_id,
+        install_kinds=registration.install_kinds,
+        ui_i18n_dir=registration.ui_i18n_dir,
+        tutorial_enabled=registration.tutorial_enabled,
+        config_path=config_path,
+        effective_source=selected.effective_source,
+    )
+
+
+def _registration_for_selected_source(
+    plugin_id: str,
+    selected: _SelectedPluginState,
+) -> InstallPluginRegistration | None:
+    if selected.runtime_load_state == "failed":
+        return None
+    config_path = Path(selected.config_path).resolve(strict=True)
+    plugin_table, has_install_declaration = _load_selected_manifest(config_path)
+    if has_install_declaration:
+        return _explicit_registration(
+            plugin_id,
+            config_path=config_path,
+            selected=selected,
+            install_table=plugin_table.get("install"),
+        )
+    return _dynamic_registration(
+        plugin_id,
+        config_path=config_path,
+        selected=selected,
     )
 
 
@@ -103,7 +282,7 @@ def _copy_legacy_galgame_tutorial_progress_if_missing(store_path: Path) -> None:
 
 
 def bootstrap_builtin_install_plugins() -> None:
-    with _builtin_install_registry_lock:
+    with _registry_lock:
         plugins_root = _plugins_root()
         if (
             "galgame_plugin" not in _install_plugin_registry
@@ -150,9 +329,53 @@ def bootstrap_builtin_install_plugins() -> None:
 
 
 def get_install_plugin_registration(plugin_id: str) -> InstallPluginRegistration | None:
+    """Resolve install metadata from the source selected by the main registry.
+
+    Manifest parsing intentionally is not cached. A source switch can therefore
+    never keep serving install metadata from an older plugin directory. If the
+    selected source changes while the manifest is being read, the complete read
+    is retried once and then fails closed.
+    """
+
     normalized_plugin_id = normalize_registered_plugin_id(plugin_id)
     bootstrap_builtin_install_plugins()
-    return _install_plugin_registry.get(normalized_plugin_id)
+    for attempt in range(2):
+        selected = _selected_plugin_state(normalized_plugin_id)
+        if selected is None or selected.runtime_load_state == "failed":
+            return None
+        try:
+            registration = _registration_for_selected_source(
+                normalized_plugin_id,
+                selected,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            if attempt == 0 and _selected_plugin_state(normalized_plugin_id) != selected:
+                logger.info(
+                    "selected source changed while rejecting install declaration for {}; retrying",
+                    normalized_plugin_id,
+                )
+                continue
+            logger.warning(
+                "install declaration rejected for selected plugin {}: {}",
+                normalized_plugin_id,
+                exc,
+            )
+            raise ValueError(
+                f"install declaration rejected for {normalized_plugin_id}: {exc}"
+            ) from exc
+
+        if _selected_plugin_state(normalized_plugin_id) == selected:
+            return registration
+        if attempt == 0:
+            logger.info(
+                "selected source changed while reading install declaration for {}; retrying",
+                normalized_plugin_id,
+            )
+    logger.warning(
+        "selected source kept changing while reading install declaration for {}; failing closed",
+        normalized_plugin_id,
+    )
+    return None
 
 
 
@@ -162,22 +385,24 @@ def register_tutorial_migration_hook(
     plugin_id: str = "",
 ) -> None:
     normalized_plugin_id = normalize_registered_plugin_id(plugin_id) if plugin_id else ""
-    # Some tests monkeypatch the pre-plugin registry shape; keep that compatibility
-    # path explicit while production code uses a plugin-id keyed hook map.
-    if isinstance(_tutorial_migration_hooks, list):
-        if hook not in _tutorial_migration_hooks:
-            _tutorial_migration_hooks.append(hook)
-        return
-    hooks = _tutorial_migration_hooks.setdefault(normalized_plugin_id, [])
-    if hook not in hooks:
-        hooks.append(hook)
+    with _registry_lock:
+        # Some third-party tests and older plugins still patch the pre-plugin
+        # list shape. Preserve that compatibility while production uses a map.
+        if isinstance(_tutorial_migration_hooks, list):
+            if hook not in _tutorial_migration_hooks:
+                _tutorial_migration_hooks.append(hook)
+            return
+        hooks = _tutorial_migration_hooks.setdefault(normalized_plugin_id, [])
+        if hook not in hooks:
+            hooks.append(hook)
 
 
 def tutorial_migration_hooks_for(plugin_id: str) -> list[Callable[[Path], None]]:
     normalized_plugin_id = normalize_registered_plugin_id(plugin_id) if plugin_id else ""
-    if isinstance(_tutorial_migration_hooks, list):
-        return list(_tutorial_migration_hooks)
-    return [
-        *_tutorial_migration_hooks.get("", []),
-        *_tutorial_migration_hooks.get(normalized_plugin_id, []),
-    ]
+    with _registry_lock:
+        if isinstance(_tutorial_migration_hooks, list):
+            return list(_tutorial_migration_hooks)
+        return [
+            *_tutorial_migration_hooks.get("", []),
+            *_tutorial_migration_hooks.get(normalized_plugin_id, []),
+        ]

--- a/plugin/server/routes/plugin_install.py
+++ b/plugin/server/routes/plugin_install.py
@@ -108,7 +108,7 @@ async def get_plugin_ui_locale(plugin_id: str) -> JSONResponse:
 @router.get("/plugin/{plugin_id}/ui-api/i18n/ui/{locale}.json")
 async def get_plugin_ui_i18n(plugin_id: str, locale: str) -> Response:
     registration = await _get_plugin_registration(plugin_id)
-    if registration.ui_i18n_dir is None:
+    if registration.ui_i18n_dir is None or registration.config_path is None:
         return Response(status_code=404)
     normalized = str(locale or "").strip()
     if ".." in normalized or "/" in normalized or "\\" in normalized:
@@ -118,6 +118,7 @@ async def get_plugin_ui_i18n(plugin_id: str, locale: str) -> Response:
 
     payload = await _run_blocking(
         _read_ui_locale_payload,
+        registration.config_path.parent,
         registration.ui_i18n_dir,
         normalized,
     )
@@ -126,16 +127,28 @@ async def get_plugin_ui_i18n(plugin_id: str, locale: str) -> Response:
     return Response(content=payload, media_type="application/json")
 
 
-def _read_ui_locale_payload(base_path: Path, locale: str) -> bytes | None:
+def _read_ui_locale_payload(
+    plugin_root: Path,
+    base_path: Path,
+    locale: str,
+) -> bytes | None:
     """Read one locale through a verified handle so path swaps cannot escape."""
 
     file_descriptor = -1
     try:
+        if not plugin_root.is_absolute():
+            return None
         base_dir = base_path.resolve(strict=True)
+        base_dir.relative_to(plugin_root)
         if not base_dir.is_dir():
             return None
         candidate = base_dir / f"{locale}.json"
-        open_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        open_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
         file_descriptor = os.open(candidate, open_flags)
 
         opened_metadata = os.fstat(file_descriptor)
@@ -150,7 +163,7 @@ def _read_ui_locale_payload(base_path: Path, locale: str) -> bytes | None:
             return None
 
         resolved = candidate.resolve(strict=True)
-        resolved.relative_to(base_dir)
+        resolved.relative_to(plugin_root)
         if not os.path.samestat(opened_metadata, resolved.stat()):
             return None
 

--- a/plugin/server/routes/plugin_install.py
+++ b/plugin/server/routes/plugin_install.py
@@ -68,9 +68,12 @@ async def _run_blocking(func: Callable[..., Any], *args: Any, **kwargs: Any) -> 
     )
 
 
-def _get_plugin_registration(plugin_id: str) -> InstallPluginRegistration:
+async def _get_plugin_registration(plugin_id: str) -> InstallPluginRegistration:
     try:
-        registration = install_registry.get_install_plugin_registration(plugin_id)
+        registration = await _run_blocking(
+            install_registry.get_install_plugin_registration,
+            plugin_id,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail="Plugin has no install API") from exc
     if registration is None:
@@ -78,12 +81,7 @@ def _get_plugin_registration(plugin_id: str) -> InstallPluginRegistration:
     return registration
 
 
-def _ensure_has_install(plugin_id: str) -> None:
-    _get_plugin_registration(plugin_id)
-
-
-def _ensure_tutorial_enabled(plugin_id: str) -> None:
-    registration = _get_plugin_registration(plugin_id)
+def _ensure_tutorial_enabled(registration: InstallPluginRegistration) -> None:
     if not registration.tutorial_enabled:
         raise HTTPException(status_code=404, detail=f"Plugin '{registration.plugin_id}' has no tutorial API")
 
@@ -94,7 +92,7 @@ class InstallStartPayload(BaseModel):
 
 @router.get("/plugin/{plugin_id}/ui-api/locale")
 async def get_plugin_ui_locale(plugin_id: str) -> JSONResponse:
-    _get_plugin_registration(plugin_id)
+    await _get_plugin_registration(plugin_id)
     try:
         from utils.language_utils import get_global_language_full
 
@@ -107,7 +105,7 @@ async def get_plugin_ui_locale(plugin_id: str) -> JSONResponse:
 
 @router.get("/plugin/{plugin_id}/ui-api/i18n/ui/{locale}.json")
 async def get_plugin_ui_i18n(plugin_id: str, locale: str) -> Response:
-    registration = _get_plugin_registration(plugin_id)
+    registration = await _get_plugin_registration(plugin_id)
     if registration.ui_i18n_dir is None:
         return Response(status_code=404)
     normalized = str(locale or "").strip()
@@ -115,13 +113,17 @@ async def get_plugin_ui_i18n(plugin_id: str, locale: str) -> Response:
         return Response(status_code=404)
     if normalized not in _ALLOWED_UI_LOCALES:
         return Response(status_code=404)
-    base_dir = registration.ui_i18n_dir.resolve()
-    file = (base_dir / f"{normalized}.json").resolve()
-    try:
-        file.relative_to(base_dir)
-    except ValueError:
-        return Response(status_code=404)
-    if not await _run_blocking(file.is_file):
+    def resolve_locale_file() -> Path | None:
+        try:
+            base_dir = registration.ui_i18n_dir.resolve(strict=True)
+            file = (base_dir / f"{normalized}.json").resolve(strict=True)
+            file.relative_to(base_dir)
+        except (FileNotFoundError, OSError, RuntimeError, ValueError):
+            return None
+        return file if file.is_file() else None
+
+    file = await _run_blocking(resolve_locale_file)
+    if file is None:
         return Response(status_code=404)
     return FileResponse(file)
 
@@ -150,10 +152,9 @@ def _normalize_ui_locale(locale: str) -> str:
 def _get_install_kind_spec(
     kind: str,
     *,
-    plugin_id: str,
+    registration: InstallPluginRegistration,
     allow_legacy_read: bool = False,
 ) -> dict[str, Any]:
-    registration = _get_plugin_registration(plugin_id)
     normalized = str(kind or "").strip().lower()
     # rapidocr + dxcam used to live here as runtime-pip-install entries; both
     # are now bundled into the main program. textractor still needs runtime
@@ -470,8 +471,8 @@ async def _start_install_task(
     payload: InstallStartPayload,
     request: Request,
 ) -> JSONResponse:
-    _ensure_has_install(plugin_id)
-    spec = _get_install_kind_spec(kind, plugin_id=plugin_id)
+    registration = await _get_plugin_registration(plugin_id)
+    spec = _get_install_kind_spec(kind, registration=registration)
     try:
         client_host = request.client.host if request.client is not None else None
         args: dict[str, object] = {"force": bool(payload.force)}
@@ -539,8 +540,12 @@ async def _start_install_task(
 
 
 async def _latest_install_task_payload(*, plugin_id: str, kind: str) -> JSONResponse:
-    _ensure_has_install(plugin_id)
-    spec = _get_install_kind_spec(kind, plugin_id=plugin_id, allow_legacy_read=True)
+    registration = await _get_plugin_registration(plugin_id)
+    spec = _get_install_kind_spec(
+        kind,
+        registration=registration,
+        allow_legacy_read=True,
+    )
     payload = await _run_blocking(
         load_latest_install_task_state,
         kind=spec["kind"],
@@ -561,8 +566,12 @@ async def _latest_install_task_payload(*, plugin_id: str, kind: str) -> JSONResp
 
 
 async def _get_install_task_payload(*, plugin_id: str, kind: str, task_id: str) -> JSONResponse:
-    _ensure_has_install(plugin_id)
-    spec = _get_install_kind_spec(kind, plugin_id=plugin_id, allow_legacy_read=True)
+    registration = await _get_plugin_registration(plugin_id)
+    spec = _get_install_kind_spec(
+        kind,
+        registration=registration,
+        allow_legacy_read=True,
+    )
     return JSONResponse(
         await _run_blocking(
             _resolve_install_task_payload,
@@ -581,8 +590,12 @@ async def _install_stream_response(
     task_id: str,
     request: Request,
 ) -> StreamingResponse:
-    _ensure_has_install(plugin_id)
-    spec = _get_install_kind_spec(kind, plugin_id=plugin_id, allow_legacy_read=True)
+    registration = await _get_plugin_registration(plugin_id)
+    spec = _get_install_kind_spec(
+        kind,
+        registration=registration,
+        allow_legacy_read=True,
+    )
     await _run_blocking(
         _resolve_install_task_payload,
         task_id,
@@ -881,7 +894,8 @@ def _normalize_tutorial_progress(raw: dict[str, Any] | None) -> dict[str, Any]:
 
 @router.get("/plugin/{plugin_id}/ui-api/tutorial/status")
 async def get_tutorial_status(plugin_id: str) -> JSONResponse:
-    _ensure_tutorial_enabled(plugin_id)
+    registration = await _get_plugin_registration(plugin_id)
+    _ensure_tutorial_enabled(registration)
     try:
         raw = await _run_blocking(_read_tutorial_progress, plugin_id)
     except Exception:
@@ -898,7 +912,8 @@ async def save_tutorial_progress(
     plugin_id: str,
     body: TutorialProgressPayload,
 ) -> JSONResponse:
-    _ensure_tutorial_enabled(plugin_id)
+    registration = await _get_plugin_registration(plugin_id)
+    _ensure_tutorial_enabled(registration)
     payload = body.model_dump(exclude_unset=True)
     try:
         current = _normalize_tutorial_progress(await _run_blocking(_read_tutorial_progress, plugin_id))

--- a/plugin/server/routes/plugin_install.py
+++ b/plugin/server/routes/plugin_install.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import stat
 import threading
 import time
 from collections.abc import Callable, Mapping
@@ -9,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
 from plugin._types.models import RunCreateRequest
@@ -113,19 +115,53 @@ async def get_plugin_ui_i18n(plugin_id: str, locale: str) -> Response:
         return Response(status_code=404)
     if normalized not in _ALLOWED_UI_LOCALES:
         return Response(status_code=404)
-    def resolve_locale_file() -> Path | None:
-        try:
-            base_dir = registration.ui_i18n_dir.resolve(strict=True)
-            file = (base_dir / f"{normalized}.json").resolve(strict=True)
-            file.relative_to(base_dir)
-        except (FileNotFoundError, OSError, RuntimeError, ValueError):
-            return None
-        return file if file.is_file() else None
 
-    file = await _run_blocking(resolve_locale_file)
-    if file is None:
+    payload = await _run_blocking(
+        _read_ui_locale_payload,
+        registration.ui_i18n_dir,
+        normalized,
+    )
+    if payload is None:
         return Response(status_code=404)
-    return FileResponse(file)
+    return Response(content=payload, media_type="application/json")
+
+
+def _read_ui_locale_payload(base_path: Path, locale: str) -> bytes | None:
+    """Read one locale through a verified handle so path swaps cannot escape."""
+
+    file_descriptor = -1
+    try:
+        base_dir = base_path.resolve(strict=True)
+        if not base_dir.is_dir():
+            return None
+        candidate = base_dir / f"{locale}.json"
+        open_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        file_descriptor = os.open(candidate, open_flags)
+
+        opened_metadata = os.fstat(file_descriptor)
+        current_metadata = os.stat(candidate, follow_symlinks=False)
+        reparse_attribute = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+        if (
+            not stat.S_ISREG(opened_metadata.st_mode)
+            or not stat.S_ISREG(current_metadata.st_mode)
+            or bool(getattr(current_metadata, "st_file_attributes", 0) & reparse_attribute)
+            or not os.path.samestat(opened_metadata, current_metadata)
+        ):
+            return None
+
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(base_dir)
+        if not os.path.samestat(opened_metadata, resolved.stat()):
+            return None
+
+        with os.fdopen(file_descriptor, "rb") as file_obj:
+            file_descriptor = -1
+            return file_obj.read()
+    except (FileNotFoundError, OSError, RuntimeError, ValueError):
+        return None
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
 
 
 def _normalize_ui_locale(locale: str) -> str:

--- a/plugin/tests/integration/test_galgame_bridge_ui_routes.py
+++ b/plugin/tests/integration/test_galgame_bridge_ui_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
+import os
 import time
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
@@ -381,7 +382,11 @@ async def test_plugin_ui_i18n_rejects_locale_file_symlink_escape(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    i18n_dir = tmp_path / "i18n"
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    config_path = plugin_root / "plugin.toml"
+    config_path.write_text('[plugin]\nid = "external_plugin"\n', encoding="utf-8")
+    i18n_dir = plugin_root / "i18n"
     i18n_dir.mkdir()
     outside_file = tmp_path / "outside.json"
     outside_file.write_text('{"secret": true}', encoding="utf-8")
@@ -395,6 +400,7 @@ async def test_plugin_ui_i18n_rejects_locale_file_symlink_escape(
         plugin_id="external_plugin",
         install_kinds={},
         ui_i18n_dir=i18n_dir,
+        config_path=config_path,
     )
 
     async def registration_for(_plugin_id: str):
@@ -419,7 +425,11 @@ async def test_plugin_ui_i18n_pins_payload_before_locale_path_is_swapped(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    i18n_dir = tmp_path / "i18n"
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    config_path = plugin_root / "plugin.toml"
+    config_path.write_text('[plugin]\nid = "external_plugin"\n', encoding="utf-8")
+    i18n_dir = plugin_root / "i18n"
     i18n_dir.mkdir()
     locale_file = i18n_dir / "en.json"
     locale_file.write_text('{"safe": true}', encoding="utf-8")
@@ -430,6 +440,7 @@ async def test_plugin_ui_i18n_pins_payload_before_locale_path_is_swapped(
         plugin_id="external_plugin",
         install_kinds={},
         ui_i18n_dir=i18n_dir,
+        config_path=config_path,
     )
 
     async def registration_for(_plugin_id: str):
@@ -462,6 +473,103 @@ async def test_plugin_ui_i18n_pins_payload_before_locale_path_is_swapped(
     assert response.status_code == 200
     assert response.body == b'{"safe": true}'
     assert b"secret" not in response.body
+
+
+@pytest.mark.asyncio
+async def test_plugin_ui_i18n_rejects_replaced_base_directory_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    config_path = plugin_root / "plugin.toml"
+    config_path.write_text('[plugin]\nid = "external_plugin"\n', encoding="utf-8")
+    i18n_dir = plugin_root / "i18n"
+    i18n_dir.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "en.json").write_text('{"secret": true}', encoding="utf-8")
+    i18n_dir.rmdir()
+    try:
+        i18n_dir.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink creation is unavailable: {exc}")
+
+    registration = galgame_install_route_module.InstallPluginRegistration(
+        plugin_id="external_plugin",
+        install_kinds={},
+        ui_i18n_dir=i18n_dir,
+        config_path=config_path,
+    )
+
+    async def registration_for(_plugin_id: str):
+        return registration
+
+    monkeypatch.setattr(
+        galgame_install_route_module,
+        "_get_plugin_registration",
+        registration_for,
+    )
+
+    response = await galgame_install_route_module.get_plugin_ui_i18n(
+        "external_plugin",
+        "en",
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_plugin_ui_i18n_opens_fifo_nonblocking_before_rejecting_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not hasattr(os, "mkfifo") or not getattr(os, "O_NONBLOCK", 0):
+        pytest.skip("FIFO nonblocking behavior requires POSIX")
+
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    config_path = plugin_root / "plugin.toml"
+    config_path.write_text('[plugin]\nid = "external_plugin"\n', encoding="utf-8")
+    i18n_dir = plugin_root / "i18n"
+    i18n_dir.mkdir()
+    fifo_path = i18n_dir / "en.json"
+    os.mkfifo(fifo_path)
+
+    registration = galgame_install_route_module.InstallPluginRegistration(
+        plugin_id="external_plugin",
+        install_kinds={},
+        ui_i18n_dir=i18n_dir,
+        config_path=config_path,
+    )
+
+    async def registration_for(_plugin_id: str):
+        return registration
+
+    original_open = os.open
+    opened_nonblocking = False
+
+    def guarded_open(path, flags, *args, **kwargs):
+        nonlocal opened_nonblocking
+        opened_nonblocking = bool(flags & os.O_NONBLOCK)
+        if not opened_nonblocking:
+            raise AssertionError("locale files must be opened nonblocking")
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(
+        galgame_install_route_module,
+        "_get_plugin_registration",
+        registration_for,
+    )
+    monkeypatch.setattr(galgame_install_route_module.os, "open", guarded_open)
+
+    response = await galgame_install_route_module.get_plugin_ui_i18n(
+        "external_plugin",
+        "en",
+    )
+
+    assert opened_nonblocking is True
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/integration/test_galgame_bridge_ui_routes.py
+++ b/plugin/tests/integration/test_galgame_bridge_ui_routes.py
@@ -415,6 +415,56 @@ async def test_plugin_ui_i18n_rejects_locale_file_symlink_escape(
 
 
 @pytest.mark.asyncio
+async def test_plugin_ui_i18n_pins_payload_before_locale_path_is_swapped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    i18n_dir = tmp_path / "i18n"
+    i18n_dir.mkdir()
+    locale_file = i18n_dir / "en.json"
+    locale_file.write_text('{"safe": true}', encoding="utf-8")
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_text('{"secret": true}', encoding="utf-8")
+
+    registration = galgame_install_route_module.InstallPluginRegistration(
+        plugin_id="external_plugin",
+        install_kinds={},
+        ui_i18n_dir=i18n_dir,
+    )
+
+    async def registration_for(_plugin_id: str):
+        return registration
+
+    original_run_blocking = galgame_install_route_module._run_blocking
+
+    async def swap_after_blocking_read(func, *args, **kwargs):
+        result = await original_run_blocking(func, *args, **kwargs)
+        locale_file.unlink()
+        outside_file.replace(locale_file)
+        return result
+
+    monkeypatch.setattr(
+        galgame_install_route_module,
+        "_get_plugin_registration",
+        registration_for,
+    )
+    monkeypatch.setattr(
+        galgame_install_route_module,
+        "_run_blocking",
+        swap_after_blocking_read,
+    )
+
+    response = await galgame_install_route_module.get_plugin_ui_i18n(
+        "external_plugin",
+        "en",
+    )
+
+    assert response.status_code == 200
+    assert response.body == b'{"safe": true}'
+    assert b"secret" not in response.body
+
+
+@pytest.mark.asyncio
 async def test_unregistered_plugin_install_route_returns_404(
     plugin_ui_async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/integration/test_galgame_bridge_ui_routes.py
+++ b/plugin/tests/integration/test_galgame_bridge_ui_routes.py
@@ -35,7 +35,9 @@ def galgame_plugin_dir() -> Path:
 def registered_install_plugins(
     monkeypatch: pytest.MonkeyPatch,
     galgame_plugin_dir: Path,
-) -> None:
+) -> Iterator[None]:
+    with state.acquire_plugins_read_lock():
+        plugins_backup = copy.deepcopy(state.plugins)
     monkeypatch.setattr(install_registry_module, "_install_plugin_registry", {})
     galgame_install_route_module.register_install_plugin(
         "galgame_plugin",
@@ -66,6 +68,35 @@ def registered_install_plugins(
         ui_i18n_dir=galgame_plugin_dir.parent / "study_companion" / "i18n",
         tutorial_enabled=True,
     )
+    with state.acquire_plugins_write_lock():
+        state.plugins.clear()
+        state.plugins.update(
+            {
+                "galgame_plugin": {
+                    "id": "galgame_plugin",
+                    "config_path": str(galgame_plugin_dir / "plugin.toml"),
+                    "entries_preview": [
+                        {"id": "galgame_install_textractor"},
+                        {"id": "galgame_download_rapidocr_models"},
+                    ],
+                    "effective_source": "builtin",
+                },
+                "study_companion": {
+                    "id": "study_companion",
+                    "config_path": str(galgame_plugin_dir.parent / "study_companion" / "plugin.toml"),
+                    "entries_preview": [
+                        {"id": "study_download_rapidocr_models"},
+                    ],
+                    "effective_source": "builtin",
+                },
+            }
+        )
+    try:
+        yield
+    finally:
+        with state.acquire_plugins_write_lock():
+            state.plugins.clear()
+            state.plugins.update(plugins_backup)
 
 
 @pytest.fixture
@@ -118,8 +149,8 @@ def registered_galgame_plugin_meta(galgame_plugin_dir: Path) -> Iterator[None]:
     plugins_backup = copy.deepcopy(state.plugins)
     try:
         with state.acquire_plugins_write_lock():
-            state.plugins.clear()
-            state.plugins["galgame_plugin"] = {
+            galgame_meta = dict(state.plugins.get("galgame_plugin") or {})
+            galgame_meta.update({
                 "id": "galgame_plugin",
                 "name": "Galgame Plugin",
                 "config_path": str(galgame_plugin_dir / "plugin.toml"),
@@ -138,7 +169,8 @@ def registered_galgame_plugin_meta(galgame_plugin_dir: Path) -> Iterator[None]:
                         "open_in": "new_tab",
                     }
                 ],
-            }
+            })
+            state.plugins["galgame_plugin"] = galgame_meta
         yield
     finally:
         with state.acquire_plugins_write_lock():
@@ -345,6 +377,44 @@ async def test_galgame_plugin_ui_i18n_api_serves_locale_bundle(
 
 
 @pytest.mark.asyncio
+async def test_plugin_ui_i18n_rejects_locale_file_symlink_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    i18n_dir = tmp_path / "i18n"
+    i18n_dir.mkdir()
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_text('{"secret": true}', encoding="utf-8")
+    locale_file = i18n_dir / "en.json"
+    try:
+        locale_file.symlink_to(outside_file)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    registration = galgame_install_route_module.InstallPluginRegistration(
+        plugin_id="external_plugin",
+        install_kinds={},
+        ui_i18n_dir=i18n_dir,
+    )
+
+    async def registration_for(_plugin_id: str):
+        return registration
+
+    monkeypatch.setattr(
+        galgame_install_route_module,
+        "_get_plugin_registration",
+        registration_for,
+    )
+
+    response = await galgame_install_route_module.get_plugin_ui_i18n(
+        "external_plugin",
+        "en",
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_unregistered_plugin_install_route_returns_404(
     plugin_ui_async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -360,9 +430,10 @@ async def test_unregistered_plugin_install_route_returns_404(
     assert response.json()["detail"] == "Plugin 'unknown_plugin' has no install API"
 
 
-def test_invalid_plugin_id_404_does_not_reflect_raw_input() -> None:
+@pytest.mark.asyncio
+async def test_invalid_plugin_id_404_does_not_reflect_raw_input() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        galgame_install_route_module._get_plugin_registration("../secret")
+        await galgame_install_route_module._get_plugin_registration("../secret")
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Plugin has no install API"
@@ -466,7 +537,6 @@ async def test_install_start_returns_retryable_state_when_local_persist_raises_v
         return RunCreateResponse(run_id="run-local-state-value-error", status="queued")
 
     async def _fake_run_blocking(func, *args, **kwargs):
-        del args, kwargs
         if getattr(func, "__name__", "") == "update_install_task_state":
             raise ValueError("invalid local state")
         return func(*args, **kwargs)
@@ -792,7 +862,21 @@ async def test_galgame_plugin_textractor_install_stream_route_emits_sse_payload(
     plugin_ui_async_client: AsyncClient,
     registered_galgame_plugin_meta,
     galgame_install_runtime_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    original_get_registration = install_registry_module.get_install_plugin_registration
+    registration_reads = 0
+
+    def counted_get_registration(plugin_id: str):
+        nonlocal registration_reads
+        registration_reads += 1
+        return original_get_registration(plugin_id)
+
+    monkeypatch.setattr(
+        install_registry_module,
+        "get_install_plugin_registration",
+        counted_get_registration,
+    )
     install_task_module.update_install_task_state(
         "run-textractor-stream",
         plugin_id="galgame_plugin",
@@ -817,6 +901,7 @@ async def test_galgame_plugin_textractor_install_stream_route_emits_sse_payload(
     payload = json.loads(body)
     assert payload["task_id"] == "run-textractor-stream"
     assert payload["status"] == "completed"
+    assert registration_reads == 1
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_ui_i18n.py
+++ b/plugin/tests/unit/plugins/test_galgame_ui_i18n.py
@@ -170,7 +170,8 @@ def test_plugin_ui_i18n_route_uses_registered_i18n_dir(monkeypatch, tmp_path: Pa
 
     response = asyncio.run(plugin_install.get_plugin_ui_i18n("custom_plugin", "en"))
 
-    assert Path(response.path) == expected_file
+    assert response.status_code == 200
+    assert response.body == expected_file.read_bytes()
 
 
 def test_plugin_ui_i18n_route_bootstraps_builtin_registration(monkeypatch) -> None:
@@ -195,7 +196,8 @@ def test_plugin_ui_i18n_route_bootstraps_builtin_registration(monkeypatch) -> No
 
     response = asyncio.run(plugin_install.get_plugin_ui_i18n("study_companion", "en"))
 
-    assert Path(response.path) == expected_file
+    assert response.status_code == 200
+    assert response.body == expected_file.read_bytes()
 
 
 def test_tutorial_store_uses_runtime_data_root(monkeypatch, tmp_path: Path) -> None:

--- a/plugin/tests/unit/plugins/test_galgame_ui_i18n.py
+++ b/plugin/tests/unit/plugins/test_galgame_ui_i18n.py
@@ -56,6 +56,25 @@ def _register_galgame_install_plugin(module, *, i18n_dir: Path = UI_I18N_DIR) ->
     )
 
 
+def _select_plugin_source(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin_id: str,
+    config_path: Path,
+    *,
+    entry_ids: tuple[str, ...] = (),
+) -> None:
+    from plugin.core.state import state
+
+    selected_meta = {
+        "id": plugin_id,
+        "config_path": str(config_path),
+        "entries_preview": [{"id": entry_id} for entry_id in entry_ids],
+        "effective_source": "builtin",
+    }
+    with state.acquire_plugins_write_lock():
+        monkeypatch.setitem(state.plugins, plugin_id, selected_meta)
+
+
 def test_galgame_ui_i18n_locale_bundles_have_same_keys() -> None:
     bundles = {
         locale: json.loads((UI_I18N_DIR / f"{locale}.json").read_text(encoding="utf-8"))
@@ -115,6 +134,15 @@ def test_galgame_ui_locale_route_falls_back_when_language_utils_unavailable(monk
     try:
         module = importlib.import_module(module_name)
         _register_galgame_install_plugin(module)
+        _select_plugin_source(
+            monkeypatch,
+            "galgame_plugin",
+            UI_I18N_DIR.parents[1] / "plugin.toml",
+            entry_ids=(
+                "galgame_install_textractor",
+                "galgame_download_rapidocr_models",
+            ),
+        )
         response = asyncio.run(module.get_plugin_ui_locale("galgame_plugin"))
 
         assert json.loads(response.body.decode("utf-8")) == {"locale": "en"}
@@ -130,12 +158,15 @@ def test_plugin_ui_i18n_route_uses_registered_i18n_dir(monkeypatch, tmp_path: Pa
     i18n_dir.mkdir()
     expected_file = i18n_dir / "en.json"
     expected_file.write_text('{"custom":"ok"}', encoding="utf-8")
+    config_path = tmp_path / "plugin.toml"
+    config_path.write_text('[plugin]\nid = "custom_plugin"\n', encoding="utf-8")
     monkeypatch.setattr(install_registry, "_install_plugin_registry", {})
     plugin_install.register_install_plugin(
         "custom_plugin",
         install_kinds={},
         ui_i18n_dir=i18n_dir,
     )
+    _select_plugin_source(monkeypatch, "custom_plugin", config_path)
 
     response = asyncio.run(plugin_install.get_plugin_ui_i18n("custom_plugin", "en"))
 
@@ -155,6 +186,12 @@ def test_plugin_ui_i18n_route_bootstraps_builtin_registration(monkeypatch) -> No
     )
     monkeypatch.setattr(install_registry, "_install_plugin_registry", {})
     monkeypatch.setattr(install_registry, "_tutorial_migration_hooks", {})
+    _select_plugin_source(
+        monkeypatch,
+        "study_companion",
+        expected_file.parents[1] / "plugin.toml",
+        entry_ids=("study_download_rapidocr_models",),
+    )
 
     response = asyncio.run(plugin_install.get_plugin_ui_i18n("study_companion", "en"))
 
@@ -232,6 +269,15 @@ def test_tutorial_progress_routes_use_blocking_runner(monkeypatch, tmp_path: Pat
     monkeypatch.setattr(install_registry, "_install_plugin_registry", {})
     monkeypatch.setattr(plugin_install, "_run_blocking", _fake_run_blocking)
     _register_galgame_install_plugin(plugin_install)
+    _select_plugin_source(
+        monkeypatch,
+        "galgame_plugin",
+        UI_I18N_DIR.parents[1] / "plugin.toml",
+        entry_ids=(
+            "galgame_install_textractor",
+            "galgame_download_rapidocr_models",
+        ),
+    )
 
     status_response = asyncio.run(plugin_install.get_tutorial_status("galgame_plugin"))
     save_response = asyncio.run(

--- a/plugin/tests/unit/server/test_install_registry.py
+++ b/plugin/tests/unit/server/test_install_registry.py
@@ -1,11 +1,109 @@
 from __future__ import annotations
 
 import builtins
+import copy
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
+from plugin.core.state import state
 from plugin.server import install_registry
+
+
+@pytest.fixture(autouse=True)
+def isolated_install_registry(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    with state.acquire_plugins_read_lock():
+        plugins_backup = copy.deepcopy(state.plugins)
+    registry_backup = dict(install_registry._install_plugin_registry)
+    hooks = install_registry._tutorial_migration_hooks
+    hooks_backup = list(hooks) if isinstance(hooks, list) else {
+        key: list(value) for key, value in hooks.items()
+    }
+    monkeypatch.setattr(install_registry, "_install_plugin_registry", {})
+    monkeypatch.setattr(install_registry, "_tutorial_migration_hooks", {})
+    with state.acquire_plugins_write_lock():
+        state.plugins.clear()
+    try:
+        yield
+    finally:
+        with state.acquire_plugins_write_lock():
+            state.plugins.clear()
+            state.plugins.update(plugins_backup)
+        install_registry._install_plugin_registry = registry_backup
+        install_registry._tutorial_migration_hooks = hooks_backup
+
+
+def _write_manifest(
+    root: Path,
+    plugin_id: str,
+    *,
+    declaration: str | None,
+) -> Path:
+    root.mkdir(parents=True)
+    manifest = root / "plugin.toml"
+    text = (
+        "[plugin]\n"
+        f'id = "{plugin_id}"\n'
+        f'name = "{plugin_id}"\n'
+        'version = "1.0.0"\n'
+        'type = "plugin"\n'
+        f'entry = "plugin.plugins.{plugin_id}:Plugin"\n'
+    )
+    if declaration is not None:
+        text += "\n" + declaration.strip() + "\n"
+    manifest.write_text(text, encoding="utf-8")
+    return manifest
+
+
+def _select_plugin(
+    plugin_id: str,
+    manifest: Path,
+    *,
+    entries: tuple[str, ...],
+    source: str = "user",
+    load_state: str | None = None,
+) -> None:
+    meta: dict[str, object] = {
+        "id": plugin_id,
+        "config_path": str(manifest),
+        "entries_preview": [{"id": entry_id} for entry_id in entries],
+        "effective_source": source,
+    }
+    if load_state is not None:
+        meta["runtime_load_state"] = load_state
+    with state.acquire_plugins_write_lock():
+        state.plugins[plugin_id] = meta
+
+
+def _select_builtin_plugins() -> None:
+    plugins_root = Path(install_registry.__file__).resolve().parents[1] / "plugins"
+    _select_plugin(
+        "galgame_plugin",
+        plugins_root / "galgame_plugin" / "plugin.toml",
+        entries=("galgame_install_textractor", "galgame_download_rapidocr_models"),
+        source="builtin",
+    )
+    _select_plugin(
+        "study_companion",
+        plugins_root / "study_companion" / "plugin.toml",
+        entries=("study_download_rapidocr_models",),
+        source="builtin",
+    )
+
+
+_DEMO_DECLARATION = """
+[plugin.install]
+enabled = true
+ui_i18n_dir = "i18n/ui"
+tutorial_enabled = true
+
+[plugin.install.kinds.models]
+entry_id = "demo_install_models"
+label = "Models"
+queued_message = "Models queued"
+entry_timeout = 600.0
+"""
 
 
 def test_builtin_install_registration_bootstraps_from_empty_registry(
@@ -13,6 +111,7 @@ def test_builtin_install_registration_bootstraps_from_empty_registry(
 ) -> None:
     monkeypatch.setattr(install_registry, "_install_plugin_registry", {})
     monkeypatch.setattr(install_registry, "_tutorial_migration_hooks", {})
+    _select_builtin_plugins()
 
     galgame = install_registry.get_install_plugin_registration("galgame_plugin")
     study = install_registry.get_install_plugin_registration("study_companion")
@@ -44,6 +143,13 @@ def test_builtin_install_registration_does_not_overwrite_existing_registration(
         install_kinds={},
         ui_i18n_dir=tmp_path,
     )
+    plugins_root = Path(install_registry.__file__).resolve().parents[1] / "plugins"
+    _select_plugin(
+        "study_companion",
+        plugins_root / "study_companion" / "plugin.toml",
+        entries=("study_download_rapidocr_models",),
+        source="builtin",
+    )
 
     study = install_registry.get_install_plugin_registration("study_companion")
 
@@ -72,6 +178,244 @@ def test_plugin_module_available_treats_import_errors_as_unavailable(
     monkeypatch.setattr(install_registry.importlib.util, "find_spec", fail_find_spec)
 
     assert install_registry._plugin_module_available("galgame_plugin") is False
+
+
+def test_explicit_install_declaration_uses_selected_registry_source(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "market" / "demo_plugin"
+    manifest = _write_manifest(
+        plugin_root,
+        "demo_plugin",
+        declaration=_DEMO_DECLARATION,
+    )
+    (plugin_root / "i18n" / "ui").mkdir(parents=True)
+    _select_plugin(
+        "demo_plugin",
+        manifest,
+        entries=("demo_install_models",),
+        source="user",
+    )
+
+    registration = install_registry.get_install_plugin_registration("demo_plugin")
+
+    assert registration is not None
+    assert set(registration.install_kinds) == {"models"}
+    assert registration.ui_i18n_dir == (plugin_root / "i18n" / "ui").resolve()
+    assert registration.tutorial_enabled is True
+    assert registration.config_path == manifest.resolve()
+    assert registration.effective_source == "user"
+    assert registration.install_kinds["models"].entry_timeout == 600.0
+
+
+def test_explicit_disabled_declaration_does_not_fall_back_to_dynamic(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "demo_plugin"
+    manifest = _write_manifest(
+        plugin_root,
+        "demo_plugin",
+        declaration="[plugin.install]\nenabled = false",
+    )
+    _select_plugin("demo_plugin", manifest, entries=("demo_install_models",))
+    install_registry.register_install_plugin(
+        "demo_plugin",
+        install_kinds={
+            "models": install_registry.InstallKindRegistration(
+                entry_id="demo_install_models",
+                label="Models",
+                queued_message="Models queued",
+            )
+        },
+    )
+
+    assert install_registry.get_install_plugin_registration("demo_plugin") is None
+
+
+def test_invalid_explicit_entry_fails_closed_without_dynamic_fallback(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "demo_plugin"
+    manifest = _write_manifest(
+        plugin_root,
+        "demo_plugin",
+        declaration=_DEMO_DECLARATION,
+    )
+    (plugin_root / "i18n" / "ui").mkdir(parents=True)
+    _select_plugin("demo_plugin", manifest, entries=("different_entry",))
+    install_registry.register_install_plugin(
+        "demo_plugin",
+        install_kinds={},
+    )
+
+    with pytest.raises(ValueError, match="demo_install_models"):
+        install_registry.get_install_plugin_registration("demo_plugin")
+
+
+def test_invalid_explicit_i18n_escape_fails_closed(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "demo_plugin"
+    declaration = _DEMO_DECLARATION.replace(
+        'ui_i18n_dir = "i18n/ui"',
+        'ui_i18n_dir = "../outside"',
+    )
+    manifest = _write_manifest(
+        plugin_root,
+        "demo_plugin",
+        declaration=declaration,
+    )
+    _select_plugin("demo_plugin", manifest, entries=("demo_install_models",))
+
+    with pytest.raises(ValueError, match="ui_i18n_dir"):
+        install_registry.get_install_plugin_registration("demo_plugin")
+
+
+def test_failed_selected_runtime_does_not_expose_install_api(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "demo_plugin"
+    manifest = _write_manifest(
+        plugin_root,
+        "demo_plugin",
+        declaration=_DEMO_DECLARATION,
+    )
+    (plugin_root / "i18n" / "ui").mkdir(parents=True)
+    _select_plugin(
+        "demo_plugin",
+        manifest,
+        entries=("demo_install_models",),
+        load_state="failed",
+    )
+
+    assert install_registry.get_install_plugin_registration("demo_plugin") is None
+
+
+def test_dynamic_registration_remains_available_for_selected_third_party_plugin(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "third_party"
+    manifest = _write_manifest(plugin_root, "third_party", declaration=None)
+    _select_plugin("third_party", manifest, entries=("third_party_install",))
+    install_registry.register_install_plugin(
+        "third_party",
+        install_kinds={
+            "models": install_registry.InstallKindRegistration(
+                entry_id="third_party_install",
+                label="Models",
+                queued_message="Models queued",
+            )
+        },
+        tutorial_enabled=True,
+    )
+
+    registration = install_registry.get_install_plugin_registration("third_party")
+
+    assert registration is not None
+    assert set(registration.install_kinds) == {"models"}
+    assert registration.tutorial_enabled is True
+
+
+def test_stale_dynamic_registration_is_hidden_when_plugin_is_not_selected() -> None:
+    install_registry.register_install_plugin("third_party", install_kinds={})
+
+    assert install_registry.get_install_plugin_registration("third_party") is None
+
+
+def test_selected_source_change_during_parse_retries_complete_read_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_root = tmp_path / "first" / "demo_plugin"
+    second_root = tmp_path / "second" / "demo_plugin"
+    first_manifest = _write_manifest(
+        first_root,
+        "demo_plugin",
+        declaration=_DEMO_DECLARATION,
+    )
+    second_manifest = _write_manifest(
+        second_root,
+        "demo_plugin",
+        declaration=_DEMO_DECLARATION,
+    )
+    (first_root / "i18n" / "ui").mkdir(parents=True)
+    (second_root / "i18n" / "ui").mkdir(parents=True)
+    _select_plugin(
+        "demo_plugin",
+        first_manifest,
+        entries=("demo_install_models",),
+        source="builtin",
+    )
+    original = install_registry._registration_for_selected_source
+    calls = 0
+
+    def switch_after_first_parse(plugin_id: str, selected):
+        nonlocal calls
+        calls += 1
+        registration = original(plugin_id, selected)
+        if calls == 1:
+            _select_plugin(
+                "demo_plugin",
+                second_manifest,
+                entries=("demo_install_models",),
+                source="user",
+            )
+        return registration
+
+    monkeypatch.setattr(
+        install_registry,
+        "_registration_for_selected_source",
+        switch_after_first_parse,
+    )
+
+    registration = install_registry.get_install_plugin_registration("demo_plugin")
+
+    assert calls == 2
+    assert registration is not None
+    assert registration.config_path == second_manifest.resolve()
+    assert registration.effective_source == "user"
+
+
+def test_selected_source_continuously_changing_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    roots = [
+        tmp_path / "first" / "demo_plugin",
+        tmp_path / "second" / "demo_plugin",
+    ]
+    manifests = [
+        _write_manifest(root, "demo_plugin", declaration=_DEMO_DECLARATION)
+        for root in roots
+    ]
+    for root in roots:
+        (root / "i18n" / "ui").mkdir(parents=True)
+    _select_plugin(
+        "demo_plugin",
+        manifests[0],
+        entries=("demo_install_models",),
+        source="builtin",
+    )
+    original = install_registry._registration_for_selected_source
+    calls = 0
+
+    def keep_switching(plugin_id: str, selected):
+        nonlocal calls
+        registration = original(plugin_id, selected)
+        calls += 1
+        next_index = calls % 2
+        _select_plugin(
+            "demo_plugin",
+            manifests[next_index],
+            entries=("demo_install_models",),
+            source="user" if next_index else "builtin",
+        )
+        return registration
+
+    monkeypatch.setattr(
+        install_registry,
+        "_registration_for_selected_source",
+        keep_switching,
+    )
+
+    assert install_registry.get_install_plugin_registration("demo_plugin") is None
+    assert calls == 2
 
 
 def test_tutorial_migration_hooks_for_normalizes_plugin_id(

--- a/plugin/tests/unit/server/test_plugin_cli_route.py
+++ b/plugin/tests/unit/server/test_plugin_cli_route.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 import subprocess
+from types import SimpleNamespace
 import zipfile
 
 import pytest
@@ -152,6 +153,20 @@ class _MemoryUploadFile:
 
     async def read(self) -> bytes:
         return b"demo"
+
+
+def _market_install_override(plugin_id: str) -> dict[str, object]:
+    return {
+        "channel": "market",
+        "mode": "install",
+        "market_detail": {
+            "plugin_market_id": plugin_id,
+            "version": "1.0.0",
+            "package_url": f"https://example.invalid/{plugin_id}.neko-plugin",
+            "expected_plugin_toml_id": plugin_id,
+            "published_at": "2026-09-02T00:00:00Z",
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -1626,3 +1641,270 @@ async def test_market_record_failure_removes_new_code_but_preserves_reused_profi
     assert not (user_root / plugin_id).exists()
     assert preserved.read_bytes() == b"do-not-delete\n"
     assert not list(packages_root.glob("*.neko-plugin"))
+
+
+@pytest.mark.asyncio
+async def test_market_fresh_install_refreshes_after_source_row_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_id = "market_refresh_demo"
+    package_source_root = tmp_path / "package-source"
+    package_source_root.mkdir()
+    package_path = package_source_root / f"{plugin_id}.neko-plugin"
+    pack_plugin(_make_plugin_dir(tmp_path / "source", plugin_id=plugin_id), package_path)
+    builtin_root = tmp_path / "builtin"
+    user_root = tmp_path / "user-plugins"
+    packages_root = tmp_path / "packages"
+    profiles_root = tmp_path / "profiles"
+    _patch_plugin_cli_settings(
+        monkeypatch,
+        builtin_root=builtin_root,
+        user_root=user_root,
+        packages_root=packages_root,
+        profiles_root=profiles_root,
+    )
+    manager = InstallSourceManager(
+        lock_path=tmp_path / "plugins.lock.json",
+        builtin_root=builtin_root,
+        user_root=user_root,
+        scanner=PluginDirectoryScanner(builtin_root, user_root),
+    )
+    refresh_calls: list[tuple[str, bool]] = []
+
+    async def refresh_plugin(requested_id: str, *, force: bool = False) -> dict[str, object]:
+        installed_dir = user_root / plugin_id
+        source_view = manager.to_api_view(plugin_id, directory_path=installed_dir)
+        assert source_view["source"] == "market"
+        assert installed_dir.joinpath("plugin.toml").is_file()
+        refresh_calls.append((requested_id, force))
+        return {"success": True, "plugin": {"id": requested_id}}
+
+    monkeypatch.setattr(
+        plugin_cli_service,
+        "plugin_registry_service",
+        SimpleNamespace(refresh_plugin=refresh_plugin),
+        raising=False,
+    )
+    set_global_manager(manager)
+    try:
+        result = await PluginCliService().upload_and_install(
+            filename=package_path.name,
+            package_path=str(package_path),
+            install_source_override=_market_install_override(plugin_id),
+        )
+    finally:
+        set_global_manager(None)
+
+    assert refresh_calls == [(plugin_id, True)]
+    assert result.get("install_source_warning") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("install_mode", ["upgrade", "reinstall"])
+async def test_market_upgrade_and_reinstall_do_not_use_fresh_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_mode: str,
+) -> None:
+    plugin_id = f"market_no_fresh_refresh_{install_mode}"
+    package_path = tmp_path / f"{plugin_id}.neko-plugin"
+    package_path.write_bytes(b"package")
+    target_dir = tmp_path / "user-plugins" / plugin_id
+    target_dir.mkdir(parents=True)
+    (target_dir / "plugin.toml").write_text(
+        f'[plugin]\nid = "{plugin_id}"\n',
+        encoding="utf-8",
+    )
+    service = PluginCliService()
+
+    monkeypatch.setattr(
+        service,
+        "_save_package_file_sync",
+        lambda **_kwargs: {"path": str(package_path), "name": package_path.name},
+    )
+    monkeypatch.setattr(service, "_sha256_file", lambda _path: "a" * 64)
+
+    async def plan_install(**_kwargs: object) -> dict[str, object]:
+        return {"action": "upgrade"}
+
+    async def install(**_kwargs: object) -> dict[str, object]:
+        return {
+            "unpacked_plugins": [
+                {
+                    "target_dir": str(target_dir),
+                    "target_plugin_id": plugin_id,
+                }
+            ],
+            "package_id": plugin_id,
+            "profile_dir": "",
+        }
+
+    monkeypatch.setattr(service, "plan_install", plan_install)
+    monkeypatch.setattr(service, "install", install)
+
+    class _Manager:
+        builtin_root = tmp_path / "builtin"
+        user_root = target_dir.parent
+
+        def record_market_upgrade(self, **_kwargs: object):
+            return (
+                SimpleNamespace(
+                    channel="market",
+                    directory_name=plugin_id,
+                    plugin_id=plugin_id,
+                    source_detail=SimpleNamespace(
+                        version="1.0.0",
+                        package_sha256="a" * 64,
+                        payload_hash=None,
+                        published_at="2026-09-02T00:00:00Z",
+                        previous_version="0.9.0",
+                    ),
+                ),
+                [],
+            )
+
+    monkeypatch.setattr(service, "_require_install_source_manager", lambda: _Manager())
+    refresh_calls: list[str] = []
+
+    async def unexpected_refresh(requested_id: str) -> None:
+        refresh_calls.append(requested_id)
+
+    monkeypatch.setattr(
+        plugin_cli_service,
+        "_refresh_committed_market_install",
+        unexpected_refresh,
+    )
+
+    result = await service.upload_and_install(
+        filename=package_path.name,
+        package_path=str(package_path),
+        install_source_override={
+            **_market_install_override(plugin_id),
+            "mode": install_mode,
+        },
+    )
+
+    assert result["install"]["channel"] == "market"
+    assert refresh_calls == []
+
+
+@pytest.mark.asyncio
+async def test_market_fresh_refresh_failure_keeps_committed_install_and_warns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_id = "market_refresh_warning"
+    package_source_root = tmp_path / "package-source"
+    package_source_root.mkdir()
+    package_path = package_source_root / f"{plugin_id}.neko-plugin"
+    pack_plugin(_make_plugin_dir(tmp_path / "source", plugin_id=plugin_id), package_path)
+    builtin_root = tmp_path / "builtin"
+    user_root = tmp_path / "user-plugins"
+    packages_root = tmp_path / "packages"
+    profiles_root = tmp_path / "profiles"
+    _patch_plugin_cli_settings(
+        monkeypatch,
+        builtin_root=builtin_root,
+        user_root=user_root,
+        packages_root=packages_root,
+        profiles_root=profiles_root,
+    )
+    manager = InstallSourceManager(
+        lock_path=tmp_path / "plugins.lock.json",
+        builtin_root=builtin_root,
+        user_root=user_root,
+        scanner=PluginDirectoryScanner(builtin_root, user_root),
+    )
+
+    async def fail_refresh(_plugin_id: str, *, force: bool = False) -> dict[str, object]:
+        assert force is True
+        raise RuntimeError("injected registry refresh failure")
+
+    monkeypatch.setattr(
+        plugin_cli_service,
+        "plugin_registry_service",
+        SimpleNamespace(refresh_plugin=fail_refresh),
+        raising=False,
+    )
+    set_global_manager(manager)
+    try:
+        result = await PluginCliService().upload_and_install(
+            filename=package_path.name,
+            package_path=str(package_path),
+            install_source_override=_market_install_override(plugin_id),
+        )
+    finally:
+        set_global_manager(None)
+
+    installed_dir = user_root / plugin_id
+    assert installed_dir.joinpath("plugin.toml").is_file()
+    assert manager.to_api_view(plugin_id, directory_path=installed_dir)["source"] == "market"
+    assert "registry refresh" in str(result["install_source_warning"]).lower()
+    assert "injected registry refresh failure" in str(result["install_source_warning"])
+
+
+@pytest.mark.asyncio
+async def test_market_fresh_cancellation_waits_for_post_commit_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_id = "market_refresh_cancel"
+    package_source_root = tmp_path / "package-source"
+    package_source_root.mkdir()
+    package_path = package_source_root / f"{plugin_id}.neko-plugin"
+    pack_plugin(_make_plugin_dir(tmp_path / "source", plugin_id=plugin_id), package_path)
+    builtin_root = tmp_path / "builtin"
+    user_root = tmp_path / "user-plugins"
+    _patch_plugin_cli_settings(
+        monkeypatch,
+        builtin_root=builtin_root,
+        user_root=user_root,
+        packages_root=tmp_path / "packages",
+        profiles_root=tmp_path / "profiles",
+    )
+    manager = InstallSourceManager(
+        lock_path=tmp_path / "plugins.lock.json",
+        builtin_root=builtin_root,
+        user_root=user_root,
+        scanner=PluginDirectoryScanner(builtin_root, user_root),
+    )
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def refresh_plugin(_plugin_id: str, *, force: bool = False) -> dict[str, object]:
+        assert force is True
+        assert manager.to_api_view(
+            plugin_id,
+            directory_path=user_root / plugin_id,
+        )["source"] == "market"
+        refresh_started.set()
+        await release_refresh.wait()
+        return {"success": True}
+
+    monkeypatch.setattr(
+        plugin_cli_service,
+        "plugin_registry_service",
+        SimpleNamespace(refresh_plugin=refresh_plugin),
+        raising=False,
+    )
+    set_global_manager(manager)
+    try:
+        task = asyncio.create_task(
+            PluginCliService().upload_and_install(
+                filename=package_path.name,
+                package_path=str(package_path),
+                install_source_override=_market_install_override(plugin_id),
+            )
+        )
+        await asyncio.wait_for(refresh_started.wait(), timeout=5.0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_refresh.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        set_global_manager(None)
+
+    assert (user_root / plugin_id / "plugin.toml").is_file()

--- a/plugin/tests/unit/server/test_plugin_registry_service.py
+++ b/plugin/tests/unit/server/test_plugin_registry_service.py
@@ -172,6 +172,7 @@ async def test_refresh_registry_syncs_metadata_and_marks_missing_running_plugin(
         with module.state.acquire_plugins_read_lock():
             demo_meta = dict(module.state.plugins["demo_plugin"])
             running_removed = dict(module.state.plugins["running_removed"])
+            assert "demo_plugin_1" not in module.state.plugins
 
         assert demo_meta["runtime_enabled"] is True
         assert demo_meta["runtime_auto_start"] is False

--- a/plugin/tests/unit/test_config_schema.py
+++ b/plugin/tests/unit/test_config_schema.py
@@ -122,3 +122,153 @@ def test_partial_plugin_config_accepts_active_types(plugin_type: str) -> None:
     config = {"plugin": {"type": plugin_type}}
 
     assert validate_plugin_config_partial(config) is config
+
+
+def _install_declaration() -> dict[str, object]:
+    return {
+        "enabled": True,
+        "ui_i18n_dir": "i18n/ui",
+        "tutorial_enabled": True,
+        "kinds": {
+            "rapidocr_models": {
+                "entry_id": "demo_download_rapidocr_models",
+                "label": "RapidOCR Models",
+                "queued_message": "RapidOCR model download queued",
+                "entry_timeout": 600.0,
+            }
+        },
+    }
+
+
+def test_plugin_install_declaration_is_optional_and_structured() -> None:
+    without_install = validate_plugin_config(_base_config())
+    assert without_install.plugin.install is None
+
+    config = _base_config()
+    plugin = config["plugin"]
+    assert isinstance(plugin, dict)
+    plugin["install"] = _install_declaration()
+
+    validated = validate_plugin_config(config)
+
+    assert validated.plugin.install is not None
+    assert validated.plugin.install.enabled is True
+    assert validated.plugin.install.ui_i18n_dir == "i18n/ui"
+    assert set(validated.plugin.install.kinds) == {"rapidocr_models"}
+    assert validated.plugin.install.kinds["rapidocr_models"].entry_timeout == 600.0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("entry_id", ""),
+        ("entry_id", " padded"),
+        ("label", ""),
+        ("label", "padded "),
+        ("queued_message", ""),
+        ("queued_message", " padded "),
+    ],
+)
+def test_plugin_install_rejects_empty_or_padded_kind_text(
+    field: str,
+    value: object,
+) -> None:
+    config = _base_config()
+    plugin = config["plugin"]
+    assert isinstance(plugin, dict)
+    declaration = _install_declaration()
+    kinds = declaration["kinds"]
+    assert isinstance(kinds, dict)
+    kind = kinds["rapidocr_models"]
+    assert isinstance(kind, dict)
+    kind[field] = value
+    plugin["install"] = declaration
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_plugin_config(config)
+
+    assert field in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "timeout",
+    [True, 0, -1, "600", float("nan"), float("inf"), float("-inf")],
+)
+def test_plugin_install_rejects_invalid_entry_timeout(timeout: object) -> None:
+    config = _base_config()
+    plugin = config["plugin"]
+    assert isinstance(plugin, dict)
+    declaration = _install_declaration()
+    kinds = declaration["kinds"]
+    assert isinstance(kinds, dict)
+    kind = kinds["rapidocr_models"]
+    assert isinstance(kind, dict)
+    kind["entry_timeout"] = timeout
+    plugin["install"] = declaration
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_plugin_config(config)
+
+    assert "entry_timeout" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("kind", ["RapidOCR", "rapid-ocr", " rapidocr", "rapidocr ", "1ocr"])
+def test_plugin_install_rejects_noncanonical_kind(kind: str) -> None:
+    config = _base_config()
+    plugin = config["plugin"]
+    assert isinstance(plugin, dict)
+    declaration = _install_declaration()
+    kinds = declaration["kinds"]
+    assert isinstance(kinds, dict)
+    kinds[kind] = kinds.pop("rapidocr_models")
+    plugin["install"] = declaration
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_plugin_config(config)
+
+    assert "kinds" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "install",
+    [
+        {"enabled": False, "kinds": {"rapidocr_models": _install_declaration()["kinds"]["rapidocr_models"]}},
+        {"enabled": False, "tutorial_enabled": True},
+        {"enabled": False, "ui_i18n_dir": "i18n"},
+    ],
+)
+def test_disabled_plugin_install_rejects_capabilities(install: dict[str, object]) -> None:
+    config = _base_config()
+    plugin = config["plugin"]
+    assert isinstance(plugin, dict)
+    plugin["install"] = install
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_plugin_config(config)
+
+    assert "install" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "install",
+    [
+        {"enabled": True, "unknown": True},
+        {
+            "enabled": True,
+            "kinds": {
+                "rapidocr_models": {
+                    **_install_declaration()["kinds"]["rapidocr_models"],
+                    "unknown": True,
+                }
+            },
+        },
+    ],
+)
+def test_plugin_install_rejects_unknown_fields(install: dict[str, object]) -> None:
+    config = _base_config()
+    plugin = config["plugin"]
+    assert isinstance(plugin, dict)
+    plugin["install"] = install
+
+    with pytest.raises(ConfigValidationError):
+        validate_plugin_config(config)

--- a/plugin/tests/unit/test_neko_plugin_cli_cli.py
+++ b/plugin/tests/unit/test_neko_plugin_cli_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import zipfile
 from pathlib import Path
@@ -66,6 +67,41 @@ def _tamper_package(package_path: Path, target_name: str) -> None:
     with zipfile.ZipFile(package_path, "w", compression=zipfile.ZIP_DEFLATED) as dst:
         for info, data in entries:
             dst.writestr(info, data)
+
+
+def _append_install_declaration(
+    plugin_dir: Path,
+    *,
+    ui_i18n_dir: str = "i18n/ui",
+    timeout: str = "600.0",
+) -> None:
+    (plugin_dir / "i18n" / "ui").mkdir(parents=True, exist_ok=True)
+    manifest_path = plugin_dir / "plugin.toml"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8")
+        + "\n[plugin.install]\n"
+        + "enabled = true\n"
+        + f'ui_i18n_dir = "{ui_i18n_dir}"\n'
+        + "tutorial_enabled = true\n"
+        + "\n[plugin.install.kinds.rapidocr_models]\n"
+        + 'entry_id = "cli_demo_download_rapidocr_models"\n'
+        + 'label = "RapidOCR Models"\n'
+        + 'queued_message = "RapidOCR model download queued"\n'
+        + f"entry_timeout = {timeout}\n",
+        encoding="utf-8",
+    )
+
+
+def _append_raw_install_declaration(plugin_dir: Path, declaration: str) -> None:
+    (plugin_dir / "i18n" / "ui").mkdir(parents=True, exist_ok=True)
+    manifest_path = plugin_dir / "plugin.toml"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8")
+        + "\n"
+        + declaration.strip()
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def test_cli_runtime_install_is_disabled_without_writing_plugin_directories(
@@ -339,6 +375,253 @@ def test_validate_plugin_dir_reports_invalid_toml_without_crashing(tmp_path: Pat
     issues = validate_plugin_dir(plugin_dir)
 
     assert any(level == "error" and "plugin.toml could not be read" in message for level, message in issues)
+
+
+def test_validate_plugin_dir_accepts_install_declaration_and_i18n_directory(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_install_declaration(plugin_dir)
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert not any(level == "error" and "install" in message for level, message in issues)
+    assert not any("[plugin].install is not a recognized" in message for _level, message in issues)
+
+
+def test_validate_plugin_dir_accepts_missing_and_empty_disabled_install_declaration(
+    tmp_path: Path,
+) -> None:
+    without_install = _make_plugin_dir(tmp_path / "without")
+    assert not any(
+        level == "error" and "install" in message
+        for level, message in validate_plugin_dir(without_install)
+    )
+
+    disabled = _make_plugin_dir(tmp_path / "disabled")
+    _append_raw_install_declaration(
+        disabled,
+        """
+        [plugin.install]
+        enabled = false
+        """,
+    )
+    assert not any(
+        level == "error" and "install" in message
+        for level, message in validate_plugin_dir(disabled)
+    )
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        """
+        [plugin.install]
+        enabled = true
+        unknown = true
+        """,
+        """
+        [plugin.install]
+        enabled = true
+        [plugin.install.kinds.models]
+        entry_id = "demo_install_models"
+        label = "Models"
+        queued_message = "Models queued"
+        entry_timeout = 600.0
+        unknown = true
+        """,
+    ],
+)
+def test_validate_plugin_dir_rejects_unknown_install_fields(
+    tmp_path: Path,
+    declaration: str,
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_raw_install_declaration(plugin_dir, declaration)
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(
+        level == "error" and "not a recognized plugin.toml field" in message
+        for level, message in issues
+    )
+
+
+@pytest.mark.parametrize("kind", ["RapidOCR", "rapid-ocr", "1ocr"])
+def test_validate_plugin_dir_rejects_noncanonical_install_kind(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_raw_install_declaration(
+        plugin_dir,
+        f"""
+        [plugin.install]
+        enabled = true
+        [plugin.install.kinds.{kind}]
+        entry_id = "demo_install_models"
+        label = "Models"
+        queued_message = "Models queued"
+        entry_timeout = 600.0
+        """,
+    )
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(
+        level == "error" and "must match ^[a-z][a-z0-9_]*$" in message
+        for level, message in issues
+    )
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        """
+        [plugin.install]
+        tutorial_enabled = false
+        """,
+        """
+        [plugin.install]
+        enabled = "true"
+        """,
+        """
+        [plugin.install]
+        enabled = false
+        tutorial_enabled = true
+        """,
+        """
+        [plugin.install]
+        enabled = false
+        ui_i18n_dir = "i18n/ui"
+        """,
+        """
+        [plugin.install]
+        enabled = false
+        [plugin.install.kinds.models]
+        entry_id = "demo_install_models"
+        label = "Models"
+        queued_message = "Models queued"
+        entry_timeout = 600.0
+        """,
+    ],
+)
+def test_validate_plugin_dir_rejects_invalid_or_contradictory_install_enablement(
+    tmp_path: Path,
+    declaration: str,
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_raw_install_declaration(plugin_dir, declaration)
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(level == "error" and "install" in message for level, message in issues)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("entry_id", ""),
+        ("entry_id", " padded"),
+        ("label", ""),
+        ("label", "padded "),
+        ("queued_message", ""),
+        ("queued_message", " padded "),
+    ],
+)
+def test_validate_plugin_dir_rejects_empty_or_padded_install_text(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    fields = {
+        "entry_id": "demo_install_models",
+        "label": "Models",
+        "queued_message": "Models queued",
+    }
+    fields[field] = value
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_raw_install_declaration(
+        plugin_dir,
+        "\n".join(
+            [
+                "[plugin.install]",
+                "enabled = true",
+                "[plugin.install.kinds.models]",
+                f'entry_id = {json.dumps(fields["entry_id"])}',
+                f'label = {json.dumps(fields["label"])}',
+                f'queued_message = {json.dumps(fields["queued_message"])}',
+                "entry_timeout = 600.0",
+            ]
+        ),
+    )
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(level == "error" and field in message for level, message in issues)
+
+
+@pytest.mark.parametrize("ui_i18n_dir", ["../outside", "/absolute/i18n"])
+def test_validate_plugin_dir_rejects_install_i18n_escape(
+    tmp_path: Path,
+    ui_i18n_dir: str,
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_install_declaration(plugin_dir, ui_i18n_dir=ui_i18n_dir)
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(
+        level == "error" and "ui_i18n_dir" in message
+        for level, message in issues
+    )
+
+
+def test_validate_plugin_dir_rejects_missing_install_i18n_directory(tmp_path: Path) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_install_declaration(plugin_dir, ui_i18n_dir="missing-i18n")
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(
+        level == "error" and "ui_i18n_dir" in message
+        for level, message in issues
+    )
+
+
+def test_validate_plugin_dir_rejects_install_i18n_symlink_escape(tmp_path: Path) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    outside = tmp_path / "outside-i18n"
+    outside.mkdir()
+    link = plugin_dir / "linked-i18n"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    _append_install_declaration(plugin_dir, ui_i18n_dir="linked-i18n")
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(
+        level == "error" and "ui_i18n_dir" in message
+        for level, message in issues
+    )
+
+
+@pytest.mark.parametrize("timeout", ["true", "0", "-1", '"600"', "nan", "inf"])
+def test_validate_plugin_dir_rejects_invalid_install_timeout(
+    tmp_path: Path,
+    timeout: str,
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path)
+    _append_install_declaration(plugin_dir, timeout=timeout)
+
+    issues = validate_plugin_dir(plugin_dir)
+
+    assert any(
+        level == "error" and "entry_timeout" in message
+        for level, message in issues
+    )
 
 
 def test_validate_plugin_dir_reports_invalid_config_example_without_crashing(tmp_path: Path) -> None:


### PR DESCRIPTION
## 改动概述

为插件提供通用的 `[plugin.install]` 声明能力，使安装入口、i18n 与 tutorial 元数据始终从主 registry 当前选中的插件 source 读取；同时让 Market fresh install 在 source 信息提交后立即刷新目标插件，无需重启即可被宿主发现。

- 增加严格的 install schema 与 CLI 静态校验，拒绝未知字段、非法 kind、无效 timeout 及目录逃逸。
- 显式声明优先于现有进程内动态注册；非法或禁用声明 fail closed，第三方旧注册 API 保持兼容。
- manifest 读取不缓存，读取前后复核 selected source；发生切换时完整重试一次。
- 安装路由在单次请求内固定 registration，阻塞文件操作进入 worker，并阻止 locale 文件通过符号链接越界读取。
- Market fresh install 在 source row 提交后刷新一次；刷新失败保留已提交安装并返回明确 warning。

## 关键技术决策

- 不建立第二套 registry snapshot，安装元数据直接服从主 registry 的 source 选择。
- source row 是 fresh install 的提交点；提交后的 refresh 失败不能伪造文件或 source rollback。
- 本 PR 保留两个 builtin bootstrap、Galgame tutorial hook 和第三方动态注册，为后续逐个移除 builtin 提供可独立交付的宿主基线。

## 风险与边界

- 本 PR 不删除内置 Study 或 Galgame，也不加入两者的 legacy manifest 特例。
- 不处理 upgrade、reinstall、builtin override 或通用 source switch 的即时刷新。
- 不修改 replacement、uninstall、operation lock 等安装事务。
- 不重构插件 SDK、Market 展示或 RapidOCR/Textractor 私有宿主依赖。
- 主要回归风险集中在 selected source 切换期间的安装元数据解析和 fresh install 后刷新；相关路径采用重试、fail-closed 与提交后 warning 边界。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持在插件清单中声明由宿主管理的安装动作、安装类型、超时、教程及界面本地化配置。
  - 插件安装配置支持更严格的格式、字段及路径校验。

- **安全性与稳定性**
  - 加强本地化资源路径及文件校验，阻止路径遍历、符号链接和特殊文件访问。
  - 市场插件完成全新安装后自动刷新注册信息；刷新失败时保留安装结果并提供警告。
  - 改进安装来源变更及无效配置处理，避免使用过期安装信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->