### PR TITLE
fix(chat): 隔离破冰与 GalGame 推荐选项

### DIFF
--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1005,6 +1005,20 @@
         });
     }
 
+    function isNewUserIcebreakerChatMessage(message) {
+        if (!message) return false;
+        var messageId = typeof message.id === 'string' ? message.id : '';
+        if (messageId.indexOf('icebreaker-user-') === 0
+                || messageId.indexOf('icebreaker-assistant-') === 0) {
+            return true;
+        }
+        if (message.source === 'new_user_icebreaker') return true;
+        var icebreaker = message.icebreaker && typeof message.icebreaker === 'object'
+            ? message.icebreaker
+            : {};
+        return icebreaker.source === 'new_user_icebreaker';
+    }
+
     function getRecentGalgameMessageHistory() {
         var msgs = Array.isArray(I.state.messages) ? I.state.messages : [];
         var collected = [];
@@ -1013,6 +1027,13 @@
             if (!m) continue;
             if (isYuiGuideChatMessage(m)) continue;
             if (m.role !== 'assistant' && m.role !== 'user') continue;
+            if (isNewUserIcebreakerChatMessage(m)) {
+                // While the latest conversation turn belongs to the scripted
+                // icebreaker, do not fall back to an older ordinary assistant
+                // turn and generate unrelated GalGame choices for it.
+                if (!collected.length) return [];
+                continue;
+            }
             var text = '';
             if (Array.isArray(m.blocks)) {
                 for (var j = 0; j < m.blocks.length; j++) {
@@ -2001,7 +2022,7 @@
         // when the message came in via voice / proactive / sendTextPayload
         // rather than the React composer. Invalidate any pending GalGame fetch
         // so its response can't render against the old turn context.
-        if (normalized.role === 'user') {
+        if (normalized.role === 'user' || isNewUserIcebreakerChatMessage(normalized)) {
             I.invalidatePendingGalgameRequest();
         }
         I.renderWindow();

--- a/static/app/app-react-chat-window/resize-drag-and-api.js
+++ b/static/app/app-react-chat-window/resize-drag-and-api.js
@@ -518,8 +518,22 @@
             I.clearChoicePromptBySource('new_user_icebreaker', 'new-user-icebreaker-reset');
         });
 
-        // Refresh option list whenever an assistant turn finishes streaming.
-        window.addEventListener('neko-assistant-turn-end', function () {
+        function isNewUserIcebreakerTurnEndEvent(event) {
+            var detail = event && event.detail && typeof event.detail === 'object'
+                ? event.detail
+                : {};
+            if (detail.source === 'new_user_icebreaker') return true;
+            var meta = detail.meta && typeof detail.meta === 'object' ? detail.meta : {};
+            if (meta.source === 'new_user_icebreaker' || meta.kind === 'new_user_icebreaker') {
+                return true;
+            }
+            var metaEvent = meta.event && typeof meta.event === 'object' ? meta.event : {};
+            return metaEvent.source === 'new_user_icebreaker';
+        }
+
+        // Refresh option list whenever an ordinary assistant turn finishes streaming.
+        window.addEventListener('neko-assistant-turn-end', function (event) {
+            if (isNewUserIcebreakerTurnEndEvent(event)) return;
             if (!I.state.galgameModeEnabled) return;
             // Skip when the chat overlay is hidden — otherwise galgame mode's
             // default-on flag would spam /api/galgame/options (and summary-tier

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1610,6 +1610,45 @@ def test_galgame_history_excludes_tutorial_guide_messages():
     assert history_block.index("if (!m) continue;") < history_block.index("if (isYuiGuideChatMessage(m)) continue;")
 
 
+def test_galgame_history_excludes_new_user_icebreaker_messages():
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    history_block = react_host.split("function getRecentGalgameMessageHistory()", 1)[1].split(
+        "function pickAcceptLanguage",
+        1,
+    )[0]
+
+    assert "function isNewUserIcebreakerChatMessage(message)" in react_host
+    assert "if (isNewUserIcebreakerChatMessage(m))" in history_block
+    assert "if (!collected.length) return [];" in history_block
+    append_block = react_host.split("function appendMessage(message)", 1)[1].split(
+        "function updateMessage",
+        1,
+    )[0]
+    assert "normalized.role === 'user' || isNewUserIcebreakerChatMessage(normalized)" in append_block
+    assert "invalidatePendingGalgameRequest();" in append_block
+
+
+def test_galgame_turn_end_listener_ignores_new_user_icebreaker():
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    guard_block = react_host.split("function isNewUserIcebreakerTurnEndEvent(event)", 1)[1].split(
+        "window.addEventListener('neko-assistant-turn-end'",
+        1,
+    )[0]
+    listener_block = react_host.split(
+        "window.addEventListener('neko-assistant-turn-end', function (event)",
+        1,
+    )[1].split("\n        });", 1)[0]
+
+    assert "detail.meta" in guard_block
+    assert "meta.source === 'new_user_icebreaker'" in guard_block
+    assert "meta.kind === 'new_user_icebreaker'" in guard_block
+    assert "meta.event" in guard_block
+    assert "source === 'new_user_icebreaker'" in guard_block
+    assert "if (isNewUserIcebreakerTurnEndEvent(event)) return;" in listener_block
+
+
 def test_galgame_option_template_follows_interface_language():
     react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 改动概述 / Summary

修复新用户破冰流程误触发 GalGame 动态推荐选项的问题。

- 过滤来源为 `new_user_icebreaker` 的助手轮结束事件，避免调用 `/api/galgame/options`。
- 将破冰消息从 GalGame 最近对话历史中排除，并在破冰消息到达时取消遗留请求。
- 保留破冰结束后的正常 GalGame 恢复行为：下一轮普通助手回复仍会生成推荐选项。
- 补充破冰事件与消息历史隔离的回归测试。

## 回归报告 / Regression Report

不适用：本 PR 未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本 PR 仅修改 2 个运行时 JavaScript 文件和 1 个测试文件，属于同一缺陷的最小修复。

## 测试 / Testing

- `node --check static/app/app-react-chat-window/resize-drag-and-api.js`
- `node --check static/app/app-react-chat-window/message-bundle-actions-and-prompts.js`
- `.venv/bin/python -m pytest tests/unit/test_react_chat_window_static.py tests/unit/test_new_user_icebreaker_static_contracts.py -q`（164 passed, 1 skipped）
- 行为隔离检查：破冰消息不进入 GalGame 历史，破冰 `turn-end` 被过滤，后续普通消息仍可生成 GalGame 历史。
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 新用户破冰消息不再被纳入 GalGame 对话历史，避免生成不相关的选项。
  * 新用户破冰流程期间，挂起的 GalGame 请求会被正确失效。
  * 新用户破冰回合结束时不再触发 GalGame 选项刷新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->