### PR TITLE
ci(nightly): 在桌面 nightly 里加一条 Linux arm64 试验腿

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -889,7 +889,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"}]' || '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"},{"os":"macos-15","platform":"mac-x64","portable_key":"mac_x64","builder_platform":"macos","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/mac/N.E.K.O.app","python_artifact":"python-backend-mac-x64","electron_args":"--mac --x64","artifact_name":"desktop-mac-x64"},{"os":"macos-latest","platform":"mac-arm64","portable_key":"mac_arm64","builder_platform":"macos","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/mac-arm64/N.E.K.O.app","python_artifact":"python-backend-mac-arm64","electron_args":"--mac --arm64","artifact_name":"desktop-mac-arm64"},{"os":"ubuntu-latest","platform":"linux","portable_key":"linux_x64","builder_platform":"linux","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/linux-unpacked","python_artifact":"python-backend-linux","electron_args":"--linux","artifact_name":"desktop-linux-x64"},{"os":"ubuntu-24.04-arm","platform":"linux-arm64","portable_key":"linux_arm64","builder_platform":"linux","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/linux-arm64-unpacked","python_artifact":"python-backend-linux-arm64","electron_args":"--linux --arm64","artifact_name":"desktop-linux-arm64","experimental":true}]') }}
+        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"}]' || '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"},{"os":"macos-15","platform":"mac-x64","portable_key":"mac_x64","builder_platform":"macos","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/mac/N.E.K.O.app","python_artifact":"python-backend-mac-x64","electron_args":"--mac --x64","artifact_name":"desktop-mac-x64"},{"os":"macos-latest","platform":"mac-arm64","portable_key":"mac_arm64","builder_platform":"macos","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/mac-arm64/N.E.K.O.app","python_artifact":"python-backend-mac-arm64","electron_args":"--mac --arm64","artifact_name":"desktop-mac-arm64"},{"os":"ubuntu-latest","platform":"linux","portable_key":"linux_x64","builder_platform":"linux","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/linux-unpacked","python_artifact":"python-backend-linux","electron_args":"--linux","artifact_name":"desktop-linux-x64"},{"os":"ubuntu-24.04-arm","platform":"linux-arm64","portable_key":"linux_arm64","builder_platform":"linux","portable_arch_args":"--arm64","builder_target_args":"-c.linux.target=AppImage -c.linux.target=deb -c.linux.target=tar.gz","skip_portable_channel":true,"portable_dir":"dist/portable-stage/linux-arm64-unpacked","python_artifact":"python-backend-linux-arm64","electron_args":"--linux --arm64","artifact_name":"desktop-linux-arm64","experimental":true}]') }}
 
     runs-on: ${{ matrix.os }}
     # 同 build-python：linux-arm64 是试验腿，失败不应让 nightly 发布判红
@@ -1035,10 +1035,17 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
+      # `builder_target_args` 只有 linux-arm64 非空。N.E.K.O.-PC 的 package.json 把
+      # build.linux.target 三个 target 的 arch 写死成 ["x64"]，而 electron-builder 的
+      # computeArchToTargetNamesMap 只在 CLI 显式给了 target 名时才无视配置里的 arch：
+      # 光传 `--arm64` 会解析成 {arm64: [], x64: [AppImage, deb, tar.gz]}，也就是在
+      # arm64 机器上打出一套 x64 产物，文件名和真正的 x64 腿逐字相同，在 nightly 扁平的
+      # release/ 目录里互相覆盖。重复的 -c.linux.target= 把目标列表整个换掉，解析结果
+      # 才是 {arm64: [AppImage, deb, tar.gz]}；x64 腿传空串，行为不变。
       - name: Build Electron app (macOS/Linux)
         if: runner.os != 'Windows'
         working-directory: electron-app
-        run: node scripts/build-electron-distribution.js ${{ matrix.builder_platform }} ${{ matrix.portable_arch_args }} --publish never
+        run: node scripts/build-electron-distribution.js ${{ matrix.builder_platform }} ${{ matrix.portable_arch_args }} ${{ matrix.builder_target_args }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ (github.event_name == 'schedule' || inputs.skip_signing == 'true') && 'false' || 'true' }}
@@ -1052,8 +1059,14 @@ jobs:
 
       # Build a separate marked unpacked tree for the self-managed Portable
       # channel. On macOS the marker is added by afterPack before signing.
