### PR TITLE
fix(ci): mac-x64 改用 Intel runner，并加产物架构闸门

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -470,6 +470,15 @@ jobs:
           set -euo pipefail
           .venv/bin/python scripts/check_nuitka_dist.py dist/Xiao8 --plugin-stage build/nuitka-plugins
 
+      # 与 build-desktop.yml 的同名步骤对偶（#2898）。这个 workflow 只有 linux x64
+      # 一条腿，期望架构写死即可。
+      - name: Verify dist CPU architecture
+        shell: bash
+        run: |
+          set -euo pipefail
+          .venv/bin/python scripts/check_dist_arch.py dist/Xiao8 \
+            --expect-arch x64 --expect-platform linux
+
       - name: Upload Python backend artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe"}]' || '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe"},{"os":"macos-15","platform":"mac-x64","python_arch":"x64","artifact_name":"python-backend-mac-x64","output_binary":"projectneko_server"},{"os":"macos-latest","platform":"mac-arm64","artifact_name":"python-backend-mac-arm64","output_binary":"projectneko_server"},{"os":"ubuntu-latest","platform":"linux","artifact_name":"python-backend-linux","output_binary":"projectneko_server"}]') }}
+        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe","expect_arch":"x64","expect_platform":"win"}]' || '[{"os":"windows-latest","platform":"win","artifact_name":"python-backend-win","output_binary":"projectneko_server.exe","expect_arch":"x64","expect_platform":"win"},{"os":"macos-15-intel","platform":"mac-x64","python_arch":"x64","artifact_name":"python-backend-mac-x64","output_binary":"projectneko_server","expect_arch":"x64","expect_platform":"mac"},{"os":"macos-latest","platform":"mac-arm64","artifact_name":"python-backend-mac-arm64","output_binary":"projectneko_server","expect_arch":"arm64","expect_platform":"mac"},{"os":"ubuntu-latest","platform":"linux","artifact_name":"python-backend-linux","output_binary":"projectneko_server","expect_arch":"x64","expect_platform":"linux"}]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 300
@@ -847,6 +847,23 @@ jobs:
             .venv/bin/python scripts/check_nuitka_dist.py "$NEKO_NUITKA_RUNTIME_DIR" --plugin-stage build/nuitka-plugins
           fi
 
+      # 产物架构闸门（#2898）。`macos-15` 是 Apple Silicon 镜像，mac-x64 那条腿曾经在
+      # 它上面构建，`actions/setup-python` 的 architecture: x64 只让 Python 走 Rosetta，
+      # Nuitka 照样吐 arm64，Playwright 也按宿主架构下成了 chrome-mac-arm64 —— 整整几个
+      # 月的 Intel Mac 版都启动不了，而流水线全绿。runner 已换成 macos-15-intel，这一步
+      # 是防它（以及任何一条腿）再无声地跑偏：不匹配就直接红，不上传。
+      - name: Verify dist CPU architecture
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            .venv/Scripts/python.exe scripts/check_dist_arch.py dist/Xiao8 \
+              --expect-arch "${{ matrix.expect_arch }}" --expect-platform "${{ matrix.expect_platform }}"
+          else
+            .venv/bin/python scripts/check_dist_arch.py "$NEKO_NUITKA_RUNTIME_DIR" \
+              --expect-arch "${{ matrix.expect_arch }}" --expect-platform "${{ matrix.expect_platform }}"
+          fi
+
       # Nuitka signs macOS app bundles when it creates them. The steps above
       # then add Playwright and plugin payloads inside the bundle, invalidating
       # that seal. Restore a valid ad-hoc signature for the backend artifact;
