### PR TITLE
修复角色云存档被误当作完整快照导入的问题，确保恢复角色时保留我的档案，并兼容旧版快照

### DIFF
--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -1279,6 +1279,37 @@ def test_local_cloudsave_round_trip_restores_runtime_truth(tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("manifest_update", "error_match"),
+    [
+        ({"snapshot_kind": "character_collection"}, "fingerprint mismatch"),
+        ({"fingerprint": ""}, "fingerprint is required"),
+    ],
+    ids=["kind_tamper", "missing_fingerprint"],
+)
+def test_schema_two_manifest_binds_snapshot_kind_to_fingerprint(
+    tmp_path, manifest_update, error_match,
+):
+    cm = _make_config_manager(tmp_path)
+
+    from utils.cloudsave_runtime import export_local_cloudsave_snapshot, import_local_cloudsave_snapshot
+
+    _write_runtime_state(cm)
+    export_local_cloudsave_snapshot(cm)
+    manifest = json.loads(cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
+    manifest.update(manifest_update)
+    atomic_write_json(
+        cm.cloudsave_manifest_path,
+        manifest,
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        import_local_cloudsave_snapshot(cm)
+
+
+@pytest.mark.unit
 def test_local_cloudsave_import_failure_restores_recent_redirects(tmp_path):
     cm = _make_config_manager(tmp_path)
 
@@ -1417,7 +1448,9 @@ def _tamper_manifest_with_memory_key(cm, hostile_key: str, placement_relative_pa
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["files"][hostile_key] = {"sha256": "0" * 64, "size": 2}
     # 攻击场景里 manifest 由存档作者产出，fingerprint 留空即可跳过一致性校验，
-    # 因此路径约束不能依赖 fingerprint 这道闸。
+    # 因此旧版路径约束不能依赖 fingerprint 这道闸。
+    manifest["schema_version"] = 1
+    manifest["min_reader_schema_version"] = 1
     manifest["fingerprint"] = ""
     atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
 
@@ -2451,8 +2484,17 @@ def test_legacy_snapshot_without_kind_uses_merge_semantics(tmp_path, marker_sequ
         (source_cm.cloudsave_catalog_dir / "current_character.json").read_text(encoding="utf-8")
     )
     manifest.pop("snapshot_kind", None)
+    manifest["schema_version"] = 1
+    manifest["min_reader_schema_version"] = 1
     if marker_sequence is None:
         assert int(marker_payload["entry_sequence_number"]) == int(manifest["sequence_number"])
+        from utils.cloudsave_runtime.staging import _build_manifest_fingerprint
+
+        manifest["fingerprint"] = _build_manifest_fingerprint(
+            client_id=str(manifest.get("client_id") or ""),
+            sequence_number=int(manifest.get("sequence_number") or 0),
+            files=manifest["files"],
+        )
     else:
         marker_payload["entry_sequence_number"] = marker_sequence
         atomic_write_json(
@@ -2492,6 +2534,7 @@ def test_schema_one_stale_full_kind_uses_merge_semantics(tmp_path):
     target_cm = _make_config_manager(tmp_path / "target")
 
     from utils.cloudsave_runtime import export_local_cloudsave_snapshot, import_local_cloudsave_snapshot
+    from utils.cloudsave_runtime.staging import _build_manifest_fingerprint
 
     _write_runtime_state(source_cm, character_name="云端角色")
     export_local_cloudsave_snapshot(source_cm)
@@ -2499,6 +2542,11 @@ def test_schema_one_stale_full_kind_uses_merge_semantics(tmp_path):
     assert manifest["snapshot_kind"] == "full_runtime"
     manifest["schema_version"] = 1
     manifest["min_reader_schema_version"] = 1
+    manifest["fingerprint"] = _build_manifest_fingerprint(
+        client_id=str(manifest.get("client_id") or ""),
+        sequence_number=int(manifest.get("sequence_number") or 0),
+        files=manifest["files"],
+    )
     atomic_write_json(
         source_cm.cloudsave_manifest_path,
         manifest,
@@ -2529,11 +2577,19 @@ def test_legacy_character_collection_repairs_missing_owner_without_replacing_rol
     target_cm = _make_config_manager(tmp_path / "target")
 
     from utils.cloudsave_runtime import export_cloudsave_character_unit, import_local_cloudsave_snapshot
+    from utils.cloudsave_runtime.staging import _build_manifest_fingerprint
 
     _write_runtime_state(source_cm, character_name="云端角色")
     export_cloudsave_character_unit(source_cm, "云端角色")
     manifest = json.loads(source_cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
     manifest.pop("snapshot_kind", None)
+    manifest["schema_version"] = 1
+    manifest["min_reader_schema_version"] = 1
+    manifest["fingerprint"] = _build_manifest_fingerprint(
+        client_id=str(manifest.get("client_id") or ""),
+        sequence_number=int(manifest.get("sequence_number") or 0),
+        files=manifest["files"],
+    )
     atomic_write_json(
         source_cm.cloudsave_manifest_path,
         manifest,

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -2435,7 +2435,8 @@ def test_character_collection_import_preserves_owner_globals_and_unrelated_chara
 
 
 @pytest.mark.unit
-def test_legacy_collection_with_retained_full_markers_uses_merge_semantics(tmp_path):
+@pytest.mark.parametrize("marker_sequence", [None, "invalid"], ids=["collision", "malformed"])
+def test_legacy_snapshot_without_kind_uses_merge_semantics(tmp_path, marker_sequence):
     source_cm = _make_config_manager(tmp_path / "source")
     target_cm = _make_config_manager(tmp_path / "target")
 
@@ -2448,8 +2449,17 @@ def test_legacy_collection_with_retained_full_markers_uses_merge_semantics(tmp_p
         (source_cm.cloudsave_catalog_dir / "current_character.json").read_text(encoding="utf-8")
     )
     manifest.pop("snapshot_kind", None)
-    manifest["sequence_number"] = int(marker_payload["entry_sequence_number"]) + 1
-    manifest["fingerprint"] = ""
+    if marker_sequence is None:
+        assert int(marker_payload["entry_sequence_number"]) == int(manifest["sequence_number"])
+    else:
+        marker_payload["entry_sequence_number"] = marker_sequence
+        atomic_write_json(
+            source_cm.cloudsave_catalog_dir / "current_character.json",
+            marker_payload,
+            ensure_ascii=False,
+            indent=2,
+        )
+        manifest["fingerprint"] = ""
     atomic_write_json(
         source_cm.cloudsave_manifest_path,
         manifest,

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -1218,6 +1218,7 @@ def test_local_cloudsave_round_trip_restores_runtime_truth(tmp_path):
 
     export_result = export_local_cloudsave_snapshot(cm)
     assert export_result["manifest"]["sequence_number"] == 1
+    assert export_result["manifest"]["snapshot_kind"] == "full_runtime"
     assert (cm.cloudsave_dir / "profiles" / "characters.json").is_file()
     assert (cm.cloudsave_dir / "memory" / "小满" / "recent.json").is_file()
     assert (cm.cloudsave_dir / "bindings" / "小满.json").is_file()
@@ -2258,8 +2259,31 @@ def test_export_cloudsave_character_unit_updates_only_single_character_scope(tmp
     assert not (cm.cloudsave_dir / "catalog" / "current_character.json").exists()
 
     manifest_payload = json.loads(cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["snapshot_kind"] == "character_collection"
     assert "characters/小满/profile.json" in manifest_payload["files"]
     assert "profiles/characters.json" in manifest_payload["files"]
+
+
+@pytest.mark.unit
+def test_character_upload_converts_full_snapshot_to_role_only_scope(tmp_path):
+    cm = _make_config_manager(tmp_path)
+
+    from utils.cloudsave_runtime import export_cloudsave_character_unit, export_local_cloudsave_snapshot
+
+    _write_runtime_state(cm, character_name="小满")
+    export_local_cloudsave_snapshot(cm)
+    assert (cm.cloudsave_profiles_dir / "conversation_settings.json").is_file()
+    assert (cm.cloudsave_catalog_dir / "current_character.json").is_file()
+
+    result = export_cloudsave_character_unit(cm, "小满", overwrite=True)
+
+    profiles = json.loads((cm.cloudsave_profiles_dir / "characters.json").read_text(encoding="utf-8"))
+    assert set(profiles) == {"猫娘"}
+    assert result["manifest"]["snapshot_kind"] == "character_collection"
+    assert "profiles/conversation_settings.json" not in result["manifest"]["files"]
+    assert "catalog/current_character.json" not in result["manifest"]["files"]
+    assert not (cm.cloudsave_profiles_dir / "conversation_settings.json").exists()
+    assert not (cm.cloudsave_catalog_dir / "current_character.json").exists()
 
 
 @pytest.mark.unit
@@ -2355,7 +2379,78 @@ def test_single_character_upload_rebuilds_legacy_mirrors_from_sharded_cloud_unio
     result = import_local_cloudsave_snapshot(target_cm)
 
     assert result["applied_character_count"] == 2
-    assert set((target_cm.load_characters().get("猫娘") or {}).keys()) == {"角色A", "角色B"}
+    assert result["snapshot_kind"] == "character_collection"
+    imported_characters = target_cm.load_characters()
+    assert {"角色A", "角色B"} <= set((imported_characters.get("猫娘") or {}).keys())
+    assert imported_characters["主人"]["档案名"]
+
+
+@pytest.mark.unit
+def test_character_collection_import_preserves_owner_globals_and_unrelated_character(tmp_path):
+    source_cm = _make_config_manager(tmp_path / "source")
+    target_cm = _make_config_manager(tmp_path / "target")
+
+    from utils.cloudsave_runtime import export_cloudsave_character_unit, import_local_cloudsave_snapshot
+
+    _write_runtime_state(source_cm, character_name="云端角色")
+    export_cloudsave_character_unit(source_cm, "云端角色")
+
+    _write_runtime_state(target_cm, character_name="本地角色")
+    target_characters = target_cm.load_characters()
+    target_characters["主人"]["档案名"] = "本地主人"
+    target_characters["当前猫娘"] = "本地角色"
+    target_cm.save_characters(target_characters, bypass_write_fence=True)
+    target_preferences_path = Path(target_cm.get_runtime_config_path("user_preferences.json"))
+    target_preferences_path.parent.mkdir(parents=True, exist_ok=True)
+    target_preferences_path.write_text('[{"local_global":"keep"}]', encoding="utf-8")
+    unrelated_recent = Path(target_cm.memory_dir) / "本地角色" / "recent.json"
+    unrelated_recent_before = unrelated_recent.read_bytes()
+
+    shutil.copytree(source_cm.cloudsave_dir, target_cm.cloudsave_dir, dirs_exist_ok=True)
+    result = import_local_cloudsave_snapshot(target_cm)
+
+    imported_characters = target_cm.load_characters()
+    assert result["snapshot_kind"] == "character_collection"
+    assert imported_characters["主人"]["档案名"] == "本地主人"
+    assert imported_characters["当前猫娘"] == "本地角色"
+    assert {"本地角色", "云端角色"} <= set(imported_characters["猫娘"])
+    assert json.loads(target_preferences_path.read_text(encoding="utf-8")) == [
+        {"local_global": "keep"},
+    ]
+    assert unrelated_recent.read_bytes() == unrelated_recent_before
+    assert (Path(target_cm.memory_dir) / "云端角色" / "recent.json").is_file()
+
+
+@pytest.mark.unit
+def test_legacy_character_collection_repairs_missing_owner_without_replacing_roles(tmp_path):
+    source_cm = _make_config_manager(tmp_path / "source")
+    target_cm = _make_config_manager(tmp_path / "target")
+
+    from utils.cloudsave_runtime import export_cloudsave_character_unit, import_local_cloudsave_snapshot
+
+    _write_runtime_state(source_cm, character_name="云端角色")
+    export_cloudsave_character_unit(source_cm, "云端角色")
+    manifest = json.loads(source_cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
+    manifest.pop("snapshot_kind", None)
+    atomic_write_json(
+        source_cm.cloudsave_manifest_path,
+        manifest,
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    _write_runtime_state(target_cm, character_name="本地角色")
+    broken_characters = target_cm.load_characters()
+    broken_characters.pop("主人", None)
+    target_cm.save_characters(broken_characters, bypass_write_fence=True)
+    shutil.copytree(source_cm.cloudsave_dir, target_cm.cloudsave_dir, dirs_exist_ok=True)
+
+    result = import_local_cloudsave_snapshot(target_cm)
+
+    repaired_characters = target_cm.load_characters()
+    assert result["snapshot_kind"] == "character_collection"
+    assert repaired_characters["主人"]["档案名"]
+    assert {"本地角色", "云端角色"} <= set(repaired_characters["猫娘"])
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -2251,7 +2251,7 @@ def test_export_cloudsave_character_unit_updates_only_single_character_scope(tmp
 
     assert result["character_name"] == "小满"
     assert result["detail"]["item"]["relation_state"] == "matched"
-    assert (cm.cloudsave_dir / "profiles" / "characters.json").is_file()
+    assert (cm.cloudsave_dir / "profiles" / "character_collection.json").is_file()
     assert (cm.cloudsave_dir / "bindings" / "小满.json").is_file()
     assert (cm.cloudsave_dir / "memory" / "小满" / "recent.json").is_file()
     assert (cm.cloudsave_dir / "characters" / "小满" / "meta.json").is_file()
@@ -2260,8 +2260,13 @@ def test_export_cloudsave_character_unit_updates_only_single_character_scope(tmp
 
     manifest_payload = json.loads(cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
     assert manifest_payload["snapshot_kind"] == "character_collection"
+    assert manifest_payload["schema_version"] == 2
+    assert manifest_payload["min_reader_schema_version"] == 2
     assert "characters/小满/profile.json" in manifest_payload["files"]
-    assert "profiles/characters.json" in manifest_payload["files"]
+    assert "profiles/character_collection.json" in manifest_payload["files"]
+    # Old readers require this monolithic full-runtime path. Omitting it makes
+    # them reject a collection before applying any destructive replacement.
+    assert "profiles/characters.json" not in manifest_payload["files"]
 
 
 @pytest.mark.unit
@@ -2277,11 +2282,16 @@ def test_character_upload_converts_full_snapshot_to_role_only_scope(tmp_path):
 
     result = export_cloudsave_character_unit(cm, "小满", overwrite=True)
 
-    profiles = json.loads((cm.cloudsave_profiles_dir / "characters.json").read_text(encoding="utf-8"))
+    profiles = json.loads(
+        (cm.cloudsave_profiles_dir / "character_collection.json").read_text(encoding="utf-8")
+    )
     assert set(profiles) == {"猫娘"}
     assert result["manifest"]["snapshot_kind"] == "character_collection"
+    assert "profiles/character_collection.json" in result["manifest"]["files"]
+    assert "profiles/characters.json" not in result["manifest"]["files"]
     assert "profiles/conversation_settings.json" not in result["manifest"]["files"]
     assert "catalog/current_character.json" not in result["manifest"]["files"]
+    assert not (cm.cloudsave_profiles_dir / "characters.json").exists()
     assert not (cm.cloudsave_profiles_dir / "conversation_settings.json").exists()
     assert not (cm.cloudsave_catalog_dir / "current_character.json").exists()
 
@@ -2334,7 +2344,7 @@ def test_single_character_cloudsave_operations_support_embedded_dot_names(tmp_pa
 
 
 @pytest.mark.unit
-def test_single_character_upload_rebuilds_legacy_mirrors_from_sharded_cloud_union(tmp_path):
+def test_single_character_upload_rebuilds_collection_from_sharded_cloud_union(tmp_path):
     source_cm = _make_config_manager(tmp_path / "source")
     target_cm = _make_config_manager(tmp_path / "target")
 
@@ -2369,9 +2379,12 @@ def test_single_character_upload_rebuilds_legacy_mirrors_from_sharded_cloud_unio
 
     export_cloudsave_character_unit(source_cm, "角色A", overwrite=True)
 
-    repaired_profiles = json.loads((source_cm.cloudsave_profiles_dir / "characters.json").read_text(encoding="utf-8"))
+    repaired_profiles = json.loads(
+        (source_cm.cloudsave_profiles_dir / "character_collection.json").read_text(encoding="utf-8")
+    )
     repaired_catalog = json.loads((source_cm.cloudsave_catalog_dir / "catgirls_index.json").read_text(encoding="utf-8"))
     assert set((repaired_profiles.get("猫娘") or {}).keys()) == {"角色A", "角色B"}
+    assert not (source_cm.cloudsave_profiles_dir / "characters.json").exists()
     assert {entry.get("character_name") for entry in repaired_catalog.get("characters") or []} == {"角色A", "角色B"}
 
     shutil.copytree(source_cm.cloudsave_dir, target_cm.cloudsave_dir, dirs_exist_ok=True)
@@ -2419,6 +2432,46 @@ def test_character_collection_import_preserves_owner_globals_and_unrelated_chara
     ]
     assert unrelated_recent.read_bytes() == unrelated_recent_before
     assert (Path(target_cm.memory_dir) / "云端角色" / "recent.json").is_file()
+
+
+@pytest.mark.unit
+def test_legacy_collection_with_retained_full_markers_uses_merge_semantics(tmp_path):
+    source_cm = _make_config_manager(tmp_path / "source")
+    target_cm = _make_config_manager(tmp_path / "target")
+
+    from utils.cloudsave_runtime import export_local_cloudsave_snapshot, import_local_cloudsave_snapshot
+
+    _write_runtime_state(source_cm, character_name="云端角色")
+    export_local_cloudsave_snapshot(source_cm)
+    manifest = json.loads(source_cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
+    marker_payload = json.loads(
+        (source_cm.cloudsave_catalog_dir / "current_character.json").read_text(encoding="utf-8")
+    )
+    manifest.pop("snapshot_kind", None)
+    manifest["sequence_number"] = int(marker_payload["entry_sequence_number"]) + 1
+    manifest["fingerprint"] = ""
+    atomic_write_json(
+        source_cm.cloudsave_manifest_path,
+        manifest,
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    _write_runtime_state(target_cm, character_name="本地角色")
+    target_characters = target_cm.load_characters()
+    target_characters["主人"]["档案名"] = "本地主人"
+    target_cm.save_characters(target_characters, bypass_write_fence=True)
+    unrelated_recent = Path(target_cm.memory_dir) / "本地角色" / "recent.json"
+    unrelated_recent_before = unrelated_recent.read_bytes()
+
+    shutil.copytree(source_cm.cloudsave_dir, target_cm.cloudsave_dir, dirs_exist_ok=True)
+    result = import_local_cloudsave_snapshot(target_cm)
+
+    imported_characters = target_cm.load_characters()
+    assert result["snapshot_kind"] == "character_collection"
+    assert imported_characters["主人"]["档案名"] == "本地主人"
+    assert {"本地角色", "云端角色"} <= set(imported_characters["猫娘"])
+    assert unrelated_recent.read_bytes() == unrelated_recent_before
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -1218,6 +1218,8 @@ def test_local_cloudsave_round_trip_restores_runtime_truth(tmp_path):
 
     export_result = export_local_cloudsave_snapshot(cm)
     assert export_result["manifest"]["sequence_number"] == 1
+    assert export_result["manifest"]["schema_version"] == 2
+    assert export_result["manifest"]["min_reader_schema_version"] == 2
     assert export_result["manifest"]["snapshot_kind"] == "full_runtime"
     assert (cm.cloudsave_dir / "profiles" / "characters.json").is_file()
     assert (cm.cloudsave_dir / "memory" / "小满" / "recent.json").is_file()
@@ -2460,6 +2462,43 @@ def test_legacy_snapshot_without_kind_uses_merge_semantics(tmp_path, marker_sequ
             indent=2,
         )
         manifest["fingerprint"] = ""
+    atomic_write_json(
+        source_cm.cloudsave_manifest_path,
+        manifest,
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    _write_runtime_state(target_cm, character_name="本地角色")
+    target_characters = target_cm.load_characters()
+    target_characters["主人"]["档案名"] = "本地主人"
+    target_cm.save_characters(target_characters, bypass_write_fence=True)
+    unrelated_recent = Path(target_cm.memory_dir) / "本地角色" / "recent.json"
+    unrelated_recent_before = unrelated_recent.read_bytes()
+
+    shutil.copytree(source_cm.cloudsave_dir, target_cm.cloudsave_dir, dirs_exist_ok=True)
+    result = import_local_cloudsave_snapshot(target_cm)
+
+    imported_characters = target_cm.load_characters()
+    assert result["snapshot_kind"] == "character_collection"
+    assert imported_characters["主人"]["档案名"] == "本地主人"
+    assert {"本地角色", "云端角色"} <= set(imported_characters["猫娘"])
+    assert unrelated_recent.read_bytes() == unrelated_recent_before
+
+
+@pytest.mark.unit
+def test_schema_one_stale_full_kind_uses_merge_semantics(tmp_path):
+    source_cm = _make_config_manager(tmp_path / "source")
+    target_cm = _make_config_manager(tmp_path / "target")
+
+    from utils.cloudsave_runtime import export_local_cloudsave_snapshot, import_local_cloudsave_snapshot
+
+    _write_runtime_state(source_cm, character_name="云端角色")
+    export_local_cloudsave_snapshot(source_cm)
+    manifest = json.loads(source_cm.cloudsave_manifest_path.read_text(encoding="utf-8"))
+    assert manifest["snapshot_kind"] == "full_runtime"
+    manifest["schema_version"] = 1
+    manifest["min_reader_schema_version"] = 1
     atomic_write_json(
         source_cm.cloudsave_manifest_path,
         manifest,

--- a/utils/cloudsave_autocloud.py
+++ b/utils/cloudsave_autocloud.py
@@ -275,6 +275,7 @@ class CloudSaveManager:
         manifest_fingerprint = str(manifest.get("fingerprint") or "")
         snapshot_sequence_number = int(manifest.get("sequence_number") or 0)
         snapshot_exported_at_utc = str(manifest.get("exported_at_utc") or "")
+        snapshot_kind = str(manifest.get("snapshot_kind") or "")
         last_applied_manifest_fingerprint = str(cloud_state.get("last_applied_manifest_fingerprint") or "")
         runtime_has_user_content = runtime_root_has_user_content(
             self.config_manager.app_docs_dir,
@@ -317,6 +318,7 @@ class CloudSaveManager:
             "has_snapshot": has_snapshot,
             "snapshot_sequence_number": snapshot_sequence_number,
             "snapshot_exported_at_utc": snapshot_exported_at_utc,
+            "snapshot_kind": snapshot_kind,
             "manifest_fingerprint": manifest_fingerprint,
             "last_applied_manifest_fingerprint": last_applied_manifest_fingerprint,
             "startup_import_required": startup_import_required,

--- a/utils/cloudsave_runtime/bootstrap.py
+++ b/utils/cloudsave_runtime/bootstrap.py
@@ -46,6 +46,7 @@ def build_default_cloudsave_manifest(*, client_id: str = "") -> dict[str, Any]:
         "device_id": "",
         "sequence_number": 0,
         "exported_at_utc": "",
+        "snapshot_kind": "",
         "files": {},
         "fingerprint": "",
     }
@@ -96,6 +97,9 @@ def ensure_cloudsave_manifest(config_manager, *, preserve_existing_client_id: bo
         changed = True
     if "exported_at_utc" not in manifest:
         manifest["exported_at_utc"] = ""
+        changed = True
+    if "snapshot_kind" not in manifest:
+        manifest["snapshot_kind"] = ""
         changed = True
     if "files" not in manifest or not isinstance(manifest.get("files"), dict):
         manifest["files"] = {}

--- a/utils/cloudsave_runtime/operations.py
+++ b/utils/cloudsave_runtime/operations.py
@@ -116,6 +116,9 @@ from .staging import (
 
 SNAPSHOT_KIND_CHARACTER_COLLECTION = "character_collection"
 SNAPSHOT_KIND_FULL_RUNTIME = "full_runtime"
+CHARACTER_COLLECTION_PROFILE_PATH = "profiles/character_collection.json"
+LEGACY_RUNTIME_PROFILE_PATH = "profiles/characters.json"
+CLOUDSAVE_READER_SCHEMA_VERSION = 2
 _SUPPORTED_SNAPSHOT_KINDS = {
     SNAPSHOT_KIND_CHARACTER_COLLECTION,
     SNAPSHOT_KIND_FULL_RUNTIME,
@@ -147,8 +150,41 @@ def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, P
         return snapshot_kind
 
     if full_runtime_markers <= set(staged_entries):
-        return SNAPSHOT_KIND_FULL_RUNTIME
+        # A legacy single-character upload rebuilt the manifest from every
+        # file already on disk. When it followed a full export, the two
+        # global marker files survived even though the newer upload only
+        # represented a character collection. The current-character marker
+        # carries the sequence of the full export, so only treat the legacy
+        # bundle as a proven full snapshot when it agrees with the manifest.
+        # Any malformed or missing sequence stays on the non-destructive path.
+        marker_payload = _load_staged_json_file(
+            staged_entries, "catalog/current_character.json",
+        )
+        manifest_sequence = int(manifest.get("sequence_number") or 0)
+        marker_sequence = (
+            int(
+                marker_payload.get("entry_sequence_number")
+                or marker_payload.get("sequence_number")
+                or 0
+            )
+            if isinstance(marker_payload, dict)
+            else 0
+        )
+        if manifest_sequence > 0 and marker_sequence == manifest_sequence:
+            return SNAPSHOT_KIND_FULL_RUNTIME
     return SNAPSHOT_KIND_CHARACTER_COLLECTION
+
+
+def _validate_manifest_reader_compatibility(manifest: dict[str, Any]) -> None:
+    try:
+        min_reader_schema_version = int(manifest.get("min_reader_schema_version") or 1)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid cloudsave minimum reader schema version") from exc
+    if min_reader_schema_version > CLOUDSAVE_READER_SCHEMA_VERSION:
+        raise ValueError(
+            "cloudsave snapshot requires a newer reader schema: "
+            f"{min_reader_schema_version}"
+        )
 
 
 def _has_usable_master_profile(payload: Any) -> bool:
@@ -287,9 +323,9 @@ def export_cloudsave_character_unit(config_manager, character_name: str, *, over
                 for name, payload in sorted(merged_cloud_character_map.items())
             },
         }
-        staged_entries["profiles/characters.json"] = _stage_json_file(
+        staged_entries[CHARACTER_COLLECTION_PROFILE_PATH] = _stage_json_file(
             stage_root,
-            "profiles/characters.json",
+            CHARACTER_COLLECTION_PROFILE_PATH,
             cloud_profiles_payload,
         )
 
@@ -368,6 +404,7 @@ def export_cloudsave_character_unit(config_manager, character_name: str, *, over
         delete_targets: set[Path] = {
             path
             for path in (
+                config_manager.cloudsave_profiles_dir / "characters.json",
                 config_manager.cloudsave_profiles_dir / "conversation_settings.json",
                 config_manager.cloudsave_catalog_dir / "current_character.json",
             )
@@ -388,6 +425,7 @@ def export_cloudsave_character_unit(config_manager, character_name: str, *, over
 
         mutation_targets = {
             config_manager.cloudsave_profiles_dir / "characters.json",
+            config_manager.cloudsave_profiles_dir / "character_collection.json",
             config_manager.cloudsave_bindings_dir / f"{character_name}.json",
             config_manager.cloudsave_catalog_dir / "catgirls_index.json",
             config_manager.cloudsave_catalog_dir / "character_tombstones.json",
@@ -1130,8 +1168,8 @@ def _rebuild_cloudsave_manifest_from_disk(
     }
     manifest.update(
         {
-            "schema_version": 1,
-            "min_reader_schema_version": 1,
+            "schema_version": 2,
+            "min_reader_schema_version": 2,
             "min_app_version": "",
             "client_id": str(client_id or manifest.get("client_id", "")),
             "device_id": str(manifest.get("device_id", "")),
@@ -1454,6 +1492,7 @@ def import_local_cloudsave_snapshot(
             stage="prepare_import",
         )
         manifest = load_cloudsave_manifest(config_manager)
+        _validate_manifest_reader_compatibility(manifest)
         manifest_files = manifest.get("files") or {}
         if not isinstance(manifest_files, dict) or not manifest_files:
             raise ValueError("cloudsave manifest does not contain any staged files")
@@ -1486,13 +1525,18 @@ def import_local_cloudsave_snapshot(
         if manifest.get("fingerprint") and manifest["fingerprint"] != computed_fingerprint:
             raise ValueError("cloudsave manifest fingerprint mismatch")
 
+        snapshot_kind = _resolve_snapshot_kind(manifest, staged_entries)
+        profile_path = (
+            CHARACTER_COLLECTION_PROFILE_PATH
+            if snapshot_kind == SNAPSHOT_KIND_CHARACTER_COLLECTION
+            and CHARACTER_COLLECTION_PROFILE_PATH in staged_entries
+            else LEGACY_RUNTIME_PROFILE_PATH
+        )
         cloud_characters_payload = _load_staged_json_file(
-            staged_entries, "profiles/characters.json", required=True,
+            staged_entries, profile_path, required=True,
         )
         if not isinstance(cloud_characters_payload, dict):
-            raise ValueError("profiles/characters.json must contain a JSON object")
-
-        snapshot_kind = _resolve_snapshot_kind(manifest, staged_entries)
+            raise ValueError(f"{profile_path} must contain a JSON object")
 
         conversation_settings = _load_staged_json_file(staged_entries, "profiles/conversation_settings.json") or {}
         if not isinstance(conversation_settings, dict):
@@ -1512,16 +1556,16 @@ def import_local_cloudsave_snapshot(
 
         snapshot_character_map = deepcopy(cloud_characters_payload.get("猫娘") or {})
         if not isinstance(snapshot_character_map, dict):
-            raise ValueError("profiles/characters.json 猫娘 must contain a JSON object")
+            raise ValueError(f"{profile_path} 猫娘 must contain a JSON object")
         live_character_names = sorted(snapshot_character_map.keys())
         name_audit = audit_cloudsave_character_names(live_character_names, tombstone_names)
         _raise_for_name_audit(name_audit, context="import")
 
         catalog_character_names = _parse_catalog_character_names(catalog_index_payload)
         if catalog_character_names and catalog_character_names != set(live_character_names):
-            raise ValueError("catalog/catgirls_index.json is inconsistent with profiles/characters.json")
+            raise ValueError(f"catalog/catgirls_index.json is inconsistent with {profile_path}")
         if binding_payloads and set(binding_payloads) != set(live_character_names):
-            raise ValueError("bindings/ payloads are inconsistent with profiles/characters.json")
+            raise ValueError(f"bindings/ payloads are inconsistent with {profile_path}")
 
         for tombstone_name in tombstone_names:
             snapshot_character_map.pop(tombstone_name, None)

--- a/utils/cloudsave_runtime/operations.py
+++ b/utils/cloudsave_runtime/operations.py
@@ -128,11 +128,12 @@ _SUPPORTED_SNAPSHOT_KINDS = {
 def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, Path]) -> str:
     """Resolve explicit snapshot semantics and fail safe for legacy manifests.
 
-    Before ``snapshot_kind`` existed, per-character exports omitted both global
-    payloads while full exports always included them.  Treating an ambiguous
-    legacy payload as a character collection is intentionally conservative: a
-    merge can leave extra local data behind, while a mistaken full replacement
-    can erase the owner profile and unrelated character memories.
+    Before ``snapshot_kind`` existed, per-character exports did not stage the
+    global payloads but could retain copies from an earlier full export.
+    Treating every ambiguous legacy payload as a character collection is
+    intentionally conservative: a merge can leave extra local data behind,
+    while a mistaken full replacement can erase the owner profile and
+    unrelated character memories.
     """
     full_runtime_markers = {
         "profiles/conversation_settings.json",
@@ -149,29 +150,12 @@ def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, P
             raise ValueError("full_runtime cloudsave snapshot is missing required global payloads")
         return snapshot_kind
 
-    if full_runtime_markers <= set(staged_entries):
-        # A legacy single-character upload rebuilt the manifest from every
-        # file already on disk. When it followed a full export, the two
-        # global marker files survived even though the newer upload only
-        # represented a character collection. The current-character marker
-        # carries the sequence of the full export, so only treat the legacy
-        # bundle as a proven full snapshot when it agrees with the manifest.
-        # Any malformed or missing sequence stays on the non-destructive path.
-        marker_payload = _load_staged_json_file(
-            staged_entries, "catalog/current_character.json",
-        )
-        manifest_sequence = int(manifest.get("sequence_number") or 0)
-        marker_sequence = (
-            int(
-                marker_payload.get("entry_sequence_number")
-                or marker_payload.get("sequence_number")
-                or 0
-            )
-            if isinstance(marker_payload, dict)
-            else 0
-        )
-        if manifest_sequence > 0 and marker_sequence == manifest_sequence:
-            return SNAPSHOT_KIND_FULL_RUNTIME
+    # Legacy full exports and single-character uploads can have identical file
+    # shapes. A character upload rebuilt its manifest from files already on
+    # disk, retaining both global markers from an earlier full export; across
+    # devices, its new sequence can also collide with the retained marker's
+    # sequence. There is therefore no reliable proof that a kind-less manifest
+    # is a full snapshot. Always choose the non-destructive merge semantics.
     return SNAPSHOT_KIND_CHARACTER_COLLECTION
 
 

--- a/utils/cloudsave_runtime/operations.py
+++ b/utils/cloudsave_runtime/operations.py
@@ -139,8 +139,16 @@ def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, P
         "profiles/conversation_settings.json",
         "catalog/current_character.json",
     }
+    try:
+        schema_version = int(manifest.get("schema_version") or 1)
+    except (TypeError, ValueError):
+        schema_version = 1
     snapshot_kind = str(manifest.get("snapshot_kind") or "").strip()
-    if snapshot_kind:
+    # Legacy writers preserve unknown top-level keys while rebuilding the
+    # manifest, so a stale ``full_runtime`` kind can survive a character-only
+    # upload. Those writers reset schema_version to 1; only schema 2+ binds the
+    # kind to writer semantics we understand.
+    if snapshot_kind and schema_version >= 2:
         if snapshot_kind not in _SUPPORTED_SNAPSHOT_KINDS:
             raise ValueError(f"unsupported cloudsave snapshot kind: {snapshot_kind}")
         if (
@@ -1404,8 +1412,8 @@ def export_local_cloudsave_snapshot(
 
         manifest.update(
             {
-                "schema_version": 1,
-                "min_reader_schema_version": 1,
+                "schema_version": 2,
+                "min_reader_schema_version": 2,
                 "min_app_version": "",
                 "client_id": str(cloud_state.get("client_id", "")),
                 "device_id": str(manifest.get("device_id", "")),

--- a/utils/cloudsave_runtime/operations.py
+++ b/utils/cloudsave_runtime/operations.py
@@ -114,6 +114,68 @@ from .staging import (
 )
 
 
+SNAPSHOT_KIND_CHARACTER_COLLECTION = "character_collection"
+SNAPSHOT_KIND_FULL_RUNTIME = "full_runtime"
+_SUPPORTED_SNAPSHOT_KINDS = {
+    SNAPSHOT_KIND_CHARACTER_COLLECTION,
+    SNAPSHOT_KIND_FULL_RUNTIME,
+}
+
+
+def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, Path]) -> str:
+    """Resolve explicit snapshot semantics and fail safe for legacy manifests.
+
+    Before ``snapshot_kind`` existed, per-character exports omitted both global
+    payloads while full exports always included them.  Treating an ambiguous
+    legacy payload as a character collection is intentionally conservative: a
+    merge can leave extra local data behind, while a mistaken full replacement
+    can erase the owner profile and unrelated character memories.
+    """
+    full_runtime_markers = {
+        "profiles/conversation_settings.json",
+        "catalog/current_character.json",
+    }
+    snapshot_kind = str(manifest.get("snapshot_kind") or "").strip()
+    if snapshot_kind:
+        if snapshot_kind not in _SUPPORTED_SNAPSHOT_KINDS:
+            raise ValueError(f"unsupported cloudsave snapshot kind: {snapshot_kind}")
+        if (
+            snapshot_kind == SNAPSHOT_KIND_FULL_RUNTIME
+            and not full_runtime_markers <= set(staged_entries)
+        ):
+            raise ValueError("full_runtime cloudsave snapshot is missing required global payloads")
+        return snapshot_kind
+
+    if full_runtime_markers <= set(staged_entries):
+        return SNAPSHOT_KIND_FULL_RUNTIME
+    return SNAPSHOT_KIND_CHARACTER_COLLECTION
+
+
+def _has_usable_master_profile(payload: Any) -> bool:
+    return bool(
+        isinstance(payload, dict)
+        and str(payload.get("档案名") or "").strip()
+    )
+
+
+def _runtime_characters_with_safe_master(config_manager) -> dict[str, Any]:
+    runtime_payload = config_manager.load_characters()
+    if not isinstance(runtime_payload, dict):
+        runtime_payload = {}
+    runtime_payload = deepcopy(runtime_payload)
+
+    if not _has_usable_master_profile(runtime_payload.get("主人")):
+        defaults = config_manager.get_default_characters()
+        default_master = defaults.get("主人") if isinstance(defaults, dict) else None
+        if not _has_usable_master_profile(default_master):
+            raise ValueError("default characters payload does not contain a usable master profile")
+        runtime_payload["主人"] = deepcopy(default_master)
+
+    if not isinstance(runtime_payload.get("猫娘"), dict):
+        runtime_payload["猫娘"] = {}
+    return runtime_payload
+
+
 def _assert_single_character_name_safe(character_name: str, *, context: str) -> None:
     audit_result = audit_cloudsave_character_names([character_name])
     try:
@@ -217,15 +279,13 @@ def export_cloudsave_character_unit(config_manager, character_name: str, *, over
 
         staged_entries: dict[str, Path] = {}
         existing_cloud_character_map, _tombstone_names = _load_cloudsave_character_payloads(config_manager)
-        cloud_profiles_payload = _load_json_if_exists(config_manager.cloudsave_profiles_dir / "characters.json")
-        if not isinstance(cloud_profiles_payload, dict):
-            cloud_profiles_payload = {}
-        cloud_profiles_payload = deepcopy(cloud_profiles_payload)
         merged_cloud_character_map = deepcopy(existing_cloud_character_map)
         merged_cloud_character_map[character_name] = deepcopy(character_payload)
-        cloud_profiles_payload["猫娘"] = {
-            name: deepcopy(payload)
-            for name, payload in sorted(merged_cloud_character_map.items())
+        cloud_profiles_payload = {
+            "猫娘": {
+                name: deepcopy(payload)
+                for name, payload in sorted(merged_cloud_character_map.items())
+            },
         }
         staged_entries["profiles/characters.json"] = _stage_json_file(
             stage_root,
@@ -305,7 +365,14 @@ def export_cloudsave_character_unit(config_manager, character_name: str, *, over
 
         existing_cloud_memory_root = config_manager.cloudsave_memory_dir / character_name
         existing_cloud_character_root = config_manager.cloudsave_dir / "characters" / character_name
-        delete_targets: set[Path] = set()
+        delete_targets: set[Path] = {
+            path
+            for path in (
+                config_manager.cloudsave_profiles_dir / "conversation_settings.json",
+                config_manager.cloudsave_catalog_dir / "current_character.json",
+            )
+            if path.exists()
+        }
         for base_dir in (existing_cloud_memory_root, existing_cloud_character_root / "memory"):
             if not base_dir.is_dir():
                 continue
@@ -324,6 +391,8 @@ def export_cloudsave_character_unit(config_manager, character_name: str, *, over
             config_manager.cloudsave_bindings_dir / f"{character_name}.json",
             config_manager.cloudsave_catalog_dir / "catgirls_index.json",
             config_manager.cloudsave_catalog_dir / "character_tombstones.json",
+            config_manager.cloudsave_profiles_dir / "conversation_settings.json",
+            config_manager.cloudsave_catalog_dir / "current_character.json",
             config_manager.cloudsave_dir / "characters" / character_name,
             config_manager.cloudsave_memory_dir / character_name,
             config_manager.cloudsave_manifest_path,
@@ -1068,6 +1137,7 @@ def _rebuild_cloudsave_manifest_from_disk(
             "device_id": str(manifest.get("device_id", "")),
             "sequence_number": int(sequence_number),
             "exported_at_utc": exported_at,
+            "snapshot_kind": SNAPSHOT_KIND_CHARACTER_COLLECTION,
             "files": files,
         }
     )
@@ -1319,6 +1389,7 @@ def export_local_cloudsave_snapshot(
                 "device_id": str(manifest.get("device_id", "")),
                 "sequence_number": sequence_number,
                 "exported_at_utc": exported_at,
+                "snapshot_kind": SNAPSHOT_KIND_FULL_RUNTIME,
                 "files": files,
             }
         )
@@ -1415,9 +1486,13 @@ def import_local_cloudsave_snapshot(
         if manifest.get("fingerprint") and manifest["fingerprint"] != computed_fingerprint:
             raise ValueError("cloudsave manifest fingerprint mismatch")
 
-        characters_payload = _load_staged_json_file(staged_entries, "profiles/characters.json", required=True)
-        if not isinstance(characters_payload, dict):
+        cloud_characters_payload = _load_staged_json_file(
+            staged_entries, "profiles/characters.json", required=True,
+        )
+        if not isinstance(cloud_characters_payload, dict):
             raise ValueError("profiles/characters.json must contain a JSON object")
+
+        snapshot_kind = _resolve_snapshot_kind(manifest, staged_entries)
 
         conversation_settings = _load_staged_json_file(staged_entries, "profiles/conversation_settings.json") or {}
         if not isinstance(conversation_settings, dict):
@@ -1431,12 +1506,14 @@ def import_local_cloudsave_snapshot(
         tombstones = tombstones_state.get("tombstones") or []
         tombstone_names = [tombstone["character_name"] for tombstone in tombstones]
 
-        sensitive_findings = scan_for_sensitive_values(characters_payload, path="profiles.characters")
+        sensitive_findings = scan_for_sensitive_values(cloud_characters_payload, path="profiles.characters")
         if sensitive_findings:
             raise ValueError(f"sensitive values detected in import payload: {', '.join(sensitive_findings)}")
 
-        character_map = deepcopy(characters_payload.get("猫娘") or {})
-        live_character_names = sorted(character_map.keys())
+        snapshot_character_map = deepcopy(cloud_characters_payload.get("猫娘") or {})
+        if not isinstance(snapshot_character_map, dict):
+            raise ValueError("profiles/characters.json 猫娘 must contain a JSON object")
+        live_character_names = sorted(snapshot_character_map.keys())
         name_audit = audit_cloudsave_character_names(live_character_names, tombstone_names)
         _raise_for_name_audit(name_audit, context="import")
 
@@ -1447,22 +1524,57 @@ def import_local_cloudsave_snapshot(
             raise ValueError("bindings/ payloads are inconsistent with profiles/characters.json")
 
         for tombstone_name in tombstone_names:
-            character_map.pop(tombstone_name, None)
-        characters_payload["猫娘"] = character_map
+            snapshot_character_map.pop(tombstone_name, None)
 
-        requested_current_name = str(characters_payload.get("当前猫娘") or "").strip()
+        requested_current_name = str(cloud_characters_payload.get("当前猫娘") or "").strip()
         if isinstance(current_character_catalog_payload, dict):
             catalog_current_name = str(current_character_catalog_payload.get("current_character_name") or "").strip()
             if catalog_current_name:
                 requested_current_name = catalog_current_name
 
-        imported_character_names = sorted(character_map.keys())
-        if requested_current_name and requested_current_name in character_map:
-            characters_payload["当前猫娘"] = requested_current_name
-        elif imported_character_names:
-            characters_payload["当前猫娘"] = imported_character_names[0]
+        applied_character_names = sorted(snapshot_character_map.keys())
+        if snapshot_kind == SNAPSHOT_KIND_CHARACTER_COLLECTION:
+            runtime_characters_path = Path(
+                config_manager.get_runtime_config_path("characters.json")
+            )
+            runtime_characters_existed = runtime_characters_path.is_file()
+            characters_payload = _runtime_characters_with_safe_master(config_manager)
+            merged_character_map = deepcopy(characters_payload.get("猫娘") or {})
+            for tombstone_name in tombstone_names:
+                merged_character_map.pop(tombstone_name, None)
+            merged_character_map.update(snapshot_character_map)
+            characters_payload["猫娘"] = merged_character_map
+
+            local_current_name = str(characters_payload.get("当前猫娘") or "").strip()
+            if (
+                runtime_characters_existed
+                and local_current_name
+                and local_current_name in merged_character_map
+            ):
+                characters_payload["当前猫娘"] = local_current_name
+            elif requested_current_name and requested_current_name in merged_character_map:
+                characters_payload["当前猫娘"] = requested_current_name
+            elif applied_character_names:
+                characters_payload["当前猫娘"] = applied_character_names[0]
+            elif local_current_name and local_current_name in merged_character_map:
+                characters_payload["当前猫娘"] = local_current_name
+            elif merged_character_map:
+                characters_payload["当前猫娘"] = sorted(merged_character_map)[0]
+            else:
+                characters_payload["当前猫娘"] = ""
         else:
-            characters_payload["当前猫娘"] = ""
+            characters_payload = deepcopy(cloud_characters_payload)
+            characters_payload["猫娘"] = snapshot_character_map
+            if not _has_usable_master_profile(characters_payload.get("主人")):
+                safe_runtime_payload = _runtime_characters_with_safe_master(config_manager)
+                characters_payload["主人"] = deepcopy(safe_runtime_payload["主人"])
+
+            if requested_current_name and requested_current_name in snapshot_character_map:
+                characters_payload["当前猫娘"] = requested_current_name
+            elif applied_character_names:
+                characters_payload["当前猫娘"] = applied_character_names[0]
+            else:
+                characters_payload["当前猫娘"] = ""
         apply_time = _utc_now_iso()
         backup_root = config_manager.cloudsave_backups_dir / f"import-{apply_time.replace(':', '').replace('.', '')}"
 
@@ -1475,12 +1587,13 @@ def import_local_cloudsave_snapshot(
             Path(config_manager.get_runtime_config_path("characters.json")): characters_stage_path,
         }
 
-        preferences_stage_path = _stage_json_file(
-            stage_root,
-            "__runtime__/user_preferences.json",
-            _build_runtime_preferences_payload(config_manager, conversation_settings),
-        )
-        runtime_targets[Path(config_manager.get_runtime_config_path("user_preferences.json"))] = preferences_stage_path
+        if snapshot_kind == SNAPSHOT_KIND_FULL_RUNTIME:
+            preferences_stage_path = _stage_json_file(
+                stage_root,
+                "__runtime__/user_preferences.json",
+                _build_runtime_preferences_payload(config_manager, conversation_settings),
+            )
+            runtime_targets[Path(config_manager.get_runtime_config_path("user_preferences.json"))] = preferences_stage_path
 
         memory_entries: list[tuple[str, str, Path]] = []
         for relative_path, staged_path in staged_entries.items():
@@ -1526,7 +1639,7 @@ def import_local_cloudsave_snapshot(
 
         delete_file_targets: set[Path] = set()
         delete_dir_targets: set[Path] = set()
-        for character_name in imported_character_names:
+        for character_name in applied_character_names:
             character_dir = Path(config_manager.memory_dir) / character_name
             for filename in MANAGED_MEMORY_FILENAMES:
                 relative_path = f"memory/{character_name}/{filename}"
@@ -1590,7 +1703,10 @@ def import_local_cloudsave_snapshot(
                     # character's stray marker never will be, however
                     # firmly something holds it.
                     continue
-                if child.name not in imported_character_names:
+                if snapshot_kind == SNAPSHOT_KIND_FULL_RUNTIME:
+                    if child.name not in applied_character_names:
+                        delete_dir_targets.add(child)
+                elif child.name in tombstone_names:
                     delete_dir_targets.add(child)
 
         recent_targets = {
@@ -1598,7 +1714,7 @@ def import_local_cloudsave_snapshot(
             for target_path in set(runtime_targets) | delete_file_targets
             if target_path.name == "recent.json"
         }
-        for character_name in imported_character_names:
+        for character_name in applied_character_names:
             recent_targets.update(
                 list_character_recent_paths(config_manager, character_name)
             )
@@ -1616,7 +1732,7 @@ def import_local_cloudsave_snapshot(
             }
             imported_recent_paths = {
                 recent_path
-                for character_name in imported_character_names
+                for character_name in applied_character_names
                 for recent_path in list_character_recent_paths(
                     config_manager, character_name,
                 )
@@ -1715,11 +1831,12 @@ def import_local_cloudsave_snapshot(
                 # evicting would fence away a staged-but-unflushed snapshot.
                 # Removed names are the opposite case: their directories really
                 # are gone, so they retire.
-                revive_character_runtime_caches(*imported_character_names)
+                revive_character_runtime_caches(*applied_character_names)
                 retire_character_runtime_caches(*removed_character_names)
                 return {
                     "manifest_fingerprint": computed_fingerprint,
-                    "applied_character_count": len(imported_character_names),
+                    "snapshot_kind": snapshot_kind,
+                    "applied_character_count": len(applied_character_names),
                     "name_audit": name_audit,
                 }
             except Exception:

--- a/utils/cloudsave_runtime/operations.py
+++ b/utils/cloudsave_runtime/operations.py
@@ -125,6 +125,13 @@ _SUPPORTED_SNAPSHOT_KINDS = {
 }
 
 
+def _manifest_schema_version(manifest: dict[str, Any]) -> int:
+    try:
+        return int(manifest.get("schema_version") or 1)
+    except (TypeError, ValueError):
+        return 1
+
+
 def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, Path]) -> str:
     """Resolve explicit snapshot semantics and fail safe for legacy manifests.
 
@@ -139,10 +146,7 @@ def _resolve_snapshot_kind(manifest: dict[str, Any], staged_entries: dict[str, P
         "profiles/conversation_settings.json",
         "catalog/current_character.json",
     }
-    try:
-        schema_version = int(manifest.get("schema_version") or 1)
-    except (TypeError, ValueError):
-        schema_version = 1
+    schema_version = _manifest_schema_version(manifest)
     snapshot_kind = str(manifest.get("snapshot_kind") or "").strip()
     # Legacy writers preserve unknown top-level keys while rebuilding the
     # manifest, so a stale ``full_runtime`` kind can survive a character-only
@@ -1175,6 +1179,7 @@ def _rebuild_cloudsave_manifest_from_disk(
         client_id=str(manifest.get("client_id", "")),
         sequence_number=int(manifest.get("sequence_number") or 0),
         files=files,
+        snapshot_kind=SNAPSHOT_KIND_CHARACTER_COLLECTION,
     )
     save_cloudsave_manifest(config_manager, manifest)
     return manifest
@@ -1427,6 +1432,7 @@ def export_local_cloudsave_snapshot(
             client_id=manifest["client_id"],
             sequence_number=sequence_number,
             files=files,
+            snapshot_kind=SNAPSHOT_KIND_FULL_RUNTIME,
         )
 
         _assert_deadline_not_exceeded(
@@ -1509,12 +1515,22 @@ def import_local_cloudsave_snapshot(
             }
             for relative_path, staged_path in sorted(staged_entries.items())
         }
+        schema_version = _manifest_schema_version(manifest)
+        fingerprint_snapshot_kind = (
+            str(manifest.get("snapshot_kind") or "").strip()
+            if schema_version >= 2
+            else ""
+        )
+        manifest_fingerprint = str(manifest.get("fingerprint") or "")
+        if schema_version >= 2 and fingerprint_snapshot_kind and not manifest_fingerprint:
+            raise ValueError("schema 2 cloudsave manifest fingerprint is required")
         computed_fingerprint = _build_manifest_fingerprint(
             client_id=str(manifest.get("client_id", "")),
             sequence_number=int(manifest.get("sequence_number") or 0),
             files=computed_files,
+            snapshot_kind=fingerprint_snapshot_kind,
         )
-        if manifest.get("fingerprint") and manifest["fingerprint"] != computed_fingerprint:
+        if manifest_fingerprint and manifest_fingerprint != computed_fingerprint:
             raise ValueError("cloudsave manifest fingerprint mismatch")
 
         snapshot_kind = _resolve_snapshot_kind(manifest, staged_entries)

--- a/utils/cloudsave_runtime/snapshots.py
+++ b/utils/cloudsave_runtime/snapshots.py
@@ -552,8 +552,10 @@ def _load_cloudsave_character_payloads(config_manager) -> tuple[dict[str, dict[s
     tombstone_names = _load_cloudsave_tombstone_names(config_manager)
     cloud_characters: dict[str, dict[str, Any]] = {}
 
-    characters_payload = _load_json_if_exists(config_manager.cloudsave_profiles_dir / "characters.json")
-    if isinstance(characters_payload, dict):
+    for profile_name in ("characters.json", "character_collection.json"):
+        characters_payload = _load_json_if_exists(config_manager.cloudsave_profiles_dir / profile_name)
+        if not isinstance(characters_payload, dict):
+            continue
         for character_name, character_payload in (characters_payload.get("猫娘") or {}).items():
             if character_name in tombstone_names or not isinstance(character_payload, dict):
                 continue

--- a/utils/cloudsave_runtime/staging.py
+++ b/utils/cloudsave_runtime/staging.py
@@ -200,12 +200,21 @@ def _cleanup_empty_parent_dirs(path: Path, stop_at: Path) -> None:
         current = current.parent
 
 
-def _build_manifest_fingerprint(*, client_id: str, sequence_number: int, files: dict[str, Any]) -> str:
+def _build_manifest_fingerprint(
+    *,
+    client_id: str,
+    sequence_number: int,
+    files: dict[str, Any],
+    snapshot_kind: str = "",
+) -> str:
     payload = {
         "client_id": client_id,
         "sequence_number": int(sequence_number),
         "files": files,
     }
+    normalized_snapshot_kind = str(snapshot_kind or "").strip()
+    if normalized_snapshot_kind:
+        payload["snapshot_kind"] = normalized_snapshot_kind
     return _sha256_bytes(_json_canonical_dumps(payload).encode("utf-8"))
 
 


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复角色云存档被误当作完整快照导入的问题，确保恢复角色时保留我的档案，并兼容旧版快照

## 测试 / Testing

创建快照并清理本地数据后重新启动软件确认我的档案没有被清空


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 云端存档支持区分完整运行时快照与角色集合快照。
  * 存档状态可显示快照类型。
  * 角色集合导出与导入支持合并角色数据，并保留全局设置及无关角色。
  * 支持从不同版本存档中读取并合并角色数据。

* **兼容性改进**
  * 旧版存档可继续导入，并自动采用安全的合并方式。
  * 继续兼容旧版角色数据路径及格式。
  * 导入时校验快照类型、指纹和读取器版本，降低数据不匹配风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->