### PR TITLE
为状态 Toast 增加精确鼠标命中检测，避免全屏透明窗口阻挡桌面点

### DIFF
--- a/templates/toast.html
+++ b/templates/toast.html
@@ -565,17 +565,6 @@
             drainPnQueue();
         }
 
-        document.addEventListener('visibilitychange', function() {
-            if (document.hidden) stopStatusPointerTracking(false);
-            else if (isStatusToastVisible() && !prominentNoticeInteractive) startStatusPointerTracking();
-        });
-
-        window.addEventListener('beforeunload', function() {
-            prominentNoticeInteractive = false;
-            stopStatusPointerTracking(true);
-            setToastMouseThrough(true, true);
-        });
-
         // ===== IPC 监听（Electron 环境下由 preload-toast.js 注入 API）=====
         if (api) {
             // status toast / voice preparing：文本由调用方传入，不依赖 i18n
@@ -596,6 +585,17 @@
                 whenI18nReady(function() { showProminentNotice(data); });
             });
         }
+
+        document.addEventListener('visibilitychange', function() {
+            if (document.hidden) stopStatusPointerTracking(false);
+            else if (isStatusToastVisible() && !prominentNoticeInteractive) startStatusPointerTracking();
+        });
+
+        window.addEventListener('beforeunload', function() {
+            prominentNoticeInteractive = false;
+            stopStatusPointerTracking(true);
+            setToastMouseThrough(true, true);
+        });
 
         console.log('[Toast] 页面初始化完成');
     })();

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -65,9 +65,102 @@
         var statusToast = document.getElementById('status-toast');
         var statusTimeout = null;
         var cleanupTimer = null;
