### PR TITLE
test(storage): 阻断 pytest 写进开发机真实运行根

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,10 +178,10 @@ from tests.clock_guard import pytest_runtest_call  # noqa: F401,E402
 # 一旦泄漏到进程环境，后面每个"临时" ConfigManager 都会无视 patch 过的目录、直接写进
 # 开发机的真实运行根（2026-09-01 就这样把六个角色从 characters.json 里抹掉了）。
 # 同 clock_guard：pytest 按名字发现 hook，这个导入没有显式调用点但不是死代码。
-from tests.storage_root_env_guard import (  # noqa: F401,E402
-    pytest_runtest_setup,
-    pytest_runtest_teardown,
-    pytest_sessionstart,
+from tests.storage_root_env_guard import (  # noqa: E402
+    pytest_runtest_setup,  # noqa: F401
+    pytest_runtest_teardown,  # noqa: F401
+    pytest_sessionstart,  # noqa: F401
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,14 @@ _logger_config_module.RobustLoggerConfig._get_documents_directory = (
     lambda self, _root=_NEKO_TEST_LOG_ROOT: _root
 )
 
+# 同理，但针对运行根本身：get_config_manager() 的 migrate 默认为 True，
+# 谁先 import 那 7 个模块级单例之一，谁就在真实运行根上跑完整条迁移链。
+# 必须在任何产品模块被 import 之前装好（见 tests/real_root_isolation.py）。
+from utils.config_manager import ConfigManager as _ConfigManagerForIsolation
+from tests import real_root_isolation as _real_root_isolation
+
+_real_root_isolation.install(_ConfigManagerForIsolation)
+
 import asyncio
 import asyncio.runners
 import asyncio.coroutines
@@ -165,6 +173,34 @@ KEY_MAPPING = {
 # pytest 按名字在 conftest 命名空间里发现 hook，所以这个导入没有显式调用点
 # ——它不是死代码：把它删掉，全进程时钟守卫就整个失效（改回全局 patch 也不再转红）。
 from tests.clock_guard import pytest_runtest_call  # noqa: F401,E402
+
+# 存储根环境变量守卫（见 tests/storage_root_env_guard.py）：NEKO_STORAGE_SELECTED_ROOT
+# 一旦泄漏到进程环境，后面每个"临时" ConfigManager 都会无视 patch 过的目录、直接写进
+# 开发机的真实运行根（2026-09-01 就这样把六个角色从 characters.json 里抹掉了）。
+# 同 clock_guard：pytest 按名字发现 hook，这个导入没有显式调用点但不是死代码。
+from tests.storage_root_env_guard import (  # noqa: F401,E402
+    pytest_runtest_setup,
+    pytest_runtest_teardown,
+    pytest_sessionstart,
+)
+
+
+@pytest.fixture
+def real_root_resolution():
+    """Restore ConfigManager's genuine directory resolution for this test.
+
+    tests/conftest.py stubs it session-wide so no unpatched ConfigManager can
+    reach the user's real runtime root. Tests whose SUBJECT is that resolution
+    ask for this fixture; they patch sys.platform / Path.home / the environment
+    themselves and run inside tmp_path, so the real methods stay off the
+    developer's directories.
+    """
+    from utils.config_manager import ConfigManager
+
+    from tests import real_root_isolation
+
+    with real_root_isolation.real_resolution(ConfigManager):
+        yield
 
 
 def pytest_addoption(parser):

--- a/tests/real_root_isolation.py
+++ b/tests/real_root_isolation.py
@@ -42,9 +42,15 @@ over this and restores back to it.
 
 from __future__ import annotations
 
+import atexit
 import contextlib
+import os
+import shutil
 import tempfile
 from pathlib import Path
+
+# Escape hatch for inspecting what a run wrote into the stand-in root.
+KEEP_ROOT_ENV = "NEKO_TEST_KEEP_APPDATA_ROOT"
 
 _PATCHED_METHODS = (
     "_get_standard_data_directory_candidates",
@@ -57,11 +63,32 @@ _ISOLATED_ROOT: Path | None = None
 _ORIGINALS: dict[str, object] = {}
 
 
+def _discard_root(root: Path) -> None:
+    """Delete the stand-in root at process exit.
+
+    One per PROCESS, so under ``-n auto`` a full run mints one per worker plus
+    one for the controller, and each holds a whole N.E.K.O tree -- config,
+    memory, card faces, migration workspaces. Measured on a dev machine: three
+    full runs left 42 directories and 45 MB behind. atexit rather than
+    ``pytest_sessionfinish`` because the root is minted at conftest IMPORT
+    time, before any hook or fixture exists, and a collection-time crash never
+    reaches sessionfinish.
+
+    ``ignore_errors`` because on Windows a still-open SQLite handle makes the
+    unlink fail, and leaving a temp directory behind must never be what turns
+    a green run red.
+    """
+    if os.environ.get(KEEP_ROOT_ENV, "").strip():
+        return
+    shutil.rmtree(root, ignore_errors=True)
+
+
 def isolated_app_data_root() -> Path:
     """The throwaway parent directory that stands in for the app-data root."""
     global _ISOLATED_ROOT
     if _ISOLATED_ROOT is None:
         _ISOLATED_ROOT = Path(tempfile.mkdtemp(prefix="neko_test_appdata_"))
+        atexit.register(_discard_root, _ISOLATED_ROOT)
     return _ISOLATED_ROOT
 
 

--- a/tests/real_root_isolation.py
+++ b/tests/real_root_isolation.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Point every unpatched ConfigManager at a throwaway root instead of the user's.
+
+``get_config_manager()`` defaults to ``migrate=True``, and migration is
+triggered from nowhere else -- so the FIRST module-level
+``_config_manager = get_config_manager()`` to be imported runs the whole
+chain (config dir, card faces, memory files, the legacy Documents sweep and
+the ``.mig-staging`` reclaim) against whatever root the machine resolves.
+There are seven such module-level singletons and about three hundred bare
+call sites; on a developer machine that root is the real one. Measured: the
+suite created character directories in the user's ``memory/``, truncated
+``config/core_config.json`` to ``{"coreApi": "free"}``, and left
+``.mig-staging`` workspaces behind.
+
+The lever is ConfigManager's own directory resolution, not ``LOCALAPPDATA``:
+that variable is shared with unrelated tooling -- redirecting it sends uv's
+wheel cache somewhere uv cannot write, and
+``test_hatch_artifacts_explicitly_exclude_local_endpointing_weights`` fails
+building an sdist for reasons that have nothing to do with N.E.K.O.
+
+Three hooks, because the root is reachable three ways: the standard app-data
+directory is where a fresh install lands, and the two legacy lists are what
+the import sweep walks looking for an older install to adopt -- leaving
+those pointed at the real Documents tree means the sweep still reads (and
+stages inside) the user's data even when the destination is a temp dir.
+
+Tests that patch these themselves are unaffected: ``patch.object`` installs
+over this and restores back to it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tempfile
+from pathlib import Path
+
+_PATCHED_METHODS = (
+    "_get_standard_data_directory_candidates",
+    "_get_legacy_storage_candidates",
+    "_get_legacy_document_candidates",
+    "get_legacy_app_root_candidates",
+)
+
+_ISOLATED_ROOT: Path | None = None
+_ORIGINALS: dict[str, object] = {}
+
+
+def isolated_app_data_root() -> Path:
+    """The throwaway parent directory that stands in for the app-data root."""
+    global _ISOLATED_ROOT
+    if _ISOLATED_ROOT is None:
+        _ISOLATED_ROOT = Path(tempfile.mkdtemp(prefix="neko_test_appdata_"))
+    return _ISOLATED_ROOT
+
+
+def install(config_manager_class) -> None:
+    """Redirect the class's root resolution. Idempotent."""
+    if getattr(config_manager_class, "_neko_test_root_isolated", False):
+        return
+
+    # getattr, not __dict__: these live on a storage-roots mixin, not on
+    # ConfigManager itself, so a __dict__ lookup raises KeyError. Restoring
+    # via setattr then shadows the mixin with the very same function.
+    for name in _PATCHED_METHODS:
+        _ORIGINALS[name] = getattr(config_manager_class, name)
+
+    root = isolated_app_data_root()
+    config_manager_class._get_standard_data_directory_candidates = lambda self: [root]
+    config_manager_class._get_legacy_storage_candidates = lambda self: []
+    config_manager_class._get_legacy_document_candidates = lambda self: []
+    config_manager_class.get_legacy_app_root_candidates = lambda self: []
+    config_manager_class._neko_test_root_isolated = True
+
+
+@contextlib.contextmanager
+def real_resolution(config_manager_class):
+    """Put the genuine resolution methods back for one test.
+
+    For the handful of tests whose subject IS this resolution -- platform
+    branches of the app-data candidates, the legacy-candidate ordering, the
+    CFA read-only-Documents fallback. They drive it inside their own tmp
+    sandbox with ``sys.platform`` and ``Path.home`` patched, so the real
+    methods there never reach the developer's directories.
+    """
+    if not _ORIGINALS:
+        yield
+        return
+    stubs = {name: getattr(config_manager_class, name) for name in _PATCHED_METHODS}
+    for name, original in _ORIGINALS.items():
+        setattr(config_manager_class, name, original)
+    try:
+        yield
+    finally:
+        for name, stub in stubs.items():
+            setattr(config_manager_class, name, stub)

--- a/tests/storage_root_env_guard.py
+++ b/tests/storage_root_env_guard.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Keep the storage-root env vars from steering a test into real user data.
+
+``ConfigManager`` honours ``NEKO_STORAGE_SELECTED_ROOT`` (and the anchor /
+cloudsave siblings) above every other root candidate: when the variable is
+set, the patched ``_get_documents_directory`` and
+``_get_standard_data_directory_candidates`` that test helpers install are
+never consulted (see ``utils/config_manager/storage_roots.py``). The launcher
+and the plugin host export exactly these keys into ``os.environ`` for their
+child processes, computed from the machine's REAL storage policy. So a test
+that reaches either exporter unpatched, or sets one of the keys by hand and
+never restores it, leaves the developer's real runtime root in the
+environment for every later test of the session -- and each of those then
+constructs a "temporary" ``ConfigManager`` that writes into the real root.
+
+Measured on 2026-09-01 on a developer machine: about fifty fixture
+directories appeared under ``memory/``, ``config/characters.json`` was
+replaced by ``{"current":"A"}`` (six real characters gone from the roster),
+``workshop_config.json`` pointed at a pytest tmp dir, and ``root_state.json``
+recorded a pytest path as its last migration source.
+
+Two layers, both runtime checks so they are indifferent to how the value was
+set:
+
+- session start drops any inherited value with a visible warning, so a shell
+  started from the app cannot hand its layout to the test process;
+- every test is wrapped: the keys are snapshotted before setup and restored
+  after teardown, and a test that changed them without cleaning up errors
+  with the diff. ``monkeypatch`` restores during teardown, so its users are
+  never flagged; the check runs after all finalizers.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import MutableMapping
+
+import pytest
+
+from utils.storage.layout import (
+    NEKO_STORAGE_ANCHOR_ROOT_ENV,
+    NEKO_STORAGE_CLOUDSAVE_ROOT_ENV,
+    NEKO_STORAGE_SELECTED_ROOT_ENV,
+)
+
+STORAGE_ROOT_ENV_KEYS: tuple[str, ...] = (
+    NEKO_STORAGE_SELECTED_ROOT_ENV,
+    NEKO_STORAGE_ANCHOR_ROOT_ENV,
+    NEKO_STORAGE_CLOUDSAVE_ROOT_ENV,
+)
+
+_SNAPSHOT_KEY: pytest.StashKey[dict[str, str | None]] = pytest.StashKey()
+
+
+def snapshot_storage_root_env(environ: MutableMapping[str, str] | None = None) -> dict[str, str | None]:
+    env = os.environ if environ is None else environ
+    return {key: env.get(key) for key in STORAGE_ROOT_ENV_KEYS}
+
+
+def restore_storage_root_env(
+    snapshot: dict[str, str | None],
+    environ: MutableMapping[str, str] | None = None,
+) -> dict[str, tuple[str | None, str | None]]:
+    """Put every guarded key back to ``snapshot``; return ``{key: (expected, found)}`` for the ones that had drifted."""
+    env = os.environ if environ is None else environ
+    drifted: dict[str, tuple[str | None, str | None]] = {}
+    for key in STORAGE_ROOT_ENV_KEYS:
+        expected = snapshot.get(key)
+        found = env.get(key)
+        if found == expected:
+            continue
+        drifted[key] = (expected, found)
+        if expected is None:
+            env.pop(key, None)
+        else:
+            env[key] = expected
+    return drifted
+
+
+def clear_inherited_storage_root_env(environ: MutableMapping[str, str] | None = None) -> dict[str, str]:
+    """Drop the guarded keys; return what was removed."""
+    env = os.environ if environ is None else environ
+    cleared: dict[str, str] = {}
+    for key in STORAGE_ROOT_ENV_KEYS:
+        value = env.pop(key, None)
+        if value is not None:
+            cleared[key] = value
+    return cleared
+
+
+def describe_storage_root_env_leak(nodeid: str, drifted: dict[str, tuple[str | None, str | None]]) -> str:
+    lines = [
+        f"{nodeid} 改了存储根环境变量却没有恢复（已替它还原）：",
+    ]
+    for key, (expected, found) in drifted.items():
+        lines.append(f"  {key}: {expected!r} -> {found!r}")
+    lines.append(
+        "这些变量在 ConfigManager 里压过所有 patch 过的目录候选，泄漏到后面的用例就会把"
+        "临时 ConfigManager 指向开发机的真实运行根并写脏用户数据。"
+        "改用 monkeypatch.setenv/delenv，或者把 launcher/plugin host 里的 "
+        "export_storage_layout_to_env 调用 patch 掉。"
+    )
+    return "\n".join(lines)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    cleared = clear_inherited_storage_root_env()
+    if cleared:
+        session.config.issue_config_time_warning(
+            pytest.PytestConfigWarning(
+                "已从测试进程环境里清掉继承来的存储根变量，否则每个临时 ConfigManager 都会指向"
+                f"真实运行根：{cleared}"
+            ),
+            stacklevel=2,
+        )
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_setup(item: pytest.Item):
+    # tryfirst + wrapper: the snapshot is taken before any fixture runs.
+    item.stash[_SNAPSHOT_KEY] = snapshot_storage_root_env()
+    yield
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None):
+    outcome = yield
+    # After yield every fixture finalizer (monkeypatch included) has run, so
+    # whatever is still different from the snapshot was left behind on purpose
+    # or by accident -- either way it must not reach the next test.
+    snapshot = item.stash.get(_SNAPSHOT_KEY, None)
+    if snapshot is None:
+        return
+    drifted = restore_storage_root_env(snapshot)
+    if drifted and outcome.excinfo is None:  # do not mask a teardown that already failed
+        pytest.fail(describe_storage_root_env_leak(item.nodeid, drifted), pytrace=False)

--- a/tests/unit/test_cloudsave_config_manager.py
+++ b/tests/unit/test_cloudsave_config_manager.py
@@ -271,7 +271,7 @@ def test_state_save_entrypoints_report_target_directory_blockers(tmp_path):
 
 
 @pytest.mark.unit
-def test_get_documents_directory_preserves_first_readable_legacy_candidate(tmp_path):
+def test_get_documents_directory_preserves_first_readable_legacy_candidate(tmp_path, real_root_resolution):
     import utils.config_manager as config_manager_module
     from utils.config_manager import ConfigManager
 
@@ -313,7 +313,7 @@ def test_get_documents_directory_preserves_first_readable_legacy_candidate(tmp_p
 
 
 @pytest.mark.unit
-def test_get_documents_directory_ignores_non_document_legacy_roots_for_cfa_detection(tmp_path):
+def test_get_documents_directory_ignores_non_document_legacy_roots_for_cfa_detection(tmp_path, real_root_resolution):
     import utils.config_manager as config_manager_module
     from utils.config_manager import ConfigManager
 
@@ -367,7 +367,7 @@ def test_get_documents_directory_ignores_non_document_legacy_roots_for_cfa_detec
 
 
 @pytest.mark.unit
-def test_get_documents_directory_uses_linux_xdg_fallback_when_xdg_data_home_missing(tmp_path):
+def test_get_documents_directory_uses_linux_xdg_fallback_when_xdg_data_home_missing(tmp_path, real_root_resolution):
     import utils.config_manager as config_manager_module
     from utils.config_manager import ConfigManager
 

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -3341,7 +3341,7 @@ def test_cloud_export_rejects_redirected_recent_snapshot(tmp_path):
 
 
 @pytest.mark.unit
-def test_standard_data_candidates_on_unix_platforms(tmp_path):
+def test_standard_data_candidates_on_unix_platforms(tmp_path, real_root_resolution):
     from utils.config_manager import ConfigManager
 
     fake_home = tmp_path / "home"

--- a/tests/unit/test_real_root_isolation.py
+++ b/tests/unit/test_real_root_isolation.py
@@ -87,12 +87,20 @@ def test_real_resolution_restores_the_genuine_methods_and_puts_the_stubs_back():
 
 
 def test_real_resolution_puts_the_stubs_back_even_when_the_body_raises():
+    # try/except rather than pytest.raises: this asserts two things about one
+    # event -- the exception still escapes, AND the stubs are back afterwards.
+    # Spelling the control flow out keeps both visible (and keeps static
+    # analysers from reading everything after the block as unreachable).
     stub = ConfigManager._get_standard_data_directory_candidates
+    escaped = False
 
-    with pytest.raises(RuntimeError):
+    try:
         with isolation.real_resolution(ConfigManager):
             raise RuntimeError("boom")
+    except RuntimeError:
+        escaped = True
 
+    assert escaped, "real_resolution swallowed the body's exception"
     assert ConfigManager._get_standard_data_directory_candidates is stub
 
 

--- a/tests/unit/test_real_root_isolation.py
+++ b/tests/unit/test_real_root_isolation.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Behaviour of tests/real_root_isolation.py."""
+
+from pathlib import Path
+
+import pytest
+
+from tests import real_root_isolation as isolation
+from utils.config_manager import ConfigManager
+
+pytestmark = pytest.mark.unit
+
+
+def test_no_unpatched_config_manager_can_reach_a_real_documents_tree():
+    # The invariant the whole module exists for, asserted on the resolution
+    # inputs rather than on the resolved app_docs_dir: that one legitimately
+    # follows whatever storage_policy.json is on disk, and sibling tests write
+    # policies pointing at their own tmp_path. Asserting the resolved root
+    # therefore passes alone and fails in a full run -- measured.
+    #
+    # The legacy lists matter as much as the standard candidate: pointing only
+    # the destination at a temp dir still lets the import sweep read the user's
+    # Documents tree and mint migration workspaces inside it.
+    config_manager = ConfigManager("N.E.K.O")
+    stand_in = isolation.isolated_app_data_root()
+
+    assert config_manager._get_standard_data_directory_candidates() == [stand_in]
+    assert config_manager._get_legacy_storage_candidates() == []
+    assert config_manager._get_legacy_document_candidates() == []
+    assert config_manager.get_legacy_app_root_candidates() == []
+
+
+def test_discard_root_deletes_the_tree(tmp_path, monkeypatch):
+    monkeypatch.delenv(isolation.KEEP_ROOT_ENV, raising=False)
+    root = tmp_path / "stand-in"
+    (root / "config").mkdir(parents=True)
+    (root / "config" / "characters.json").write_text("{}", encoding="utf-8")
+
+    isolation._discard_root(root)
+
+    assert not root.exists()
+
+
+def test_discard_root_keeps_the_tree_when_the_escape_hatch_is_set(tmp_path, monkeypatch):
+    monkeypatch.setenv(isolation.KEEP_ROOT_ENV, "1")
+    root = tmp_path / "stand-in"
+    root.mkdir()
+
+    isolation._discard_root(root)
+
+    assert root.exists()
+
+
+def test_discard_root_swallows_a_failed_removal(monkeypatch, tmp_path):
+    # A still-open SQLite handle on Windows makes the unlink fail; a leftover
+    # temp directory must never be what turns a green run red.
+    monkeypatch.delenv(isolation.KEEP_ROOT_ENV, raising=False)
+    monkeypatch.setattr(
+        isolation.shutil,
+        "rmtree",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("locked")) if not kw.get("ignore_errors") else None,
+    )
+
+    isolation._discard_root(tmp_path / "whatever")  # must not raise
+
+
+def test_real_resolution_restores_the_genuine_methods_and_puts_the_stubs_back():
+    stub = ConfigManager._get_standard_data_directory_candidates
+
+    with isolation.real_resolution(ConfigManager):
+        inside = ConfigManager._get_standard_data_directory_candidates
+        assert inside is not stub
+
+    assert ConfigManager._get_standard_data_directory_candidates is stub
+
+
+def test_real_resolution_puts_the_stubs_back_even_when_the_body_raises():
+    stub = ConfigManager._get_standard_data_directory_candidates
+
+    with pytest.raises(RuntimeError):
+        with isolation.real_resolution(ConfigManager):
+            raise RuntimeError("boom")
+
+    assert ConfigManager._get_standard_data_directory_candidates is stub
+
+
+def test_install_is_idempotent_and_does_not_capture_its_own_stub():
+    # A second install() must not overwrite the saved originals with the stubs
+    # it already put there -- that would make real_resolution restore a stub.
+    before = dict(isolation._ORIGINALS)
+
+    isolation.install(ConfigManager)
+
+    assert isolation._ORIGINALS == before
+    with isolation.real_resolution(ConfigManager):
+        assert ConfigManager._get_standard_data_directory_candidates.__name__ == (
+            "_get_standard_data_directory_candidates"
+        )
+
+
+def test_the_stand_in_root_is_stable_within_a_process():
+    assert isolation.isolated_app_data_root() is isolation.isolated_app_data_root()
+    assert isinstance(isolation.isolated_app_data_root(), Path)

--- a/tests/unit/test_storage_root_env_guard.py
+++ b/tests/unit/test_storage_root_env_guard.py
@@ -1,0 +1,128 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Behaviour of tests/storage_root_env_guard.py.
+
+The guard's hook glue is three lines around these helpers; the helpers carry
+the decisions (what counts as drift, what gets restored, what the message
+names), so they are what gets pinned here.
+"""
+
+import os
+
+import pytest
+
+from tests import storage_root_env_guard as guard
+from utils.storage.layout import (
+    NEKO_STORAGE_ANCHOR_ROOT_ENV,
+    NEKO_STORAGE_CLOUDSAVE_ROOT_ENV,
+    NEKO_STORAGE_SELECTED_ROOT_ENV,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_guarded_keys_are_exactly_the_layout_exporter_keys():
+    # export_storage_layout_to_env writes these three; a fourth key added there
+    # without extending the guard would leak silently.
+    assert set(guard.STORAGE_ROOT_ENV_KEYS) == {
+        NEKO_STORAGE_SELECTED_ROOT_ENV,
+        NEKO_STORAGE_ANCHOR_ROOT_ENV,
+        NEKO_STORAGE_CLOUDSAVE_ROOT_ENV,
+    }
+
+
+def test_storage_root_env_is_absent_when_a_test_starts():
+    # The invariant the session-start clear and the per-test restore together
+    # promise: nothing inherited, nothing left over from an earlier test.
+    for key in guard.STORAGE_ROOT_ENV_KEYS:
+        assert key not in os.environ, key
+
+
+def test_restore_puts_back_removed_and_overwritten_keys_and_reports_them():
+    snapshot = {
+        NEKO_STORAGE_SELECTED_ROOT_ENV: r"D:\real",
+        NEKO_STORAGE_ANCHOR_ROOT_ENV: None,
+        NEKO_STORAGE_CLOUDSAVE_ROOT_ENV: None,
+    }
+    env = {
+        NEKO_STORAGE_SELECTED_ROOT_ENV: r"C:\tmp\leak",   # overwritten
+        NEKO_STORAGE_ANCHOR_ROOT_ENV: r"C:\tmp\anchor",   # newly set
+        "UNRELATED": "kept",
+    }
+
+    drifted = guard.restore_storage_root_env(snapshot, env)
+
+    assert drifted == {
+        NEKO_STORAGE_SELECTED_ROOT_ENV: (r"D:\real", r"C:\tmp\leak"),
+        NEKO_STORAGE_ANCHOR_ROOT_ENV: (None, r"C:\tmp\anchor"),
+    }
+    assert env == {NEKO_STORAGE_SELECTED_ROOT_ENV: r"D:\real", "UNRELATED": "kept"}
+
+
+def test_restore_reports_nothing_when_env_matches_snapshot():
+    env = {NEKO_STORAGE_SELECTED_ROOT_ENV: r"C:\tmp\root"}
+    snapshot = guard.snapshot_storage_root_env(env)
+
+    assert guard.restore_storage_root_env(snapshot, env) == {}
+    assert env == {NEKO_STORAGE_SELECTED_ROOT_ENV: r"C:\tmp\root"}
+
+
+def test_restore_also_removes_a_key_the_test_deleted_then_set_back_differently():
+    snapshot = {key: None for key in guard.STORAGE_ROOT_ENV_KEYS}
+    env = {NEKO_STORAGE_CLOUDSAVE_ROOT_ENV: r"C:\tmp\cloud"}
+
+    drifted = guard.restore_storage_root_env(snapshot, env)
+
+    assert list(drifted) == [NEKO_STORAGE_CLOUDSAVE_ROOT_ENV]
+    assert env == {}
+
+
+def test_clear_inherited_removes_only_guarded_keys_and_returns_them():
+    env = {
+        NEKO_STORAGE_SELECTED_ROOT_ENV: r"D:\real",
+        NEKO_STORAGE_CLOUDSAVE_ROOT_ENV: r"D:\real\cloudsave",
+        "PATH": "x",
+    }
+
+    cleared = guard.clear_inherited_storage_root_env(env)
+
+    assert cleared == {
+        NEKO_STORAGE_SELECTED_ROOT_ENV: r"D:\real",
+        NEKO_STORAGE_CLOUDSAVE_ROOT_ENV: r"D:\real\cloudsave",
+    }
+    assert env == {"PATH": "x"}
+    assert guard.clear_inherited_storage_root_env(env) == {}
+
+
+def test_leak_message_names_the_test_and_every_drifted_key():
+    message = guard.describe_storage_root_env_leak(
+        "tests/unit/test_x.py::test_y",
+        {NEKO_STORAGE_SELECTED_ROOT_ENV: (None, r"D:\real")},
+    )
+
+    assert "tests/unit/test_x.py::test_y" in message
+    assert NEKO_STORAGE_SELECTED_ROOT_ENV in message
+    # repr, not the bare string: it is what separates an unset key from one set
+    # to "" -- both of which the guard has to be able to report distinctly.
+    assert repr(r"D:\real") in message
+    assert "None" in message
+    assert "monkeypatch" in message
+
+
+def test_monkeypatched_env_is_not_reported_as_a_leak(monkeypatch):
+    # monkeypatch restores in its own teardown, which runs before the guard's
+    # post-teardown comparison; this test passing under the live guard is the
+    # end-to-end proof that legitimate per-test overrides stay green.
+    monkeypatch.setenv(NEKO_STORAGE_SELECTED_ROOT_ENV, r"C:\tmp\per-test-root")
+    assert os.environ[NEKO_STORAGE_SELECTED_ROOT_ENV] == r"C:\tmp\per-test-root"


### PR DESCRIPTION
## 起因

用户报"改不了角色名，而且除了 `test` 之外一个角色卡都选不了"。改名弹窗报：

```
重命名角色失败: Refusing to overwrite existing path while merging directories
D:\Documents\N.E.K.O\memory\test -> D:\Documents\N.E.K.O\memory\悠怡:
conflict at anti_repeat_corpus.json
```

改名功能本身没有问题。真实原因是**在本机跑 pytest 会写进用户真实的 N.E.K.O 运行根**：
`config/characters.json` 被整个替换成 `{"current":"A"}`，六个真角色从名册消失，
应用重启后按默认流程建了个 `test`。角色的记忆、卡面、人设都还在磁盘上，只是名册被抹了。

于是把 `test` 改名成"看起来空着"的 `悠怡` 时，磁盘上 `memory/悠怡/`（facts.json 126KB）
还完整躺着，`_merge_directories` 的预检正确地拒绝覆盖。**报错是护栏在正常工作，不是缺陷。**

## 两条独立通路（均已实测确认）

**通路一：`NEKO_STORAGE_SELECTED_ROOT` 泄漏进进程环境。**
这个变量在 `utils/config_manager/storage_roots.py` 里压过所有被 patch 的目录候选，
测试 helper 里 patch 的 `_get_documents_directory` /
`_get_standard_data_directory_candidates` 全部失效。
`launcher_core/runtime.py` 与 `plugin/core/host.py` 都会调
`export_storage_layout_to_env(layout)` 而不传 `environ=`，直接写真实 `os.environ`，
且 layout 取自真实 storage policy。

用一个假的角色根做对照：变量一指过去，
`test_storage_location_status_exposes_completed_migration_notice`
就把该根的 `characters.json` 写成 `{"current":"A"}`、`workshop_config.json` 写成
pytest 临时路径 —— 与真实根上的损坏痕迹逐字节吻合。不设变量时同一条用例对真实根零改动。

**通路二：导入期迁移，不依赖环境变量。**
`get_config_manager()` 的 `migrate` 默认为 `True`，而 `_ensure_config_manager_migrated`
是全仓唯一的迁移触发点（`grep` 确认）。产品里有 7 处模块级
`_config_manager = get_config_manager()` 和约 307 处裸调用，
**哪个模块先被 import 就由哪个在真实根上跑完整条迁移链**
（`migrate_config_files` / `migrate_default_card_faces` / `migrate_memory_files` /
`migrate_legacy_documents_memory` + `.mig-staging` 回收）。

用写路径探针实测：`tests/unit/test_cloudsave_config_manager.py` 里触发者是
`utils/preferences.py:39`；换成不导入它的 `tests/unit/test_character_memory_regression.py`，
触发者变成 `main_logic/omni_realtime_client/_gemini_support.py:78`。
**所以"改某一行 `migrate=False`"是无效修复，本 PR 不采用。**

## 本 PR 的两个守卫

**`tests/storage_root_env_guard.py`** 封通路一。sessionstart 清掉继承来的值并出显式
`PytestConfigWarning`；每条用例前后快照/还原那三个 key，没还原的用例报错并点名。
挂法与既有的 `tests/clock_guard.py` 对偶（pytest 按名字在 conftest 命名空间发现 hook）。

**`tests/real_root_isolation.py`** 封通路二。杠杆是 ConfigManager 自己的目录解析。

> ⚠️ 不要用 `LOCALAPPDATA` 当隔离开关：它同时是 uv 的缓存目录，改它会让
> `test_hatch_artifacts_explicitly_exclude_local_endpointing_weights` 因 uv 写不了缓存而红。
> 全量实测 31 red，其中 27 条与本仓无关。

四个方法一起挡（`_get_standard_data_directory_candidates` + 两个 legacy 候选 +
`get_legacy_app_root_candidates`）：只挡标准数据目录不够，legacy 扫描照样会读真实
Documents 树并在里面建迁移工作区。测这四个方法本身的 4 条用例走新增的
`real_root_resolution` fixture 还原真方法 —— 它们在 `tmp_path` 里自己 patch
`sys.platform` / `Path.home`，真方法碰不到开发机目录。

## 验证

**变异验证**（护栏必须能转红）：造两条真实泄漏写法的用例
（`export_storage_layout_to_env` 不带 `environ=`、直接赋值 `os.environ[...]`），
守卫在场时两条都报错、跟随用例仍绿；拆掉守卫后两条泄漏静默通过、跟随用例转红。

**端到端**：假角色根 + 泄漏的环境变量，守卫在场时名册不再被覆盖。

**全量 A/B**（`pytest tests/unit -n auto --dist loadfile`，24787 条，与 CI 同参）：

| | 失败 | 真实根改动 |
|---|---|---|
| 基线 | 4 | `core_config.json` 被截断成 `{"coreApi": "free"}`，11 个夹具目录 |
| 本 PR | **0**（24648 passed） | **无**（find 全树 diff 为空） |

基线那 4 条红全部是 `test_storage_layout.py`，根因是真实根里残留的 `.mig-unrecorded`
被导入测试临时根导致 `mkdir` 撞车 —— 隔离之后自行转绿，并非本 PR 改动所致。

## 范围

**产品代码零改动。** 通路二的产品侧收口（把迁移改成启动链路显式触发）要给约 307 个
调用点重新定义时序契约，还要在启动链路挑一个既在 phase-0 之后、又在首次读配置之前的
位置，与"启动链路禁阻塞"冲突；且它解决的不是本问题（产品自己跑迁移是正确行为）。
不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试**
  - 隔离测试期间的应用数据目录，避免意外访问开发机真实运行目录。
  - 自动清理继承的存储根环境变量，并检测测试用例中的环境泄漏。
  - 支持特定测试临时使用真实路径解析，并在测试结束后恢复隔离环境。
  - 测试结束后自动清理隔离目录，并支持按需保留。
  - 补充环境变量保护、真实路径隔离及 Linux/XDG 路径解析场景的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->