### PR TITLE
fix(card-maker): stabilize forge avatar placement

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -178,6 +178,7 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/css/character_personality_onboarding.css",
     _PROJECT_ROOT / "static/js/character_personality_onboarding.js",
     _PROJECT_ROOT / "static/css/card_maker.css",
+    _PROJECT_ROOT / "static/js/card_maker_embed_layout.js",
     _PROJECT_ROOT / "static/js/card_maker.js",
     _PROJECT_ROOT / "static/js/card_maker_embed_bootstrap.js",
     _PROJECT_ROOT / "static/libs/live2dcubismcore.min.js",

--- a/static/js/card_maker.js
+++ b/static/js/card_maker.js
@@ -121,6 +121,8 @@
     const EMBED_MODEL_HEIGHT_RATIO = 1.34;
     const EMBED_MODEL_CENTER_X_RATIO = 0.22;
     const EMBED_MODEL_CENTER_Y_RATIO = 0.67;
+    const embedModelLayout = window.NEKOCardMakerEmbedLayout;
+    const embedThreeFrameCache = new WeakMap();
     const autoSaveDefaultCardFace = _urlParams.get('auto_save_default') === '1';
     const closeAfterAutoSave = _urlParams.get('close_on_save') === '1';
     const fallbackDefaultOnClose = _urlParams.get('fallback_default_on_close') === '1';
@@ -683,11 +685,53 @@
         if (lighting) {
             window.lanlan_config.lighting = lighting;
         }
-        await window.vrmManager.loadModel(modelPath);
+        await window.vrmManager.loadModel(modelPath, {
+            embed: isEmbedMode,
+            addShadow: !isEmbedMode
+        });
+        if (isEmbedMode) {
+            // The forge preview is intentionally static, like the Live2D
+            // minimal embed. Freeze the first idle pose so animated bones do
+            // not become a moving layout reference during window resizes.
+            window.vrmManager.seekVRMAAnimation?.(0, { paused: true });
+        }
         // 制卡页居中；嵌入页使用与 Live2D 对称的左侧半身构图。
         resizeModelRendererForCard('vrm');
-        if (isEmbedMode) frameThreeModelForEmbed(window.vrmManager);
+        if (isEmbedMode) frameVRMModelForEmbed(window.vrmManager);
         else centerThreeCamera(window.vrmManager);
+    }
+
+    async function loadMMDIdlePoseForEmbed(mgr) {
+        let idleAnimation = '';
+        try {
+            const response = await fetch('/api/characters');
+            if (response.ok) {
+                const characters = await response.json();
+                const character = characters?.['猫娘']?.[currentCharaName];
+                const configured = Array.isArray(character?.mmd_idle_animations)
+                    ? character.mmd_idle_animations
+                    : [character?.mmd_idle_animation];
+                idleAnimation = configured.find(path => typeof path === 'string' && path.trim()) || '';
+            }
+        } catch (error) {
+            console.warn('[CardExport] 获取 MMD 待机姿势失败，使用内置姿势:', error);
+        }
+        const fallbackAnimation = '/static/mmd/animation/wait03.vmd';
+        const candidates = [idleAnimation, fallbackAnimation]
+            .filter((path, index, values) => path && values.indexOf(path) === index);
+        for (const path of candidates) {
+            try {
+                await mgr.loadAnimation(path, { immediate: true, fadeDuration: 0 });
+                // loadAnimation applies frame zero synchronously and leaves the
+                // action paused. Mark it paused explicitly so IK/Grant and the
+                // render loop do not turn the forge pose into a moving reference.
+                mgr.pauseAnimation?.();
+                mgr.currentModel?.mesh?.updateMatrixWorld?.(true);
+                return;
+            } catch (error) {
+                console.warn('[CardExport] MMD 待机姿势加载失败:', path, error);
+            }
+        }
     }
 
     async function loadMMDModel(modelPath) {
@@ -701,20 +745,18 @@
                 throw new Error('MMDManager 未定义');
             }
         }