+        var prominentNoticeInteractive = false;
+        var toastMouseThroughState = null;
+        var statusPointerPollTimer = null;
+        var statusPointerPollGeneration = 0;
+        var STATUS_POINTER_POLL_MS = 50;
+
+        function setToastMouseThrough(ignore, force) {
+            if (!api || typeof api.setMouseThrough !== 'function') return;
+            ignore = !!ignore;
+            if (!force && toastMouseThroughState === ignore) return;
+            toastMouseThroughState = ignore;
+            api.setMouseThrough(ignore);
+        }
+
+        function isStatusToastVisible() {
+            return !!statusToast
+                && statusToast.classList.contains('show')
+                && !statusToast.classList.contains('hide')
+                && !document.hidden;
+        }
+
+        function isCursorInsideStatusToast(point) {
+            if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) return false;
+            var rect = statusToast.getBoundingClientRect();
+            if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+            return point.x >= rect.left && point.x < rect.right
+                && point.y >= rect.top && point.y < rect.bottom;
+        }
+
+        function stopStatusPointerTracking(keepCurrentMouseState) {
+            statusPointerPollGeneration += 1;
+            if (statusPointerPollTimer) {
+                clearTimeout(statusPointerPollTimer);
+                statusPointerPollTimer = null;
+            }
+            if (!keepCurrentMouseState && !prominentNoticeInteractive) {
+                setToastMouseThrough(true);
+            }
+        }
+
+        function pollStatusPointer(generation) {
+            if (generation !== statusPointerPollGeneration) return;
+            if (prominentNoticeInteractive || !isStatusToastVisible()) {
+                stopStatusPointerTracking(prominentNoticeInteractive);
+                return;
+            }
+
+            var cursorPointPromise;
+            try {
+                cursorPointPromise = api.getCursorPoint();
+            } catch (_) {
+                stopStatusPointerTracking(false);
+                return;
+            }
+
+            Promise.resolve(cursorPointPromise).then(function(point) {
+                if (generation !== statusPointerPollGeneration
+                    || prominentNoticeInteractive
+                    || !isStatusToastVisible()) return;
+                setToastMouseThrough(!isCursorInsideStatusToast(point));
+            }).catch(function() {
+                // 光标 IPC 异常时立即回到穿透态，不能让透明全屏窗口留在桌面上拦截输入。
+                if (generation === statusPointerPollGeneration) {
+                    stopStatusPointerTracking(false);
+                }
+            }).then(function() {
+                if (generation !== statusPointerPollGeneration
+                    || prominentNoticeInteractive
+                    || !isStatusToastVisible()) return;
+                statusPointerPollTimer = setTimeout(function() {
+                    statusPointerPollTimer = null;
+                    pollStatusPointer(generation);
+                }, STATUS_POINTER_POLL_MS);
+            });
+        }
+
+        function startStatusPointerTracking() {
+            stopStatusPointerTracking(true);
+            if (prominentNoticeInteractive) return;
+
+            // 旧版 Electron preload、普通网页环境和 Niri 小窗均安全降级为全程穿透。
+            if (!api
+                || api.supportsStatusPointerTracking === false
+                || typeof api.getCursorPoint !== 'function') {
+                setToastMouseThrough(true);
+                return;
+            }
+
+            setToastMouseThrough(true);
+            var generation = statusPointerPollGeneration;
+            pollStatusPointer(generation);
+        }
 
         var toastRemaining = 3000; var toastStart = 0; var showTimer = null;
         function hideStatusNow() {
+            stopStatusPointerTracking(false);
             if (showTimer) { clearTimeout(showTimer); showTimer = null; }
             if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
             if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
@@ -79,7 +172,7 @@
             if (_cb) { _cb.disabled = true; _cb.tabIndex = -1; _cb.setAttribute('aria-hidden','true'); if (document.activeElement === _cb) _cb.blur(); }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
-            cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; if (api && api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) api.setMouseThrough(true); }, 400);
+            cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 400);
         }
         function scheduleHide(ms) {
             if (statusTimeout) clearTimeout(statusTimeout);
@@ -89,6 +182,7 @@
         function showStatusToast(message, duration) {
             if (duration == null) duration = 3000;
             if (!message || !message.trim()) {
+                stopStatusPointerTracking(false);
                 if (showTimer) { clearTimeout(showTimer); showTimer=null; }
                 if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
                 if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
@@ -99,7 +193,7 @@
                 var _cb2=statusToast.querySelector('#status-toast-close'); if(_cb2){ _cb2.disabled=true; _cb2.tabIndex=-1; _cb2.setAttribute('aria-hidden','true'); if(document.activeElement===_cb2) _cb2.blur(); }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
-                cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; if (api && api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) api.setMouseThrough(true); }, 400);
+                cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 400);
                 toastRemaining=null; toastStart=null;
                 return;
             }
@@ -128,12 +222,15 @@
             }
             closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
             closeBtn.onclick = function(e){ e.stopPropagation(); hideStatusNow(); };
-            if (api && api.setMouseThrough) api.setMouseThrough(false);
             statusToast.style.display = 'block';
             statusToast.style.visibility = 'visible';
             statusToast.style.paddingRight = '36px';
             statusToast.classList.remove('hide');
-            showTimer = setTimeout(function() { statusToast.classList.add('show'); showTimer=null; }, 10);
+            showTimer = setTimeout(function() {
+                statusToast.classList.add('show');
+                showTimer=null;
+                startStatusPointerTracking();
+            }, 10);
             if (statusToast._enter) statusToast.removeEventListener('mouseenter', statusToast._enter);
             if (statusToast._leave) statusToast.removeEventListener('mouseleave', statusToast._leave);
             if (statusToast._focusIn) statusToast.removeEventListener('focusin', statusToast._focusIn);
@@ -356,7 +453,9 @@
             var displayText = notice.message || notice.message_en || '';
 
             // 通知主进程：取消鼠标穿透（需要点击确认按钮）
-            if (api) api.setMouseThrough(false);
+            prominentNoticeInteractive = true;
+            stopStatusPointerTracking(true);
+            setToastMouseThrough(false);
 
             var overlay = document.createElement('div');
             overlay.id = 'prominent-notice-overlay';
