### PR TITLE
feat(plugin): 增加安全 Local App Bridge

### DIFF
--- a/docs/design/local-app-installations.md
+++ b/docs/design/local-app-installations.md
@@ -1,0 +1,63 @@
+# Local App installation registry
+
+N.E.K.O keeps executable locations separate from plugin manifests. A plugin may
+declare `[plugin.local_app]` authorization and operation mappings, but it cannot
+choose a program path or process arguments.
+
+Before starting N.E.K.O, set `NEKO_LOCAL_APP_INSTALLATIONS_FILE` to the absolute
+path of a host-owned JSON file. The file is read once before the loopback bridge
+listener starts; later plugin or renderer input cannot change it.
+
+```json
+{
+  "version": 1,
+  "installations": [
+    {
+      "app_id": "knowledge_dungeon",
+      "title": "Knowledge Dungeon",
+      "executable": "C:\\Program Files\\N.E.K.O Apps\\Knowledge Dungeon\\Knowledge Dungeon.exe",
+      "args": []
+    }
+  ]
+}
+```
+
+The executable must be an existing absolute regular-file path. Arguments are
+fixed by this file. An installation is enabled only when an enabled plugin also
+declares the same `app_id`; unknown IDs fail closed. The browser UI sends only
+the `app_id`. Pairing material is delivered to the child solely through stdin.
+
+## Independent Electron repository in development
+
+For a development checkout, the trusted file may point at the locally installed
+Node executable and Electron CLI, keeping the independent repository path in
+fixed arguments.
+For example, replace these generic paths with absolute paths on the host:
+
+```json
+{
+  "version": 1,
+  "installations": [
+    {
+      "app_id": "knowledge_dungeon",
+      "title": "Knowledge Dungeon",
+      "executable": "C:\\Program Files\\nodejs\\node.exe",
+      "args": [
+        "D:\\src\\N.E.K.O-Knowledge-Dungeon\\node_modules\\electron\\cli.js",
+        "D:\\src\\N.E.K.O-Knowledge-Dungeon"
+      ]
+    }
+  ]
+}
+```
+
+Then point N.E.K.O at the file before startup:
+
+```powershell
+$env:NEKO_LOCAL_APP_INSTALLATIONS_FILE = 'D:\neko-config\local-app-installations.json'
+```
+
+The Electron main process must read exactly one JSON line from stdin for its
+launch material. It must not expect the launch code in arguments or environment
+variables. If the independent project uses another Electron entry, change only
+the host-owned fixed `args` array.

--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -28,6 +28,21 @@ describe('plugin hosted UI API', () => {
     })
   })
 
