### PR TITLE
fix(seo): keep paid baselines manual

### DIFF
--- a/.github/workflows/dataforseo.yml
+++ b/.github/workflows/dataforseo.yml
@@ -1,12 +1,9 @@
 name: SEO GEO Daily Report
 
 run-name: >-
-  SEO/GEO - ${{ github.event_name == 'schedule' && 'daily-paid-depth-100-aio' || inputs.run_mode || 'validation' }}
+  SEO/GEO - ${{ inputs.run_mode || 'validation' }}
 
 on:
-  schedule:
-    # 08:15 Asia/Shanghai, after the .cn source repository's 07:45 baseline.
-    - cron: '15 0 * * *'
   pull_request:
     paths:
       - 'docs/scripts/dataforseo/**'
@@ -78,15 +75,14 @@ jobs:
   report:
     if: >-
       github.repository == 'Project-N-E-K-O/N.E.K.O' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule')
+      github.event_name == 'workflow_dispatch'
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      COLLECTION_KIND: ${{ github.event_name == 'schedule' && 'paid' || inputs.run_mode }}
-      SERP_DEPTH: ${{ (github.event_name == 'schedule' || inputs.run_mode == 'paid') && '100' || inputs.serp_depth }}
-      INCLUDE_AI_OVERVIEW: ${{ (github.event_name == 'schedule' || inputs.run_mode == 'paid') && 'true' || inputs.include_ai_overview }}
+      COLLECTION_KIND: ${{ inputs.run_mode }}
+      SERP_DEPTH: ${{ inputs.run_mode == 'paid' && '100' || inputs.serp_depth }}
+      INCLUDE_AI_OVERVIEW: ${{ inputs.run_mode == 'paid' && 'true' || inputs.include_ai_overview }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/contributing/dataforseo-seo-monitoring.md
+++ b/docs/contributing/dataforseo-seo-monitoring.md
@@ -11,16 +11,17 @@ It is not browser code and is never bundled into VitePress. DataForSEO credentia
 
 ## Safety and evidence contract
 
-DataForSEO bills by request, but the daily baseline is deliberately **not** hidden behind a cost-saving kill switch. A skipped run and a real zero are different facts:
+DataForSEO bills by request, so GitHub Actions never starts a paid run on a timer. A skipped run and a real zero are different facts:
 
 - pull requests run tests and three `dry-run` plans only; they receive no billing credentials;
 - manual workflow dispatch defaults to `dry-run` and sends no paid request;
-- the 08:15 Asia/Shanghai schedule always runs the paid baseline at SERP depth 100 with AI Overview loading enabled;
+- the workflow has no `schedule` trigger; routine free observation runs locally, outside GitHub Actions;
+- a paid baseline must be started manually and always uses SERP depth 100 with AI Overview loading enabled;
 - there is no `ENABLE_PAID_DATAFORSEO_SCHEDULE` variable; an old variable with that name has no effect and should be removed from repository settings;
 - SERP depth 100 may bill up to ten result pages per query;
 - each SERP request sets `max_crawl_pages` from that depth, making the displayed page count a hard crawl limit;
-- asynchronous AI Overview loading can add a charge to every SERP request and is intentionally included in the scheduled visibility baseline;
-- one scheduled run tracks 19 `.online` English queries, 8 `.cn` Chinese queries, and 3 `.online` Chinese documentation queries;
+- asynchronous AI Overview loading can add a charge to every SERP request and is intentionally included in a manually dispatched paid baseline;
+- one paid run tracks 19 `.online` English queries, 8 `.cn` Chinese queries, and 3 `.online` Chinese documentation queries;
 - explicit transient SERP API failures that report zero cost retry only the failed keyword, at most three attempts with backoff;
 - ambiguous network, response-body, or JSON failures are never retried automatically because the completed request may already have been billed;
 - a failed response reporting any nonzero cost is never retried automatically, preventing an accidental duplicate charge;
@@ -123,7 +124,7 @@ Use `--output <path>` for a different report path and `--config <path>` for an a
 6. Run `paid`; paid dispatches always force depth 100 and AIO on, even if the dry-run-only inputs were changed.
 7. Download the fixed-name `seo-geo-daily-report` diagnostic artifact. It always contains raw reports, all execution manifests, the unified JSON and the unified Markdown, including evidence from a failed gate.
 8. A successful paid run on `main` also uploads `seo-geo-daily-paid-baseline`. Only this gate-verified artifact is eligible for next-run rank/AIO comparisons; dry-runs, failed paid runs, and feature-branch runs cannot replace it.
-9. The daily 08:15 schedule is automatic after merge. Missing credentials, a missing core report, or a failed technical/content invariant makes the run fail after the diagnostic artifact has been uploaded.
+9. There is no automatic paid schedule. Start a paid baseline manually after reviewing the dry-run plan and budget; missing credentials, a missing core report, or a failed technical/content invariant makes it fail after the diagnostic artifact has been uploaded.
 
 Pull requests run the unit tests and committed-config dry-run only. They never receive DataForSEO secrets and never execute a paid request.
 

--- a/docs/contributing/seo-geo-daily-monitoring.md
+++ b/docs/contributing/seo-geo-daily-monitoring.md
@@ -1,10 +1,10 @@
 # SEO/GEO 日报与自动监控
 
-`SEO GEO Daily Report` 工作流每天北京时间 08:15 生成同一份 Markdown + JSON artifact；它排在 `.cn` 源仓库 07:45 的排名基线之后。日报遵循 `gingiris-seo-geo-agent` 的四阶段顺序：技术健康 → GSC/GA4 → 排名与 AI 引用 → P0/P1/P2 动作。模板见 [`seo/reports/TEMPLATE.md`](/seo/reports/TEMPLATE)，N.E.K.O 双站适配和完成定义见 [`seo/reports/SKILL-INTEGRATION.md`](/seo/reports/SKILL-INTEGRATION)。
+`SEO GEO Daily Report` GitHub 工作流不再定时启动；它保留 PR 零费用验证和维护者手动付费基线。本地免费日报可按 `gingiris-seo-geo-agent` 的四阶段顺序运行：技术健康 → GSC/GA4 → 排名与 AI 引用 → P0/P1/P2 动作。模板见 [`seo/reports/TEMPLATE.md`](/seo/reports/TEMPLATE)，N.E.K.O 双站适配和完成定义见 [`seo/reports/SKILL-INTEGRATION.md`](/seo/reports/SKILL-INTEGRATION)。
 
-## 每天实际执行什么
+## 手动付费基线实际执行什么
 
-定时任务不是 `auth-check` 或零费用计划，而是一次真实付费基线：
+维护者明确选择 `paid` 后，工作流执行一次真实付费基线：
 
 - `.online en / United States`：19 个英文文档与品类词，Google Organic depth 100，AIO 开启，同时读取搜索量与可用的 KD；
 - `.cn zh-CN / China`：8 个产品主页/功能词，Google Ads Volume + Google Organic depth 100，AIO 开启，跳过不受支持的 Labs KD；
@@ -32,7 +32,7 @@
 | `UNKNOWN` | 没有凭证、artifact 或可验证证据 |
 | `UNSUPPORTED` | 供应商不支持该口径，例如 China KD |
 
-每天的生产门禁要求 **DataForSEO 排名/Volume + 两站 GSC + 两站 GA4 + 两站 IndexNow 执行证据 + 两站技术 SEO** 都不是缺失、失败或部分状态；同时逐字段校验固定 `8 + 19 + 3` 个 observed depth-100 排名、每段/每词采集时间确属上海时区当日日报、Volume 状态、AIO 布尔结果、搜索频率/引用频率汇总、费用、GSC 动态 finalized 最新日/两个 7 日窗口/sitemap 覆盖、两个不同的 GA4 数字 Property/昨日与两个 7 日窗口、IndexNow 的时间/URL 数/响应/artifact，以及首页、robots sitemap 声明、sitemap URL 数、Bing/IndexNow 文件、`lang`、canonical、hreflang、GA4 Measurement ID 和 AI crawler 策略。否则 workflow 会先保留完整诊断 artifact，再明确失败，而不是产生“顶层 complete、正文为空”的绿色日报。
+手动付费基线的生产门禁要求 **DataForSEO 排名/Volume + 两站 GSC + 两站 GA4 + 两站 IndexNow 执行证据 + 两站技术 SEO** 都不是缺失、失败或部分状态；同时逐字段校验固定 `8 + 19 + 3` 个 observed depth-100 排名、每段/每词采集时间确属上海时区当日日报、Volume 状态、AIO 布尔结果、搜索频率/引用频率汇总、费用、GSC 动态 finalized 最新日/两个 7 日窗口/sitemap 覆盖、两个不同的 GA4 数字 Property/昨日与两个 7 日窗口、IndexNow 的时间/URL 数/响应/artifact，以及首页、robots sitemap 声明、sitemap URL 数、Bing/IndexNow 文件、`lang`、canonical、hreflang、GA4 Measurement ID 和 AI crawler 策略。否则 workflow 会先保留完整诊断 artifact，再明确失败，而不是产生“顶层 complete、正文为空”的绿色日报。
 
 ## Repository 配置
 

--- a/docs/scripts/dataforseo/workflow.test.mjs
+++ b/docs/scripts/dataforseo/workflow.test.mjs
@@ -23,13 +23,15 @@ async function readMaintainerGuide() {
   )
 }
 