@@ -442,9 +541,14 @@
                 overlay.style.animation = 'pnOverlayOut 0.2s ease forwards';
                 setTimeout(function() {
                     overlay.remove();
-                    // 恢复鼠标穿透：仅当 #status-toast 不再展示时才恢复
-                    if (api && !document.getElementById('status-toast').classList.contains('show')) api.setMouseThrough(true);
+                    prominentNoticeInteractive = false;
                     onDismiss();
+                    // onDismiss 会同步拉起队列中的下一个重要通知；只有队列真的结束后，
+                    // 才恢复普通状态提示的矩形命中或整窗穿透。
+                    if (!prominentNoticeInteractive) {
+                        if (isStatusToastVisible()) startStatusPointerTracking();
+                        else setToastMouseThrough(true);
+                    }
                 }, 200);
             }
             btn.addEventListener('click', dismiss);
@@ -460,6 +564,17 @@
             pnQueue.push({ notice: notice, dedupeKey: dedupeKey });
             drainPnQueue();
         }
+
+        document.addEventListener('visibilitychange', function() {
+            if (document.hidden) stopStatusPointerTracking(false);
+            else if (isStatusToastVisible() && !prominentNoticeInteractive) startStatusPointerTracking();
+        });
+
+        window.addEventListener('beforeunload', function() {
+            prominentNoticeInteractive = false;
+            stopStatusPointerTracking(true);
+            setToastMouseThrough(true, true);
+        });
 
         // ===== IPC 监听（Electron 环境下由 preload-toast.js 注入 API）=====
         if (api) {

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -1,0 +1,272 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const templatePath = path.resolve(__dirname, '../../templates/toast.html');
+const html = fs.readFileSync(templatePath, 'utf8');
+const inlineScript = Array.from(html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g))
+  .map((match) => match[1])
+  .find((source) => source.includes('// ===== Toast API'));
+
+function createClassList() {
+  const names = new Set();
+  return {
+    add(...values) { values.forEach((value) => names.add(value)); },
+    remove(...values) { values.forEach((value) => names.delete(value)); },
+    contains(value) { return names.has(value); },
+  };
+}
+
+function createElement(tagName = 'div') {
+  const listeners = new Map();
+  const attributes = new Map();
+  const element = {
+    id: '',
+    tagName: tagName.toUpperCase(),
+    nodeType: 1,
+    parentNode: null,
+    childNodes: [],
+    classList: createClassList(),
+    style: { cssText: '' },
+    textContent: '',
+    innerHTML: '',
+    disabled: false,
+    tabIndex: 0,
+    appendChild(child) {
+      child.parentNode = this;
+      this.childNodes.push(child);
+      return child;
+    },
+    remove() {
+      if (!this.parentNode) return;
+      this.parentNode.childNodes = this.parentNode.childNodes.filter((child) => child !== this);
+      this.parentNode = null;
+    },
+    querySelector(selector) {
+      if (!selector.startsWith('#')) return null;
+      return findElement(this, (child) => child.id === selector.slice(1));
+    },
+    setAttribute(name, value) { attributes.set(name, String(value)); },
+    removeAttribute(name) { attributes.delete(name); },
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) listeners.delete(type);
+    },
+    dispatch(type, event = {}) {
+      const listener = listeners.get(type);
+      if (listener) listener(event);
+    },
+    matches() { return false; },
+    focus() { document.activeElement = this; },
+    blur() { if (document.activeElement === this) document.activeElement = null; },
+    getBoundingClientRect() {
+      return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    },
+    _attributes: attributes,
+  };
+  return element;
+}
+
+function findElement(root, predicate) {
+  for (const child of root.childNodes) {
+    if (predicate(child)) return child;
+    const nested = findElement(child, predicate);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+let document = null;
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createHarness() {
+  const callbacks = {};
+  const mouseThrough = [];
+  const timers = new Map();
+  const windowListeners = new Map();
+  const documentListeners = new Map();
+  let nextTimerId = 0;
+  let cursorPoint = { x: 20, y: 20 };
+  let cursorProvider = () => Promise.resolve(cursorPoint);
+
+  const body = createElement('body');
+  const head = createElement('head');
+  const statusToast = createElement('div');
+  statusToast.id = 'status-toast';
+  statusToast.getBoundingClientRect = () => ({
+    left: 100,
+    top: 40,
+    right: 300,
+    bottom: 100,
+    width: 200,
+    height: 60,
+  });
+  body.appendChild(statusToast);
+
+  document = {
+    body,
+    head,
+    hidden: false,
+    activeElement: null,
+    createElement,
+    getElementById(id) {
+      if (statusToast.id === id) return statusToast;
+      return findElement(body, (element) => element.id === id)
+        || findElement(head, (element) => element.id === id);
+    },
+    querySelector(selector) {
+      if (selector === 'style[data-toast-close]') {
+        return findElement(head, (element) => (
+          element.tagName === 'STYLE' && element._attributes.has('data-toast-close')
+        ));
+      }
+      return null;
+    },
+    addEventListener(type, listener) { documentListeners.set(type, listener); },
+  };
+
+  const api = {
+    supportsStatusPointerTracking: true,
+    getCursorPoint() { return cursorProvider(); },
+    setMouseThrough(ignore) { mouseThrough.push(ignore); },
+    onShowStatusToast(callback) { callbacks.status = callback; },
+    onShowVoicePreparing(callback) { callbacks.voicePreparing = callback; },
+    onHideVoicePreparing(callback) { callbacks.voiceHide = callback; },
+    onShowReadyToSpeak(callback) { callbacks.voiceReady = callback; },
+    onShowProminentNotice(callback) { callbacks.prominent = callback; },
+  };
+  const window = {
+    nekoToastAPI: api,
+    t(_key, options) { return options.defaultValue; },
+    addEventListener(type, listener) { windowListeners.set(type, listener); },
+    removeEventListener() {},
+  };
+
+  vm.runInNewContext(inlineScript, {
+    window,
+    document,
+    console: { log() {} },
+    Promise,
+    Date,
+    Number,
+    Array,
+    Object,
+    String,
+    JSON,
+    Math,
+    setTimeout(callback, delay) {
+      nextTimerId += 1;
+      timers.set(nextTimerId, { callback, delay });
+      return nextTimerId;
+    },
+    clearTimeout(id) { timers.delete(id); },
+  }, { filename: templatePath });
+
+  return {
+    statusToast,
+    mouseThrough,
+    setCursor(point) { cursorPoint = point; },
+    setCursorProvider(provider) { cursorProvider = provider; },
+    emitStatus(message = 'saved') { callbacks.status({ message, duration: 3000 }); },
+    emitProminent(message = 'important') { callbacks.prominent({ message }); },
+    runTimer(delay) {
+      const match = Array.from(timers.entries()).find(([, timer]) => timer.delay === delay);
+      assert.ok(match, `expected a pending ${delay}ms timer`);
+      timers.delete(match[0]);
+      match[1].callback();
+    },
+    hasTimer(delay) {
+      return Array.from(timers.values()).some((timer) => timer.delay === delay);
+    },
+    getProminentButton() {
+      const overlay = document.getElementById('prominent-notice-overlay');
+      assert.ok(overlay);
+      return findElement(overlay, (element) => element.tagName === 'BUTTON');
+    },
+    dispatchBeforeUnload() { windowListeners.get('beforeunload')(); },
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test('ordinary status toast only captures input while the cursor is inside its rectangle', async () => {
+  const harness = createHarness();
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true]);
+
+  harness.setCursor({ x: 150, y: 60 });
+  harness.runTimer(50);
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true, false]);
+
+  harness.setCursor({ x: 20, y: 20 });
+  harness.runTimer(50);
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true, false, true]);
+
+  harness.setCursor({ x: 150, y: 60 });
+  harness.runTimer(50);
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true, false, true, false]);
+
+  const closeButton = harness.statusToast.querySelector('#status-toast-close');
+  closeButton.onclick({ stopPropagation() {} });
+  assert.deepEqual(harness.mouseThrough, [true, false, true, false, true]);
+  assert.equal(harness.hasTimer(50), false);
+});
+
+test('stale cursor results cannot make a prominent notice mouse-through', async () => {
+  const harness = createHarness();
+  const pendingCursor = createDeferred();
+  harness.setCursorProvider(() => pendingCursor.promise);
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  assert.deepEqual(harness.mouseThrough, [true]);
+
+  harness.emitProminent('first');
+  harness.emitProminent('second');
+  assert.deepEqual(harness.mouseThrough, [true, false]);
+
+  pendingCursor.resolve({ x: 20, y: 20 });
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true, false]);
+  assert.equal(harness.hasTimer(50), false);
+
+  harness.getProminentButton().dispatch('click');
+  harness.runTimer(200);
+  assert.deepEqual(harness.mouseThrough, [true, false]);
+
+  harness.getProminentButton().dispatch('click');
+  harness.runTimer(200);
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true, false, true]);
+});
+
+test('page teardown force-restores desktop passthrough', () => {
+  const harness = createHarness();
+
+  harness.emitProminent();
+  assert.deepEqual(harness.mouseThrough, [false]);
+  harness.dispatchBeforeUnload();
+  assert.deepEqual(harness.mouseThrough, [false, true]);
+});