-        if (!window.mmdManager.core?.renderer) {
+        if (!window.mmdManager.renderer) {
             await window.mmdManager.init('mmd-canvas', 'mmd-container');
         }
         resizeModelRendererForCard('mmd');
-        await window.mmdManager.loadModel(modelPath);
+        await window.mmdManager.loadModel(modelPath, { embed: isEmbedMode });
+        if (isEmbedMode) {
+            await loadMMDIdlePoseForEmbed(window.mmdManager);
+        }
         // 制卡页居中；嵌入页使用与 Live2D/VRM 对称的左侧半身构图。
-        const mmdProxy = {
-            scene: window.mmdManager.core?.scene,
-            camera: window.mmdManager.core?.camera,
-            renderer: window.mmdManager.core?.renderer
-        };
         resizeModelRendererForCard('mmd');
-        if (isEmbedMode) frameThreeModelForEmbed(mmdProxy);
-        else centerThreeCamera(mmdProxy);
+        if (isEmbedMode) frameMMDModelForEmbed(window.mmdManager);
+        else centerThreeCamera(window.mmdManager);
     }
 
     async function loadPNGTuberModel(cfg) {
@@ -723,6 +765,19 @@
         const pngtuberConfig = Object.assign({}, cfg?.pngtuber || {});
         if (!pngtuberConfig.idle_image && cfg?.model_path) {
             pngtuberConfig.idle_image = cfg.model_path;
+        }
+        if (isEmbedMode) {
+            // The forge preview is its own coordinate system. Never seed the
+            // PNGTuber runtime with offsets or scale saved by the desktop pet.
+            Object.assign(pngtuberConfig, {
+                scale: 1,
+                offset_x: 0,
+                offset_y: 0,
+                mobile_scale: 1,
+                mobile_offset_x: 0,
+                mobile_offset_y: 0,
+                position_anchor: 'center'
+            });
         }
         assertExportablePNGTuberConfig(pngtuberConfig);
         window.lanlan_config = window.lanlan_config || {};
@@ -790,24 +845,59 @@
         model.y = screen.height * EMBED_MODEL_CENTER_Y_RATIO;
     }
 