@@ -879,7 +896,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"}]' || '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"},{"os":"macos-15","platform":"mac-x64","portable_key":"mac_x64","builder_platform":"macos","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/mac/N.E.K.O.app","python_artifact":"python-backend-mac-x64","electron_args":"--mac --x64","artifact_name":"desktop-mac-x64"},{"os":"macos-latest","platform":"mac-arm64","portable_key":"mac_arm64","builder_platform":"macos","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/mac-arm64/N.E.K.O.app","python_artifact":"python-backend-mac-arm64","electron_args":"--mac --arm64","artifact_name":"desktop-mac-arm64"},{"os":"ubuntu-latest","platform":"linux","portable_key":"linux_x64","builder_platform":"linux","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/linux-unpacked","python_artifact":"python-backend-linux","electron_args":"--linux","artifact_name":"desktop-linux-x64"}]') }}
+        include: ${{ fromJSON(inputs.windows_only && '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"}]' || '[{"os":"windows-latest","platform":"win","portable_key":"win","builder_platform":"windows","portable_dir":"dist/win-unpacked","python_artifact":"python-backend-win","electron_args":"--win","artifact_name":"desktop-win-x64"},{"os":"macos-15-intel","platform":"mac-x64","portable_key":"mac_x64","builder_platform":"macos","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/mac/N.E.K.O.app","python_artifact":"python-backend-mac-x64","electron_args":"--mac --x64","artifact_name":"desktop-mac-x64"},{"os":"macos-latest","platform":"mac-arm64","portable_key":"mac_arm64","builder_platform":"macos","portable_arch_args":"--arm64","portable_dir":"dist/portable-stage/mac-arm64/N.E.K.O.app","python_artifact":"python-backend-mac-arm64","electron_args":"--mac --arm64","artifact_name":"desktop-mac-arm64"},{"os":"ubuntu-latest","platform":"linux","portable_key":"linux_x64","builder_platform":"linux","portable_arch_args":"--x64","portable_dir":"dist/portable-stage/linux-unpacked","python_artifact":"python-backend-linux","electron_args":"--linux","artifact_name":"desktop-linux-x64"}]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180

--- a/scripts/check_dist_arch.py
+++ b/scripts/check_dist_arch.py
@@ -31,17 +31,23 @@ a mis-resolved electron-builder/Nuitka target would fail the same way.
 
 ## What it checks
 
-- The main entry binary's declared CPU type.
-- Every native library outside the vendored browser tree (``.so``/``.dylib``/
-  ``.pyd``/``.dll``).
+- The main entry binary's CPU type and container format.
+- Every packaged native binary. Three filename shapes, because a plain suffix
+  allowlist misses two real ones: versioned ELF sonames such as
+  ``libpython3.11.so.1.0`` (whose ``Path.suffix`` is ``.0``) and the
+  extensionless helpers Nuitka's Playwright plugin packages
+  (``playwright/driver/node``).
+- That the container format matches the target platform. A Windows PE that
+  survived inside a macOS bundle has a perfectly matching *architecture*, so
+  only the format check catches it -- and this repo does keep all three
+  platforms' Steam natives in the source tree, stripped by ``rm -f`` at build
+  time.
 - Inside ``playwright_browsers/``, both that no path component carries the
   *opposite* architecture token (#2898's bad build shipped
   ``chromium-1208/chrome-mac-arm64`` inside an x64 bundle) and that no bundled
   binary *is* the opposite architecture. The directory check alone is not
   enough: Playwright also uses tokenless names such as ``chrome-mac``, under
-  which a wrong-arch Chromium would pass unnoticed. The browser's own
-  executables carry no filename suffix, so this scan dispatches on the file
-  magic rather than on ``.so``/``.dylib``.
+  which a wrong-arch Chromium would pass unnoticed.
 
 Headers are parsed directly, so this runs identically on all three CI hosts and
 needs neither ``lipo`` nor ``file``.
@@ -52,6 +58,11 @@ import argparse
 import struct
 import sys
 from pathlib import Path
+from typing import NamedTuple
+
+MACHO = "mach-o"
+ELF = "elf"
+PE = "pe"
 
 # Mach-O
 _MACHO_MAGICS = {
@@ -60,7 +71,16 @@ _MACHO_MAGICS = {
     b"\xce\xfa\xed\xfe": "<",  # MH_MAGIC (32-bit)
     b"\xfe\xed\xfa\xce": ">",
 }
-_MACHO_FAT_MAGICS = {b"\xca\xfe\xba\xbe": ">", b"\xbe\xba\xfe\xca": "<"}
+# FAT_MAGIC/FAT_CIGAM carry 20-byte fat_arch records; FAT_MAGIC_64/FAT_CIGAM_64
+# (trailing byte 0xbf, not 0xbe) carry 32-byte fat_arch_64 records. Both are
+# valid universal binaries -- reading only the 32-bit form reports a 64-bit fat
+# main binary as "not an executable" and skips a 64-bit fat dylib entirely.
+_MACHO_FAT_MAGICS = {
+    b"\xca\xfe\xba\xbe": (">", 20),
+    b"\xbe\xba\xfe\xca": ("<", 20),
+    b"\xca\xfe\xba\xbf": (">", 32),
+    b"\xbf\xba\xfe\xca": ("<", 32),
+}
 _MACHO_CPU = {0x01000007: "x64", 0x0100000C: "arm64", 0x00000007: "x86", 0x0000000C: "arm"}
 
 # ELF
@@ -69,7 +89,9 @@ _ELF_MACHINE = {62: "x64", 183: "arm64", 3: "x86", 40: "arm"}
 # PE
 _PE_MACHINE = {0x8664: "x64", 0xAA64: "arm64", 0x014C: "x86", 0x01C0: "arm"}
 
-_NATIVE_SUFFIXES = (".so", ".dylib", ".pyd", ".dll")
+_FORMAT_BY_PLATFORM = {"mac": MACHO, "linux": ELF, "win": PE}
+
+_NATIVE_SUFFIXES = (".so", ".dylib", ".pyd", ".dll", ".exe")
 _ARCH_TOKENS = ("x64", "arm64")
 # 供应商目录里出现的架构写法不止一种（chrome-mac-x64 / chrome-linux-arm64 / mac-arm64 ...），
 # 用「对立架构的词元」做黑名单，比要求某个确切目录名更耐得住 Playwright 改布局。
@@ -83,6 +105,16 @@ _VENDORED_BROWSER_DIR = "playwright_browsers"
 _OPPOSITE_ARCH = {"x64": "arm64", "arm64": "x64"}
 # 只是别让畸形目录把这一步拖死；正常 Chromium 包也就几千个文件。
 _BROWSER_SCAN_FILE_LIMIT = 50000
+# PE 的 e_lfanew 指向可执行头。真实文件里它是几百字节；给个宽松上界，免得
+# 一个伪造值让我们去读整个文件。
+_MAX_PE_HEADER_OFFSET = 4 * 1024 * 1024
+
+
+class BinaryInfo(NamedTuple):
+    """The container format and the CPU architectures a binary declares."""
+
+    format: str
+    arches: list[str]
 
 
 def _read_head(path: Path, size: int = 64) -> bytes:
@@ -90,52 +122,68 @@ def _read_head(path: Path, size: int = 64) -> bytes:
         return handle.read(size)
 
 
-def read_arches(path: Path) -> list[str] | None:
-    """Return the architectures a binary declares, or None if it is not one.
+def read_binary(path: Path) -> BinaryInfo | None:
+    """Inspect a file's header, or return None when it is not an executable.
 
     A Mach-O fat binary reports every slice it carries; every other format
     reports a single entry.
     """
-    head = _read_head(path)
+    try:
+        head = _read_head(path)
+    except OSError:
+        return None
     if len(head) < 20:
         return None
 
     magic = head[:4]
     if magic in _MACHO_FAT_MAGICS:
-        endian = _MACHO_FAT_MAGICS[magic]
+        endian, record_size = _MACHO_FAT_MAGICS[magic]
         (count,) = struct.unpack(endian + "I", head[4:8])
-        # 每个 fat_arch 是 20 字节，cputype 在其起始处；限个上界，别让畸形头把内存吃穿。
+        # 限个上界，别让畸形头把内存吃穿。
         if count > 64:
             return None
-        blob = _read_head(path, 8 + 20 * count)
+        blob = _read_head(path, 8 + record_size * count)
         arches: list[str] = []
         for index in range(count):
-            offset = 8 + 20 * index
+            offset = 8 + record_size * index
             if offset + 4 > len(blob):
                 break
             (cpu,) = struct.unpack(endian + "I", blob[offset : offset + 4])
             arches.append(_MACHO_CPU.get(cpu, f"unknown(0x{cpu:08x})"))
-        return arches or None
+        return BinaryInfo(MACHO, arches) if arches else None
 
     if magic in _MACHO_MAGICS:
         endian = _MACHO_MAGICS[magic]
         (cpu,) = struct.unpack(endian + "I", head[4:8])
-        return [_MACHO_CPU.get(cpu, f"unknown(0x{cpu:08x})")]
+        return BinaryInfo(MACHO, [_MACHO_CPU.get(cpu, f"unknown(0x{cpu:08x})")])
 
     if magic == b"\x7fELF":
         endian = "<" if head[5] == 1 else ">"
         (machine,) = struct.unpack(endian + "H", head[18:20])
-        return [_ELF_MACHINE.get(machine, f"unknown({machine})")]
+        return BinaryInfo(ELF, [_ELF_MACHINE.get(machine, f"unknown({machine})")])
 
     if magic[:2] == b"MZ":
+        # 浏览器树里每个普通文件都会流经这里，其中不乏「恰好以 MZ 开头」的数据文件。
+        # 头不足 0x40 字节时切片是空的，struct.unpack 会抛 struct.error 把闸门整个
+        # 打崩；伪造的巨大 pe_offset 还会让 _read_head 去要一个无界的读。两处都挡住。
+        if len(head) < 0x40:
+            return None
         (pe_offset,) = struct.unpack("<I", head[0x3C:0x40])
+        if pe_offset > _MAX_PE_HEADER_OFFSET:
+            return None
         blob = _read_head(path, pe_offset + 8)
         if len(blob) < pe_offset + 8 or blob[pe_offset : pe_offset + 4] != b"PE\x00\x00":
             return None
         (machine,) = struct.unpack("<H", blob[pe_offset + 4 : pe_offset + 6])
-        return [_PE_MACHINE.get(machine, f"unknown(0x{machine:04x})")]
+        return BinaryInfo(PE, [_PE_MACHINE.get(machine, f"unknown(0x{machine:04x})")])
 
     return None
+
+
+def read_arches(path: Path) -> list[str] | None:
+    """Convenience wrapper returning just the architectures."""
+    info = read_binary(path)
+    return None if info is None else info.arches
 
 
 def _entry_binary(dist_root: Path, platform: str) -> Path | None:
@@ -153,25 +201,32 @@ def _entry_binary(dist_root: Path, platform: str) -> Path | None:
         candidates = [dist_root / "projectneko_server.exe"]
     for candidate in candidates:
         # macOS 的 dist 根上还有个同名 shell wrapper（exec 进 .app），它不是 Mach-O，
-        # read_arches 返回 None —— 跳过继续找真的那个，别把 wrapper 当主程序放行。
-        if candidate.is_file() and read_arches(candidate) is not None:
+        # read_binary 返回 None —— 跳过继续找真的那个，别把 wrapper 当主程序放行。
+        if candidate.is_file() and read_binary(candidate) is not None:
             return candidate
     return None
 
 
-def _iter_native_libs(dist_root: Path):
+def _looks_native(path: Path) -> bool:
+    """Is this filename shaped like something that could be a native binary?"""
+    return path.suffix.lower() in _NATIVE_SUFFIXES or ".so." in path.name.lower() or not path.suffix
+
+
+def _iter_native_binaries(dist_root: Path):
     for path in dist_root.rglob("*"):
         if not path.is_file() or path.is_symlink():
             continue
-        if _VENDORED_BROWSER_DIR in path.parts:
+        # 用相对路径判断，别把 dist_root 的祖先目录名算进来。
+        if _VENDORED_BROWSER_DIR in path.relative_to(dist_root).parts:
             continue
-        if path.suffix.lower() in _NATIVE_SUFFIXES:
+        if _looks_native(path):
             yield path
 
 
 def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[str]:
     """Return a list of human-readable problems; empty means the dist is clean."""
     issues: list[str] = []
+    expect_format = _FORMAT_BY_PLATFORM[platform]
 
     entry = _entry_binary(dist_root, platform)
     if entry is None:
@@ -180,26 +235,44 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
             f"{dist_root}"
         )
     else:
-        arches = read_arches(entry) or []
-        if expect_arch not in arches:
+        info = read_binary(entry)
+        assert info is not None  # _entry_binary only returns readable binaries
+        if expect_arch not in info.arches:
             issues.append(
-                f"main binary is {'/'.join(arches) or 'unreadable'}, expected {expect_arch}: "
-                f"{entry.relative_to(dist_root)}"
+                f"main binary is {'/'.join(info.arches) or 'unreadable'}, expected "
+                f"{expect_arch}: {entry.relative_to(dist_root)}"
+            )
+        if info.format != expect_format:
+            issues.append(
+                f"main binary is a {info.format} file but {platform} builds must be "
+                f"{expect_format}: {entry.relative_to(dist_root)}"
             )
 
     mismatched: list[str] = []
-    for lib in _iter_native_libs(dist_root):
-        arches = read_arches(lib)
-        if arches is None:
-            # 后缀像原生库但根本不是可执行格式（占位文件、文本 stub）——不是架构问题。
+    foreign_format: list[str] = []
+    for lib in _iter_native_binaries(dist_root):
+        info = read_binary(lib)
+        if info is None:
+            # 名字像原生库但根本不是可执行格式（占位文件、文本 stub）——不是架构问题。
             continue
-        if expect_arch not in arches:
-            mismatched.append(f"{lib.relative_to(dist_root)} is {'/'.join(arches)}")
+        relative = lib.relative_to(dist_root)
+        if info.format != expect_format:
+            # 跨平台库混进来时架构反而是「对」的（Windows DLL 也是 PE x64），
+            # 只有格式这一维能抓住它，所以单独归一类报。
+            foreign_format.append(f"{relative} is {info.format}")
+        elif expect_arch not in info.arches:
+            mismatched.append(f"{relative} is {'/'.join(info.arches)}")
     if mismatched:
         shown = ", ".join(sorted(mismatched)[:10])
         issues.append(
-            f"{len(mismatched)} native library/libraries are not {expect_arch}: {shown}"
+            f"{len(mismatched)} native binary/binaries are not {expect_arch}: {shown}"
             + (" ..." if len(mismatched) > 10 else "")
+        )
+    if foreign_format:
+        shown = ", ".join(sorted(foreign_format)[:10])
+        issues.append(
+            f"{len(foreign_format)} native binary/binaries are not {expect_format} "
+            f"(wrong platform): {shown}" + (" ..." if len(foreign_format) > 10 else "")
         )
 
     browser_root = dist_root / _VENDORED_BROWSER_DIR
@@ -209,7 +282,11 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
             str(path.relative_to(dist_root))
             for path in browser_root.rglob("*")
             if path.is_dir()
-            and any(token in part.lower() for part in path.parts for token in tokens)
+            and any(
+                token in part.lower()
+                for part in path.relative_to(browser_root).parts
+                for token in tokens
+            )
         )
         if bad_paths:
             issues.append(
@@ -219,14 +296,18 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
 
         opposite = _OPPOSITE_ARCH.get(expect_arch)
         wrong_binaries: list[str] = []
-        for scanned, path in enumerate(sorted(browser_root.rglob("*"))):
+        # 直接迭代 rglob，别先 sorted() 把整棵树物化 —— 那样上限形同虚设，
+        # 树一大就先把内存吃光。只对最后要打印的结果排序。
+        scanned = 0
+        for path in browser_root.rglob("*"):
             if scanned >= _BROWSER_SCAN_FILE_LIMIT:
                 break
+            scanned += 1
             if not path.is_file() or path.is_symlink():
                 continue
-            arches = read_arches(path)
-            if arches and opposite in arches and expect_arch not in arches:
-                wrong_binaries.append(f"{path.relative_to(dist_root)} is {'/'.join(arches)}")
+            info = read_binary(path)
+            if info and opposite in info.arches and expect_arch not in info.arches:
+                wrong_binaries.append(f"{path.relative_to(dist_root)} is {'/'.join(info.arches)}")
         if wrong_binaries:
             shown = ", ".join(sorted(wrong_binaries)[:5])
             issues.append(
@@ -255,7 +336,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--expect-platform",
         required=True,
-        choices=("win", "mac", "linux"),
+        choices=tuple(_FORMAT_BY_PLATFORM),
         help="Host platform this build targets",
     )
     args = parser.parse_args(argv)

--- a/scripts/check_dist_arch.py
+++ b/scripts/check_dist_arch.py
@@ -1,0 +1,264 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assert that a built dist actually contains the CPU architecture it claims.
+
+Run right after the Nuitka build, before the artifact is uploaded.
+
+## Why this exists
+
+Issue #2898: the nightly ``mac-x64`` backend was arm64. The ``mac-x64`` matrix
+leg ran on the ``macos-15`` runner, which is Apple Silicon -- ``actions/setup-python``
+with ``architecture: x64`` only makes *Python* run under Rosetta, while Nuitka
+still emits a native arm64 binary and Playwright still downloads the host's
+browser build. Nothing in the pipeline looked at the produced Mach-O, so a
+completely unusable Intel build shipped for months.
+
+The runner label is fixed separately; this gate is what keeps the class of bug
+from coming back silently on any platform, including the Linux arm64 leg where
+a mis-resolved electron-builder/Nuitka target would fail the same way.
+
+## What it checks
+
+- The main entry binary's declared CPU type.
+- Every native library outside the vendored browser tree (``.so``/``.dylib``/
+  ``.pyd``/``.dll``).
+- Inside ``playwright_browsers/``, that no path component carries the *opposite*
+  architecture token. The vendored browser has its own layout and its own
+  third-party binaries, so it is matched by directory naming rather than by
+  header scanning (#2898's bad build shipped ``chromium-1208/chrome-mac-arm64``
+  inside an x64 bundle).
+
+Headers are parsed directly, so this runs identically on all three CI hosts and
+needs neither ``lipo`` nor ``file``.
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+# Mach-O
+_MACHO_MAGICS = {
+    b"\xcf\xfa\xed\xfe": "<",  # MH_MAGIC_64, little-endian host order
+    b"\xfe\xed\xfa\xcf": ">",  # MH_CIGAM_64
+    b"\xce\xfa\xed\xfe": "<",  # MH_MAGIC (32-bit)
+    b"\xfe\xed\xfa\xce": ">",
+}
+_MACHO_FAT_MAGICS = {b"\xca\xfe\xba\xbe": ">", b"\xbe\xba\xfe\xca": "<"}
+_MACHO_CPU = {0x01000007: "x64", 0x0100000C: "arm64", 0x00000007: "x86", 0x0000000C: "arm"}
+
+# ELF
+_ELF_MACHINE = {62: "x64", 183: "arm64", 3: "x86", 40: "arm"}
+
+# PE
+_PE_MACHINE = {0x8664: "x64", 0xAA64: "arm64", 0x014C: "x86", 0x01C0: "arm"}
+
+_NATIVE_SUFFIXES = (".so", ".dylib", ".pyd", ".dll")
+_ARCH_TOKENS = ("x64", "arm64")
+# 供应商目录里出现的架构写法不止一种（chrome-mac-x64 / chrome-linux-arm64 / mac-arm64 ...），
+# 用「对立架构的词元」做黑名单，比要求某个确切目录名更耐得住 Playwright 改布局。
+_OPPOSITE_TOKENS = {
+    "x64": ("-arm64", "_arm64", "aarch64"),
+    "arm64": ("-x64", "_x64", "-x86_64", "_x86_64", "amd64"),
+}
+_VENDORED_BROWSER_DIR = "playwright_browsers"
+
+
+def _read_head(path: Path, size: int = 64) -> bytes:
+    with path.open("rb") as handle:
+        return handle.read(size)
+
+
+def read_arches(path: Path) -> list[str] | None:
+    """Return the architectures a binary declares, or None if it is not one.
+
+    A Mach-O fat binary reports every slice it carries; every other format
+    reports a single entry.
+    """
+    head = _read_head(path)
+    if len(head) < 20:
+        return None
+
+    magic = head[:4]
+    if magic in _MACHO_FAT_MAGICS:
+        endian = _MACHO_FAT_MAGICS[magic]
+        (count,) = struct.unpack(endian + "I", head[4:8])
+        # 每个 fat_arch 是 20 字节，cputype 在其起始处；限个上界，别让畸形头把内存吃穿。
+        if count > 64:
+            return None
+        blob = _read_head(path, 8 + 20 * count)
+        arches: list[str] = []
+        for index in range(count):
+            offset = 8 + 20 * index
+            if offset + 4 > len(blob):
+                break
+            (cpu,) = struct.unpack(endian + "I", blob[offset : offset + 4])
+            arches.append(_MACHO_CPU.get(cpu, f"unknown(0x{cpu:08x})"))
+        return arches or None
+
+    if magic in _MACHO_MAGICS:
+        endian = _MACHO_MAGICS[magic]
+        (cpu,) = struct.unpack(endian + "I", head[4:8])
+        return [_MACHO_CPU.get(cpu, f"unknown(0x{cpu:08x})")]
+
+    if magic == b"\x7fELF":
+        endian = "<" if head[5] == 1 else ">"
+        (machine,) = struct.unpack(endian + "H", head[18:20])
+        return [_ELF_MACHINE.get(machine, f"unknown({machine})")]
+
+    if magic[:2] == b"MZ":
+        (pe_offset,) = struct.unpack("<I", head[0x3C:0x40])
+        blob = _read_head(path, pe_offset + 8)
+        if len(blob) < pe_offset + 8 or blob[pe_offset : pe_offset + 4] != b"PE\x00\x00":
+            return None
+        (machine,) = struct.unpack("<H", blob[pe_offset + 4 : pe_offset + 6])
+        return [_PE_MACHINE.get(machine, f"unknown(0x{machine:04x})")]
+
+    return None
+
+
+def _entry_binary(dist_root: Path, platform: str) -> Path | None:
+    """Locate the main server binary for a platform, or None when absent.
+
+    macOS wraps the Nuitka output in ``projectneko_server.app``; the runtime dir
+    handed to this script may be either the bundle root or its ``MacOS`` dir.
+    """
+    candidates = [
+        dist_root / "projectneko_server.exe",
+        dist_root / "projectneko_server",
+        dist_root / "projectneko_server.app" / "Contents" / "MacOS" / "projectneko_server",
+    ]
+    if platform == "win":
+        candidates = [dist_root / "projectneko_server.exe"]
+    for candidate in candidates:
+        # macOS 的 dist 根上还有个同名 shell wrapper（exec 进 .app），它不是 Mach-O，
+        # read_arches 返回 None —— 跳过继续找真的那个，别把 wrapper 当主程序放行。
+        if candidate.is_file() and read_arches(candidate) is not None:
+            return candidate
+    return None
+
+
+def _iter_native_libs(dist_root: Path):
+    for path in dist_root.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        if _VENDORED_BROWSER_DIR in path.parts:
+            continue
+        if path.suffix.lower() in _NATIVE_SUFFIXES:
+            yield path
+
+
+def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[str]:
+    """Return a list of human-readable problems; empty means the dist is clean."""
+    issues: list[str] = []
+
+    entry = _entry_binary(dist_root, platform)
+    if entry is None:
+        issues.append(
+            "main server binary not found (or not a recognisable executable) under "
+            f"{dist_root}"
+        )
+    else:
+        arches = read_arches(entry) or []
+        if expect_arch not in arches:
+            issues.append(
+                f"main binary is {'/'.join(arches) or 'unreadable'}, expected {expect_arch}: "
+                f"{entry.relative_to(dist_root)}"
+            )
+
+    mismatched: list[str] = []
+    for lib in _iter_native_libs(dist_root):
+        arches = read_arches(lib)
+        if arches is None:
+            # 后缀像原生库但根本不是可执行格式（占位文件、文本 stub）——不是架构问题。
+            continue
+        if expect_arch not in arches:
+            mismatched.append(f"{lib.relative_to(dist_root)} is {'/'.join(arches)}")
+    if mismatched:
+        shown = ", ".join(sorted(mismatched)[:10])
+        issues.append(
+            f"{len(mismatched)} native library/libraries are not {expect_arch}: {shown}"
+            + (" ..." if len(mismatched) > 10 else "")
+        )
+
+    browser_root = dist_root / _VENDORED_BROWSER_DIR
+    if browser_root.is_dir():
+        tokens = _OPPOSITE_TOKENS.get(expect_arch, ())
+        bad_paths = sorted(
+            str(path.relative_to(dist_root))
+            for path in browser_root.rglob("*")
+            if path.is_dir()
+            and any(token in part.lower() for part in path.parts for token in tokens)
+        )
+        if bad_paths:
+            issues.append(
+                f"vendored browser tree carries non-{expect_arch} directories: "
+                + ", ".join(bad_paths[:5])
+            )
+
+    return issues
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "dist_root",
+        nargs="?",
+        default="dist/Xiao8",
+        help="Path to the built dist root (default: dist/Xiao8)",
+    )
+    parser.add_argument(
+        "--expect-arch",
+        required=True,
+        choices=_ARCH_TOKENS,
+        help="CPU architecture this build is supposed to be",
+    )
+    parser.add_argument(
+        "--expect-platform",
+        required=True,
+        choices=("win", "mac", "linux"),
+        help="Host platform this build targets",
+    )
+    args = parser.parse_args(argv)
+
+    dist_root = Path(args.dist_root).resolve()
+    if not dist_root.is_dir():
+        print(f"[FAIL] dist root does not exist or is not a directory: {dist_root}", file=sys.stderr)
+        return 1
+
+    issues = check_dist_arch(dist_root, args.expect_arch, args.expect_platform)
+    if issues:
+        print(
+            f"[FAIL] {dist_root} does not match {args.expect_platform}/{args.expect_arch}:",
+            file=sys.stderr,
+        )
+        for issue in issues:
+            print(f"  - {issue}", file=sys.stderr)
+        print(
+            "\nHint: this almost always means the matrix leg ran on a runner whose "
+            "native architecture differs from the one it claims to build (see #2898, "
+            "where mac-x64 ran on the Apple Silicon `macos-15` image). Check the "
+            "`runs-on` label for this leg before touching anything else.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"[OK] dist matches {args.expect_platform}/{args.expect_arch}: {dist_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_dist_arch.py
+++ b/scripts/check_dist_arch.py
@@ -44,8 +44,8 @@ a mis-resolved electron-builder/Nuitka target would fail the same way.
   time.
 - Inside ``playwright_browsers/``, both that no path component carries the
   *opposite* architecture token (#2898's bad build shipped
-  ``chromium-1208/chrome-mac-arm64`` inside an x64 bundle) and that no bundled
-  binary *is* the opposite architecture. The directory check alone is not
+  ``chromium-1208/chrome-mac-arm64`` inside an x64 bundle) and that every
+  bundled binary carries the expected one. The directory check alone is not
   enough: Playwright also uses tokenless names such as ``chrome-mac``, under
   which a wrong-arch Chromium would pass unnoticed.
 
@@ -100,9 +100,6 @@ _OPPOSITE_TOKENS = {
     "arm64": ("-x64", "_x64", "-x86_64", "_x86_64", "amd64"),
 }
 _VENDORED_BROWSER_DIR = "playwright_browsers"
-# 供应商树按「只禁对立架构」判，不要求逐个命中期望架构：Chromium 里带一两个
-# 32 位/无法识别的小工具是正常的，而整树跑偏必然大面积撞上对立架构。
-_OPPOSITE_ARCH = {"x64": "arm64", "arm64": "x64"}
 # 只是别让畸形目录把这一步拖死；正常 Chromium 包也就几千个文件。
 _BROWSER_SCAN_FILE_LIMIT = 50000
 # PE 的 e_lfanew 指向可执行头。真实文件里它是几百字节；给个宽松上界，免得
@@ -278,7 +275,6 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
     browser_root = dist_root / _VENDORED_BROWSER_DIR
     if browser_root.is_dir():
         tokens = _OPPOSITE_TOKENS.get(expect_arch, ())
-        opposite = _OPPOSITE_ARCH.get(expect_arch)
         bad_paths: list[str] = []
         wrong_binaries: list[str] = []
         wrong_format: list[str] = []
@@ -310,7 +306,11 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
                 # 和 dist 主体同一条判据：装错平台的浏览器架构反而是「对」的
                 # （chrome-mac 底下的 PE x64 满足 x64），只有格式这维抓得住。
                 wrong_format.append(f"{relative} is {info.format}")
-            elif opposite in info.arches and expect_arch not in info.arches:
+            elif expect_arch not in info.arches:
+                # 和 dist 主体同一条判据：不含期望架构就是错的，不只是「恰好是对立
+                # 架构」才算。原来这里放宽成只禁对立架构，理由是「Chromium 带一两个
+                # 32 位小工具属正常」—— 那是推测，拿不出证据，而且让 x86 的浏览器
+                # 二进制在 x64 包里畅通无阻。
                 wrong_binaries.append(f"{relative} is {'/'.join(info.arches)}")
         if bad_paths:
             issues.append(
@@ -320,7 +320,7 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
         if wrong_binaries:
             shown = ", ".join(sorted(wrong_binaries)[:5])
             issues.append(
-                f"vendored browser tree contains {len(wrong_binaries)} {opposite} "
+                f"vendored browser tree contains {len(wrong_binaries)} non-{expect_arch} "
                 f"binary/binaries: {shown}"
                 + (" ..." if len(wrong_binaries) > 5 else "")
             )

--- a/scripts/check_dist_arch.py
+++ b/scripts/check_dist_arch.py
@@ -278,27 +278,13 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
     browser_root = dist_root / _VENDORED_BROWSER_DIR
     if browser_root.is_dir():
         tokens = _OPPOSITE_TOKENS.get(expect_arch, ())
-        bad_paths = sorted(
-            str(path.relative_to(dist_root))
-            for path in browser_root.rglob("*")
-            if path.is_dir()
-            and any(
-                token in part.lower()
-                for part in path.relative_to(browser_root).parts
-                for token in tokens
-            )
-        )
-        if bad_paths:
-            issues.append(
-                f"vendored browser tree carries non-{expect_arch} directories: "
-                + ", ".join(bad_paths[:5])
-            )
-
         opposite = _OPPOSITE_ARCH.get(expect_arch)
+        bad_paths: list[str] = []
         wrong_binaries: list[str] = []
         wrong_format: list[str] = []
-        # 直接迭代 rglob，别先 sorted() 把整棵树物化 —— 那样上限形同虚设，
-        # 树一大就先把内存吃光。只对最后要打印的结果排序。
+        # 目录名和字节两道检查走同一次遍历。分两次走的话上限只约束得住第二次，
+        # 第一次照样把整棵树走完，那个上限就是摆设。也别先 sorted() 把树物化，
+        # 只对最后要打印的结果排序。
         scanned = 0
         truncated = False
         for path in browser_root.rglob("*"):
@@ -306,18 +292,31 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
                 truncated = True
                 break
             scanned += 1
+            relative = path.relative_to(dist_root)
+            if path.is_dir():
+                if any(
+                    token in part.lower()
+                    for part in path.relative_to(browser_root).parts
+                    for token in tokens
+                ):
+                    bad_paths.append(str(relative))
+                continue
             if not path.is_file() or path.is_symlink():
                 continue
             info = read_binary(path)
             if info is None:
                 continue
-            relative = path.relative_to(dist_root)
             if info.format != expect_format:
                 # 和 dist 主体同一条判据：装错平台的浏览器架构反而是「对」的
                 # （chrome-mac 底下的 PE x64 满足 x64），只有格式这维抓得住。
                 wrong_format.append(f"{relative} is {info.format}")
             elif opposite in info.arches and expect_arch not in info.arches:
                 wrong_binaries.append(f"{relative} is {'/'.join(info.arches)}")
+        if bad_paths:
+            issues.append(
+                f"vendored browser tree carries non-{expect_arch} directories: "
+                + ", ".join(sorted(bad_paths)[:5])
+            )
         if wrong_binaries:
             shown = ", ".join(sorted(wrong_binaries)[:5])
             issues.append(

--- a/scripts/check_dist_arch.py
+++ b/scripts/check_dist_arch.py
@@ -296,24 +296,48 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
 
         opposite = _OPPOSITE_ARCH.get(expect_arch)
         wrong_binaries: list[str] = []
+        wrong_format: list[str] = []
         # 直接迭代 rglob，别先 sorted() 把整棵树物化 —— 那样上限形同虚设，
         # 树一大就先把内存吃光。只对最后要打印的结果排序。
         scanned = 0
+        truncated = False
         for path in browser_root.rglob("*"):
             if scanned >= _BROWSER_SCAN_FILE_LIMIT:
+                truncated = True
                 break
             scanned += 1
             if not path.is_file() or path.is_symlink():
                 continue
             info = read_binary(path)
-            if info and opposite in info.arches and expect_arch not in info.arches:
-                wrong_binaries.append(f"{path.relative_to(dist_root)} is {'/'.join(info.arches)}")
+            if info is None:
+                continue
+            relative = path.relative_to(dist_root)
+            if info.format != expect_format:
+                # 和 dist 主体同一条判据：装错平台的浏览器架构反而是「对」的
+                # （chrome-mac 底下的 PE x64 满足 x64），只有格式这维抓得住。
+                wrong_format.append(f"{relative} is {info.format}")
+            elif opposite in info.arches and expect_arch not in info.arches:
+                wrong_binaries.append(f"{relative} is {'/'.join(info.arches)}")
         if wrong_binaries:
             shown = ", ".join(sorted(wrong_binaries)[:5])
             issues.append(
                 f"vendored browser tree contains {len(wrong_binaries)} {opposite} "
                 f"binary/binaries: {shown}"
                 + (" ..." if len(wrong_binaries) > 5 else "")
+            )
+        if wrong_format:
+            shown = ", ".join(sorted(wrong_format)[:5])
+            issues.append(
+                f"vendored browser tree contains {len(wrong_format)} non-{expect_format} "
+                f"binary/binaries (wrong platform): {shown}"
+                + (" ..." if len(wrong_format) > 5 else "")
+            )
+        if truncated:
+            # 截断了就等于「后面那截没验过」。这里必须 fail-closed：否则一个越过
+            # 上限的错架构二进制会让整个闸门静默放行，比不设上限更糟。
+            issues.append(
+                f"vendored browser tree exceeds the {_BROWSER_SCAN_FILE_LIMIT}-file scan "
+                "cap, so it could not be fully verified"
             )
 
     return issues

--- a/scripts/check_dist_arch.py
+++ b/scripts/check_dist_arch.py
@@ -34,11 +34,14 @@ a mis-resolved electron-builder/Nuitka target would fail the same way.
 - The main entry binary's declared CPU type.
 - Every native library outside the vendored browser tree (``.so``/``.dylib``/
   ``.pyd``/``.dll``).
-- Inside ``playwright_browsers/``, that no path component carries the *opposite*
-  architecture token. The vendored browser has its own layout and its own
-  third-party binaries, so it is matched by directory naming rather than by
-  header scanning (#2898's bad build shipped ``chromium-1208/chrome-mac-arm64``
-  inside an x64 bundle).
+- Inside ``playwright_browsers/``, both that no path component carries the
+  *opposite* architecture token (#2898's bad build shipped
+  ``chromium-1208/chrome-mac-arm64`` inside an x64 bundle) and that no bundled
+  binary *is* the opposite architecture. The directory check alone is not
+  enough: Playwright also uses tokenless names such as ``chrome-mac``, under
+  which a wrong-arch Chromium would pass unnoticed. The browser's own
+  executables carry no filename suffix, so this scan dispatches on the file
+  magic rather than on ``.so``/``.dylib``.
 
 Headers are parsed directly, so this runs identically on all three CI hosts and
 needs neither ``lipo`` nor ``file``.
@@ -75,6 +78,11 @@ _OPPOSITE_TOKENS = {
     "arm64": ("-x64", "_x64", "-x86_64", "_x86_64", "amd64"),
 }
 _VENDORED_BROWSER_DIR = "playwright_browsers"
+# 供应商树按「只禁对立架构」判，不要求逐个命中期望架构：Chromium 里带一两个
+# 32 位/无法识别的小工具是正常的，而整树跑偏必然大面积撞上对立架构。
+_OPPOSITE_ARCH = {"x64": "arm64", "arm64": "x64"}
+# 只是别让畸形目录把这一步拖死；正常 Chromium 包也就几千个文件。
+_BROWSER_SCAN_FILE_LIMIT = 50000
 
 
 def _read_head(path: Path, size: int = 64) -> bytes:
@@ -207,6 +215,24 @@ def check_dist_arch(dist_root: Path, expect_arch: str, platform: str) -> list[st
             issues.append(
                 f"vendored browser tree carries non-{expect_arch} directories: "
                 + ", ".join(bad_paths[:5])
+            )
+
+        opposite = _OPPOSITE_ARCH.get(expect_arch)
+        wrong_binaries: list[str] = []
+        for scanned, path in enumerate(sorted(browser_root.rglob("*"))):
+            if scanned >= _BROWSER_SCAN_FILE_LIMIT:
+                break
+            if not path.is_file() or path.is_symlink():
+                continue
+            arches = read_arches(path)
+            if arches and opposite in arches and expect_arch not in arches:
+                wrong_binaries.append(f"{path.relative_to(dist_root)} is {'/'.join(arches)}")
+        if wrong_binaries:
+            shown = ", ".join(sorted(wrong_binaries)[:5])
+            issues.append(
+                f"vendored browser tree contains {len(wrong_binaries)} {opposite} "
+                f"binary/binaries: {shown}"
+                + (" ..." if len(wrong_binaries) > 5 else "")
             )
 
     return issues

--- a/tests/unit/test_check_dist_arch.py
+++ b/tests/unit/test_check_dist_arch.py
@@ -1,0 +1,213 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behaviour tests for the dist architecture gate that guards issue #2898."""
+from __future__ import annotations
+
+import importlib.util
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+_SPEC = importlib.util.spec_from_file_location(
+    "check_dist_arch", ROOT / "scripts" / "check_dist_arch.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+check_dist_arch = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_dist_arch"] = check_dist_arch
+_SPEC.loader.exec_module(check_dist_arch)
+
+
+_MACHO_CPU_BY_ARCH = {"x64": 0x01000007, "arm64": 0x0100000C}
+_ELF_MACHINE_BY_ARCH = {"x64": 62, "arm64": 183}
+_PE_MACHINE_BY_ARCH = {"x64": 0x8664, "arm64": 0xAA64}
+
+
+def macho(arch: str) -> bytes:
+    return b"\xcf\xfa\xed\xfe" + struct.pack("<I", _MACHO_CPU_BY_ARCH[arch]) + b"\x00" * 56
+
+
+def macho_fat(*arches: str) -> bytes:
+    blob = b"\xca\xfe\xba\xbe" + struct.pack(">I", len(arches))
+    for arch in arches:
+        blob += struct.pack(">I", _MACHO_CPU_BY_ARCH[arch]) + b"\x00" * 16
+    return blob + b"\x00" * 64
+
+
+def elf(arch: str) -> bytes:
+    head = bytearray(b"\x7fELF" + b"\x00" * 60)
+    head[4] = 2  # ELFCLASS64
+    head[5] = 1  # ELFDATA2LSB
+    head[18:20] = struct.pack("<H", _ELF_MACHINE_BY_ARCH[arch])
+    return bytes(head)
+
+
+def pe(arch: str) -> bytes:
+    pe_offset = 0x80
+    head = bytearray(b"\x00" * (pe_offset + 8))
+    head[0:2] = b"MZ"
+    head[0x3C:0x40] = struct.pack("<I", pe_offset)
+    head[pe_offset : pe_offset + 4] = b"PE\x00\x00"
+    head[pe_offset + 4 : pe_offset + 6] = struct.pack("<H", _PE_MACHINE_BY_ARCH[arch])
+    return bytes(head)
+
+
+def write(path: Path, payload: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return path
+
+
+@pytest.fixture()
+def mac_bundle(tmp_path: Path):
+    """A macOS-shaped dist: shell wrapper at the root, real Mach-O inside the .app."""
+
+    def build(entry_arch: str, lib_arch: str | None = None) -> Path:
+        root = tmp_path / "Xiao8"
+        write(
+            root / "projectneko_server",
+            b'#!/bin/bash\nexec "$(dirname "$0")/projectneko_server.app/Contents/MacOS/projectneko_server" "$@"\n',
+        )
+        write(
+            root / "projectneko_server.app" / "Contents" / "MacOS" / "projectneko_server",
+            macho(entry_arch),
+        )
+        write(
+            root / "projectneko_server.app" / "Contents" / "MacOS" / "unicodedata.so",
+            macho(lib_arch or entry_arch),
+        )
+        return root
+
+    return build
+
+
+def test_clean_x64_mac_dist_passes(mac_bundle) -> None:
+    root = mac_bundle("x64")
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+
+
+def test_issue_2898_shape_is_rejected(mac_bundle) -> None:
+    """The exact #2898 build: mac-x64 artifact whose Mach-O is arm64."""
+    root = mac_bundle("arm64")
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert issues, "an arm64 binary in an x64 bundle must not pass"
+    assert any("main binary is arm64" in issue for issue in issues)
+
+
+def test_shell_wrapper_at_root_does_not_shadow_the_real_binary(mac_bundle) -> None:
+    """The root `projectneko_server` is a text wrapper, not the Mach-O to inspect.
+
+    Without the "skip candidates that are not binaries" guard, the wrapper is
+    found first, `read_arches` returns None, and the arm64 payload sails through.
+    """
+    root = mac_bundle("arm64")
+    entry = check_dist_arch._entry_binary(root, "mac")
+    assert entry is not None
+    assert entry.name == "projectneko_server"
+    assert entry.parent.name == "MacOS"
+    assert check_dist_arch.read_arches(entry) == ["arm64"]
+
+
+def test_mismatched_native_library_is_reported(mac_bundle) -> None:
+    root = mac_bundle("x64", lib_arch="arm64")
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("native library" in issue and "unicodedata.so" in issue for issue in issues)
+
+
+def test_universal_binary_containing_the_expected_arch_passes(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho_fat("x64", "arm64"))
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+    assert check_dist_arch.check_dist_arch(root, "arm64", "mac") == []
+
+
+def test_vendored_browser_directory_with_opposite_arch_token_is_rejected(tmp_path: Path) -> None:
+    """#2898 also shipped chromium-1208/chrome-mac-arm64 inside the x64 bundle."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    (root / "playwright_browsers" / "chromium-1208" / "chrome-mac-arm64").mkdir(parents=True)
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("vendored browser tree" in issue for issue in issues)
+
+
+def test_vendored_browser_directory_matching_the_build_passes(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    (root / "playwright_browsers" / "chromium-1208" / "chrome-mac-x64").mkdir(parents=True)
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+
+
+def test_vendored_browser_binaries_are_not_header_scanned(tmp_path: Path) -> None:
+    """The browser tree is judged by directory naming, not by scanning its libs."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    write(
+        root / "playwright_browsers" / "chromium-1208" / "chrome-mac" / "libEGL.dylib",
+        macho("arm64"),
+    )
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+
+
+@pytest.mark.parametrize(
+    ("payload", "platform", "suffix"),
+    [(elf, "linux", ".so"), (pe, "win", ".dll")],
+)
+def test_elf_and_pe_dists_are_checked_too(tmp_path: Path, payload, platform, suffix) -> None:
+    root = tmp_path / "Xiao8"
+    entry = "projectneko_server.exe" if platform == "win" else "projectneko_server"
+    write(root / entry, payload("x64"))
+    write(root / f"native{suffix}", payload("arm64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", platform)
+    assert any("native library" in issue for issue in issues)
+
+    write(root / f"native{suffix}", payload("x64"))
+    assert check_dist_arch.check_dist_arch(root, "x64", platform) == []
+
+
+def test_linux_arm64_dist_is_accepted(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", elf("arm64"))
+    write(root / "native.so", elf("arm64"))
+    assert check_dist_arch.check_dist_arch(root, "arm64", "linux") == []
+    assert check_dist_arch.check_dist_arch(root, "x64", "linux") != []
+
+
+def test_missing_entry_binary_is_an_error(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    root.mkdir(parents=True)
+    issues = check_dist_arch.check_dist_arch(root, "x64", "linux")
+    assert any("main server binary not found" in issue for issue in issues)
+
+
+def test_non_binary_files_with_native_suffixes_are_ignored(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", elf("x64"))
+    write(root / "placeholder.so", b"not a binary at all\n")
+    assert check_dist_arch.check_dist_arch(root, "x64", "linux") == []
+
+
+def test_cli_exit_codes(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", elf("arm64"))
+    assert (
+        check_dist_arch.main([str(root), "--expect-arch", "arm64", "--expect-platform", "linux"])
+        == 0
+    )
+    assert (
+        check_dist_arch.main([str(root), "--expect-arch", "x64", "--expect-platform", "linux"]) == 1
+    )
+    assert "#2898" in capsys.readouterr().err

--- a/tests/unit/test_check_dist_arch.py
+++ b/tests/unit/test_check_dist_arch.py
@@ -151,14 +151,40 @@ def test_vendored_browser_directory_matching_the_build_passes(tmp_path: Path) ->
     assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
 
 
-def test_vendored_browser_binaries_are_not_header_scanned(tmp_path: Path) -> None:
-    """The browser tree is judged by directory naming, not by scanning its libs."""
+def test_tokenless_browser_directory_with_wrong_arch_binary_is_rejected(tmp_path: Path) -> None:
+    """Playwright also uses tokenless names like `chrome-mac`.
+
+    Directory-name matching alone would let a wrong-arch Chromium through, so
+    the browser tree is header-scanned as well.
+    """
     root = tmp_path / "Xiao8"
     write(root / "projectneko_server", macho("x64"))
-    write(
-        root / "playwright_browsers" / "chromium-1208" / "chrome-mac" / "libEGL.dylib",
-        macho("arm64"),
+    browser = root / "playwright_browsers" / "chromium-1208" / "chrome-mac"
+    write(browser / "libEGL.dylib", macho("arm64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("vendored browser tree contains" in issue for issue in issues)
+
+
+def test_suffixless_browser_executable_is_scanned(tmp_path: Path) -> None:
+    """Chromium's own executable has no filename suffix; dispatch on magic."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("arm64"))
+    browser = (
+        root / "playwright_browsers" / "chromium-1208" / "chrome-mac"
+        / "Chromium.app" / "Contents" / "MacOS"
     )
+    write(browser / "Chromium", macho("x64"))
+    issues = check_dist_arch.check_dist_arch(root, "arm64", "mac")
+    assert any("vendored browser tree contains" in issue for issue in issues)
+
+
+def test_matching_browser_tree_passes(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    browser = root / "playwright_browsers" / "chromium-1208" / "chrome-mac"
+    write(browser / "libEGL.dylib", macho("x64"))
+    write(browser / "Chromium.app" / "Contents" / "MacOS" / "Chromium", macho("x64"))
+    write(browser / "icudtl.dat", b"binary blob, not an executable\n")
     assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
 
 

--- a/tests/unit/test_check_dist_arch.py
+++ b/tests/unit/test_check_dist_arch.py
@@ -402,3 +402,23 @@ def test_browser_tree_with_wrong_container_format_is_rejected(tmp_path: Path) ->
     write(root / "playwright_browsers" / "chromium-1208" / "chrome-mac" / "chrome.dll", pe("x64"))
     issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
     assert any("wrong platform" in issue and "chrome.dll" in issue for issue in issues)
+
+
+def test_directory_token_walk_is_capped_too(tmp_path: Path, monkeypatch) -> None:
+    """The cap must bound the directory-name pass as well as the byte pass.
+
+    Two separate walks would leave this one unbounded, which makes the cap --
+    and the fail-closed message that goes with it -- theatre.
+    """
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    browsers = root / "playwright_browsers"
+    for index in range(40):
+        (browsers / f"chrome-mac-arm64-{index}").mkdir(parents=True)
+
+    monkeypatch.setattr(check_dist_arch, "_BROWSER_SCAN_FILE_LIMIT", 3)
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("could not be fully verified" in issue for issue in issues)
+    reported = [issue for issue in issues if "non-x64 directories" in issue]
+    # 上限是 3，40 个坏目录不可能全被看到；真全看到了就说明这道遍历没受限。
+    assert not reported or reported[0].count("chrome-mac-arm64-") <= 3

--- a/tests/unit/test_check_dist_arch.py
+++ b/tests/unit/test_check_dist_arch.py
@@ -384,6 +384,21 @@ def test_browser_scan_honours_its_file_cap(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(check_dist_arch, "read_binary", counting_read_binary)
     monkeypatch.setattr(check_dist_arch, "_BROWSER_SCAN_FILE_LIMIT", 3)
-    check_dist_arch.check_dist_arch(root, "x64", "mac")
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
     browser_reads = [p for p in seen if "playwright_browsers" in p.parts]
     assert len(browser_reads) <= 3
+    # 截断即「没验完」，必须 fail-closed：否则越过上限的错架构二进制会静默放行。
+    assert any("could not be fully verified" in issue for issue in issues)
+
+
+def test_browser_tree_with_wrong_container_format_is_rejected(tmp_path: Path) -> None:
+    """A Windows browser build inside a macOS bundle is PE x64: the arch test passes it.
+
+    `_iter_native_binaries()` skips `playwright_browsers`, so nothing else would
+    look at this file either.
+    """
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    write(root / "playwright_browsers" / "chromium-1208" / "chrome-mac" / "chrome.dll", pe("x64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("wrong platform" in issue and "chrome.dll" in issue for issue in issues)

--- a/tests/unit/test_check_dist_arch.py
+++ b/tests/unit/test_check_dist_arch.py
@@ -32,7 +32,7 @@ sys.modules["check_dist_arch"] = check_dist_arch
 _SPEC.loader.exec_module(check_dist_arch)
 
 
-_MACHO_CPU_BY_ARCH = {"x64": 0x01000007, "arm64": 0x0100000C}
+_MACHO_CPU_BY_ARCH = {"x64": 0x01000007, "arm64": 0x0100000C, "x86": 0x00000007}
 _ELF_MACHINE_BY_ARCH = {"x64": 62, "arm64": 183}
 _PE_MACHINE_BY_ARCH = {"x64": 0x8664, "arm64": 0xAA64}
 
@@ -422,3 +422,18 @@ def test_directory_token_walk_is_capped_too(tmp_path: Path, monkeypatch) -> None
     reported = [issue for issue in issues if "non-x64 directories" in issue]
     # 上限是 3，40 个坏目录不可能全被看到；真全看到了就说明这道遍历没受限。
     assert not reported or reported[0].count("chrome-mac-arm64-") <= 3
+
+
+def test_browser_binary_of_a_third_architecture_is_rejected(tmp_path: Path) -> None:
+    """Neither the expected arch nor its opposite: an x86 helper in an x64 bundle.
+
+    The browser tree used to run a denylist ("only the opposite arch fails"),
+    which let this through. It now uses the same strict rule as the rest of the
+    dist: not carrying the expected architecture is enough to fail.
+    """
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    browser = root / "playwright_browsers" / "chromium-1208" / "chrome-mac"
+    write(browser / "helper", macho("x86"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("non-x64" in issue and "helper" in issue for issue in issues)

--- a/tests/unit/test_check_dist_arch.py
+++ b/tests/unit/test_check_dist_arch.py
@@ -125,7 +125,7 @@ def test_shell_wrapper_at_root_does_not_shadow_the_real_binary(mac_bundle) -> No
 def test_mismatched_native_library_is_reported(mac_bundle) -> None:
     root = mac_bundle("x64", lib_arch="arm64")
     issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
-    assert any("native library" in issue and "unicodedata.so" in issue for issue in issues)
+    assert any("native binary" in issue and "unicodedata.so" in issue for issue in issues)
 
 
 def test_universal_binary_containing_the_expected_arch_passes(tmp_path: Path) -> None:
@@ -198,7 +198,7 @@ def test_elf_and_pe_dists_are_checked_too(tmp_path: Path, payload, platform, suf
     write(root / entry, payload("x64"))
     write(root / f"native{suffix}", payload("arm64"))
     issues = check_dist_arch.check_dist_arch(root, "x64", platform)
-    assert any("native library" in issue for issue in issues)
+    assert any("native binary" in issue for issue in issues)
 
     write(root / f"native{suffix}", payload("x64"))
     assert check_dist_arch.check_dist_arch(root, "x64", platform) == []
@@ -237,3 +237,153 @@ def test_cli_exit_codes(tmp_path: Path, capsys) -> None:
         check_dist_arch.main([str(root), "--expect-arch", "x64", "--expect-platform", "linux"]) == 1
     )
     assert "#2898" in capsys.readouterr().err
+
+
+def macho_fat64(*arches: str) -> bytes:
+    """FAT_MAGIC_64 universal binary: 32-byte fat_arch_64 records."""
+    blob = b"\xca\xfe\xba\xbf" + struct.pack(">I", len(arches))
+    for arch in arches:
+        blob += struct.pack(">I", _MACHO_CPU_BY_ARCH[arch]) + b"\x00" * 28
+    return blob + b"\x00" * 64
+
+
+def test_fat64_universal_binary_is_understood(tmp_path: Path) -> None:
+    """FAT_MAGIC_64 (cafebabf) is as valid a universal binary as the 32-bit header."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho_fat64("x64", "arm64"))
+    info = check_dist_arch.read_binary(root / "projectneko_server")
+    assert info is not None and info.format == check_dist_arch.MACHO
+    assert set(info.arches) == {"x64", "arm64"}
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+
+
+def test_fat64_binary_with_only_the_wrong_arch_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho_fat64("arm64"))
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") != []
+
+
+def test_versioned_elf_soname_is_scanned(tmp_path: Path) -> None:
+    """`libpython3.11.so.1.0` has Path.suffix `.0`, so a suffix allowlist misses it."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", elf("x64"))
+    write(root / "libpython3.11.so.1.0", elf("arm64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "linux")
+    assert any("libpython3.11.so.1.0" in issue for issue in issues)
+
+
+def test_extensionless_helper_executable_is_scanned(tmp_path: Path) -> None:
+    """Nuitka's Playwright plugin packages a bare `playwright/driver/node`."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", elf("x64"))
+    write(root / "playwright" / "driver" / "node", elf("arm64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "linux")
+    assert any("node" in issue for issue in issues)
+
+
+def test_windows_helper_exe_is_scanned(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server.exe", pe("x64"))
+    write(root / "playwright" / "driver" / "node.exe", pe("arm64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "win")
+    assert any("node.exe" in issue for issue in issues)
+
+
+def test_foreign_container_format_is_rejected_even_when_the_arch_matches(tmp_path: Path) -> None:
+    """A leftover Windows DLL in a mac bundle is PE x64: the arch check alone passes it."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    write(root / "steam_api64.dll", pe("x64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "mac")
+    assert any("wrong platform" in issue and "steam_api64.dll" in issue for issue in issues)
+
+
+def test_entry_binary_of_the_wrong_container_format_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server.exe", elf("x64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "win")
+    assert any("must be pe" in issue for issue in issues)
+
+
+def test_workspace_path_containing_an_arch_token_does_not_trip_the_gate(tmp_path: Path) -> None:
+    """Only paths below the dist root may be matched against arch tokens.
+
+    A CI workspace directory named e.g. `runner-arm64-workspace` must not make a
+    correct x64 bundle fail.
+    """
+    root = tmp_path / "runner-arm64-workspace" / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    (root / "playwright_browsers" / "chromium-1208" / "chrome-mac-x64").mkdir(parents=True)
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+
+
+def test_vendored_browser_exclusion_is_relative_to_the_dist_root(tmp_path: Path) -> None:
+    """An ancestor named playwright_browsers must not hide the whole dist from the scan."""
+    root = tmp_path / "playwright_browsers" / "Xiao8"
+    write(root / "projectneko_server", elf("x64"))
+    write(root / "native.so", elf("arm64"))
+    issues = check_dist_arch.check_dist_arch(root, "x64", "linux")
+    assert any("native.so" in issue for issue in issues)
+
+
+def test_short_mz_file_does_not_crash_the_gate(tmp_path: Path) -> None:
+    """A 20..63 byte data file starting with `MZ` used to raise struct.error.
+
+    The browser scan feeds every ordinary file to the header reader, so a data
+    blob that merely begins with those two bytes must be shrugged off, not
+    allowed to take the whole build down.
+    """
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    write(root / "playwright_browsers" / "chrome-mac" / "blob.dat", b"MZ" + b"\x00" * 30)
+    assert check_dist_arch.read_binary(root / "playwright_browsers" / "chrome-mac" / "blob.dat") is None
+    assert check_dist_arch.check_dist_arch(root, "x64", "mac") == []
+
+
+def test_forged_pe_offset_is_not_followed(tmp_path: Path, monkeypatch) -> None:
+    """A bogus e_lfanew must not turn into an unbounded read.
+
+    Asserting only that the file is rejected proves nothing: a 4 GiB read
+    request against a 64-byte file also returns 64 bytes and is rejected the
+    same way. The invariant worth holding is the *size we ask for*.
+    """
+    root = tmp_path / "Xiao8"
+    blob = bytearray(b"\x00" * 64)
+    blob[0:2] = b"MZ"
+    blob[0x3C:0x40] = struct.pack("<I", 0xFFFFFFF0)
+    path = write(root / "forged.dll", bytes(blob))
+
+    requested: list[int] = []
+    real_read_head = check_dist_arch._read_head
+
+    def recording_read_head(target: Path, size: int = 64) -> bytes:
+        requested.append(size)
+        return real_read_head(target, size)
+
+    monkeypatch.setattr(check_dist_arch, "_read_head", recording_read_head)
+    assert check_dist_arch.read_binary(path) is None
+    assert max(requested) <= check_dist_arch._MAX_PE_HEADER_OFFSET + 8, (
+        f"read a forged PE offset unbounded: asked for {max(requested)} bytes"
+    )
+
+
+def test_browser_scan_honours_its_file_cap(tmp_path: Path, monkeypatch) -> None:
+    """The cap must bound the walk itself, not just the reporting."""
+    root = tmp_path / "Xiao8"
+    write(root / "projectneko_server", macho("x64"))
+    browser = root / "playwright_browsers" / "chrome-mac"
+    for index in range(12):
+        write(browser / f"lib{index}.dylib", macho("arm64"))
+
+    seen: list[Path] = []
+    real_read_binary = check_dist_arch.read_binary
+
+    def counting_read_binary(path: Path):
+        seen.append(path)
+        return real_read_binary(path)
+
+    monkeypatch.setattr(check_dist_arch, "read_binary", counting_read_binary)
+    monkeypatch.setattr(check_dist_arch, "_BROWSER_SCAN_FILE_LIMIT", 3)
+    check_dist_arch.check_dist_arch(root, "x64", "mac")
+    browser_reads = [p for p in seen if "playwright_browsers" in p.parts]
+    assert len(browser_reads) <= 3

--- a/tests/unit/test_desktop_build_arch_contract.py
+++ b/tests/unit/test_desktop_build_arch_contract.py
@@ -1,0 +1,157 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every desktop matrix leg must build the architecture its runner is native to.
+
+Issue #2898: the ``mac-x64`` leg ran on ``macos-15``, which is an Apple Silicon
+image. ``actions/setup-python`` with ``architecture: x64`` puts Python under
+Rosetta but Nuitka still emits arm64, so an unusable "Intel" build shipped for
+months with a fully green pipeline.
+
+The runner-label table below is the part that carries the weight: it is the fact
+nobody checked. Adding a leg on an unlisted label fails here rather than silently
+producing the wrong binary.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+CROSS_PLATFORM_WORKFLOW = ROOT / ".github" / "workflows" / "build-desktop.yml"
+LINUX_WORKFLOW = ROOT / ".github" / "workflows" / "build-desktop-linux.yml"
+ARCH_GATE_SCRIPT = ROOT / "scripts" / "check_dist_arch.py"
+GATE_STEP_NAME = "Verify dist CPU architecture"
+
+# GitHub-hosted runner label -> the CPU architecture that image natively builds.
+# Source: https://github.com/actions/runner-images README label table.
+_RUNNER_NATIVE_ARCH = {
+    "windows-latest": "x64",
+    "macos-15-intel": "x64",
+    "macos-15-large": "x64",
+    "macos-15": "arm64",
+    "macos-latest": "arm64",
+    "ubuntu-latest": "x64",
+    "ubuntu-24.04": "x64",
+    "ubuntu-24.04-arm": "arm64",
+    "ubuntu-22.04-arm": "arm64",
+}
+
+
+def _load(path: Path) -> dict:
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _matrix_entries(workflow: dict, job: str) -> list[dict]:
+    include = workflow["jobs"][job]["strategy"]["matrix"]["include"]
+    if isinstance(include, list):
+        return include
+    # `include: ${{ fromJSON(inputs.windows_only && '[...]' || '[...]') }}`
+    branches = re.findall(r"'(\[\{.*?\}\])'", include)
+    assert len(branches) == 2, f"unexpected matrix expression for {job}: {include[:120]}"
+    entries: list[dict] = []
+    for branch in branches:
+        entries.extend(json.loads(branch))
+    return entries
+
+
+def _steps(workflow: dict, job: str) -> dict[str, dict]:
+    return {s["name"]: s for s in workflow["jobs"][job]["steps"] if "name" in s}
+
+
+def test_arch_gate_script_exists() -> None:
+    assert ARCH_GATE_SCRIPT.is_file()
+
+
+@pytest.mark.parametrize("job", ["build-python", "build-electron"])
+def test_every_leg_runs_on_a_known_runner_label(job: str) -> None:
+    workflow = _load(CROSS_PLATFORM_WORKFLOW)
+    unknown = sorted(
+        {e["os"] for e in _matrix_entries(workflow, job)} - set(_RUNNER_NATIVE_ARCH)
+    )
+    assert not unknown, (
+        f"{job} uses runner label(s) with no recorded native architecture: {unknown}. "
+        "Add them to _RUNNER_NATIVE_ARCH after checking actions/runner-images, "
+        "otherwise nothing stops a repeat of #2898."
+    )
+
+
+def test_build_python_legs_declare_the_arch_their_runner_actually_builds() -> None:
+    """The #2898 assertion: mac-x64 on an Apple Silicon image must not pass."""
+    workflow = _load(CROSS_PLATFORM_WORKFLOW)
+    wrong = [
+        (e["platform"], e["os"], e.get("expect_arch"), _RUNNER_NATIVE_ARCH[e["os"]])
+        for e in _matrix_entries(workflow, "build-python")
+        if e.get("expect_arch") != _RUNNER_NATIVE_ARCH[e["os"]]
+    ]
+    assert not wrong, f"leg(s) claim an arch their runner does not build natively: {wrong}"
+
+
+def test_build_electron_mac_and_linux_legs_match_their_backend_runner() -> None:
+    """The Electron shell and the Python backend for one platform must agree.
+
+    Downloading an x64 backend into an arm64 shell (or the reverse) reproduces
+    #2898 from the other side.
+    """
+    workflow = _load(CROSS_PLATFORM_WORKFLOW)
+    backend_arch = {
+        e["artifact_name"]: _RUNNER_NATIVE_ARCH[e["os"]]
+        for e in _matrix_entries(workflow, "build-python")
+    }
+    mismatched = [
+        (e["artifact_name"], e["os"], _RUNNER_NATIVE_ARCH[e["os"]], backend_arch[e["python_artifact"]])
+        for e in _matrix_entries(workflow, "build-electron")
+        if _RUNNER_NATIVE_ARCH[e["os"]] != backend_arch[e["python_artifact"]]
+    ]
+    assert not mismatched, f"Electron shell / backend architecture mismatch: {mismatched}"
+
+
+def test_every_build_python_leg_carries_the_gate_inputs() -> None:
+    workflow = _load(CROSS_PLATFORM_WORKFLOW)
+    missing = [
+        e["artifact_name"]
+        for e in _matrix_entries(workflow, "build-python")
+        if not e.get("expect_arch") or not e.get("expect_platform")
+    ]
+    assert not missing, f"matrix leg(s) without expect_arch/expect_platform: {missing}"
+
+
+def test_cross_platform_workflow_runs_the_gate_before_upload() -> None:
+    workflow = _load(CROSS_PLATFORM_WORKFLOW)
+    steps = workflow["jobs"]["build-python"]["steps"]
+    names = [s.get("name") for s in steps]
+    assert GATE_STEP_NAME in names
+    gate = _steps(workflow, "build-python")[GATE_STEP_NAME]
+    assert "scripts/check_dist_arch.py" in gate["run"]
+    assert "${{ matrix.expect_arch }}" in gate["run"]
+    assert "${{ matrix.expect_platform }}" in gate["run"]
+    # 闸门必须在产物上传之前跑，否则坏包照样发出去。
+    assert names.index(GATE_STEP_NAME) < names.index("Upload Python backend artifact")
+
+
+def test_linux_only_workflow_runs_the_same_gate_before_upload() -> None:
+    workflow = _load(LINUX_WORKFLOW)
+    steps = workflow["jobs"]["build-python"]["steps"]
+    names = [s.get("name") for s in steps]
+    assert GATE_STEP_NAME in names
+    gate = _steps(workflow, "build-python")[GATE_STEP_NAME]
+    assert "scripts/check_dist_arch.py" in gate["run"]
+    assert "--expect-arch x64" in gate["run"]
+    assert names.index(GATE_STEP_NAME) < names.index("Upload Python backend artifact")


### PR DESCRIPTION
Closes #2898

## 根因

`mac-x64` 那条腿一直跑在 `macos-15` 上。查 [actions/runner-images 的 label 表](https://github.com/actions/runner-images#available-images)：

| label | 架构 |
|---|---|
| `macos-15` | **arm64**（Apple Silicon） |
| `macos-15-intel` | x64 |
| `macos-latest` | arm64（现指向 macOS 26） |

`actions/setup-python` 的 `architecture: x64` 只让 **Python** 走 Rosetta，Nuitka 照样吐原生 arm64，Playwright 也按宿主架构下成了 `chrome-mac-arm64`。结果就是 issue 里报的 `Bad CPU type in executable` —— 而流水线全绿，从 8 月挂到现在。

## 改了什么

**1. 换 runner** — `build-python` / `build-electron` 的 mac-x64 腿 `macos-15` → `macos-15-intel`。

**2. 加产物架构闸门** — 新增 [`scripts/check_dist_arch.py`](scripts/check_dist_arch.py)，直接读 Mach-O / ELF / PE 头判架构，**不依赖 `lipo` / `file`**，三个 CI 宿主上行为一致。检查三件事：

- 主二进制的 CPU type（fat binary 逐 slice 看，含期望架构即放行）
- `playwright_browsers/` 之外的全部 `.so` / `.dylib` / `.pyd` / `.dll`
- vendored 浏览器树里不许出现对立架构词元 —— issue 里那个坏包正是 `chromium-1208/chrome-mac-arm64`。这里用「对立词元黑名单」而不是「要求某个确切目录名」，是为了扛得住 Playwright 改布局

一个容易踩空的点：macOS dist 根上的 `projectneko_server` 是个 shell wrapper（`exec` 进 `.app`），不是 Mach-O。天真地取第一个同名文件会拿到它、`read_arches` 返回 `None`、坏包直接放行。所以查找主程序时跳过「不是可执行格式」的候选。

**3. 接进两个 workflow** — `build-desktop.yml` 每条腿带 `expect_arch` / `expect_platform`，在**上传产物之前**跑闸门；`build-desktop-linux.yml` 加对偶的一步。

## 测试

`tests/unit/test_check_dist_arch.py`（14 条）—— 合成 Mach-O / fat / ELF / PE 头，覆盖 #2898 的确切形状、universal binary、wrapper 遮蔽、浏览器目录词元、后缀像原生库但不是二进制的占位文件。

**变异验证**（护栏本身会不会红）：

| 变异 | 结果 |
|---|---|
| 去掉 wrapper 守卫 | 3 failed |
| 主二进制架构断言恒真 | 2 failed |
| 原生库扫描恒真 | 3 failed |
| 浏览器词元黑名单置空 | 1 failed |
| fat binary 只认首个 slice | 1 failed |

`tests/unit/test_desktop_build_arch_contract.py`（8 条）—— 拿 **runner label → 原生架构表** 校验每条腿声明的架构，而不是复述 YAML。这张表才是当初没人查的那个事实；用没登记过的 label 加新腿会直接红。

**A/B 验证**：把 runner 退回 `macos-15`，立刻红在

```
assert not [('mac-x64', 'macos-15', 'x64', 'arm64')]
```

只删闸门步骤也红。还原后全绿。

其余 8 个读 build-desktop.yml 的存量结构测试：131 passed / 8 skipped。docstring 禁 CJK 门（`--base origin/main`）绿。

## 没做的

- **没动 `macos-latest`（mac-arm64 腿）**。它现在指向 macOS 26 arm64，架构是对的，但会随 GitHub 的 `-latest` 迁移漂移，两条 mac 腿因此跑在不同 OS 版本上。要不要钉成 `macos-15` 是另一个决定，不在本 PR。
- **闸门只挂在 `build-python`**。Electron 腿消费的就是这里已经查过的 backend artifact，shell 自身的架构由 electron-builder 的 `--x64` / `--arm64` 显式决定。

## 还没验证的

`macos-15-intel` 上的实际构建没跑过 —— Intel 机器上的 Nuitka / Playwright / 依赖轮子可能还有别的坑。需要一次真 nightly 才知道。issue 里 @Tuffy2013 说过合并后可以帮忙在 Intel Mac 上端到端验证。

## 评审轮补的（dde7acd / 1f60430）

Reviewer 一共提了 8 条，**收 7 驳 1**。驳的是「加启动 + 轮询 `/health` 的冒烟检查」—— 那是运行时可启动性，和本 PR 的主张是两件事，且要在构建 job 里拉起整个后端（绑端口、载 onnx、扫插件），既慢又是新的不稳定源。值得做，但该单独提、且覆盖全部四条腿。

收下的 7 条里，5 条是**闸门会漏掉真实存在的产物形态**：

| 漏检 | 后果 |
|---|---|
| 版本化 ELF soname（`libpython3.11.so.1.0` 的 `Path.suffix` 是 `.0`） | Linux dist 里绝大多数共享库根本没被扫到；`.so` 符号链接也兜不住，因为显式跳过 symlink |
| 无后缀的原生 helper | 后缀表里连 `.exe` 都没有，`playwright/driver/node` 完全漏 —— 而两个 workflow 都明确依赖 Nuitka 的 playwright 插件打包它 |
| `FAT_MAGIC_64`（`cafebabf`，32 字节 `fat_arch_64`） | 一红一绿两个方向：这种主程序被判「不是可执行文件」（假红阻塞），这种 dylib 被静默跳过（假绿） |
| 容器格式没校验 | **跨平台库混进来时架构反而是「对」的** —— Windows 的 `steam_api64.dll` 也是 PE x64，在 mac x64 包里架构检查完全通过。这仓库正好把三平台 Steam 原生库存在源码树里靠 `rm -f` 剥离，漏剥就是这个形状 |
| 浏览器树只按目录名判 | Playwright 也用无词元的 `chrome-mac`，那种情况下装错架构的 Chromium 直接放行 |

另外 2 条是**我把扫描面扩到「每个普通文件」时自己引入的崩溃路径**：长度 20..63 字节且以 `MZ` 开头的数据文件会让 `struct.unpack` 抛 `struct.error` 打崩闸门；伪造的巨大 `pe_offset` 会发起无界读。浏览器树扫描也不再先 `sorted()` 物化整棵树（那样文件数上限形同虚设）。

reviewer 指出 `path.parts` 含 `dist_root` 祖先这条时，**同类还有第二处没人提到**：排除 `playwright_browsers` 也是绝对路径判断，祖先里有同名目录会让整棵树对扫描隐身。那个方向是假绿，比原报的假红更危险。两处都改 `relative_to`，两个方向各加一条测试。

### 第三轮（5c0eb1b）

两家 reviewer 独立收敛到同样两条，都是上一 commit 的直接后果：

- **文件数上限是 fail-open 的** —— 截断后直接 `break`，不往 `issues` 里加任何东西，于是越过上限的错架构二进制会让整个闸门静默放行，**比不设上限更糟**。改成截断即报「没验完」。
- **浏览器树只判了架构没判格式** —— `chrome-mac` 底下的 PE x64 既满足架构判据，又因为 `_iter_native_binaries()` 排除 `playwright_browsers` 而不被别处检查；macOS 包里混进整套 Windows 浏览器会完全放行。补上和 dist 主体同一条格式判据。

### 变异验证

累计 11 个变异全部被杀。其中一个值得单独说：

`pe_offset` 上界那条**第一次是存活的**。原测试只断言「文件被拒」，而没有上界时行为一模一样 —— 4 GiB 的读请求打在 64 字节文件上也返回 64 字节、同样被拒。测试写错了，等于没测到不变量。改成记录并断言**实际请求的读取长度**之后才立得住。

最终 `tests/unit/test_check_dist_arch.py` 28 条 + `test_desktop_build_arch_contract.py` 8 条 + 存量 workflow 结构测试，全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 新增 Linux arm64 桌面构建与发行包支持。
  - 构建流程会校验发行包及浏览器组件的目标 CPU 架构和操作系统平台，减少架构不匹配的安装包发布。
  - Linux arm64 nightly 发布会根据实际生成的发行包显示对应条目。

- **测试**
  - 增加跨平台构建架构契约和发行包架构校验，覆盖多种二进制格式及常见错误场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

