### PR TITLE
fix(tests): node harness 把「脚本卡住」和「node 根本没跑起来」分开

### DIFF
--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -339,9 +339,27 @@ if (deadlineMs > 0) {
     }
   });
 
+  // Which compile is the harness script?  Not simply the first one: an
+  // inherited NODE_OPTIONS can add its own preloads, and an ESM `--import`
+  // module is evaluated after CommonJS `--require` ones, so a CommonJS
+  // dependency it pulls in would compile after this hook is installed and
+  // before the harness script.  Arming there would put pre-main startup back
+  // inside the script's budget -- the very thing keying off compile was meant
+  // to take out of it.
+  //
+  // The main module identifies itself: `process.mainModule` is set once node
+  // starts loading it, so a preload's dependency is never `=== mainModule`.
+  // `node -` is the exception -- it has no main module and compiles as
+  // `[stdin]-wrapper` -- so that shape is matched explicitly, and only while
+  // there is no main module to compare against.
+  function isHarnessScript(module, filename) {
+    if (nativeProcess.mainModule) return module === nativeProcess.mainModule;
+    return String(filename).slice(0, 7) === '[stdin]';
+  }
+
   const originalCompile = Module.prototype._compile;
   Module.prototype._compile = function (content, filename) {
-    if (startedAt === null) {
+    if (startedAt === null && isHarnessScript(this, filename)) {
       startedAt = millisNow();
       Module.prototype._compile = originalCompile;
 

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -34,11 +34,130 @@ Locale encoding
 Both runners here take the script off the command line and pin UTF-8 in both
 directions.  Node lookup and the node-missing policy (skip vs. hard failure)
 stay with each caller, since the suites deliberately differ there.
+
+A third failure mode showed up once the suite ran under ``pytest -n auto`` on
+the Windows runner: ``subprocess.TimeoutExpired`` with nothing else to go on.
+A bare ceiling around ``subprocess.run`` cannot say which of two very different
+things happened, and the two want opposite responses:
+
+The script never settled
+    A ``setInterval`` the harness forgot to clear, or an ``await`` on a promise
+    nothing resolves, keeps node's event loop alive forever.  That is a real
+    defect in the harness and must stay red however often it is retried.
+
+The node process never got going
+    Process creation, the read of the script off disk, or V8 bootstrap stalled
+    on the runner.  Nothing in the script is reached, so no ceiling the caller
+    picks can help and no assertion is being tested; retrying is the only
+    sensible answer.
+
+They are told apart by giving the script its own deadline *inside* node.  The
+appended watchdog fires only if something is still holding the event loop open,
+prints what that something is, and exits non-zero -- so the first case fails
+deterministically, with the leaked handle named, and is never retried.  The
+subprocess ceiling then sits a few seconds above that deadline, which means a
+surviving ``TimeoutExpired`` can only be the second case: node never reached
+the watchdog.  That one is retried once, and if the retry stalls too, both
+attempts' output travels with the error instead of being thrown away.
 """
 
 import os
 import subprocess
 import tempfile
+
+
+# Script deadline for callers that pass no ``timeout`` of their own.  Their
+# ceiling today is the 25-minute job cap, so anything finite is an improvement;
+# the slowest harness in the suite measures 5.1s.
+_DEFAULT_WATCHDOG_SECONDS = 120.0
+# Head-room between the script's own deadline and the subprocess ceiling.  The
+# gap is what the watchdog needs to fire, write its diagnosis and exit, and it
+# is the only thing that makes a surviving ``TimeoutExpired`` mean "node never
+# ran the script".  Callers keep exactly the script budget they asked for.
+_SPAWN_SLACK_SECONDS = 5.0
+# Distinctive exit code so a watchdog kill is never mistaken for an assertion
+# failure or an uncaught exception, both of which leave node with 1.
+_WATCHDOG_EXIT_CODE = 87
+
+_WATCHDOG_TEMPLATE = r"""
+;(function () {
+  // Everything goes through globalThis on purpose.  Harness scripts routinely
+  // shadow the timer globals at module scope to drive a fake clock
+  // (`const setTimeout = (cb) => cb()`), and an appended watchdog calling the
+  // bare name would get handed that fake -- fired instantly, in one case.  A
+  // `const` shadow is worse still: it puts the bare name in the temporal dead
+  // zone for the whole module, so merely reading it throws.
+  var g = globalThis;
+  var deadline = g.setTimeout(function () {
+    var held;
+    try {
+      held = typeof g.process.getActiveResourcesInfo === 'function'
+        ? g.JSON.stringify(g.process.getActiveResourcesInfo())
+        : '<getActiveResourcesInfo unavailable on this node>';
+    } catch (err) {
+      held = '<unavailable: ' + err + '>';
+    }
+    var message = '\n[node_harness] the script still had pending work after '
+      + '__SECONDS__s.\n'
+      + '[node_harness] event loop is held by: ' + held + '\n'
+      + '[node_harness] a harness that never settles has usually left a timer '
+      + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
+      + 'nothing resolves.\n';
+    try {
+      // writeSync, because process.exit() does not flush a pending async pipe
+      // write and stderr to a pipe is async on Windows -- the diagnosis is the
+      // whole point, so it must not be the part that gets dropped.
+      require('node:fs').writeSync(2, message);
+    } catch (err) {
+      g.process.stderr.write(message);
+    }
+    g.process.exit(__EXIT_CODE__);
+  }, __MILLIS__);
+  // unref() so the watchdog cannot itself be the reason node stays up: with no
+  // other handle open node exits first and the watchdog never fires, which is
+  // exactly the healthy case.
+  if (deadline && typeof deadline.unref === 'function') deadline.unref();
+})();
+"""
+
+
+def _excerpt(blob, limit: int = 400) -> str:
+    """Readable, bounded view of whatever a stalled attempt had emitted."""
+    if blob is None:
+        return "<none>"
+    if isinstance(blob, bytes):
+        blob = blob.decode("utf-8", "replace")
+    if len(blob) > limit:
+        blob = blob[:limit] + "..."
+    return repr(blob)
+
+
+class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
+    """Both spawn attempts hit the ceiling without node exiting.
+
+    Subclasses ``TimeoutExpired`` so existing ``except`` clauses keep working,
+    and carries what each attempt managed to emit.  Empty output on both means
+    node never reached the first line of the script.
+    """
+
+    def __init__(self, cmd, timeout, attempts):
+        super().__init__(cmd, timeout)
+        self.attempts = list(attempts)
+
+    def __str__(self) -> str:
+        lines = [
+            super().__str__(),
+            "",
+            "Both attempts stalled before node exited, and the in-script "
+            "watchdog never fired -- so the script itself was not the thing "
+            "that hung; the node process never got far enough to arm it.",
+        ]
+        for index, attempt in enumerate(self.attempts, 1):
+            lines.append(
+                f"  attempt {index}: stdout={_excerpt(attempt.stdout)} "
+                f"stderr={_excerpt(attempt.stderr)}"
+            )
+        return "\n".join(lines)
 
 
 def _utf8(kwargs: dict) -> dict:
@@ -49,21 +168,89 @@ def _utf8(kwargs: dict) -> dict:
     return merged
 
 
+def _budgeted(kwargs: dict) -> tuple[dict, float]:
+    """Split the caller's ceiling into a script deadline and a spawn ceiling.
+
+    The caller's ``timeout`` stays the budget the *script* gets; the ceiling
+    handed to ``subprocess.run`` is raised by the slack, so a script that
+    overruns is killed from inside node with a diagnosis rather than from
+    outside with none.
+    """
+    merged = dict(kwargs)
+    timeout = merged.get("timeout")
+    if timeout is None:
+        return merged, _DEFAULT_WATCHDOG_SECONDS
+    watchdog = float(timeout)
+    merged["timeout"] = watchdog + _SPAWN_SLACK_SECONDS
+    return merged, watchdog
+
+
+def _with_watchdog(script: str, seconds: float) -> str:
+    """Append the self-deadline that turns a hung script into a named failure.
+
+    Appended rather than prepended so line numbers in the caller's own stack
+    traces keep pointing at the caller's own code.  It runs once the script's
+    synchronous top level is done, which is precisely when the event loop takes
+    over and a leaked handle starts to matter.
+    """
+    watchdog = (
+        _WATCHDOG_TEMPLATE
+        .replace("__SECONDS__", f"{seconds:g}")
+        .replace("__MILLIS__", str(int(seconds * 1000)))
+        .replace("__EXIT_CODE__", str(_WATCHDOG_EXIT_CODE))
+    )
+    return script + "\n" + watchdog
+
+
+def _run_retrying_spawn_stalls(next_attempt, cmd_for_error):
+    """Run once, and once more if node stalled without ever reaching the script.
+
+    ``next_attempt`` is called per attempt so a caller that stages a temp file
+    gets a fresh one, rather than a second attempt inheriting whatever state
+    the killed first attempt left behind.
+    """
+    attempts = []
+    for attempt in (1, 2):
+        argv, run_kwargs = next_attempt()
+        try:
+            return subprocess.run(argv, **run_kwargs)
+        except subprocess.TimeoutExpired as exc:
+            attempts.append(exc)
+            if attempt == 2:
+                raise NodeHarnessSpawnTimeout(
+                    cmd_for_error, exc.timeout, attempts
+                ) from exc
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
 def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.CompletedProcess[str]:
     """Run ``script`` from a temp file under ``node_path``.
 
     Use this when the script is large or grows with the behaviour it simulates.
     Extra keyword arguments go straight to ``subprocess.run``.
     """
-    with tempfile.NamedTemporaryFile(
-        "w", suffix=".js", delete=False, encoding="utf-8"
-    ) as handle:
-        handle.write(script)
-        script_path = handle.name
+    merged, watchdog_seconds = _budgeted(_utf8(kwargs))
+    guarded = _with_watchdog(script, watchdog_seconds)
+    staged: list[str] = []
+
+    def _attempt():
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".js", delete=False, encoding="utf-8"
+        ) as handle:
+            handle.write(guarded)
+            staged.append(handle.name)
+        return [node_path, staged[-1]], merged
+
     try:
-        return subprocess.run([node_path, script_path], **_utf8(kwargs))
+        return _run_retrying_spawn_stalls(_attempt, [node_path, "<temp script>"])
     finally:
-        os.unlink(script_path)
+        for path in staged:
+            # Best effort: a killed node on Windows can still hold the file for
+            # a moment, and losing a temp file must not mask the real error.
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
 
 def run_node_stdin(node_path: str, script: str, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -73,4 +260,9 @@ def run_node_stdin(node_path: str, script: str, **kwargs) -> subprocess.Complete
     stdin form; stdin has no length ceiling, so only the encoding pin matters
     here. Extra keyword arguments go straight to ``subprocess.run``.
     """
-    return subprocess.run([node_path, "-"], input=script, **_utf8(kwargs))
+    merged, watchdog_seconds = _budgeted(_utf8(kwargs))
+    guarded = _with_watchdog(script, watchdog_seconds)
+    return _run_retrying_spawn_stalls(
+        lambda: ([node_path, "-"], dict(merged, input=guarded)),
+        [node_path, "-"],
+    )

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -89,11 +89,12 @@ One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
 no amount of retrying will make that script finish.  What separates it from a
 genuine spawn stall is evidence: measured on Windows, whatever the script wrote
 before it blocked still reaches the parent, while a node that never reached the
-script emits nothing at all.  So a stalled attempt that produced output is
-reported straight away, and only a silent one is retried.  A synchronous block
-that also printed nothing stays ambiguous, and the error says so rather than
-picking a side -- as does the case of a caller that never captured output at
-all, where the silence is nobody watching rather than nothing said.
+script emits nothing at all.  Which of the two happened is not inferred from output -- a caller
+that does not capture cannot show any, so silence would mean both things at
+once.  The preload drops a marker file the moment node compiles the script, so
+the launcher knows as a fact whether anything was under test: an attempt that
+never got that far is repeated, and one that did is reported as it stands,
+because a second run would block in exactly the same place.
 """
 
 import atexit
@@ -137,7 +138,7 @@ class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
     came with output and was not worth repeating; two means both were silent.
     """
 
-    def __init__(self, cmd, timeout, attempts):
+    def __init__(self, cmd, timeout, attempts, started=False):
         # Carry the last attempt's output on the exception the way
         # ``subprocess.run`` would have: a caller that catches
         # ``TimeoutExpired`` and reads ``.stdout``/``.stderr`` (or ``.output``)
@@ -150,16 +151,22 @@ class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
             stderr=getattr(last, "stderr", None),
         )
         self.attempts = list(attempts)
+        self.started = started
 
     def __str__(self) -> str:
-        diagnosis = (
-            "Stalled before node exited, and the in-script watchdog never "
-            "fired. Either node never reached the script (process creation, "
-            "reading it off disk, V8 bootstrap), or the script blocked the "
-            "event loop synchronously -- a timer cannot interrupt that. Each "
-            "attempt's output below is the evidence, where there was a pipe "
-            "to collect it: anything at all means the script did run."
-        )
+        if self.started:
+            diagnosis = (
+                "The script ran and then stalled without the watchdog firing, "
+                "which a timer cannot interrupt: it blocked the event loop "
+                "synchronously. Not retried -- a second run would block the "
+                "same way."
+            )
+        else:
+            diagnosis = (
+                "node never reached the harness script -- process creation, "
+                "reading it off disk, or V8 bootstrap stalled. Nothing was "
+                "under test, so the attempt was repeated."
+            )
         lines = [super().__str__(), "", diagnosis]
         if not any(_observed_output(attempt) for attempt in self.attempts):
             lines.append(
@@ -230,6 +237,11 @@ def _budgeted(kwargs: dict) -> tuple[dict, float]:
 # than a substitution into the source keeps the preload file identical for every
 # call, so it can be written once per process instead of once per invocation.
 _DEADLINE_ENV = "NEKO_NODE_HARNESS_DEADLINE_MS"
+# Where the preload records that node reached the harness script.  Retrying is
+# only ever right for an attempt that never got that far, and output is a poor
+# proxy for it: a caller that does not capture cannot show any, so "silent" and
+# "never started" look identical from out here.  The file makes it a fact.
+_MARKER_ENV = "NEKO_NODE_HARNESS_STARTED_MARKER"
 
 _PRELOAD_SOURCE = r"""
 // Preloaded with `node --require`, so this runs before the harness script, in
@@ -248,6 +260,7 @@ const Module = require('node:module');
 const nativeProcess = process;
 const armTimer = timers.setTimeout.bind(timers);
 const writeSync = fs.writeSync.bind(fs);
+const writeFileSync = fs.writeFileSync.bind(fs);
 const exitNow = nativeProcess.exit.bind(nativeProcess);
 const stringify = JSON.stringify.bind(JSON);
 // Monotonic, and snapshotted like everything else.  Three harnesses in this
@@ -332,6 +345,16 @@ if (deadlineMs > 0) {
       startedAt = millisNow();
       Module.prototype._compile = originalCompile;
 
+      // Tell the launcher the script really started.  Best effort: if this
+      // cannot be written the launcher falls back to judging by output, which
+      // is where it was before.
+      try {
+        const marker = nativeProcess.env.NEKO_NODE_HARNESS_STARTED_MARKER;
+        if (marker) writeFileSync(marker, '1');
+      } catch (err) {
+        // Nothing to do; the deadline itself is unaffected.
+      }
+
       // ...and this covers the script that never exits at all.  unref() so the
       // watchdog is never itself the reason node stays up: with nothing else
       // holding the loop, node exits first and the hook above does the
@@ -397,10 +420,29 @@ def _preload_path() -> str:
         return _preload_file
 
 
-def _guarded(merged: dict, deadline_seconds: float) -> tuple[list[str], dict]:
+def _new_marker() -> str:
+    """A path the preload will create once node reaches the harness script."""
+    handle, path = tempfile.mkstemp(suffix=".neko-harness-started")
+    os.close(handle)
+    os.unlink(path)  # its *existence* is the signal, so start from absent
+    return path
+
+
+def _script_started(marker: str, exc: subprocess.TimeoutExpired) -> bool:
+    """Did this attempt get as far as running the harness script?
+
+    The marker is the direct answer.  Output is kept as a fallback for the case
+    where the marker could not be written at all: it is one-directional, but
+    anything on either stream still proves the script ran.
+    """
+    return os.path.exists(marker) or _emitted_anything(exc)
+
+
+def _guarded(merged: dict, deadline_seconds: float, marker: str) -> tuple[list[str], dict]:
     """The ``--require`` argument and the environment carrying the deadline."""
     base = merged.get("env")
     environment = dict(os.environ if base is None else base)
+    environment[_MARKER_ENV] = marker
     # Floor at 1ms: a sub-millisecond budget must still arm the guard, and
     # rounding it to 0 is how the preload gets switched off by accident.
     environment[_DEADLINE_ENV] = str(max(1, int(deadline_seconds * 1000)))
@@ -416,15 +458,24 @@ def _run_retrying_spawn_stalls(next_attempt, cmd_for_error):
     """
     attempts = []
     for attempt in (1, 2):
-        argv, run_kwargs = next_attempt()
+        argv, run_kwargs, marker = next_attempt()
         try:
             return subprocess.run(argv, **run_kwargs)
         except subprocess.TimeoutExpired as exc:
             attempts.append(exc)
-            if attempt == 2 or _emitted_anything(exc):
+            started = _script_started(marker, exc)
+            if attempt == 2 or started:
                 raise NodeHarnessSpawnTimeout(
-                    cmd_for_error, exc.timeout, attempts
+                    cmd_for_error, exc.timeout, attempts, started=started
                 ) from exc
+        finally:
+            try:
+                os.unlink(marker)
+            except OSError:
+                # Absent is the normal case: the preload only creates it once
+                # node reaches the script, and there is nothing to clean up
+                # otherwise.
+                pass
     raise AssertionError("unreachable")  # pragma: no cover
 
 
@@ -434,17 +485,18 @@ def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.Complet
     Use this when the script is large or grows with the behaviour it simulates.
     Extra keyword arguments go straight to ``subprocess.run``.
     """
-    merged, deadline_seconds = _budgeted(_utf8(kwargs))
-    preload, merged = _guarded(merged, deadline_seconds)
+    budget, deadline_seconds = _budgeted(_utf8(kwargs))
     staged: list[str] = []
 
     def _attempt():
+        marker = _new_marker()
+        preload, merged = _guarded(budget, deadline_seconds, marker)
         with tempfile.NamedTemporaryFile(
             "w", suffix=".js", delete=False, encoding="utf-8"
         ) as handle:
             handle.write(script)
             staged.append(handle.name)
-        return [node_path, *preload, staged[-1]], merged
+        return [node_path, *preload, staged[-1]], merged, marker
 
     try:
         return _run_retrying_spawn_stalls(_attempt, [node_path, "<temp script>"])
@@ -466,9 +518,11 @@ def run_node_stdin(node_path: str, script: str, **kwargs) -> subprocess.Complete
     stdin form; stdin has no length ceiling, so only the encoding pin matters
     here. Extra keyword arguments go straight to ``subprocess.run``.
     """
-    merged, deadline_seconds = _budgeted(_utf8(kwargs))
-    preload, merged = _guarded(merged, deadline_seconds)
-    return _run_retrying_spawn_stalls(
-        lambda: ([node_path, *preload, "-"], dict(merged, input=script)),
-        [node_path, "-"],
-    )
+    budget, deadline_seconds = _budgeted(_utf8(kwargs))
+
+    def _attempt():
+        marker = _new_marker()
+        preload, merged = _guarded(budget, deadline_seconds, marker)
+        return [node_path, *preload, "-"], dict(merged, input=script), marker
+
+    return _run_retrying_spawn_stalls(_attempt, [node_path, "-"])

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -84,6 +84,14 @@ below.  A preloaded module has none of these problems -- it runs before the
 script, in a scope the script cannot reach, and leaves the script byte-for-byte
 as the caller wrote it.
 
+One boundary is worth naming: the deadline is armed from a CommonJS compile
+hook, so a harness evaluated as an ES module would never arm it and would be
+left with only the outer ceiling.  Every harness here is CommonJS, and the only
+way to change that from outside -- an inherited
+NODE_OPTIONS=--input-type=module -- makes all 26 of them fail immediately on
+their first require, so the guard cannot go quietly blind while the suites
+still pass.  Adding an ES-module harness would need this revisited.
+
 One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
 {}`` never yields, and a timer cannot interrupt the thread it is queued on --
 no amount of retrying will make that script finish.  What separates it from a

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -164,10 +164,12 @@ class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
     def __str__(self) -> str:
         if self.started:
             diagnosis = (
-                "The script ran and then stalled without the watchdog firing, "
-                "which a timer cannot interrupt: it blocked the event loop "
-                "synchronously. Not retried -- a second run would block the "
-                "same way."
+                "node reached the harness script and then stalled without "
+                "the watchdog firing. Either the script's top level blocked "
+                "the event loop or compiling it did -- a timer cannot "
+                "interrupt either, and from out here they look the same. Not "
+                "retried: a second run stalls the same way, and repeating a "
+                "script that may already have run is the worse mistake."
             )
         else:
             diagnosis = (
@@ -371,9 +373,18 @@ if (deadlineMs > 0) {
       startedAt = millisNow();
       Module.prototype._compile = originalCompile;
 
-      // Tell the launcher the script really started.  Best effort: if this
-      // cannot be written the launcher falls back to judging by output, which
-      // is where it was before.
+      // Tell the launcher node reached the script.  This is written before
+      // `originalCompile` rather than after, and the difference matters:
+      // `_compile` both compiles the module *and* runs it, so "after" would
+      // mean "after the whole top level", and a script that blocks the event
+      // loop would never mark at all -- it would look like a spawn stall and
+      // be retried, which is the one thing that must not happen to a script
+      // that may already have had effects.  The cost is that a stall in
+      // compilation itself also counts as reached; the error message says so
+      // rather than claiming to know which it was.
+      //
+      // Best effort: if this cannot be written the launcher falls back to
+      // judging by output, which is where it was before.
       try {
         const marker = nativeProcess.env.NEKO_NODE_HARNESS_STARTED_MARKER;
         if (marker) writeFileSync(marker, '1');

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -282,7 +282,7 @@ def _with_watchdog(script: str, seconds: float) -> str:
     watchdog = (
         _WATCHDOG_TEMPLATE
         .replace("__SECONDS__", f"{seconds:g}")
-        .replace("__MILLIS__", "9000")  # MUTANT
+        .replace("__MILLIS__", str(int(seconds * 1000)))
         .replace("__EXIT_CODE__", str(_WATCHDOG_EXIT_CODE))
     )
     return script + "\n" + watchdog

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -61,7 +61,10 @@ the way out, covering the script that merely ran long and then ended and the one
 that calls ``process.exit()`` itself; every way out of node passes through it,
 and an ``exitCode`` assigned there overrides even ``process.exit(0)``.  The
 subprocess ceiling sits a few seconds above the deadline, so a surviving
-``TimeoutExpired`` means node never got as far as the preload.
+``TimeoutExpired`` means node never got as far as the preload.  The script's
+budget is counted from the preload, not from process start: everything before it
+is bootstrap, which is the stall the ceiling is there to catch and retry, and
+charging it to the script would report a slow *spawn* as a script timeout.
 
 The guard is a preload rather than text spliced into the script, because a
 harness script is not a safe place to stand.  Injected code resolves its names
@@ -213,7 +216,10 @@ def _budgeted(kwargs: dict) -> tuple[dict, float]:
     merged = dict(kwargs)
     timeout = merged.get("timeout")
     watchdog = _DEFAULT_WATCHDOG_SECONDS if timeout is None else float(timeout)
-    merged["timeout"] = watchdog + _SPAWN_SLACK_SECONDS
+    if watchdog > 0:
+        merged["timeout"] = watchdog + _SPAWN_SLACK_SECONDS
+    # A zero or negative timeout is a caller asking to fail immediately.  Adding
+    # slack to it would hand a slow script five seconds of grace it never had.
     return merged, watchdog
 
 
@@ -224,54 +230,84 @@ _DEADLINE_ENV = "NEKO_NODE_HARNESS_DEADLINE_MS"
 
 _PRELOAD_SOURCE = r"""
 // Preloaded with `node --require`, so this runs before the harness script, in
-// its own module scope, out of reach of anything the harness declares or
-// overwrites.  Nothing here is resolved in the caller's scope.
+// its own module scope, out of reach of anything the harness declares.
 const timers = require('node:timers');
 const fs = require('node:fs');
 
-const deadlineMs = Number(process.env.NEKO_NODE_HARNESS_DEADLINE_MS || 0);
+// Snapshot every moving part before the script gets a turn.  A preload is out
+// of reach of the caller's *lexical* scope, but not of shared objects: these
+// harnesses stub `process.exit` (a normal thing to do when the code under test
+// exits on error), hang browser shims off `global`, and `require('node:fs')`
+// hands the script the very same module object this one is holding.  A binding
+// taken here cannot be reached afterwards, which closes that class rather than
+// moving it one name further along.
+const nativeProcess = process;
+const armTimer = timers.setTimeout.bind(timers);
+const writeSync = fs.writeSync.bind(fs);
+const exitNow = nativeProcess.exit.bind(nativeProcess);
+const stringify = JSON.stringify.bind(JSON);
+const activeResources = typeof nativeProcess.getActiveResourcesInfo === 'function'
+  ? nativeProcess.getActiveResourcesInfo.bind(nativeProcess)
+  : null;
+
+const deadlineMs = Number(nativeProcess.env.NEKO_NODE_HARNESS_DEADLINE_MS || 0);
 const EXIT_CODE = 87;
+
+// The budget starts here, not at process start.  Everything before this point
+// is node bootstrap -- exactly the pre-script stall the outer ceiling exists to
+// catch and retry -- so charging it to the script would report a healthy script
+// as a harness timeout on precisely the slow spawn this launcher was written
+// for, and would do it *instead of* retrying.
+const startedAt = Date.now();
+
+function overdue() {
+  return Date.now() - startedAt > deadlineMs;
+}
 
 function diagnose(prefix) {
   let held;
   try {
-    held = typeof process.getActiveResourcesInfo === 'function'
-      ? JSON.stringify(process.getActiveResourcesInfo())
+    held = activeResources
+      ? stringify(activeResources())
       : '<getActiveResourcesInfo unavailable on this node>';
   } catch (err) {
     held = '<unavailable: ' + err + '>';
   }
-  // writeSync, because process.exit() does not flush a pending async pipe write
-  // and stderr to a pipe is async on Windows -- the diagnosis is the whole
-  // point, so it must not be the part that gets dropped.
-  fs.writeSync(
-    2,
-    '\n[node_harness] ' + prefix + ' ' + (deadlineMs / 1000) + 's after node '
-    + 'started.\n'
-    + '[node_harness] event loop is held by: ' + held + '\n'
-    + '[node_harness] a harness that never settles has usually left a timer '
-    + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
-    + 'nothing resolves.\n'
-  );
+  try {
+    // writeSync, because process.exit() does not flush a pending async pipe
+    // write and stderr to a pipe is async on Windows -- the diagnosis is the
+    // whole point, so it must not be the part that gets dropped.
+    writeSync(
+      2,
+      '\n[node_harness] ' + prefix + ' ' + (deadlineMs / 1000) + 's after the '
+      + 'script started.\n'
+      + '[node_harness] event loop is held by: ' + held + '\n'
+      + '[node_harness] a harness that never settles has usually left a timer '
+      + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
+      + 'nothing resolves.\n'
+    );
+  } catch (err) {
+    // Nothing left to report with; the exit code still carries the verdict.
+  }
 }
 
 if (deadlineMs > 0) {
   // Covers every way out of node: the loop draining, an explicit process.exit()
   // in the script, an uncaught throw.  An exitCode assigned in an 'exit'
   // listener overrides even process.exit(0).
-  process.on('exit', function () {
-    if (Math.round(process.uptime() * 1000) > deadlineMs) {
+  nativeProcess.on('exit', function () {
+    if (overdue()) {
       diagnose('the script was still running');
-      process.exitCode = EXIT_CODE;
+      nativeProcess.exitCode = EXIT_CODE;
     }
   });
 
   // ...and this covers the script that never exits at all.  unref() so the
   // watchdog is never itself the reason node stays up: with nothing else
   // holding the loop, node exits first and the hook above does the checking.
-  const deadline = timers.setTimeout(function () {
+  const deadline = armTimer(function () {
     diagnose('the script still had pending work');
-    process.exit(EXIT_CODE);
+    exitNow(EXIT_CODE);
   }, deadlineMs);
   if (deadline && typeof deadline.unref === 'function') deadline.unref();
 }
@@ -315,7 +351,9 @@ def _guarded(merged: dict, deadline_seconds: float) -> tuple[list[str], dict]:
     """The ``--require`` argument and the environment carrying the deadline."""
     base = merged.get("env")
     environment = dict(os.environ if base is None else base)
-    environment[_DEADLINE_ENV] = str(int(deadline_seconds * 1000))
+    # Floor at 1ms: a sub-millisecond budget must still arm the guard, and
+    # rounding it to 0 is how the preload gets switched off by accident.
+    environment[_DEADLINE_ENV] = str(max(1, int(deadline_seconds * 1000)))
     return ["--require", _preload_path()], dict(merged, env=environment)
 
 

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -58,6 +58,14 @@ deterministically, with the leaked handle named, and is never retried.  The
 subprocess ceiling then sits a few seconds above that deadline, so a
 surviving ``TimeoutExpired`` means the watchdog never got to run.
 
+The deadline has to be enforced two ways, because ``unref()`` cuts both.  A
+script still holding the loop open gets the timer.  A script that merely ran
+long and then finished would sail past it -- node exits before an unref'd timer
+on an otherwise empty loop -- so the overdue case is checked once, synchronously,
+at the moment the watchdog arms.  Without that second half, moving the caller's
+timeout off ``subprocess.run`` and into the script would have quietly stopped
+the timeout from meaning anything for every script that overruns and completes.
+
 One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
 {}`` never yields, and a timer cannot interrupt the thread it is queued on --
 no amount of retrying will make that script finish.  What separates it from a
@@ -104,17 +112,8 @@ _WATCHDOG_TEMPLATE = r"""
   } catch (err) {
     timer = g.setTimeout;
   }
-  // Charge node startup and the script's synchronous top level against the
-  // budget, because the outer ceiling is charged for them too.  Arming for the
-  // full deadline here would put the watchdog at (startup + top level +
-  // deadline) while the ceiling sits at (deadline + slack): any top level
-  // heavier than the slack and the ceiling wins, losing the diagnosis. Nothing
-  // can fire during a synchronous top level, but the moment it ends the budget
-  // is already spent and the watchdog should say so.
-  var spent = Math.round((g.process.uptime ? g.process.uptime() : 0) * 1000);
-  var budget = __MILLIS__ - spent;
-  if (!(budget > 1)) budget = 1;
-  var deadline = timer(function () {
+
+  function report(prefix) {
     var held;
     try {
       held = typeof g.process.getActiveResourcesInfo === 'function'
@@ -123,8 +122,8 @@ _WATCHDOG_TEMPLATE = r"""
     } catch (err) {
       held = '<unavailable: ' + err + '>';
     }
-    var message = '\n[node_harness] the script still had pending work '
-      + '__SECONDS__s after node started.\n'
+    var message = '\n[node_harness] ' + prefix + ' __SECONDS__s after node '
+      + 'started.\n'
       + '[node_harness] event loop is held by: ' + held + '\n'
       + '[node_harness] a harness that never settles has usually left a timer '
       + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
@@ -138,6 +137,26 @@ _WATCHDOG_TEMPLATE = r"""
       g.process.stderr.write(message);
     }
     g.process.exit(__EXIT_CODE__);
+  }
+
+  // Charge node startup and the script's synchronous top level against the
+  // budget, because the outer ceiling is charged for them too.  Arming for the
+  // full deadline here would put the watchdog at (startup + top level +
+  // deadline) while the ceiling sits at (deadline + slack): any top level
+  // heavier than the slack and the ceiling wins, losing the diagnosis.
+  var spent = Math.round((g.process.uptime ? g.process.uptime() : 0) * 1000);
+  var budget = __MILLIS__ - spent;
+
+  if (budget <= 0) {
+    // Already over budget by the time the top level finished.  Scheduling a
+    // timer here would be worse than useless: it is unref'd, so with the loop
+    // otherwise empty node exits 0 before the callback ever runs, and the
+    // caller's timeout silently stops meaning anything.  Fail now instead.
+    report('the script was still running');
+  }
+
+  var deadline = timer(function () {
+    report('the script still had pending work');
   }, budget);
   // unref() so the watchdog cannot itself be the reason node stays up: with no
   // other handle open node exits first and the watchdog never fires, which is
@@ -263,7 +282,7 @@ def _with_watchdog(script: str, seconds: float) -> str:
     watchdog = (
         _WATCHDOG_TEMPLATE
         .replace("__SECONDS__", f"{seconds:g}")
-        .replace("__MILLIS__", str(int(seconds * 1000)))
+        .replace("__MILLIS__", "9000")  # MUTANT
         .replace("__EXIT_CODE__", str(_WATCHDOG_EXIT_CODE))
     )
     return script + "\n" + watchdog

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -61,10 +61,13 @@ the way out, covering the script that merely ran long and then ended and the one
 that calls ``process.exit()`` itself; every way out of node passes through it,
 and an ``exitCode`` assigned there overrides even ``process.exit(0)``.  The
 subprocess ceiling sits a few seconds above the deadline, so a surviving
-``TimeoutExpired`` means node never got as far as the preload.  The script's
-budget is counted from the preload, not from process start: everything before it
-is bootstrap, which is the stall the ceiling is there to catch and retry, and
-charging it to the script would report a slow *spawn* as a script timeout.
+``TimeoutExpired`` means node never got that far.  The script's budget starts
+when node compiles the harness script -- not at process start, and not when the
+preload runs, since a ``--require`` module is loaded before node reads the main
+script at all.  Bootstrap, reading the temp file and draining ``node -`` stdin
+are therefore outside it: they are the stall the ceiling is there to catch and
+retry, and charging them to the script would report a slow *spawn* as a script
+timeout, instead of retrying it.
 
 The guard is a preload rather than text spliced into the script, because a
 harness script is not a safe place to stand.  Injected code resolves its names
@@ -233,6 +236,7 @@ _PRELOAD_SOURCE = r"""
 // its own module scope, out of reach of anything the harness declares.
 const timers = require('node:timers');
 const fs = require('node:fs');
+const Module = require('node:module');
 
 // Snapshot every moving part before the script gets a turn.  A preload is out
 // of reach of the caller's *lexical* scope, but not of shared objects: these
@@ -263,15 +267,25 @@ const activeResources = typeof nativeProcess.getActiveResourcesInfo === 'functio
 const deadlineMs = Number(nativeProcess.env.NEKO_NODE_HARNESS_DEADLINE_MS || 0);
 const EXIT_CODE = __EXIT_CODE__;
 
-// The budget starts here, not at process start.  Everything before this point
-// is node bootstrap -- exactly the pre-script stall the outer ceiling exists to
-// catch and retry -- so charging it to the script would report a healthy script
-// as a harness timeout on precisely the slow spawn this launcher was written
-// for, and would do it *instead of* retrying.
-const startedAt = millisNow();
+// The budget starts when node compiles the harness script, not when this
+// preload runs and not at process start.  A `--require` module is loaded before
+// node reads and compiles the main script, so everything up to that point --
+// bootstrap, reading the temp file, draining `node -` stdin -- is pre-script
+// work.  That is precisely the stall the outer ceiling exists to catch and
+// retry; charging it to the script would report a slow *spawn* as a script
+// timeout, and would do it *instead of* retrying, which is the one outcome this
+// launcher was written to avoid.
+//
+// `Module.prototype._compile` is the marker: it fires for a file main module
+// and for `node -` alike (`[stdin]-wrapper`), before the script's first
+// statement runs.  The patch removes itself on the first call, so only the main
+// module is measured and anything the script requires later is untouched.
+let startedAt = null;
 
 function overdue() {
-  return millisNow() - startedAt > deadlineMs;
+  // Never started == never the script's fault.  Staying quiet here leaves the
+  // outer ceiling to time out, which is what gets the attempt retried.
+  return startedAt !== null && millisNow() - startedAt > deadlineMs;
 }
 
 function diagnose(prefix) {
@@ -312,14 +326,24 @@ if (deadlineMs > 0) {
     }
   });
 
-  // ...and this covers the script that never exits at all.  unref() so the
-  // watchdog is never itself the reason node stays up: with nothing else
-  // holding the loop, node exits first and the hook above does the checking.
-  const deadline = armTimer(function () {
-    diagnose('the script still had pending work');
-    exitNow(EXIT_CODE);
-  }, deadlineMs);
-  if (deadline && typeof deadline.unref === 'function') deadline.unref();
+  const originalCompile = Module.prototype._compile;
+  Module.prototype._compile = function (content, filename) {
+    if (startedAt === null) {
+      startedAt = millisNow();
+      Module.prototype._compile = originalCompile;
+
+      // ...and this covers the script that never exits at all.  unref() so the
+      // watchdog is never itself the reason node stays up: with nothing else
+      // holding the loop, node exits first and the hook above does the
+      // checking.
+      const deadline = armTimer(function () {
+        diagnose('the script still had pending work');
+        exitNow(EXIT_CODE);
+      }, deadlineMs);
+      if (deadline && typeof deadline.unref === 'function') deadline.unref();
+    }
+    return originalCompile.call(this, content, filename);
+  };
 }
 """
 

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -246,6 +246,16 @@ const armTimer = timers.setTimeout.bind(timers);
 const writeSync = fs.writeSync.bind(fs);
 const exitNow = nativeProcess.exit.bind(nativeProcess);
 const stringify = JSON.stringify.bind(JSON);
+// Monotonic, and snapshotted like everything else.  Three harnesses in this
+// repo pin Date.now to a fake clock (test_app_websocket_static,
+// test_avatar_annotation_frontend x2), which would freeze the deadline check
+// for exactly the scripts most likely to need it; hrtime is also immune to the
+// wall clock being adjusted underneath a long run.
+const hrtime = nativeProcess.hrtime && typeof nativeProcess.hrtime.bigint === 'function'
+  ? nativeProcess.hrtime.bigint.bind(nativeProcess.hrtime)
+  : null;
+const wallClock = Date.now.bind(Date);
+const millisNow = hrtime ? function () { return Number(hrtime() / 1000000n); } : wallClock;
 const activeResources = typeof nativeProcess.getActiveResourcesInfo === 'function'
   ? nativeProcess.getActiveResourcesInfo.bind(nativeProcess)
   : null;
@@ -258,10 +268,10 @@ const EXIT_CODE = __EXIT_CODE__;
 // catch and retry -- so charging it to the script would report a healthy script
 // as a harness timeout on precisely the slow spawn this launcher was written
 // for, and would do it *instead of* retrying.
-const startedAt = Date.now();
+const startedAt = millisNow();
 
 function overdue() {
-  return Date.now() - startedAt > deadlineMs;
+  return millisNow() - startedAt > deadlineMs;
 }
 
 function diagnose(prefix) {

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -251,7 +251,7 @@ const activeResources = typeof nativeProcess.getActiveResourcesInfo === 'functio
   : null;
 
 const deadlineMs = Number(nativeProcess.env.NEKO_NODE_HARNESS_DEADLINE_MS || 0);
-const EXIT_CODE = 87;
+const EXIT_CODE = __EXIT_CODE__;
 
 // The budget starts here, not at process start.  Everything before this point
 // is node bootstrap -- exactly the pre-script stall the outer ceiling exists to
@@ -313,6 +313,20 @@ if (deadlineMs > 0) {
 }
 """
 
+def _rendered_preload() -> str:
+    """The preload with the exit code bound to the Python constant.
+
+    The substitution is the only one, and it does not vary per call, so the file
+    written from this is still identical for every invocation.  It exists so
+    that 87 has one definition: the JS carried its own literal for a while,
+    which is a drift waiting to happen between the guard and every test that
+    asserts on the code it exits with.
+    """
+    rendered = _PRELOAD_SOURCE.replace("__EXIT_CODE__", str(_WATCHDOG_EXIT_CODE))
+    assert "__EXIT_CODE__" not in rendered
+    return rendered
+
+
 _preload_guard = threading.Lock()
 _preload_file: str | None = None
 
@@ -324,6 +338,8 @@ def _drop_preload() -> None:
         try:
             os.unlink(_preload_file)
         except OSError:
+            # Deliberate: this runs at interpreter exit, where a leaked temp
+            # file is not worth raising over and there is nobody left to tell.
             pass
         _preload_file = None
 
@@ -341,7 +357,7 @@ def _preload_path() -> str:
             with tempfile.NamedTemporaryFile(
                 "w", suffix=".neko-harness-guard.js", delete=False, encoding="utf-8"
             ) as handle:
-                handle.write(_PRELOAD_SOURCE)
+                handle.write(_rendered_preload())
             _preload_file = handle.name
             atexit.register(_drop_preload)
         return _preload_file

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -51,23 +51,32 @@ The node process never got going
     picks can help and no assertion is being tested; retrying is the only
     sensible answer.
 
-They are told apart by giving the script its own deadline *inside* node.  The
-appended watchdog fires only if something is still holding the event loop open,
-prints what that something is, and exits non-zero -- so the first case fails
-deterministically, with the leaked handle named, and is never retried.  The
-subprocess ceiling then sits a few seconds above that deadline, so a
-surviving ``TimeoutExpired`` means the watchdog never got to run.
+They are told apart by giving the script its own deadline inside node, carried
+by a module preloaded with ``node --require``.  It arms two things.  A timer,
+``unref()``-ed so it is never itself the reason node stays up, fires only while
+something else still holds the event loop open, prints what that something is,
+and exits 87 -- so a harness that leaked a handle fails deterministically, with
+the leak named, and is never retried.  An ``exit`` hook re-checks the budget on
+the way out, covering the script that merely ran long and then ended and the one
+that calls ``process.exit()`` itself; every way out of node passes through it,
+and an ``exitCode`` assigned there overrides even ``process.exit(0)``.  The
+subprocess ceiling sits a few seconds above the deadline, so a surviving
+``TimeoutExpired`` means node never got as far as the preload.
 
-The deadline needs two enforcers, because ``unref()`` cuts both ways.  A script
-still holding the loop open is caught by the timer.  A script that merely ran
-long and then ended sails straight past it -- node exits before an unref'd timer
-on an otherwise empty loop -- and so does one that calls ``process.exit()`` in
-its own top level, which never reaches appended code at all.  Both are caught by
-an ``exit`` hook that re-checks the budget: every way out of node passes through
-it, and an ``exitCode`` assigned there overrides even an explicit
-``process.exit(0)``.  Without that half, moving the caller's timeout off
-``subprocess.run`` and into the script would have quietly stopped the timeout
-from meaning anything for every script that overruns and then terminates.
+The guard is a preload rather than text spliced into the script, because a
+harness script is not a safe place to stand.  Injected code resolves its names
+in the caller's module scope, and these harnesses routinely install fake clocks
+and browser shims: ``const setTimeout = cb => cb()`` shadows the bare name for
+the whole module (temporal dead zone included, so merely reading it throws),
+``global.window = global`` turns ``window.setTimeout = fake`` into an overwrite
+of the real one, and the same goes for ``globalThis``, ``Function``, ``process``
+and every other identifier a guard might reach for.  Splicing also has to dodge
+the script's own text: a hashbang counts only at the very start of the source, a
+``'use strict'`` directive stops being a directive the moment any statement
+precedes it, and anything taking a line of its own renumbers every stack frame
+below.  A preloaded module has none of these problems -- it runs before the
+script, in a scope the script cannot reach, and leaves the script byte-for-byte
+as the caller wrote it.
 
 One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
 {}`` never yields, and a timer cannot interrupt the thread it is queued on --
@@ -81,10 +90,11 @@ picking a side -- as does the case of a caller that never captured output at
 all, where the silence is nobody watching rather than nothing said.
 """
 
+import atexit
 import os
-import re
 import subprocess
 import tempfile
+import threading
 
 
 # Script deadline for callers that pass no ``timeout`` of their own.  Their
@@ -99,100 +109,7 @@ _SPAWN_SLACK_SECONDS = 5.0
 # Distinctive exit code so a watchdog kill is never mistaken for an assertion
 # failure or an uncaught exception, both of which leave node with 1.
 _WATCHDOG_EXIT_CODE = 87
-# A directive such as 'use strict'.  Not anchored to a whole line: a directive
-# may carry a trailing comment or share its line with the next statement, and
-# matching only the line-sized form would put the prologue in front of it --
-# which silently demotes it from a directive to a string expression.
-_DIRECTIVE = re.compile(r"""([\'\"])use [a-z]+\1[ \t]*(?:;|$)""")
-# A node hashbang is only honoured at the very start of the source.
-_HASHBANG = "#!"
 
-# Registered before the script runs, on the script's own first line so no line
-# number moves.  It has to be here rather than in the appended block because a
-# script that calls ``process.exit()`` in its top level never reaches appended
-# code at all -- measured: an 800ms busy loop then ``process.exit(0)`` under a
-# 0.2s timeout came back 0.  Every way out of node passes through 'exit', and an
-# ``exitCode`` assigned in that handler overrides even an explicit exit(0).
-# Written on one line, with no ``//`` comments, because both of those would
-# swallow the caller's own first line.
-_WATCHDOG_PROLOGUE = (
-    ";(function(){var g=Function('return this')();var d=__MILLIS__;"
-    "g.process.on('exit',function(){"
-    "var e=Math.round((g.process.uptime?g.process.uptime():0)*1000);"
-    "if(e>d){try{require('node:fs').writeSync(2,"
-    "'\\n[node_harness] the script was still running __SECONDS__s after node started.\\n'"
-    ");}catch(err){}g.process.exitCode=__EXIT_CODE__;}});})();"
-)
-
-_WATCHDOG_TEMPLATE = r"""
-;(function () {
-  // The timer comes from node:timers, not from a name in scope.  Harness
-  // scripts routinely install a fake clock, and they reach the watchdog through
-  // two different doors: `const setTimeout = (cb) => cb()` shadows the bare name
-  // for the whole module (temporal dead zone included, so merely reading it
-  // throws), and a harness that has done `global.window = global` overwrites the
-  // real thing when it sets `window.setTimeout`.  The module export is behind
-  // both.  The global itself comes from Function('return this')() rather than
-  // the name globalThis, because a harness declaring `const globalThis` puts
-  // that name in the temporal dead zone for the whole module -- the prologue
-  // runs before the declaration, so merely reading it would throw.
-  var g = Function('return this')();
-  var timer;
-  try {
-    timer = require('node:timers').setTimeout;
-  } catch (err) {
-    timer = g.setTimeout;
-  }
-
-  var deadlineMs = __MILLIS__;
-
-  function elapsed() {
-    return Math.round((g.process.uptime ? g.process.uptime() : 0) * 1000);
-  }
-
-  function diagnose(prefix) {
-    var held;
-    try {
-      held = typeof g.process.getActiveResourcesInfo === 'function'
-        ? g.JSON.stringify(g.process.getActiveResourcesInfo())
-        : '<getActiveResourcesInfo unavailable on this node>';
-    } catch (err) {
-      held = '<unavailable: ' + err + '>';
-    }
-    var message = '\n[node_harness] ' + prefix + ' __SECONDS__s after node '
-      + 'started.\n'
-      + '[node_harness] event loop is held by: ' + held + '\n'
-      + '[node_harness] a harness that never settles has usually left a timer '
-      + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
-      + 'nothing resolves.\n';
-    try {
-      // writeSync, because process.exit() does not flush a pending async pipe
-      // write and stderr to a pipe is async on Windows -- the diagnosis is the
-      // whole point, so it must not be the part that gets dropped.
-      require('node:fs').writeSync(2, message);
-    } catch (err) {
-      g.process.stderr.write(message);
-    }
-  }
-
-  // Charge node startup and the script's synchronous top level against the
-  // budget, because the outer ceiling is charged for them too.  Arming for the
-  // full deadline would put the watchdog at (startup + top level + deadline)
-  // while the ceiling sits at (deadline + slack): any top level heavier than
-  // the slack and the ceiling wins, losing the diagnosis.
-  var budget = deadlineMs - elapsed();
-  if (budget < 1) budget = 1;
-
-  var deadline = timer(function () {
-    diagnose('the script still had pending work');
-    g.process.exit(__EXIT_CODE__);
-  }, budget);
-  // unref() so the watchdog cannot itself be the reason node stays up: with no
-  // other handle open node exits first, and the exit hook above is what holds
-  // the deadline on that path.
-  if (deadline && typeof deadline.unref === 'function') deadline.unref();
-})();
-"""
 
 
 def _excerpt(blob, limit: int = 400) -> str:
@@ -300,75 +217,106 @@ def _budgeted(kwargs: dict) -> tuple[dict, float]:
     return merged, watchdog
 
 
-def _fill(template: str, seconds: float) -> str:
-    """Bind one watchdog template to this call's deadline."""
-    return (
-        template
-        .replace("__SECONDS__", f"{seconds:g}")
-        .replace("__MILLIS__", str(int(seconds * 1000)))
-        .replace("__EXIT_CODE__", str(_WATCHDOG_EXIT_CODE))
-    )
+# How the preload receives this call's deadline.  An environment variable rather
+# than a substitution into the source keeps the preload file identical for every
+# call, so it can be written once per process instead of once per invocation.
+_DEADLINE_ENV = "NEKO_NODE_HARNESS_DEADLINE_MS"
+
+_PRELOAD_SOURCE = r"""
+// Preloaded with `node --require`, so this runs before the harness script, in
+// its own module scope, out of reach of anything the harness declares or
+// overwrites.  Nothing here is resolved in the caller's scope.
+const timers = require('node:timers');
+const fs = require('node:fs');
+
+const deadlineMs = Number(process.env.NEKO_NODE_HARNESS_DEADLINE_MS || 0);
+const EXIT_CODE = 87;
+
+function diagnose(prefix) {
+  let held;
+  try {
+    held = typeof process.getActiveResourcesInfo === 'function'
+      ? JSON.stringify(process.getActiveResourcesInfo())
+      : '<getActiveResourcesInfo unavailable on this node>';
+  } catch (err) {
+    held = '<unavailable: ' + err + '>';
+  }
+  // writeSync, because process.exit() does not flush a pending async pipe write
+  // and stderr to a pipe is async on Windows -- the diagnosis is the whole
+  // point, so it must not be the part that gets dropped.
+  fs.writeSync(
+    2,
+    '\n[node_harness] ' + prefix + ' ' + (deadlineMs / 1000) + 's after node '
+    + 'started.\n'
+    + '[node_harness] event loop is held by: ' + held + '\n'
+    + '[node_harness] a harness that never settles has usually left a timer '
+    + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
+    + 'nothing resolves.\n'
+  );
+}
+
+if (deadlineMs > 0) {
+  // Covers every way out of node: the loop draining, an explicit process.exit()
+  // in the script, an uncaught throw.  An exitCode assigned in an 'exit'
+  // listener overrides even process.exit(0).
+  process.on('exit', function () {
+    if (Math.round(process.uptime() * 1000) > deadlineMs) {
+      diagnose('the script was still running');
+      process.exitCode = EXIT_CODE;
+    }
+  });
+
+  // ...and this covers the script that never exits at all.  unref() so the
+  // watchdog is never itself the reason node stays up: with nothing else
+  // holding the loop, node exits first and the hook above does the checking.
+  const deadline = timers.setTimeout(function () {
+    diagnose('the script still had pending work');
+    process.exit(EXIT_CODE);
+  }, deadlineMs);
+  if (deadline && typeof deadline.unref === 'function') deadline.unref();
+}
+"""
+
+_preload_guard = threading.Lock()
+_preload_file: str | None = None
 
 
-def _splice_prologue(script: str, prologue: str) -> str:
-    """Put ``prologue`` before the script's first statement, on its line.
+def _drop_preload() -> None:
+    """Remove the preload file at interpreter exit; losing it is not an error."""
+    global _preload_file
+    if _preload_file:
+        try:
+            os.unlink(_preload_file)
+        except OSError:
+            pass
+        _preload_file = None
 
-    Two constraints pull against each other.  It has to run before the script
-    can exit, and it must not renumber the script's own lines, so it goes inside
-    the first line that carries code rather than on a line of its own.
 
-    Two things must stay in front of it.  A hashbang counts only at the very
-    start of the source, so a prologue before it is a syntax error.  A directive
-    prologue (``'use strict';``) stops being a directive the moment any
-    statement precedes it -- silently, taking strict mode with it -- and it may
-    carry a trailing comment or share its line with the next statement, so the
-    insertion point is a column, not a line.
+def _preload_path() -> str:
+    """Path to this process's preload module, written on first use.
+
+    The contents never vary -- the deadline arrives by environment variable --
+    so one file serves every call in the process rather than one per invocation.
+    Under ``pytest -n auto`` each worker is its own process and gets its own.
     """
-    assert "\n" not in prologue, (
-        "the prologue shares a line with the first statement of the script, so a "
-        "newline in it would move every line below and truncate that statement"
-    )
-    lines = script.split("\n")
-
-    def _next_code_line(index: int) -> int:
-        while index < len(lines) and not lines[index].strip():
-            index += 1
-        return index
-
-    index = _next_code_line(0)
-    if index < len(lines) and lines[index].lstrip().startswith(_HASHBANG):
-        index = _next_code_line(index + 1)
-    if index >= len(lines):
-        return script + "\n" + prologue
-
-    column = len(lines[index]) - len(lines[index].lstrip())
-    while True:
-        directive = _DIRECTIVE.match(lines[index], column)
-        if not directive:
-            break
-        column = directive.end()
-        if lines[index][column:].strip():
-            break  # a statement follows on the same line; go in front of it
-        following = _next_code_line(index + 1)
-        if following >= len(lines):
-            return script + "\n" + prologue
-        index = following
-        column = len(lines[index]) - len(lines[index].lstrip())
-
-    lines[index] = lines[index][:column] + prologue + lines[index][column:]
-    return "\n".join(lines)
+    global _preload_file
+    with _preload_guard:
+        if _preload_file is None or not os.path.exists(_preload_file):
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".neko-harness-guard.js", delete=False, encoding="utf-8"
+            ) as handle:
+                handle.write(_PRELOAD_SOURCE)
+            _preload_file = handle.name
+            atexit.register(_drop_preload)
+        return _preload_file
 
 
-def _with_watchdog(script: str, seconds: float) -> str:
-    """Wrap ``script`` in the two halves that make its deadline real.
-
-    The timer goes at the end, where the event loop has taken over and a leaked
-    handle starts to matter, and where it can stay off the caller's line
-    numbering.  The exit hook goes at the front, because the paths it covers end
-    the process before appended code exists.
-    """
-    guarded = _splice_prologue(script, _fill(_WATCHDOG_PROLOGUE, seconds))
-    return guarded + "\n" + _fill(_WATCHDOG_TEMPLATE, seconds)
+def _guarded(merged: dict, deadline_seconds: float) -> tuple[list[str], dict]:
+    """The ``--require`` argument and the environment carrying the deadline."""
+    base = merged.get("env")
+    environment = dict(os.environ if base is None else base)
+    environment[_DEADLINE_ENV] = str(int(deadline_seconds * 1000))
+    return ["--require", _preload_path()], dict(merged, env=environment)
 
 
 def _run_retrying_spawn_stalls(next_attempt, cmd_for_error):
@@ -398,17 +346,17 @@ def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.Complet
     Use this when the script is large or grows with the behaviour it simulates.
     Extra keyword arguments go straight to ``subprocess.run``.
     """
-    merged, watchdog_seconds = _budgeted(_utf8(kwargs))
-    guarded = _with_watchdog(script, watchdog_seconds)
+    merged, deadline_seconds = _budgeted(_utf8(kwargs))
+    preload, merged = _guarded(merged, deadline_seconds)
     staged: list[str] = []
 
     def _attempt():
         with tempfile.NamedTemporaryFile(
             "w", suffix=".js", delete=False, encoding="utf-8"
         ) as handle:
-            handle.write(guarded)
+            handle.write(script)
             staged.append(handle.name)
-        return [node_path, staged[-1]], merged
+        return [node_path, *preload, staged[-1]], merged
 
     try:
         return _run_retrying_spawn_stalls(_attempt, [node_path, "<temp script>"])
@@ -430,9 +378,9 @@ def run_node_stdin(node_path: str, script: str, **kwargs) -> subprocess.Complete
     stdin form; stdin has no length ceiling, so only the encoding pin matters
     here. Extra keyword arguments go straight to ``subprocess.run``.
     """
-    merged, watchdog_seconds = _budgeted(_utf8(kwargs))
-    guarded = _with_watchdog(script, watchdog_seconds)
+    merged, deadline_seconds = _budgeted(_utf8(kwargs))
+    preload, merged = _guarded(merged, deadline_seconds)
     return _run_retrying_spawn_stalls(
-        lambda: ([node_path, "-"], dict(merged, input=guarded)),
+        lambda: ([node_path, *preload, "-"], dict(merged, input=script)),
         [node_path, "-"],
     )

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -64,9 +64,10 @@ no amount of retrying will make that script finish.  What separates it from a
 genuine spawn stall is evidence: measured on Windows, whatever the script wrote
 before it blocked still reaches the parent, while a node that never reached the
 script emits nothing at all.  So a stalled attempt that produced output is
-reported straight away, and only a completely silent one is retried.  A
-synchronous block that also printed nothing stays ambiguous, and the error says
-so rather than picking a side.
+reported straight away, and only a silent one is retried.  A synchronous block
+that also printed nothing stays ambiguous, and the error says so rather than
+picking a side -- as does the case of a caller that never captured output at
+all, where the silence is nobody watching rather than nothing said.
 """
 
 import os
@@ -103,6 +104,16 @@ _WATCHDOG_TEMPLATE = r"""
   } catch (err) {
     timer = g.setTimeout;
   }
+  // Charge node startup and the script's synchronous top level against the
+  // budget, because the outer ceiling is charged for them too.  Arming for the
+  // full deadline here would put the watchdog at (startup + top level +
+  // deadline) while the ceiling sits at (deadline + slack): any top level
+  // heavier than the slack and the ceiling wins, losing the diagnosis. Nothing
+  // can fire during a synchronous top level, but the moment it ends the budget
+  // is already spent and the watchdog should say so.
+  var spent = Math.round((g.process.uptime ? g.process.uptime() : 0) * 1000);
+  var budget = __MILLIS__ - spent;
+  if (!(budget > 1)) budget = 1;
   var deadline = timer(function () {
     var held;
     try {
@@ -112,8 +123,8 @@ _WATCHDOG_TEMPLATE = r"""
     } catch (err) {
       held = '<unavailable: ' + err + '>';
     }
-    var message = '\n[node_harness] the script still had pending work after '
-      + '__SECONDS__s.\n'
+    var message = '\n[node_harness] the script still had pending work '
+      + '__SECONDS__s after node started.\n'
       + '[node_harness] event loop is held by: ' + held + '\n'
       + '[node_harness] a harness that never settles has usually left a timer '
       + 'armed (clearInterval/clearTimeout) or is awaiting a promise that '
@@ -127,7 +138,7 @@ _WATCHDOG_TEMPLATE = r"""
       g.process.stderr.write(message);
     }
     g.process.exit(__EXIT_CODE__);
-  }, __MILLIS__);
+  }, budget);
   // unref() so the watchdog cannot itself be the reason node stays up: with no
   // other handle open node exits first and the watchdog never fires, which is
   // exactly the healthy case.
@@ -175,10 +186,16 @@ class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
             "fired. Either node never reached the script (process creation, "
             "reading it off disk, V8 bootstrap), or the script blocked the "
             "event loop synchronously -- a timer cannot interrupt that. Each "
-            "attempt's output below is the evidence: anything at all means the "
-            "script did run, and nothing at all means it probably never did."
+            "attempt's output below is the evidence, where there was a pipe "
+            "to collect it: anything at all means the script did run."
         )
         lines = [super().__str__(), "", diagnosis]
+        if not any(_observed_output(attempt) for attempt in self.attempts):
+            lines.append(
+                "  note: this caller does not capture output, so the silence "
+                "below is unobserved rather than empty -- pass "
+                "capture_output=True to tell the two apart."
+            )
         for index, attempt in enumerate(self.attempts, 1):
             lines.append(
                 f"  attempt {index}: stdout={_excerpt(attempt.stdout)} "
@@ -196,6 +213,18 @@ def _emitted_anything(exc: subprocess.TimeoutExpired) -> bool:
     not, which is why silence is what gets the retry.
     """
     return bool(exc.stdout) or bool(exc.stderr)
+
+
+def _observed_output(exc: subprocess.TimeoutExpired) -> bool:
+    """Was there a pipe to observe in the first place?
+
+    A caller that does not capture leaves the child on the inherited handles,
+    and ``communicate()`` then hands back ``None`` rather than ``""``.  Those
+    two look identical to :func:`_emitted_anything` and mean opposite things --
+    "the script printed nothing" versus "nobody was watching" -- so the
+    distinction has to survive as far as the error message.
+    """
+    return exc.stdout is not None or exc.stderr is not None
 
 
 def _utf8(kwargs: dict) -> dict:

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -58,13 +58,16 @@ deterministically, with the leaked handle named, and is never retried.  The
 subprocess ceiling then sits a few seconds above that deadline, so a
 surviving ``TimeoutExpired`` means the watchdog never got to run.
 
-The deadline has to be enforced two ways, because ``unref()`` cuts both.  A
-script still holding the loop open gets the timer.  A script that merely ran
-long and then finished would sail past it -- node exits before an unref'd timer
-on an otherwise empty loop -- so the overdue case is checked once, synchronously,
-at the moment the watchdog arms.  Without that second half, moving the caller's
-timeout off ``subprocess.run`` and into the script would have quietly stopped
-the timeout from meaning anything for every script that overruns and completes.
+The deadline needs two enforcers, because ``unref()`` cuts both ways.  A script
+still holding the loop open is caught by the timer.  A script that merely ran
+long and then ended sails straight past it -- node exits before an unref'd timer
+on an otherwise empty loop -- and so does one that calls ``process.exit()`` in
+its own top level, which never reaches appended code at all.  Both are caught by
+an ``exit`` hook that re-checks the budget: every way out of node passes through
+it, and an ``exitCode`` assigned there overrides even an explicit
+``process.exit(0)``.  Without that half, moving the caller's timeout off
+``subprocess.run`` and into the script would have quietly stopped the timeout
+from meaning anything for every script that overruns and then terminates.
 
 One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
 {}`` never yields, and a timer cannot interrupt the thread it is queued on --
@@ -79,6 +82,7 @@ all, where the silence is nobody watching rather than nothing said.
 """
 
 import os
+import re
 import subprocess
 import tempfile
 
@@ -95,6 +99,25 @@ _SPAWN_SLACK_SECONDS = 5.0
 # Distinctive exit code so a watchdog kill is never mistaken for an assertion
 # failure or an uncaught exception, both of which leave node with 1.
 _WATCHDOG_EXIT_CODE = 87
+# A leading string-literal statement, i.e. a directive such as 'use strict'.
+_DIRECTIVE = re.compile(r"""^(['\"])use [a-z]+\1\s*;?$""")
+
+# Registered before the script runs, on the script's own first line so no line
+# number moves.  It has to be here rather than in the appended block because a
+# script that calls ``process.exit()`` in its top level never reaches appended
+# code at all -- measured: an 800ms busy loop then ``process.exit(0)`` under a
+# 0.2s timeout came back 0.  Every way out of node passes through 'exit', and an
+# ``exitCode`` assigned in that handler overrides even an explicit exit(0).
+# Written on one line, with no ``//`` comments, because both of those would
+# swallow the caller's own first line.
+_WATCHDOG_PROLOGUE = (
+    ";(function(){var g=globalThis;var d=__MILLIS__;"
+    "g.process.on('exit',function(){"
+    "var e=Math.round((g.process.uptime?g.process.uptime():0)*1000);"
+    "if(e>d){try{require('node:fs').writeSync(2,"
+    "'\\n[node_harness] the script was still running __SECONDS__s after node started.\\n'"
+    ");}catch(err){}g.process.exitCode=__EXIT_CODE__;}});})();"
+)
 
 _WATCHDOG_TEMPLATE = r"""
 ;(function () {
@@ -113,7 +136,13 @@ _WATCHDOG_TEMPLATE = r"""
     timer = g.setTimeout;
   }
 
-  function report(prefix) {
+  var deadlineMs = __MILLIS__;
+
+  function elapsed() {
+    return Math.round((g.process.uptime ? g.process.uptime() : 0) * 1000);
+  }
+
+  function diagnose(prefix) {
     var held;
     try {
       held = typeof g.process.getActiveResourcesInfo === 'function'
@@ -136,31 +165,23 @@ _WATCHDOG_TEMPLATE = r"""
     } catch (err) {
       g.process.stderr.write(message);
     }
-    g.process.exit(__EXIT_CODE__);
   }
 
   // Charge node startup and the script's synchronous top level against the
   // budget, because the outer ceiling is charged for them too.  Arming for the
-  // full deadline here would put the watchdog at (startup + top level +
-  // deadline) while the ceiling sits at (deadline + slack): any top level
-  // heavier than the slack and the ceiling wins, losing the diagnosis.
-  var spent = Math.round((g.process.uptime ? g.process.uptime() : 0) * 1000);
-  var budget = __MILLIS__ - spent;
-
-  if (budget <= 0) {
-    // Already over budget by the time the top level finished.  Scheduling a
-    // timer here would be worse than useless: it is unref'd, so with the loop
-    // otherwise empty node exits 0 before the callback ever runs, and the
-    // caller's timeout silently stops meaning anything.  Fail now instead.
-    report('the script was still running');
-  }
+  // full deadline would put the watchdog at (startup + top level + deadline)
+  // while the ceiling sits at (deadline + slack): any top level heavier than
+  // the slack and the ceiling wins, losing the diagnosis.
+  var budget = deadlineMs - elapsed();
+  if (budget < 1) budget = 1;
 
   var deadline = timer(function () {
-    report('the script still had pending work');
+    diagnose('the script still had pending work');
+    g.process.exit(__EXIT_CODE__);
   }, budget);
   // unref() so the watchdog cannot itself be the reason node stays up: with no
-  // other handle open node exits first and the watchdog never fires, which is
-  // exactly the healthy case.
+  // other handle open node exits first, and the exit hook above is what holds
+  // the deadline on that path.
   if (deadline && typeof deadline.unref === 'function') deadline.unref();
 })();
 """
@@ -271,21 +292,54 @@ def _budgeted(kwargs: dict) -> tuple[dict, float]:
     return merged, watchdog
 
 
-def _with_watchdog(script: str, seconds: float) -> str:
-    """Append the self-deadline that turns a hung script into a named failure.
-
-    Appended rather than prepended so line numbers in the caller's own stack
-    traces keep pointing at the caller's own code.  It runs once the script's
-    synchronous top level is done, which is precisely when the event loop takes
-    over and a leaked handle starts to matter.
-    """
-    watchdog = (
-        _WATCHDOG_TEMPLATE
+def _fill(template: str, seconds: float) -> str:
+    """Bind one watchdog template to this call's deadline."""
+    return (
+        template
         .replace("__SECONDS__", f"{seconds:g}")
         .replace("__MILLIS__", str(int(seconds * 1000)))
         .replace("__EXIT_CODE__", str(_WATCHDOG_EXIT_CODE))
     )
-    return script + "\n" + watchdog
+
+
+def _splice_prologue(script: str, prologue: str) -> str:
+    """Put ``prologue`` before the script's first statement, on its line.
+
+    Two constraints pull against each other.  It has to run before the script
+    can exit, and it must not renumber the script's own lines, so it goes at the
+    front of the first line that carries code rather than on a line of its own.
+
+    It must also land *after* a directive prologue: one harness opens with
+    ``'use strict';``, and a statement in front of it silently demotes that from
+    a directive to an ordinary string expression, taking strict mode with it.
+    """
+    assert "\n" not in prologue, (
+        "the prologue shares a line with the first statement of the script, "
+        "so a newline in it would move every line below and truncate that "
+        "statement"
+    )
+    lines = script.split("\n")
+    index = 0
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+    while index < len(lines) and _DIRECTIVE.match(lines[index].strip()):
+        index += 1
+    if index >= len(lines):  # nothing but blanks and directives
+        return script + "\n" + prologue
+    lines[index] = prologue + lines[index]
+    return "\n".join(lines)
+
+
+def _with_watchdog(script: str, seconds: float) -> str:
+    """Wrap ``script`` in the two halves that make its deadline real.
+
+    The timer goes at the end, where the event loop has taken over and a leaked
+    handle starts to matter, and where it can stay off the caller's line
+    numbering.  The exit hook goes at the front, because the paths it covers end
+    the process before appended code exists.
+    """
+    guarded = _splice_prologue(script, _fill(_WATCHDOG_PROLOGUE, seconds))
+    return guarded + "\n" + _fill(_WATCHDOG_TEMPLATE, seconds)
 
 
 def _run_retrying_spawn_stalls(next_attempt, cmd_for_error):

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -99,8 +99,13 @@ _SPAWN_SLACK_SECONDS = 5.0
 # Distinctive exit code so a watchdog kill is never mistaken for an assertion
 # failure or an uncaught exception, both of which leave node with 1.
 _WATCHDOG_EXIT_CODE = 87
-# A leading string-literal statement, i.e. a directive such as 'use strict'.
-_DIRECTIVE = re.compile(r"""^(['\"])use [a-z]+\1\s*;?$""")
+# A directive such as 'use strict'.  Not anchored to a whole line: a directive
+# may carry a trailing comment or share its line with the next statement, and
+# matching only the line-sized form would put the prologue in front of it --
+# which silently demotes it from a directive to a string expression.
+_DIRECTIVE = re.compile(r"""([\'\"])use [a-z]+\1[ \t]*(?:;|$)""")
+# A node hashbang is only honoured at the very start of the source.
+_HASHBANG = "#!"
 
 # Registered before the script runs, on the script's own first line so no line
 # number moves.  It has to be here rather than in the appended block because a
@@ -111,7 +116,7 @@ _DIRECTIVE = re.compile(r"""^(['\"])use [a-z]+\1\s*;?$""")
 # Written on one line, with no ``//`` comments, because both of those would
 # swallow the caller's own first line.
 _WATCHDOG_PROLOGUE = (
-    ";(function(){var g=globalThis;var d=__MILLIS__;"
+    ";(function(){var g=Function('return this')();var d=__MILLIS__;"
     "g.process.on('exit',function(){"
     "var e=Math.round((g.process.uptime?g.process.uptime():0)*1000);"
     "if(e>d){try{require('node:fs').writeSync(2,"
@@ -127,8 +132,11 @@ _WATCHDOG_TEMPLATE = r"""
   // for the whole module (temporal dead zone included, so merely reading it
   // throws), and a harness that has done `global.window = global` overwrites the
   // real thing when it sets `window.setTimeout`.  The module export is behind
-  // both.  Everything else goes through globalThis for the same reason.
-  var g = globalThis;
+  // both.  The global itself comes from Function('return this')() rather than
+  // the name globalThis, because a harness declaring `const globalThis` puts
+  // that name in the temporal dead zone for the whole module -- the prologue
+  // runs before the declaration, so merely reading it would throw.
+  var g = Function('return this')();
   var timer;
   try {
     timer = require('node:timers').setTimeout;
@@ -306,27 +314,48 @@ def _splice_prologue(script: str, prologue: str) -> str:
     """Put ``prologue`` before the script's first statement, on its line.
 
     Two constraints pull against each other.  It has to run before the script
-    can exit, and it must not renumber the script's own lines, so it goes at the
-    front of the first line that carries code rather than on a line of its own.
+    can exit, and it must not renumber the script's own lines, so it goes inside
+    the first line that carries code rather than on a line of its own.
 
-    It must also land *after* a directive prologue: one harness opens with
-    ``'use strict';``, and a statement in front of it silently demotes that from
-    a directive to an ordinary string expression, taking strict mode with it.
+    Two things must stay in front of it.  A hashbang counts only at the very
+    start of the source, so a prologue before it is a syntax error.  A directive
+    prologue (``'use strict';``) stops being a directive the moment any
+    statement precedes it -- silently, taking strict mode with it -- and it may
+    carry a trailing comment or share its line with the next statement, so the
+    insertion point is a column, not a line.
     """
     assert "\n" not in prologue, (
-        "the prologue shares a line with the first statement of the script, "
-        "so a newline in it would move every line below and truncate that "
-        "statement"
+        "the prologue shares a line with the first statement of the script, so a "
+        "newline in it would move every line below and truncate that statement"
     )
     lines = script.split("\n")
-    index = 0
-    while index < len(lines) and not lines[index].strip():
-        index += 1
-    while index < len(lines) and _DIRECTIVE.match(lines[index].strip()):
-        index += 1
-    if index >= len(lines):  # nothing but blanks and directives
+
+    def _next_code_line(index: int) -> int:
+        while index < len(lines) and not lines[index].strip():
+            index += 1
+        return index
+
+    index = _next_code_line(0)
+    if index < len(lines) and lines[index].lstrip().startswith(_HASHBANG):
+        index = _next_code_line(index + 1)
+    if index >= len(lines):
         return script + "\n" + prologue
-    lines[index] = prologue + lines[index]
+
+    column = len(lines[index]) - len(lines[index].lstrip())
+    while True:
+        directive = _DIRECTIVE.match(lines[index], column)
+        if not directive:
+            break
+        column = directive.end()
+        if lines[index][column:].strip():
+            break  # a statement follows on the same line; go in front of it
+        following = _next_code_line(index + 1)
+        if following >= len(lines):
+            return script + "\n" + prologue
+        index = following
+        column = len(lines[index]) - len(lines[index].lstrip())
+
+    lines[index] = lines[index][:column] + prologue + lines[index][column:]
     return "\n".join(lines)
 
 

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -55,10 +55,18 @@ They are told apart by giving the script its own deadline *inside* node.  The
 appended watchdog fires only if something is still holding the event loop open,
 prints what that something is, and exits non-zero -- so the first case fails
 deterministically, with the leaked handle named, and is never retried.  The
-subprocess ceiling then sits a few seconds above that deadline, which means a
-surviving ``TimeoutExpired`` can only be the second case: node never reached
-the watchdog.  That one is retried once, and if the retry stalls too, both
-attempts' output travels with the error instead of being thrown away.
+subprocess ceiling then sits a few seconds above that deadline, so a
+surviving ``TimeoutExpired`` means the watchdog never got to run.
+
+One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
+{}`` never yields, and a timer cannot interrupt the thread it is queued on --
+no amount of retrying will make that script finish.  What separates it from a
+genuine spawn stall is evidence: measured on Windows, whatever the script wrote
+before it blocked still reaches the parent, while a node that never reached the
+script emits nothing at all.  So a stalled attempt that produced output is
+reported straight away, and only a completely silent one is retried.  A
+synchronous block that also printed nothing stays ambiguous, and the error says
+so rather than picking a side.
 """
 
 import os
@@ -81,14 +89,21 @@ _WATCHDOG_EXIT_CODE = 87
 
 _WATCHDOG_TEMPLATE = r"""
 ;(function () {
-  // Everything goes through globalThis on purpose.  Harness scripts routinely
-  // shadow the timer globals at module scope to drive a fake clock
-  // (`const setTimeout = (cb) => cb()`), and an appended watchdog calling the
-  // bare name would get handed that fake -- fired instantly, in one case.  A
-  // `const` shadow is worse still: it puts the bare name in the temporal dead
-  // zone for the whole module, so merely reading it throws.
+  // The timer comes from node:timers, not from a name in scope.  Harness
+  // scripts routinely install a fake clock, and they reach the watchdog through
+  // two different doors: `const setTimeout = (cb) => cb()` shadows the bare name
+  // for the whole module (temporal dead zone included, so merely reading it
+  // throws), and a harness that has done `global.window = global` overwrites the
+  // real thing when it sets `window.setTimeout`.  The module export is behind
+  // both.  Everything else goes through globalThis for the same reason.
   var g = globalThis;
-  var deadline = g.setTimeout(function () {
+  var timer;
+  try {
+    timer = require('node:timers').setTimeout;
+  } catch (err) {
+    timer = g.setTimeout;
+  }
+  var deadline = timer(function () {
     var held;
     try {
       held = typeof g.process.getActiveResourcesInfo === 'function'
@@ -133,31 +148,54 @@ def _excerpt(blob, limit: int = 400) -> str:
 
 
 class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
-    """Both spawn attempts hit the ceiling without node exiting.
+    """The run hit the ceiling without node exiting.
 
     Subclasses ``TimeoutExpired`` so existing ``except`` clauses keep working,
-    and carries what each attempt managed to emit.  Empty output on both means
-    node never reached the first line of the script.
+    and carries what each attempt managed to emit.  One attempt means the stall
+    came with output and was not worth repeating; two means both were silent.
     """
 
     def __init__(self, cmd, timeout, attempts):
-        super().__init__(cmd, timeout)
+        # Carry the last attempt's output on the exception the way
+        # ``subprocess.run`` would have: a caller that catches
+        # ``TimeoutExpired`` and reads ``.stdout``/``.stderr`` (or ``.output``)
+        # must not get None just because the launcher wrapped the error.
+        last = attempts[-1] if attempts else None
+        super().__init__(
+            cmd,
+            timeout,
+            output=getattr(last, "stdout", None),
+            stderr=getattr(last, "stderr", None),
+        )
         self.attempts = list(attempts)
 
     def __str__(self) -> str:
-        lines = [
-            super().__str__(),
-            "",
-            "Both attempts stalled before node exited, and the in-script "
-            "watchdog never fired -- so the script itself was not the thing "
-            "that hung; the node process never got far enough to arm it.",
-        ]
+        diagnosis = (
+            "Stalled before node exited, and the in-script watchdog never "
+            "fired. Either node never reached the script (process creation, "
+            "reading it off disk, V8 bootstrap), or the script blocked the "
+            "event loop synchronously -- a timer cannot interrupt that. Each "
+            "attempt's output below is the evidence: anything at all means the "
+            "script did run, and nothing at all means it probably never did."
+        )
+        lines = [super().__str__(), "", diagnosis]
         for index, attempt in enumerate(self.attempts, 1):
             lines.append(
                 f"  attempt {index}: stdout={_excerpt(attempt.stdout)} "
                 f"stderr={_excerpt(attempt.stderr)}"
             )
         return "\n".join(lines)
+
+
+def _emitted_anything(exc: subprocess.TimeoutExpired) -> bool:
+    """Did this stalled attempt prove the script ran?
+
+    ``subprocess.run`` kills the child on timeout and then collects whatever it
+    had already written, so this is real evidence rather than a guess.  It is
+    one-directional: output means the script ran, silence does not prove it did
+    not, which is why silence is what gets the retry.
+    """
+    return bool(exc.stdout) or bool(exc.stderr)
 
 
 def _utf8(kwargs: dict) -> dict:
@@ -174,13 +212,13 @@ def _budgeted(kwargs: dict) -> tuple[dict, float]:
     The caller's ``timeout`` stays the budget the *script* gets; the ceiling
     handed to ``subprocess.run`` is raised by the slack, so a script that
     overruns is killed from inside node with a diagnosis rather than from
-    outside with none.
+    outside with none.  A caller that passes no timeout gets the default
+    deadline and a ceiling to match: it used to get neither, which left a
+    synchronously blocked script running until the job cap.
     """
     merged = dict(kwargs)
     timeout = merged.get("timeout")
-    if timeout is None:
-        return merged, _DEFAULT_WATCHDOG_SECONDS
-    watchdog = float(timeout)
+    watchdog = _DEFAULT_WATCHDOG_SECONDS if timeout is None else float(timeout)
     merged["timeout"] = watchdog + _SPAWN_SLACK_SECONDS
     return merged, watchdog
 
@@ -216,7 +254,7 @@ def _run_retrying_spawn_stalls(next_attempt, cmd_for_error):
             return subprocess.run(argv, **run_kwargs)
         except subprocess.TimeoutExpired as exc:
             attempts.append(exc)
-            if attempt == 2:
+            if attempt == 2 or _emitted_anything(exc):
                 raise NodeHarnessSpawnTimeout(
                     cmd_for_error, exc.timeout, attempts
                 ) from exc
@@ -245,11 +283,12 @@ def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.Complet
         return _run_retrying_spawn_stalls(_attempt, [node_path, "<temp script>"])
     finally:
         for path in staged:
-            # Best effort: a killed node on Windows can still hold the file for
-            # a moment, and losing a temp file must not mask the real error.
             try:
                 os.unlink(path)
             except OSError:
+                # Best effort on purpose: a killed node on Windows can still
+                # hold the file for a moment, and a leaked temp file must not
+                # replace the real error with a cleanup one.
                 pass
 
 

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -97,12 +97,13 @@ One in-script hang escapes the watchdog: a synchronous block.  ``while (true)
 no amount of retrying will make that script finish.  What separates it from a
 genuine spawn stall is evidence: measured on Windows, whatever the script wrote
 before it blocked still reaches the parent, while a node that never reached the
-script emits nothing at all.  Which of the two happened is not inferred from output -- a caller
-that does not capture cannot show any, so silence would mean both things at
-once.  The preload drops a marker file the moment node compiles the script, so
-the launcher knows as a fact whether anything was under test: an attempt that
-never got that far is repeated, and one that did is reported as it stands,
-because a second run would block in exactly the same place.
+script emits nothing at all.  Which of the two happened is never inferred from output.  Output
+answers a different question in both directions: a caller that does not capture
+can never show any, and an inherited ``NODE_OPTIONS`` preload that prints before
+stalling shows some without the harness being reached at all.  The preload drops
+a marker file the moment node compiles the script, and that file is the whole
+signal: an attempt that never got that far is repeated, and one that did is
+reported as it stands, because a second run would stall in the same place.
 """
 
 import atexit
@@ -178,41 +179,12 @@ class NodeHarnessSpawnTimeout(subprocess.TimeoutExpired):
                 "under test, so the attempt was repeated."
             )
         lines = [super().__str__(), "", diagnosis]
-        if not any(_observed_output(attempt) for attempt in self.attempts):
-            lines.append(
-                "  note: this caller does not capture output, so the silence "
-                "below is unobserved rather than empty -- pass "
-                "capture_output=True to tell the two apart."
-            )
         for index, attempt in enumerate(self.attempts, 1):
             lines.append(
                 f"  attempt {index}: stdout={_excerpt(attempt.stdout)} "
                 f"stderr={_excerpt(attempt.stderr)}"
             )
         return "\n".join(lines)
-
-
-def _emitted_anything(exc: subprocess.TimeoutExpired) -> bool:
-    """Did this stalled attempt prove the script ran?
-
-    ``subprocess.run`` kills the child on timeout and then collects whatever it
-    had already written, so this is real evidence rather than a guess.  It is
-    one-directional: output means the script ran, silence does not prove it did
-    not, which is why silence is what gets the retry.
-    """
-    return bool(exc.stdout) or bool(exc.stderr)
-
-
-def _observed_output(exc: subprocess.TimeoutExpired) -> bool:
-    """Was there a pipe to observe in the first place?
-
-    A caller that does not capture leaves the child on the inherited handles,
-    and ``communicate()`` then hands back ``None`` rather than ``""``.  Those
-    two look identical to :func:`_emitted_anything` and mean opposite things --
-    "the script printed nothing" versus "nobody was watching" -- so the
-    distinction has to survive as far as the error message.
-    """
-    return exc.stdout is not None or exc.stderr is not None
 
 
 def _utf8(kwargs: dict) -> dict:
@@ -444,12 +416,18 @@ def _preload_path() -> str:
     The contents never vary -- the deadline arrives by environment variable --
     so one file serves every call in the process rather than one per invocation.
     Under ``pytest -n auto`` each worker is its own process and gets its own.
+
+    ``.cjs``, not ``.js``: the guard is CommonJS, and a ``.js`` file inherits
+    its module type from the nearest ``package.json``.  Should the system temp
+    directory ever sit inside a package declaring ``"type": "module"``, every
+    call would die on the guard's first ``require``.  The suffix pins the type
+    regardless of where the file lands.
     """
     global _preload_file
     with _preload_guard:
         if _preload_file is None or not os.path.exists(_preload_file):
             with tempfile.NamedTemporaryFile(
-                "w", suffix=".neko-harness-guard.js", delete=False, encoding="utf-8"
+                "w", suffix=".neko-harness-guard.cjs", delete=False, encoding="utf-8"
             ) as handle:
                 handle.write(_rendered_preload())
             _preload_file = handle.name
@@ -465,14 +443,16 @@ def _new_marker() -> str:
     return path
 
 
-def _script_started(marker: str, exc: subprocess.TimeoutExpired) -> bool:
-    """Did this attempt get as far as running the harness script?
+def _script_started(marker: str) -> bool:
+    """Did this attempt get as far as the harness script?
 
-    The marker is the direct answer.  Output is kept as a fallback for the case
-    where the marker could not be written at all: it is one-directional, but
-    anything on either stream still proves the script ran.
+    The marker and nothing else.  Output used to serve as a fallback, and it was
+    wrong in both directions: a caller that does not capture can never show any,
+    and an inherited ``NODE_OPTIONS`` preload that prints before stalling would
+    show some without the harness ever being reached.  The marker is written by
+    the guard itself, at the one moment that actually answers the question.
     """
-    return os.path.exists(marker) or _emitted_anything(exc)
+    return os.path.exists(marker)
 
 
 def _guarded(merged: dict, deadline_seconds: float, marker: str) -> tuple[list[str], dict]:
@@ -500,7 +480,7 @@ def _run_retrying_spawn_stalls(next_attempt, cmd_for_error):
             return subprocess.run(argv, **run_kwargs)
         except subprocess.TimeoutExpired as exc:
             attempts.append(exc)
-            started = _script_started(marker, exc)
+            started = _script_started(marker)
             if attempt == 2 or started:
                 raise NodeHarnessSpawnTimeout(
                     cmd_for_error, exc.timeout, attempts, started=started

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -240,6 +240,34 @@ def test_a_healthy_harness_is_untouched_by_the_watchdog(runner):
     assert result.stderr == ""
 
 
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_script_that_merely_runs_long_still_fails_its_deadline(runner):
+    """A script that overruns and then finishes must not pass.
+
+    Moving the caller's timeout off ``subprocess.run`` and into the script put
+    this at risk: the watchdog is unref'd, so on an otherwise empty loop node
+    exits 0 before an overdue timer can fire, and a 1.5s script under a 0.5s
+    timeout came back green (measured) where it used to be killed at 0.5s. The
+    overdue case is therefore decided synchronously when the watchdog arms.
+    """
+    node_path = _node_or_skip()
+
+    script = (
+        "var until = Date.now() + 1500;\n"
+        "while (Date.now() < until) {}\n"
+        "process.stdout.write('done');\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=0.5)
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (
+        "跑超了预算再结束的脚本必须红，否则调用方的 timeout 什么也不保证："
+        f"rc={result.returncode} stdout={result.stdout!r}"
+    )
+    assert "still running" in result.stderr, (
+        f"诊断要说清是「跑太久」而不是「卡住不动」：{result.stderr!r}"
+    )
+
+
 def test_a_heavy_synchronous_top_level_does_not_push_the_watchdog_past_the_ceiling(
     monkeypatch,
 ):

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -963,6 +963,53 @@ def test_a_zero_timeout_still_fails_fast_and_still_arms_the_guard(monkeypatch):
 
 
 @pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_another_preloads_dependency_does_not_start_the_budget(runner):
+    """The clock must start at the harness script, not at the first compile.
+
+    An inherited ``NODE_OPTIONS`` can add preloads of its own, and an ESM
+    ``--import`` module is evaluated after CommonJS ``--require`` ones -- so a
+    CommonJS dependency it pulls in compiles after the guard is installed and
+    before the harness script. Keying on "first compile" armed the deadline
+    there, putting pre-main startup back inside the script's budget.
+
+    The witness is a preload slower than the whole budget: if its time is
+    charged to the script, an otherwise instant script comes back 87.
+    """
+    node_path = _node_or_skip()
+
+    directory = Path(node_harness._preload_path()).parent
+    dependency = directory / "neko-probe-dep.cjs"
+    slow_import = directory / "neko-probe-slow.mjs"
+    dependency.write_text("module.exports = 1;\n", encoding="utf-8")
+    slow_import.write_text(
+        "import { createRequire } from 'node:module';\n"
+        "const require = createRequire(import.meta.url);\n"
+        f"require({str(dependency)!r}.split('\\\\').join('/'));\n"
+        "const until = Date.now() + 800;\n"
+        "while (Date.now() < until) {}\n",
+        encoding="utf-8",
+    )
+    try:
+        result = runner(
+            node_path,
+            "process.stdout.write('ok');\n",
+            capture_output=True,
+            check=False,
+            timeout=0.5,
+            env={**os.environ, "NODE_OPTIONS": f"--import {slow_import.as_uri()}"},
+        )
+    finally:
+        dependency.unlink(missing_ok=True)
+        slow_import.unlink(missing_ok=True)
+
+    assert result.returncode == 0, (
+        "别人的预载花掉的时间被算进了脚本预算："
+        f"rc={result.returncode} stderr={result.stderr[:300]!r}"
+    )
+    assert result.stdout == "ok"
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
 def test_the_preload_marks_that_the_script_actually_started(runner):
     """The marker is the launcher's only direct evidence, so prove it appears.
 

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -962,39 +962,134 @@ def test_a_zero_timeout_still_fails_fast_and_still_arms_the_guard(monkeypatch):
     )
 
 
-def test_a_script_that_never_compiles_is_left_to_the_ceiling_to_retry():
-    """If the script never started, the guard must stay out of the way.
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_the_preload_marks_that_the_script_actually_started(runner):
+    """The marker is the launcher's only direct evidence, so prove it appears.
 
-    A ``--require`` preload is loaded before node reads the main script, so a
-    stall in reading or compiling it sits inside the preload's lifetime. Marking
-    that 87 would be a clean, deterministic exit -- and therefore *not* retried,
-    which is exactly backwards for the pre-script stall this launcher exists to
-    recover from. The deadline only starts once ``_compile`` has fired.
+    Everything downstream -- whether a stall gets retried, and which of the two
+    stories the error tells -- hangs off this file existing.
     """
     node_path = _node_or_skip()
+    seen = {}
+    real_run = node_harness.subprocess.run
 
-    # NODE_OPTIONS carries a second preload that throws while loading, so node
-    # dies before the main script is ever compiled -- the closest reproducible
-    # stand-in for "the script never started".
-    exploding = Path(node_harness._preload_path()).with_name("neko-explode.js")
-    exploding.write_text("throw new Error('boom');\n", encoding="utf-8")
+    def _watching_run(argv, **kwargs):
+        result = real_run(argv, **kwargs)
+        marker = (kwargs.get("env") or {})[node_harness._MARKER_ENV]
+        seen["existed"] = os.path.exists(marker)
+        return result
+
+    node_harness.subprocess.run = _watching_run
     try:
-        result = run_node_script(
-            node_path,
-            "process.stdout.write('never');\n",
-            capture_output=True,
-            check=False,
-            timeout=5,
-            env={**os.environ, "NODE_OPTIONS": f"--require {exploding}"},
+        result = runner(
+            node_path, "process.stdout.write('ok');\n",
+            capture_output=True, check=False, timeout=6,
         )
     finally:
-        exploding.unlink(missing_ok=True)
+        node_harness.subprocess.run = real_run
 
-    assert result.returncode != node_harness._WATCHDOG_EXIT_CODE, (
-        "脚本根本没被编译过，不该被判成「脚本超时」——那是不可重试的确定性失败，"
-        f"而这正是要留给外层 ceiling 重试的情况：rc={result.returncode}"
+    assert result.returncode == 0
+    assert seen["existed"] is True, "脚本明明跑了，标记却没落下来"
+
+
+def test_a_stall_before_the_script_started_is_retried():
+    """No marker means nothing was under test, so the attempt is repeated.
+
+    This is the whole point of the retry: a spawn that never reached the script
+    has run no assertions, and no ceiling the caller picks can help it.
+    """
+    calls = []
+    ok = subprocess.CompletedProcess(["node"], 0, "ok", "")
+
+    def _fake_run(argv, **kwargs):
+        calls.append(kwargs.get("env", {}).get(node_harness._MARKER_ENV))
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
+        return ok
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        assert run_node_script("node", "process.stdout.write('ok');", timeout=3) is ok
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 2
+    assert calls[0] != calls[1], "每次尝试要有自己的标记，否则上一次的会误导下一次"
+
+
+def test_a_stall_after_the_script_started_is_not_retried_even_with_no_output():
+    """The fix for the case output could never have answered.
+
+    A caller that does not capture leaves ``TimeoutExpired.stdout`` as None, so
+    the old output test read "silent" and retried -- repeating whatever the
+    script had already done. The marker answers it directly: the script ran, so
+    a second run would block in the same place.
+    """
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        # Stand in for the preload: node reached the script and marked it.
+        Path(kwargs["env"][node_harness._MARKER_ENV]).write_text("1", encoding="utf-8")
+        # No capture, so both streams come back as None -- indistinguishable
+        # from silence without the marker.
+        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script("node", "process.stdout.write('ok');", timeout=1)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 1, (
+        f"脚本已经跑过了就不该重试——重跑一遍只会在同一个地方卡住，"
+        f"顺带把它已经做过的事再做一遍：{len(calls)} 次"
     )
-    assert result.stdout == ""
+    assert excinfo.value.started is True
+    assert "blocked the event loop synchronously" in str(excinfo.value)
+
+
+def test_the_error_says_which_of_the_two_stalls_it_was():
+    """The dual: a never-started stall must not be described as a script hang."""
+    def _fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script("node", "process.stdout.write('ok');", capture_output=True, timeout=1)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert excinfo.value.started is False
+    message = str(excinfo.value)
+    assert "never reached the harness script" in message
+    assert "blocked the event loop synchronously" not in message
+
+
+def test_the_marker_is_cleaned_up_after_a_run():
+    """One marker per attempt, and none of them outlive the call."""
+    seen = []
+
+    def _fake_run(argv, **kwargs):
+        marker = kwargs["env"][node_harness._MARKER_ENV]
+        Path(marker).write_text("1", encoding="utf-8")
+        seen.append(marker)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        run_node_script("node", "process.stdout.write('ok');", timeout=3)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(seen) == 1
+    assert not os.path.exists(seen[0]), f"标记文件留在盘上了：{seen[0]}"
 
 
 def test_the_script_budget_is_counted_from_the_preload_not_process_start():

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -1033,9 +1033,13 @@ def test_the_exit_code_has_exactly_one_definition():
     ``_WATCHDOG_EXIT_CODE`` unreferenced in the module and two places to change.
     """
     rendered = node_harness._rendered_preload()
+    declaration = f"const EXIT_CODE = {node_harness._WATCHDOG_EXIT_CODE};"
 
-    assert f"const EXIT_CODE = {node_harness._WATCHDOG_EXIT_CODE};" in rendered
-    assert "__EXIT_CODE__" not in rendered
+    # count == 1, not `in`: _rendered_preload() replaces every placeholder, so a
+    # duplicated one would emit two declarations and `in` would still pass.
+    assert rendered.count(declaration) == 1, rendered.count(declaration)
+    assert node_harness._PRELOAD_SOURCE.count('__EXIT_CODE__') == 1
+    assert '__EXIT_CODE__' not in rendered
     assert "= 87;" not in node_harness._PRELOAD_SOURCE, (
         "预载不该再自带一个 87 的字面量，否则和 Python 常量会各改各的"
     )

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -694,8 +694,11 @@ def test_a_synchronously_blocked_script_is_reported_not_retried():
     assert _as_text(error.attempts[0].stdout) == "started", (
         "同步卡死之前写出去的东西必须还能拿到——这是区分它和「node 没跑起来」的唯一证据"
     )
-    assert "blocked the event loop synchronously" in str(error), (
+    assert "reached the harness script" in str(error), (
         f"报错不能一口咬定是 node 没跑起来：{error}"
+    )
+    assert "blocked the event loop or compiling it did" in str(error), (
+        f"也不能反过来断言一定是同步阻塞——标记只证明到过脚本：{error}"
     )
 
 
@@ -1097,7 +1100,41 @@ def test_a_stall_after_the_script_started_is_not_retried_even_with_no_output():
         f"顺带把它已经做过的事再做一遍：{len(calls)} 次"
     )
     assert excinfo.value.started is True
-    assert "blocked the event loop synchronously" in str(excinfo.value)
+    message = str(excinfo.value)
+    # The marker is written before the module is compiled *and run*, so a stall
+    # in compilation reaches here too. The message must not claim to know which.
+    assert "blocked the event loop or compiling it did" in message, message
+    assert "reached the harness script" in message
+
+
+def test_a_started_stall_does_not_claim_to_know_which_kind_it_was():
+    """The marker proves node reached the script, and nothing finer.
+
+    It is written before ``_compile``, which compiles *and* runs the module --
+    deliberately, because writing it after would leave a synchronously blocked
+    script unmarked and get it retried. The price is that a stall in
+    compilation lands here too, so the message offers both readings instead of
+    asserting the one it cannot distinguish.
+    """
+    def _fake_run(argv, **kwargs):
+        Path(kwargs["env"][node_harness._MARKER_ENV]).write_text("1", encoding="utf-8")
+        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script(
+                "node", "process.stdout.write('ok');", capture_output=True, timeout=1
+            )
+    finally:
+        node_harness.subprocess.run = original
+
+    message = str(excinfo.value)
+    assert "compiling it did" in message
+    assert "blocked the event loop synchronously." not in message, (
+        f"这句话断言了我们分辨不出来的事：{message}"
+    )
 
 
 def test_the_error_says_which_of_the_two_stalls_it_was():

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -240,6 +240,40 @@ def test_a_healthy_harness_is_untouched_by_the_watchdog(runner):
     assert result.stderr == ""
 
 
+def test_a_heavy_synchronous_top_level_does_not_push_the_watchdog_past_the_ceiling(
+    monkeypatch,
+):
+    """The deadline is measured from node start, not from when the watchdog arms.
+
+    The watchdog is appended, so it arms only after the script's synchronous top
+    level finishes - but the outer ceiling has been running since the spawn. Arm
+    for the full deadline and the two clocks drift apart by exactly that top
+    level; any top level heavier than the slack and the ceiling fires first,
+    taking the diagnosis with it.
+
+    Driven with a shrunken slack so the case costs ~2s instead of ~9s.
+    """
+    node_path = _node_or_skip()
+    monkeypatch.setattr(node_harness, "_SPAWN_SLACK_SECONDS", 1.0)
+
+    # 2s of synchronous top level - twice the slack - and then a leaked timer.
+    script = (
+        "var until = Date.now() + 2000;\n"
+        "while (Date.now() < until) {}\n"
+        "setInterval(function () {}, 1000);\n"
+        "process.stdout.write('started');\n"
+    )
+    result = run_node_script(
+        node_path, script, capture_output=True, check=False, timeout=2
+    )
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (
+        "同步 top-level 吃掉的时间必须算进 deadline，否则 watchdog 会被外层 ceiling "
+        f"抢先杀掉、诊断全丢：rc={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "[node_harness]" in result.stderr
+
+
 def test_the_spawn_ceiling_sits_above_the_script_deadline(monkeypatch):
     """The caller's timeout is the script's budget; the spawn gets slack on top.
 
@@ -261,8 +295,8 @@ def test_the_spawn_ceiling_sits_above_the_script_deadline(monkeypatch):
     run_node_script("node", "process.stdout.write('ok');", timeout=12)
 
     assert seen["timeout"] == 12 + node_harness._SPAWN_SLACK_SECONDS
-    assert "}, 12000);" in seen["script"], (
-        f"watchdog 必须按调用方的 timeout 武装，而不是别的值：{seen['script'][-400:]!r}"
+    assert "var budget = 12000 - spent;" in seen["script"], (
+        f"watchdog 必须按调用方的 timeout 武装，而不是别的值：{seen['script'][-600:]!r}"
     )
 
 
@@ -282,7 +316,7 @@ def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypa
         node_harness._DEFAULT_WATCHDOG_SECONDS + node_harness._SPAWN_SLACK_SECONDS
     ), "没给 timeout 的调用方以前连外层 ceiling 都没有，同步卡死能一路跑到 job cap"
     millis = int(node_harness._DEFAULT_WATCHDOG_SECONDS * 1000)
-    assert f"}}, {millis});" in seen["script"]
+    assert f"var budget = {millis} - spent;" in seen["script"]
 
 
 def test_a_spawn_that_stalls_once_is_retried():
@@ -505,7 +539,94 @@ def test_a_stall_that_only_wrote_to_stderr_is_not_retried():
     assert len(calls) == 1, "只往 stderr 写的脚本同样证明它跑起来了，不该重试"
 
 
-def test_the_wrapped_error_keeps_the_last_attempt_output_where_callers_look():
+def test_a_caller_that_captures_nothing_is_told_its_silence_proves_nothing():
+    """Eight call sites do not capture, so their stalls can never show output.
+
+    ``communicate()`` returns None rather than "" when there was no pipe, which
+    is indistinguishable from an empty capture unless the error says so. Without
+    that line the message would tell the reader the script probably never ran,
+    on a run where nothing was ever in a position to observe it.
+    """
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            # No capture_output: exactly what test_pngtuber_static_contracts.py
+            # and friends do.
+            run_node_script("node", "process.stdout.write('ok');", timeout=1)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 2, "看不见输出时无从判断，重试仍是对的默认"
+    message = str(excinfo.value)
+    assert "unobserved rather than empty" in message, (
+        f"没抓输出的调用方必须被告知这份「安静」什么也证明不了：{message}"
+    )
+    assert "probably never" not in message, (
+        f"没有管道可看的时候不能下「脚本没跑起来」的结论：{message}"
+    )
+
+
+def test_a_capturing_caller_is_not_given_the_unobserved_note():
+    """The dual: a real empty capture is evidence, and must not be hedged away."""
+
+    def _fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script(
+                "node", "process.stdout.write('ok');", capture_output=True, timeout=1
+            )
+    finally:
+        node_harness.subprocess.run = original
+
+    assert "unobserved rather than empty" not in str(excinfo.value)
+
+
+def test_the_wrapped_error_reports_the_second_attempt_not_the_first():
+    """With two attempts, ``.stdout`` must be the retry's, not the first try's.
+
+    Reachable and distinguishing: attempt 1 stalls silently (so it earns the
+    retry), attempt 2 stalls with output. Picking ``attempts[0]`` would hand the
+    caller the empty one and hide the only evidence in the run.
+    """
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
+        raise subprocess.TimeoutExpired(
+            argv, kwargs.get("timeout"), output="second-out", stderr="second-err"
+        )
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script(
+                "node", "process.stdout.write('ok');", capture_output=True, timeout=1
+            )
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 2
+    assert excinfo.value.stdout == "second-out"
+    assert excinfo.value.stderr == "second-err"
+    # Both are still listed; only the exception's own fields follow the last one.
+    assert str(excinfo.value).count("attempt ") == 2
+
+
+def test_the_wrapped_error_keeps_a_stalled_attempt_output_where_callers_look():
     """``except TimeoutExpired`` reading ``.stdout`` must not regress to None.
 
     ``subprocess.run`` fills those in after killing the child; wrapping the

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -278,7 +278,9 @@ def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypa
     monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
     run_node_script("node", "process.stdout.write('ok');")
 
-    assert seen["timeout"] is None, "没给 timeout 的调用方不该被凭空加上一个外层 ceiling"
+    assert seen["timeout"] == (
+        node_harness._DEFAULT_WATCHDOG_SECONDS + node_harness._SPAWN_SLACK_SECONDS
+    ), "没给 timeout 的调用方以前连外层 ceiling 都没有，同步卡死能一路跑到 job cap"
     millis = int(node_harness._DEFAULT_WATCHDOG_SECONDS * 1000)
     assert f"}}, {millis});" in seen["script"]
 
@@ -313,14 +315,17 @@ def test_a_spawn_that_stalls_once_is_retried():
 
 
 def test_a_spawn_that_keeps_stalling_reports_both_attempts():
-    """The dual: retrying must not become a way to hide a reproducible stall."""
+    """The dual: retrying must not become a way to hide a reproducible stall.
+
+    A stall only earns a retry when it was completely silent, so a two-attempt
+    run is by construction two silent attempts - and the error has to say that
+    twice over rather than collapsing it into one line.
+    """
     calls = []
 
     def _fake_run(argv, **kwargs):
         calls.append(argv)
-        raise subprocess.TimeoutExpired(
-            argv, kwargs.get("timeout"), output=f"partial-{len(calls)}", stderr=""
-        )
+        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
 
     original = node_harness.subprocess.run
     node_harness.subprocess.run = _fake_run
@@ -333,8 +338,11 @@ def test_a_spawn_that_keeps_stalling_reports_both_attempts():
     assert len(calls) == 2, "重试次数必须有界"
     assert isinstance(excinfo.value, NodeHarnessSpawnTimeout)
     message = str(excinfo.value)
-    assert "partial-1" in message and "partial-2" in message, (
-        f"两次尝试各自吐了什么必须跟着错误一起报出来：{message}"
+    assert "attempt 1:" in message and "attempt 2:" in message, (
+        f"两次尝试都得各自列出来：{message}"
+    )
+    assert message.count("stdout=") == 2 and message.count("stderr=") == 2, (
+        f"每次尝试各自吐了什么必须跟着错误一起报出来：{message}"
     )
 
 
@@ -348,6 +356,44 @@ _SHADOWS_THE_TIMERS = (
     "setTimeout(function () {});\n"
     "process.stdout.write('ok');\n"
 )
+
+
+# The other door to the same problem: a harness that aliases window onto the
+# global object (four files do) turns `window.setTimeout = fake` into an
+# overwrite of the real global, which a `globalThis.setTimeout` watchdog would
+# happily pick up.
+_OVERWRITES_THE_GLOBAL_TIMER = (
+    "globalThis.window = globalThis;\n"
+    "window.setTimeout = (callback) => { callback(); return 0; };\n"
+    "window.setInterval = (callback) => { callback(); return 0; };\n"
+    "setTimeout(function () {});\n"
+    "process.stdout.write('ok');\n"
+)
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_overwrites_the_global_timer_still_runs_clean(runner):
+    """`global.window = global` makes `window.setTimeout = fake` a real overwrite.
+
+    Reading the timer off ``globalThis`` survives a module-scope ``const``
+    shadow but not this, so the watchdog takes it from ``node:timers`` instead -
+    behind both doors.
+    """
+    node_path = _node_or_skip()
+
+    result = runner(
+        node_path,
+        _OVERWRITES_THE_GLOBAL_TIMER,
+        capture_output=True,
+        check=False,
+        timeout=6,
+    )
+
+    assert result.returncode == 0, (
+        f"被改写掉的全局 setTimeout 不能牵动 watchdog：stderr={result.stderr!r}"
+    )
+    assert result.stdout == "ok"
+    assert result.stderr == ""
 
 
 @pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
@@ -370,3 +416,116 @@ def test_a_harness_that_shadows_the_timers_still_runs_clean(runner):
     )
     assert result.stdout == "ok"
     assert result.stderr == ""
+
+
+# A script the watchdog cannot save: a synchronous block never yields, so the
+# timer it is queued behind can never run. What separates it from a node that
+# never started is that anything written first still reaches the parent.
+_BLOCKS_THE_EVENT_LOOP = (
+    "process.stdout.write('started');\n"
+    "while (true) {}\n"
+)
+
+
+def test_a_synchronously_blocked_script_is_reported_not_retried():
+    """The one in-script hang the watchdog cannot catch must still not be retried.
+
+    ``while (true) {}`` never yields, so the watchdog's own timer never runs and
+    the stall reaches the outer ceiling looking exactly like a spawn stall. It
+    is not one, and a second spawn cannot help. Measured on Windows: what the
+    script wrote before blocking still arrives, so the output is the tell.
+    """
+    node_path = _node_or_skip()
+
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        # 1s, so the run costs one ceiling (1 + slack) rather than two.
+        run_node_script(
+            node_path, _BLOCKS_THE_EVENT_LOOP, capture_output=True, timeout=1
+        )
+
+    error = excinfo.value
+    assert isinstance(error, NodeHarnessSpawnTimeout)
+    assert len(error.attempts) == 1, (
+        f"卡住但吐了东西的脚本证明它跑起来了，重试没有意义：{error.attempts}"
+    )
+    assert error.attempts[0].stdout == "started", (
+        "同步卡死之前写出去的东西必须还能拿到——这是区分它和「node 没跑起来」的唯一证据"
+    )
+    assert "blocked the event loop synchronously" in str(error), (
+        f"报错不能一口咬定是 node 没跑起来：{error}"
+    )
+
+
+def test_a_silent_stall_is_still_retried():
+    """The dual: with no output there is nothing to conclude, so retry stands."""
+    calls = []
+    ok = subprocess.CompletedProcess(["node"], 0, "ok", "")
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(
+                argv, kwargs.get("timeout"), output="", stderr=""
+            )
+        return ok
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        assert run_node_script("node", "process.stdout.write('ok');", timeout=3) is ok
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 2
+
+
+def test_a_stall_that_only_wrote_to_stderr_is_not_retried():
+    """Evidence is evidence whichever stream it came out of.
+
+    A harness that reports through ``console.error`` leaves its trace on stderr
+    alone; counting only stdout would send that straight back into a pointless
+    retry. Found by mutation - nothing else in this file covered it.
+    """
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        raise subprocess.TimeoutExpired(
+            argv, kwargs.get("timeout"), output="", stderr="started"
+        )
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_node_script("node", "process.stdout.write('ok');", timeout=1)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 1, "只往 stderr 写的脚本同样证明它跑起来了，不该重试"
+
+
+def test_the_wrapped_error_keeps_the_last_attempt_output_where_callers_look():
+    """``except TimeoutExpired`` reading ``.stdout`` must not regress to None.
+
+    ``subprocess.run`` fills those in after killing the child; wrapping the
+    error in a subclass and forgetting to pass them through would quietly take
+    that away from every caller.
+    """
+
+    def _fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(
+            argv, kwargs.get("timeout"), output="partial-out", stderr="partial-err"
+        )
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script("node", "process.stdout.write('ok');", timeout=1)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert excinfo.value.stdout == "partial-out"
+    assert excinfo.value.output == "partial-out"
+    assert excinfo.value.stderr == "partial-err"

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -1131,7 +1131,9 @@ def test_a_started_stall_does_not_claim_to_know_which_kind_it_was():
         node_harness.subprocess.run = original
 
     message = str(excinfo.value)
-    assert "compiling it did" in message
+    # The whole phrase: asserting only the tail would still pass on a message
+    # that offered compilation alone, which is the opposite of what this pins.
+    assert "blocked the event loop or compiling it did" in message, message
     assert "blocked the event loop synchronously." not in message, (
         f"这句话断言了我们分辨不出来的事：{message}"
     )

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -994,4 +994,19 @@ def test_one_preload_file_serves_the_whole_process():
     second = node_harness._preload_path()
 
     assert first == second
-    assert Path(first).read_text(encoding="utf-8") == node_harness._PRELOAD_SOURCE
+    assert Path(first).read_text(encoding="utf-8") == node_harness._rendered_preload()
+
+
+def test_the_exit_code_has_exactly_one_definition():
+    """The guard's exit code and the tests' expectation cannot drift apart.
+
+    The preload carried its own literal 87 for a while, which left
+    ``_WATCHDOG_EXIT_CODE`` unreferenced in the module and two places to change.
+    """
+    rendered = node_harness._rendered_preload()
+
+    assert f"const EXIT_CODE = {node_harness._WATCHDOG_EXIT_CODE};" in rendered
+    assert "__EXIT_CODE__" not in rendered
+    assert "= 87;" not in node_harness._PRELOAD_SOURCE, (
+        "预载不该再自带一个 87 的字面量，否则和 Python 常量会各改各的"
+    )

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -174,6 +174,20 @@ def test_shared_launcher_pins_utf8(runner):
     assert '"encoding"] = "utf-8"' in helper_body, "_utf8 必须强制 encoding，而不是 setdefault"
 
 
+def _as_text(blob) -> str:
+    """Decode what a stalled attempt emitted, whichever platform produced it.
+
+    ``subprocess.run`` re-runs ``communicate()`` after killing the child only on
+    Windows, so only there do ``TimeoutExpired.stdout``/``.stderr`` come back
+    decoded. On POSIX they are whatever ``_check_timeout`` joined together --
+    raw bytes -- and a test comparing against ``str`` is green on the CI runner
+    and red on any developer's machine.
+    """
+    if isinstance(blob, bytes):
+        return blob.decode("utf-8", "replace")
+    return blob
+
+
 def _node_or_skip() -> str:
     node_path = shutil.which("node")
     if not node_path:
@@ -241,6 +255,72 @@ def test_a_healthy_harness_is_untouched_by_the_watchdog(runner):
 
 
 @pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+@pytest.mark.parametrize(
+    "opening",
+    [
+        pytest.param("'use strict'; // 说明\n", id="directive-with-trailing-comment"),
+        pytest.param("'use strict'; let first = 1;\n", id="directive-sharing-its-line"),
+        pytest.param('"use strict"\n', id="double-quoted-no-semicolon"),
+    ],
+)
+def test_use_strict_survives_in_its_less_tidy_forms(runner, opening):
+    """A directive is a statement, not a line, so the splice point is a column.
+
+    Anchoring the match to a whole line covers only the tidiest spelling; the
+    other three put the prologue in front of the directive and take strict mode
+    with it, silently and greenly.
+    """
+    node_path = _node_or_skip()
+
+    script = opening + "undeclaredOnPurpose = 1;\nprocess.stdout.write('ok');\n"
+    result = runner(node_path, script, capture_output=True, check=False, timeout=6)
+
+    assert result.returncode != 0, (
+        f"这种写法下 'use strict' 被挤掉了：rc={result.returncode} "
+        f"stdout={result.stdout!r}"
+    )
+    assert "ReferenceError" in result.stderr, result.stderr[:400]
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_leading_hashbang_still_parses(runner):
+    """Node honours ``#!`` only at the very start of the source."""
+    node_path = _node_or_skip()
+
+    script = "#!/usr/bin/env node\nprocess.stdout.write('ok');\n"
+    result = runner(node_path, script, capture_output=True, check=False, timeout=6)
+
+    assert result.returncode == 0, (
+        f"prologue 挤到 hashbang 前面会直接语法错误：stderr={result.stderr[:300]!r}"
+    )
+    assert result.stdout == "ok"
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_shadows_globalThis_still_runs(runner):
+    """``const globalThis`` puts that name in the TDZ for the whole module.
+
+    The prologue runs before the declaration initialises, so reading the bare
+    name would throw before the harness reached its first statement. The global
+    is fetched through ``Function('return this')()`` instead, which does not
+    participate in the caller's lexical scope.
+    """
+    node_path = _node_or_skip()
+
+    script = (
+        "process.stdout.write('ok');\n"
+        "const globalThis = { fake: true };\n"
+        "void globalThis;\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=6)
+
+    assert result.returncode == 0, (
+        f"被影子化的 globalThis 不该把 prologue 打挂：stderr={result.stderr[:300]!r}"
+    )
+    assert result.stdout == "ok"
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
 def test_a_leading_use_strict_survives_the_prologue(runner):
     """The guard must go after a directive, never in front of it.
 
@@ -276,8 +356,13 @@ def test_the_prologue_does_not_renumber_the_scripts_own_lines(runner):
     result = runner(node_path, script, capture_output=True, check=False, timeout=6)
 
     assert result.returncode != 0
-    assert ":3" in result.stderr, (
+    # <file>:<line>:<column>, so a bare ":3" also matches a column of 3 on the
+    # wrong line. Mutation confirmed it: "prologue given its own line" survived.
+    assert re.search(r":3:\d+", result.stderr), (
         f"抛错行号应仍是脚本自己的第 3 行：{result.stderr[:400]!r}"
+    )
+    assert not re.search(r":4:\d+", result.stderr), (
+        f"行号被 prologue 挤下去了一行：{result.stderr[:400]!r}"
     )
 
 
@@ -600,7 +685,7 @@ def test_a_synchronously_blocked_script_is_reported_not_retried():
     assert len(error.attempts) == 1, (
         f"卡住但吐了东西的脚本证明它跑起来了，重试没有意义：{error.attempts}"
     )
-    assert error.attempts[0].stdout == "started", (
+    assert _as_text(error.attempts[0].stdout) == "started", (
         "同步卡死之前写出去的东西必须还能拿到——这是区分它和「node 没跑起来」的唯一证据"
     )
     assert "blocked the event loop synchronously" in str(error), (

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -32,11 +32,19 @@ exactly what a new harness file would slip past.
 
 import ast
 import re
+import shutil
+import subprocess
 import tomllib
 from pathlib import Path
 
 import pytest
 
+from tests import node_harness
+from tests.node_harness import (
+    NodeHarnessSpawnTimeout,
+    run_node_script,
+    run_node_stdin,
+)
 from tests.repo_ast_cache import parse_source_file
 
 TESTS_ROOT = Path(__file__).resolve().parents[1]
@@ -164,3 +172,201 @@ def test_shared_launcher_pins_utf8(runner):
     )
     helper_body = ast.get_source_segment(source, helper) or ""
     assert '"encoding"] = "utf-8"' in helper_body, "_utf8 必须强制 encoding，而不是 setdefault"
+
+
+def _node_or_skip() -> str:
+    node_path = shutil.which("node")
+    if not node_path:
+        pytest.skip("node is required for the launcher's own liveness tests")
+    return node_path
+
+
+# A script that finishes its work but leaves a timer armed. Node's event loop
+# stays alive forever on it, which is the shape every "harness hangs" report in
+# this repo has taken.
+_LEAKS_A_TIMER = "setInterval(function () {}, 1000);\nprocess.stdout.write('started');\n"
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_leaks_a_timer_fails_with_the_leak_named(runner):
+    """A never-settling script must die from inside node, saying what held it.
+
+    Before the watchdog this ran out the caller's ``subprocess.run`` ceiling and
+    surfaced as a bare ``TimeoutExpired`` naming only ``node.EXE`` and a temp
+    file - indistinguishable from a runner that never started node at all, and
+    with nothing in it to act on.
+    """
+    node_path = _node_or_skip()
+
+    # 3s, not the caller-typical 10-60: this test deliberately waits out the
+    # deadline, so the budget is CI time spent on purpose.
+    result = runner(
+        node_path, _LEAKS_A_TIMER, capture_output=True, check=False, timeout=3
+    )
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (
+        "泄漏 handle 的脚本必须由 watchdog 结束，而不是被外层 ceiling 杀掉："
+        f"rc={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "[node_harness]" in result.stderr
+    assert "Timeout" in result.stderr, (
+        f"诊断必须点名还占着事件循环的 handle：{result.stderr!r}"
+    )
+    # The script's own output is still there: the watchdog reports, it does not
+    # replace what the harness was saying.
+    assert result.stdout == "started"
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_healthy_harness_is_untouched_by_the_watchdog(runner):
+    """The dual: a script that settles must see no trace of the guard.
+
+    Without this the watchdog could "pass" the test above by firing on
+    everything, and every caller asserting ``result.stdout == "ok"`` or
+    ``result.stderr == ""`` would go red.
+    """
+    node_path = _node_or_skip()
+
+    result = runner(
+        node_path,
+        "process.stdout.write('ok');\n",
+        capture_output=True,
+        check=False,
+        timeout=6,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "ok"
+    assert result.stderr == ""
+
+
+def test_the_spawn_ceiling_sits_above_the_script_deadline(monkeypatch):
+    """The caller's timeout is the script's budget; the spawn gets slack on top.
+
+    This ordering is the whole basis for telling the two failures apart. If the
+    two deadlines were equal, the subprocess kill would race the watchdog and a
+    hung script could still surface as an undiagnosed ``TimeoutExpired`` - and
+    then get retried, which is exactly what must not happen to a real defect.
+    """
+    assert node_harness._SPAWN_SLACK_SECONDS > 0, "没有间隙就没有先后，分类失效"
+
+    seen = {}
+
+    def _fake_run(argv, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        seen["script"] = kwargs.get("input") or Path(argv[1]).read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
+    run_node_script("node", "process.stdout.write('ok');", timeout=12)
+
+    assert seen["timeout"] == 12 + node_harness._SPAWN_SLACK_SECONDS
+    assert "}, 12000);" in seen["script"], (
+        f"watchdog 必须按调用方的 timeout 武装，而不是别的值：{seen['script'][-400:]!r}"
+    )
+
+
+def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypatch):
+    """No ceiling at all used to mean "hang until the 25-minute job cap"."""
+    seen = {}
+
+    def _fake_run(argv, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        seen["script"] = Path(argv[1]).read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
+    run_node_script("node", "process.stdout.write('ok');")
+
+    assert seen["timeout"] is None, "没给 timeout 的调用方不该被凭空加上一个外层 ceiling"
+    millis = int(node_harness._DEFAULT_WATCHDOG_SECONDS * 1000)
+    assert f"}}, {millis});" in seen["script"]
+
+
+def test_a_spawn_that_stalls_once_is_retried():
+    """A stall with the script never reached is the runner's fault, not ours.
+
+    ``node.EXE`` has come back from a Windows runner having burned 30s without
+    reaching the first line of a 55ms script. Nothing in the harness can make
+    that attempt succeed, and no assertion was under test, so the run is
+    repeated rather than reported as a contract violation.
+    """
+    calls = []
+    ok = subprocess.CompletedProcess(["node"], 0, "ok", "")
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
+        return ok
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        result = run_node_script("node", "process.stdout.write('ok');", timeout=3)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert result is ok
+    assert len(calls) == 2, "第一次 spawn 卡死后必须再试一次"
+    assert calls[0][1] != calls[1][1], "重试要用新的临时脚本，别继承上一次被 kill 时的残留"
+
+
+def test_a_spawn_that_keeps_stalling_reports_both_attempts():
+    """The dual: retrying must not become a way to hide a reproducible stall."""
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        raise subprocess.TimeoutExpired(
+            argv, kwargs.get("timeout"), output=f"partial-{len(calls)}", stderr=""
+        )
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            run_node_script("node", "process.stdout.write('ok');", timeout=3)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert len(calls) == 2, "重试次数必须有界"
+    assert isinstance(excinfo.value, NodeHarnessSpawnTimeout)
+    message = str(excinfo.value)
+    assert "partial-1" in message and "partial-2" in message, (
+        f"两次尝试各自吐了什么必须跟着错误一起报出来：{message}"
+    )
+
+
+# Three suites drive fake clocks by shadowing the timer globals at module scope.
+# `const` makes that shadow cover the whole module, temporal dead zone included,
+# so an appended guard reading the bare name gets the fake or throws outright.
+_SHADOWS_THE_TIMERS = (
+    "const setTimeout = (callback) => { callback(); return 0; };\n"
+    "const clearTimeout = () => {};\n"
+    "const setInterval = (callback) => { callback(); return 0; };\n"
+    "setTimeout(function () {});\n"
+    "process.stdout.write('ok');\n"
+)
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_shadows_the_timers_still_runs_clean(runner):
+    """The guard must not be steerable by the script it is guarding.
+
+    Found the hard way: the first version called the bare ``setTimeout`` and
+    ``tests/unit/test_avatar_annotation_frontend.py`` -- whose harness replaces
+    it with ``(callback) => callback()`` -- ran the watchdog's own callback on
+    the spot and died at exit 87 with nothing wrong with it.
+    """
+    node_path = _node_or_skip()
+
+    result = runner(
+        node_path, _SHADOWS_THE_TIMERS, capture_output=True, check=False, timeout=6
+    )
+
+    assert result.returncode == 0, (
+        f"被 harness 影子化的 setTimeout 不能牵动 watchdog：stderr={result.stderr!r}"
+    )
+    assert result.stdout == "ok"
+    assert result.stderr == ""

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -861,6 +861,35 @@ def test_the_wrapped_error_keeps_a_stalled_attempt_output_where_callers_look():
 
 
 @pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_pins_date_now_cannot_freeze_the_deadline(runner):
+    """Three harnesses in this repo pin ``Date.now`` to a fake clock.
+
+    ``test_app_websocket_static.py`` and ``test_avatar_annotation_frontend.py``
+    both do it to drive TTL logic. Reading the clock through the global at check
+    time froze ``overdue()`` for them -- the guard was inert for exactly the
+    suites that simulate the passage of time. The preload takes a monotonic
+    clock before the script gets a turn.
+    """
+    node_path = _node_or_skip()
+
+    # Date.now pinned, then real time burned through a clock the fake cannot
+    # reach. Under the old lookup this returned 0.
+    script = (
+        "Date.now = () => 1000000;\n"
+        "const until = process.hrtime.bigint() + 500000000n;\n"
+        "while (process.hrtime.bigint() < until) {}\n"
+        "process.stdout.write('done');\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=0.1)
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (
+        f"被钉死的 Date.now 不该冻住 deadline：rc={result.returncode} "
+        f"stdout={result.stdout!r}"
+    )
+    assert "still running" in result.stderr
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
 def test_a_harness_that_stubs_process_exit_cannot_disarm_the_timer(runner):
     """``process.exit = () => {}`` is a normal stub, not sabotage.
 
@@ -942,8 +971,8 @@ def test_the_script_budget_is_counted_from_the_preload_not_process_start():
     """
     preload = node_harness._PRELOAD_SOURCE
 
-    assert "const startedAt = Date.now();" in preload
-    assert "Date.now() - startedAt > deadlineMs" in preload
+    assert "const startedAt = millisNow();" in preload
+    assert "millisNow() - startedAt > deadlineMs" in preload
     assert "uptime()" not in preload, (
         "uptime() 从进程启动算起，会把 node 自己的 bootstrap 记到脚本头上"
     )

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -491,16 +491,21 @@ def test_the_spawn_ceiling_sits_above_the_script_deadline(monkeypatch):
 
     def _fake_run(argv, **kwargs):
         seen["timeout"] = kwargs.get("timeout")
-        seen["script"] = kwargs.get("input") or Path(argv[1]).read_text(encoding="utf-8")
+        seen["argv"] = argv
+        seen["env"] = kwargs.get("env") or {}
+        seen["script"] = kwargs.get("input") or Path(argv[-1]).read_text(encoding="utf-8")
         return subprocess.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
     run_node_script("node", "process.stdout.write('ok');", timeout=12)
 
     assert seen["timeout"] == 12 + node_harness._SPAWN_SLACK_SECONDS
-    assert "var deadlineMs = 12000;" in seen["script"], (
-        f"watchdog 必须按调用方的 timeout 武装，而不是别的值：{seen['script'][-600:]!r}"
+    assert seen["env"][node_harness._DEADLINE_ENV] == "12000", (
+        f"watchdog 必须按调用方的 timeout 武装，而不是别的值：{seen['env'].get(node_harness._DEADLINE_ENV)!r}"
     )
+    assert "--require" in seen["argv"], seen["argv"]
+    # The script itself must reach node exactly as the caller wrote it.
+    assert seen["script"] == "process.stdout.write('ok');", seen["script"]
 
 
 def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypatch):
@@ -509,7 +514,7 @@ def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypa
 
     def _fake_run(argv, **kwargs):
         seen["timeout"] = kwargs.get("timeout")
-        seen["script"] = Path(argv[1]).read_text(encoding="utf-8")
+        seen["env"] = kwargs.get("env") or {}
         return subprocess.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
@@ -519,7 +524,7 @@ def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypa
         node_harness._DEFAULT_WATCHDOG_SECONDS + node_harness._SPAWN_SLACK_SECONDS
     ), "没给 timeout 的调用方以前连外层 ceiling 都没有，同步卡死能一路跑到 job cap"
     millis = int(node_harness._DEFAULT_WATCHDOG_SECONDS * 1000)
-    assert f"var deadlineMs = {millis};" in seen["script"]
+    assert seen["env"][node_harness._DEADLINE_ENV] == str(millis)
 
 
 def test_a_spawn_that_stalls_once_is_retried():
@@ -548,7 +553,7 @@ def test_a_spawn_that_stalls_once_is_retried():
 
     assert result is ok
     assert len(calls) == 2, "第一次 spawn 卡死后必须再试一次"
-    assert calls[0][1] != calls[1][1], "重试要用新的临时脚本，别继承上一次被 kill 时的残留"
+    assert calls[0][-1] != calls[1][-1], "重试要用新的临时脚本，别继承上一次被 kill 时的残留"
 
 
 def test_a_spawn_that_keeps_stalling_reports_both_attempts():
@@ -853,3 +858,51 @@ def test_the_wrapped_error_keeps_a_stalled_attempt_output_where_callers_look():
     assert excinfo.value.stdout == "partial-out"
     assert excinfo.value.output == "partial-out"
     assert excinfo.value.stderr == "partial-err"
+
+
+def test_the_guard_never_edits_the_script_it_is_guarding():
+    """The script reaches node byte-for-byte as the caller wrote it.
+
+    Every splicing bug this launcher has had -- a demoted ``'use strict'``, a
+    broken hashbang, renumbered stack frames, a guard reading an identifier the
+    harness had shadowed -- came from injecting text into the caller's source.
+    The guard is a preloaded module now, so the source is not touched at all.
+    """
+    seen = {}
+    awkward = (
+        "#!/usr/bin/env node\n"
+        "'use strict'; // 说明\n"
+        "const setTimeout = (cb) => cb();\n"
+        "const globalThis = {};\n"
+        "process.stdout.write('ok');\n"
+    )
+
+    def _fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["script"] = Path(argv[-1]).read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        run_node_script("node", awkward, timeout=5)
+    finally:
+        node_harness.subprocess.run = original
+
+    assert seen["script"] == awkward, "脚本被改写了，注入式护栏的所有坑就都回来了"
+    assert seen["argv"][1] == "--require", seen["argv"]
+    assert seen["argv"][2].endswith(".neko-harness-guard.js"), seen["argv"]
+
+
+def test_one_preload_file_serves_the_whole_process():
+    """The deadline rides in the environment, so the file never varies.
+
+    Writing one per invocation would put a fresh, never-before-seen ``.js`` into
+    the temp directory on every single harness call -- more of exactly the file
+    churn this launcher is trying to stop paying for.
+    """
+    first = node_harness._preload_path()
+    second = node_harness._preload_path()
+
+    assert first == second
+    assert Path(first).read_text(encoding="utf-8") == node_harness._PRELOAD_SOURCE

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -860,6 +860,95 @@ def test_the_wrapped_error_keeps_a_stalled_attempt_output_where_callers_look():
     assert excinfo.value.stderr == "partial-err"
 
 
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_stubs_process_exit_cannot_disarm_the_timer(runner):
+    """``process.exit = () => {}`` is a normal stub, not sabotage.
+
+    A harness testing code that exits on error will stub it. The preload
+    resolved ``process.exit`` when the timer fired, so the stub swallowed the
+    kill and the run hung to the outer ceiling; the binding is taken at preload
+    time now, before the script can touch it.
+    """
+    node_path = _node_or_skip()
+
+    script = (
+        "process.exit = () => {};\n"
+        "setInterval(function () {}, 1000);\n"
+        "process.stdout.write('started');\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=2)
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (
+        f"被打桩的 process.exit 不该让 watchdog 失效：rc={result.returncode}"
+    )
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_replaces_the_global_process_still_runs(runner):
+    """A browser shim may do ``global.process = { env: {} }``.
+
+    The preload is out of reach of the caller's lexical scope but not of the
+    global object, so resolving ``process`` at fire time picked up the
+    replacement and died in the exit hook with a TypeError -- turning a healthy
+    script into a failure.
+    """
+    node_path = _node_or_skip()
+
+    script = (
+        "const native = process;\n"
+        "global.process = { env: {} };\n"
+        "native.stdout.write('ok');\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=6)
+
+    assert result.returncode == 0, (
+        f"换掉全局 process 不该把健康脚本打红：stderr={result.stderr[:300]!r}"
+    )
+    assert result.stdout == "ok"
+
+
+def test_a_zero_timeout_still_fails_fast_and_still_arms_the_guard(monkeypatch):
+    """``timeout=0`` means fail now, not "five seconds and no guard".
+
+    The slack is added only to a positive budget, and the deadline is floored at
+    1ms so rounding cannot switch the preload off -- ``int(0 * 1000)`` did, and
+    the preload's own ``deadlineMs > 0`` check then skipped everything.
+    """
+    seen = {}
+
+    def _fake_run(argv, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        seen["env"] = kwargs.get("env") or {}
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
+    run_node_script("node", "process.stdout.write('ok');", timeout=0)
+
+    assert seen["timeout"] == 0, (
+        f"timeout=0 的调用方要的是立刻失败，不是多给 5 秒：{seen['timeout']!r}"
+    )
+    assert seen["env"][node_harness._DEADLINE_ENV] == "1", (
+        f"预算再小也必须武装护栏，不能被取整成 0 关掉：{seen['env'].get(node_harness._DEADLINE_ENV)!r}"
+    )
+
+
+def test_the_script_budget_is_counted_from_the_preload_not_process_start():
+    """Bootstrap time belongs to the spawn stall, not to the script.
+
+    Structural, because a slow V8 bootstrap cannot be induced on demand -- but
+    the distinction matters more than most: ``process.uptime()`` includes the
+    pre-script delay this launcher exists to tell apart, so a healthy script on
+    a slow spawn would be reported as a harness timeout *instead of* retried.
+    """
+    preload = node_harness._PRELOAD_SOURCE
+
+    assert "const startedAt = Date.now();" in preload
+    assert "Date.now() - startedAt > deadlineMs" in preload
+    assert "uptime()" not in preload, (
+        "uptime() 从进程启动算起，会把 node 自己的 bootstrap 记到脚本头上"
+    )
+
+
 def test_the_guard_never_edits_the_script_it_is_guarding():
     """The script reaches node byte-for-byte as the caller wrote it.
 

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -241,6 +241,96 @@ def test_a_healthy_harness_is_untouched_by_the_watchdog(runner):
 
 
 @pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_leading_use_strict_survives_the_prologue(runner):
+    """The guard must go after a directive, never in front of it.
+
+    ``tests/unit/test_assistant_speech_finalize_static.py`` opens its harness
+    with ``'use strict';``. A statement placed before it demotes it from a
+    directive to an ordinary string expression -- silently, with strict mode
+    gone and the harness still green. Here the assignment to an undeclared name
+    is the witness: it throws under strict mode and quietly succeeds without it.
+    """
+    node_path = _node_or_skip()
+
+    script = "'use strict';\nundeclaredOnPurpose = 1;\nprocess.stdout.write('ok');\n"
+    result = runner(node_path, script, capture_output=True, check=False, timeout=6)
+
+    assert result.returncode != 0, (
+        f"'use strict' 被挤掉了：赋值给未声明变量本该抛 ReferenceError，"
+        f"却拿到 rc={result.returncode} stdout={result.stdout!r}"
+    )
+    assert "ReferenceError" in result.stderr, result.stderr[:400]
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_the_prologue_does_not_renumber_the_scripts_own_lines(runner):
+    """A stack trace must still point at the line the caller wrote.
+
+    The prologue rides on the front of the first statement's line rather than
+    taking a line of its own, so a throw on the script's line 3 still reports
+    line 3.
+    """
+    node_path = _node_or_skip()
+
+    script = "const a = 1;\nconst b = 2;\nthrow new Error('boom');\n"
+    result = runner(node_path, script, capture_output=True, check=False, timeout=6)
+
+    assert result.returncode != 0
+    assert ":3" in result.stderr, (
+        f"抛错行号应仍是脚本自己的第 3 行：{result.stderr[:400]!r}"
+    )
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_script_that_exits_itself_cannot_escape_its_deadline(runner):
+    """``process.exit(0)`` in the top level never reaches appended code.
+
+    The dual of the natural-completion case, and it defeats an arming-time check
+    too: the script terminates before the watchdog is even installed. Only a
+    hook on the exit itself sees it. Measured: an 800ms busy loop followed by
+    ``process.exit(0)`` under a 0.2s timeout came back rc=0 before this.
+    """
+    node_path = _node_or_skip()
+
+    script = (
+        "var until = Date.now() + 800;\n"
+        "while (Date.now() < until) {}\n"
+        "process.stdout.write('done');\n"
+        "process.exit(0);\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=0.2)
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (
+        "脚本自己 exit(0) 也不能绕过调用方的 timeout："
+        f"rc={result.returncode} stdout={result.stdout!r}"
+    )
+    assert "still running" in result.stderr
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_script_inside_its_budget_keeps_its_own_exit_code(runner):
+    """The dual: the hook must only fire when the budget is actually blown.
+
+    Ten harnesses end on ``process.exit(1)`` to signal their own failure. A hook
+    that rewrote every exit code would turn each of those into 87 and make the
+    two indistinguishable.
+    """
+    node_path = _node_or_skip()
+
+    result = runner(
+        node_path,
+        "process.stdout.write('bye');\nprocess.exit(3);\n",
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 3, f"预算之内的退出码必须原样保留：{result.returncode}"
+    assert result.stdout == "bye"
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
 def test_a_script_that_merely_runs_long_still_fails_its_deadline(runner):
     """A script that overruns and then finishes must not pass.
 
@@ -323,7 +413,7 @@ def test_the_spawn_ceiling_sits_above_the_script_deadline(monkeypatch):
     run_node_script("node", "process.stdout.write('ok');", timeout=12)
 
     assert seen["timeout"] == 12 + node_harness._SPAWN_SLACK_SECONDS
-    assert "var budget = 12000 - spent;" in seen["script"], (
+    assert "var deadlineMs = 12000;" in seen["script"], (
         f"watchdog 必须按调用方的 timeout 武装，而不是别的值：{seen['script'][-600:]!r}"
     )
 
@@ -344,7 +434,7 @@ def test_a_caller_without_a_timeout_still_gets_a_finite_script_deadline(monkeypa
         node_harness._DEFAULT_WATCHDOG_SECONDS + node_harness._SPAWN_SLACK_SECONDS
     ), "没给 timeout 的调用方以前连外层 ceiling 都没有，同步卡死能一路跑到 job cap"
     millis = int(node_harness._DEFAULT_WATCHDOG_SECONDS * 1000)
-    assert f"var budget = {millis} - spent;" in seen["script"]
+    assert f"var deadlineMs = {millis};" in seen["script"]
 
 
 def test_a_spawn_that_stalls_once_is_retried():

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -31,6 +31,7 @@ exactly what a new harness file would slip past.
 """
 
 import ast
+import os
 import re
 import shutil
 import subprocess
@@ -961,6 +962,41 @@ def test_a_zero_timeout_still_fails_fast_and_still_arms_the_guard(monkeypatch):
     )
 
 
+def test_a_script_that_never_compiles_is_left_to_the_ceiling_to_retry():
+    """If the script never started, the guard must stay out of the way.
+
+    A ``--require`` preload is loaded before node reads the main script, so a
+    stall in reading or compiling it sits inside the preload's lifetime. Marking
+    that 87 would be a clean, deterministic exit -- and therefore *not* retried,
+    which is exactly backwards for the pre-script stall this launcher exists to
+    recover from. The deadline only starts once ``_compile`` has fired.
+    """
+    node_path = _node_or_skip()
+
+    # NODE_OPTIONS carries a second preload that throws while loading, so node
+    # dies before the main script is ever compiled -- the closest reproducible
+    # stand-in for "the script never started".
+    exploding = Path(node_harness._preload_path()).with_name("neko-explode.js")
+    exploding.write_text("throw new Error('boom');\n", encoding="utf-8")
+    try:
+        result = run_node_script(
+            node_path,
+            "process.stdout.write('never');\n",
+            capture_output=True,
+            check=False,
+            timeout=5,
+            env={**os.environ, "NODE_OPTIONS": f"--require {exploding}"},
+        )
+    finally:
+        exploding.unlink(missing_ok=True)
+
+    assert result.returncode != node_harness._WATCHDOG_EXIT_CODE, (
+        "脚本根本没被编译过，不该被判成「脚本超时」——那是不可重试的确定性失败，"
+        f"而这正是要留给外层 ceiling 重试的情况：rc={result.returncode}"
+    )
+    assert result.stdout == ""
+
+
 def test_the_script_budget_is_counted_from_the_preload_not_process_start():
     """Bootstrap time belongs to the spawn stall, not to the script.
 
@@ -971,11 +1007,65 @@ def test_the_script_budget_is_counted_from_the_preload_not_process_start():
     """
     preload = node_harness._PRELOAD_SOURCE
 
-    assert "const startedAt = millisNow();" in preload
-    assert "millisNow() - startedAt > deadlineMs" in preload
+    assert "let startedAt = null;" in preload
+    assert "startedAt = millisNow();" in preload
+    assert "startedAt !== null && millisNow() - startedAt > deadlineMs" in preload
+    assert "Module.prototype._compile" in preload, (
+        "预算要从「node 编译脚本」那一刻起算，靠的就是这个钩子"
+    )
     assert "uptime()" not in preload, (
         "uptime() 从进程启动算起，会把 node 自己的 bootstrap 记到脚本头上"
     )
+
+
+def test_the_child_keeps_the_environment_it_would_have_inherited(monkeypatch):
+    """The deadline is *added* to the environment, not substituted for it.
+
+    Found by mutation: replacing the inherited environment with a bare dict
+    survived every test. A harness that reads an env var -- or anything relying
+    on PATH, NODE_OPTIONS, or the locale -- would start failing for reasons with
+    no connection to what it tests.
+    """
+    monkeypatch.setenv("NEKO_HARNESS_ENV_WITNESS", "kept")
+    seen = {}
+
+    def _fake_run(argv, **kwargs):
+        seen["env"] = kwargs.get("env") or {}
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(node_harness.subprocess, "run", _fake_run)
+    run_node_script("node", "process.stdout.write('ok');", timeout=5)
+
+    assert seen["env"].get("NEKO_HARNESS_ENV_WITNESS") == "kept", (
+        "继承来的环境被整个换掉了，调用方依赖的 env 会莫名其妙消失"
+    )
+    assert seen["env"][node_harness._DEADLINE_ENV] == "5000"
+
+
+@pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
+def test_a_harness_that_stubs_fs_writesync_still_gets_the_diagnosis(runner):
+    """``require('node:fs')`` hands the script the preload's own module object.
+
+    Found by mutation: reading ``fs.writeSync`` at report time instead of
+    binding it up front survived, because the surviving tests only checked the
+    exit code -- which comes from a different snapshot. The diagnosis is the
+    part that tells the next person what leaked, so it is the part worth
+    pinning.
+    """
+    node_path = _node_or_skip()
+
+    script = (
+        "require('node:fs').writeSync = () => {};\n"
+        "setInterval(function () {}, 1000);\n"
+        "process.stdout.write('started');\n"
+    )
+    result = runner(node_path, script, capture_output=True, check=False, timeout=2)
+
+    assert result.returncode == node_harness._WATCHDOG_EXIT_CODE
+    assert "[node_harness]" in result.stderr, (
+        f"被打桩的 fs.writeSync 把诊断吞掉了：stderr={result.stderr!r}"
+    )
+    assert "still had pending work" in result.stderr
 
 
 def test_the_guard_never_edits_the_script_it_is_guarding():

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -725,83 +725,37 @@ def test_a_silent_stall_is_still_retried():
     assert len(calls) == 2
 
 
-def test_a_stall_that_only_wrote_to_stderr_is_not_retried():
-    """Evidence is evidence whichever stream it came out of.
+def test_output_from_a_pre_main_preload_does_not_count_as_started():
+    """Output proves nothing about the harness, in either direction.
 
-    A harness that reports through ``console.error`` leaves its trace on stderr
-    alone; counting only stdout would send that straight back into a pointless
-    retry. Found by mutation - nothing else in this file covered it.
+    An inherited ``NODE_OPTIONS=--require`` module runs before the guard and
+    before the script; if it prints and then stalls, the old output fallback
+    read that as "the harness ran" and suppressed the retry -- for an attempt
+    where the harness was never reached at all.
     """
     calls = []
+    ok = subprocess.CompletedProcess(["node"], 0, "ok", "")
 
     def _fake_run(argv, **kwargs):
         calls.append(argv)
-        raise subprocess.TimeoutExpired(
-            argv, kwargs.get("timeout"), output="", stderr="started"
-        )
-
-    original = node_harness.subprocess.run
-    node_harness.subprocess.run = _fake_run
-    try:
-        with pytest.raises(subprocess.TimeoutExpired):
-            run_node_script("node", "process.stdout.write('ok');", timeout=1)
-    finally:
-        node_harness.subprocess.run = original
-
-    assert len(calls) == 1, "只往 stderr 写的脚本同样证明它跑起来了，不该重试"
-
-
-def test_a_caller_that_captures_nothing_is_told_its_silence_proves_nothing():
-    """Eight call sites do not capture, so their stalls can never show output.
-
-    ``communicate()`` returns None rather than "" when there was no pipe, which
-    is indistinguishable from an empty capture unless the error says so. Without
-    that line the message would tell the reader the script probably never ran,
-    on a run where nothing was ever in a position to observe it.
-    """
-    calls = []
-
-    def _fake_run(argv, **kwargs):
-        calls.append(argv)
-        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"))
-
-    original = node_harness.subprocess.run
-    node_harness.subprocess.run = _fake_run
-    try:
-        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
-            # No capture_output: exactly what test_pngtuber_static_contracts.py
-            # and friends do.
-            run_node_script("node", "process.stdout.write('ok');", timeout=1)
-    finally:
-        node_harness.subprocess.run = original
-
-    assert len(calls) == 2, "看不见输出时无从判断，重试仍是对的默认"
-    message = str(excinfo.value)
-    assert "unobserved rather than empty" in message, (
-        f"没抓输出的调用方必须被告知这份「安静」什么也证明不了：{message}"
-    )
-    assert "probably never" not in message, (
-        f"没有管道可看的时候不能下「脚本没跑起来」的结论：{message}"
-    )
-
-
-def test_a_capturing_caller_is_not_given_the_unobserved_note():
-    """The dual: a real empty capture is evidence, and must not be hedged away."""
-
-    def _fake_run(argv, **kwargs):
-        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout"), output="", stderr="")
-
-    original = node_harness.subprocess.run
-    node_harness.subprocess.run = _fake_run
-    try:
-        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
-            run_node_script(
-                "node", "process.stdout.write('ok');", capture_output=True, timeout=1
+        if len(calls) == 1:
+            # Output, but no marker: exactly what a chatty pre-main preload
+            # leaves behind.
+            raise subprocess.TimeoutExpired(
+                argv, kwargs.get("timeout"), output="from a preload", stderr="noise"
             )
+        return ok
+
+    original = node_harness.subprocess.run
+    node_harness.subprocess.run = _fake_run
+    try:
+        assert run_node_script("node", "process.stdout.write('ok');", timeout=3) is ok
     finally:
         node_harness.subprocess.run = original
 
-    assert "unobserved rather than empty" not in str(excinfo.value)
+    assert len(calls) == 2, (
+        "预载在主脚本之前吐的东西不能算「脚本跑过了」——那次尝试该重试"
+    )
 
 
 def test_the_wrapped_error_reports_the_second_attempt_not_the_first():
@@ -835,7 +789,10 @@ def test_the_wrapped_error_reports_the_second_attempt_not_the_first():
     assert excinfo.value.stdout == "second-out"
     assert excinfo.value.stderr == "second-err"
     # Both are still listed; only the exception's own fields follow the last one.
-    assert str(excinfo.value).count("attempt ") == 2
+    # Count the per-attempt lines, not the word: the diagnosis prose says
+    # "the attempt was repeated" and would inflate a bare substring count.
+    listed = [l for l in str(excinfo.value).splitlines() if l.startswith("  attempt ")]
+    assert len(listed) == 2, listed
 
 
 def test_the_wrapped_error_keeps_a_stalled_attempt_output_where_callers_look():
@@ -1281,7 +1238,7 @@ def test_the_guard_never_edits_the_script_it_is_guarding():
 
     assert seen["script"] == awkward, "脚本被改写了，注入式护栏的所有坑就都回来了"
     assert seen["argv"][1] == "--require", seen["argv"]
-    assert seen["argv"][2].endswith(".neko-harness-guard.js"), seen["argv"]
+    assert seen["argv"][2].endswith(".neko-harness-guard.cjs"), seen["argv"]
 
 
 def test_one_preload_file_serves_the_whole_process():

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -963,7 +963,7 @@ def test_a_zero_timeout_still_fails_fast_and_still_arms_the_guard(monkeypatch):
 
 
 @pytest.mark.parametrize("runner", [run_node_script, run_node_stdin])
-def test_another_preloads_dependency_does_not_start_the_budget(runner):
+def test_another_preloads_dependency_does_not_start_the_budget(runner, tmp_path):
     """The clock must start at the harness script, not at the first compile.
 
     An inherited ``NODE_OPTIONS`` can add preloads of its own, and an ESM
@@ -977,9 +977,10 @@ def test_another_preloads_dependency_does_not_start_the_budget(runner):
     """
     node_path = _node_or_skip()
 
-    directory = Path(node_harness._preload_path()).parent
-    dependency = directory / "neko-probe-dep.cjs"
-    slow_import = directory / "neko-probe-slow.mjs"
+    # tmp_path, not the shared temp dir: fixed names there let one parametrised
+    # instance delete the .mjs another is still loading.
+    dependency = tmp_path / "neko-probe-dep.cjs"
+    slow_import = tmp_path / "neko-probe-slow.mjs"
     dependency.write_text("module.exports = 1;\n", encoding="utf-8")
     slow_import.write_text(
         "import { createRequire } from 'node:module';\n"


### PR DESCRIPTION
## 现象

`tests/unit/test_badminton_improvement_contract.py::test_badminton_deferred_character_resolution_starts_only_active_requests` 在 Windows CI 上间歇 30 秒超时：

```
subprocess.TimeoutExpired: Command '['C:\Program Files\nodejs\node.EXE', 'C:\...\Temp\tmprxd2d7yf.js']' timed out after 30 seconds
```

main 最近 8 次 Unit Tests 里撞到 2 次（run 33610251092、以及 PR #3035 的 run 33647379696）。#3035 完全没碰 `tests/` 或 `static/`，所以是 main 上的存量 flake，不是哪个 PR 引入的。

## 不是 harness 有一条路径不 resolve

这是最先要排掉的假设。三个方向都指向同一个结论：

**代码层面。** `startRoute()` 里的 `heartbeatTimer` / `drainTimer` 只在 `res.ok` 分支里 `setInterval`，而这个 harness 的 `post('/route/start')` 恒返回 `{ ok: false }`——四个场景一个都走不到那两行。每个 `await` 的 promise 都由驱动代码显式 resolve。

**实测。** 40/40 次全部落在 51–58 ms，其中 37 ms 是 node 自身启动，脚本本体约 17 ms。32 路 CPU 超订之下分布纹丝不动：

| 负载 | n | min | p50 | p95 | max |
|---|---|---|---|---|---|
| 空闲 | 20 | 0.051 | 0.054 | 0.055 | 0.056 |
| 32 路超订 | 20 | 0.052 | 0.055 | 0.057 | 0.058 |

**traceback 落点。** CI 的报错在 `subprocess.py:1630`。3.11 里那一行是 **stdout reader 线程**那条（`orig_timeout` 这个变量只出现在 `_communicate`，`_wait` 用的是 `timeout`）。也就是说 node 进程整整 30 秒活着、握着 stdout 管道没退出。

## 也不是 runner 整体变慢

那次 run 全程 1008 s，对比同一套件 634–707 s 的中位数只慢 1.56 倍，而 55 ms 变成 30 s 是 545 倍。

全仓 46 个 node harness 调用点里有 15 个用的是更紧的 10 s 上限，跨最近 10 次红 run 一次都没超时过——均匀变慢的话先倒的应该是它们。

剩下的解释只有一个：**那一次 spawn 卡在了脚本之外**——建进程、把脚本从盘上读进来、或者 V8 bootstrap。测试对此无能为力，而且此时一条断言都还没跑到。

## 改法

不是把 30 s 调大，是让这两种情况能被分开。

**脚本自带 deadline。** 往每个 harness 脚本尾部追加一个 `unref()` 过的 watchdog。`unref` 意味着事件循环空了 node 照常先退出、watchdog 永不触发；只有真的还有 handle 攥着循环时它才会响，把 `process.getActiveResourcesInfo()` 打出来并以 87 退出。于是「忘了 `clearInterval`」「`await` 一个永远不来的 promise」变成一条点名到具体 handle 的确定性失败，而不是一个没有任何信息的超时——也因此永远不会被重试。

**外层 ceiling 抬高 5 秒。** 调用方给的 `timeout` 仍然是脚本自己的预算，一秒不减；`subprocess` 的上限比它高 5 秒。这个先后顺序是整个分类的地基：`TimeoutExpired` 活下来就说明 watchdog 没来得及跑。

**静默的那种重试一次。** 卡住但吐了东西 = 脚本跑过 = 立刻报、不重试；只有全程静默才重试。两次都卡则抛 `NodeHarnessSpawnTimeout`（`TimeoutExpired` 的子类，现有 `except` 不受影响，最后一次的 stdout/stderr 照常挂在 `.stdout`/`.stderr` 上）。

**没传 `timeout` 的 23 个调用点**原本的上限是 25 分钟的 job cap，现在拿到 120 s 的脚本 deadline。全仓最慢的 harness 实测 5.1 s。

### 一个中途踩到的坑

watchdog 一律走 `globalThis`。第一版调的是裸 `setTimeout`，被 `tests/unit/test_avatar_annotation_frontend.py` 当场打脸——那个 harness 用 `const setTimeout = (callback) => callback()` 驱动假时钟，watchdog 拿到的是它的假货、当场自杀。`const` 影子更狠：整个模块作用域连读一下都会撞 TDZ。仓库里有 3 个文件这么干。已补 `test_a_harness_that_shadows_the_timers_still_runs_clean` 钉住。

## Summary by CodeRabbit

- **可靠性改进**
  - 改进 Node 脚本超时处理，区分启动超时与执行中阻塞，并支持启动阶段有限次数重试。
  - 脚本计时从正式启动阶段开始，减少预加载和输入处理造成的误判。
  - 超时报告提供更完整的诊断信息，并保留脚本输出。
  - 文件与标准输入运行方式均获得一致的超时保护。
  - 改进启动状态识别及每次尝试后的资源清理。
  - CommonJS 脚本支持该启动监控，ES 模块脚本不启用此监控。
- **测试**
  - 增加对超时、重试、输出保留、环境继承及异常诊断等场景的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 最终形态

护栏是一个 `node --require` 预加载的模块 —— **被测脚本一个字节都不改**。它在脚本之前运行、有自己的模块作用域，并在启动时把之后要用的一切快照下来（`process` / `exit` / `writeSync` / `writeFileSync` / timer / 单调时钟 / `JSON.stringify`），因为预载够不到调用方的词法作用域，却够得到共享对象。

预算从 **node 编译 harness 脚本**那一刻起算（`Module.prototype._compile`，认准主模块，`node -` 走 `[stdin]-wrapper`）。此前的一切 —— bootstrap、读临时文件、抽干 stdin、别人预载的依赖 —— 都在预算之外，因为那正是外层 ceiling 要抓并重试的东西。

两个执行器兑现这个 deadline：`unref()` 的 timer 管「根本不退出」，`exit` 钩子管「跑超了然后结束」（含脚本自己 `process.exit(0)`、未捕获抛出）。

重试与否**不靠猜**：预载在编译时落一个标记文件，launcher 据此确定「有没有东西被测过」。没到过脚本 → 重试；到过 → 原样报告。

## Review 收敛记录

17 个 commit。每一条都实测确认过，不是照单全收：

| 收下的（按发现顺序） | 判据 |
|---|---|
| 同步卡死被当成 spawn stall 重试 | 分类反转 |
| `TimeoutExpired` 丢掉 `.stdout`/`.stderr` | 与 `subprocess.run` 行为不一致 |
| 没传 `timeout` 的 23 个调用点连 ceiling 都没有 | 能跑到 25 分钟 job cap |
| 跑超预算再结束的脚本返回 0 | **我引入的回归** |
| 脚本自己 `exit(0)` 绕过 deadline | 分类反转 |
| `'use strict'` / hashbang / 行号被注入破坏 | 静默降级 |
| `setTimeout` / `globalThis` / `Function` / `process` / `Date.now` / `fs.writeSync` 可被影子化 | `Date.now` 点名 3 个真实 harness；`process.exit` 是常规打桩 |
| POSIX 上 `TimeoutExpired` 是 bytes | 测试只在 Windows CI 绿 |
| `timeout=0` 被变成「5 秒且无护栏」 | 两头都错 |
| 预算含 bootstrap / 含 ingestion / 认第一次编译 | 分类反转 ×3 |
| 退出码双定义、空 `except`、`count == 1`、probe 文件共享目录 | 测试卫生 |

**没收下的 5 条**（留开待人判，理由在各自 thread）：

| 意见 | 不收的理由 |
|---|---|
| watchdog 保持 `ref` 直到脚本报完成 | 要给 46 个调用点加握手，健康脚本从 55ms 变成等满 deadline |
| `Popen` 构造期卡死不受 ceiling 管 | 要把 CreateProcess 挪到线程 join，卡死时留下杀不掉的孤儿线程；本次 traceback 落在 stdout reader 线程，进程是建出来了的 |
| Windows 上 `.stdout` 是 bytes | 实测为 `str`（`_utf8()` 钉了 encoding）。POSIX 那条是另一回事，已收下 |
| 后注册的 `exit` 监听器能改回 `exitCode` | 对抗性场景：能这么写也能 `process.reallyExit(0)`；诊断仍在 stderr、ceiling 仍兜底 |
| ESM stdin 入口不触发 CJS 编译钩子 | 自相矛盾：`--input-type=module` 下 26 个 CJS harness 第一句 `require` 就炸（实测 rc=1），护栏不会在套件还绿时悄悄失效。边界已写进 docstring |

## 一次自己造的事故

`5649960` 里推上去过一个**变异体**（`__MILLIS__` 写死 9000）—— 变异脚本在后台跑的同时我做了 `git add` + push，提交拍到了中间态。Greptile 报 P1 才发现，已在 `3209c56` 撤回。

值得记的是：那个 mutant **被 5 条用例打红**。测试是有效的，失效的是流程 —— 我提交的那份内容，没有任何一次测试跑过它。变异脚本随后加了四道：脏树拒跑、还原从 `git show HEAD:` 取、退出前断言与 HEAD 逐字节相同、锁文件防并发。

## 验证

契约套件 **66 passed**；41 个使用 node harness 的测试文件全量 **902 passed / 1 skipped**；健康脚本耗时分布无变化（p50 0.051s，n=242）；`scripts/check_docstring_no_cjk.py --base origin/main` 退出 0。

变异验证累计 30+ 个 mutant，全部收敛到零存活或已说明的等价变异。其中变异**独立抓到过我自己的两处盲点**：行号断言 `":3" in stderr` 会匹配列号；`fs.writeSync` 不快照时只看退出码的用例发现不了诊断被吞。

## 留给后面的

`test_avatar_annotation_frontend.py` 有两次调用实测 5.05s、上限 10s —— 2 倍余量，是这套件里下一个最可能超时的地方。本 PR 没动它。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 Node harness 启动超时检测，仅在确认启动标记生成后判定启动成功。
  * 优化文件与标准输入运行路径的超时重试和诊断，减少误判。
  * 改进超时错误提示，覆盖启动阶段及事件循环阻塞等情况。
  * 固定预加载脚本采用 CommonJS 解析，避免受项目模块配置影响。
  * 优化启动计时，避免将依赖模块编译时间计入统计。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->