-    function frameThreeModelForEmbed(mgr) {
+    function frameVRMModelForEmbed(mgr) {
+        const model = mgr?.currentModel?.vrm?.scene || mgr?.currentModel?.scene;
+        frameThreeModelForEmbed(mgr, model);
+    }
+
+    function frameMMDModelForEmbed(mgr) {
+        frameThreeModelForEmbed(mgr, mgr?.currentModel?.mesh);
+    }
+
+    function frameThreeModelForEmbed(mgr, model) {
         const THREE = window.THREE;
-        if (!THREE || !mgr?.scene || !mgr?.camera || !mgr?.renderer) return;
+        if (!THREE || !model || !mgr?.camera || !mgr?.renderer || !embedModelLayout) return;
         try {
-            const box = new THREE.Box3().setFromObject(mgr.scene);
-            if (box.isEmpty()) return;
-            const center = box.getCenter(new THREE.Vector3());
-            const size = box.getSize(new THREE.Vector3());
+            let bounds = embedThreeFrameCache.get(model);
+            if (!bounds) {
+                model.updateMatrixWorld?.(true);
+                const box = new THREE.Box3().setFromObject(model);
+                if (box.isEmpty()) return;
+                const measuredCenter = box.getCenter(new THREE.Vector3());
+                const measuredSize = box.getSize(new THREE.Vector3());
+                bounds = {
+                    center: measuredCenter.clone(),
+                    size: measuredSize.clone()
+                };
+                embedThreeFrameCache.set(model, bounds);
+            }
+            // Reuse the first stable pose's bounds. Re-measuring a skinned
+            // model during resize makes the camera follow whichever animation
+            // frame happened to be active, which is the source of VRM/MMD
+            // model-specific drift.
+            const center = bounds.center;
+            const size = bounds.size;
             const modelHeight = size.y > 0 ? size.y : 1.5;
             const fov = mgr.camera.fov * (Math.PI / 180);
-            const distance = (modelHeight / 2) / Math.tan(fov / 2) / EMBED_MODEL_HEIGHT_RATIO;
-            const horizontalShift = Math.max(size.x, modelHeight * 0.35) * 0.72;
+            const viewport = mgr.renderer.domElement?.getBoundingClientRect?.();
+            const viewportWidth = Number(viewport?.width) || Number(mgr.renderer.domElement?.clientWidth) || window.innerWidth;
+            const viewportHeight = Number(viewport?.height) || Number(mgr.renderer.domElement?.clientHeight) || window.innerHeight;
+            const frame = embedModelLayout.resolvePerspectiveFrame(
+                viewportWidth,
+                viewportHeight,
+                size.x > 0 ? size.x : modelHeight * 0.35,
+                modelHeight,
+                fov
+            );
+            const cameraX = center.x - frame.ndcX * frame.halfViewWidth;
+            const cameraY = center.y - frame.ndcY * frame.halfViewHeight;
             const target = new THREE.Vector3(
-                center.x + horizontalShift,
-                center.y + modelHeight * 0.1,
+                cameraX,
+                cameraY,
                 center.z
             );
-            mgr.camera.position.set(target.x, target.y, center.z + Math.abs(distance));
+            mgr.camera.up?.set?.(0, 1, 0);
+            mgr.camera.position.set(cameraX, cameraY, center.z + frame.distance);
             mgr.camera.lookAt(target);
             mgr.camera.updateProjectionMatrix();
             mgr._cameraTarget?.copy?.(target);
@@ -822,10 +912,47 @@
 
     function framePNGTuberForEmbed(mgr) {
         const source = getPNGTuberDrawableSource(mgr);
-        if (!source?.style) return;
-        source.style.objectPosition = '22% 64%';
-        source.style.transformOrigin = '22% 64%';
-        source.style.transform = `scale(${EMBED_MODEL_HEIGHT_RATIO})`;
+        if (!source?.style || !embedModelLayout || !mgr?.config) return;
+        const viewportWidth = Math.max(1, window.innerWidth);
+        const viewportHeight = Math.max(1, window.innerHeight);
+        const sourceWidth = mgr.isLayeredActive?.()
+            ? Number(mgr.layeredCanvasLogicalWidth)
+            : Number(source.naturalWidth || source.width);
+        const sourceHeight = mgr.isLayeredActive?.()
+            ? Number(mgr.layeredCanvasLogicalHeight)
+            : Number(source.naturalHeight || source.height);
+        const contained = embedModelLayout.resolveContainedSize(
+            viewportWidth,
+            viewportHeight,
+            sourceWidth,
+            sourceHeight
+        );
+        const frame = embedModelLayout.resolveFrame(
+            viewportWidth,
+            viewportHeight,
+            contained.width,
+            contained.height
+        );
+        source.style.width = contained.width + 'px';
+        source.style.height = contained.height + 'px';
+        source.style.objectFit = 'contain';
+        source.style.objectPosition = 'center center';
+
+        const offsetX = frame.centerX - viewportWidth / 2;
+        const offsetY = frame.centerY - viewportHeight / 2;
+        Object.assign(mgr.config, {
+            scale: frame.scale,
+            offset_x: offsetX,
+            offset_y: offsetY,
+            mobile_scale: frame.scale,
+            mobile_offset_x: offsetX,
+            mobile_offset_y: offsetY,
+            position_anchor: 'center'
+        });
+        // PNGTuber animation calls applyTransform repeatedly. Put the forge
+        // placement into that authoritative path so breathing cannot restore
+        // desktop offsets after this function returns.
+        mgr.applyTransform?.();
     }
 
     function prepareHiddenModelViewport() {
@@ -892,13 +1019,7 @@
             return;
         }
 
-        const mgr = type === 'vrm'
-            ? window.vrmManager
-            : {
-                renderer: window.mmdManager?.core?.renderer,
-                camera: window.mmdManager?.core?.camera,
-                effect: window.mmdManager?.core?.effect || window.mmdManager?.effect
-            };
+        const mgr = type === 'vrm' ? window.vrmManager : window.mmdManager;
         const renderer = mgr?.renderer;
         if (!renderer) return;
         renderer.setPixelRatio?.(ratio);
@@ -912,7 +1033,10 @@
             mgr.camera.updateProjectionMatrix?.();
         }
         mgr.effect?.setSize?.(w, h);
-        if (isEmbedMode) frameThreeModelForEmbed(mgr);
+        if (isEmbedMode) {
+            if (type === 'vrm') frameVRMModelForEmbed(mgr);
+            else frameMMDModelForEmbed(mgr);
+        }
     }
 
     function syncEmbedModelViewport() {
@@ -1158,9 +1282,10 @@
                 mgr.renderer.render(mgr.scene, mgr.camera);
             }
         } else if (currentModelType === 'mmd') {
-            const core = window.mmdManager?.core;
-            if (core?.renderer && core?.scene && core?.camera) {
-                core.renderer.render(core.scene, core.camera);
+            const mgr = window.mmdManager;
+            if (mgr?.renderer && mgr?.scene && mgr?.camera) {
+                if (mgr.useOutlineEffect && mgr.effect) mgr.effect.render(mgr.scene, mgr.camera);
+                else mgr.renderer.render(mgr.scene, mgr.camera);
             }
         } else if (currentModelType === 'pngtuber') {
             const mgr = window.cardMakerPNGTuberManager;

--- a/static/js/card_maker_embed_layout.js
+++ b/static/js/card_maker_embed_layout.js
@@ -1,0 +1,88 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.NEKOCardMakerEmbedLayout = api;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    // These values describe YUI's visible pixels in the previous canvas-based
+    // framing (roughly 25.4%, 66.2%, and 1.253x tall), rounded into a stable
+    // provider-independent forge coordinate system.
+    const HEIGHT_RATIO = 1.25;
+    const CENTER_X_RATIO = 0.25;
+    const CENTER_Y_RATIO = 0.66;
+    // Mirroring the center distance keeps every visible model inside the
+    // complete left half of the stage, before the forge machine begins.
+    const MAX_WIDTH_RATIO = CENTER_X_RATIO * 2;
+
+    function positiveNumber(value, fallback = 1) {
+        const number = Number(value);
+        return Number.isFinite(number) && number > 0 ? number : fallback;
+    }
+
+    function resolveFrame(viewportWidth, viewportHeight, contentWidth, contentHeight) {
+        const width = positiveNumber(viewportWidth);
+        const height = positiveNumber(viewportHeight);
+        const modelWidth = positiveNumber(contentWidth);
+        const modelHeight = positiveNumber(contentHeight);
+        const heightScale = (height * HEIGHT_RATIO) / modelHeight;
+        const widthScale = (width * MAX_WIDTH_RATIO) / modelWidth;
+
+        return {
+            centerX: width * CENTER_X_RATIO,
+            centerY: height * CENTER_Y_RATIO,
+            maxWidth: width * MAX_WIDTH_RATIO,
+            maxHeight: height * HEIGHT_RATIO,
+            scale: Math.min(heightScale, widthScale)
+        };
+    }
+
+    function resolveContainedSize(viewportWidth, viewportHeight, sourceWidth, sourceHeight) {
+        const width = positiveNumber(viewportWidth);
+        const height = positiveNumber(viewportHeight);
+        const assetWidth = positiveNumber(sourceWidth);
+        const assetHeight = positiveNumber(sourceHeight);
+        const containScale = Math.min(width / assetWidth, height / assetHeight);
+
+        return {
+            width: assetWidth * containScale,
+            height: assetHeight * containScale
+        };
+    }
+
+    function resolvePerspectiveFrame(viewportWidth, viewportHeight, contentWidth, contentHeight, verticalFovRadians) {
+        const width = positiveNumber(viewportWidth);
+        const height = positiveNumber(viewportHeight);
+        const modelWidth = positiveNumber(contentWidth);
+        const modelHeight = positiveNumber(contentHeight);
+        const fov = positiveNumber(verticalFovRadians, Math.PI / 4);
+        const tangent = Math.max(0.000001, Math.tan(fov / 2));
+        const aspect = width / height;
+        const heightDistance = modelHeight / (2 * tangent * HEIGHT_RATIO);
+        const widthDistance = modelWidth / (2 * tangent * aspect * MAX_WIDTH_RATIO);
+        const distance = Math.max(heightDistance, widthDistance, 0.01);
+        const halfViewHeight = distance * tangent;
+
+        return {
+            distance,
+            ndcX: CENTER_X_RATIO * 2 - 1,
+            ndcY: 1 - CENTER_Y_RATIO * 2,
+            halfViewHeight,
+            halfViewWidth: halfViewHeight * aspect
+        };
+    }
+
+    return Object.freeze({
+        HEIGHT_RATIO,
+        CENTER_X_RATIO,
+        CENTER_Y_RATIO,
+        MAX_WIDTH_RATIO,
+        resolveFrame,
+        resolveContainedSize,
+        resolvePerspectiveFrame
+    });
+});

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -437,6 +437,7 @@ class MMDCore {
 
     async loadModel(modelUrl, options = {}, managerLoadToken = null) {
         const THREE = window.THREE;
+        const embed = options.embed === true;
         if (!THREE) {
             throw new Error('Three.js 库未加载，无法加载 MMD 模型');
         }
@@ -591,8 +592,11 @@ class MMDCore {
             // 材质诊断日志
             this._logMaterialDiagnostics(mmd);
 
-            // 恢复保存的偏好设置（位置/旋转/缩放）
-            await this._restoreUserPreferences(mmd, modelUrl);
+            // The forge embed owns its own camera and model coordinate system.
+            // Desktop position/scale/camera preferences must never leak into it.
+            if (!embed) {
+                await this._restoreUserPreferences(mmd, modelUrl);
+            }
 
             return modelInfo;
         } catch (error) {

--- a/static/vrm/vrm-core.js
+++ b/static/vrm/vrm-core.js
@@ -736,6 +736,7 @@ class VRMCore {
 
     async loadModel(modelUrl, options = {}, managerLoadToken = null) {
         const THREE = window.THREE;
+        const embed = options.embed === true;
         if (!THREE) {
             const errorMsg = window.t ? window.t('vrm.error.threeNotLoadedForModel') : 'Three.js库未加载，无法加载VRM模型';
             throw new Error(errorMsg);
@@ -880,7 +881,8 @@ class VRMCore {
 
             // 获取保存的用户偏好设置
             let preferences = null;
-            try {
+            if (!embed) {
+                try {
                 // 添加超时保护（5秒超时）
                 const controller = new AbortController();
                 const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -965,8 +967,9 @@ class VRMCore {
                         return false;
                     });
                 }
-            } catch (error) {
-                console.error('[VRM Core] 获取用户偏好设置失败:', error);
+                } catch (error) {
+                    console.error('[VRM Core] 获取用户偏好设置失败:', error);
+                }
             }
 
             if (preferences) {
@@ -1066,7 +1069,7 @@ class VRMCore {
             
             const hasSavedRotation = VRMCore._isFiniteRotation(savedRotation);
             
-            if (!hasSavedRotation && typeof this.saveUserPreferences === 'function') {
+            if (!embed && !hasSavedRotation && typeof this.saveUserPreferences === 'function') {
                 // 标准化位置为普通对象 {x, y, z}
                 // 始终从 vrm.scene 获取当前位置，确保 z 值有效
                 // （旧版偏好设置可能只有 x 和 y，没有 z 值）

--- a/templates/card_maker.html
+++ b/templates/card_maker.html
@@ -201,6 +201,7 @@
         window.__NEKO_CARD_MAKER_EMBED__ = {{ card_maker_embed | tojson }};
         window.renderQuality = window.__NEKO_CARD_MAKER_EMBED__ ? 'medium' : 'high';
     </script>
+    <script src="/static/js/card_maker_embed_layout.js?v={{ static_asset_version | default('0') }}"></script>
 
     {% if not card_maker_embed %}
     <!-- Live2D SDK -->

--- a/tests/unit/card_maker_embed_layout.test.js
+++ b/tests/unit/card_maker_embed_layout.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const layout = require('../../static/js/card_maker_embed_layout.js');
+
+test('uses the normalized forge left-lane anchor for VRM and PNGTuber', () => {
+    const frame = layout.resolveFrame(1470, 770, 390, 770);
+
+    assert.equal(frame.centerX, 1470 * 0.25);
+    assert.equal(frame.centerY, 770 * 0.66);
+    assert.equal(frame.scale, 1.25);
+    assert.equal(frame.maxWidth, 1470 * 0.5);
+});
+
+test('fits unusually wide models inside the left forge boundary', () => {
+    const frame = layout.resolveFrame(1470, 770, 1000, 770);
+
+    assert.equal(frame.scale, frame.maxWidth / 1000);
+    assert.ok(1000 * frame.scale <= 1470 * 0.5);
+    assert.ok(770 * frame.scale <= 770 * 1.25);
+});
+
+test('preserves PNGTuber aspect ratio before applying the shared frame', () => {
+    const contained = layout.resolveContainedSize(1470, 770, 3678, 4182);
+
+    assert.equal(contained.height, 770);
+    assert.ok(Math.abs(contained.width / contained.height - 3678 / 4182) < 1e-12);
+});
+
+test('perspective framing keeps narrow and wide 3D models on the same screen anchor', () => {
+    for (const modelWidth of [0.5, 1.5, 4]) {
+        const frame = layout.resolvePerspectiveFrame(1470, 770, modelWidth, 2, Math.PI / 3);
+        const projectedCenterX = (frame.ndcX + 1) / 2;
+        const projectedCenterY = (1 - frame.ndcY) / 2;
+        const projectedWidth = modelWidth / (2 * frame.halfViewWidth);
+        const projectedHeight = 2 / (2 * frame.halfViewHeight);
+
+        assert.ok(Math.abs(projectedCenterX - 0.25) < 1e-12);
+        assert.ok(Math.abs(projectedCenterY - 0.66) < 1e-12);
+        assert.ok(projectedWidth <= 0.5 + 1e-12);
+        assert.ok(projectedHeight <= 1.25 + 1e-12);
+    }
+});

--- a/tests/unit/test_card_maker_embed_static.py
+++ b/tests/unit/test_card_maker_embed_static.py
@@ -26,6 +26,7 @@ def test_card_maker_exposes_transparent_model_embed_mode() -> None:
     template = (ROOT / "templates" / "card_maker.html").read_text(encoding="utf-8")
     css = (ROOT / "static" / "css" / "card_maker.css").read_text(encoding="utf-8")
     script = (ROOT / "static" / "js" / "card_maker.js").read_text(encoding="utf-8")
+    layout = (ROOT / "static" / "js" / "card_maker_embed_layout.js").read_text(encoding="utf-8")
     bootstrap = (ROOT / "static" / "js" / "card_maker_embed_bootstrap.js").read_text(encoding="utf-8")
     model_runtime = (ROOT / "static" / "live2d" / "live2d-model.js").read_text(encoding="utf-8")
 
@@ -48,12 +49,18 @@ def test_card_maker_exposes_transparent_model_embed_mode() -> None:
     )[1].split("}", 1)[0]
     assert "notifyEmbedHost('error');" in config_error_handler
     assert "if (!isEmbedMode) {\n                startPreviewLoop();\n                refreshPreview();" in script
+    assert "const HEIGHT_RATIO = 1.25;" in layout
+    assert "const CENTER_X_RATIO = 0.25;" in layout
+    assert "const CENTER_Y_RATIO = 0.66;" in layout
+    assert "const MAX_WIDTH_RATIO = CENTER_X_RATIO * 2;" in layout
+    assert "window.NEKOCardMakerEmbedLayout" in script
+    assert "card_maker_embed_layout.js?v={{ static_asset_version" in template
     assert "const EMBED_MODEL_HEIGHT_RATIO = 1.34;" in script
     assert "const EMBED_MODEL_CENTER_X_RATIO = 0.22;" in script
     assert "const EMBED_MODEL_CENTER_Y_RATIO = 0.67;" in script
     assert "frameLive2DModelForEmbed(window.live2dManager);" in script
-    assert "frameThreeModelForEmbed(window.vrmManager);" in script
-    assert "frameThreeModelForEmbed(mmdProxy);" in script
+    assert "frameVRMModelForEmbed(window.vrmManager);" in script
+    assert "frameMMDModelForEmbed(window.mmdManager);" in script
     assert "framePNGTuberForEmbed(mgr);" in script
     assert "isEmbedMode ? Math.max(1, window.innerWidth) : CARD_BASE_WIDTH" in script
     assert "window.addEventListener('resize'" in script
@@ -68,6 +75,40 @@ def test_card_maker_exposes_transparent_model_embed_mode() -> None:
     assert "loadEmotionMapping: false" in script
     assert "const minimalEmbed = options.minimalEmbed === true;" in model_runtime
     assert "minimalEmbed ? 480 : 2000" in model_runtime
+
+
+def test_card_maker_embed_fixes_vrm_mmd_and_pngtuber_without_scanning_live2d() -> None:
+    script = (ROOT / "static" / "js" / "card_maker.js").read_text(encoding="utf-8")
+    vrm_core = (ROOT / "static" / "vrm" / "vrm-core.js").read_text(encoding="utf-8")
+    mmd_core = (ROOT / "static" / "mmd" / "mmd-core.js").read_text(encoding="utf-8")
+
+    assert "function getLive2DVisibleBoundsForEmbed" not in script
+    assert "mgr._getDrawableDirectScreenRect(index, true)" not in script
+    assert "function frameVRMModelForEmbed" in script
+    assert "function frameMMDModelForEmbed" in script
+    assert "const box = new THREE.Box3().setFromObject(model);" in script
+    assert "embedThreeFrameCache.get(model)" in script
+    assert "embedThreeFrameCache.set(model, bounds)" in script
+    assert "embed: isEmbedMode,\n            addShadow: !isEmbedMode" in script
+    assert "if (!embed) {" in vrm_core
+    assert "if (!embed && !hasSavedRotation" in vrm_core
+    assert "window.mmdManager.loadModel(modelPath, { embed: isEmbedMode })" in script
+    assert "await loadMMDIdlePoseForEmbed(window.mmdManager);" in script
+    assert "mgr.pauseAnimation?.();" in script
+    assert "const embed = options.embed === true;" in mmd_core
+    assert "if (!embed) {\n                await this._restoreUserPreferences(mmd, modelUrl);" in mmd_core
+    assert "window.mmdManager.core?.renderer" not in script
+    assert "if (!window.mmdManager.renderer)" in script
+
+    for field in (
+        "offset_x: 0",
+        "offset_y: 0",
+        "mobile_offset_x: 0",
+        "mobile_offset_y: 0",
+        "position_anchor: 'center'",
+    ):
+        assert field in script
+    assert "mgr.applyTransform?.();" in script
 
 
 def test_card_maker_embed_runtime_loaders_are_provider_symmetric() -> None:
@@ -86,11 +127,13 @@ def test_embed_template_omits_full_editor_runtimes() -> None:
     full_editor = render_card_maker("maker")
 
     assert "/static/js/card_maker_embed_bootstrap.js?v=test-version" in embedded
+    assert "/static/js/card_maker_embed_layout.js?v=test-version" in embedded
     assert "/static/libs/live2dcubismcore.min.js" not in embedded
     assert "/static/vrm/vrm-init.js" not in embedded
     assert "/static/mmd/mmd-init.js" not in embedded
     assert "/static/i18n-i18next.js" not in embedded
     assert "/static/js/card_maker_embed_bootstrap.js" not in full_editor
+    assert "/static/js/card_maker_embed_layout.js?v=test-version" in full_editor
     assert "/static/libs/live2dcubismcore.min.js" in full_editor
     assert "/static/vrm/vrm-init.js" in full_editor
     assert "/static/mmd/mmd-init.js" in full_editor
@@ -116,6 +159,7 @@ def test_versioned_runtime_assets_change_static_asset_version(monkeypatch) -> No
             "static/live2d/live2d-core.js",
             "static/live2d/live2d-emotion.js",
             "static/live2d/live2d-model.js",
+            "static/js/card_maker_embed_layout.js",
             "static/mmd/mmd-init.js",
             "static/social-embed.js",
         )
@@ -151,5 +195,6 @@ def test_template_versioned_static_assets_are_tracked() -> None:
     tracked_paths = set(pages_router._YUI_GUIDE_ASSET_VERSION_PATHS)
     assert referenced_paths
     assert ROOT / "static/js/card_maker_embed_bootstrap.js" in referenced_paths
+    assert ROOT / "static/js/card_maker_embed_layout.js" in referenced_paths
     assert referenced_paths <= tracked_paths
     assert ROOT / "static/app/app-chat.js" in tracked_paths


### PR DESCRIPTION
## 改动概述 / Summary

- 为 PNGTuber、VRM 与 MMD 锻造嵌入页统一左侧构图规则，并对异常宽模型增加边界约束。
- 隔离桌面宠物保存的位置、缩放和相机偏好，缓存稳定的 3D 几何边界，避免窗口缩放或动画帧造成漂移。
- 修正 MMD 初始化与渲染对象引用，加载并暂停待机姿势，避免 MIKU 以 T Pose 出现在锻造页。
- 保留现有 Live2D 固定公式，不加入可见像素扫描。

## 回归报告 / Regression Report

- 改动内容：`main_routers/pages_router.py` 将新的共享嵌入布局脚本纳入静态资源版本计算，保证 Docker、网页端与 Electron 获取同一版本资源。
- 理由与必要性：锻造页此前错误读取 MMD manager 层级，并让 PNGTuber、VRM、MMD 继承桌面坐标；缓存命中时还可能继续使用旧脚本，因此需要同步更新资源版本入口。
- 改动前：PNGTuber 会随桌面偏移，VRM/MMD 会因保存偏好、动画姿势和窗口尺寸出现错位；MMD 可能停在 T Pose。
- 改动后：三类模型按视口 25% x / 66% y 锚点固定在铸造机左侧，超宽模型保持在左半区，桌面偏好不会污染锻造页；MMD 使用暂停的待机姿势。
- 潜在回归与验证：影响 `/card_maker?mode=embed` 的静态资源版本、模型加载和 resize 链路。已用单元测试覆盖锚点、宽度边界、资源追踪及 provider 对称性，并在 Docker 中用 Miku MMD、sensei.vrm、sister1.0.vrm 在 1100x770、1470x770、1600x900 三种视口实测。

## 不拆分理由 / Why Not Split

本 PR 仅包含一个锻造页模型定位问题的共享布局实现、各 provider 接入和对应测试；代码与回归覆盖必须同步提交以保持行为对偶。

## 测试 / Testing

- `node --check static/js/card_maker.js`
- `node --check static/js/card_maker_embed_layout.js`
- `node --check static/vrm/vrm-core.js`
- `node --check static/mmd/mmd-core.js`
- `node --test tests/unit/card_maker_embed_layout.test.js`（4 passed）
- `uv run pytest tests/unit/test_card_maker_embed_static.py -q`（7 passed）
- Docker 运行时验证：Miku MMD、`sensei.vrm`、`sister1.0.vrm` 在三个视口尺寸下投影中心始终保持 25% x / 66% y。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化嵌入模式下 VRM、MMD 和 PNGTuber 模型的取景、缩放与定位。
  - 支持更稳定的初始姿态，减少模型调整或缩放时的画面漂移。
  - 嵌入模型将使用专属布局规则，不再套用桌面模式的位置、缩放和旋转设置。

- **兼容性**
  - 改善不同模型比例及透视效果下的画布适配表现。

- **测试**
  - 新增并完善嵌入布局及多种模型类型的自动化测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->