+      # skip_portable_channel 只有 linux-arm64 为 true：N.E.K.O.-PC 的 getTargetKey()
+      # 对 linux + arm64 返回 null，下面两个 create-portable-update.js 步骤会直接抛
+      # `Unsupported Portable target: linux-arm64` / `Invalid AppImage target`。把 arm64
+      # 接进 Portable 自更新通道要同时改闭源的 N.E.K.O.-PC（targetKey、manifest 资产名
+      # 正则、客户端解析），是独立决定；在那之前 arm64 只出 AppImage/deb/tar.gz 原始
+      # 产物，不进增量自更新。这一步的 --dir 产物只被那两步消费，一并跳过。
       - name: Build Electron app (macOS/Linux Portable directory)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.skip_portable_channel != true
         working-directory: electron-app
         run: node scripts/build-electron-distribution.js ${{ matrix.builder_platform }} --dir ${{ matrix.portable_arch_args }} --publish never -c.directories.output=dist/portable-stage
         env:
@@ -1067,7 +1080,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Download previous Portable manifests
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.previous_portable_release != ''
+        if: (startsWith(github.ref, 'refs/tags/v') || inputs.previous_portable_release != '') && matrix.skip_portable_channel != true
         working-directory: electron-app
         shell: bash
         env:
@@ -1131,7 +1144,7 @@ jobs:
             ${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
 
       - name: Create macOS/Linux Portable directory update assets
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.skip_portable_channel != true
         working-directory: electron-app
         shell: bash
         env:
@@ -1157,7 +1170,7 @@ jobs:
             ${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
 
       - name: Create Linux AppImage full and differential update assets
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.skip_portable_channel != true
         working-directory: electron-app
         shell: bash
         env:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1295,6 +1295,20 @@ jobs:
             SIGNING_NOTE="signed"
           fi
 
+          # linux-arm64 是 continue-on-error 的试验腿，红了不会挡住这一步发布，
+          # 但那时它的 artifact 根本没上传。表格行必须跟着实际产物走，否则发布说明
+          # 会一直挂着两条下不到的下载。判据用 artifact 目录名（本 workflow 矩阵里
+          # 自己定的 artifact_name），不猜 electron-builder 的输出文件名。
+          NL=$'\n'
+          ARM64_DESKTOP_ROW=""
+          ARM64_BACKEND_ROW=""
+          if [ -d "artifacts/desktop-linux-arm64" ]; then
+            ARM64_DESKTOP_ROW="${NL}| Linux arm64 (experimental) | \`N.E.K.O-*-arm64.AppImage\` / \`.deb\` / \`.tar.gz\` |"
+          fi
+          if [ -d "artifacts/python-backend-linux-arm64" ]; then
+            ARM64_BACKEND_ROW="${NL}| Linux arm64 (experimental) | \`python-backend-linux-arm64-*.zip\` |"
+          fi
+
           gh release create nightly release/* \
             --title "Nightly Build ${DATE}" \
             --target "${{ github.sha }}" \
@@ -1315,8 +1329,7 @@ jobs:
           | Windows x64 | \`N.E.K.O_*_win.zip\` (Portable) |
           | macOS Intel | \`N.E.K.O-*.dmg\` / \`.zip\` |
           | macOS Apple Silicon | \`N.E.K.O-*-arm64.dmg\` / \`.zip\` |
-          | Linux x64 | \`N.E.K.O-*.AppImage\` / \`.deb\` / \`.tar.gz\` |
-          | Linux arm64 (experimental) | \`N.E.K.O-*-arm64.AppImage\` / \`.deb\` / \`.tar.gz\` |
+          | Linux x64 | \`N.E.K.O-*.AppImage\` / \`.deb\` / \`.tar.gz\` |${ARM64_DESKTOP_ROW}
 
           ### Python Backend Only (standalone, no Electron)
           | Platform | File |
@@ -1324,8 +1337,7 @@ jobs:
           | Windows x64 | \`python-backend-win-*.zip\` |
           | macOS Intel | \`python-backend-mac-x64-*.zip\` |
           | macOS Apple Silicon | \`python-backend-mac-arm64-*.zip\` |
-          | Linux x64 | \`python-backend-linux-*.zip\` |
-          | Linux arm64 (experimental) | \`python-backend-linux-arm64-*.zip\` |
+          | Linux x64 | \`python-backend-linux-*.zip\` |${ARM64_BACKEND_ROW}
 
           ---
           Built from [\`${VERSION}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -126,9 +126,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe"}]' || '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe"},{"os":"macos-15","platform":"mac-x64","python_arch":"x64","artifact_name":"python-backend-mac-x64","output_binary":"projectneko_server"},{"os":"macos-latest","platform":"mac-arm64","artifact_name":"python-backend-mac-arm64","output_binary":"projectneko_server"},{"os":"ubuntu-latest","platform":"linux","artifact_name":"python-backend-linux","output_binary":"projectneko_server"}]') }}
+        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe"}]' || '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe"},{"os":"macos-15","platform":"mac-x64","python_arch":"x64","artifact_name":"python-backend-mac-x64","output_binary":"projectneko_server"},{"os":"macos-latest","platform":"mac-arm64","artifact_name":"python-backend-mac-arm64","output_binary":"projectneko_server"},{"os":"ubuntu-latest","platform":"linux","artifact_name":"python-backend-linux","output_binary":"projectneko_server"},{"os":"ubuntu-24.04-arm","platform":"linux-arm64","artifact_name":"python-backend-linux-arm64","output_binary":"projectneko_server","experimental":true}]') }}
 
     runs-on: ${{ matrix.os }}
+    # 试验性矩阵项（linux-arm64）单独失败时不把整个 job 判红：nightly 发布的门是
+    # `needs.build-python.result == 'success'`，arm64 这条腿一红，正式的
+    # win / mac / linux-x64 产物就会跟着一起不发布。
+    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 300
     steps:
       - name: Checkout backend repo
@@ -550,6 +554,12 @@ jobs:
           elif [[ "$RUNNER_OS" == "Linux" ]]; then
             rm -f steamworks/SteamworksPy.dylib steamworks/libsteam_api.dylib \
                   steamworks/SteamworksPy64.dll steamworks/steam_api64.dll steamworks/steam_api64.lib
+            # 仓库里的 Steam .so 只有 x86-64 一份，喂给 arm64 runner 上的 Nuitka
+            # 会撞上和 macOS 分支同一个 arch-mismatch FATAL；Steam 也没有 arm64
+            # Linux 客户端，所以在非 x86_64 的 Linux 上整块剥掉、不打包。
+            if [[ "$(uname -m)" != "x86_64" ]]; then
+              rm -f steamworks/SteamworksPy.so steamworks/libsteam_api.so
+            fi
             if [ -f "steamworks/libsteam_api.so" ]; then
               NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.so=libsteam_api.so"
             fi
@@ -879,9 +889,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"}]' || '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"},{"os":"macos-15","platform":"mac-x64","portable_key":"mac_x64","builder_platform":"macos","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/mac/N.E.K.O.app","python_artifact":"python-backend-mac-x64","electron_args":"--mac --x64","artifact_name":"desktop-mac-x64"},{"os":"macos-latest","platform":"mac-arm64","portable_key":"mac_arm64","builder_platform":"macos","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/mac-arm64/N.E.K.O.app","python_artifact":"python-backend-mac-arm64","electron_args":"--mac --arm64","artifact_name":"desktop-mac-arm64"},{"os":"ubuntu-latest","platform":"linux","portable_key":"linux_x64","builder_platform":"linux","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/linux-unpacked","python_artifact":"python-backend-linux","electron_args":"--linux","artifact_name":"desktop-linux-x64"}]') }}
+        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"}]' || '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"},{"os":"macos-15","platform":"mac-x64","portable_key":"mac_x64","builder_platform":"macos","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/mac/N.E.K.O.app","python_artifact":"python-backend-mac-x64","electron_args":"--mac --x64","artifact_name":"desktop-mac-x64"},{"os":"macos-latest","platform":"mac-arm64","portable_key":"mac_arm64","builder_platform":"macos","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/mac-arm64/N.E.K.O.app","python_artifact":"python-backend-mac-arm64","electron_args":"--mac --arm64","artifact_name":"desktop-mac-arm64"},{"os":"ubuntu-latest","platform":"linux","portable_key":"linux_x64","builder_platform":"linux","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/linux-unpacked","python_artifact":"python-backend-linux","electron_args":"--linux","artifact_name":"desktop-linux-x64"},{"os":"ubuntu-24.04-arm","platform":"linux-arm64","portable_key":"linux_arm64","builder_platform":"linux","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/linux-arm64-unpacked","python_artifact":"python-backend-linux-arm64","electron_args":"--linux --arm64","artifact_name":"desktop-linux-arm64","experimental":true}]') }}
 
     runs-on: ${{ matrix.os }}
+    # 同 build-python：linux-arm64 是试验腿，失败不应让 nightly 发布判红
+    # （nightly 的门是 `needs.build-electron.result != 'failure'`）。
+    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 180
     steps:
       - name: Checkout Electron frontend
@@ -1084,13 +1097,13 @@ jobs:
           else
             echo "No previous ${PORTABLE_KEY} Portable manifest found in release ${PREVIOUS_RELEASE_TAG}; this release will contain a full package only"
           fi
-          if [[ "$PORTABLE_KEY" == "linux_x64" ]]; then
+          if [[ "$PORTABLE_KEY" == linux_* ]]; then
             APPIMAGE_URL="$(gh api "$RELEASE_ENDPOINT" \
-              --jq '[.assets[] | select(.name | endswith("_linux_x64_appimage_manifest.json"))][0].browser_download_url // empty' \
+              --jq '[.assets[] | select(.name | endswith("_" + env.PORTABLE_KEY + "_appimage_manifest.json"))][0].browser_download_url // empty' \
               2>/dev/null || true)"
             if [[ -n "$APPIMAGE_URL" ]]; then
               curl --fail --location --retry 3 "$APPIMAGE_URL" \
-                --output previous-portable/previous-linux_x64_appimage-manifest.json
+                --output "previous-portable/previous-${PORTABLE_KEY}_appimage-manifest.json"
             fi
           fi
 
@@ -1133,7 +1146,8 @@ jobs:
           PLATFORM=linux
           ARCH=x64
           [[ "$PORTABLE_KEY" == mac_* ]] && PLATFORM=darwin
-          [[ "$PORTABLE_KEY" == "mac_arm64" ]] && ARCH=arm64
+          # mac_arm64 与 linux_arm64 共用同一条后缀判据，别退回逐个平台列举。
+          [[ "$PORTABLE_KEY" == *_arm64 ]] && ARCH=arm64
           node scripts/create-portable-update.js \
             --dir "$PORTABLE_DIR" \
             --platform "$PLATFORM" \
@@ -1146,18 +1160,20 @@ jobs:
         if: runner.os == 'Linux'
         working-directory: electron-app
         shell: bash
+        env:
+          PORTABLE_KEY: ${{ matrix.portable_key }}
         run: |
           set -euo pipefail
           shopt -s nullglob
           APPIMAGES=(dist/*.AppImage)
           [[ ${#APPIMAGES[@]} -eq 1 ]] || { echo "Expected exactly one AppImage"; exit 1; }
           PREVIOUS_ARGS=()
-          PREVIOUS=previous-portable/previous-linux_x64_appimage-manifest.json
+          PREVIOUS="previous-portable/previous-${PORTABLE_KEY}_appimage-manifest.json"
           if [[ -f "$PREVIOUS" ]]; then PREVIOUS_ARGS=(--previous "$PREVIOUS"); fi
           PORTABLE_VERSION="$(node -p "require('./package.json').version")"
           node scripts/create-portable-update.js \
             --appimage "${APPIMAGES[0]}" \
-            --arch x64 \
+            --arch "${PORTABLE_KEY#linux_}" \
             --version "$PORTABLE_VERSION" \
             --out dist/portable-update \
             ${PREVIOUS_ARGS[@]+"${PREVIOUS_ARGS[@]}"}
@@ -1300,6 +1316,7 @@ jobs:
           | macOS Intel | \`N.E.K.O-*.dmg\` / \`.zip\` |
           | macOS Apple Silicon | \`N.E.K.O-*-arm64.dmg\` / \`.zip\` |
           | Linux x64 | \`N.E.K.O-*.AppImage\` / \`.deb\` / \`.tar.gz\` |
+          | Linux arm64 (experimental) | \`N.E.K.O-*-arm64.AppImage\` / \`.deb\` / \`.tar.gz\` |
 
           ### Python Backend Only (standalone, no Electron)
           | Platform | File |
@@ -1308,6 +1325,7 @@ jobs:
           | macOS Intel | \`python-backend-mac-x64-*.zip\` |
           | macOS Apple Silicon | \`python-backend-mac-arm64-*.zip\` |
           | Linux x64 | \`python-backend-linux-*.zip\` |
+          | Linux arm64 (experimental) | \`python-backend-linux-arm64-*.zip\` |
 
           ---
           Built from [\`${VERSION}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})

--- a/tests/unit/test_desktop_windows_workflow_contract.py
+++ b/tests/unit/test_desktop_windows_workflow_contract.py
@@ -104,7 +104,7 @@ def test_reusable_build_honors_signing_inputs_and_distribution_wrapper() -> None
     assert distribution["run"] == (
         "node scripts/build-electron-distribution.js "
         "${{ matrix.builder_platform }} ${{ matrix.portable_arch_args }} "
-        "--publish never"
+        "${{ matrix.builder_target_args }} --publish never"
     )
 
     nightly_steps = _steps_by_name(workflow, "nightly")


### PR DESCRIPTION
Closes #2907（Feature Request: Add prebuild version for linux/arm64）

## 做了什么

`build-desktop.yml`（桌面 nightly）的 `build-python` / `build-electron` 两个矩阵各加一条 `ubuntu-24.04-arm` 的腿：

| 矩阵项 | runner | 产物 |
|---|---|---|
| `linux-arm64` (build-python) | `ubuntu-24.04-arm` | `python-backend-linux-arm64` |
| `linux-arm64` (build-electron) | `ubuntu-24.04-arm` | `desktop-linux-arm64`（AppImage / deb / tar.gz） |

产物走原有的 `Organize release files` 通配（`artifacts/python-backend-*`、`artifacts/desktop-*`），自动进 nightly release。

## 失败隔离

这条腿标 `"experimental":true`，两个 job 都加 `continue-on-error: ${{ matrix.experimental || false }}`。

nightly 发布的门是 `needs.build-python.result == 'success' && needs.build-electron.result != 'failure'`。不隔离的话，arm64 这条新腿一旦红，**正式的 win / mac / linux-x64 产物会跟着一起不发布**。

release notes 里那两行 arm64 按 `artifacts/desktop-linux-arm64` / `artifacts/python-backend-linux-arm64` 是否存在**条件输出** —— 腿红了不上传 artifact，行也就不出现，不会挂着两条下不到的下载。

## 两处必须绕开的堵点（拿本地 N.E.K.O.-PC checkout 实跑查出来的）

**1. `build.linux.target` 把 arch 写死成 `["x64"]`**

electron-builder 的 `computeArchToTargetNamesMap` 只在 CLI 显式给了 target 名时才无视配置里的 arch。光传 `--arm64`，解析结果是：

```
{arm64: [], x64: ["AppImage","deb","tar.gz"]}
```

也就是 arm64 腿会在 arm64 机器上打出一整套 **x64** 产物，文件名和真 x64 腿逐字相同，在 nightly 扁平的 `release/` 目录里互相覆盖。

修法是再传三个 `-c.linux.target=`（矩阵字段 `builder_target_args`，其余腿为空串），解析结果才是 `{arm64: ["AppImage","deb","tar.gz"]}`。x64 腿传空串，实测解析结果不变。`--dir` 的 portable-stage 分支本来就显式给了 target 名，不受影响。

**2. `getTargetKey()` 不认 linux + arm64**

`src/main/portable-update.js` 的 `getTargetKey('linux','arm64',…)` 对 archive / appimage 两种 distribution 都返回 `null`，两个 `create-portable-update.js` 步骤会直接抛 `Unsupported Portable target: linux-arm64` / `Invalid AppImage target`。

**没有**去扩 `getTargetKey()`：那要改闭源的 N.E.K.O.-PC，且会把 arm64 拉进 Portable 增量自更新通道（manifest 资产名正则、客户端 targetKey 解析都得跟着动），是一个独立的产品决定。在那之前，整条 Portable 链对 arm64 腿用 `skip_portable_channel` 跳过（含只被那两步消费的 `--dir` 构建），arm64 先只出 AppImage/deb/tar.gz 原始产物，**不进增量自更新**。

## 顺带按 arch 参数化的几处写死 x64 的 Linux 逻辑

- **Steam 原生库**：仓库里 `steamworks/*.so` 只有 x86-64 一份，喂给 arm64 runner 上的 Nuitka 会撞上和现有 macOS 分支同一个 arch-mismatch FATAL；Steam 本来也没有 arm64 Linux 客户端 —— 非 `x86_64` 的 Linux 上整块 `rm -f`。
- **Portable 差分基线**：写死的 `previous-linux_x64_appimage-manifest.json` 与 jq 过滤串改成按 `$PORTABLE_KEY` 取；AppImage 的 `--arch x64` 改成 `${PORTABLE_KEY#linux_}`。（arm64 腿现在走不到这里，但保留对偶。）
- **ARCH 推导**：`[[ "$PORTABLE_KEY" == "mac_arm64" ]]` 改成 `[[ "$PORTABLE_KEY" == *_arm64 ]]`，mac / linux 共用一条后缀判据。

## 验证

- `yaml.safe_load` + 两个矩阵 JSON 解出来逐条核对（各 5 条腿，只有 arm64 带 `experimental` / `builder_target_args` / `skip_portable_channel`）。
- 改动过的三个 `run:` 块 `bash -n` 过。
- jq 换成 `env.PORTABLE_KEY` 后拿真 nightly release 打过对照：`linux_x64` 仍取到现有的 `..._linux_x64_appimage_manifest.json`（真阳性），`linux_arm64` 返回空。
- release notes 那一步原样抽出来、stub 掉 `gh` 跑 A/B：有 artifact 目录时两张表各多一行，没有时渲染与本 PR 之前逐字节一致。
- electron-builder 的 `normalizeOptions` + `computeArchToTargetNamesMap` 在本地 N.E.K.O.-PC checkout 上实跑，四种 CLI 组合的解析结果逐个打印核对（见上）。
- `pytest` 5 个读 build-desktop.yml 的结构测试全绿；`test_desktop_windows_workflow_contract.py` 里 wrapper 参数串的断言已同步。

## 还没验证的

arm64 这条腿**实际能不能跑通**没验过 —— 要验就得 `workflow_dispatch` 跑一次完整 nightly，而那会覆盖掉线上的 `nightly` release。剩余风险点：`ubuntu-24.04-arm` 上的 Playwright Chromium、Nuitka on aarch64、以及 arm64 的 Electron/AppImage 运行时依赖。这也正是加 `continue-on-error` 的原因。

## 留给后续的决定

要不要让 Linux arm64 进 Portable 增量自更新通道。要的话得在 N.E.K.O.-PC 开配套 PR：`getTargetKey` 支持 `linux_arm64` / `linux_arm64_appimage`、`findPortableManifestAsset` 的资产名正则加上这两个 key、以及对应测试；然后把这里的 `skip_portable_channel` 摘掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增实验性的 Linux arm64 Python 后端与 Electron 桌面端构建产物。
  - Linux arm64 提供 AppImage、deb 和 tar.gz 格式。
  - 发布说明仅在对应产物实际可用时展示下载项。
- **改进**
  - Linux 构建会根据目标架构生成匹配的更新信息。
  - Linux arm64 不参与 Portable 目录及增量更新流程。
- **兼容性**
  - 非 x86_64 Linux 平台不再包含不匹配的 Steam 原生库。
  - Linux arm64 构建异常不会阻止其他正式平台发布。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