+  it('launches a local app with only app_id and a same-origin UI token', async () => {
+    getMock.mockResolvedValue({ token: 'ui-csrf-token' })
+    postMock.mockResolvedValue({ success: true, app_id: 'knowledge_dungeon' })
+    const { launchLocalApp } = await import('./plugins')
+
+    await launchLocalApp('knowledge_dungeon')
+
+    expect(getMock).toHaveBeenCalledWith('/local-app/ui-token')
+    expect(postMock).toHaveBeenCalledWith(
+      '/local-app/launch',
+      { app_id: 'knowledge_dungeon' },
+      { headers: { 'X-CSRF-Token': 'ui-csrf-token' } },
+    )
+  })
+
   it('preserves URLSearchParams when merging locale', async () => {
     const { getPlugins } = await import('./plugins')
     const input = new URLSearchParams([

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -109,6 +109,17 @@ export function reloadAllPlugins(): Promise<{
   return post('/plugins/reload')
 }
 
+/** Launch a host-installed local app. Executable details never cross this API. */
+export async function launchLocalApp(appId: string): Promise<{
+  success: boolean
+  app_id: string
+}> {
+  const token = await get<{ token: string }>('/local-app/ui-token')
+  return post('/local-app/launch', { app_id: appId }, {
+    headers: { 'X-CSRF-Token': token.token },
+  })
+}
+
 /**
  * 删除插件目录并刷新注册表
  */

--- a/frontend/plugin-manager/src/composables/usePluginListContextActions.ts
+++ b/frontend/plugin-manager/src/composables/usePluginListContextActions.ts
@@ -1,7 +1,7 @@
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { deletePlugin } from '@/api/plugins'
+import { deletePlugin, launchLocalApp } from '@/api/plugins'
 import { buildPluginCli } from '@/api/pluginCli'
 import { usePluginStore } from '@/stores/plugin'
 import type { PluginListAction, PluginMeta } from '@/types/api'
@@ -61,6 +61,15 @@ export function usePluginListContextActions() {
       id: 'reload',
       kind: 'builtin',
     })
+    if (plugin.local_app) {
+      actions.push({
+        id: 'launch_local_app',
+        kind: 'builtin',
+        label: `${t('plugins.start')} ${plugin.local_app.title}`,
+        disabled: !plugin.local_app.available,
+        requires_running: true,
+      })
+    }
     actions.push(
       {
         id: 'build',
@@ -257,6 +266,13 @@ export function usePluginListContextActions() {
         }
         await pluginStore.reload(plugin.id)
         ElMessage.success(t('messages.pluginReloaded'))
+        return
+      case 'launch_local_app':
+        if (!plugin.local_app) {
+          return
+        }
+        await launchLocalApp(plugin.local_app.app_id)
+        ElMessage.success(`${plugin.local_app.title}: ${t('messages.operationSuccess')}`)
         return
       case 'build': {
         const result = await buildPluginCli({

--- a/frontend/plugin-manager/src/composables/usePluginListUiActionContract.test.ts
+++ b/frontend/plugin-manager/src/composables/usePluginListUiActionContract.test.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ElMessage } from 'element-plus'
-import { deletePlugin } from '@/api/plugins'
+import { deletePlugin, launchLocalApp } from '@/api/plugins'
 import { usePluginListContextActions } from './usePluginListContextActions'
 import type { PluginListAction, PluginMeta } from '@/types/api'
 
@@ -41,7 +41,7 @@ vi.mock('@/stores/plugin', () => ({
   }),
 }))
 
-vi.mock('@/api/plugins', () => ({ deletePlugin: vi.fn() }))
+vi.mock('@/api/plugins', () => ({ deletePlugin: vi.fn(), launchLocalApp: vi.fn() }))
 vi.mock('@/api/pluginCli', () => ({ buildPluginCli: vi.fn() }))
 vi.mock('@/utils/openExternal', () => ({
   openExternalUrl: mocks.openExternalUrl,
@@ -63,6 +63,40 @@ beforeEach(() => {
 })
 
 describe('plugin list UI action navigation contract', () => {
+  it('launches only the host-declared app id and disables missing installations', async () => {
+    const plugin: PluginMeta = {
+      id: 'study_companion',
+      name: 'Study Companion',
+      description: 'Study Companion',
+      version: '1.0.0',
+      status: 'running',
+      local_app: {
+        app_id: 'knowledge_dungeon',
+        title: 'Knowledge Dungeon',
+        available: true,
+      },
+    }
+    const { buildActions, executeAction } = usePluginListContextActions()
+    const action = buildActions(plugin).find(
+      (candidate) => candidate.id === 'launch_local_app',
+    )
+
+    expect(action).toMatchObject({
+      kind: 'builtin',
+      disabled: false,
+      requires_running: true,
+    })
+    await executeAction(action!, plugin)
+    expect(launchLocalApp).toHaveBeenCalledWith('knowledge_dungeon')
+    expect(ElMessage.success).toHaveBeenCalled()
+
+    plugin.local_app!.available = false
+    const disabled = buildActions(plugin).find(
+      (candidate) => candidate.id === 'launch_local_app',
+    )
+    expect(disabled?.disabled).toBe(true)
+  })
+
   it('uses openExternalUrl for the default new-tab path', async () => {
     const plugin = makePlugin({
       id: 'open_ui',

--- a/frontend/plugin-manager/src/types/api.ts
+++ b/frontend/plugin-manager/src/types/api.ts
@@ -141,6 +141,11 @@ export interface PluginMeta {
   i18n?: Record<string, any>
   status?: string
   list_actions?: PluginListAction[]
+  local_app?: {
+    app_id: string
+    title: string
+    available: boolean
+  }
   install_source?: PluginInstallSource
 }
 

--- a/plugin/core/communication.py
+++ b/plugin/core/communication.py
@@ -346,6 +346,79 @@ class PluginCommunicationResourceManager:
             req_id, msg, timeout, f"custom event {event_type}.{event_id}",
         )
 
+    async def trigger_trusted_local_app(
+        self,
+        *,
+        context: dict[str, str],
+        operation: str,
+        payload: dict[str, object],
+        timeout: float = PLUGIN_TRIGGER_TIMEOUT,
+    ) -> Any:
+        """Invoke a host-authorized local-app handler in the plugin process.
+
+        This command is deliberately unavailable from PluginContext and the
+        plugin-to-plugin router. Its identity comes from the authenticated
+        Local App Bridge session in the host process.
+        """
+        return await self._run_on_owner_loop(
+            self._trigger_trusted_local_app_local(
+                context=context,
+                operation=operation,
+                payload=payload,
+                timeout=timeout,
+            )
+        )
+
+    async def _trigger_trusted_local_app_local(
+        self,
+        *,
+        context: dict[str, str],
+        operation: str,
+        payload: dict[str, object],
+        timeout: float,
+    ) -> Any:
+        req_id = str(uuid.uuid4())
+        msg = {
+            "type": "TRUSTED_LOCAL_APP_INVOKE",
+            "req_id": req_id,
+            "context": dict(context),
+            "operation": operation,
+            "payload": dict(payload),
+            "timeout": timeout,
+        }
+        try:
+            return await self._send_command_and_wait_local(
+                req_id,
+                msg,
+                timeout,
+                f"trusted local app operation {operation}",
+            )
+        except PluginExecutionError as exc:
+            if "Execution timed out" in str(exc):
+                raise TimeoutError(
+                    "trusted local app operation outcome is unconfirmed"
+                ) from exc
+            raise
+        except (asyncio.CancelledError, TimeoutError):
+            # The result may already have committed in the child. Cancel work
+            # best-effort, but preserve the ambiguous outcome for the caller.
+            self._pending_futures.pop(req_id, None)
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(
+                        self.transport.send_command(
+                            {
+                                "type": "CANCEL_TRUSTED_LOCAL_APP",
+                                "req_id": req_id,
+                            }
+                        )
+                    ),
+                    timeout=0.25,
+                )
+            except (Exception, asyncio.CancelledError):
+                pass
+            raise
+
     async def send_freeze_command(self, timeout: float = PLUGIN_TRIGGER_TIMEOUT) -> Dict[str, Any]:
         return await self._run_on_owner_loop(self._send_freeze_command_local(timeout))
 

--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -45,6 +45,11 @@ from plugin.sdk.shared.core.finish import normalize_structured_data
 from plugin.sdk.shared.core.result_contract import model_schema_from_type
 from plugin.sdk.shared.core.router import PluginRouter
 from plugin.sdk.plugin.ui import UI_ACTION_META_ATTR, UI_CONTEXT_META_ATTR
+from plugin.sdk.local_app import (
+    TrustedLocalAppPluginContext,
+    collect_trusted_local_app_operations,
+    get_trusted_local_app_operation,
+)
 from plugin.core.bus.types import dispatch_bus_change
 from plugin.core.zmq_transport import (
     HostTransport, ChildTransport, CH_CMD, CH_RES, CH_STS, CH_MSG, CH_COMM, CH_RESP,
@@ -922,6 +927,12 @@ def _plugin_process_runner(
         entry_meta_map: Dict[str, Any] = {}  # 存储 EventMeta 用于获取自定义配置（如 timeout）
         events_by_type: Dict[str, Dict[str, Any]] = {}
         ui_context_map: Dict[str, Any] = {}
+        trusted_local_app_operations = collect_trusted_local_app_operations(instance)
+        if trusted_local_app_operations:
+            logger.info(
+                "Plugin trusted local app operations collected: {}",
+                sorted(trusted_local_app_operations),
+            )
 
         def _get_ui_context_meta(member: Any) -> dict[str, Any] | None:
             candidates: list[Any] = [member]
@@ -1408,6 +1419,9 @@ def _plugin_process_runner(
                 if not method:
                     raise PluginEntryNotFoundError(plugin_id, entry_id)
 
+                if get_trusted_local_app_operation(method) is not None:
+                    raise PluginEntryNotFoundError(plugin_id, entry_id)
+
                 if not (asyncio.iscoroutinefunction(method) or inspect.iscoroutinefunction(method)):
                     ret["error"] = f"Entry '{entry_id}' must be 'async def'. Sync entries are not supported."
                     return
@@ -1466,6 +1480,67 @@ def _plugin_process_runner(
                 except Exception:
                     logger.exception("Failed to send response for req_id={}", req_id)
 
+        async def _handle_trusted_local_app(msg: dict):
+            req_id = str(msg.get("req_id") or "unknown")
+            operation = msg.get("operation")
+            raw_context = msg.get("context")
+            payload = msg.get("payload")
+            ret = {"req_id": req_id, "success": False, "data": None, "error": None}
+
+            try:
+                if not isinstance(operation, str) or not operation:
+                    raise ValueError("trusted local app operation is invalid")
+                if not isinstance(raw_context, dict):
+                    raise ValueError("trusted local app context is invalid")
+                if not isinstance(payload, dict):
+                    raise ValueError("trusted local app payload is invalid")
+                trusted_context = TrustedLocalAppPluginContext.from_mapping(raw_context)
+                method = trusted_local_app_operations.get(operation)
+                if method is None:
+                    raise PluginEntryNotFoundError(plugin_id, operation)
+                requested_timeout = msg.get("timeout", PLUGIN_TRIGGER_TIMEOUT)
+                if (
+                    isinstance(requested_timeout, bool)
+                    or not isinstance(requested_timeout, (int, float))
+                    or not math.isfinite(float(requested_timeout))
+                    or requested_timeout <= 0
+                ):
+                    raise ValueError("trusted local app timeout is invalid")
+                with ctx._handler_scope(f"trusted_local_app.{operation}"):
+                    result = await _run_with_watchdog(
+                        method(trusted_context, dict(payload)),
+                        f"trusted_local_app.{operation}",
+                        float(requested_timeout),
+                    )
+                if hasattr(result, "is_ok") and callable(result.is_ok):
+                    if result.is_ok():
+                        ret["success"] = True
+                        ret["data"] = result.value
+                    else:
+                        ret["error"] = str(result.error or "Unknown error")
+                else:
+                    ret["success"] = True
+                    ret["data"] = result
+            except asyncio.CancelledError:
+                ret["error"] = "Execution cancelled"
+            except asyncio.TimeoutError:
+                ret["error"] = "Execution timed out"
+            except Exception as exc:
+                logger.warning(
+                    "Trusted local app operation failed: operation={}, err_type={}",
+                    operation,
+                    type(exc).__name__,
+                )
+                ret["error"] = "Trusted local app operation failed"
+            finally:
+                try:
+                    res_sender.put(ret, timeout=10.0)
+                except Exception:
+                    logger.exception(
+                        "Failed to send trusted local app response for req_id={}",
+                        req_id,
+                    )
+
         async def _handle_trigger_custom(msg: dict):
             event_type = msg.get("event_type")
             event_id = msg.get("event_id")
@@ -1489,6 +1564,10 @@ def _plugin_process_runner(
 
             try:
                 if not method:
+                    ret["error"] = f"Custom event '{event_type}.{event_id}' not found"
+                    return
+
+                if get_trusted_local_app_operation(method) is not None:
                     ret["error"] = f"Custom event '{event_type}.{event_id}' not found"
                     return
 
@@ -1673,6 +1752,18 @@ def _plugin_process_runner(
                         logger.info("[Plugin Process] Cancel sent for run_id={}", run_id)
                     continue
 
+                # Only the host communication manager emits this command type.
+                if msg_type == "CANCEL_TRUSTED_LOCAL_APP":
+                    request_id = msg.get("req_id")
+                    task = (
+                        _run_tasks.get(f"trusted:{request_id}")
+                        if isinstance(request_id, str) and request_id
+                        else None
+                    )
+                    if task and not task.done():
+                        task.cancel()
+                    continue
+
                 # ── FREEZE ──
                 if msg_type == "FREEZE":
                     req_id = msg.get("req_id", "unknown")
@@ -1741,6 +1832,17 @@ def _plugin_process_runner(
                     task = asyncio.create_task(_handle_trigger_custom(msg))
                     _run_tasks[task_key] = task
                     task.add_done_callback(lambda _t, key=task_key: _run_tasks.pop(key, None))
+                    continue
+
+                # ── TRUSTED_LOCAL_APP_INVOKE ──
+                if msg_type == "TRUSTED_LOCAL_APP_INVOKE":
+                    req_id = str(msg.get("req_id") or uuid.uuid4())
+                    task_key = f"trusted:{req_id}"
+                    task = asyncio.create_task(_handle_trusted_local_app(msg))
+                    _run_tasks[task_key] = task
+                    task.add_done_callback(
+                        lambda _t, key=task_key: _run_tasks.pop(key, None)
+                    )
                     continue
 
                 # ── UI_CONTEXT ──
@@ -2142,6 +2244,22 @@ class PluginHost:
         # 发送 TRIGGER 命令到子进程并等待结果
         # 委托给通信资源管理器处理
         return await self.comm_manager.trigger(entry_id, args, timeout)
+
+    async def trigger_trusted_local_app(
+        self,
+        *,
+        context: dict[str, str],
+        operation: str,
+        payload: dict[str, object],
+        timeout: float = PLUGIN_TRIGGER_TIMEOUT,
+    ) -> Any:
+        """Invoke a dedicated handler over the host-only IPC command path."""
+        return await self.comm_manager.trigger_trusted_local_app(
+            context=context,
+            operation=operation,
+            payload=payload,
+            timeout=timeout,
+        )
 
     async def cancel_run(self, run_id: str) -> None:
         """Propagate a run cancellation to the child process.

--- a/plugin/sdk/local_app.py
+++ b/plugin/sdk/local_app.py
@@ -1,0 +1,102 @@
+"""Host-only local application invocation contracts for plugin adapters.
+
+These handlers are intentionally separate from plugin entries, custom events,
+and LLM tools.  Merely decorating a method does not make it remotely callable:
+the host must also register an explicit app/scope/operation policy and target.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+TRUSTED_LOCAL_APP_META_ATTR = "__neko_trusted_local_app_operation__"
+_OPERATION_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$")
+_CANONICAL_OPERATION_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedLocalAppPluginContext:
+    """Identity asserted by the host after local-app session validation."""
+
+    app_id: str
+    client_id: str
+    session_id: str
+    scope: str
+    operation: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> TrustedLocalAppPluginContext:
+        required = {"app_id", "client_id", "session_id", "scope", "operation"}
+        if set(value) != required:
+            raise ValueError("trusted local app context fields are invalid")
+        fields: dict[str, str] = {}
+        for name in required:
+            raw = value[name]
+            if not isinstance(raw, str) or _OPERATION_RE.fullmatch(raw) is None:
+                raise ValueError(f"trusted local app context {name} is invalid")
+            fields[name] = raw
+        return cls(**fields)
+
+
+def trusted_local_app_operation(operation: str) -> Callable[[_F], _F]:
+    """Mark an async adapter method as a host-only local-app operation."""
+
+    if (
+        not isinstance(operation, str)
+        or _CANONICAL_OPERATION_RE.fullmatch(operation) is None
+    ):
+        raise ValueError("operation must be a valid identifier")
+
+    def decorator(func: _F) -> _F:
+        if not inspect.iscoroutinefunction(func):
+            raise TypeError("trusted local app operation must be async")
+        setattr(func, TRUSTED_LOCAL_APP_META_ATTR, operation)
+        return func
+
+    return decorator
+
+
+def get_trusted_local_app_operation(member: object) -> str | None:
+    """Return trusted operation metadata through bound/wrapped callables."""
+
+    candidates: list[object] = [member]
+    func = getattr(member, "__func__", None)
+    if func is not None:
+        candidates.append(func)
+    current = getattr(member, "__wrapped__", None)
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        candidates.append(current)
+        wrapped_func = getattr(current, "__func__", None)
+        if wrapped_func is not None:
+            candidates.append(wrapped_func)
+        current = getattr(current, "__wrapped__", None)
+    for candidate in candidates:
+        operation = getattr(candidate, TRUSTED_LOCAL_APP_META_ATTR, None)
+        if isinstance(operation, str) and operation:
+            return operation
+    return None
+
+
+def collect_trusted_local_app_operations(
+    instance: object,
+) -> dict[str, Callable[..., Any]]:
+    """Collect a plugin's dedicated trusted handlers, rejecting duplicates."""
+
+    operations: dict[str, Callable[..., Any]] = {}
+    for _name, member in inspect.getmembers(instance, predicate=callable):
+        operation = get_trusted_local_app_operation(member)
+        if operation is None:
+            continue
+        if operation in operations:
+            raise ValueError(f"duplicate trusted local app operation: {operation}")
+        if not inspect.iscoroutinefunction(member):
+            raise TypeError(f"trusted local app operation must be async: {operation}")
+        operations[operation] = member
+    return operations

--- a/plugin/server/application/plugins/query_service.py
+++ b/plugin/server/application/plugins/query_service.py
@@ -519,6 +519,23 @@ def _build_plugin_list_sync(locale: str | None = None) -> list[dict[str, object]
             )
             plugin_i18n = load_plugin_i18n_from_meta(plugin_meta)
             _resolve_plugin_display_fields(plugin_info, plugin_i18n, locale=effective_locale)
+            # Import lazily to keep application.plugins package initialization
+            # acyclic. The runtime exposes only app_id/title/availability here;
+            # executable paths and launch credentials stay host-private.
+            from plugin.server.local_app_bridge.runtime import (
+                get_local_app_bridge_runtime,
+            )
+
+            local_app = get_local_app_bridge_runtime().describe_plugin_app(
+                plugin_id,
+                fallback_title=str(plugin_info.get("name") or plugin_id),
+            )
+            if local_app is not None:
+                plugin_info["local_app"] = {
+                    "app_id": local_app.app_id,
+                    "title": local_app.title,
+                    "available": local_app.available,
+                }
             plugin_i18n_payload = _plugin_card_i18n_payload(plugin_meta, plugin_i18n)
             if plugin_i18n_payload:
                 plugin_info["i18n"] = plugin_i18n_payload

--- a/plugin/server/application/plugins/trusted_local_app_dispatch.py
+++ b/plugin/server/application/plugins/trusted_local_app_dispatch.py
@@ -1,0 +1,92 @@
+"""Host-only dispatch from an authenticated local app into a plugin process."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from plugin.core.state import state
+from plugin.server.local_app_bridge.contracts import require_identifier
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+
+
+@runtime_checkable
+class _HostHealth(Protocol):
+    alive: bool
+
+
+@runtime_checkable
+class TrustedLocalAppHost(Protocol):
+    def health_check(self) -> _HostHealth: ...
+
+    async def trigger_trusted_local_app(
+        self,
+        *,
+        context: Mapping[str, str],
+        operation: str,
+        payload: Mapping[str, object],
+        timeout: float,
+    ) -> object: ...
+
+
+class TrustedLocalAppPluginDispatch:
+    """Resolve the current host for every call and invoke its private IPC path."""
+
+    async def invoke(
+        self,
+        *,
+        plugin_id: str,
+        plugin_operation: str,
+        context: Mapping[str, str],
+        payload: Mapping[str, object],
+        timeout: float,
+    ) -> object:
+        plugin_id = require_identifier(plugin_id, "plugin_id")
+        plugin_operation = require_identifier(plugin_operation, "plugin_operation")
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(float(timeout))
+            or timeout <= 0
+        ):
+            raise ValueError("timeout must be a positive finite number")
+
+        host = await asyncio.to_thread(self._resolve_host, plugin_id)
+        health = await asyncio.to_thread(host.health_check)
+        if not health.alive:
+            raise LocalAppBridgeError(
+                "plugin_not_ready", 503, "Operation target is unavailable"
+            )
+        try:
+            return await host.trigger_trusted_local_app(
+                context=dict(context),
+                operation=plugin_operation,
+                payload=dict(payload),
+                timeout=float(timeout),
+            )
+        except asyncio.CancelledError:
+            raise
+        except TimeoutError as exc:
+            raise LocalAppBridgeError(
+                "operation_outcome_unconfirmed",
+                409,
+                "Operation outcome requires idempotent reconciliation",
+            ) from exc
+        except LocalAppBridgeError:
+            raise
+        except Exception as exc:
+            raise LocalAppBridgeError(
+                "plugin_operation_failed", 502, "Operation target failed"
+            ) from exc
+
+    @staticmethod
+    def _resolve_host(plugin_id: str) -> TrustedLocalAppHost:
+        hosts = state.get_plugin_hosts_snapshot_cached(timeout=1.0)
+        host = hosts.get(plugin_id)
+        if not isinstance(host, TrustedLocalAppHost):
+            raise LocalAppBridgeError(
+                "plugin_not_found", 503, "Operation target is unavailable"
+            )
+        return host

--- a/plugin/server/lifecycle.py
+++ b/plugin/server/lifecycle.py
@@ -22,6 +22,16 @@ from plugin.server.messaging.proactive_bridge import start_proactive_bridge, sto
 from plugin.server.messaging.plane_runner import MessagePlaneRunner, build_message_plane_runner
 from plugin.server.monitoring.metrics import metrics_collector
 from plugin.server.messaging.request_router import plugin_router
+from plugin.server.local_app_bridge.runtime import (
+    start_local_app_bridge,
+    stop_local_app_bridge,
+)
+from plugin.server.local_app_bridge.manifest import (
+    configure_local_app_bridge_from_registry,
+)
+from plugin.server.local_app_bridge.host_installations import (
+    configure_local_app_installations_from_host,
+)
 from plugin.settings import PLUGIN_SHUTDOWN_TIMEOUT, PLUGIN_SHUTDOWN_TOTAL_TIMEOUT
 from utils.logger_config import get_module_logger
 
@@ -248,6 +258,29 @@ class ServerLifecycleService:
 
         await self._refresh_registry_and_start_autostart_plugins()
 
+        try:
+            local_app_issues = await configure_local_app_bridge_from_registry()
+            for issue in local_app_issues:
+                logger.warning(
+                    "local app manifest ignored: plugin_id={}, code={}",
+                    issue.plugin_id,
+                    issue.code,
+                )
+            installation_issues = await configure_local_app_installations_from_host()
+            for issue in installation_issues:
+                logger.warning(
+                    "local app installation registry ignored: code={}",
+                    issue.code,
+                )
+            local_app_origin = await start_local_app_bridge()
+            logger.info("local app bridge started: origin={}", local_app_origin)
+        except (RuntimeError, ValueError, TypeError, OSError) as exc:
+            logger.warning(
+                "local app bridge start failed: err_type={}, err={}",
+                type(exc).__name__,
+                str(exc),
+            )
+
         await bus_subscription_manager.start()
         logger.debug("bus subscription manager started")
 
@@ -344,6 +377,14 @@ class ServerLifecycleService:
             logger.warning("failed to emit server_shutdown_begin event: {}", exc)
 
         had_errors = False
+
+        # Stop accepting local-app operations before plugin hosts begin their
+        # parallel shutdown. close() also cancels bridge-owned in-flight tasks.
+        try:
+            await stop_local_app_bridge()
+        except (RuntimeError, ValueError, TypeError, OSError) as exc:
+            had_errors = True
+            logger.warning("failed to stop local app bridge: {}", exc)
 
         # Phase 1: sync signals (instant)
         for stop_fn, label in [

--- a/plugin/server/local_app_bridge/__init__.py
+++ b/plugin/server/local_app_bridge/__init__.py
@@ -1,0 +1,65 @@
+from plugin.server.local_app_bridge.contracts import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    LAUNCH_CODE_TTL_SECONDS,
+    MAX_BODY_BYTES,
+    PAIR_RATE_LIMIT,
+    PROTOCOL_VERSION,
+    SESSION_RATE_LIMIT,
+    SESSION_ABSOLUTE_TTL_SECONDS,
+    SESSION_IDLE_TTL_SECONDS,
+    DispatchEnvelope,
+    LaunchMaterial,
+    LocalAppPolicy,
+    PairResult,
+    SessionIdentity,
+)
+from plugin.server.local_app_bridge.dispatcher import TrustedDispatchContext
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+from plugin.server.local_app_bridge.http_server import LocalAppBridgeHttpServer
+from plugin.server.local_app_bridge.launch import (
+    launch_local_app,
+    write_launch_material,
+)
+from plugin.server.local_app_bridge.runtime import (
+    LocalAppBridgeRuntime,
+    LocalAppInstallation,
+    LocalAppLaunchResult,
+    LocalAppPluginRegistration,
+    LocalAppPluginTarget,
+    get_local_app_bridge_runtime,
+    launch_registered_local_app,
+    start_local_app_bridge,
+    stop_local_app_bridge,
+)
+from plugin.server.local_app_bridge.service import LocalAppBridgeService
+
+__all__ = [
+    "ACCESS_TOKEN_TTL_SECONDS",
+    "LAUNCH_CODE_TTL_SECONDS",
+    "MAX_BODY_BYTES",
+    "PAIR_RATE_LIMIT",
+    "PROTOCOL_VERSION",
+    "SESSION_RATE_LIMIT",
+    "SESSION_ABSOLUTE_TTL_SECONDS",
+    "SESSION_IDLE_TTL_SECONDS",
+    "DispatchEnvelope",
+    "LaunchMaterial",
+    "LocalAppBridgeError",
+    "LocalAppBridgeHttpServer",
+    "LocalAppBridgeService",
+    "LocalAppBridgeRuntime",
+    "LocalAppInstallation",
+    "LocalAppLaunchResult",
+    "LocalAppPluginRegistration",
+    "LocalAppPluginTarget",
+    "LocalAppPolicy",
+    "PairResult",
+    "SessionIdentity",
+    "TrustedDispatchContext",
+    "get_local_app_bridge_runtime",
+    "launch_local_app",
+    "launch_registered_local_app",
+    "start_local_app_bridge",
+    "stop_local_app_bridge",
+    "write_launch_material",
+]

--- a/plugin/server/local_app_bridge/contracts.py
+++ b/plugin/server/local_app_bridge/contracts.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError, bad_request
+
+PROTOCOL_VERSION = 1
+MAX_BODY_BYTES = 64 * 1024
+LAUNCH_CODE_TTL_SECONDS = 60.0
+ACCESS_TOKEN_TTL_SECONDS = 15 * 60.0
+SESSION_IDLE_TTL_SECONDS = 30 * 60.0
+SESSION_ABSOLUTE_TTL_SECONDS = 8 * 60 * 60.0
+MAX_ACTIVE_SESSIONS = 256
+MAX_PENDING_LAUNCH_CODES = 512
+SESSION_RATE_LIMIT = 30
+SESSION_RATE_WINDOW_SECONDS = 10.0
+PAIR_RATE_LIMIT = 5
+PAIR_RATE_WINDOW_SECONDS = 60.0
+MAX_RATE_LIMIT_BUCKETS = 1024
+
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$")
+
+
+def require_identifier(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER_RE.fullmatch(value) is None:
+        raise bad_request("invalid_identity", f"Invalid {field_name}")
+    return value
+
+
+def require_exact_fields(
+    value: object,
+    *,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or any(not isinstance(key, str) for key in value):
+        raise bad_request()
+    keys = frozenset(value)
+    if not required.issubset(keys) or not keys.issubset(required | optional):
+        raise bad_request("invalid_fields", "Request fields do not match the contract")
+    return value
+
+
+def json_size(value: object) -> int:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise bad_request(
+            "invalid_json_value", "Payload must contain JSON values"
+        ) from exc
+    return len(encoded)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppPolicy:
+    app_id: str
+    allowed_operations: Mapping[str, frozenset[str]]
+
+    def __post_init__(self) -> None:
+        require_identifier(self.app_id, "app_id")
+        if (
+            not isinstance(self.allowed_operations, Mapping)
+            or not self.allowed_operations
+        ):
+            raise ValueError("allowed_operations must be a non-empty mapping")
+        normalized: dict[str, frozenset[str]] = {}
+        for scope, operations in self.allowed_operations.items():
+            normalized_scope = require_identifier(scope, "scope")
+            if not isinstance(operations, frozenset) or not operations:
+                raise ValueError(
+                    "each scope must have a non-empty frozenset of operations"
+                )
+            normalized[normalized_scope] = frozenset(
+                require_identifier(operation, "operation") for operation in operations
+            )
+        object.__setattr__(self, "allowed_operations", MappingProxyType(normalized))
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchMaterial:
+    bridge_origin: str
+    app_id: str
+    client_id: str
+    launch_code: str = field(repr=False)
+    protocol_version: int = PROTOCOL_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "protocol_version": self.protocol_version,
+            "bridge_origin": self.bridge_origin,
+            "app_id": self.app_id,
+            "client_id": self.client_id,
+            "launch_code": self.launch_code,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SessionIdentity:
+    app_id: str
+    client_id: str
+    session_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class PairResult:
+    identity: SessionIdentity
+    access_token: str = field(repr=False)
+    granted_scopes: frozenset[str] = frozenset()
+    access_token_expires_in: int = int(ACCESS_TOKEN_TTL_SECONDS)
+    session_idle_timeout: int = int(SESSION_IDLE_TTL_SECONDS)
+    session_absolute_timeout: int = int(SESSION_ABSOLUTE_TTL_SECONDS)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "app_id": self.identity.app_id,
+            "client_id": self.identity.client_id,
+            "session_id": self.identity.session_id,
+            "access_token": self.access_token,
+            "granted_scopes": sorted(self.granted_scopes),
+            "access_token_expires_in": self.access_token_expires_in,
+            "session_idle_timeout": self.session_idle_timeout,
+            "session_absolute_timeout": self.session_absolute_timeout,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchEnvelope:
+    identity: SessionIdentity
+    scope: str
+    operation: str
+    payload: Mapping[str, object]
+
+    @classmethod
+    def from_mapping(cls, value: object) -> DispatchEnvelope:
+        body = require_exact_fields(
+            value,
+            required=frozenset(
+                {
+                    "protocol_version",
+                    "app_id",
+                    "client_id",
+                    "session_id",
+                    "scope",
+                    "operation",
+                    "payload",
+                }
+            ),
+        )
+        if body["protocol_version"] != PROTOCOL_VERSION:
+            raise bad_request("unsupported_protocol", "Unsupported protocol version")
+        payload = body["payload"]
+        if not isinstance(payload, Mapping) or any(
+            not isinstance(key, str) for key in payload
+        ):
+            raise bad_request("invalid_payload", "Payload must be an object")
+        if json_size(payload) > MAX_BODY_BYTES:
+            raise LocalAppBridgeError("payload_too_large", 413, "Payload is too large")
+        return cls(
+            identity=SessionIdentity(
+                app_id=require_identifier(body["app_id"], "app_id"),
+                client_id=require_identifier(body["client_id"], "client_id"),
+                session_id=require_identifier(body["session_id"], "session_id"),
+            ),
+            scope=require_identifier(body["scope"], "scope"),
+            operation=require_identifier(body["operation"], "operation"),
+            payload=dict(payload),
+        )

--- a/plugin/server/local_app_bridge/dispatcher.py
+++ b/plugin/server/local_app_bridge/dispatcher.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+
+from plugin.server.local_app_bridge.contracts import LocalAppPolicy, SessionIdentity
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError, forbidden
+
+TrustedHandler = Callable[
+    ["TrustedDispatchContext", Mapping[str, object]], Awaitable[object]
+]
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedDispatchContext:
+    identity: SessionIdentity
+    scope: str
+    operation: str
+
+
+class HostDispatchAuthority:
+    """Opaque capability owned by the bridge service, never serialized."""
+
+    __slots__ = ("_proof",)
+
+    def __init__(self, proof: object) -> None:
+        self._proof = proof
+
+
+class TrustedLocalAppDispatcher:
+    """Host-memory-only operation registry, separate from plugin entries/events."""
+
+    def __init__(self) -> None:
+        self._policies: dict[str, LocalAppPolicy] = {}
+        self._handlers: dict[tuple[str, str, str], TrustedHandler] = {}
+        self._proof = object()
+        self._closed = False
+
+    def _issue_authority(self) -> HostDispatchAuthority:
+        return HostDispatchAuthority(self._proof)
+
+    def register_app(self, policy: LocalAppPolicy) -> None:
+        if self._closed:
+            raise RuntimeError("dispatcher is closed")
+        if policy.app_id in self._policies:
+            raise ValueError(f"app already registered: {policy.app_id}")
+        self._policies[policy.app_id] = policy
+
+    def register_operation(
+        self,
+        *,
+        app_id: str,
+        scope: str,
+        operation: str,
+        handler: TrustedHandler,
+    ) -> None:
+        policy = self._policies.get(app_id)
+        if policy is None:
+            raise ValueError(f"app is not registered: {app_id}")
+        if operation not in policy.allowed_operations.get(scope, frozenset()):
+            raise ValueError("operation is outside the app policy allowlist")
+        if not asyncio.iscoroutinefunction(handler):
+            raise TypeError("trusted handler must be async")
+        key = (app_id, scope, operation)
+        if key in self._handlers:
+            raise ValueError("trusted operation is already registered")
+        self._handlers[key] = handler
+
+    def allowed_scopes(self, app_id: str) -> frozenset[str]:
+        policy = self._policies.get(app_id)
+        if policy is None:
+            raise forbidden("app_not_registered")
+        return frozenset(policy.allowed_operations)
+
+    async def dispatch(
+        self,
+        *,
+        authority: HostDispatchAuthority,
+        identity: SessionIdentity,
+        scope: str,
+        operation: str,
+        payload: Mapping[str, object],
+    ) -> object:
+        if authority._proof is not self._proof:
+            raise forbidden("untrusted_dispatch")
+        if self._closed:
+            raise LocalAppBridgeError("bridge_closed", 503, "Bridge is unavailable")
+        policy = self._policies.get(identity.app_id)
+        if policy is None or operation not in policy.allowed_operations.get(
+            scope, frozenset()
+        ):
+            raise forbidden("operation_forbidden")
+        handler = self._handlers.get((identity.app_id, scope, operation))
+        if handler is None:
+            raise LocalAppBridgeError(
+                "operation_unavailable", 503, "Operation is unavailable"
+            )
+        try:
+            return await handler(
+                TrustedDispatchContext(
+                    identity=identity, scope=scope, operation=operation
+                ),
+                dict(payload),
+            )
+        except asyncio.CancelledError:
+            raise
+        except LocalAppBridgeError:
+            raise
+        except Exception as exc:
+            raise LocalAppBridgeError(
+                "operation_failed", 500, "Operation failed"
+            ) from exc
+
+    def close(self) -> None:
+        self._closed = True
+        self._handlers.clear()
+        self._policies.clear()

--- a/plugin/server/local_app_bridge/errors.py
+++ b/plugin/server/local_app_bridge/errors.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+
+class LocalAppBridgeError(Exception):
+    """A transport-safe bridge error which never carries secret material."""
+
+    __slots__ = ("code", "status_code", "message", "retry_after")
+
+    def __init__(
+        self,
+        code: str,
+        status_code: int,
+        message: str,
+        *,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.message = message
+        self.retry_after = retry_after
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def bad_request(
+    code: str = "invalid_request", message: str = "Invalid request"
+) -> LocalAppBridgeError:
+    return LocalAppBridgeError(code=code, status_code=400, message=message)
+
+
+def unauthorized(code: str = "unauthorized") -> LocalAppBridgeError:
+    return LocalAppBridgeError(
+        code=code, status_code=401, message="Authentication failed"
+    )
+
+
+def forbidden(code: str = "forbidden") -> LocalAppBridgeError:
+    return LocalAppBridgeError(
+        code=code, status_code=403, message="Request is not permitted"
+    )

--- a/plugin/server/local_app_bridge/host_installations.py
+++ b/plugin/server/local_app_bridge/host_installations.py
@@ -1,0 +1,122 @@
+"""Load host-private local-app launch targets before the bridge binds."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+from plugin.server.local_app_bridge.runtime import (
+    LocalAppInstallation,
+    get_local_app_bridge_runtime,
+)
+
+LOCAL_APP_INSTALLATIONS_FILE_ENV = "NEKO_LOCAL_APP_INSTALLATIONS_FILE"
+MAX_INSTALLATIONS_FILE_BYTES = 64 * 1024
+MAX_INSTALLATIONS = 64
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppInstallationIssue:
+    code: str
+
+
+class _InvalidInstallationConfig(ValueError):
+    pass
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _InvalidInstallationConfig("duplicate_json_key")
+        result[key] = value
+    return result
+
+
+def _load_installations(path: Path) -> tuple[LocalAppInstallation, ...]:
+    if not path.is_absolute() or not path.is_file():
+        raise _InvalidInstallationConfig("installations_file_invalid")
+    try:
+        encoded = path.read_bytes()
+        if len(encoded) > MAX_INSTALLATIONS_FILE_BYTES:
+            raise _InvalidInstallationConfig("installations_file_too_large")
+        payload = json.loads(
+            encoded.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except _InvalidInstallationConfig:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise _InvalidInstallationConfig("installations_file_unreadable") from exc
+    if not isinstance(payload, dict) or set(payload) != {"version", "installations"}:
+        raise _InvalidInstallationConfig("installations_fields_invalid")
+    if payload["version"] != 1:
+        raise _InvalidInstallationConfig("installations_version_unsupported")
+    raw_installations = payload["installations"]
+    if (
+        not isinstance(raw_installations, list)
+        or len(raw_installations) > MAX_INSTALLATIONS
+    ):
+        raise _InvalidInstallationConfig("installations_list_invalid")
+    installations: list[LocalAppInstallation] = []
+    try:
+        for raw in raw_installations:
+            if not isinstance(raw, dict) or set(raw) != {
+                "app_id",
+                "title",
+                "executable",
+                "args",
+            }:
+                raise _InvalidInstallationConfig("installation_fields_invalid")
+            executable = raw["executable"]
+            args = raw["args"]
+            if not isinstance(executable, str) or not Path(executable).is_absolute():
+                raise _InvalidInstallationConfig("installation_executable_invalid")
+            if not isinstance(args, list):
+                raise _InvalidInstallationConfig("installation_args_invalid")
+            installations.append(
+                LocalAppInstallation(
+                    app_id=raw["app_id"],
+                    title=raw["title"],
+                    executable=Path(executable),
+                    args=tuple(args),
+                )
+            )
+    except _InvalidInstallationConfig:
+        raise
+    except (LocalAppBridgeError, OSError, TypeError, ValueError) as exc:
+        raise _InvalidInstallationConfig("installation_invalid") from exc
+    return tuple(installations)
+
+
+async def configure_local_app_installations_from_host() -> tuple[
+    LocalAppInstallationIssue, ...
+]:
+    """Apply one host-owned file; invalid input disables launch, not plugins."""
+    runtime = get_local_app_bridge_runtime()
+    raw_path = os.getenv(LOCAL_APP_INSTALLATIONS_FILE_ENV, "").strip()
+    if not raw_path:
+        runtime.configure_installations(())
+        return ()
+    try:
+        installations = await asyncio.to_thread(_load_installations, Path(raw_path))
+        runtime.configure_installations(installations)
+    except (
+        _InvalidInstallationConfig,
+        LocalAppBridgeError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        runtime.configure_installations(())
+        code = (
+            str(exc)
+            if isinstance(exc, _InvalidInstallationConfig)
+            else "installations_configuration_invalid"
+        )
+        return (LocalAppInstallationIssue(code=code),)
+    return ()

--- a/plugin/server/local_app_bridge/http_server.py
+++ b/plugin/server/local_app_bridge/http_server.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Any
+
+from plugin.server.local_app_bridge.contracts import (
+    MAX_BODY_BYTES,
+    PROTOCOL_VERSION,
+    DispatchEnvelope,
+    require_exact_fields,
+)
+from plugin.server.local_app_bridge.errors import (
+    LocalAppBridgeError,
+    bad_request,
+    forbidden,
+    unauthorized,
+)
+from plugin.server.local_app_bridge.service import (
+    LocalAppBridgeService,
+    identity_from_mapping,
+)
+
+MAX_HEADER_BYTES = 8192
+READ_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(frozen=True, slots=True)
+class _HttpRequest:
+    method: str
+    path: str
+    headers: Mapping[str, str]
+    body: object
+
+
+class LocalAppBridgeHttpServer:
+    """Minimal single-request HTTP/1.1 server bound exclusively to IPv4 loopback."""
+
+    def __init__(self, service: LocalAppBridgeService) -> None:
+        self._service = service
+        self._server: asyncio.Server | None = None
+        self._port: int | None = None
+        self._connections: set[asyncio.Task[None]] = set()
+        self._closed = False
+
+    @property
+    def port(self) -> int:
+        if self._port is None:
+            raise RuntimeError("bridge server is not running")
+        return self._port
+
+    @property
+    def origin(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def start(self) -> str:
+        if self._closed:
+            raise RuntimeError("bridge server is closed")
+        if self._server is not None:
+            return self.origin
+        self._server = await asyncio.start_server(
+            self._accept_connection,
+            host="127.0.0.1",
+            port=0,
+            limit=MAX_HEADER_BYTES + 1,
+        )
+        sockets = self._server.sockets or ()
+        if len(sockets) != 1:
+            await self.close()
+            raise RuntimeError("bridge must own exactly one loopback listener")
+        host, port = sockets[0].getsockname()[:2]
+        if host != "127.0.0.1" or not isinstance(port, int) or port <= 0:
+            await self.close()
+            raise RuntimeError("bridge listener escaped the loopback boundary")
+        self._port = port
+        return self.origin
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        server = self._server
+        self._server = None
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        current = asyncio.current_task()
+        tasks = [task for task in self._connections if task is not current]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._connections.clear()
+        await self._service.close()
+        self._port = None
+
+    async def _accept_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._connections.add(task)
+        try:
+            peer = writer.get_extra_info("peername")
+            if not isinstance(peer, tuple) or not peer or peer[0] != "127.0.0.1":
+                raise forbidden("loopback_required")
+            request = await self._read_request(reader)
+            self._validate_headers(request.headers)
+            status, payload = await self._route(request)
+        except asyncio.CancelledError:
+            writer.close()
+            with contextlib.suppress(ConnectionError, OSError):
+                await writer.wait_closed()
+            if task is not None:
+                self._connections.discard(task)
+            raise
+        except LocalAppBridgeError as exc:
+            status = exc.status_code
+            payload = {"ok": False, "error": {"code": exc.code, "message": exc.message}}
+            if exc.retry_after is not None:
+                payload["error"]["retry_after"] = round(exc.retry_after, 3)
+        except Exception:
+            status = 500
+            payload = {
+                "ok": False,
+                "error": {"code": "internal_error", "message": "Internal error"},
+            }
+        try:
+            with contextlib.suppress(ConnectionError, OSError):
+                await self._write_response(writer, status, payload)
+        finally:
+            if not writer.is_closing():
+                writer.close()
+                with contextlib.suppress(ConnectionError, OSError):
+                    await writer.wait_closed()
+            if task is not None:
+                self._connections.discard(task)
+
+    async def _read_request(self, reader: asyncio.StreamReader) -> _HttpRequest:
+        try:
+            header_block = await asyncio.wait_for(
+                reader.readuntil(b"\r\n\r\n"),
+                timeout=READ_TIMEOUT_SECONDS,
+            )
+        except asyncio.LimitOverrunError as exc:
+            raise LocalAppBridgeError(
+                "headers_too_large", 431, "Request headers are too large"
+            ) from exc
+        except (asyncio.IncompleteReadError, TimeoutError) as exc:
+            raise bad_request("invalid_http", "Invalid HTTP request") from exc
+        if len(header_block) > MAX_HEADER_BYTES:
+            raise LocalAppBridgeError(
+                "headers_too_large", 431, "Request headers are too large"
+            )
+        try:
+            lines = header_block[:-4].decode("ascii").split("\r\n")
+            method, path, version = lines[0].split(" ", 2)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise bad_request("invalid_http", "Invalid HTTP request") from exc
+        if (
+            version != "HTTP/1.1"
+            or method not in {"GET", "POST"}
+            or not path.startswith("/")
+        ):
+            raise bad_request("invalid_http", "Invalid HTTP request")
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            if ":" not in line:
+                raise bad_request("invalid_http", "Invalid HTTP request")
+            name, raw_value = line.split(":", 1)
+            name = name.strip().lower()
+            if not name or name in headers:
+                raise bad_request("invalid_http", "Invalid HTTP request")
+            headers[name] = raw_value.strip()
+        if "transfer-encoding" in headers:
+            raise bad_request(
+                "transfer_encoding_forbidden", "Transfer encoding is not supported"
+            )
+        raw_length = headers.get("content-length", "0")
+        try:
+            content_length = int(raw_length)
+        except ValueError as exc:
+            raise bad_request(
+                "invalid_content_length", "Invalid content length"
+            ) from exc
+        if content_length < 0:
+            raise bad_request("invalid_content_length", "Invalid content length")
+        if content_length > MAX_BODY_BYTES:
+            raise LocalAppBridgeError(
+                "body_too_large", 413, "Request body is too large"
+            )
+        try:
+            body_bytes = await asyncio.wait_for(
+                reader.readexactly(content_length),
+                timeout=READ_TIMEOUT_SECONDS,
+            )
+        except (asyncio.IncompleteReadError, TimeoutError) as exc:
+            raise bad_request("incomplete_body", "Incomplete request body") from exc
+        if content_length == 0:
+            body: object = {}
+        else:
+            if (
+                headers.get("content-type", "").split(";", 1)[0].strip().lower()
+                != "application/json"
+            ):
+                raise LocalAppBridgeError(
+                    "json_required", 415, "JSON content is required"
+                )
+            try:
+                body = json.loads(body_bytes)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise bad_request("invalid_json", "Invalid JSON") from exc
+        return _HttpRequest(method=method, path=path, headers=headers, body=body)
+
+    def _validate_headers(self, headers: Mapping[str, str]) -> None:
+        if headers.get("host") != f"127.0.0.1:{self.port}":
+            raise forbidden("invalid_host")
+        if "origin" in headers:
+            raise forbidden("browser_origin_forbidden")
+
+    async def _route(self, request: _HttpRequest) -> tuple[int, Mapping[str, object]]:
+        if request.method == "GET" and request.path == "/v1/health":
+            require_exact_fields(request.body, required=frozenset())
+            return 200, {"ok": True, "protocol_version": PROTOCOL_VERSION}
+        if request.method != "POST":
+            raise LocalAppBridgeError("route_not_found", 404, "Route not found")
+        if request.path == "/v1/pair":
+            body = require_exact_fields(
+                request.body,
+                required=frozenset(
+                    {"protocol_version", "app_id", "client_id", "launch_code"}
+                ),
+            )
+            self._require_protocol(body)
+            result = await self._service.pair(
+                launch_code=self._text(body["launch_code"]),
+                app_id=self._text(body["app_id"]),
+                client_id=self._text(body["client_id"]),
+            )
+            return 200, {"ok": True, **result.to_dict()}
+        if request.path == "/v1/dispatch":
+            envelope = DispatchEnvelope.from_mapping(request.body)
+            result = await self._service.dispatch(
+                envelope,
+                access_token=self._bearer_token(request.headers),
+            )
+            return 200, {
+                "ok": True,
+                "protocol_version": PROTOCOL_VERSION,
+                "result": result,
+            }
+        if request.path in {"/v1/sessions/rotate", "/v1/sessions/close"}:
+            body = require_exact_fields(
+                request.body,
+                required=frozenset(
+                    {"protocol_version", "app_id", "client_id", "session_id"}
+                ),
+            )
+            self._require_protocol(body)
+            identity = identity_from_mapping(body)
+            token = self._bearer_token(request.headers)
+            if request.path.endswith("/rotate"):
+                result = await self._service.rotate(
+                    identity=identity, access_token=token
+                )
+                return 200, {"ok": True, **result.to_dict()}
+            await self._service.close_session(identity=identity, access_token=token)
+            return 200, {"ok": True, "protocol_version": PROTOCOL_VERSION}
+        raise LocalAppBridgeError("route_not_found", 404, "Route not found")
+
+    @staticmethod
+    def _require_protocol(body: Mapping[str, Any]) -> None:
+        if body["protocol_version"] != PROTOCOL_VERSION:
+            raise bad_request("unsupported_protocol", "Unsupported protocol version")
+
+    @staticmethod
+    def _text(value: object) -> str:
+        if not isinstance(value, str) or not value:
+            raise bad_request()
+        return value
+
+    @staticmethod
+    def _bearer_token(headers: Mapping[str, str]) -> str:
+        authorization = headers.get("authorization", "")
+        scheme, separator, token = authorization.partition(" ")
+        if separator != " " or scheme.lower() != "bearer" or not token or " " in token:
+            raise unauthorized("invalid_authorization")
+        return token
+
+    @staticmethod
+    async def _write_response(
+        writer: asyncio.StreamWriter,
+        status: int,
+        payload: Mapping[str, object],
+    ) -> None:
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        phrase = HTTPStatus(status).phrase
+        writer.write(
+            (
+                f"HTTP/1.1 {status} {phrase}\r\n"
+                "Content-Type: application/json; charset=utf-8\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Cache-Control: no-store\r\n"
+                "Connection: close\r\n"
+                "X-Content-Type-Options: nosniff\r\n"
+                "\r\n"
+            ).encode("ascii")
+            + body
+        )
+        try:
+            await writer.drain()
+        finally:
+            writer.close()
+            with contextlib.suppress(ConnectionError, OSError):
+                await writer.wait_closed()

--- a/plugin/server/local_app_bridge/launch.py
+++ b/plugin/server/local_app_bridge/launch.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from plugin.server.local_app_bridge.contracts import LaunchMaterial
+
+MAX_LAUNCH_MATERIAL_BYTES = 4096
+
+
+async def write_launch_material(
+    writer: asyncio.StreamWriter,
+    material: LaunchMaterial,
+) -> None:
+    """Write the sole secret through a pipe/stdin, never argv or logs."""
+
+    encoded = (
+        json.dumps(material.to_dict(), ensure_ascii=False, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    if len(encoded) > MAX_LAUNCH_MATERIAL_BYTES:
+        raise ValueError("launch material exceeds the bounded pipe contract")
+    writer.write(encoded)
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+
+async def launch_local_app(
+    executable: str | Path,
+    *,
+    args: Sequence[str] = (),
+    material: LaunchMaterial,
+) -> asyncio.subprocess.Process:
+    """Launch an app with public argv and deliver credentials only over stdin."""
+
+    if any(material.launch_code in str(argument) for argument in args):
+        raise ValueError("launch code must not appear in process arguments")
+    process = await asyncio.create_subprocess_exec(
+        str(executable),
+        *(str(argument) for argument in args),
+        stdin=asyncio.subprocess.PIPE,
+    )
+    if process.stdin is None:
+        process.kill()
+        await process.wait()
+        raise RuntimeError("local app stdin pipe is unavailable")
+    try:
+        await write_launch_material(process.stdin, material)
+    except BaseException:
+        process.kill()
+        await process.wait()
+        raise
+    return process

--- a/plugin/server/local_app_bridge/manifest.py
+++ b/plugin/server/local_app_bridge/manifest.py
@@ -1,0 +1,164 @@
+"""Strict host-side loading of local-app registrations from plugin manifests."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from plugin.core.state import state
+from plugin.server.local_app_bridge.contracts import (
+    LocalAppPolicy,
+    require_identifier,
+)
+from plugin.server.local_app_bridge.runtime import (
+    LocalAppPluginRegistration,
+    LocalAppPluginTarget,
+    get_local_app_bridge_runtime,
+)
+
+MAX_MANIFEST_APPS = 64
+MAX_OPERATIONS_PER_APP = 32
+_CANONICAL_OPERATION_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppManifestIssue:
+    plugin_id: str
+    code: str
+
+
+class _InvalidManifest(ValueError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _registry_snapshot() -> dict[str, dict[str, object]]:
+    with state.acquire_plugins_read_lock():
+        return {
+            plugin_id: dict(metadata)
+            for plugin_id, metadata in state.plugins.items()
+            if isinstance(plugin_id, str) and isinstance(metadata, dict)
+        }
+
+
+def _parse_registration(
+    *, plugin_id: str, config_path: Path
+) -> LocalAppPluginRegistration | None:
+    try:
+        with config_path.open("rb") as stream:
+            manifest = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise _InvalidManifest("manifest_unreadable") from exc
+    plugin = manifest.get("plugin")
+    if not isinstance(plugin, dict):
+        raise _InvalidManifest("plugin_table_invalid")
+    raw_local_app = plugin.get("local_app")
+    if raw_local_app is None:
+        return None
+    if not isinstance(raw_local_app, dict) or set(raw_local_app) != {
+        "app_id",
+        "scope",
+        "operations",
+    }:
+        raise _InvalidManifest("local_app_fields_invalid")
+    try:
+        app_id = require_identifier(raw_local_app["app_id"], "app_id")
+        scope = require_identifier(raw_local_app["scope"], "scope")
+    except Exception as exc:
+        raise _InvalidManifest("local_app_identity_invalid") from exc
+    operations = raw_local_app["operations"]
+    if (
+        not isinstance(operations, dict)
+        or not operations
+        or len(operations) > MAX_OPERATIONS_PER_APP
+    ):
+        raise _InvalidManifest("local_app_operations_invalid")
+    targets: list[LocalAppPluginTarget] = []
+    try:
+        for external_operation, plugin_operation in operations.items():
+            if (
+                not isinstance(external_operation, str)
+                or _CANONICAL_OPERATION_RE.fullmatch(external_operation) is None
+                or not isinstance(plugin_operation, str)
+                or _CANONICAL_OPERATION_RE.fullmatch(plugin_operation) is None
+            ):
+                raise ValueError("operation is not canonical")
+            targets.append(
+                LocalAppPluginTarget(
+                    scope=scope,
+                    operation=require_identifier(
+                        external_operation, "external_operation"
+                    ),
+                    plugin_id=plugin_id,
+                    plugin_operation=require_identifier(
+                        plugin_operation, "plugin_operation"
+                    ),
+                )
+            )
+    except Exception as exc:
+        raise _InvalidManifest("local_app_operations_invalid") from exc
+    return LocalAppPluginRegistration(
+        policy=LocalAppPolicy(
+            app_id=app_id,
+            allowed_operations={
+                scope: frozenset(target.operation for target in targets)
+            },
+        ),
+        targets=tuple(targets),
+    )
+
+
+def _discover_registrations(
+    snapshot: dict[str, dict[str, object]],
+) -> tuple[tuple[LocalAppPluginRegistration, ...], tuple[LocalAppManifestIssue, ...]]:
+    by_app: dict[str, tuple[str, LocalAppPluginRegistration]] = {}
+    blocked_apps: set[str] = set()
+    issues: list[LocalAppManifestIssue] = []
+    for plugin_id in sorted(snapshot):
+        metadata = snapshot[plugin_id]
+        if metadata.get("runtime_enabled") is not True:
+            continue
+        raw_path = metadata.get("config_path")
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        try:
+            registration = _parse_registration(
+                plugin_id=plugin_id,
+                config_path=Path(raw_path).resolve(strict=False),
+            )
+        except _InvalidManifest as exc:
+            issues.append(LocalAppManifestIssue(plugin_id, exc.code))
+            continue
+        if registration is None:
+            continue
+        app_id = registration.policy.app_id
+        if app_id in blocked_apps:
+            issues.append(LocalAppManifestIssue(plugin_id, "duplicate_app_id"))
+            continue
+        previous = by_app.pop(app_id, None)
+        if previous is not None:
+            previous_plugin_id, _registration = previous
+            blocked_apps.add(app_id)
+            issues.append(LocalAppManifestIssue(previous_plugin_id, "duplicate_app_id"))
+            issues.append(LocalAppManifestIssue(plugin_id, "duplicate_app_id"))
+            continue
+        if len(by_app) >= MAX_MANIFEST_APPS:
+            issues.append(LocalAppManifestIssue(plugin_id, "app_capacity_reached"))
+            continue
+        by_app[app_id] = (plugin_id, registration)
+    registrations = tuple(item[1] for item in by_app.values())
+    return registrations, tuple(issues)
+
+
+async def configure_local_app_bridge_from_registry() -> tuple[
+    LocalAppManifestIssue, ...
+]:
+    """Load immutable declarations and freeze them before the listener starts."""
+    snapshot = await asyncio.to_thread(_registry_snapshot)
+    registrations, issues = await asyncio.to_thread(_discover_registrations, snapshot)
+    get_local_app_bridge_runtime().configure_plugin_apps(registrations)
+    return issues

--- a/plugin/server/local_app_bridge/rate_limit.py
+++ b/plugin/server/local_app_bridge/rate_limit.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from plugin.server.local_app_bridge.contracts import (
+    MAX_RATE_LIMIT_BUCKETS,
+    PAIR_RATE_LIMIT,
+    PAIR_RATE_WINDOW_SECONDS,
+    SESSION_RATE_LIMIT,
+    SESSION_RATE_WINDOW_SECONDS,
+)
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+
+
+@dataclass(slots=True)
+class _Bucket:
+    timestamps: deque[float] = field(default_factory=deque)
+    last_seen: float = 0.0
+
+
+class LocalAppRateLimiter:
+    """Bounded monotonic-clock sliding windows for pair and session traffic."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        max_buckets: int = MAX_RATE_LIMIT_BUCKETS,
+    ) -> None:
+        if max_buckets < 2:
+            raise ValueError("max_buckets must be at least 2")
+        self._clock = clock
+        self._max_buckets = max_buckets
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    async def check_pair(self, *, app_id: str, client_id: str) -> None:
+        # The global bucket prevents bypass by churning forged client ids; the
+        # bound identity bucket keeps one app launch from consuming all attempts.
+        await self._check(
+            "pair:global", limit=PAIR_RATE_LIMIT * 4, window=PAIR_RATE_WINDOW_SECONDS
+        )
+        await self._check(
+            f"pair:{app_id}:{client_id}",
+            limit=PAIR_RATE_LIMIT,
+            window=PAIR_RATE_WINDOW_SECONDS,
+        )
+
+    async def check_session(self, session_id: str) -> None:
+        await self._check(
+            f"session:{session_id}",
+            limit=SESSION_RATE_LIMIT,
+            window=SESSION_RATE_WINDOW_SECONDS,
+        )
+
+    async def cleanup(self) -> None:
+        async with self._lock:
+            self._cleanup_locked(
+                self._clock(),
+                max(PAIR_RATE_WINDOW_SECONDS, SESSION_RATE_WINDOW_SECONDS),
+            )
+
+    async def close(self) -> None:
+        async with self._lock:
+            self._closed = True
+            self._buckets.clear()
+
+    @property
+    def bucket_count(self) -> int:
+        return len(self._buckets)
+
+    async def _check(self, key: str, *, limit: int, window: float) -> None:
+        now = self._clock()
+        async with self._lock:
+            if self._closed:
+                raise LocalAppBridgeError("bridge_closed", 503, "Bridge is unavailable")
+            self._cleanup_locked(
+                now, max(PAIR_RATE_WINDOW_SECONDS, SESSION_RATE_WINDOW_SECONDS)
+            )
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                self._ensure_capacity_locked()
+                bucket = _Bucket(last_seen=now)
+                self._buckets[key] = bucket
+            cutoff = now - window
+            while bucket.timestamps and bucket.timestamps[0] <= cutoff:
+                bucket.timestamps.popleft()
+            bucket.last_seen = now
+            if len(bucket.timestamps) >= limit:
+                retry_after = max(0.001, bucket.timestamps[0] + window - now)
+                raise LocalAppBridgeError(
+                    "rate_limited",
+                    429,
+                    "Too many requests",
+                    retry_after=retry_after,
+                )
+            bucket.timestamps.append(now)
+
+    def _cleanup_locked(self, now: float, retention: float) -> None:
+        cutoff = now - retention
+        for key, bucket in tuple(self._buckets.items()):
+            if bucket.last_seen <= cutoff:
+                self._buckets.pop(key, None)
+
+    def _ensure_capacity_locked(self) -> None:
+        if len(self._buckets) < self._max_buckets:
+            return
+        oldest_key = min(self._buckets, key=lambda key: self._buckets[key].last_seen)
+        self._buckets.pop(oldest_key, None)

--- a/plugin/server/local_app_bridge/runtime.py
+++ b/plugin/server/local_app_bridge/runtime.py
@@ -1,0 +1,414 @@
+"""Explicit lifecycle and provider-neutral plugin target registration."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import math
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from plugin.server.application.plugins.trusted_local_app_dispatch import (
+    TrustedLocalAppPluginDispatch,
+)
+from plugin.server.local_app_bridge.contracts import (
+    LaunchMaterial,
+    LocalAppPolicy,
+    require_identifier,
+)
+from plugin.server.local_app_bridge.http_server import LocalAppBridgeHttpServer
+from plugin.server.local_app_bridge.launch import launch_local_app
+from plugin.server.local_app_bridge.service import LocalAppBridgeService
+from utils.config_manager import get_config_manager
+
+
+_LOCAL_APP_CLIENT_ID_DOMAIN = b"local-app-client-v1\0"
+MAX_LAUNCHED_LOCAL_APP_PROCESSES = 16
+
+
+async def _derive_persistent_client_id(app_id: str) -> str:
+    """Derive a stable, app-scoped identity without exposing the host ID."""
+
+    normalized_app_id = require_identifier(app_id, "app_id")
+
+    def derive() -> str:
+        client_id, client_proof = (
+            get_config_manager().ensure_cloudsave_client_credentials()
+        )
+        if not isinstance(client_id, str) or not client_id:
+            raise RuntimeError("host client identity is unavailable")
+        if not isinstance(client_proof, str) or not client_proof:
+            raise RuntimeError("host client proof is unavailable")
+        message = (
+            _LOCAL_APP_CLIENT_ID_DOMAIN
+            + normalized_app_id.encode("utf-8")
+            + b"\0"
+            + client_id.encode("utf-8")
+        )
+        digest = hmac.new(
+            client_proof.encode("utf-8"), message, hashlib.sha256
+        ).hexdigest()
+        return f"lac_{digest}"
+
+    return require_identifier(await asyncio.to_thread(derive), "client_id")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppPluginTarget:
+    scope: str
+    operation: str
+    plugin_id: str
+    plugin_operation: str
+    timeout: float = 30.0
+
+    def __post_init__(self) -> None:
+        require_identifier(self.scope, "scope")
+        require_identifier(self.operation, "operation")
+        require_identifier(self.plugin_id, "plugin_id")
+        require_identifier(self.plugin_operation, "plugin_operation")
+        if (
+            isinstance(self.timeout, bool)
+            or not isinstance(self.timeout, (int, float))
+            or not math.isfinite(float(self.timeout))
+            or self.timeout <= 0
+        ):
+            raise ValueError("target timeout must be a positive finite number")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppPluginRegistration:
+    policy: LocalAppPolicy
+    targets: tuple[LocalAppPluginTarget, ...]
+
+    def __post_init__(self) -> None:
+        target_keys = {(target.scope, target.operation) for target in self.targets}
+        policy_keys = {
+            (scope, operation)
+            for scope, operations in self.policy.allowed_operations.items()
+            for operation in operations
+        }
+        if not target_keys or len(target_keys) != len(self.targets):
+            raise ValueError("local app targets must be non-empty and unique")
+        if target_keys != policy_keys:
+            raise ValueError("local app targets must exactly match the app policy")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppInstallation:
+    """Host-owned launch target, deliberately separate from plugin metadata."""
+
+    app_id: str
+    title: str
+    executable: Path
+    args: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        require_identifier(self.app_id, "app_id")
+        if (
+            not isinstance(self.title, str)
+            or not self.title.strip()
+            or len(self.title.strip()) > 128
+            or any(ord(character) < 32 for character in self.title)
+        ):
+            raise ValueError("local app title is invalid")
+        executable = Path(self.executable).expanduser().resolve(strict=True)
+        if not executable.is_file():
+            raise ValueError("local app executable must be a regular file")
+        if not isinstance(self.args, tuple) or len(self.args) > 32:
+            raise ValueError("local app arguments exceed the bounded contract")
+        normalized_args: list[str] = []
+        for argument in self.args:
+            if (
+                not isinstance(argument, str)
+                or len(argument) > 1024
+                or any(ord(character) < 32 for character in argument)
+            ):
+                raise ValueError("local app argument is invalid")
+            normalized_args.append(argument)
+        object.__setattr__(self, "executable", executable)
+        object.__setattr__(self, "title", self.title.strip())
+        object.__setattr__(self, "args", tuple(normalized_args))
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppLaunchResult:
+    app_id: str
+    client_id: str
+    process_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAppDescriptor:
+    app_id: str
+    title: str
+    available: bool
+
+
+ClientIdProvider = Callable[[str], Awaitable[str]]
+ProcessLauncher = Callable[..., Awaitable[asyncio.subprocess.Process]]
+
+
+class LocalAppBridgeRuntime:
+    """Own one listener per plugin-host lifecycle and retain registrations."""
+
+    def __init__(
+        self,
+        *,
+        client_id_provider: ClientIdProvider | None = None,
+        process_launcher: ProcessLauncher | None = None,
+    ) -> None:
+        self._registrations: dict[str, LocalAppPluginRegistration] = {}
+        self._installations: dict[str, LocalAppInstallation] = {}
+        self._service: LocalAppBridgeService | None = None
+        self._server: LocalAppBridgeHttpServer | None = None
+        self._client_id_provider = client_id_provider or _derive_persistent_client_id
+        self._process_launcher = process_launcher or launch_local_app
+        self._launched_processes: set[asyncio.subprocess.Process] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_running(self) -> bool:
+        return self._server is not None
+
+    @property
+    def origin(self) -> str:
+        server = self._server
+        if server is None:
+            raise RuntimeError("local app bridge is not running")
+        return server.origin
+
+    def register_plugin_app(self, registration: LocalAppPluginRegistration) -> None:
+        if self._service is not None or self._server is not None:
+            raise RuntimeError("local app registrations are frozen while running")
+        app_id = registration.policy.app_id
+        if app_id in self._registrations:
+            raise ValueError(f"app already registered: {app_id}")
+        self._registrations[app_id] = registration
+
+    def configure_plugin_apps(
+        self, registrations: tuple[LocalAppPluginRegistration, ...]
+    ) -> None:
+        """Replace host-owned manifest registrations before listener startup."""
+        if self._service is not None or self._server is not None:
+            raise RuntimeError("local app registrations are frozen while running")
+        configured: dict[str, LocalAppPluginRegistration] = {}
+        for registration in registrations:
+            app_id = registration.policy.app_id
+            if app_id in configured:
+                raise ValueError(f"duplicate app registration: {app_id}")
+            configured[app_id] = registration
+        self._registrations = configured
+
+    def configure_installations(
+        self, installations: Sequence[LocalAppInstallation]
+    ) -> None:
+        """Freeze host-owned executable locations before listener startup."""
+        if self._service is not None or self._server is not None:
+            raise RuntimeError("local app installations are frozen while running")
+        configured: dict[str, LocalAppInstallation] = {}
+        for installation in installations:
+            if installation.app_id not in self._registrations:
+                raise ValueError(
+                    f"local app installation is not manifest-authorized: {installation.app_id}"
+                )
+            if installation.app_id in configured:
+                raise ValueError(
+                    f"duplicate local app installation: {installation.app_id}"
+                )
+            configured[installation.app_id] = installation
+        self._installations = configured
+
+    def authorized_app_ids(self) -> frozenset[str]:
+        return frozenset(self._registrations)
+
+    def describe_plugin_app(
+        self, plugin_id: str, *, fallback_title: str
+    ) -> LocalAppDescriptor | None:
+        """Return the frontend-safe subset of one authorized declaration."""
+        if not isinstance(plugin_id, str) or not plugin_id:
+            return None
+        for app_id, registration in self._registrations.items():
+            if not all(
+                target.plugin_id == plugin_id for target in registration.targets
+            ):
+                continue
+            installation = self._installations.get(app_id)
+            title = installation.title if installation is not None else fallback_title
+            return LocalAppDescriptor(
+                app_id=app_id,
+                title=str(title).strip() or app_id,
+                available=installation is not None and self.is_running,
+            )
+        return None
+
+    async def start(self) -> str:
+        async with self._lock:
+            if self._server is not None:
+                return self._server.origin
+            service = LocalAppBridgeService()
+            for registration in self._registrations.values():
+                self._install_registration(service, registration)
+            server = LocalAppBridgeHttpServer(service)
+            # Publish the service before the listener await so a synchronous
+            # registration scheduled during bind cannot be missed.
+            self._service = service
+            try:
+                origin = await server.start()
+            except BaseException:
+                self._service = None
+                await server.close()
+                raise
+            self._server = server
+            return origin
+
+    async def close(self) -> None:
+        async with self._lock:
+            server = self._server
+            self._server = None
+            self._service = None
+            if server is not None:
+                await server.close()
+            processes = tuple(self._launched_processes)
+            self._launched_processes.clear()
+            if processes:
+                await asyncio.gather(
+                    *(self._stop_process(process) for process in processes),
+                    return_exceptions=True,
+                )
+
+    async def launch_registered_app(self, app_id: str) -> LocalAppLaunchResult:
+        """Launch one host-installed app; callers cannot supply executable data."""
+        normalized_app_id = require_identifier(app_id, "app_id")
+        async with self._lock:
+            service = self._service
+            server = self._server
+            if service is None or server is None:
+                raise RuntimeError("local app bridge is not running")
+            registration = self._registrations.get(normalized_app_id)
+            installation = self._installations.get(normalized_app_id)
+            if registration is None or installation is None:
+                raise LookupError("local app is not registered and installed")
+            self._launched_processes = {
+                launched
+                for launched in self._launched_processes
+                if launched.returncode is None
+            }
+            if len(self._launched_processes) >= MAX_LAUNCHED_LOCAL_APP_PROCESSES:
+                raise RuntimeError("local app process capacity is reached")
+            client_id = require_identifier(
+                await self._client_id_provider(normalized_app_id), "client_id"
+            )
+            material = await service.issue_launch_material(
+                bridge_origin=server.origin,
+                app_id=normalized_app_id,
+                client_id=client_id,
+                requested_scopes=frozenset(registration.policy.allowed_operations),
+            )
+            process = await self._process_launcher(
+                installation.executable,
+                args=installation.args,
+                material=material,
+            )
+            process_id = process.pid
+            if not isinstance(process_id, int) or process_id <= 0:
+                if process.returncode is None:
+                    process.kill()
+                    await process.wait()
+                raise RuntimeError("local app process did not provide a process id")
+            if process.returncode is None:
+                self._launched_processes.add(process)
+            return LocalAppLaunchResult(
+                app_id=normalized_app_id,
+                client_id=client_id,
+                process_id=process_id,
+            )
+
+    async def issue_launch_material(
+        self,
+        *,
+        app_id: str,
+        client_id: str,
+        requested_scopes: frozenset[str],
+    ) -> LaunchMaterial:
+        service = self._service
+        server = self._server
+        if service is None or server is None:
+            raise RuntimeError("local app bridge is not running")
+        return await service.issue_launch_material(
+            bridge_origin=server.origin,
+            app_id=app_id,
+            client_id=client_id,
+            requested_scopes=requested_scopes,
+        )
+
+    @staticmethod
+    def _install_registration(
+        service: LocalAppBridgeService,
+        registration: LocalAppPluginRegistration,
+    ) -> None:
+        service.register_app(registration.policy)
+        plugin_dispatch = TrustedLocalAppPluginDispatch()
+        for target in registration.targets:
+
+            async def handler(context, payload, *, _target=target):
+                return await plugin_dispatch.invoke(
+                    plugin_id=_target.plugin_id,
+                    plugin_operation=_target.plugin_operation,
+                    context={
+                        "app_id": context.identity.app_id,
+                        "client_id": context.identity.client_id,
+                        "session_id": context.identity.session_id,
+                        "scope": context.scope,
+                        "operation": context.operation,
+                    },
+                    payload=payload,
+                    timeout=float(_target.timeout),
+                )
+
+            service.register_operation(
+                app_id=registration.policy.app_id,
+                scope=target.scope,
+                operation=target.operation,
+                handler=handler,
+            )
+
+    @staticmethod
+    async def _stop_process(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2.0)
+            return
+        except TimeoutError:
+            pass
+        try:
+            process.kill()
+        except ProcessLookupError:
+            return
+        await process.wait()
+
+
+_runtime = LocalAppBridgeRuntime()
+
+
+def get_local_app_bridge_runtime() -> LocalAppBridgeRuntime:
+    return _runtime
+
+
+async def start_local_app_bridge() -> str:
+    return await _runtime.start()
+
+
+async def stop_local_app_bridge() -> None:
+    await _runtime.close()
+
+
+async def launch_registered_local_app(app_id: str) -> LocalAppLaunchResult:
+    """Host-only callable entry point used by trusted product UI assembly."""
+    return await _runtime.launch_registered_app(app_id)

--- a/plugin/server/local_app_bridge/service.py
+++ b/plugin/server/local_app_bridge/service.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+from plugin.server.local_app_bridge.contracts import (
+    MAX_BODY_BYTES,
+    DispatchEnvelope,
+    LaunchMaterial,
+    LocalAppPolicy,
+    PairResult,
+    SessionIdentity,
+    json_size,
+    require_identifier,
+)
+from plugin.server.local_app_bridge.dispatcher import (
+    TrustedHandler,
+    TrustedLocalAppDispatcher,
+)
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError, forbidden
+from plugin.server.local_app_bridge.rate_limit import LocalAppRateLimiter
+from plugin.server.local_app_bridge.sessions import LocalAppSessionStore
+
+
+class LocalAppBridgeService:
+    """Provider-neutral orchestration for pairing and trusted local dispatch."""
+
+    def __init__(
+        self,
+        *,
+        sessions: LocalAppSessionStore | None = None,
+        dispatcher: TrustedLocalAppDispatcher | None = None,
+        operation_timeout: float = 30.0,
+        rate_limiter: LocalAppRateLimiter | None = None,
+    ) -> None:
+        if operation_timeout <= 0:
+            raise ValueError("operation_timeout must be positive")
+        self._sessions = sessions or LocalAppSessionStore()
+        self._dispatcher = dispatcher or TrustedLocalAppDispatcher()
+        self._authority = self._dispatcher._issue_authority()
+        self._rate_limiter = rate_limiter or LocalAppRateLimiter()
+        self._operation_timeout = operation_timeout
+        self._closed = False
+
+    def register_app(self, policy: LocalAppPolicy) -> None:
+        self._require_open()
+        self._dispatcher.register_app(policy)
+
+    def register_operation(
+        self,
+        *,
+        app_id: str,
+        scope: str,
+        operation: str,
+        handler: TrustedHandler,
+    ) -> None:
+        self._require_open()
+        self._dispatcher.register_operation(
+            app_id=app_id,
+            scope=scope,
+            operation=operation,
+            handler=handler,
+        )
+
+    async def issue_launch_material(
+        self,
+        *,
+        bridge_origin: str,
+        app_id: str,
+        client_id: str,
+        requested_scopes: frozenset[str],
+    ) -> LaunchMaterial:
+        self._require_open()
+        require_identifier(app_id, "app_id")
+        require_identifier(client_id, "client_id")
+        allowed_scopes = self._dispatcher.allowed_scopes(app_id)
+        if not requested_scopes or not requested_scopes.issubset(allowed_scopes):
+            raise forbidden("scope_forbidden")
+        launch_code = await self._sessions.issue_launch_code(
+            app_id=app_id,
+            client_id=client_id,
+            scopes=requested_scopes,
+        )
+        return LaunchMaterial(
+            bridge_origin=bridge_origin,
+            app_id=app_id,
+            client_id=client_id,
+            launch_code=launch_code,
+        )
+
+    async def pair(
+        self, *, launch_code: str, app_id: str, client_id: str
+    ) -> PairResult:
+        self._require_open()
+        await self._rate_limiter.check_pair(app_id=app_id, client_id=client_id)
+        return await self._sessions.exchange_launch_code(
+            launch_code=launch_code,
+            app_id=app_id,
+            client_id=client_id,
+        )
+
+    async def dispatch(
+        self, envelope: DispatchEnvelope, *, access_token: str
+    ) -> object:
+        self._require_open()
+        if json_size(envelope.payload) > MAX_BODY_BYTES:
+            raise LocalAppBridgeError("payload_too_large", 413, "Payload is too large")
+        lease = await self._sessions.authorize(
+            identity=envelope.identity,
+            scope=envelope.scope,
+            access_token=access_token,
+        )
+        await self._rate_limiter.check_session(envelope.identity.session_id)
+        # The limiter is an await point: verify ownership again before any
+        # trusted handler is allowed to create externally visible state.
+        await self._sessions.confirm_lease(lease)
+        try:
+            async with asyncio.timeout(self._operation_timeout):
+                result = await self._dispatcher.dispatch(
+                    authority=self._authority,
+                    identity=lease.identity,
+                    scope=envelope.scope,
+                    operation=envelope.operation,
+                    payload=envelope.payload,
+                )
+        except TimeoutError as exc:
+            raise LocalAppBridgeError(
+                "operation_outcome_unconfirmed",
+                409,
+                "Operation outcome requires idempotent reconciliation",
+            ) from exc
+        try:
+            await self._sessions.confirm_lease(lease)
+        except LocalAppBridgeError as exc:
+            raise LocalAppBridgeError(
+                "operation_outcome_unconfirmed",
+                409,
+                "Operation outcome requires idempotent reconciliation",
+            ) from exc
+        try:
+            result_size = json_size(result)
+        except LocalAppBridgeError as exc:
+            raise LocalAppBridgeError(
+                "invalid_operation_response",
+                502,
+                "Operation returned an invalid response",
+            ) from exc
+        if result_size > MAX_BODY_BYTES:
+            raise LocalAppBridgeError(
+                "response_too_large", 502, "Operation response is too large"
+            )
+        return result
+
+    async def rotate(
+        self, *, identity: SessionIdentity, access_token: str
+    ) -> PairResult:
+        self._require_open()
+        await self._sessions.authenticate_control(
+            identity=identity,
+            access_token=access_token,
+        )
+        await self._rate_limiter.check_session(identity.session_id)
+        return await self._sessions.rotate_access_token(
+            identity=identity,
+            access_token=access_token,
+        )
+
+    async def close_session(
+        self, *, identity: SessionIdentity, access_token: str
+    ) -> None:
+        self._require_open()
+        await self._sessions.authenticate_control(
+            identity=identity,
+            access_token=access_token,
+        )
+        await self._rate_limiter.check_session(identity.session_id)
+        await self._sessions.close_session(identity=identity, access_token=access_token)
+
+    async def cleanup(self) -> None:
+        if not self._closed:
+            await self._sessions.cleanup()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._sessions.close()
+        await self._rate_limiter.close()
+        self._dispatcher.close()
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise LocalAppBridgeError("bridge_closed", 503, "Bridge is unavailable")
+
+
+def identity_from_mapping(value: Mapping[str, object]) -> SessionIdentity:
+    return SessionIdentity(
+        app_id=require_identifier(value.get("app_id"), "app_id"),
+        client_id=require_identifier(value.get("client_id"), "client_id"),
+        session_id=require_identifier(value.get("session_id"), "session_id"),
+    )

--- a/plugin/server/local_app_bridge/sessions.py
+++ b/plugin/server/local_app_bridge/sessions.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import secrets
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+from plugin.server.local_app_bridge.contracts import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    LAUNCH_CODE_TTL_SECONDS,
+    MAX_ACTIVE_SESSIONS,
+    MAX_PENDING_LAUNCH_CODES,
+    SESSION_ABSOLUTE_TTL_SECONDS,
+    SESSION_IDLE_TTL_SECONDS,
+    PairResult,
+    SessionIdentity,
+)
+from plugin.server.local_app_bridge.errors import (
+    LocalAppBridgeError,
+    forbidden,
+    unauthorized,
+)
+
+
+def _secret_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+@dataclass(slots=True)
+class _LaunchGrant:
+    code_hash: str
+    app_id: str
+    client_id: str
+    scopes: frozenset[str]
+    expires_at: float
+
+
+@dataclass(slots=True)
+class _Session:
+    identity: SessionIdentity
+    scopes: frozenset[str]
+    token_hash: str
+    token_expires_at: float
+    created_at: float
+    last_activity_at: float
+    generation: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SessionLease:
+    identity: SessionIdentity
+    scope: str
+    token_hash: str = field(repr=False)
+    generation: int = 1
+
+
+class LocalAppSessionStore:
+    """Concurrency-safe in-memory launch grants and bounded sessions."""
+
+    def __init__(self, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._lock = asyncio.Lock()
+        self._launch_grants: dict[str, _LaunchGrant] = {}
+        self._spent_launch_codes: dict[str, float] = {}
+        self._sessions: dict[str, _Session] = {}
+        self._closed = False
+
+    async def issue_launch_code(
+        self,
+        *,
+        app_id: str,
+        client_id: str,
+        scopes: Iterable[str],
+    ) -> str:
+        code = secrets.token_urlsafe(32)
+        code_hash = _secret_hash(code)
+        now = self._clock()
+        async with self._lock:
+            self._require_open()
+            self._cleanup_locked(now)
+            if len(self._launch_grants) >= MAX_PENDING_LAUNCH_CODES:
+                raise LocalAppBridgeError(
+                    "launch_capacity_reached", 503, "Bridge is at capacity"
+                )
+            self._launch_grants[code_hash] = _LaunchGrant(
+                code_hash=code_hash,
+                app_id=app_id,
+                client_id=client_id,
+                scopes=frozenset(scopes),
+                expires_at=now + LAUNCH_CODE_TTL_SECONDS,
+            )
+        return code
+
+    async def exchange_launch_code(
+        self,
+        *,
+        launch_code: str,
+        app_id: str,
+        client_id: str,
+    ) -> PairResult:
+        code_hash = _secret_hash(launch_code)
+        now = self._clock()
+        async with self._lock:
+            self._require_open()
+            self._cleanup_spent_locked(now)
+            if code_hash in self._spent_launch_codes:
+                raise LocalAppBridgeError(
+                    "launch_code_replayed", 409, "Launch code was already used"
+                )
+            grant = self._launch_grants.get(code_hash)
+            if grant is None:
+                self._cleanup_locked(now)
+                raise unauthorized("invalid_launch_code")
+            if now >= grant.expires_at:
+                self._launch_grants.pop(code_hash, None)
+                self._mark_spent_locked(code_hash, now)
+                raise unauthorized("launch_code_expired")
+            if not hmac.compare_digest(grant.app_id, app_id) or not hmac.compare_digest(
+                grant.client_id, client_id
+            ):
+                raise forbidden("launch_identity_mismatch")
+            self._cleanup_sessions_locked(now)
+            if len(self._sessions) >= MAX_ACTIVE_SESSIONS:
+                raise LocalAppBridgeError(
+                    "session_capacity_reached", 503, "Bridge is at capacity"
+                )
+            self._launch_grants.pop(code_hash, None)
+            self._mark_spent_locked(code_hash, now)
+            session_id = f"las_{secrets.token_urlsafe(24)}"
+            token = secrets.token_urlsafe(48)
+            identity = SessionIdentity(
+                app_id=app_id, client_id=client_id, session_id=session_id
+            )
+            self._sessions[session_id] = _Session(
+                identity=identity,
+                scopes=grant.scopes,
+                token_hash=_secret_hash(token),
+                token_expires_at=now + ACCESS_TOKEN_TTL_SECONDS,
+                created_at=now,
+                last_activity_at=now,
+            )
+            return PairResult(
+                identity=identity, access_token=token, granted_scopes=grant.scopes
+            )
+
+    async def authorize(
+        self,
+        *,
+        identity: SessionIdentity,
+        scope: str,
+        access_token: str,
+    ) -> SessionLease:
+        now = self._clock()
+        token_hash = _secret_hash(access_token)
+        async with self._lock:
+            self._require_open()
+            session = self._require_live_session_locked(identity.session_id, now)
+            self._verify_identity(session, identity)
+            if not hmac.compare_digest(session.token_hash, token_hash):
+                raise unauthorized("invalid_access_token")
+            if now >= session.token_expires_at:
+                raise unauthorized("access_token_expired")
+            if scope not in session.scopes:
+                raise forbidden("scope_forbidden")
+            session.last_activity_at = now
+            return SessionLease(
+                identity=session.identity,
+                scope=scope,
+                token_hash=token_hash,
+                generation=session.generation,
+            )
+
+    async def authenticate_control(
+        self,
+        *,
+        identity: SessionIdentity,
+        access_token: str,
+    ) -> SessionLease:
+        now = self._clock()
+        token_hash = _secret_hash(access_token)
+        async with self._lock:
+            self._require_open()
+            session = self._require_live_session_locked(identity.session_id, now)
+            self._verify_identity(session, identity)
+            if not hmac.compare_digest(session.token_hash, token_hash):
+                raise unauthorized("invalid_access_token")
+            if now >= session.token_expires_at:
+                raise unauthorized("access_token_expired")
+            session.last_activity_at = now
+            return SessionLease(
+                identity=session.identity,
+                scope="",
+                token_hash=token_hash,
+                generation=session.generation,
+            )
+
+    async def confirm_lease(self, lease: SessionLease) -> None:
+        now = self._clock()
+        async with self._lock:
+            self._require_open()
+            session = self._require_live_session_locked(lease.identity.session_id, now)
+            self._verify_identity(session, lease.identity)
+            if session.generation != lease.generation or not hmac.compare_digest(
+                session.token_hash, lease.token_hash
+            ):
+                raise LocalAppBridgeError(
+                    "session_changed", 409, "Session changed during operation"
+                )
+
+    async def rotate_access_token(
+        self,
+        *,
+        identity: SessionIdentity,
+        access_token: str,
+    ) -> PairResult:
+        now = self._clock()
+        supplied_hash = _secret_hash(access_token)
+        async with self._lock:
+            self._require_open()
+            session = self._require_live_session_locked(identity.session_id, now)
+            self._verify_identity(session, identity)
+            if not hmac.compare_digest(session.token_hash, supplied_hash):
+                raise unauthorized("invalid_access_token")
+            if now >= session.token_expires_at:
+                raise unauthorized("access_token_expired")
+            token = secrets.token_urlsafe(48)
+            session.token_hash = _secret_hash(token)
+            session.token_expires_at = now + ACCESS_TOKEN_TTL_SECONDS
+            session.last_activity_at = now
+            session.generation += 1
+            return PairResult(
+                identity=session.identity,
+                access_token=token,
+                granted_scopes=session.scopes,
+            )
+
+    async def close_session(
+        self,
+        *,
+        identity: SessionIdentity,
+        access_token: str,
+    ) -> None:
+        now = self._clock()
+        supplied_hash = _secret_hash(access_token)
+        async with self._lock:
+            self._require_open()
+            session = self._require_live_session_locked(identity.session_id, now)
+            self._verify_identity(session, identity)
+            if not hmac.compare_digest(session.token_hash, supplied_hash):
+                raise unauthorized("invalid_access_token")
+            self._sessions.pop(identity.session_id, None)
+
+    async def cleanup(self) -> None:
+        async with self._lock:
+            self._cleanup_locked(self._clock())
+
+    async def close(self) -> None:
+        async with self._lock:
+            self._closed = True
+            self._launch_grants.clear()
+            self._spent_launch_codes.clear()
+            self._sessions.clear()
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise LocalAppBridgeError("bridge_closed", 503, "Bridge is unavailable")
+
+    def _require_live_session_locked(self, session_id: str, now: float) -> _Session:
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise unauthorized("invalid_session")
+        if now - session.last_activity_at >= SESSION_IDLE_TTL_SECONDS:
+            self._sessions.pop(session_id, None)
+            raise unauthorized("session_idle_expired")
+        if now - session.created_at >= SESSION_ABSOLUTE_TTL_SECONDS:
+            self._sessions.pop(session_id, None)
+            raise unauthorized("session_absolute_expired")
+        return session
+
+    @staticmethod
+    def _verify_identity(session: _Session, identity: SessionIdentity) -> None:
+        expected = session.identity
+        if not (
+            hmac.compare_digest(expected.app_id, identity.app_id)
+            and hmac.compare_digest(expected.client_id, identity.client_id)
+            and hmac.compare_digest(expected.session_id, identity.session_id)
+        ):
+            raise forbidden("session_identity_mismatch")
+
+    def _cleanup_locked(self, now: float) -> None:
+        for code_hash, grant in tuple(self._launch_grants.items()):
+            if now >= grant.expires_at:
+                self._launch_grants.pop(code_hash, None)
+        self._cleanup_spent_locked(now)
+        self._cleanup_sessions_locked(now)
+
+    def _cleanup_spent_locked(self, now: float) -> None:
+        for code_hash, expires_at in tuple(self._spent_launch_codes.items()):
+            if now >= expires_at:
+                self._spent_launch_codes.pop(code_hash, None)
+
+    def _cleanup_sessions_locked(self, now: float) -> None:
+        for session_id, session in tuple(self._sessions.items()):
+            if (
+                now - session.last_activity_at >= SESSION_IDLE_TTL_SECONDS
+                or now - session.created_at >= SESSION_ABSOLUTE_TTL_SECONDS
+            ):
+                self._sessions.pop(session_id, None)
+
+    def _mark_spent_locked(self, code_hash: str, now: float) -> None:
+        if len(self._spent_launch_codes) >= MAX_PENDING_LAUNCH_CODES:
+            oldest = min(
+                self._spent_launch_codes, key=self._spent_launch_codes.__getitem__
+            )
+            self._spent_launch_codes.pop(oldest, None)
+        self._spent_launch_codes[code_hash] = now + LAUNCH_CODE_TTL_SECONDS

--- a/plugin/server/routes/plugins.py
+++ b/plugin/server/routes/plugins.py
@@ -1,9 +1,14 @@
 """
 插件管理路由
 """
+import secrets
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, ConfigDict
+from starlette.responses import JSONResponse
+
+from config import AUTOSTART_CSRF_TOKEN
 
 from plugin.logging_config import get_logger
 from plugin.server.application.plugins import (
@@ -15,12 +20,82 @@ from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure.auth import require_admin
 from plugin.server.infrastructure.error_mapping import raise_http_from_domain
 from plugin.server.lifecycle import ensure_plugin_messaging_started
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+from plugin.server.local_app_bridge.runtime import launch_registered_local_app
+from utils.host_origin_guard import is_http_browser_origin_allowed
 
 router = APIRouter()
 logger = get_logger("server.routes.plugins")
 query_service = PluginQueryService()
 lifecycle_service = PluginLifecycleService()
 registry_service = PluginRegistryService()
+
+_LOCAL_APP_CSRF_HEADER = "X-CSRF-Token"
+
+
+class LocalAppLaunchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    app_id: str
+
+
+def _require_trusted_product_ui(request: Request) -> None:
+    # Native/no-Origin callers use the in-process launch API. The HTTP surface
+    # exists only for the N.E.K.O product UI and must not become a generic
+    # loopback process launcher.
+    if not (request.headers.get("origin") or request.headers.get("referer")):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "local_app_ui_origin_required"},
+        )
+    if not is_http_browser_origin_allowed(request.scope):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "local_app_ui_origin_forbidden"},
+        )
+
+
+@router.get("/local-app/ui-token")
+async def local_app_ui_token(request: Request) -> JSONResponse:
+    _require_trusted_product_ui(request)
+    return JSONResponse(
+        {"token": AUTOSTART_CSRF_TOKEN},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.post("/local-app/launch")
+async def launch_local_app_endpoint(
+    request: Request,
+    payload: LocalAppLaunchRequest,
+    _: str = require_admin,
+) -> dict[str, object]:
+    _require_trusted_product_ui(request)
+    provided_token = request.headers.get(_LOCAL_APP_CSRF_HEADER, "")
+    if not AUTOSTART_CSRF_TOKEN or not secrets.compare_digest(
+        provided_token, AUTOSTART_CSRF_TOKEN
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "local_app_ui_csrf_failed"},
+        )
+    try:
+        result = await launch_registered_local_app(payload.app_id)
+    except LocalAppBridgeError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code},
+        ) from exc
+    except (LookupError, OSError, RuntimeError):
+        logger.warning(
+            "local app launch unavailable: app_id={}, error=safe_redacted",
+            payload.app_id,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "local_app_unavailable"},
+        ) from None
+    return {"success": True, "app_id": result.app_id}
 
 
 @router.get("/plugin/status")

--- a/plugin/tests/unit/core/test_communication_trusted_local_app.py
+++ b/plugin/tests/unit/core/test_communication_trusted_local_app.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from plugin.core.communication import PluginCommunicationResourceManager
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+class _Transport:
+    def __init__(self) -> None:
+        self.commands: list[dict[str, object]] = []
+        self.sent = asyncio.Event()
+
+    async def send_command(self, message: dict[str, object]) -> None:
+        self.commands.append(message)
+        self.sent.set()
+
+
+@pytest.mark.asyncio
+async def test_trusted_command_has_dedicated_type_and_routes_response() -> None:
+    transport = _Transport()
+    manager = PluginCommunicationResourceManager(
+        plugin_id="fixture",
+        transport=transport,  # type: ignore[arg-type]
+    )
+    task = asyncio.create_task(
+        manager.trigger_trusted_local_app(
+            context={
+                "app_id": "app",
+                "client_id": "client",
+                "session_id": "session",
+                "scope": "scope",
+                "operation": "operation",
+            },
+            operation="target-operation",
+            payload={"request_id": "request-1"},
+            timeout=1.0,
+        )
+    )
+    await transport.sent.wait()
+    command = transport.commands[0]
+    assert command["type"] == "TRUSTED_LOCAL_APP_INVOKE"
+    assert command["operation"] == "target-operation"
+    request_id = str(command["req_id"])
+    manager._dispatch_result(
+        {"req_id": request_id, "success": True, "data": {"accepted": True}}
+    )
+    assert await task == {"accepted": True}
+    assert manager.get_pending_requests_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_sends_dedicated_cancel_and_drops_pending_future() -> None:
+    transport = _Transport()
+    manager = PluginCommunicationResourceManager(
+        plugin_id="fixture",
+        transport=transport,  # type: ignore[arg-type]
+    )
+    task = asyncio.create_task(
+        manager.trigger_trusted_local_app(
+            context={
+                "app_id": "app",
+                "client_id": "client",
+                "session_id": "session",
+                "scope": "scope",
+                "operation": "operation",
+            },
+            operation="target-operation",
+            payload={},
+            timeout=30.0,
+        )
+    )
+    await transport.sent.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert [command["type"] for command in transport.commands] == [
+        "TRUSTED_LOCAL_APP_INVOKE",
+        "CANCEL_TRUSTED_LOCAL_APP",
+    ]
+    assert transport.commands[1]["req_id"] == transport.commands[0]["req_id"]
+    assert manager.get_pending_requests_count() == 0
+    # A response arriving after cancellation is isolated by request id and
+    # cannot complete another invocation.
+    manager._dispatch_result(
+        {
+            "req_id": transport.commands[0]["req_id"],
+            "success": True,
+            "data": {"late": True},
+        }
+    )
+    assert manager.get_pending_requests_count() == 0

--- a/plugin/tests/unit/core/test_host_trusted_local_app.py
+++ b/plugin/tests/unit/core/test_host_trusted_local_app.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from plugin._types.exceptions import PluginExecutionError
+from plugin.core.host import PluginProcessHost
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+@pytest.mark.asyncio
+async def test_host_only_invocation_crosses_process_with_verified_context(
+    tmp_path,
+) -> None:
+    config_path = tmp_path / "plugin.toml"
+    config_path.write_text("[plugin]\nname='trusted-local-app'\n", encoding="utf-8")
+    host = PluginProcessHost(
+        plugin_id="trusted_local_app_fixture",
+        entry_point=(
+            "tests.fixtures.plugin_test_trusted_local_app_fixture:"
+            "TrustedLocalAppFixturePlugin"
+        ),
+        config_path=config_path,
+    )
+    context = {
+        "app_id": "knowledge_dungeon",
+        "client_id": "electron-1",
+        "session_id": "session-1",
+        "scope": "study_companion:dungeon",
+        "operation": "knowledge_dungeon.bootstrap",
+    }
+
+    try:
+        await host.start(
+            message_target_queue=asyncio.Queue(),
+            startup_timeout=5.0,
+            startup_failure="fail",
+        )
+        result = await host.trigger_trusted_local_app(
+            context=context,
+            operation="knowledge_dungeon.bootstrap",
+            payload={"request_id": "request-1"},
+            timeout=2.0,
+        )
+        assert result == {
+            "context": context,
+            "payload": {"request_id": "request-1"},
+        }
+        aliased = await host.trigger_trusted_local_app(
+            context=context,
+            operation="private.stacked",
+            payload={"request_id": "request-2"},
+            timeout=2.0,
+        )
+        assert aliased == {
+            "context": "knowledge_dungeon.bootstrap",
+            "payload": {"request_id": "request-2"},
+        }
+
+        # A trusted handler is not a normal entry even when its Python method
+        # name is known to the caller.
+        with pytest.raises(PluginExecutionError, match="not found"):
+            await host.trigger("bootstrap", {}, timeout=2.0)
+        with pytest.raises(PluginExecutionError, match="not found"):
+            await host.trigger_custom_event(
+                "fixture", "stacked_trusted", {}, timeout=2.0
+            )
+    finally:
+        await host.shutdown(timeout=1.0)

--- a/plugin/tests/unit/sdk/test_sdk_local_app.py
+++ b/plugin/tests/unit/sdk/test_sdk_local_app.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from plugin.sdk.local_app import (
+    TrustedLocalAppPluginContext,
+    collect_trusted_local_app_operations,
+    trusted_local_app_operation,
+)
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def test_trusted_context_rejects_forged_or_extra_fields() -> None:
+    valid = {
+        "app_id": "app",
+        "client_id": "client",
+        "session_id": "session",
+        "scope": "scope",
+        "operation": "operation",
+    }
+    assert TrustedLocalAppPluginContext.from_mapping(valid).app_id == "app"
+    with pytest.raises(ValueError, match="fields"):
+        TrustedLocalAppPluginContext.from_mapping({**valid, "admin": "true"})
+    with pytest.raises(ValueError, match="app_id"):
+        TrustedLocalAppPluginContext.from_mapping({**valid, "app_id": "bad app"})
+
+
+def test_decorator_requires_async_handler_and_collector_rejects_duplicates() -> None:
+    with pytest.raises(ValueError, match="valid identifier"):
+        trusted_local_app_operation("operation")
+
+    with pytest.raises(TypeError, match="must be async"):
+
+        @trusted_local_app_operation("demo.operation")
+        def _sync_handler() -> None:
+            return None
+
+    class _Duplicate:
+        @trusted_local_app_operation("demo.operation")
+        async def first(self) -> None:
+            return None
+
+        @trusted_local_app_operation("demo.operation")
+        async def second(self) -> None:
+            return None
+
+    with pytest.raises(ValueError, match="duplicate"):
+        collect_trusted_local_app_operations(_Duplicate())
+
+
+def test_collector_only_returns_dedicated_handlers() -> None:
+    class _Adapter:
+        async def ordinary(self) -> None:
+            return None
+
+        @trusted_local_app_operation("demo.operation")
+        async def trusted(self) -> None:
+            return None
+
+    adapter = _Adapter()
+    assert collect_trusted_local_app_operations(adapter) == {
+        "demo.operation": adapter.trusted
+    }

--- a/plugin/tests/unit/server/test_local_app_bridge_host_installations.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_host_installations.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from plugin.server.local_app_bridge import host_installations as module
+from plugin.server.local_app_bridge.contracts import LocalAppPolicy
+from plugin.server.local_app_bridge.runtime import (
+    LocalAppBridgeRuntime,
+    LocalAppPluginRegistration,
+    LocalAppPluginTarget,
+)
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def _registration(app_id: str = "knowledge_dungeon") -> LocalAppPluginRegistration:
+    return LocalAppPluginRegistration(
+        policy=LocalAppPolicy(
+            app_id=app_id,
+            allowed_operations={
+                "study_companion:dungeon": frozenset({"knowledge_dungeon.bootstrap"})
+            },
+        ),
+        targets=(
+            LocalAppPluginTarget(
+                scope="study_companion:dungeon",
+                operation="knowledge_dungeon.bootstrap",
+                plugin_id="study_companion",
+                plugin_operation="knowledge_dungeon.bootstrap",
+            ),
+        ),
+    )
+
+
+def _write_config(
+    path: Path,
+    *,
+    app_id: str = "knowledge_dungeon",
+    executable: str | None = None,
+    extra: dict[str, object] | None = None,
+) -> None:
+    installation: dict[str, object] = {
+        "app_id": app_id,
+        "title": "Knowledge Dungeon",
+        "executable": executable or sys.executable,
+        "args": ["--product-mode"],
+    }
+    installation.update(extra or {})
+    path.write_text(
+        json.dumps({"version": 1, "installations": [installation]}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_host_file_configures_only_manifest_authorized_installation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runtime = LocalAppBridgeRuntime()
+    runtime.register_plugin_app(_registration())
+    config_path = tmp_path / "local-app-installations.json"
+    _write_config(config_path)
+    monkeypatch.setenv(module.LOCAL_APP_INSTALLATIONS_FILE_ENV, str(config_path))
+    monkeypatch.setattr(module, "get_local_app_bridge_runtime", lambda: runtime)
+
+    issues = await module.configure_local_app_installations_from_host()
+    await runtime.start()
+    descriptor = runtime.describe_plugin_app(
+        "study_companion", fallback_title="Study Companion"
+    )
+
+    assert issues == ()
+    assert descriptor is not None
+    assert descriptor.app_id == "knowledge_dungeon"
+    assert descriptor.title == "Knowledge Dungeon"
+    assert descriptor.available is True
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_app_id_fails_closed_without_changing_plugin_registration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runtime = LocalAppBridgeRuntime()
+    runtime.register_plugin_app(_registration())
+    config_path = tmp_path / "local-app-installations.json"
+    _write_config(config_path, app_id="untrusted_app")
+    monkeypatch.setenv(module.LOCAL_APP_INSTALLATIONS_FILE_ENV, str(config_path))
+    monkeypatch.setattr(module, "get_local_app_bridge_runtime", lambda: runtime)
+
+    issues = await module.configure_local_app_installations_from_host()
+    await runtime.start()
+    descriptor = runtime.describe_plugin_app(
+        "study_companion", fallback_title="Study Companion"
+    )
+
+    assert issues == (
+        module.LocalAppInstallationIssue("installations_configuration_invalid"),
+    )
+    assert descriptor is not None
+    assert descriptor.available is False
+    await runtime.close()
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_code"),
+    [
+        (
+            {
+                "version": 1,
+                "installations": [
+                    {
+                        "app_id": "knowledge_dungeon",
+                        "title": "Knowledge Dungeon",
+                        "executable": "relative.exe",
+                        "args": [],
+                    }
+                ],
+            },
+            "installation_executable_invalid",
+        ),
+        (
+            {"version": 1, "installations": [], "unexpected": True},
+            "installations_fields_invalid",
+        ),
+    ],
+)
+def test_host_file_rejects_relative_paths_and_extra_fields(
+    tmp_path: Path, payload: dict[str, object], expected_code: str
+) -> None:
+    config_path = tmp_path / "local-app-installations.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(module._InvalidInstallationConfig, match=expected_code):
+        module._load_installations(config_path)
+
+
+@pytest.mark.asyncio
+async def test_missing_host_file_configuration_disables_launch_without_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured: list[tuple[object, ...]] = []
+
+    class _Runtime:
+        @staticmethod
+        def configure_installations(installations: tuple[object, ...]) -> None:
+            configured.append(installations)
+
+    monkeypatch.delenv(module.LOCAL_APP_INSTALLATIONS_FILE_ENV, raising=False)
+    monkeypatch.setattr(module, "get_local_app_bridge_runtime", _Runtime)
+
+    assert await module.configure_local_app_installations_from_host() == ()
+    assert configured == [()]

--- a/plugin/tests/unit/server/test_local_app_bridge_http.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_http.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from plugin.server.local_app_bridge import (
+    LocalAppBridgeHttpServer,
+    LocalAppBridgeService,
+    LocalAppPolicy,
+)
+
+pytestmark = pytest.mark.plugin_unit
+
+
+async def _request(
+    port: int,
+    method: str,
+    path: str,
+    *,
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    encoded = json.dumps(body or {}, separators=(",", ":")).encode()
+    request_headers = {
+        "Host": f"127.0.0.1:{port}",
+        "Content-Type": "application/json",
+        "Content-Length": str(len(encoded)),
+        **(headers or {}),
+    }
+    lines = [
+        f"{method} {path} HTTP/1.1",
+        *(f"{key}: {value}" for key, value in request_headers.items()),
+        "",
+        "",
+    ]
+    writer.write("\r\n".join(lines).encode("ascii") + encoded)
+    await writer.drain()
+    status_line = await reader.readline()
+    if not status_line:
+        raise ConnectionError("bridge closed before a response was committed")
+    status = int(status_line.split()[1])
+    response_headers: dict[bytes, bytes] = {}
+    while True:
+        line = await reader.readline()
+        if line == b"\r\n":
+            break
+        name, value = line.split(b":", 1)
+        response_headers[name.lower()] = value.strip()
+    response_body = await reader.readexactly(int(response_headers[b"content-length"]))
+    writer.close()
+    await writer.wait_closed()
+    return status, json.loads(response_body)
+
+
+async def _running_bridge() -> tuple[LocalAppBridgeService, LocalAppBridgeHttpServer]:
+    async def echo(_context: object, payload: object) -> object:
+        return {"echo": payload}
+
+    service = LocalAppBridgeService()
+    service.register_app(LocalAppPolicy("demo.app", {"demo:read": frozenset({"echo"})}))
+    service.register_operation(
+        app_id="demo.app", scope="demo:read", operation="echo", handler=echo
+    )
+    server = LocalAppBridgeHttpServer(service)
+    await server.start()
+    return service, server
+
+
+@pytest.mark.asyncio
+async def test_http_pair_and_trusted_dispatch_end_to_end() -> None:
+    service, server = await _running_bridge()
+    assert server.origin.startswith("http://127.0.0.1:")
+    material = await service.issue_launch_material(
+        bridge_origin=server.origin,
+        app_id="demo.app",
+        client_id="client-1",
+        requested_scopes=frozenset({"demo:read"}),
+    )
+    status, paired = await _request(
+        server.port,
+        "POST",
+        "/v1/pair",
+        body={
+            "protocol_version": 1,
+            "app_id": "demo.app",
+            "client_id": "client-1",
+            "launch_code": material.launch_code,
+        },
+    )
+    assert status == 200 and paired["ok"] is True
+    assert paired["access_token_expires_in"] == 900
+
+    status, dispatched = await _request(
+        server.port,
+        "POST",
+        "/v1/dispatch",
+        body={
+            "protocol_version": 1,
+            "app_id": "demo.app",
+            "client_id": "client-1",
+            "session_id": paired["session_id"],
+            "scope": "demo:read",
+            "operation": "echo",
+            "payload": {"value": 7},
+        },
+        headers={"Authorization": f"Bearer {paired['access_token']}"},
+    )
+    assert status == 200
+    assert dispatched["result"] == {"echo": {"value": 7}}
+
+    identity_body = {
+        "protocol_version": 1,
+        "app_id": "demo.app",
+        "client_id": "client-1",
+        "session_id": paired["session_id"],
+    }
+    status, rotated = await _request(
+        server.port,
+        "POST",
+        "/v1/sessions/rotate",
+        body=identity_body,
+        headers={"Authorization": f"Bearer {paired['access_token']}"},
+    )
+    assert status == 200 and rotated["access_token"] != paired["access_token"]
+    status, closed = await _request(
+        server.port,
+        "POST",
+        "/v1/sessions/close",
+        body=identity_body,
+        headers={"Authorization": f"Bearer {rotated['access_token']}"},
+    )
+    assert status == 200 and closed["ok"] is True
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_http_rejects_browser_origin_bad_host_extra_fields_and_wrong_token() -> (
+    None
+):
+    service, server = await _running_bridge()
+    material = await service.issue_launch_material(
+        bridge_origin=server.origin,
+        app_id="demo.app",
+        client_id="client-1",
+        requested_scopes=frozenset({"demo:read"}),
+    )
+    pair_body = {
+        "protocol_version": 1,
+        "app_id": "demo.app",
+        "client_id": "client-1",
+        "launch_code": material.launch_code,
+    }
+    status, response = await _request(
+        server.port,
+        "POST",
+        "/v1/pair",
+        body=pair_body,
+        headers={"Origin": "http://127.0.0.1:9999"},
+    )
+    assert status == 403 and response["error"]["code"] == "browser_origin_forbidden"
+    status, response = await _request(
+        server.port,
+        "POST",
+        "/v1/pair",
+        body={**pair_body, "extra": True},
+    )
+    assert status == 400 and response["error"]["code"] == "invalid_fields"
+    status, paired = await _request(server.port, "POST", "/v1/pair", body=pair_body)
+    assert status == 200
+
+    dispatch_body = {
+        "protocol_version": 1,
+        "app_id": "demo.app",
+        "client_id": "client-1",
+        "session_id": paired["session_id"],
+        "scope": "demo:read",
+        "operation": "echo",
+        "payload": {},
+    }
+    status, response = await _request(
+        server.port,
+        "POST",
+        "/v1/dispatch",
+        body=dispatch_body,
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert status == 401 and response["error"]["code"] == "invalid_access_token"
+    status, response = await _request(
+        server.port,
+        "GET",
+        "/v1/health",
+        headers={"Host": "localhost:1234"},
+    )
+    assert status == 403 and response["error"]["code"] == "invalid_host"
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_http_enforces_body_limit_and_releases_listener() -> None:
+    _service, server = await _running_bridge()
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.port)
+    writer.write(
+        (
+            "POST /v1/pair HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{server.port}\r\n"
+            "Content-Type: application/json\r\n"
+            "Content-Length: 65537\r\n\r\n"
+        ).encode("ascii")
+    )
+    await writer.drain()
+    status_line = await reader.readline()
+    assert status_line.startswith(b"HTTP/1.1 413")
+    writer.close()
+    await writer.wait_closed()
+    port = server.port
+    await server.close()
+    with pytest.raises((ConnectionRefusedError, OSError)):
+        await asyncio.open_connection("127.0.0.1", port)
+
+
+@pytest.mark.asyncio
+async def test_http_rate_limit_returns_retry_after() -> None:
+    service, server = await _running_bridge()
+    material = await service.issue_launch_material(
+        bridge_origin=server.origin,
+        app_id="demo.app",
+        client_id="client-1",
+        requested_scopes=frozenset({"demo:read"}),
+    )
+    _, paired = await _request(
+        server.port,
+        "POST",
+        "/v1/pair",
+        body={
+            "protocol_version": 1,
+            "app_id": "demo.app",
+            "client_id": "client-1",
+            "launch_code": material.launch_code,
+        },
+    )
+    body = {
+        "protocol_version": 1,
+        "app_id": "demo.app",
+        "client_id": "client-1",
+        "session_id": paired["session_id"],
+        "scope": "demo:read",
+        "operation": "echo",
+        "payload": {},
+    }
+    for _ in range(30):
+        status, _response = await _request(
+            server.port,
+            "POST",
+            "/v1/dispatch",
+            body=body,
+            headers={"Authorization": f"Bearer {paired['access_token']}"},
+        )
+        assert status == 200
+    status, response = await _request(
+        server.port,
+        "POST",
+        "/v1/dispatch",
+        body=body,
+        headers={"Authorization": f"Bearer {paired['access_token']}"},
+    )
+    assert status == 429
+    assert response["error"]["code"] == "rate_limited"
+    assert response["error"]["retry_after"] > 0
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_http_rejects_oversized_headers_and_close_cancels_slow_reader() -> None:
+    _service, server = await _running_bridge()
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.port)
+    writer.write(
+        (
+            "GET /v1/health HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{server.port}\r\n"
+            f"X-Fill: {'x' * 9000}\r\n\r\n"
+        ).encode("ascii")
+    )
+    await writer.drain()
+    assert (await reader.readline()).startswith(b"HTTP/1.1 431")
+    writer.close()
+    await writer.wait_closed()
+
+    slow_reader, slow_writer = await asyncio.open_connection("127.0.0.1", server.port)
+    slow_writer.write(b"POST /v1/pair HTTP/1.1\r\n")
+    await slow_writer.drain()
+    await asyncio.wait_for(server.close(), timeout=1)
+    assert await asyncio.wait_for(slow_reader.read(), timeout=1) == b""
+    slow_writer.close()
+    await slow_writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_server_close_cancels_in_flight_dispatch_before_releasing_resources() -> (
+    None
+):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def blocked(_context: object, _payload: object) -> object:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    service = LocalAppBridgeService()
+    service.register_app(
+        LocalAppPolicy("demo.app", {"demo:read": frozenset({"blocked"})})
+    )
+    service.register_operation(
+        app_id="demo.app",
+        scope="demo:read",
+        operation="blocked",
+        handler=blocked,
+    )
+    server = LocalAppBridgeHttpServer(service)
+    await server.start()
+    material = await service.issue_launch_material(
+        bridge_origin=server.origin,
+        app_id="demo.app",
+        client_id="client-1",
+        requested_scopes=frozenset({"demo:read"}),
+    )
+    _, paired = await _request(
+        server.port,
+        "POST",
+        "/v1/pair",
+        body={
+            "protocol_version": 1,
+            "app_id": "demo.app",
+            "client_id": "client-1",
+            "launch_code": material.launch_code,
+        },
+    )
+    request_task = asyncio.create_task(
+        _request(
+            server.port,
+            "POST",
+            "/v1/dispatch",
+            body={
+                "protocol_version": 1,
+                "app_id": "demo.app",
+                "client_id": "client-1",
+                "session_id": paired["session_id"],
+                "scope": "demo:read",
+                "operation": "blocked",
+                "payload": {"request_id": "request-1"},
+            },
+            headers={"Authorization": f"Bearer {paired['access_token']}"},
+        )
+    )
+    await started.wait()
+    await asyncio.wait_for(server.close(), timeout=1)
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    with pytest.raises((asyncio.IncompleteReadError, ConnectionError)):
+        await request_task

--- a/plugin/tests/unit/server/test_local_app_bridge_launch.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_launch.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from plugin.server.local_app_bridge.contracts import LaunchMaterial, LocalAppPolicy
+from plugin.server.local_app_bridge.launch import launch_local_app
+from plugin.server.local_app_bridge.runtime import (
+    LocalAppBridgeRuntime,
+    LocalAppInstallation,
+    LocalAppPluginRegistration,
+    LocalAppPluginTarget,
+    _derive_persistent_client_id,
+)
+from plugin.server.local_app_bridge import runtime as runtime_module
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def _registration(app_id: str = "knowledge_dungeon") -> LocalAppPluginRegistration:
+    scope = "study_companion:dungeon"
+    operation = "knowledge_dungeon.bootstrap"
+    return LocalAppPluginRegistration(
+        policy=LocalAppPolicy(
+            app_id=app_id,
+            allowed_operations={scope: frozenset({operation})},
+        ),
+        targets=(
+            LocalAppPluginTarget(
+                scope=scope,
+                operation=operation,
+                plugin_id="study_companion",
+                plugin_operation=operation,
+            ),
+        ),
+    )
+
+
+class _FakeProcess:
+    def __init__(self, pid: int = 4321) -> None:
+        self.pid = pid
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        return self.returncode or 0
+
+
+@pytest.mark.asyncio
+async def test_host_launch_uses_only_frozen_installation_and_manifest_scope(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "knowledge-dungeon.exe"
+    executable.write_bytes(b"test executable placeholder")
+    calls: list[dict[str, object]] = []
+    process = _FakeProcess()
+
+    async def client_id_provider(app_id: str) -> str:
+        assert app_id == "knowledge_dungeon"
+        return "lac_stable"
+
+    async def process_launcher(
+        selected_executable: Path,
+        *,
+        args: tuple[str, ...],
+        material: LaunchMaterial,
+    ) -> _FakeProcess:
+        calls.append(
+            {
+                "executable": selected_executable,
+                "args": args,
+                "material": material,
+            }
+        )
+        return process
+
+    runtime = LocalAppBridgeRuntime(
+        client_id_provider=client_id_provider,
+        process_launcher=process_launcher,
+    )
+    runtime.register_plugin_app(_registration())
+    runtime.configure_installations(
+        (
+            LocalAppInstallation(
+                app_id="knowledge_dungeon",
+                title="Knowledge Dungeon",
+                executable=executable,
+                args=("--product-mode",),
+            ),
+        )
+    )
+    origin = await runtime.start()
+
+    result = await runtime.launch_registered_app("knowledge_dungeon")
+
+    assert result.app_id == "knowledge_dungeon"
+    assert result.client_id == "lac_stable"
+    assert result.process_id == 4321
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["executable"] == executable.resolve()
+    assert call["args"] == ("--product-mode",)
+    material = call["material"]
+    assert isinstance(material, LaunchMaterial)
+    assert material.bridge_origin == origin
+    assert material.app_id == "knowledge_dungeon"
+    assert material.client_id == "lac_stable"
+    service = runtime._service
+    assert service is not None
+    paired = await service.pair(
+        launch_code=material.launch_code,
+        app_id=material.app_id,
+        client_id=material.client_id,
+    )
+    assert paired.granted_scopes == frozenset({"study_companion:dungeon"})
+
+    await runtime.close()
+    assert process.terminated is True
+
+
+@pytest.mark.asyncio
+async def test_host_launch_requires_both_manifest_registration_and_installation(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "registered.exe"
+    executable.write_bytes(b"placeholder")
+
+    async def client_id_provider(_app_id: str) -> str:
+        return "lac_stable"
+
+    async def should_not_launch(**_kwargs: object) -> _FakeProcess:
+        raise AssertionError("unregistered app must not launch")
+
+    runtime = LocalAppBridgeRuntime(
+        client_id_provider=client_id_provider,
+        process_launcher=should_not_launch,
+    )
+    with pytest.raises(ValueError, match="manifest-authorized"):
+        runtime.configure_installations(
+            (
+                LocalAppInstallation(
+                    app_id="knowledge_dungeon",
+                    title="Knowledge Dungeon",
+                    executable=executable,
+                ),
+            )
+        )
+
+    runtime = LocalAppBridgeRuntime(
+        client_id_provider=client_id_provider,
+        process_launcher=should_not_launch,
+    )
+    runtime.register_plugin_app(_registration())
+    await runtime.start()
+    with pytest.raises(LookupError, match="registered and installed"):
+        await runtime.launch_registered_app("knowledge_dungeon")
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_installation_registration_freezes_when_listener_starts(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "registered.exe"
+    executable.write_bytes(b"placeholder")
+    installation = LocalAppInstallation(
+        app_id="knowledge_dungeon",
+        title="Knowledge Dungeon",
+        executable=executable,
+    )
+    runtime = LocalAppBridgeRuntime()
+    runtime.register_plugin_app(_registration())
+    runtime.configure_installations((installation,))
+    await runtime.start()
+
+    with pytest.raises(RuntimeError, match="frozen"):
+        runtime.configure_installations((installation,))
+
+    await runtime.close()
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("bad\nargument",),
+        ("x" * 1025,),
+        tuple(str(index) for index in range(33)),
+    ],
+)
+def test_installation_rejects_unbounded_or_control_arguments(
+    tmp_path: Path, args: tuple[str, ...]
+) -> None:
+    executable = tmp_path / "registered.exe"
+    executable.write_bytes(b"placeholder")
+
+    with pytest.raises(ValueError, match="argument"):
+        LocalAppInstallation(
+            app_id="knowledge_dungeon",
+            title="Knowledge Dungeon",
+            executable=executable,
+            args=args,
+        )
+
+
+@pytest.mark.asyncio
+async def test_persistent_client_id_is_deterministic_and_app_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ConfigManager:
+        @staticmethod
+        def ensure_cloudsave_client_credentials() -> tuple[str, str]:
+            return "host-client-id", "host-client-proof"
+
+    monkeypatch.setattr(runtime_module, "get_config_manager", lambda: _ConfigManager())
+
+    first = await _derive_persistent_client_id("knowledge_dungeon")
+    restarted = await _derive_persistent_client_id("knowledge_dungeon")
+    different_app = await _derive_persistent_client_id("another_app")
+
+    assert first == restarted
+    assert first.startswith("lac_") and len(first) == 68
+    assert first != different_app
+    assert "host-client-id" not in first
+    assert "host-client-proof" not in first
+
+
+@pytest.mark.asyncio
+async def test_default_launcher_delivers_material_only_through_stdin(
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "material.json"
+    script = (
+        "import pathlib,sys; "
+        "pathlib.Path(sys.argv[1]).write_bytes(sys.stdin.buffer.readline())"
+    )
+    material = LaunchMaterial(
+        bridge_origin="http://127.0.0.1:49123",
+        app_id="knowledge_dungeon",
+        client_id="lac_stable",
+        launch_code="one-time-secret",
+    )
+
+    process = await launch_local_app(
+        sys.executable,
+        args=("-c", script, str(output_path)),
+        material=material,
+    )
+    assert await asyncio.wait_for(process.wait(), timeout=5.0) == 0
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == material.to_dict()

--- a/plugin/tests/unit/server/test_local_app_bridge_manifest.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_manifest.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugin.server.local_app_bridge import manifest as module
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def _write_manifest(
+    root: Path,
+    plugin_id: str,
+    *,
+    app_id: str = "knowledge_dungeon",
+    operation: str = "knowledge_dungeon.bootstrap",
+    plugin_operation: str = "knowledge_dungeon.bootstrap",
+    extra: str = "",
+) -> Path:
+    path = root / plugin_id / "plugin.toml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "\n".join(
+            [
+                "[plugin]",
+                f'id = "{plugin_id}"',
+                "",
+                "[plugin.local_app]",
+                f'app_id = "{app_id}"',
+                'scope = "study_companion:dungeon"',
+                extra,
+                "",
+                "[plugin.local_app.operations]",
+                f'"{operation}" = "{plugin_operation}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _metadata(path: Path, *, enabled: bool = True) -> dict[str, object]:
+    return {"config_path": str(path), "runtime_enabled": enabled}
+
+
+def test_valid_manifest_builds_fixed_host_target(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, "study_companion")
+    registrations, issues = module._discover_registrations(
+        {"study_companion": _metadata(path)}
+    )
+    assert issues == ()
+    assert len(registrations) == 1
+    registration = registrations[0]
+    assert registration.policy.app_id == "knowledge_dungeon"
+    assert registration.policy.allowed_operations == {
+        "study_companion:dungeon": frozenset({"knowledge_dungeon.bootstrap"})
+    }
+    assert registration.targets[0].plugin_id == "study_companion"
+    assert registration.targets[0].plugin_operation == "knowledge_dungeon.bootstrap"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_code"),
+    [
+        ({"extra": 'unexpected = "value"'}, "local_app_fields_invalid"),
+        (
+            {"operation": "KnowledgeDungeon.Bootstrap"},
+            "local_app_operations_invalid",
+        ),
+        (
+            {"plugin_operation": "bootstrap"},
+            "local_app_operations_invalid",
+        ),
+    ],
+)
+def test_invalid_declaration_only_disables_local_app_capability(
+    tmp_path: Path,
+    kwargs: dict[str, str],
+    expected_code: str,
+) -> None:
+    path = _write_manifest(tmp_path, "otherwise_valid_plugin", **kwargs)
+    registrations, issues = module._discover_registrations(
+        {"otherwise_valid_plugin": _metadata(path)}
+    )
+    assert registrations == ()
+    assert issues == (
+        module.LocalAppManifestIssue("otherwise_valid_plugin", expected_code),
+    )
+
+
+def test_duplicate_app_id_disables_both_plugins(tmp_path: Path) -> None:
+    first = _write_manifest(tmp_path, "first")
+    second = _write_manifest(tmp_path, "second")
+    registrations, issues = module._discover_registrations(
+        {"first": _metadata(first), "second": _metadata(second)}
+    )
+    assert registrations == ()
+    assert issues == (
+        module.LocalAppManifestIssue("first", "duplicate_app_id"),
+        module.LocalAppManifestIssue("second", "duplicate_app_id"),
+    )
+
+
+def test_disabled_plugin_declaration_is_not_registered(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, "disabled")
+    assert module._discover_registrations(
+        {"disabled": _metadata(path, enabled=False)}
+    ) == ((), ())
+
+
+@pytest.mark.asyncio
+async def test_registry_configuration_is_installed_as_one_frozen_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path, "study_companion")
+    configured: list[tuple[object, ...]] = []
+
+    class _Runtime:
+        def configure_plugin_apps(self, registrations: tuple[object, ...]) -> None:
+            configured.append(registrations)
+
+    monkeypatch.setattr(
+        module,
+        "_registry_snapshot",
+        lambda: {"study_companion": _metadata(path)},
+    )
+    monkeypatch.setattr(module, "get_local_app_bridge_runtime", _Runtime)
+
+    issues = await module.configure_local_app_bridge_from_registry()
+
+    assert issues == ()
+    assert len(configured) == 1 and len(configured[0]) == 1

--- a/plugin/tests/unit/server/test_local_app_bridge_rate_limit.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_rate_limit.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+from plugin.server.local_app_bridge.rate_limit import LocalAppRateLimiter
+
+pytestmark = pytest.mark.plugin_unit
+
+
+@dataclass
+class _Clock:
+    now: float = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@pytest.mark.asyncio
+async def test_session_rate_limit_is_thirty_requests_per_ten_seconds() -> None:
+    clock = _Clock()
+    limiter = LocalAppRateLimiter(clock=clock)
+    for _ in range(30):
+        await limiter.check_session("session-1")
+    with pytest.raises(LocalAppBridgeError) as limited:
+        await limiter.check_session("session-1")
+    assert limited.value.status_code == 429
+    assert limited.value.retry_after == 10.0
+    clock.now = 10.0
+    await limiter.check_session("session-1")
+
+
+@pytest.mark.asyncio
+async def test_pair_limit_is_stricter_and_scoped_to_bound_identity() -> None:
+    clock = _Clock()
+    limiter = LocalAppRateLimiter(clock=clock)
+    for _ in range(5):
+        await limiter.check_pair(app_id="demo.app", client_id="client-1")
+    with pytest.raises(LocalAppBridgeError) as limited:
+        await limiter.check_pair(app_id="demo.app", client_id="client-1")
+    assert limited.value.code == "rate_limited"
+    await limiter.check_pair(app_id="demo.app", client_id="client-2")
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_buckets_are_bounded_evicted_and_cleaned() -> None:
+    clock = _Clock()
+    limiter = LocalAppRateLimiter(clock=clock, max_buckets=3)
+    await limiter.check_session("one")
+    clock.now += 1
+    await limiter.check_session("two")
+    clock.now += 1
+    await limiter.check_session("three")
+    clock.now += 1
+    await limiter.check_session("four")
+    assert limiter.bucket_count == 3
+    clock.now += 61
+    await limiter.cleanup()
+    assert limiter.bucket_count == 0
+    await limiter.close()
+    with pytest.raises(LocalAppBridgeError) as closed:
+        await limiter.check_session("five")
+    assert closed.value.code == "bridge_closed"

--- a/plugin/tests/unit/server/test_local_app_bridge_runtime.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_runtime.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from plugin.server.local_app_bridge import (
+    DispatchEnvelope,
+    LocalAppBridgeRuntime,
+    LocalAppPluginRegistration,
+    LocalAppPluginTarget,
+    LocalAppPolicy,
+)
+from plugin.server.local_app_bridge import runtime as runtime_module
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def _registration() -> LocalAppPluginRegistration:
+    return LocalAppPluginRegistration(
+        policy=LocalAppPolicy(
+            app_id="knowledge_dungeon",
+            allowed_operations={
+                "study_companion:dungeon": frozenset(
+                    {
+                        "knowledge_dungeon.bootstrap",
+                        "knowledge_dungeon.perform_action",
+                    }
+                )
+            },
+        ),
+        targets=(
+            LocalAppPluginTarget(
+                scope="study_companion:dungeon",
+                operation="knowledge_dungeon.bootstrap",
+                plugin_id="study_companion",
+                plugin_operation="knowledge_dungeon.bootstrap",
+            ),
+            LocalAppPluginTarget(
+                scope="study_companion:dungeon",
+                operation="knowledge_dungeon.perform_action",
+                plugin_id="study_companion",
+                plugin_operation="knowledge_dungeon.perform_action",
+            ),
+        ),
+    )
+
+
+def test_registration_must_exactly_cover_policy() -> None:
+    registration = _registration()
+    with pytest.raises(ValueError, match="exactly match"):
+        LocalAppPluginRegistration(
+            policy=registration.policy,
+            targets=registration.targets[:1],
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_maps_verified_session_to_fixed_plugin_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class _Dispatch:
+        async def invoke(self, **kwargs: object) -> object:
+            calls.append(dict(kwargs))
+            return {"accepted": True}
+
+    monkeypatch.setattr(runtime_module, "TrustedLocalAppPluginDispatch", _Dispatch)
+    runtime = LocalAppBridgeRuntime()
+    runtime.register_plugin_app(_registration())
+
+    first_origin = await runtime.start()
+    assert first_origin.startswith("http://127.0.0.1:")
+    assert await runtime.start() == first_origin
+    material = await runtime.issue_launch_material(
+        app_id="knowledge_dungeon",
+        client_id="electron-1",
+        requested_scopes=frozenset({"study_companion:dungeon"}),
+    )
+    service = runtime._service
+    assert service is not None
+    paired = await service.pair(
+        launch_code=material.launch_code,
+        app_id=material.app_id,
+        client_id=material.client_id,
+    )
+    result = await service.dispatch(
+        DispatchEnvelope(
+            identity=paired.identity,
+            scope="study_companion:dungeon",
+            operation="knowledge_dungeon.bootstrap",
+            payload={"request_id": "request-1"},
+        ),
+        access_token=paired.access_token,
+    )
+    assert result == {"accepted": True}
+    assert calls == [
+        {
+            "plugin_id": "study_companion",
+            "plugin_operation": "knowledge_dungeon.bootstrap",
+            "context": {
+                "app_id": "knowledge_dungeon",
+                "client_id": "electron-1",
+                "session_id": paired.identity.session_id,
+                "scope": "study_companion:dungeon",
+                "operation": "knowledge_dungeon.bootstrap",
+            },
+            "payload": {"request_id": "request-1"},
+            "timeout": 30.0,
+        }
+    ]
+
+    await runtime.close()
+    assert runtime.is_running is False
+    # Registration is configuration, so a lifecycle restart restores it while
+    # tokens and sessions from the old service stay invalidated.
+    second_origin = await runtime.start()
+    assert second_origin.startswith("http://127.0.0.1:")
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_server_lifecycle_stops_listener_before_plugin_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.server import lifecycle
+
+    calls: list[str] = []
+
+    class _State:
+        plugin_hosts: dict[str, object] = {}
+        plugins: dict[str, object] = {}
+        event_handlers: dict[str, object] = {}
+
+        @staticmethod
+        def acquire_plugin_hosts_write_lock():
+            return contextlib.nullcontext()
+
+        @staticmethod
+        def acquire_plugins_write_lock():
+            return contextlib.nullcontext()
+
+        @staticmethod
+        def acquire_event_handlers_write_lock():
+            return contextlib.nullcontext()
+
+        @staticmethod
+        def close_plugin_resources() -> None:
+            return None
+
+    async def _stop_local() -> None:
+        calls.append("local_app_bridge")
+
+    async def _stop_hosts() -> bool:
+        calls.append("plugin_hosts")
+        return False
+
+    async def _noop_async(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(lifecycle, "state", _State())
+    monkeypatch.setattr(lifecycle, "emit_lifecycle_event", lambda _event: None)
+    monkeypatch.setattr(lifecycle, "stop_local_app_bridge", _stop_local)
+    monkeypatch.setattr(lifecycle, "stop_bridge", lambda: None)
+    monkeypatch.setattr(lifecycle, "stop_proactive_bridge", lambda: None)
+    monkeypatch.setattr(lifecycle.metrics_collector, "stop", _noop_async)
+    monkeypatch.setattr(
+        lifecycle.status_manager, "shutdown_status_consumer", _noop_async
+    )
+    monkeypatch.setattr(lifecycle.bus_subscription_manager, "stop", _noop_async)
+    monkeypatch.setattr(lifecycle.plugin_router, "stop", _noop_async)
+    service = lifecycle.ServerLifecycleService()
+    monkeypatch.setattr(service, "_shutdown_hosts", _stop_hosts)
+
+    result = await service._shutdown_internal()
+
+    assert result.had_errors is False
+    assert calls == ["local_app_bridge", "plugin_hosts"]
+
+
+@pytest.mark.asyncio
+async def test_registration_is_frozen_once_listener_bind_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bind_started = asyncio.Event()
+    finish_bind = asyncio.Event()
+
+    class _Server:
+        def __init__(self, service) -> None:
+            self.service = service
+            self.origin = "http://127.0.0.1:49123"
+
+        async def start(self) -> str:
+            bind_started.set()
+            await finish_bind.wait()
+            return self.origin
+
+        async def close(self) -> None:
+            await self.service.close()
+
+    monkeypatch.setattr(runtime_module, "LocalAppBridgeHttpServer", _Server)
+    runtime = LocalAppBridgeRuntime()
+    start_task = asyncio.create_task(runtime.start())
+    await bind_started.wait()
+    with pytest.raises(RuntimeError, match="frozen"):
+        runtime.register_plugin_app(_registration())
+    finish_bind.set()
+    assert await start_task == "http://127.0.0.1:49123"
+    await runtime.close()

--- a/plugin/tests/unit/server/test_local_app_bridge_service.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_service.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from plugin.server.local_app_bridge import (
+    DispatchEnvelope,
+    LocalAppBridgeError,
+    LocalAppBridgeService,
+    LocalAppPolicy,
+    SessionIdentity,
+)
+from plugin.server.local_app_bridge.contracts import LaunchMaterial
+from plugin.server.local_app_bridge.dispatcher import TrustedLocalAppDispatcher
+from plugin.server.local_app_bridge.launch import (
+    launch_local_app,
+    write_launch_material,
+)
+from plugin.server.local_app_bridge.sessions import LocalAppSessionStore
+
+pytestmark = pytest.mark.plugin_unit
+
+
+async def _service_and_session(
+    handler: Any,
+) -> tuple[LocalAppBridgeService, str, SessionIdentity]:
+    service = LocalAppBridgeService(operation_timeout=0.2)
+    service.register_app(
+        LocalAppPolicy(
+            app_id="demo.app",
+            allowed_operations={"demo:read": frozenset({"echo"})},
+        )
+    )
+    service.register_operation(
+        app_id="demo.app",
+        scope="demo:read",
+        operation="echo",
+        handler=handler,
+    )
+    material = await service.issue_launch_material(
+        bridge_origin="http://127.0.0.1:49123",
+        app_id="demo.app",
+        client_id="client-1",
+        requested_scopes=frozenset({"demo:read"}),
+    )
+    paired = await service.pair(
+        launch_code=material.launch_code,
+        app_id=material.app_id,
+        client_id=material.client_id,
+    )
+    return service, paired.access_token, paired.identity
+
+
+@pytest.mark.asyncio
+async def test_trusted_dispatch_is_allowlisted_and_receives_bound_identity() -> None:
+    seen: list[object] = []
+
+    async def echo(context: object, payload: object) -> object:
+        seen.append(context)
+        return {"echo": payload}
+
+    service, token, identity = await _service_and_session(echo)
+    envelope = DispatchEnvelope(
+        identity=identity,
+        scope="demo:read",
+        operation="echo",
+        payload={"value": 3},
+    )
+    assert await service.dispatch(envelope, access_token=token) == {
+        "echo": {"value": 3}
+    }
+    assert getattr(seen[0], "identity") == identity
+
+    forbidden_envelope = DispatchEnvelope(
+        identity=identity,
+        scope="demo:read",
+        operation="not-registered",
+        payload={},
+    )
+    with pytest.raises(LocalAppBridgeError) as denied:
+        await service.dispatch(forbidden_envelope, access_token=token)
+    assert denied.value.code == "operation_forbidden"
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_session_close_during_handler_fails_closed_at_identity_fence() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed(_context: object, _payload: object) -> object:
+        started.set()
+        await release.wait()
+        return {"late": True}
+
+    service, token, identity = await _service_and_session(delayed)
+    task = asyncio.create_task(
+        service.dispatch(
+            DispatchEnvelope(identity, "demo:read", "echo", {}),
+            access_token=token,
+        )
+    )
+    await started.wait()
+    await service.close_session(identity=identity, access_token=token)
+    release.set()
+    with pytest.raises(LocalAppBridgeError) as stale:
+        await task
+    assert stale.value.code == "operation_outcome_unconfirmed"
+    assert "reconciliation" in stale.value.message
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_token_rotation_during_handler_requires_idempotent_reconciliation() -> (
+    None
+):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed(_context: object, _payload: object) -> object:
+        started.set()
+        await release.wait()
+        return {"possibly_committed": True}
+
+    service, token, identity = await _service_and_session(delayed)
+    task = asyncio.create_task(
+        service.dispatch(
+            DispatchEnvelope(
+                identity, "demo:read", "echo", {"request_id": "request-1"}
+            ),
+            access_token=token,
+        )
+    )
+    await started.wait()
+    await service.rotate(identity=identity, access_token=token)
+    release.set()
+    with pytest.raises(LocalAppBridgeError) as uncertain:
+        await task
+    assert uncertain.value.code == "operation_outcome_unconfirmed"
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_timeout_and_invalid_response_are_safe() -> None:
+    async def slow(_context: object, _payload: object) -> object:
+        await asyncio.sleep(1)
+        return {}
+
+    service, token, identity = await _service_and_session(slow)
+    with pytest.raises(LocalAppBridgeError) as timed_out:
+        await service.dispatch(
+            DispatchEnvelope(identity, "demo:read", "echo", {}),
+            access_token=token,
+        )
+    assert timed_out.value.code == "operation_outcome_unconfirmed"
+    await service.close()
+
+    async def invalid(_context: object, _payload: object) -> object:
+        return object()
+
+    service, token, identity = await _service_and_session(invalid)
+    with pytest.raises(LocalAppBridgeError) as invalid_response:
+        await service.dispatch(
+            DispatchEnvelope(identity, "demo:read", "echo", {}),
+            access_token=token,
+        )
+    assert invalid_response.value.code == "invalid_operation_response"
+    assert invalid_response.value.status_code == 502
+    await service.close()
+
+
+def test_dispatch_envelope_rejects_extra_fields_and_oversized_payload() -> None:
+    valid = {
+        "protocol_version": 1,
+        "app_id": "demo.app",
+        "client_id": "client-1",
+        "session_id": "session-1",
+        "scope": "demo:read",
+        "operation": "echo",
+        "payload": {},
+    }
+    with pytest.raises(LocalAppBridgeError) as extra:
+        DispatchEnvelope.from_mapping({**valid, "forged_identity": "yes"})
+    assert extra.value.code == "invalid_fields"
+    with pytest.raises(LocalAppBridgeError) as too_large:
+        DispatchEnvelope.from_mapping({**valid, "payload": {"data": "x" * (64 * 1024)}})
+    assert too_large.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_host_authority_is_bound_to_one_dispatcher_instance() -> None:
+    first = TrustedLocalAppDispatcher()
+    second = TrustedLocalAppDispatcher()
+    policy = LocalAppPolicy("demo.app", {"demo:read": frozenset({"echo"})})
+    second.register_app(policy)
+
+    async def echo(_context: object, payload: object) -> object:
+        return payload
+
+    second.register_operation(
+        app_id="demo.app", scope="demo:read", operation="echo", handler=echo
+    )
+    with pytest.raises(LocalAppBridgeError) as untrusted:
+        await second.dispatch(
+            authority=first._issue_authority(),
+            identity=SessionIdentity("demo.app", "client-1", "session-1"),
+            scope="demo:read",
+            operation="echo",
+            payload={},
+        )
+    assert untrusted.value.code == "untrusted_dispatch"
+
+
+@pytest.mark.asyncio
+async def test_rotation_during_rate_limit_wait_is_rechecked_before_handler() -> None:
+    limiter_started = asyncio.Event()
+    release_limiter = asyncio.Event()
+    handler_called = False
+
+    class _BlockingLimiter:
+        async def check_pair(self, **_kwargs: object) -> None:
+            return None
+
+        async def check_session(self, _session_id: str) -> None:
+            limiter_started.set()
+            await release_limiter.wait()
+
+        async def close(self) -> None:
+            return None
+
+    sessions = LocalAppSessionStore()
+    service = LocalAppBridgeService(
+        sessions=sessions,
+        rate_limiter=_BlockingLimiter(),  # type: ignore[arg-type]
+    )
+    service.register_app(LocalAppPolicy("demo.app", {"demo:read": frozenset({"echo"})}))
+
+    async def echo(_context: object, _payload: object) -> object:
+        nonlocal handler_called
+        handler_called = True
+        return {}
+
+    service.register_operation(
+        app_id="demo.app", scope="demo:read", operation="echo", handler=echo
+    )
+    material = await service.issue_launch_material(
+        bridge_origin="http://127.0.0.1:49123",
+        app_id="demo.app",
+        client_id="client-1",
+        requested_scopes=frozenset({"demo:read"}),
+    )
+    paired = await service.pair(
+        launch_code=material.launch_code,
+        app_id="demo.app",
+        client_id="client-1",
+    )
+    task = asyncio.create_task(
+        service.dispatch(
+            DispatchEnvelope(paired.identity, "demo:read", "echo", {}),
+            access_token=paired.access_token,
+        )
+    )
+    await limiter_started.wait()
+    await sessions.rotate_access_token(
+        identity=paired.identity,
+        access_token=paired.access_token,
+    )
+    release_limiter.set()
+    with pytest.raises(LocalAppBridgeError) as stale:
+        await task
+    assert stale.value.code == "session_changed"
+    assert handler_called is False
+    await service.close()
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.data = b""
+        self.closed = False
+
+    def write(self, value: bytes) -> None:
+        self.data += value
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_launch_material_uses_stdin_and_secret_is_not_repr_or_argv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    material = LaunchMaterial(
+        "http://127.0.0.1:49123", "demo.app", "client-1", "secret-code"
+    )
+    writer = _Writer()
+    assert "secret-code" not in repr(material)
+    await write_launch_material(writer, material)  # type: ignore[arg-type]
+    assert b"secret-code" in writer.data and writer.closed
+
+    @dataclass
+    class _Process:
+        stdin: _Writer
+        killed: bool = False
+
+        def kill(self) -> None:
+            self.killed = True
+
+        async def wait(self) -> int:
+            return 0
+
+    process = _Process(_Writer())
+    captured_args: tuple[object, ...] = ()
+
+    async def create(*args: object, **kwargs: object) -> _Process:
+        nonlocal captured_args
+        captured_args = args
+        assert kwargs["stdin"] is asyncio.subprocess.PIPE
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create)
+    returned = await launch_local_app("demo.exe", args=("--safe",), material=material)
+    assert returned is process
+    assert captured_args == ("demo.exe", "--safe")
+    assert all("secret-code" not in str(argument) for argument in captured_args)
+    assert b"secret-code" in process.stdin.data
+
+    with pytest.raises(ValueError):
+        await launch_local_app(
+            "demo.exe", args=("--code=secret-code",), material=material
+        )

--- a/plugin/tests/unit/server/test_local_app_bridge_sessions.py
+++ b/plugin/tests/unit/server/test_local_app_bridge_sessions.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from plugin.server.local_app_bridge.contracts import SessionIdentity
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+from plugin.server.local_app_bridge.sessions import LocalAppSessionStore
+
+pytestmark = pytest.mark.plugin_unit
+
+
+@dataclass
+class _Clock:
+    now: float = 10.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+async def _paired(clock: _Clock) -> tuple[LocalAppSessionStore, str, SessionIdentity]:
+    store = LocalAppSessionStore(clock=clock)
+    code = await store.issue_launch_code(
+        app_id="demo.app",
+        client_id="client-1",
+        scopes={"demo:read"},
+    )
+    result = await store.exchange_launch_code(
+        launch_code=code,
+        app_id="demo.app",
+        client_id="client-1",
+    )
+    return store, result.access_token, result.identity
+
+
+@pytest.mark.asyncio
+async def test_launch_code_is_single_use_and_bound_to_identity() -> None:
+    clock = _Clock()
+    store = LocalAppSessionStore(clock=clock)
+    code = await store.issue_launch_code(
+        app_id="demo.app",
+        client_id="client-1",
+        scopes={"demo:read"},
+    )
+    with pytest.raises(LocalAppBridgeError, match="permitted") as mismatch:
+        await store.exchange_launch_code(
+            launch_code=code,
+            app_id="demo.app",
+            client_id="forged-client",
+        )
+    assert mismatch.value.code == "launch_identity_mismatch"
+
+    paired = await store.exchange_launch_code(
+        launch_code=code,
+        app_id="demo.app",
+        client_id="client-1",
+    )
+    assert paired.granted_scopes == frozenset({"demo:read"})
+    with pytest.raises(LocalAppBridgeError) as replay:
+        await store.exchange_launch_code(
+            launch_code=code,
+            app_id="demo.app",
+            client_id="client-1",
+        )
+    assert replay.value.code == "launch_code_replayed"
+
+
+@pytest.mark.asyncio
+async def test_launch_code_expires_after_sixty_seconds() -> None:
+    clock = _Clock()
+    store = LocalAppSessionStore(clock=clock)
+    code = await store.issue_launch_code(
+        app_id="demo.app", client_id="client-1", scopes={"demo:read"}
+    )
+    clock.advance(60)
+    with pytest.raises(LocalAppBridgeError) as expired:
+        await store.exchange_launch_code(
+            launch_code=code, app_id="demo.app", client_id="client-1"
+        )
+    assert expired.value.code == "launch_code_expired"
+
+
+@pytest.mark.asyncio
+async def test_token_scope_and_all_identity_fields_are_verified() -> None:
+    clock = _Clock()
+    store, token, identity = await _paired(clock)
+    lease = await store.authorize(
+        identity=identity, scope="demo:read", access_token=token
+    )
+    await store.confirm_lease(lease)
+
+    with pytest.raises(LocalAppBridgeError) as wrong_token:
+        await store.authorize(
+            identity=identity, scope="demo:read", access_token="wrong"
+        )
+    assert wrong_token.value.code == "invalid_access_token"
+    with pytest.raises(LocalAppBridgeError) as wrong_scope:
+        await store.authorize(identity=identity, scope="demo:write", access_token=token)
+    assert wrong_scope.value.code == "scope_forbidden"
+    forged = SessionIdentity(
+        app_id=identity.app_id, client_id="other", session_id=identity.session_id
+    )
+    with pytest.raises(LocalAppBridgeError) as wrong_identity:
+        await store.authorize(identity=forged, scope="demo:read", access_token=token)
+    assert wrong_identity.value.code == "session_identity_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_access_token_rotates_and_invalidates_the_previous_generation() -> None:
+    clock = _Clock()
+    store, token, identity = await _paired(clock)
+    old_lease = await store.authorize(
+        identity=identity, scope="demo:read", access_token=token
+    )
+    clock.advance(899)
+    rotated = await store.rotate_access_token(identity=identity, access_token=token)
+    assert rotated.access_token != token
+    with pytest.raises(LocalAppBridgeError) as old_token:
+        await store.authorize(identity=identity, scope="demo:read", access_token=token)
+    assert old_token.value.code == "invalid_access_token"
+    with pytest.raises(LocalAppBridgeError) as stale_lease:
+        await store.confirm_lease(old_lease)
+    assert stale_lease.value.code == "session_changed"
+    await store.authorize(
+        identity=identity, scope="demo:read", access_token=rotated.access_token
+    )
+
+
+@pytest.mark.asyncio
+async def test_access_token_expires_at_fifteen_minutes() -> None:
+    clock = _Clock()
+    store, token, identity = await _paired(clock)
+    clock.advance(900)
+    with pytest.raises(LocalAppBridgeError) as expired:
+        await store.authorize(
+            identity=identity,
+            scope="demo:read",
+            access_token=token,
+        )
+    assert expired.value.code == "access_token_expired"
+
+
+@pytest.mark.asyncio
+async def test_token_idle_and_absolute_session_expiry_are_enforced() -> None:
+    idle_clock = _Clock()
+    idle_store, idle_token, idle_identity = await _paired(idle_clock)
+    idle_clock.advance(1800)
+    with pytest.raises(LocalAppBridgeError) as idle:
+        await idle_store.authorize(
+            identity=idle_identity, scope="demo:read", access_token=idle_token
+        )
+    assert idle.value.code == "session_idle_expired"
+
+    absolute_clock = _Clock()
+    absolute_store, current_token, absolute_identity = await _paired(absolute_clock)
+    for _ in range(35):
+        absolute_clock.advance(800)
+        rotated = await absolute_store.rotate_access_token(
+            identity=absolute_identity,
+            access_token=current_token,
+        )
+        current_token = rotated.access_token
+    absolute_clock.advance(800)
+    with pytest.raises(LocalAppBridgeError) as absolute:
+        await absolute_store.authorize(
+            identity=absolute_identity,
+            scope="demo:read",
+            access_token=current_token,
+        )
+    assert absolute.value.code == "session_absolute_expired"
+
+
+@pytest.mark.asyncio
+async def test_close_clears_all_credentials_and_is_idempotent() -> None:
+    clock = _Clock()
+    store, token, identity = await _paired(clock)
+    await store.close_session(identity=identity, access_token=token)
+    with pytest.raises(LocalAppBridgeError) as closed_session:
+        await store.authorize(identity=identity, scope="demo:read", access_token=token)
+    assert closed_session.value.code == "invalid_session"
+    await store.close()
+    await store.close()
+    with pytest.raises(LocalAppBridgeError) as closed_store:
+        await store.issue_launch_code(
+            app_id="demo.app", client_id="client-1", scopes={"demo:read"}
+        )
+    assert closed_store.value.code == "bridge_closed"
+
+
+@pytest.mark.asyncio
+async def test_session_capacity_rejects_without_consuming_launch_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.server.local_app_bridge import sessions as sessions_module
+
+    monkeypatch.setattr(sessions_module, "MAX_ACTIVE_SESSIONS", 2)
+    clock = _Clock()
+    store = LocalAppSessionStore(clock=clock)
+    active = []
+    for index in range(2):
+        code = await store.issue_launch_code(
+            app_id="demo.app",
+            client_id=f"client-{index}",
+            scopes={"demo:read"},
+        )
+        active.append(
+            await store.exchange_launch_code(
+                launch_code=code,
+                app_id="demo.app",
+                client_id=f"client-{index}",
+            )
+        )
+    waiting_code = await store.issue_launch_code(
+        app_id="demo.app", client_id="waiting", scopes={"demo:read"}
+    )
+    with pytest.raises(LocalAppBridgeError) as full:
+        await store.exchange_launch_code(
+            launch_code=waiting_code,
+            app_id="demo.app",
+            client_id="waiting",
+        )
+    assert full.value.code == "session_capacity_reached"
+    await store.close_session(
+        identity=active[0].identity,
+        access_token=active[0].access_token,
+    )
+    paired = await store.exchange_launch_code(
+        launch_code=waiting_code,
+        app_id="demo.app",
+        client_id="waiting",
+    )
+    assert paired.identity.client_id == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_pending_launch_capacity_is_bounded_and_expiry_frees_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.server.local_app_bridge import sessions as sessions_module
+
+    monkeypatch.setattr(sessions_module, "MAX_PENDING_LAUNCH_CODES", 2)
+    clock = _Clock()
+    store = LocalAppSessionStore(clock=clock)
+    await store.issue_launch_code(
+        app_id="demo.app", client_id="one", scopes={"demo:read"}
+    )
+    await store.issue_launch_code(
+        app_id="demo.app", client_id="two", scopes={"demo:read"}
+    )
+    with pytest.raises(LocalAppBridgeError) as full:
+        await store.issue_launch_code(
+            app_id="demo.app", client_id="three", scopes={"demo:read"}
+        )
+    assert full.value.code == "launch_capacity_reached"
+    clock.advance(60)
+    code = await store.issue_launch_code(
+        app_id="demo.app", client_id="three", scopes={"demo:read"}
+    )
+    assert code

--- a/plugin/tests/unit/server/test_plugin_query_status.py
+++ b/plugin/tests/unit/server/test_plugin_query_status.py
@@ -9,6 +9,7 @@ import pytest
 
 from plugin.server.application.plugins import query_service as query_module
 from plugin.server.application.plugins import router_query_service as router_module
+from plugin.server.local_app_bridge import runtime as local_app_runtime
 from plugin.server.domain.errors import ServerDomainError
 from plugin.sdk.shared.i18n import PluginI18n
 
@@ -132,6 +133,58 @@ def test_build_plugin_list_omits_internal_entries_preview(monkeypatch: pytest.Mo
     assert "entries_preview" in registry_meta
     assert "entries_preview" not in results[0]
     assert [entry["id"] for entry in results[0]["entries"]] == ["ping"]
+
+
+def test_build_plugin_list_exposes_only_safe_local_app_descriptor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        query_module.state,
+        "get_plugins_snapshot_cached",
+        lambda timeout=2.0: {
+            "study_companion": {
+                "id": "study_companion",
+                "name": "Study Companion",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        query_module.state,
+        "get_plugin_hosts_snapshot_cached",
+        lambda timeout=2.0: {},
+    )
+    monkeypatch.setattr(
+        query_module.state,
+        "get_event_handlers_snapshot_cached",
+        lambda timeout=2.0: {},
+    )
+
+    class _Runtime:
+        @staticmethod
+        def describe_plugin_app(plugin_id: str, *, fallback_title: str):
+            assert plugin_id == "study_companion"
+            assert fallback_title == "Study Companion"
+            return SimpleNamespace(
+                app_id="knowledge_dungeon",
+                title="Knowledge Dungeon",
+                available=False,
+                executable="must-not-leak",
+            )
+
+    monkeypatch.setattr(
+        local_app_runtime,
+        "get_local_app_bridge_runtime",
+        lambda: _Runtime(),
+    )
+
+    result = query_module._build_plugin_list_sync()[0]
+
+    assert result["local_app"] == {
+        "app_id": "knowledge_dungeon",
+        "title": "Knowledge Dungeon",
+        "available": False,
+    }
+    assert "must-not-leak" not in json.dumps(result)
 
 
 def test_resolve_plugin_display_fields_preserves_empty_description_without_translation() -> None:

--- a/plugin/tests/unit/server/test_plugin_routes.py
+++ b/plugin/tests/unit/server/test_plugin_routes.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from plugin.server.routes import plugins as module
 
@@ -28,3 +30,106 @@ async def test_start_plugin_endpoint_ensures_messaging_before_start(
 
     assert result == {"success": True, "plugin_id": "sample_plugin"}
     assert calls == ["ensure", "start:sample_plugin:True"]
+
+
+def _route_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(module.router)
+    return TestClient(app)
+
+
+def test_local_app_launch_route_accepts_only_app_id_from_trusted_ui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launched: list[str] = []
+
+    async def _launch(app_id: str):
+        launched.append(app_id)
+        return type("Result", (), {"app_id": app_id})()
+
+    monkeypatch.setattr(module, "AUTOSTART_CSRF_TOKEN", "test-csrf-token")
+    monkeypatch.setattr(module, "launch_registered_local_app", _launch)
+
+    with _route_client() as client:
+        token = client.get(
+            "/local-app/ui-token",
+            headers={"Origin": "http://testserver"},
+        )
+        response = client.post(
+            "/local-app/launch",
+            headers={
+                "Origin": "http://testserver",
+                "X-CSRF-Token": token.json()["token"],
+            },
+            json={"app_id": "knowledge_dungeon"},
+        )
+
+    assert token.status_code == 200
+    assert token.headers["Cache-Control"] == "no-store"
+    assert response.status_code == 200
+    assert response.json() == {"success": True, "app_id": "knowledge_dungeon"}
+    assert launched == ["knowledge_dungeon"]
+
+
+def test_local_app_launch_route_rejects_origin_csrf_and_extra_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _must_not_launch(_app_id: str):
+        raise AssertionError("rejected request must not launch")
+
+    monkeypatch.setattr(module, "AUTOSTART_CSRF_TOKEN", "test-csrf-token")
+    monkeypatch.setattr(module, "launch_registered_local_app", _must_not_launch)
+
+    with _route_client() as client:
+        missing_origin = client.post(
+            "/local-app/launch",
+            headers={"X-CSRF-Token": "test-csrf-token"},
+            json={"app_id": "knowledge_dungeon"},
+        )
+        bad_csrf = client.post(
+            "/local-app/launch",
+            headers={
+                "Origin": "http://testserver",
+                "X-CSRF-Token": "wrong",
+            },
+            json={"app_id": "knowledge_dungeon"},
+        )
+        extra_field = client.post(
+            "/local-app/launch",
+            headers={
+                "Origin": "http://testserver",
+                "X-CSRF-Token": "test-csrf-token",
+            },
+            json={
+                "app_id": "knowledge_dungeon",
+                "executable": "C:/attacker.exe",
+            },
+        )
+
+    assert missing_origin.status_code == 403
+    assert bad_csrf.status_code == 403
+    assert extra_field.status_code == 422
+
+
+def test_local_app_launch_route_returns_safe_unavailable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unavailable(_app_id: str):
+        raise OSError("C:/Users/private/secret-path/app.exe")
+
+    monkeypatch.setattr(module, "AUTOSTART_CSRF_TOKEN", "test-csrf-token")
+    monkeypatch.setattr(module, "launch_registered_local_app", _unavailable)
+
+    with _route_client() as client:
+        response = client.post(
+            "/local-app/launch",
+            headers={
+                "Origin": "http://testserver",
+                "X-CSRF-Token": "test-csrf-token",
+            },
+            json={"app_id": "knowledge_dungeon"},
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": {"code": "local_app_unavailable"}}
+    assert "secret-path" not in response.text

--- a/plugin/tests/unit/server/test_server_lifecycle.py
+++ b/plugin/tests/unit/server/test_server_lifecycle.py
@@ -103,6 +103,31 @@ async def test_startup_reconciles_existing_install_source_after_migration_before
         monkeypatch.setattr(module.metrics_collector, "start", _noop_async)
         monkeypatch.setattr(module, "start_bridge", lambda: None)
         monkeypatch.setattr(module, "start_proactive_bridge", lambda: None)
+        async def _start_local_app_bridge() -> str:
+            calls.append(("local_app_bridge", "start"))
+            return "http://127.0.0.1:49123"
+
+        async def _configure_local_app_bridge():
+            calls.append(("local_app_bridge", "configure"))
+            return ()
+
+        async def _configure_local_app_installations():
+            calls.append(("local_app_installations", "configure"))
+            return ()
+
+        monkeypatch.setattr(
+            module, "start_local_app_bridge", _start_local_app_bridge
+        )
+        monkeypatch.setattr(
+            module,
+            "configure_local_app_bridge_from_registry",
+            _configure_local_app_bridge,
+        )
+        monkeypatch.setattr(
+            module,
+            "configure_local_app_installations_from_host",
+            _configure_local_app_installations,
+        )
 
         async def _migrate_layout():
             calls.append(("layout", "migrate"))
@@ -181,6 +206,9 @@ async def test_startup_reconciles_existing_install_source_after_migration_before
             ("profile_cleanup", "retry"),
             ("registry", "refresh"),
             ("start", "auto_plugin:False"),
+            ("local_app_bridge", "configure"),
+            ("local_app_installations", "configure"),
+            ("local_app_bridge", "start"),
         ]
     finally:
         with module.state.acquire_plugins_write_lock():

--- a/plugin/tests/unit/server/test_trusted_local_app_plugin_dispatch.py
+++ b/plugin/tests/unit/server/test_trusted_local_app_plugin_dispatch.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+from plugin.server.application.plugins import trusted_local_app_dispatch as module
+from plugin.server.local_app_bridge.errors import LocalAppBridgeError
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+class _Health:
+    alive = True
+
+
+class _Host:
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+        self.calls: list[dict[str, object]] = []
+
+    def health_check(self) -> _Health:
+        return _Health()
+
+    async def trigger_trusted_local_app(self, **kwargs: object) -> object:
+        self.calls.append(dict(kwargs))
+        return {"host": self.marker}
+
+
+@pytest.mark.asyncio
+async def test_each_invocation_resolves_latest_host_after_plugin_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _Host("first")
+    second = _Host("second")
+    snapshots = iter(({"plugin": first}, {"plugin": second}))
+    monkeypatch.setattr(
+        module.state,
+        "get_plugin_hosts_snapshot_cached",
+        lambda timeout: next(snapshots),
+    )
+    dispatch = module.TrustedLocalAppPluginDispatch()
+    kwargs = {
+        "plugin_id": "plugin",
+        "plugin_operation": "operation",
+        "context": {
+            "app_id": "app",
+            "client_id": "client",
+            "session_id": "session",
+            "scope": "scope",
+            "operation": "external-operation",
+        },
+        "payload": {"request_id": "request-1"},
+        "timeout": 2.0,
+    }
+    assert await dispatch.invoke(**kwargs) == {"host": "first"}
+    assert await dispatch.invoke(**kwargs) == {"host": "second"}
+    assert len(first.calls) == len(second.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_plugin_timeout_is_reported_as_unconfirmed_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _TimeoutHost(_Host):
+        async def trigger_trusted_local_app(self, **kwargs: object) -> object:
+            raise TimeoutError
+
+    monkeypatch.setattr(
+        module.state,
+        "get_plugin_hosts_snapshot_cached",
+        lambda timeout: {"plugin": _TimeoutHost("timeout")},
+    )
+    with pytest.raises(LocalAppBridgeError) as uncertain:
+        await module.TrustedLocalAppPluginDispatch().invoke(
+            plugin_id="plugin",
+            plugin_operation="operation",
+            context={
+                "app_id": "app",
+                "client_id": "client",
+                "session_id": "session",
+                "scope": "scope",
+                "operation": "external-operation",
+            },
+            payload={"request_id": "request-1"},
+            timeout=2.0,
+        )
+    assert uncertain.value.code == "operation_outcome_unconfirmed"

--- a/tests/fixtures/plugin_test_trusted_local_app_fixture.py
+++ b/tests/fixtures/plugin_test_trusted_local_app_fixture.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from plugin.sdk.local_app import (
+    TrustedLocalAppPluginContext,
+    trusted_local_app_operation,
+)
+from plugin.sdk.plugin import NekoPluginBase, custom_event
+
+
+class TrustedLocalAppFixturePlugin(NekoPluginBase):
+    @trusted_local_app_operation("knowledge_dungeon.bootstrap")
+    async def bootstrap(
+        self,
+        context: TrustedLocalAppPluginContext,
+        payload: Mapping[str, object],
+    ) -> dict[str, object]:
+        return {
+            "context": {
+                "app_id": context.app_id,
+                "client_id": context.client_id,
+                "session_id": context.session_id,
+                "scope": context.scope,
+                "operation": context.operation,
+            },
+            "payload": dict(payload),
+        }
+
+    @custom_event(event_type="fixture", id="stacked_trusted")
+    @trusted_local_app_operation("private.stacked")
+    async def stacked_trusted(
+        self,
+        context: TrustedLocalAppPluginContext,
+        payload: Mapping[str, object],
+    ) -> dict[str, object]:
+        return {"context": context.operation, "payload": dict(payload)}


### PR DESCRIPTION
## 概要

- 增加仅监听 127.0.0.1 随机端口的通用 Local App Bridge
- 增加一次性启动码、短期轮换 token、session 身份绑定、限流与严格 HTTP/JSON
- 增加独立 TRUSTED_LOCAL_APP_INVOKE IPC，隔离普通 TRIGGER/custom event
- 从插件 manifest 声明 app_id/scope/operation 映射
- 通过宿主私有安装表启动 Electron，路径与参数不接受插件或 Renderer 输入
- 插件管理页增加安全启动动作

## 安全边界

- 启动材料只通过子进程 stdin 传递
- 前端只提交 app_id
- client_id 按 app 使用 HMAC 派生，避免跨应用关联
- 错误 scope、身份、token、重放启动码及额外 JSON 字段均 fail closed
- N.E.K.O core 不包含知识副本业务规则

## 验证

- Local App、PluginHost、路由和生命周期定向测试：77 passed
- 定向覆盖率：85.88%
- Ruff、compileall、异步阻塞、模块分层与 diff 检查：通过
- GitNexus：LOW risk，0 affected processes
- 未运行全量测试
- 插件管理前端 Vitest 因隔离 worktree 依赖不完整未执行

配套插件 PR：https://github.com/MomiJiSan/n.e.k.o_plugin_study_companion/pull/92
配套客户端 PR：https://github.com/MomiJiSan/N.E.K.O-Knowledge-Dungeon/pull/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持从插件列表查看并启动已配置的本地应用。
  * 新增安全的本地应用桥接能力，支持配对、会话管理、权限控制、令牌轮换和可信操作调用。
  * 支持通过配置文件注册本地主机应用，并通过标准输入安全传递启动材料。
  * 增加请求校验、访问控制、速率限制及错误处理机制。

* **文档**
  * 新增本地应用安装与注册配置说明。

* **测试**
  * 新增覆盖启动、配对、会话、权限、安全校验及生命周期管理的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->