--- a/tests/unit/test_toast_pointer_passthrough.py
+++ b/tests/unit/test_toast_pointer_passthrough.py
@@ -1,0 +1,53 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOAST_TEMPLATE = PROJECT_ROOT / "templates" / "toast.html"
+BEHAVIOR_TEST = (
+    PROJECT_ROOT / "tests" / "frontend" / "toast_pointer_passthrough.test.cjs"
+)
+
+
+def test_status_toast_uses_precise_pointer_tracking_instead_of_fullscreen_capture():
+    source = TOAST_TEMPLATE.read_text(encoding="utf-8")
+    status_section = source.split("// ===== Status Toast =====", 1)[1].split(
+        "// ===== Voice Preparing Toast =====", 1
+    )[0]
+
+    assert "getBoundingClientRect()" in status_section
+    assert "api.getCursorPoint()" in status_section
+    assert "setToastMouseThrough(!isCursorInsideStatusToast(point));" in status_section
+    assert "if (api && api.setMouseThrough) api.setMouseThrough(false);" not in status_section
+    assert "stopStatusPointerTracking(false);" in status_section
+
+
+def test_prominent_notice_owns_mouse_state_across_async_status_results():
+    source = TOAST_TEMPLATE.read_text(encoding="utf-8")
+    prominent_section = source.split("// ===== Prominent Notice =====", 1)[1].split(
+        "// ===== IPC 监听", 1
+    )[0]
+
+    assert "prominentNoticeInteractive = true;" in prominent_section
+    assert "stopStatusPointerTracking(true);" in prominent_section
+    assert "setToastMouseThrough(false);" in prominent_section
+    assert "onDismiss();" in prominent_section
+    assert "if (!prominentNoticeInteractive)" in prominent_section
+
+
+def test_toast_pointer_passthrough_behavior():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for Toast pointer passthrough tests")
+
+    run_node_script(
+        node,
+        "require(" + repr(str(BEHAVIOR_TEST)) + ");",
+        check=True,
+        cwd=PROJECT_ROOT,
+        timeout=15,
+    )


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

为状态 Toast 增加精确鼠标命中检测，避免全屏透明窗口阻挡桌面点
[为 Toast 页面提供全局光标坐标桥接，支持提示区域内动态启用鼠标交互](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/471)

## 测试 / Testing

确认出现弹窗时不会导致穿透出现问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化状态提示的鼠标交互：光标位于提示区域内时可正常操作，移出后恢复鼠标穿透。
  - 改善重要通知与状态提示同时出现或异步更新时的交互状态，避免鼠标状态异常。
  - 页面隐藏或关闭时会自动恢复鼠标穿透，减少提示残留对桌面操作的影响。

- **Tests**
  - 增加对提示区域鼠标穿透、重要通知交互及页面卸载场景的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->