-test('scheduled and manually dispatched paid runs force a depth-100 AIO baseline', async () => {
+test('paid baselines require manual dispatch and still force depth-100 AIO', async () => {
   const workflow = await readWorkflow()
 
-  assert.match(workflow, /cron: '15 0 \* \* \*'/)
-  assert.match(workflow, /github\.event_name == 'schedule' && 'paid'/)
-  assert.match(workflow, /\(github\.event_name == 'schedule' \|\| inputs\.run_mode == 'paid'\) && '100'/)
-  assert.match(workflow, /\(github\.event_name == 'schedule' \|\| inputs\.run_mode == 'paid'\) && 'true'/)
+  assert.doesNotMatch(workflow, /\r?\n  schedule:/)
+  assert.doesNotMatch(workflow, /github\.event_name == 'schedule'/)
+  assert.match(workflow, /github\.event_name == 'workflow_dispatch'/)
+  assert.match(workflow, /COLLECTION_KIND: \$\{\{ inputs\.run_mode \}\}/)
+  assert.match(workflow, /inputs\.run_mode == 'paid' && '100'/)
+  assert.match(workflow, /inputs\.run_mode == 'paid' && 'true'/)
   assert.doesNotMatch(workflow, /ENABLE_PAID_DATAFORSEO_SCHEDULE/)
 })
 
@@ -46,15 +48,16 @@ test('forks cannot run validation or paid report jobs', async () => {
   )
 })
 
-test('maintainer documentation cannot revive the obsolete paid-schedule kill switch', async () => {
+test('maintainer documentation keeps paid collection manual', async () => {
   const guide = await readMaintainerGuide()
 
-  assert.match(guide, /08:15 Asia\/Shanghai schedule always runs the paid baseline/)
+  assert.match(guide, /workflow has no `schedule` trigger/)
+  assert.match(guide, /paid baseline must be started manually/)
   assert.match(guide, /fixed-name `seo-geo-daily-report` diagnostic artifact/)
   assert.match(guide, /`seo-geo-daily-paid-baseline`/)
   assert.match(guide, /obsolete `ENABLE_PAID_DATAFORSEO_SCHEDULE` variable/)
   assert.doesNotMatch(guide, /set `ENABLE_PAID_DATAFORSEO_SCHEDULE=true`/)
-  assert.doesNotMatch(guide, /schedule is skipped unless/)
+  assert.doesNotMatch(guide, /schedule always runs the paid baseline/)
 })
 
 test('one run collects independent CN, online-English, and online-Chinese segments', async () => {

--- a/docs/scripts/dataforseo/workflow.test.mjs
+++ b/docs/scripts/dataforseo/workflow.test.mjs
@@ -26,8 +26,8 @@ async function readMaintainerGuide() {
 test('paid baselines require manual dispatch and still force depth-100 AIO', async () => {
   const workflow = await readWorkflow()
 
-  assert.doesNotMatch(workflow, /\r?\n  schedule:/)
-  assert.doesNotMatch(workflow, /github\.event_name == 'schedule'/)
+  assert.doesNotMatch(workflow, /\bschedule\b/u)
+  assert.doesNotMatch(workflow, /\bcron\b/u)
   assert.match(workflow, /github\.event_name == 'workflow_dispatch'/)
   assert.match(workflow, /COLLECTION_KIND: \$\{\{ inputs\.run_mode \}\}/)
   assert.match(workflow, /inputs\.run_mode == 'paid' && '100'/)

--- a/docs/scripts/dataforseo/workflow.test.mjs
+++ b/docs/scripts/dataforseo/workflow.test.mjs
@@ -23,11 +23,27 @@ async function readMaintainerGuide() {
   )
 }
 
+function topLevelMapping(source, key) {
+  const lines = source.split(/\r?\n/u)
+  const start = lines.findIndex((line) => line.startsWith(`${key}:`))
+  assert.notEqual(start, -1, `missing top-level ${key} mapping`)
+
+  const block = [lines[start]]
+  for (const line of lines.slice(start + 1)) {
+    if (line && !/^\s/u.test(line)) break
+    block.push(line)
+  }
+
+  return block.join('\n').replace(/\s+#.*$/gmu, '')
+}
+
 test('paid baselines require manual dispatch and still force depth-100 AIO', async () => {
   const workflow = await readWorkflow()
+  const triggers = topLevelMapping(workflow, 'on')
 
-  assert.doesNotMatch(workflow, /\bschedule\b/u)
-  assert.doesNotMatch(workflow, /\bcron\b/u)
+  assert.doesNotMatch(triggers, /\bschedule\b/u)
+  assert.doesNotMatch(triggers, /\bcron\b/u)
+  assert.match(triggers, /\bworkflow_dispatch\b/u)
   assert.match(workflow, /github\.event_name == 'workflow_dispatch'/)
   assert.match(workflow, /COLLECTION_KIND: \$\{\{ inputs\.run_mode \}\}/)
   assert.match(workflow, /inputs\.run_mode == 'paid' && '100'/)

--- a/docs/seo/reports/README.md
+++ b/docs/seo/reports/README.md
@@ -1,6 +1,6 @@
 # N.E.K.O SEO / GEO 日报文件夹
 
-本目录保存日报契约与可审计样本；生产日报不会直接提交到 Git，而是由 `SEO GEO Daily Report` GitHub Actions 每天生成 Markdown + JSON artifact，并在 Actions Summary 中展示 Markdown。
+本目录保存日报契约与可审计样本；生产日报不会直接提交到 Git。免费日报在维护者本机运行；需要刷新付费排名基线时，由维护者审查请求计划与预算后手动触发 `SEO GEO Daily Report`，生成 Markdown + JSON artifact，并在 Actions Summary 中展示 Markdown。
 
 ## 文件
 


### PR DESCRIPTION
## Summary
- remove the automatic `schedule` trigger from the DataForSEO workflow
- keep pull-request validation zero-cost and keep paid collection available only through explicit `workflow_dispatch`
- preserve the existing paid contract: depth 100 and AI Overview are forced for a manual paid baseline
- update maintainer documentation and regression coverage so a timer cannot be reintroduced accidentally

## Why
The read-only free daily briefing now runs locally. Keeping a second GitHub-hosted daily paid baseline duplicates that responsibility, can be blocked by GitHub billing, and can call DataForSEO without a maintainer reviewing the current query plan and budget.

## Scope
This PR only changes GitHub scheduling and its documentation/tests. Bing Webmaster collection, local Baidu/360 exports, and report presentation remain separate follow-up PRs.

## Validation
- `npm test` — 108 tests passed
- three committed DataForSEO plans completed with `--dry-run` (`planned`; no API request or account balance usage)
- `git diff --check`
- credential and personal-path scan passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **变更**
  * SEO 监测与日报不再按计划自动执行，改为手动启动付费基线。
  * 付费模式继续固定使用 SERP 深度 100 并启用 AI Overview。
  * 新增本地执行免费日报的流程说明。
  * 付费运行前需审查请求计划与预算。
  * 更新相关文档与验证，明确手动触发规则及生产检查要求。
  * 报告仍以 Markdown、JSON artifact 和 Actions Summary 形式提供。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->