### PR TITLE
fix(plugin): 修复入口设置丢失导致的误调用和结果丢失

### DIFF
--- a/plugin/_types/entry_metadata.py
+++ b/plugin/_types/entry_metadata.py
@@ -1,0 +1,43 @@
+"""Transportable entry controls shared by config registration and metadata IPC.
+
+Source selection/precedence belongs to the caller. Only present fields are
+selected: an explicit false, null, empty list or empty mapping is not a fallback.
+Python validation models and callables stay in the plugin process.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+ENTRY_CONTRACT_FIELDS = (
+    "kind",
+    "auto_start",
+    "enabled",
+    "dynamic",
+    "persist",
+    "model_validate",
+    "timeout",
+    "llm_result_fields",
+    "llm_result_schema",
+    "return_message",
+    "metadata",
+    "extra",
+    "quick_action",
+    "quick_action_config",
+)
+
+
+def entry_contract_fields(source: object) -> dict[str, object]:
+    """Select controls; callers copy or JSON-normalize values at their boundary."""
+    missing = object()
+    fields: dict[str, object] = {}
+    for name in ENTRY_CONTRACT_FIELDS:
+        value = (
+            source.get(name, missing)
+            if isinstance(source, Mapping)
+            else getattr(source, name, missing)
+        )
+        if value is not missing:
+            fields[name] = value
+    return fields

--- a/plugin/core/communication.py
+++ b/plugin/core/communication.py
@@ -26,6 +26,7 @@ from plugin.settings import (
     PLUGIN_MESSAGE_FORWARD_LOG_DEDUP_WINDOW_SECONDS,
 )
 from plugin._types.exceptions import PluginExecutionError
+from plugin._types.entry_metadata import entry_contract_fields
 from plugin.logging_config import format_log_text as _format_log_text
 from plugin.core.zmq_transport import (
     HostTransport, CH_RES, CH_STS, CH_MSG, CH_MSG_BATCH, CH_COMM,
@@ -886,6 +887,13 @@ class PluginCommunicationResourceManager:
                     dynamic=True,
                     metadata=ipc_metadata,
                 )
+                # 动态入口和静态入口走同一份契约。只抄显示字段的话，/plugins 对
+                # 运行时注册的入口报 timeout=null、没有结果 schema，Agent 按默认预算
+                # 掐掉长任务。metadata 已在上面合成，dynamic 固定为真，这两个不覆盖。
+                for field_name, value in entry_contract_fields(meta_dict).items():
+                    if field_name in ("metadata", "dynamic"):
+                        continue
+                    setattr(event_meta, field_name, value)
                 handler = EventHandler(meta=event_meta, handler=lambda *args, **kwargs: None)
                 state.register_event_handler(plugin_id, handler)
                 self.logger.info("Dynamic entry registered: {} for plugin {}", entry_id, plugin_id)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from copy import deepcopy
 from datetime import datetime, timezone
 import hashlib
 import inspect
@@ -37,6 +38,7 @@ except ImportError:  # pragma: no cover
     import tomli as tomllib  # type: ignore[no-redef]
 
 from plugin._types.events import EventHandler, EventMeta, EVENT_META_ATTR
+from plugin._types.entry_metadata import entry_contract_fields
 from plugin._types.version import SDK_VERSION
 from plugin.server.infrastructure.config_resolver import resolve_plugin_config_from_path
 from plugin.server.infrastructure.runtime_overrides import (
@@ -537,9 +539,6 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
             handlers_updated = True
             if etype == "plugin_entry":
                 plugin_entry_method_map[(pid, str(eid))] = name
-    if handlers_updated:
-        state.invalidate_snapshot_cache("handlers")
-
     entries = _effective_entries(conf, pdata)
     for ent in entries:
         try:
@@ -563,13 +562,19 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
                 description=ent.get("description", "") if isinstance(ent, dict) else "",
                 input_schema=ent.get("input_schema", {}) if isinstance(ent, dict) else {},
             )
+            # The configured declaration still wins; retain all of its controls.
+            for field_name, value in entry_contract_fields(ent if isinstance(ent, dict) else {}).items():
+                setattr(entry_meta, field_name, deepcopy(value))
             eh = EventHandler(meta=entry_meta, handler=handler_fn)
             with state.acquire_event_handlers_write_lock():
                 state.event_handlers[f"{pid}.{eid}"] = eh
                 state.event_handlers[f"{pid}:plugin_entry:{eid}"] = eh
+            handlers_updated = True
         except (AttributeError, KeyError, TypeError) as e:
             logger.warning("Error parsing entry {} for plugin {}: {}", ent, pid, e, exc_info=True)
             # 继续处理其他条目，不中断整个插件加载
+    if handlers_updated:
+        state.invalidate_snapshot_cache("handlers")
 
 
 def _remove_scanned_metadata(pid: str) -> None:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -521,6 +521,7 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
     """
     # 使用模块级 logger
     handlers_updated = False
+    decorated_entries: dict[str, EventHandler] = {}
     for name, member in inspect.getmembers(cls):
         event_meta = getattr(member, EVENT_META_ATTR, None)
         if event_meta is None and hasattr(member, "__wrapped__"):
@@ -538,6 +539,7 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
                     state.event_handlers[f"{pid}:{etype}:{eid}"] = handler_obj
             handlers_updated = True
             if etype == "plugin_entry":
+                decorated_entries[str(eid)] = handler_obj
                 plugin_entry_method_map[(pid, str(eid))] = name
     entries = _effective_entries(conf, pdata)
     for ent in entries:
@@ -545,8 +547,9 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
             eid = ent.get("id") if isinstance(ent, dict) else str(ent)
             if not eid:
                 continue
+            decorated = decorated_entries.get(str(eid))
             try:
-                handler_fn = getattr(cls, eid)
+                handler_fn = decorated.handler if decorated is not None else getattr(cls, eid)
             except AttributeError:
                 logger.warning(
                     "Entry id {} for plugin {} has no handler on class {}, skipping",
@@ -555,15 +558,19 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
                     cls.__name__,
                 )
                 continue
+            declaration = ent if isinstance(ent, dict) else {}
+            base_meta = decorated.meta if decorated is not None else None
             entry_meta = EventMeta(
                 event_type="plugin_entry",
                 id=eid,
-                name=ent.get("name", "") if isinstance(ent, dict) else "",
-                description=ent.get("description", "") if isinstance(ent, dict) else "",
-                input_schema=ent.get("input_schema", {}) if isinstance(ent, dict) else {},
+                name=declaration.get("name", ""),
+                description=declaration.get("description", ""),
+                input_schema=declaration.get("input_schema", {}),
             )
-            # The configured declaration still wins; retain all of its controls.
-            for field_name, value in entry_contract_fields(ent if isinstance(ent, dict) else {}).items():
+            # Only explicitly configured fields override the decorator contract.
+            controls = entry_contract_fields(base_meta)
+            controls.update(entry_contract_fields(declaration))
+            for field_name, value in controls.items():
                 setattr(entry_meta, field_name, deepcopy(value))
             eh = EventHandler(meta=entry_meta, handler=handler_fn)
             with state.acquire_event_handlers_write_lock():
@@ -716,6 +723,22 @@ def _effective_entries(conf: dict, pdata: dict) -> Any:
             value = table["entries"]
             return value if isinstance(value, (list, dict)) else []
     return []
+
+
+def _overlay_entry_controls(
+    previews: list[dict[str, Any]], conf: dict, pdata: dict,
+) -> list[dict[str, Any]]:
+    """Apply explicit control fields to scanned or packaged previews."""
+    results = deepcopy(previews)
+    by_id = {str(entry.get("id")): entry for entry in results}
+    for declaration in _effective_entries(conf, pdata):
+        if not isinstance(declaration, dict):
+            continue
+        preview = by_id.get(str(declaration.get("id")))
+        if preview is None:
+            continue
+        preview.update(deepcopy(entry_contract_fields(declaration)))
+    return results
 
 
 def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> List[Dict[str, Any]]:
@@ -914,7 +937,7 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
         except Exception:
             continue
 
-    return results
+    return _overlay_entry_controls(results, conf, pdata)
 
 
 # ============================================================================

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -515,6 +515,25 @@ def register_plugin(
     return resolved_id
 
 
+def _declared_entry_field(
+    declaration: Dict[str, Any], base_meta: Any, field_name: str, fallback: Any
+) -> Any:
+    """Pick a display field: explicit declaration wins, absence inherits.
+
+    Same rule the control fields follow: writing an empty value is a
+    declaration, not a fallback. Only a field the declaration never mentions
+    falls back to the decorator.
+    """
+    # 缺席必须继承装饰器那份：manifest 里只覆盖一个 timeout，旧写法会把 name /
+    # description / input_schema 一起抹成空。参数 schema 抹空之后，面板和 Agent
+    # 会按"这个入口没有参数"发起调用，而子进程仍然拿装饰器的真 schema 校验，调用
+    # 直接被打回（codex）。
+    if field_name in declaration:
+        return deepcopy(declaration[field_name])
+    inherited = getattr(base_meta, field_name, None) if base_meta is not None else None
+    return deepcopy(inherited) if inherited is not None else fallback
+
+
 def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
     """
     在不实例化的情况下扫描类属性，提取 @EventHandler 元数据并填充全局表。
@@ -563,9 +582,9 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
             entry_meta = EventMeta(
                 event_type="plugin_entry",
                 id=eid,
-                name=declaration.get("name", ""),
-                description=declaration.get("description", ""),
-                input_schema=declaration.get("input_schema", {}),
+                name=_declared_entry_field(declaration, base_meta, "name", ""),
+                description=_declared_entry_field(declaration, base_meta, "description", ""),
+                input_schema=_declared_entry_field(declaration, base_meta, "input_schema", {}),
             )
             # Only explicitly configured fields override the decorator contract.
             controls = entry_contract_fields(base_meta)
@@ -893,24 +912,27 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                 if not eid or eid in seen:
                     continue
                 seen.add(eid)
-                results.append(
-                    {
-                        "id": eid,
-                        "name": ent.get("name") if isinstance(ent.get("name"), (str, dict)) else str(ent.get("name") or ""),
-                        "description": ent.get("description") if isinstance(ent.get("description"), (str, dict)) else str(ent.get("description") or ""),
-                        "event_key": f"{pid}.{eid}",
-                        "input_schema": _to_dict(ent.get("input_schema") or {}),
-                        "return_message": "",
-                        "event_type": "plugin_entry",
-                        "kind": str(ent.get("kind") or "action"),
-                        "auto_start": bool(ent.get("auto_start", False)),
-                        "timeout": ent.get("timeout"),
-                        "model_validate": bool(ent.get("model_validate", True)),
-                        "llm_result_fields": _to_string_list(ent.get("llm_result_fields")),
-                        "llm_result_schema": _to_dict(ent.get("llm_result_schema") or {}),
-                        "metadata": _to_dict(ent.get("metadata") or {}),
-                    }
-                )
+                config_preview: Dict[str, Any] = {
+                    "id": eid,
+                    "name": ent.get("name") if isinstance(ent.get("name"), (str, dict)) else str(ent.get("name") or ""),
+                    "description": ent.get("description") if isinstance(ent.get("description"), (str, dict)) else str(ent.get("description") or ""),
+                    "event_key": f"{pid}.{eid}",
+                    "input_schema": _to_dict(ent.get("input_schema") or {}),
+                    "return_message": "",
+                    "event_type": "plugin_entry",
+                    "kind": str(ent.get("kind") or "action"),
+                    "auto_start": bool(ent.get("auto_start", False)),
+                    "timeout": ent.get("timeout"),
+                    "model_validate": bool(ent.get("model_validate", True)),
+                    "llm_result_schema": _to_dict(ent.get("llm_result_schema") or {}),
+                    "metadata": _to_dict(ent.get("metadata") or {}),
+                }
+                # 只有真声明了才写这个键。消费端把 list 当成"显式声明"，凭空补一个
+                # [] 会让"只声明 llm_result_schema"的入口在列表侧拿不到派生字段，而
+                # handler 侧照样派生——同一个入口在启动前后给出两种结果。
+                if isinstance(ent.get("llm_result_fields"), list):
+                    config_preview["llm_result_fields"] = _to_string_list(ent.get("llm_result_fields"))
+                results.append(config_preview)
             else:
                 eid = str(ent)
                 if not eid or eid in seen:
@@ -929,7 +951,6 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                         "auto_start": False,
                         "timeout": None,
                         "model_validate": True,
-                        "llm_result_fields": [],
                         "llm_result_schema": {},
                         "metadata": {},
                     }

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -691,6 +691,23 @@ def _build_plugin_meta(
     return meta
 
 
+def _set_declared_result_fields(
+    preview: Dict[str, Any], declared: Any, to_string_list: Callable[[Any], List[str]]
+) -> None:
+    """Write llm_result_fields only when the source actually declared a list.
+
+    Absence and an explicit empty list mean different things downstream: the
+    consumer derives the fields from llm_result_schema when the key is missing
+    and takes a list as the final answer.
+    """
+    # 把"没声明"规范化成 []，消费端就会把它当成显式声明而不再按 schema 推导，而
+    # handler 侧照样推——同一个入口在启动前后报出两套结果字段。SDK 反推走的是
+    # schema 的 required，一个字段全带默认值的结果模型 required 为空、fields 被
+    # 塌成 None，schema 却有 properties，这条路真会走到（coderabbit）。
+    if isinstance(declared, list):
+        preview["llm_result_fields"] = to_string_list(declared)
+
+
 def _router_entry_preview(
     pid: str,
     eid: str,
@@ -719,10 +736,10 @@ def _router_entry_preview(
         "auto_start": bool(getattr(event_meta, "auto_start", False)),
         "timeout": getattr(event_meta, "timeout", None),
         "model_validate": bool(getattr(event_meta, "model_validate", True)),
-        "llm_result_fields": _to_string_list(getattr(event_meta, "llm_result_fields", None)),
         "llm_result_schema": _to_dict(getattr(event_meta, "llm_result_schema", {}) or {}),
         "metadata": _to_dict(getattr(event_meta, "metadata", {}) or {}),
     }
+    _set_declared_result_fields(preview, getattr(event_meta, "llm_result_fields", None), _to_string_list)
     meta_dict = getattr(event_meta, "metadata", None)
     if isinstance(meta_dict, dict) and "llm_result_fields" in meta_dict:
         preview["llm_result_fields"] = meta_dict["llm_result_fields"]
@@ -849,10 +866,12 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                     "auto_start": bool(getattr(event_meta, "auto_start", False)),
                     "timeout": getattr(event_meta, "timeout", None),
                     "model_validate": bool(getattr(event_meta, "model_validate", True)),
-                    "llm_result_fields": _to_string_list(getattr(event_meta, "llm_result_fields", None)),
                     "llm_result_schema": _to_dict(getattr(event_meta, "llm_result_schema", {}) or {}),
                     "metadata": _to_dict(getattr(event_meta, "metadata", {}) or {}),
                 }
+            _set_declared_result_fields(
+                entry_preview, getattr(event_meta, "llm_result_fields", None), _to_string_list
+            )
             meta_dict = getattr(event_meta, "metadata", None)
             if isinstance(meta_dict, dict) and "llm_result_fields" in meta_dict:
                 entry_preview["llm_result_fields"] = meta_dict["llm_result_fields"]
@@ -941,11 +960,9 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                     "llm_result_schema": _to_dict(ent.get("llm_result_schema") or {}),
                     "metadata": _to_dict(ent.get("metadata") or {}),
                 }
-                # 只有真声明了才写这个键。消费端把 list 当成"显式声明"，凭空补一个
-                # [] 会让"只声明 llm_result_schema"的入口在列表侧拿不到派生字段，而
-                # handler 侧照样派生——同一个入口在启动前后给出两种结果。
-                if isinstance(ent.get("llm_result_fields"), list):
-                    config_preview["llm_result_fields"] = _to_string_list(ent.get("llm_result_fields"))
+                _set_declared_result_fields(
+                    config_preview, ent.get("llm_result_fields"), _to_string_list
+                )
                 results.append(config_preview)
             else:
                 eid = str(ent)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -744,10 +744,17 @@ def _effective_entries(conf: dict, pdata: dict) -> Any:
     return []
 
 
-def _overlay_entry_controls(
+_ENTRY_DISPLAY_FIELDS = ("name", "description", "input_schema")
+
+
+def _overlay_entry_declaration(
     previews: list[dict[str, Any]], conf: dict, pdata: dict,
 ) -> list[dict[str, Any]]:
-    """Apply explicit control fields to scanned or packaged previews."""
+    """Apply every explicitly declared field to scanned or packaged previews.
+
+    Same presence-based precedence the registration path uses, display fields
+    included: preview and handler must describe one entry the same way.
+    """
     results = deepcopy(previews)
     by_id = {str(entry.get("id")): entry for entry in results}
     for declaration in _effective_entries(conf, pdata):
@@ -757,6 +764,13 @@ def _overlay_entry_controls(
         if preview is None:
             continue
         preview.update(deepcopy(entry_contract_fields(declaration)))
+        # 装饰器声明在前、id 已经进 seen，配置那条 preview 根本不会被生成，所以
+        # 配置显式改写的 name / description / input_schema 到不了列表侧。停着的
+        # 插件按装饰器 schema 报参数、跑起来的按配置那份，客户端会照两套参数构造
+        # 调用（codex）。
+        for field_name in _ENTRY_DISPLAY_FIELDS:
+            if field_name in declaration:
+                preview[field_name] = deepcopy(declaration[field_name])
     return results
 
 
@@ -958,7 +972,7 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
         except Exception:
             continue
 
-    return _overlay_entry_controls(results, conf, pdata)
+    return _overlay_entry_declaration(results, conf, pdata)
 
 
 # ============================================================================

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -840,7 +840,12 @@ def _normalized_entry_declaration(declaration: Dict[str, Any]) -> Dict[str, Any]
         elif name in _ENTRY_MAPPING_FIELDS:
             fields[name] = _entry_mapping(value)
         elif name == "llm_result_fields":
-            fields[name] = _entry_string_list(value)
+            # 只有 list 才是声明：一个写错类型的值不能变成"显式清空"，那会关掉
+            # 消费端按 schema 推导的兜底。非 list 当作没写这个键。
+            if isinstance(value, list):
+                fields[name] = _entry_string_list(value)
+            else:
+                del fields[name]
         elif name in _ENTRY_TEXT_FIELDS:
             fields[name] = value if isinstance(value, (str, dict)) else str(value or "")
     return deepcopy(fields)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -515,10 +515,23 @@ def register_plugin(
     return resolved_id
 
 
-def _declared_entry_field(
-    declaration: Dict[str, Any], base_meta: Any, field_name: str, fallback: Any
-) -> Any:
-    """Pick a display field: explicit declaration wins, absence inherits.
+def _copied_entry_value(value: Any) -> Any:
+    """A private copy of a decorator value, or the value itself if it cannot be copied.
+
+    Registry records must not alias the decorator's mutable mappings, but a
+    lock or a client handle stashed in decorator metadata makes ``deepcopy``
+    raise, and swallowing that would silently drop the configured override
+    that shares the same loop iteration. Sharing such a value is the lesser
+    harm: it is exactly what the decorator handler itself references.
+    """
+    try:
+        return deepcopy(value)
+    except Exception:
+        return value
+
+
+def _inherited_entry_field(base_meta: Any, field_name: str, fallback: Any) -> Any:
+    """A display field the declaration never mentions inherits the decorator's.
 
     Same rule the control fields follow: writing an empty value is a
     declaration, not a fallback. Only a field the declaration never mentions
@@ -528,10 +541,8 @@ def _declared_entry_field(
     # description / input_schema 一起抹成空。参数 schema 抹空之后，面板和 Agent
     # 会按"这个入口没有参数"发起调用，而子进程仍然拿装饰器的真 schema 校验，调用
     # 直接被打回（codex）。
-    if field_name in declaration:
-        return deepcopy(declaration[field_name])
     inherited = getattr(base_meta, field_name, None) if base_meta is not None else None
-    return deepcopy(inherited) if inherited is not None else fallback
+    return _copied_entry_value(inherited) if inherited is not None else fallback
 
 
 def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
@@ -577,20 +588,35 @@ def scan_static_metadata(pid: str, cls: type, conf: dict, pdata: dict) -> None:
                     cls.__name__,
                 )
                 continue
-            declaration = ent if isinstance(ent, dict) else {}
+            declared = _normalized_entry_declaration(ent if isinstance(ent, dict) else {})
             base_meta = decorated.meta if decorated is not None else None
             entry_meta = EventMeta(
                 event_type="plugin_entry",
                 id=eid,
-                name=_declared_entry_field(declaration, base_meta, "name", ""),
-                description=_declared_entry_field(declaration, base_meta, "description", ""),
-                input_schema=_declared_entry_field(declaration, base_meta, "input_schema", {}),
+                name=declared.get("name", _inherited_entry_field(base_meta, "name", "")),
+                description=declared.get(
+                    "description", _inherited_entry_field(base_meta, "description", "")
+                ),
+                input_schema=declared.get(
+                    "input_schema", _inherited_entry_field(base_meta, "input_schema", {})
+                ),
             )
             # Only explicitly configured fields override the decorator contract.
-            controls = entry_contract_fields(base_meta)
-            controls.update(entry_contract_fields(declaration))
+            # 装饰器那份按"能复制就复制"来：deepcopy 碰到装饰器塞进 metadata / extra
+            # 的锁、模块之类会抛 TypeError，被下面的 except 吞掉之后配置里的 timeout
+            # 就悄悄丢了。配置那份在规范化时已经复制过，注册记录不会和可变的配置表
+            # 互相影响。
+            controls = {
+                name: _copied_entry_value(value)
+                for name, value in entry_contract_fields(base_meta).items()
+            }
+            controls.update(
+                (name, value)
+                for name, value in declared.items()
+                if name not in _ENTRY_DISPLAY_FIELDS
+            )
             for field_name, value in controls.items():
-                setattr(entry_meta, field_name, deepcopy(value))
+                setattr(entry_meta, field_name, value)
             eh = EventHandler(meta=entry_meta, handler=handler_fn)
             with state.acquire_event_handlers_write_lock():
                 state.event_handlers[f"{pid}.{eid}"] = eh
@@ -691,9 +717,37 @@ def _build_plugin_meta(
     return meta
 
 
-def _set_declared_result_fields(
-    preview: Dict[str, Any], declared: Any, to_string_list: Callable[[Any], List[str]]
-) -> None:
+def _entry_mapping(value: Any) -> Dict[str, Any]:
+    """A mapping-valued entry field as a dict; anything else is an empty one."""
+    if isinstance(value, dict):
+        return value
+    try:
+        if hasattr(value, "model_dump"):
+            dumped = value.model_dump()
+            return dumped if isinstance(dumped, dict) else {}
+    except Exception:
+        pass
+    return {}
+
+
+def _entry_string_list(value: Any) -> List[str]:
+    """A list-valued entry field with only its distinct, non-blank strings."""
+    if not isinstance(value, list):
+        return []
+    out: List[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        field_name = item.strip()
+        if not field_name or field_name in seen:
+            continue
+        seen.add(field_name)
+        out.append(field_name)
+    return out
+
+
+def _set_declared_result_fields(preview: Dict[str, Any], declared: Any) -> None:
     """Write llm_result_fields only when the source actually declared a list.
 
     Absence and an explicit empty list mean different things downstream: the
@@ -705,16 +759,10 @@ def _set_declared_result_fields(
     # schema 的 required，一个字段全带默认值的结果模型 required 为空、fields 被
     # 塌成 None，schema 却有 properties，这条路真会走到（coderabbit）。
     if isinstance(declared, list):
-        preview["llm_result_fields"] = to_string_list(declared)
+        preview["llm_result_fields"] = _entry_string_list(declared)
 
 
-def _router_entry_preview(
-    pid: str,
-    eid: str,
-    event_meta: Any,
-    _to_dict: Callable[[Any], Dict[str, Any]],
-    _to_string_list: Callable[[Any], List[str]],
-) -> Dict[str, Any]:
+def _router_entry_preview(pid: str, eid: str, event_meta: Any) -> Dict[str, Any]:
     """Build the static preview dict for one router-declared entry.
 
     与 1) 分支保持一致：从 `event_meta` 读 return_message，避免 router 预览丢字段喵。
@@ -729,17 +777,17 @@ def _router_entry_preview(
         "name": name_obj if isinstance(name_obj, (str, dict)) else str(name_obj),
         "description": description_obj if isinstance(description_obj, (str, dict)) else str(description_obj),
         "event_key": f"{pid}.{eid}",
-        "input_schema": _to_dict(getattr(event_meta, "input_schema", {}) or {}),
+        "input_schema": _entry_mapping(getattr(event_meta, "input_schema", {}) or {}),
         "return_message": return_message_obj if isinstance(return_message_obj, (str, dict)) else str(return_message_obj),
         "event_type": "plugin_entry",
         "kind": str(getattr(event_meta, "kind", "action") or "action"),
         "auto_start": bool(getattr(event_meta, "auto_start", False)),
         "timeout": getattr(event_meta, "timeout", None),
         "model_validate": bool(getattr(event_meta, "model_validate", True)),
-        "llm_result_schema": _to_dict(getattr(event_meta, "llm_result_schema", {}) or {}),
-        "metadata": _to_dict(getattr(event_meta, "metadata", {}) or {}),
+        "llm_result_schema": _entry_mapping(getattr(event_meta, "llm_result_schema", {}) or {}),
+        "metadata": _entry_mapping(getattr(event_meta, "metadata", {}) or {}),
     }
-    _set_declared_result_fields(preview, getattr(event_meta, "llm_result_fields", None), _to_string_list)
+    _set_declared_result_fields(preview, getattr(event_meta, "llm_result_fields", None))
     meta_dict = getattr(event_meta, "metadata", None)
     if isinstance(meta_dict, dict) and "llm_result_fields" in meta_dict:
         preview["llm_result_fields"] = meta_dict["llm_result_fields"]
@@ -762,6 +810,39 @@ def _effective_entries(conf: dict, pdata: dict) -> Any:
 
 
 _ENTRY_DISPLAY_FIELDS = ("name", "description", "input_schema")
+_ENTRY_BOOL_FIELDS = ("auto_start", "enabled", "dynamic", "model_validate", "quick_action")
+_ENTRY_MAPPING_FIELDS = (
+    "input_schema", "llm_result_schema", "metadata", "extra", "quick_action_config",
+)
+_ENTRY_TEXT_FIELDS = ("name", "description", "return_message")
+
+
+def _normalized_entry_declaration(declaration: Dict[str, Any]) -> Dict[str, Any]:
+    """Every field a configured entry mentions, coerced to its wire shape.
+
+    Presence is the declaration: an explicit empty value stays an explicit
+    empty value. The shapes match what decorator previews already carry, so a
+    preview and a handler built from one declaration agree, and a manifest typo
+    (``metadata = "x"``, ``llm_result_fields = ["a", 1]``) cannot put a
+    non-mapping or a non-string item on the wire. Values are copied so registry
+    records never alias the mutable configuration tables.
+    """
+    fields = entry_contract_fields(declaration)
+    for name in _ENTRY_DISPLAY_FIELDS:
+        if name in declaration:
+            fields[name] = declaration[name]
+    for name, value in list(fields.items()):
+        if name == "kind":
+            fields[name] = str(value or "action")
+        elif name in _ENTRY_BOOL_FIELDS:
+            fields[name] = bool(value)
+        elif name in _ENTRY_MAPPING_FIELDS:
+            fields[name] = _entry_mapping(value)
+        elif name == "llm_result_fields":
+            fields[name] = _entry_string_list(value)
+        elif name in _ENTRY_TEXT_FIELDS:
+            fields[name] = value if isinstance(value, (str, dict)) else str(value or "")
+    return deepcopy(fields)
 
 
 def _overlay_entry_declaration(
@@ -770,24 +851,35 @@ def _overlay_entry_declaration(
     """Apply every explicitly declared field to scanned or packaged previews.
 
     Same presence-based precedence the registration path uses, display fields
-    included: preview and handler must describe one entry the same way.
+    included: preview and handler must describe one entry the same way. Only a
+    preview some declaration matches is rebuilt; the others pass through as
+    they are, so a plugin without an ``entries`` table costs nothing here.
     """
-    results = deepcopy(previews)
-    by_id = {str(entry.get("id")): entry for entry in results}
+    results = list(previews)
+    positions = {str(entry.get("id")): index for index, entry in enumerate(results)}
     for declaration in _effective_entries(conf, pdata):
         if not isinstance(declaration, dict):
             continue
-        preview = by_id.get(str(declaration.get("id")))
-        if preview is None:
+        position = positions.get(str(declaration.get("id")))
+        if position is None:
             continue
-        preview.update(deepcopy(entry_contract_fields(declaration)))
+        preview = dict(results[position])
         # 装饰器声明在前、id 已经进 seen，配置那条 preview 根本不会被生成，所以
         # 配置显式改写的 name / description / input_schema 到不了列表侧。停着的
         # 插件按装饰器 schema 报参数、跑起来的按配置那份，客户端会照两套参数构造
         # 调用（codex）。
-        for field_name in _ENTRY_DISPLAY_FIELDS:
-            if field_name in declaration:
-                preview[field_name] = deepcopy(declaration[field_name])
+        declared = _normalized_entry_declaration(declaration)
+        if "metadata" in declared and "llm_result_fields" not in declared:
+            # 结果字段可能是从装饰器 metadata 里提上来的（旧写法）。配置整个换掉
+            # metadata 之后，handler 侧的 query_service 在新 metadata 里找不到它，
+            # 退回 SDK 字段 / schema 推导；preview 侧要走同一条路，不能留着旧值。
+            old_metadata = preview.get("metadata")
+            if isinstance(old_metadata, dict) and "llm_result_fields" in old_metadata:
+                preview.pop("llm_result_fields", None)
+            if "llm_result_fields" in declared["metadata"]:
+                declared["llm_result_fields"] = declared["metadata"]["llm_result_fields"]
+        preview.update(declared)
+        results[position] = preview
     return results
 
 
@@ -799,32 +891,6 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
     """
     results: List[Dict[str, Any]] = []
     seen: set[str] = set()
-
-    def _to_dict(v: Any) -> Dict[str, Any]:
-        if isinstance(v, dict):
-            return v
-        try:
-            if hasattr(v, "model_dump"):
-                d = v.model_dump()
-                return d if isinstance(d, dict) else {}
-        except Exception:
-            pass
-        return {}
-
-    def _to_string_list(v: Any) -> List[str]:
-        if not isinstance(v, list):
-            return []
-        out: List[str] = []
-        seen: set[str] = set()
-        for item in v:
-            if not isinstance(item, str):
-                continue
-            field_name = item.strip()
-            if not field_name or field_name in seen:
-                continue
-            seen.add(field_name)
-            out.append(field_name)
-        return out
 
     # 1) Decorator-based metadata (@plugin_entry / EVENT_META_ATTR)
     try:
@@ -844,7 +910,7 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                 continue
             seen.add(eid)
 
-            input_schema = _to_dict(getattr(event_meta, "input_schema", {}) or {})
+            input_schema = _entry_mapping(getattr(event_meta, "input_schema", {}) or {})
             name_obj = getattr(event_meta, "name", None)
             description_obj = getattr(event_meta, "description", None)
             return_message_obj = getattr(event_meta, "return_message", None)
@@ -866,11 +932,11 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                     "auto_start": bool(getattr(event_meta, "auto_start", False)),
                     "timeout": getattr(event_meta, "timeout", None),
                     "model_validate": bool(getattr(event_meta, "model_validate", True)),
-                    "llm_result_schema": _to_dict(getattr(event_meta, "llm_result_schema", {}) or {}),
-                    "metadata": _to_dict(getattr(event_meta, "metadata", {}) or {}),
+                    "llm_result_schema": _entry_mapping(getattr(event_meta, "llm_result_schema", {}) or {}),
+                    "metadata": _entry_mapping(getattr(event_meta, "metadata", {}) or {}),
                 }
             _set_declared_result_fields(
-                entry_preview, getattr(event_meta, "llm_result_fields", None), _to_string_list
+                entry_preview, getattr(event_meta, "llm_result_fields", None)
             )
             meta_dict = getattr(event_meta, "metadata", None)
             if isinstance(meta_dict, dict) and "llm_result_fields" in meta_dict:
@@ -914,7 +980,7 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                         if not eid or eid in seen:
                             continue
                         seen.add(eid)
-                        results.append(_router_entry_preview(pid, eid, event_meta, _to_dict, _to_string_list))
+                        results.append(_router_entry_preview(pid, eid, event_meta))
 
             if instance_handled:
                 continue
@@ -932,62 +998,35 @@ def _extract_entries_preview(pid: str, cls: type, conf: dict, pdata: dict) -> Li
                 if not eid or eid in seen:
                     continue
                 seen.add(eid)
-                results.append(_router_entry_preview(pid, eid, event_meta, _to_dict, _to_string_list))
+                results.append(_router_entry_preview(pid, eid, event_meta))
     except Exception:
         pass
 
-    # 2) Config-specified entries (conf/pdata)
-    entries = _effective_entries(conf, pdata)
-    for ent in entries:
-        try:
-            if isinstance(ent, dict):
-                eid = str(ent.get("id") or "")
-                if not eid or eid in seen:
-                    continue
-                seen.add(eid)
-                config_preview: Dict[str, Any] = {
-                    "id": eid,
-                    "name": ent.get("name") if isinstance(ent.get("name"), (str, dict)) else str(ent.get("name") or ""),
-                    "description": ent.get("description") if isinstance(ent.get("description"), (str, dict)) else str(ent.get("description") or ""),
-                    "event_key": f"{pid}.{eid}",
-                    "input_schema": _to_dict(ent.get("input_schema") or {}),
-                    "return_message": "",
-                    "event_type": "plugin_entry",
-                    "kind": str(ent.get("kind") or "action"),
-                    "auto_start": bool(ent.get("auto_start", False)),
-                    "timeout": ent.get("timeout"),
-                    "model_validate": bool(ent.get("model_validate", True)),
-                    "llm_result_schema": _to_dict(ent.get("llm_result_schema") or {}),
-                    "metadata": _to_dict(ent.get("metadata") or {}),
-                }
-                _set_declared_result_fields(
-                    config_preview, ent.get("llm_result_fields"), _to_string_list
-                )
-                results.append(config_preview)
-            else:
-                eid = str(ent)
-                if not eid or eid in seen:
-                    continue
-                seen.add(eid)
-                results.append(
-                    {
-                        "id": eid,
-                        "name": "",
-                        "description": "",
-                        "event_key": f"{pid}.{eid}",
-                        "input_schema": {},
-                        "return_message": "",
-                        "event_type": "plugin_entry",
-                        "kind": "action",
-                        "auto_start": False,
-                        "timeout": None,
-                        "model_validate": True,
-                        "llm_result_schema": {},
-                        "metadata": {},
-                    }
-                )
-        except Exception:
+    # 2) Config-specified entries (conf/pdata). Only the skeleton is built here:
+    #    the declared fields are written by the overlay below, the same way it
+    #    writes them onto decorator previews, so there is one normalization.
+    for ent in _effective_entries(conf, pdata):
+        eid = str(ent.get("id") or "") if isinstance(ent, dict) else str(ent)
+        if not eid or eid in seen:
             continue
+        seen.add(eid)
+        results.append(
+            {
+                "id": eid,
+                "name": "",
+                "description": "",
+                "event_key": f"{pid}.{eid}",
+                "input_schema": {},
+                "return_message": "",
+                "event_type": "plugin_entry",
+                "kind": "action",
+                "auto_start": False,
+                "timeout": None,
+                "model_validate": True,
+                "llm_result_schema": {},
+                "metadata": {},
+            }
+        )
 
     return _overlay_entry_declaration(results, conf, pdata)
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -726,6 +726,7 @@ def _entry_mapping(value: Any) -> Dict[str, Any]:
             dumped = value.model_dump()
             return dumped if isinstance(dumped, dict) else {}
     except Exception:
+        # A model that cannot dump itself is a preview gap, not a listing failure.
         pass
     return {}
 

--- a/plugin/plugins/app_launcher/plugin.meta.json
+++ b/plugin/plugins/app_launcher/plugin.meta.json
@@ -658,6 +658,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_app",
       "input_schema": {
         "properties": {
@@ -707,11 +708,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "app_id",
+        "name",
+        "path",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_id": {},
+          "message": {},
+          "name": {},
+          "path": {}
+        },
+        "required": [
+          "app_id",
+          "name",
+          "path",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.add_app.name",
         "default": "添加软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.export_apps": {
       "auto_start": false,
@@ -722,17 +752,44 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "export_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "apps",
+        "count",
+        "export_data"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "apps": {},
+          "count": {},
+          "export_data": {}
+        },
+        "required": [
+          "apps",
+          "count",
+          "export_data"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.export_apps.name",
         "default": "导出软件配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.get_all_autostart_status": {
       "auto_start": false,
@@ -743,17 +800,44 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_all_autostart_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "autostart_apps",
+        "count",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "autostart_apps": {},
+          "count": {},
+          "message": {}
+        },
+        "required": [
+          "autostart_apps",
+          "count",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_all_autostart_status.name",
         "default": "获取所有软件开机自启状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.get_autostart_status": {
       "auto_start": false,
@@ -764,6 +848,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_autostart_status",
       "input_schema": {
         "properties": {
@@ -781,11 +866,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "app_id",
+        "app_name",
+        "enabled",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_id": {},
+          "app_name": {},
+          "enabled": {},
+          "message": {}
+        },
+        "required": [
+          "app_id",
+          "app_name",
+          "enabled",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_autostart_status.name",
         "default": "获取开机自启状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.get_available_apps": {
       "auto_start": false,
@@ -796,17 +910,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_available_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "available_apps",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "available_apps": {},
+          "count": {}
+        },
+        "required": [
+          "available_apps",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_available_apps.name",
         "default": "获取可用软件列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.get_categories": {
       "auto_start": false,
@@ -817,17 +955,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_categories",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "categories",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "categories": {},
+          "count": {}
+        },
+        "required": [
+          "categories",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_categories.name",
         "default": "获取分类列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.get_recent_apps": {
       "auto_start": false,
@@ -838,17 +1000,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_recent_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "recent_apps",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "count": {},
+          "recent_apps": {}
+        },
+        "required": [
+          "recent_apps",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_recent_apps.name",
         "default": "获取最近使用记录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.launch_app": {
       "auto_start": false,
@@ -859,6 +1045,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "launch_app",
       "input_schema": {
         "properties": {
@@ -880,11 +1067,37 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "success",
+        "message",
+        "app_name"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_name": {},
+          "message": {},
+          "success": {}
+        },
+        "required": [
+          "success",
+          "message",
+          "app_name"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.launch_app.name",
         "default": "启动软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.list_apps": {
       "auto_start": false,
@@ -895,17 +1108,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "apps",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "apps": {},
+          "count": {}
+        },
+        "required": [
+          "apps",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.list_apps.name",
         "default": "列出已注册软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.remove_app": {
       "auto_start": false,
@@ -916,6 +1153,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_app",
       "input_schema": {
         "properties": {
@@ -933,11 +1171,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted",
+        "name"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {},
+          "name": {}
+        },
+        "required": [
+          "deleted",
+          "name"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.remove_app.name",
         "default": "删除软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.set_autostart": {
       "auto_start": false,
@@ -948,6 +1209,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_autostart",
       "input_schema": {
         "properties": {
@@ -973,11 +1235,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "success",
+        "message",
+        "app_name",
+        "enabled"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_name": {},
+          "enabled": {},
+          "message": {},
+          "success": {}
+        },
+        "required": [
+          "success",
+          "message",
+          "app_name",
+          "enabled"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.set_autostart.name",
         "default": "设置开机自启"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher.update_app": {
       "auto_start": false,
@@ -988,6 +1279,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_app",
       "input_schema": {
         "properties": {
@@ -1036,11 +1328,37 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "app_id",
+        "name",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_id": {},
+          "message": {},
+          "name": {}
+        },
+        "required": [
+          "app_id",
+          "name",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.update_app.name",
         "default": "更新软件信息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:lifecycle:shutdown": {
       "auto_start": false,
@@ -1048,14 +1366,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:lifecycle:startup": {
       "auto_start": false,
@@ -1063,14 +1392,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:add_app": {
       "auto_start": false,
@@ -1081,6 +1421,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_app",
       "input_schema": {
         "properties": {
@@ -1130,11 +1471,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "app_id",
+        "name",
+        "path",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_id": {},
+          "message": {},
+          "name": {},
+          "path": {}
+        },
+        "required": [
+          "app_id",
+          "name",
+          "path",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.add_app.name",
         "default": "添加软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:export_apps": {
       "auto_start": false,
@@ -1145,17 +1515,44 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "export_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "apps",
+        "count",
+        "export_data"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "apps": {},
+          "count": {},
+          "export_data": {}
+        },
+        "required": [
+          "apps",
+          "count",
+          "export_data"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.export_apps.name",
         "default": "导出软件配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:get_all_autostart_status": {
       "auto_start": false,
@@ -1166,17 +1563,44 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_all_autostart_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "autostart_apps",
+        "count",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "autostart_apps": {},
+          "count": {},
+          "message": {}
+        },
+        "required": [
+          "autostart_apps",
+          "count",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_all_autostart_status.name",
         "default": "获取所有软件开机自启状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:get_autostart_status": {
       "auto_start": false,
@@ -1187,6 +1611,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_autostart_status",
       "input_schema": {
         "properties": {
@@ -1204,11 +1629,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "app_id",
+        "app_name",
+        "enabled",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_id": {},
+          "app_name": {},
+          "enabled": {},
+          "message": {}
+        },
+        "required": [
+          "app_id",
+          "app_name",
+          "enabled",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_autostart_status.name",
         "default": "获取开机自启状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:get_available_apps": {
       "auto_start": false,
@@ -1219,17 +1673,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_available_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "available_apps",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "available_apps": {},
+          "count": {}
+        },
+        "required": [
+          "available_apps",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_available_apps.name",
         "default": "获取可用软件列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:get_categories": {
       "auto_start": false,
@@ -1240,17 +1718,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_categories",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "categories",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "categories": {},
+          "count": {}
+        },
+        "required": [
+          "categories",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_categories.name",
         "default": "获取分类列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:get_recent_apps": {
       "auto_start": false,
@@ -1261,17 +1763,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_recent_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "recent_apps",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "count": {},
+          "recent_apps": {}
+        },
+        "required": [
+          "recent_apps",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.get_recent_apps.name",
         "default": "获取最近使用记录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:launch_app": {
       "auto_start": false,
@@ -1282,6 +1808,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "launch_app",
       "input_schema": {
         "properties": {
@@ -1303,11 +1830,37 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "success",
+        "message",
+        "app_name"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_name": {},
+          "message": {},
+          "success": {}
+        },
+        "required": [
+          "success",
+          "message",
+          "app_name"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.launch_app.name",
         "default": "启动软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:list_apps": {
       "auto_start": false,
@@ -1318,17 +1871,41 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_apps",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "apps",
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "apps": {},
+          "count": {}
+        },
+        "required": [
+          "apps",
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.list_apps.name",
         "default": "列出已注册软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:remove_app": {
       "auto_start": false,
@@ -1339,6 +1916,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_app",
       "input_schema": {
         "properties": {
@@ -1356,11 +1934,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted",
+        "name"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {},
+          "name": {}
+        },
+        "required": [
+          "deleted",
+          "name"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.remove_app.name",
         "default": "删除软件"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:set_autostart": {
       "auto_start": false,
@@ -1371,6 +1972,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_autostart",
       "input_schema": {
         "properties": {
@@ -1396,11 +1998,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "success",
+        "message",
+        "app_name",
+        "enabled"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_name": {},
+          "enabled": {},
+          "message": {},
+          "success": {}
+        },
+        "required": [
+          "success",
+          "message",
+          "app_name",
+          "enabled"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.set_autostart.name",
         "default": "设置开机自启"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "app_launcher:plugin_entry:update_app": {
       "auto_start": false,
@@ -1411,6 +2042,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_app",
       "input_schema": {
         "properties": {
@@ -1459,14 +2091,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "app_id",
+        "name",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "app_id": {},
+          "message": {},
+          "name": {}
+        },
+        "required": [
+          "app_id",
+          "name",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.update_app.name",
         "default": "更新软件信息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 201717,
   "source_files": [

--- a/plugin/plugins/bilibili_danmaku/plugin.meta.json
+++ b/plugin/plugins/bilibili_danmaku/plugin.meta.json
@@ -2109,6 +2109,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_bili_reply",
       "input_schema": {
         "properties": {
@@ -2136,11 +2137,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_bili_reply.name",
         "default": "AI代写评论"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.ask_neko_bili_send_dynamic": {
       "auto_start": false,
@@ -2151,6 +2172,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_bili_send_dynamic",
       "input_schema": {
         "properties": {
@@ -2180,11 +2202,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_bili_send_dynamic.name",
         "default": "AI代写动态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.ask_neko_bili_send_message": {
       "auto_start": false,
@@ -2195,6 +2237,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_bili_send_message",
       "input_schema": {
         "properties": {
@@ -2214,11 +2257,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_bili_send_message.name",
         "default": "AI代写私信"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.ask_neko_send_danmaku": {
       "auto_start": false,
@@ -2229,6 +2292,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_send_danmaku",
       "input_schema": {
         "properties": {
@@ -2243,11 +2307,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_send_danmaku.name",
         "default": "AI代发弹幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_check_credential": {
       "auto_start": false,
@@ -2258,17 +2342,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_check_credential",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_check_credential.name",
         "default": "检查 B站 凭证"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_comments": {
       "auto_start": false,
@@ -2279,6 +2384,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_comments",
       "input_schema": {
         "properties": {
@@ -2296,11 +2402,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_comments.name",
         "default": "获取视频评论"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_danmaku": {
       "auto_start": false,
@@ -2311,6 +2437,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_danmaku",
       "input_schema": {
         "properties": {
@@ -2328,11 +2455,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_danmaku.name",
         "default": "获取视频弹幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_favorite_content": {
       "auto_start": false,
@@ -2343,6 +2490,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_favorite_content",
       "input_schema": {
         "properties": {
@@ -2364,11 +2512,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_favorite_content.name",
         "default": "获取收藏夹内容"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_favorite_lists": {
       "auto_start": false,
@@ -2379,6 +2547,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_favorite_lists",
       "input_schema": {
         "properties": {
@@ -2390,11 +2559,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_favorite_lists.name",
         "default": "获取收藏夹列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_hot_buzzwords": {
       "auto_start": false,
@@ -2405,6 +2594,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_hot_buzzwords",
       "input_schema": {
         "properties": {
@@ -2420,11 +2610,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_hot_buzzwords.name",
         "default": "获取热搜词"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_hot_videos": {
       "auto_start": false,
@@ -2435,6 +2645,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_hot_videos",
       "input_schema": {
         "properties": {
@@ -2450,11 +2661,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_hot_videos.name",
         "default": "获取热门视频"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_list_tools": {
       "auto_start": false,
@@ -2465,17 +2696,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_list_tools",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_list_tools.name",
         "default": "列出 B站 工具"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_login": {
       "auto_start": false,
@@ -2486,17 +2738,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_login",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_login.name",
         "default": "生成 B站 登录二维码"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_login_check": {
       "auto_start": false,
@@ -2507,17 +2780,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_login_check",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_login_check.name",
         "default": "检查 B站 登录状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_rank": {
       "auto_start": false,
@@ -2528,6 +2822,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_rank",
       "input_schema": {
         "properties": {
@@ -2543,11 +2838,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_rank.name",
         "default": "获取排行榜"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_reply": {
       "auto_start": false,
@@ -2558,6 +2873,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_reply",
       "input_schema": {
         "properties": {
@@ -2583,11 +2899,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_reply.name",
         "default": "发表评论或回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_search": {
       "auto_start": false,
@@ -2598,6 +2934,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_search",
       "input_schema": {
         "properties": {
@@ -2619,11 +2956,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_search.name",
         "default": "搜索 B站 视频"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_send_dynamic": {
       "auto_start": false,
@@ -2634,6 +2991,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_send_dynamic",
       "input_schema": {
         "properties": {
@@ -2661,11 +3019,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_send_dynamic.name",
         "default": "发布动态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_send_message": {
       "auto_start": false,
@@ -2676,6 +3054,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_send_message",
       "input_schema": {
         "properties": {
@@ -2693,11 +3072,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_send_message.name",
         "default": "发送私信"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_subtitle": {
       "auto_start": false,
@@ -2708,6 +3107,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_subtitle",
       "input_schema": {
         "properties": {
@@ -2721,11 +3121,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_subtitle.name",
         "default": "获取视频字幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_user_info": {
       "auto_start": false,
@@ -2736,6 +3156,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_user_info",
       "input_schema": {
         "properties": {
@@ -2749,11 +3170,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_user_info.name",
         "default": "获取用户信息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_user_videos": {
       "auto_start": false,
@@ -2764,6 +3205,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_user_videos",
       "input_schema": {
         "properties": {
@@ -2793,11 +3235,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_user_videos.name",
         "default": "获取用户投稿"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_video_info": {
       "auto_start": false,
@@ -2808,6 +3270,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_video_info",
       "input_schema": {
         "properties": {
@@ -2821,11 +3284,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_video_info.name",
         "default": "获取视频信息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.bili_weekly_hot": {
       "auto_start": false,
@@ -2836,6 +3319,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_weekly_hot",
       "input_schema": {
         "properties": {
@@ -2847,11 +3331,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_weekly_hot.name",
         "default": "获取每周必看"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.clear_credential": {
       "auto_start": false,
@@ -2862,17 +3366,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_credential",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.clear_credential.name",
         "default": "清除B站登录凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.connect": {
       "auto_start": false,
@@ -2883,6 +3408,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "connect",
       "input_schema": {
         "properties": {
@@ -2895,11 +3421,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.connect.name",
         "default": "开始监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.disconnect": {
       "auto_start": false,
@@ -2910,17 +3456,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "disconnect",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.disconnect.name",
         "default": "停止监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.get_bg_llm_config": {
       "auto_start": false,
@@ -2931,6 +3498,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_bg_llm_config",
       "input_schema": {
         "properties": {},
@@ -2938,11 +3506,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "config"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "config": {}
+        },
+        "required": [
+          "config"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_bg_llm_config.name",
         "default": "获取背景LLM完整配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.get_danmaku": {
       "auto_start": false,
@@ -2953,6 +3541,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_danmaku",
       "input_schema": {
         "properties": {
@@ -2969,11 +3558,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_danmaku.name",
         "default": "获取直播间弹幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.get_guidance_config": {
       "auto_start": false,
@@ -2984,6 +3593,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_guidance_config",
       "input_schema": {
         "properties": {},
@@ -2991,11 +3601,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "config"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "config": {}
+        },
+        "required": [
+          "config"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_guidance_config.name",
         "default": "获取背景LLM配置与统计"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.get_status": {
       "auto_start": false,
@@ -3006,17 +3636,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_status.name",
         "default": "获取插件状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.open_ui": {
       "auto_start": false,
@@ -3027,17 +3678,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "open_ui",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.open_ui.name",
         "default": "打开弹幕控制台"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.query_danmaku": {
       "auto_start": false,
@@ -3048,6 +3710,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_danmaku",
       "input_schema": {
         "properties": {
@@ -3069,11 +3732,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_danmaku.name",
         "default": "查询弹幕历史"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.query_gifts": {
       "auto_start": false,
@@ -3084,6 +3767,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_gifts",
       "input_schema": {
         "properties": {
@@ -3102,11 +3786,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_gifts.name",
         "default": "查询礼物历史"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.query_interact": {
       "auto_start": false,
@@ -3117,6 +3821,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_interact",
       "input_schema": {
         "properties": {
@@ -3139,11 +3844,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_interact.name",
         "default": "查询互动记录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.query_stats": {
       "auto_start": false,
@@ -3154,6 +3879,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_stats",
       "input_schema": {
         "properties": {},
@@ -3161,11 +3887,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_stats.name",
         "default": "数据统计"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.reload_credential": {
       "auto_start": false,
@@ -3176,17 +3922,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "reload_credential",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.reload_credential.name",
         "default": "重新加载凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.save_credential": {
       "auto_start": false,
@@ -3197,6 +3964,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_credential",
       "input_schema": {
         "properties": {
@@ -3225,11 +3993,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_credential.name",
         "default": "保存B站登录凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.send_danmaku": {
       "auto_start": false,
@@ -3240,6 +4028,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_danmaku",
       "input_schema": {
         "properties": {
@@ -3254,11 +4043,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_danmaku.name",
         "default": "发送弹幕到直播间"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.set_danmaku_max_length": {
       "auto_start": false,
@@ -3269,6 +4078,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_danmaku_max_length",
       "input_schema": {
         "properties": {
@@ -3280,11 +4090,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_danmaku_max_length.name",
         "default": "设置弹幕最大长度"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.set_interval": {
       "auto_start": false,
@@ -3299,6 +4129,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_interval",
       "input_schema": {
         "properties": {
@@ -3313,11 +4144,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_interval.name",
         "default": "更改弹幕推送间隔"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.set_master_bili_account": {
       "auto_start": false,
@@ -3328,6 +4179,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_master_bili_account",
       "input_schema": {
         "properties": {
@@ -3345,11 +4197,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_master_bili_account.name",
         "default": "设置主人B站账号"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.set_room_id": {
       "auto_start": false,
@@ -3360,6 +4232,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_room_id",
       "input_schema": {
         "properties": {
@@ -3374,11 +4247,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_room_id.name",
         "default": "更改监听直播间"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.set_target_lanlan": {
       "auto_start": false,
@@ -3389,6 +4282,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_target_lanlan",
       "input_schema": {
         "properties": {
@@ -3400,11 +4294,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_target_lanlan.name",
         "default": "设置目标 AI"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.test_bg_llm": {
       "auto_start": false,
@@ -3415,6 +4329,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "test_bg_llm",
       "input_schema": {
         "properties": {
@@ -3435,11 +4350,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.test_bg_llm.name",
         "default": "测试背景LLM连接"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.test_guidance": {
       "auto_start": false,
@@ -3450,6 +4375,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "test_guidance",
       "input_schema": {
         "properties": {
@@ -3467,11 +4393,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "test_result"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "test_result": {}
+        },
+        "required": [
+          "test_result"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.test_guidance.name",
         "default": "测试引导词生成"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku.update_guidance_config": {
       "auto_start": false,
@@ -3482,6 +4428,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_guidance_config",
       "input_schema": {
         "properties": {
@@ -3496,11 +4443,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "updated",
+        "config"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "config": {},
+          "updated": {}
+        },
+        "required": [
+          "updated",
+          "config"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.update_guidance_config.name",
         "default": "更新背景LLM配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:lifecycle:shutdown": {
       "auto_start": false,
@@ -3508,14 +4478,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:lifecycle:startup": {
       "auto_start": false,
@@ -3523,14 +4504,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:ask_neko_bili_reply": {
       "auto_start": false,
@@ -3541,6 +4533,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_bili_reply",
       "input_schema": {
         "properties": {
@@ -3568,11 +4561,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_bili_reply.name",
         "default": "AI代写评论"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:ask_neko_bili_send_dynamic": {
       "auto_start": false,
@@ -3583,6 +4596,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_bili_send_dynamic",
       "input_schema": {
         "properties": {
@@ -3612,11 +4626,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_bili_send_dynamic.name",
         "default": "AI代写动态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:ask_neko_bili_send_message": {
       "auto_start": false,
@@ -3627,6 +4661,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_bili_send_message",
       "input_schema": {
         "properties": {
@@ -3646,11 +4681,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_bili_send_message.name",
         "default": "AI代写私信"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:ask_neko_send_danmaku": {
       "auto_start": false,
@@ -3661,6 +4716,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ask_neko_send_danmaku",
       "input_schema": {
         "properties": {
@@ -3675,11 +4731,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ask_neko_send_danmaku.name",
         "default": "AI代发弹幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_check_credential": {
       "auto_start": false,
@@ -3690,17 +4766,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_check_credential",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_check_credential.name",
         "default": "检查 B站 凭证"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_comments": {
       "auto_start": false,
@@ -3711,6 +4808,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_comments",
       "input_schema": {
         "properties": {
@@ -3728,11 +4826,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_comments.name",
         "default": "获取视频评论"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_danmaku": {
       "auto_start": false,
@@ -3743,6 +4861,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_danmaku",
       "input_schema": {
         "properties": {
@@ -3760,11 +4879,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_danmaku.name",
         "default": "获取视频弹幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_favorite_content": {
       "auto_start": false,
@@ -3775,6 +4914,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_favorite_content",
       "input_schema": {
         "properties": {
@@ -3796,11 +4936,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_favorite_content.name",
         "default": "获取收藏夹内容"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_favorite_lists": {
       "auto_start": false,
@@ -3811,6 +4971,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_favorite_lists",
       "input_schema": {
         "properties": {
@@ -3822,11 +4983,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_favorite_lists.name",
         "default": "获取收藏夹列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_hot_buzzwords": {
       "auto_start": false,
@@ -3837,6 +5018,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_hot_buzzwords",
       "input_schema": {
         "properties": {
@@ -3852,11 +5034,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_hot_buzzwords.name",
         "default": "获取热搜词"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_hot_videos": {
       "auto_start": false,
@@ -3867,6 +5069,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_hot_videos",
       "input_schema": {
         "properties": {
@@ -3882,11 +5085,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_hot_videos.name",
         "default": "获取热门视频"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_list_tools": {
       "auto_start": false,
@@ -3897,17 +5120,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_list_tools",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_list_tools.name",
         "default": "列出 B站 工具"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_login": {
       "auto_start": false,
@@ -3918,17 +5162,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_login",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_login.name",
         "default": "生成 B站 登录二维码"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_login_check": {
       "auto_start": false,
@@ -3939,17 +5204,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_login_check",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_login_check.name",
         "default": "检查 B站 登录状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_rank": {
       "auto_start": false,
@@ -3960,6 +5246,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_rank",
       "input_schema": {
         "properties": {
@@ -3975,11 +5262,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_rank.name",
         "default": "获取排行榜"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_reply": {
       "auto_start": false,
@@ -3990,6 +5297,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_reply",
       "input_schema": {
         "properties": {
@@ -4015,11 +5323,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_reply.name",
         "default": "发表评论或回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_search": {
       "auto_start": false,
@@ -4030,6 +5358,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_search",
       "input_schema": {
         "properties": {
@@ -4051,11 +5380,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_search.name",
         "default": "搜索 B站 视频"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_send_dynamic": {
       "auto_start": false,
@@ -4066,6 +5415,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_send_dynamic",
       "input_schema": {
         "properties": {
@@ -4093,11 +5443,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_send_dynamic.name",
         "default": "发布动态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_send_message": {
       "auto_start": false,
@@ -4108,6 +5478,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_send_message",
       "input_schema": {
         "properties": {
@@ -4125,11 +5496,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_send_message.name",
         "default": "发送私信"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_subtitle": {
       "auto_start": false,
@@ -4140,6 +5531,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_subtitle",
       "input_schema": {
         "properties": {
@@ -4153,11 +5545,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_subtitle.name",
         "default": "获取视频字幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_user_info": {
       "auto_start": false,
@@ -4168,6 +5580,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_user_info",
       "input_schema": {
         "properties": {
@@ -4181,11 +5594,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_user_info.name",
         "default": "获取用户信息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_user_videos": {
       "auto_start": false,
@@ -4196,6 +5629,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_user_videos",
       "input_schema": {
         "properties": {
@@ -4225,11 +5659,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_user_videos.name",
         "default": "获取用户投稿"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_video_info": {
       "auto_start": false,
@@ -4240,6 +5694,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_video_info",
       "input_schema": {
         "properties": {
@@ -4253,11 +5708,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_video_info.name",
         "default": "获取视频信息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:bili_weekly_hot": {
       "auto_start": false,
@@ -4268,6 +5743,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bili_weekly_hot",
       "input_schema": {
         "properties": {
@@ -4279,11 +5755,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bili_weekly_hot.name",
         "default": "获取每周必看"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:clear_credential": {
       "auto_start": false,
@@ -4294,17 +5790,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_credential",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.clear_credential.name",
         "default": "清除B站登录凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:connect": {
       "auto_start": false,
@@ -4315,6 +5832,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "connect",
       "input_schema": {
         "properties": {
@@ -4327,11 +5845,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.connect.name",
         "default": "开始监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:disconnect": {
       "auto_start": false,
@@ -4342,17 +5880,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "disconnect",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.disconnect.name",
         "default": "停止监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:get_bg_llm_config": {
       "auto_start": false,
@@ -4363,6 +5922,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_bg_llm_config",
       "input_schema": {
         "properties": {},
@@ -4370,11 +5930,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "config"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "config": {}
+        },
+        "required": [
+          "config"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_bg_llm_config.name",
         "default": "获取背景LLM完整配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:get_danmaku": {
       "auto_start": false,
@@ -4385,6 +5965,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_danmaku",
       "input_schema": {
         "properties": {
@@ -4401,11 +5982,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_danmaku.name",
         "default": "获取直播间弹幕"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:get_guidance_config": {
       "auto_start": false,
@@ -4416,6 +6017,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_guidance_config",
       "input_schema": {
         "properties": {},
@@ -4423,11 +6025,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "config"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "config": {}
+        },
+        "required": [
+          "config"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_guidance_config.name",
         "default": "获取背景LLM配置与统计"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:get_status": {
       "auto_start": false,
@@ -4438,17 +6060,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_status.name",
         "default": "获取插件状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:open_ui": {
       "auto_start": false,
@@ -4459,17 +6102,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "open_ui",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.open_ui.name",
         "default": "打开弹幕控制台"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:query_danmaku": {
       "auto_start": false,
@@ -4480,6 +6134,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_danmaku",
       "input_schema": {
         "properties": {
@@ -4501,11 +6156,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_danmaku.name",
         "default": "查询弹幕历史"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:query_gifts": {
       "auto_start": false,
@@ -4516,6 +6191,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_gifts",
       "input_schema": {
         "properties": {
@@ -4534,11 +6210,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_gifts.name",
         "default": "查询礼物历史"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:query_interact": {
       "auto_start": false,
@@ -4549,6 +6245,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_interact",
       "input_schema": {
         "properties": {
@@ -4571,11 +6268,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_interact.name",
         "default": "查询互动记录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:query_stats": {
       "auto_start": false,
@@ -4586,6 +6303,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_stats",
       "input_schema": {
         "properties": {},
@@ -4593,11 +6311,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.query_stats.name",
         "default": "数据统计"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:reload_credential": {
       "auto_start": false,
@@ -4608,17 +6346,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "reload_credential",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.reload_credential.name",
         "default": "重新加载凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:save_credential": {
       "auto_start": false,
@@ -4629,6 +6388,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_credential",
       "input_schema": {
         "properties": {
@@ -4657,11 +6417,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_credential.name",
         "default": "保存B站登录凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:send_danmaku": {
       "auto_start": false,
@@ -4672,6 +6452,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_danmaku",
       "input_schema": {
         "properties": {
@@ -4686,11 +6467,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_danmaku.name",
         "default": "发送弹幕到直播间"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:set_danmaku_max_length": {
       "auto_start": false,
@@ -4701,6 +6502,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_danmaku_max_length",
       "input_schema": {
         "properties": {
@@ -4712,11 +6514,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_danmaku_max_length.name",
         "default": "设置弹幕最大长度"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:set_interval": {
       "auto_start": false,
@@ -4731,6 +6553,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_interval",
       "input_schema": {
         "properties": {
@@ -4745,11 +6568,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_interval.name",
         "default": "更改弹幕推送间隔"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:set_master_bili_account": {
       "auto_start": false,
@@ -4760,6 +6603,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_master_bili_account",
       "input_schema": {
         "properties": {
@@ -4777,11 +6621,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_master_bili_account.name",
         "default": "设置主人B站账号"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:set_room_id": {
       "auto_start": false,
@@ -4792,6 +6656,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_room_id",
       "input_schema": {
         "properties": {
@@ -4806,11 +6671,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_room_id.name",
         "default": "更改监听直播间"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:set_target_lanlan": {
       "auto_start": false,
@@ -4821,6 +6706,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_target_lanlan",
       "input_schema": {
         "properties": {
@@ -4832,11 +6718,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_target_lanlan.name",
         "default": "设置目标 AI"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:test_bg_llm": {
       "auto_start": false,
@@ -4847,6 +6753,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "test_bg_llm",
       "input_schema": {
         "properties": {
@@ -4867,11 +6774,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.test_bg_llm.name",
         "default": "测试背景LLM连接"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:test_guidance": {
       "auto_start": false,
@@ -4882,6 +6799,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "test_guidance",
       "input_schema": {
         "properties": {
@@ -4899,11 +6817,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "test_result"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "test_result": {}
+        },
+        "required": [
+          "test_result"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.test_guidance.name",
         "default": "测试引导词生成"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:plugin_entry:update_guidance_config": {
       "auto_start": false,
@@ -4914,6 +6852,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_guidance_config",
       "input_schema": {
         "properties": {
@@ -4928,11 +6867,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "updated",
+        "config"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "config": {},
+          "updated": {}
+        },
+        "required": [
+          "updated",
+          "config"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.update_guidance_config.name",
         "default": "更新背景LLM配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:timer:auto_save_user_records": {
       "auto_start": true,
@@ -4940,16 +6902,30 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "timer",
+      "extra": {
+        "mode": "interval",
+        "seconds": 300
+      },
       "id": "auto_save_user_records",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "timer",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "seconds": 300
       },
-      "name": "auto_save_user_records"
+      "model_validate": true,
+      "name": "auto_save_user_records",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:timer:bg_agent": {
       "auto_start": true,
@@ -4957,16 +6933,30 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "timer",
+      "extra": {
+        "mode": "interval",
+        "seconds": 2
+      },
       "id": "bg_agent",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "timer",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "seconds": 2
       },
-      "name": "bg_agent"
+      "model_validate": true,
+      "name": "bg_agent",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "bilibili_danmaku:timer:push_danmaku": {
       "auto_start": true,
@@ -4974,19 +6964,33 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "timer",
+      "extra": {
+        "mode": "interval",
+        "seconds": 5
+      },
       "id": "push_danmaku",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "timer",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "seconds": 5
       },
-      "name": "push_danmaku"
+      "model_validate": true,
+      "name": "push_danmaku",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 914051,
   "source_files": [

--- a/plugin/plugins/bilibili_danmaku/plugin.meta.json
+++ b/plugin/plugins/bilibili_danmaku/plugin.meta.json
@@ -1371,7 +1371,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1945,7 +1944,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/plugins/claude_companion/plugin.meta.json
+++ b/plugin/plugins/claude_companion/plugin.meta.json
@@ -190,14 +190,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_events",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "清空事件日志"
+      "model_validate": true,
+      "name": "清空事件日志",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion.get_events": {
       "auto_start": false,
@@ -205,6 +216,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_events",
       "input_schema": {
         "properties": {
@@ -217,8 +229,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "count",
+        "events"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "count": {},
+          "events": {}
+        },
+        "required": [
+          "count",
+          "events"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "获取事件日志"
+      "model_validate": true,
+      "name": "获取事件日志",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion.get_status": {
       "auto_start": false,
@@ -226,14 +261,44 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "status",
+        "port",
+        "user_name",
+        "event_count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "event_count": {},
+          "port": {},
+          "status": {},
+          "user_name": {}
+        },
+        "required": [
+          "status",
+          "port",
+          "user_name",
+          "event_count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "获取状态"
+      "model_validate": true,
+      "name": "获取状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion.set_cooldown": {
       "auto_start": false,
@@ -241,6 +306,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_cooldown",
       "input_schema": {
         "properties": {
@@ -255,8 +321,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "设置冷却时间"
+      "model_validate": true,
+      "name": "设置冷却时间",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion.set_user_name": {
       "auto_start": false,
@@ -264,6 +340,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_user_name",
       "input_schema": {
         "properties": {
@@ -278,8 +355,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "设置用户名"
+      "model_validate": true,
+      "name": "设置用户名",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion.test_push": {
       "auto_start": false,
@@ -287,14 +374,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "test_push",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "测试推送"
+      "model_validate": true,
+      "name": "测试推送",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:lifecycle:shutdown": {
       "auto_start": false,
@@ -302,14 +400,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:lifecycle:startup": {
       "auto_start": false,
@@ -317,14 +426,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:plugin_entry:clear_events": {
       "auto_start": false,
@@ -332,14 +452,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_events",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "清空事件日志"
+      "model_validate": true,
+      "name": "清空事件日志",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:plugin_entry:get_events": {
       "auto_start": false,
@@ -347,6 +478,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_events",
       "input_schema": {
         "properties": {
@@ -359,8 +491,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "count",
+        "events"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "count": {},
+          "events": {}
+        },
+        "required": [
+          "count",
+          "events"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "获取事件日志"
+      "model_validate": true,
+      "name": "获取事件日志",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:plugin_entry:get_status": {
       "auto_start": false,
@@ -368,14 +523,44 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "status",
+        "port",
+        "user_name",
+        "event_count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "event_count": {},
+          "port": {},
+          "status": {},
+          "user_name": {}
+        },
+        "required": [
+          "status",
+          "port",
+          "user_name",
+          "event_count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "获取状态"
+      "model_validate": true,
+      "name": "获取状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:plugin_entry:set_cooldown": {
       "auto_start": false,
@@ -383,6 +568,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_cooldown",
       "input_schema": {
         "properties": {
@@ -397,8 +583,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "设置冷却时间"
+      "model_validate": true,
+      "name": "设置冷却时间",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:plugin_entry:set_user_name": {
       "auto_start": false,
@@ -406,6 +602,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_user_name",
       "input_schema": {
         "properties": {
@@ -420,8 +617,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "设置用户名"
+      "model_validate": true,
+      "name": "设置用户名",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "claude_companion:plugin_entry:test_push": {
       "auto_start": false,
@@ -429,17 +636,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "test_push",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "测试推送"
+      "model_validate": true,
+      "name": "测试推送",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 107242,
   "source_files": [

--- a/plugin/plugins/claude_companion/plugin.meta.json
+++ b/plugin/plugins/claude_companion/plugin.meta.json
@@ -16,7 +16,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -119,7 +118,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -146,7 +144,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -165,7 +162,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/plugins/game_agent_minecraft/plugin.meta.json
+++ b/plugin/plugins/game_agent_minecraft/plugin.meta.json
@@ -106,14 +106,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "game_agent_reload_config",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "重载游戏插件配置"
+      "model_validate": true,
+      "name": "重载游戏插件配置",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft.game_agent_status": {
       "auto_start": false,
@@ -121,14 +142,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "game_agent_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "查询 mc-agent 连接状态"
+      "model_validate": true,
+      "name": "查询 mc-agent 连接状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft.query_inventory": {
       "auto_start": false,
@@ -136,14 +178,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_inventory",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "查询当前持有"
+      "model_validate": true,
+      "name": "查询当前持有",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft:lifecycle:shutdown": {
       "auto_start": false,
@@ -151,14 +214,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft:lifecycle:startup": {
       "auto_start": false,
@@ -166,14 +240,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft:plugin_entry:game_agent_reload_config": {
       "auto_start": false,
@@ -181,14 +266,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "game_agent_reload_config",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "重载游戏插件配置"
+      "model_validate": true,
+      "name": "重载游戏插件配置",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft:plugin_entry:game_agent_status": {
       "auto_start": false,
@@ -196,14 +302,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "game_agent_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "查询 mc-agent 连接状态"
+      "model_validate": true,
+      "name": "查询 mc-agent 连接状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "game_agent_minecraft:plugin_entry:query_inventory": {
       "auto_start": false,
@@ -211,17 +338,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "query_inventory",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "查询当前持有"
+      "model_validate": true,
+      "name": "查询当前持有",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 320132,
   "source_files": [

--- a/plugin/plugins/jukebox_controller/plugin.meta.json
+++ b/plugin/plugins/jukebox_controller/plugin.meta.json
@@ -93,6 +93,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "control_jukebox",
       "input_schema": {
         "properties": {
@@ -134,8 +135,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "action",
+        "query",
+        "value",
+        "mode",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "action": {},
+          "message": {},
+          "mode": {},
+          "query": {},
+          "value": {}
+        },
+        "required": [
+          "action",
+          "query",
+          "value",
+          "mode",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "控制点歌台"
+      "model_validate": true,
+      "name": "控制点歌台",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "jukebox_controller:plugin_entry:control_jukebox": {
       "auto_start": false,
@@ -143,6 +176,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "control_jukebox",
       "input_schema": {
         "properties": {
@@ -184,11 +218,43 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "action",
+        "query",
+        "value",
+        "mode",
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "action": {},
+          "message": {},
+          "mode": {},
+          "query": {},
+          "value": {}
+        },
+        "required": [
+          "action",
+          "query",
+          "value",
+          "mode",
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "控制点歌台"
+      "model_validate": true,
+      "name": "控制点歌台",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 10264,
   "source_files": [

--- a/plugin/plugins/lifekit/plugin.meta.json
+++ b/plugin/plugins/lifekit/plugin.meta.json
@@ -2852,17 +2852,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_config",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.getConfig.name",
         "default": "获取配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "lifekit.update_config": {
       "auto_start": false,
@@ -2873,6 +2884,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_config",
       "input_schema": {
         "properties": {
@@ -2915,11 +2927,157 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "status",
+        "summary",
+        "message",
+        "config",
+        "choices",
+        "confirmation_token"
+      ],
+      "llm_result_schema": {
+        "$defs": {
+          "ClarificationResult": {
+            "properties": {
+              "choices": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Choices",
+                "type": "array"
+              },
+              "confirmation_token": {
+                "default": "",
+                "title": "Confirmation Token",
+                "type": "string"
+              },
+              "context": {
+                "additionalProperties": true,
+                "title": "Context",
+                "type": "object"
+              },
+              "status": {
+                "const": "clarify",
+                "title": "Status",
+                "type": "string"
+              },
+              "summary": {
+                "minLength": 1,
+                "title": "Summary",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "summary"
+            ],
+            "title": "ClarificationResult",
+            "type": "object"
+          },
+          "_UpdateConfigReadyResult": {
+            "properties": {
+              "config": {
+                "additionalProperties": true,
+                "title": "Config",
+                "type": "object"
+              },
+              "message": {
+                "title": "Message",
+                "type": "string"
+              },
+              "status": {
+                "const": "ready",
+                "title": "Status",
+                "type": "string"
+              },
+              "summary": {
+                "title": "Summary",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "summary",
+              "message",
+              "config"
+            ],
+            "title": "_UpdateConfigReadyResult",
+            "type": "object"
+          }
+        },
+        "discriminator": {
+          "mapping": {
+            "clarify": "#/$defs/ClarificationResult",
+            "ready": "#/$defs/_UpdateConfigReadyResult"
+          },
+          "propertyName": "status"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/_UpdateConfigReadyResult"
+          },
+          {
+            "$ref": "#/$defs/ClarificationResult"
+          }
+        ],
+        "properties": {
+          "choices": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Choices",
+            "type": "array"
+          },
+          "config": {
+            "additionalProperties": true,
+            "title": "Config",
+            "type": "object"
+          },
+          "confirmation_token": {
+            "default": "",
+            "title": "Confirmation Token",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "ready",
+              "clarify"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "summary",
+          "message",
+          "config",
+          "choices",
+          "confirmation_token"
+        ],
+        "title": "UpdateConfigResult"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.updateConfig.name",
         "default": "更新配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "lifekit:lifecycle:config_change": {
       "auto_start": false,
@@ -2927,14 +3085,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "config_change",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "config_change"
+      "model_validate": true,
+      "name": "config_change",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "lifekit:lifecycle:shutdown": {
       "auto_start": false,
@@ -2942,14 +3111,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "lifekit:lifecycle:startup": {
       "auto_start": false,
@@ -2957,14 +3137,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "lifekit:plugin_entry:get_config": {
       "auto_start": false,
@@ -2975,17 +3166,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_config",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.getConfig.name",
         "default": "获取配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "lifekit:plugin_entry:update_config": {
       "auto_start": false,
@@ -2996,6 +3198,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_config",
       "input_schema": {
         "properties": {
@@ -3038,14 +3241,160 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "status",
+        "summary",
+        "message",
+        "config",
+        "choices",
+        "confirmation_token"
+      ],
+      "llm_result_schema": {
+        "$defs": {
+          "ClarificationResult": {
+            "properties": {
+              "choices": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Choices",
+                "type": "array"
+              },
+              "confirmation_token": {
+                "default": "",
+                "title": "Confirmation Token",
+                "type": "string"
+              },
+              "context": {
+                "additionalProperties": true,
+                "title": "Context",
+                "type": "object"
+              },
+              "status": {
+                "const": "clarify",
+                "title": "Status",
+                "type": "string"
+              },
+              "summary": {
+                "minLength": 1,
+                "title": "Summary",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "summary"
+            ],
+            "title": "ClarificationResult",
+            "type": "object"
+          },
+          "_UpdateConfigReadyResult": {
+            "properties": {
+              "config": {
+                "additionalProperties": true,
+                "title": "Config",
+                "type": "object"
+              },
+              "message": {
+                "title": "Message",
+                "type": "string"
+              },
+              "status": {
+                "const": "ready",
+                "title": "Status",
+                "type": "string"
+              },
+              "summary": {
+                "title": "Summary",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "summary",
+              "message",
+              "config"
+            ],
+            "title": "_UpdateConfigReadyResult",
+            "type": "object"
+          }
+        },
+        "discriminator": {
+          "mapping": {
+            "clarify": "#/$defs/ClarificationResult",
+            "ready": "#/$defs/_UpdateConfigReadyResult"
+          },
+          "propertyName": "status"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/_UpdateConfigReadyResult"
+          },
+          {
+            "$ref": "#/$defs/ClarificationResult"
+          }
+        ],
+        "properties": {
+          "choices": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Choices",
+            "type": "array"
+          },
+          "config": {
+            "additionalProperties": true,
+            "title": "Config",
+            "type": "object"
+          },
+          "confirmation_token": {
+            "default": "",
+            "title": "Confirmation Token",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "ready",
+              "clarify"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "summary",
+          "message",
+          "config",
+          "choices",
+          "confirmation_token"
+        ],
+        "title": "UpdateConfigResult"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.updateConfig.name",
         "default": "更新配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 681065,
   "source_files": [

--- a/plugin/plugins/lifekit/plugin.meta.json
+++ b/plugin/plugins/lifekit/plugin.meta.json
@@ -19,7 +19,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/plugins/mcp_adapter/plugin.meta.json
+++ b/plugin/plugins/mcp_adapter/plugin.meta.json
@@ -485,6 +485,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_server",
       "input_schema": {
         "properties": {
@@ -567,11 +568,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.addServer.name",
         "default": "Add MCP Server"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.call_tool": {
       "auto_start": false,
@@ -582,6 +603,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "call_tool",
       "input_schema": {
         "properties": {
@@ -614,11 +636,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.callTool.name",
         "default": "Call MCP Tool"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.connect_server": {
       "auto_start": false,
@@ -629,6 +671,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "connect_server",
       "input_schema": {
         "properties": {
@@ -646,11 +689,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.connect.name",
         "default": "Connect MCP Server"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.disconnect_server": {
       "auto_start": false,
@@ -661,6 +724,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "disconnect_server",
       "input_schema": {
         "properties": {
@@ -678,11 +742,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.disconnect.name",
         "default": "Disconnect MCP Server"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.gateway_invoke": {
       "auto_start": false,
@@ -693,6 +777,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "gateway_invoke",
       "input_schema": {
         "properties": {
@@ -731,11 +816,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.gatewayInvoke.name",
         "default": "Gateway Invoke"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.list_servers": {
       "auto_start": false,
@@ -746,17 +851,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_servers",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.listServers.name",
         "default": "List MCP Servers"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.list_tools": {
       "auto_start": false,
@@ -767,6 +893,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_tools",
       "input_schema": {
         "properties": {
@@ -781,11 +908,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.listTools.name",
         "default": "List MCP Tools"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter.remove_servers": {
       "auto_start": false,
@@ -796,6 +943,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_servers",
       "input_schema": {
         "properties": {
@@ -816,11 +964,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.removeServers.name",
         "default": "Remove MCP Servers"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:lifecycle:shutdown": {
       "auto_start": false,
@@ -828,14 +996,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:lifecycle:startup": {
       "auto_start": false,
@@ -843,14 +1022,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:add_server": {
       "auto_start": false,
@@ -861,6 +1051,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_server",
       "input_schema": {
         "properties": {
@@ -943,11 +1134,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.addServer.name",
         "default": "Add MCP Server"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:call_tool": {
       "auto_start": false,
@@ -958,6 +1169,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "call_tool",
       "input_schema": {
         "properties": {
@@ -990,11 +1202,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.callTool.name",
         "default": "Call MCP Tool"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:connect_server": {
       "auto_start": false,
@@ -1005,6 +1237,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "connect_server",
       "input_schema": {
         "properties": {
@@ -1022,11 +1255,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.connect.name",
         "default": "Connect MCP Server"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:disconnect_server": {
       "auto_start": false,
@@ -1037,6 +1290,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "disconnect_server",
       "input_schema": {
         "properties": {
@@ -1054,11 +1308,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.disconnect.name",
         "default": "Disconnect MCP Server"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:gateway_invoke": {
       "auto_start": false,
@@ -1069,6 +1343,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "gateway_invoke",
       "input_schema": {
         "properties": {
@@ -1107,11 +1382,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.gatewayInvoke.name",
         "default": "Gateway Invoke"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:list_servers": {
       "auto_start": false,
@@ -1122,17 +1417,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_servers",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.listServers.name",
         "default": "List MCP Servers"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:list_tools": {
       "auto_start": false,
@@ -1143,6 +1459,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_tools",
       "input_schema": {
         "properties": {
@@ -1157,11 +1474,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.listTools.name",
         "default": "List MCP Tools"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "mcp_adapter:plugin_entry:remove_servers": {
       "auto_start": false,
@@ -1172,6 +1509,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_servers",
       "input_schema": {
         "properties": {
@@ -1192,14 +1530,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {}
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.removeServers.name",
         "default": "Remove MCP Servers"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 261548,
   "source_files": [

--- a/plugin/plugins/memo_reminder/plugin.meta.json
+++ b/plugin/plugins/memo_reminder/plugin.meta.json
@@ -200,6 +200,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_reminder",
       "input_schema": {
         "properties": {
@@ -228,8 +229,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message",
+        "trigger_at_local"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {},
+          "trigger_at_local": {}
+        },
+        "required": [
+          "message",
+          "trigger_at_local"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "添加提醒"
+      "model_validate": true,
+      "name": "添加提醒",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder.bind_task": {
       "auto_start": false,
@@ -237,6 +261,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bind_task",
       "input_schema": {
         "properties": {
@@ -254,8 +279,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "绑定Agent任务ID"
+      "model_validate": true,
+      "name": "绑定Agent任务ID",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder.clear_reminders": {
       "auto_start": false,
@@ -263,14 +298,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_reminders",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "cleared"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "cleared": {}
+        },
+        "required": [
+          "cleared"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "清空所有提醒"
+      "model_validate": true,
+      "name": "清空所有提醒",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder.delete_reminder": {
       "auto_start": false,
@@ -278,6 +334,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_reminder",
       "input_schema": {
         "properties": {
@@ -292,8 +349,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {}
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "删除提醒"
+      "model_validate": true,
+      "name": "删除提醒",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder.list_reminders": {
       "auto_start": false,
@@ -301,14 +378,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_reminders",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "count": {}
+        },
+        "required": [
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "查看提醒列表"
+      "model_validate": true,
+      "name": "查看提醒列表",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:lifecycle:shutdown": {
       "auto_start": false,
@@ -316,14 +414,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:lifecycle:startup": {
       "auto_start": false,
@@ -331,14 +440,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:plugin_entry:add_reminder": {
       "auto_start": false,
@@ -346,6 +466,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_reminder",
       "input_schema": {
         "properties": {
@@ -374,8 +495,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "message",
+        "trigger_at_local"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "message": {},
+          "trigger_at_local": {}
+        },
+        "required": [
+          "message",
+          "trigger_at_local"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "添加提醒"
+      "model_validate": true,
+      "name": "添加提醒",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:plugin_entry:bind_task": {
       "auto_start": false,
@@ -383,6 +527,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bind_task",
       "input_schema": {
         "properties": {
@@ -400,8 +545,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "绑定Agent任务ID"
+      "model_validate": true,
+      "name": "绑定Agent任务ID",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:plugin_entry:clear_reminders": {
       "auto_start": false,
@@ -409,14 +564,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_reminders",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "cleared"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "cleared": {}
+        },
+        "required": [
+          "cleared"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "清空所有提醒"
+      "model_validate": true,
+      "name": "清空所有提醒",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:plugin_entry:delete_reminder": {
       "auto_start": false,
@@ -424,6 +600,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_reminder",
       "input_schema": {
         "properties": {
@@ -438,8 +615,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {}
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "删除提醒"
+      "model_validate": true,
+      "name": "删除提醒",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "memo_reminder:plugin_entry:list_reminders": {
       "auto_start": false,
@@ -447,17 +644,38 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_reminders",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "count"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "count": {}
+        },
+        "required": [
+          "count"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "查看提醒列表"
+      "model_validate": true,
+      "name": "查看提醒列表",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 30092,
   "source_files": [

--- a/plugin/plugins/memo_reminder/plugin.meta.json
+++ b/plugin/plugins/memo_reminder/plugin.meta.json
@@ -81,7 +81,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/plugins/music_pusher/plugin.meta.json
+++ b/plugin/plugins/music_pusher/plugin.meta.json
@@ -791,6 +791,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "create_schedule_task",
       "input_schema": {
         "properties": {
@@ -831,8 +832,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "task_id",
+        "status"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "status": {},
+          "task_id": {}
+        },
+        "required": [
+          "task_id",
+          "status"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "创建定时任务"
+      "model_validate": true,
+      "name": "创建定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.delete_music_item": {
       "auto_start": false,
@@ -840,6 +864,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_music_item",
       "input_schema": {
         "properties": {
@@ -853,8 +878,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {}
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "删除音乐素材"
+      "model_validate": true,
+      "name": "删除音乐素材",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.delete_schedule_task": {
       "auto_start": false,
@@ -862,6 +907,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_schedule_task",
       "input_schema": {
         "properties": {
@@ -875,8 +921,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {},
+          "task_id": {}
+        },
+        "required": [
+          "deleted",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "删除定时任务"
+      "model_validate": true,
+      "name": "删除定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.get_push_settings": {
       "auto_start": false,
@@ -884,14 +953,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_push_settings",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "attach_prompt_on_push"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "attach_prompt_on_push": {}
+        },
+        "required": [
+          "attach_prompt_on_push"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "获取推送设置"
+      "model_validate": true,
+      "name": "获取推送设置",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.list_music_items": {
       "auto_start": false,
@@ -899,14 +989,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_music_items",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "列出音乐素材"
+      "model_validate": true,
+      "name": "列出音乐素材",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.list_schedule_tasks": {
       "auto_start": false,
@@ -914,14 +1025,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_schedule_tasks",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "列出定时任务"
+      "model_validate": true,
+      "name": "列出定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.push_music_url": {
       "auto_start": false,
@@ -929,6 +1061,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "push_music_url",
       "input_schema": {
         "properties": {
@@ -964,8 +1097,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "pushed",
+        "chain",
+        "url"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "chain": {},
+          "pushed": {},
+          "url": {}
+        },
+        "required": [
+          "pushed",
+          "chain",
+          "url"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "推送音乐链接"
+      "model_validate": true,
+      "name": "推送音乐链接",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.report_playback_state": {
       "auto_start": false,
@@ -973,6 +1132,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "report_playback_state",
       "input_schema": {
         "properties": {
@@ -1000,8 +1160,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "updated"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "updated": {}
+        },
+        "required": [
+          "updated"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "上报播放状态"
+      "model_validate": true,
+      "name": "上报播放状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.run": {
       "auto_start": false,
@@ -1009,6 +1189,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "run",
       "input_schema": {
         "properties": {
@@ -1042,8 +1223,37 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "pushed",
+        "url",
+        "title",
+        "artist"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "artist": {},
+          "pushed": {},
+          "title": {},
+          "url": {}
+        },
+        "required": [
+          "pushed",
+          "url",
+          "title",
+          "artist"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "通用推歌入口"
+      "model_validate": true,
+      "name": "通用推歌入口",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.run_schedule_task_now": {
       "auto_start": false,
@@ -1051,6 +1261,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "run_schedule_task_now",
       "input_schema": {
         "properties": {
@@ -1068,8 +1279,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "queued",
+        "task_id",
+        "started_immediately"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "queued": {},
+          "started_immediately": {},
+          "task_id": {}
+        },
+        "required": [
+          "queued",
+          "task_id",
+          "started_immediately"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "立即执行任务"
+      "model_validate": true,
+      "name": "立即执行任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.set_push_settings": {
       "auto_start": false,
@@ -1077,6 +1314,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_push_settings",
       "input_schema": {
         "properties": {
@@ -1090,8 +1328,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "attach_prompt_on_push"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "attach_prompt_on_push": {}
+        },
+        "required": [
+          "attach_prompt_on_push"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "设置推送开关"
+      "model_validate": true,
+      "name": "设置推送开关",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.skip_current_track": {
       "auto_start": false,
@@ -1099,6 +1357,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "skip_current_track",
       "input_schema": {
         "properties": {
@@ -1118,8 +1377,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "accepted",
+        "direction",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "accepted": {},
+          "direction": {},
+          "task_id": {}
+        },
+        "required": [
+          "accepted",
+          "direction",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "切换当前曲目"
+      "model_validate": true,
+      "name": "切换当前曲目",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.stop_schedule_task": {
       "auto_start": false,
@@ -1127,6 +1412,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "stop_schedule_task",
       "input_schema": {
         "properties": {
@@ -1138,8 +1424,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "stopped",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "stopped": {},
+          "task_id": {}
+        },
+        "required": [
+          "stopped",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "停止执行任务"
+      "model_validate": true,
+      "name": "停止执行任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.toggle_schedule_task": {
       "auto_start": false,
@@ -1147,6 +1456,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "toggle_schedule_task",
       "input_schema": {
         "properties": {
@@ -1160,8 +1470,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "action",
+        "task_id",
+        "ok"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "action": {},
+          "ok": {},
+          "task_id": {}
+        },
+        "required": [
+          "action",
+          "task_id",
+          "ok"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "切换运行或停止"
+      "model_validate": true,
+      "name": "切换运行或停止",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.update_schedule_task": {
       "auto_start": false,
@@ -1169,6 +1505,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_schedule_task",
       "input_schema": {
         "properties": {
@@ -1210,8 +1547,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "updated",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "task_id": {},
+          "updated": {}
+        },
+        "required": [
+          "updated",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "更新定时任务"
+      "model_validate": true,
+      "name": "更新定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher.upload_music_file": {
       "auto_start": false,
@@ -1219,6 +1579,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "upload_music_file",
       "input_schema": {
         "properties": {
@@ -1263,8 +1624,37 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "saved",
+        "pushed",
+        "music_url_absolute",
+        "duration_sec"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "duration_sec": {},
+          "music_url_absolute": {},
+          "pushed": {},
+          "saved": {}
+        },
+        "required": [
+          "saved",
+          "pushed",
+          "music_url_absolute",
+          "duration_sec"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "上传音乐并自动推送"
+      "model_validate": true,
+      "name": "上传音乐并自动推送",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:lifecycle:shutdown": {
       "auto_start": false,
@@ -1272,14 +1662,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:lifecycle:startup": {
       "auto_start": false,
@@ -1287,14 +1688,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:create_schedule_task": {
       "auto_start": false,
@@ -1302,6 +1714,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "create_schedule_task",
       "input_schema": {
         "properties": {
@@ -1342,8 +1755,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "task_id",
+        "status"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "status": {},
+          "task_id": {}
+        },
+        "required": [
+          "task_id",
+          "status"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "创建定时任务"
+      "model_validate": true,
+      "name": "创建定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:delete_music_item": {
       "auto_start": false,
@@ -1351,6 +1787,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_music_item",
       "input_schema": {
         "properties": {
@@ -1364,8 +1801,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {}
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "删除音乐素材"
+      "model_validate": true,
+      "name": "删除音乐素材",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:delete_schedule_task": {
       "auto_start": false,
@@ -1373,6 +1830,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_schedule_task",
       "input_schema": {
         "properties": {
@@ -1386,8 +1844,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "deleted",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "deleted": {},
+          "task_id": {}
+        },
+        "required": [
+          "deleted",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "删除定时任务"
+      "model_validate": true,
+      "name": "删除定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:get_push_settings": {
       "auto_start": false,
@@ -1395,14 +1876,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_push_settings",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "attach_prompt_on_push"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "attach_prompt_on_push": {}
+        },
+        "required": [
+          "attach_prompt_on_push"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "获取推送设置"
+      "model_validate": true,
+      "name": "获取推送设置",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:list_music_items": {
       "auto_start": false,
@@ -1410,14 +1912,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_music_items",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "列出音乐素材"
+      "model_validate": true,
+      "name": "列出音乐素材",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:list_schedule_tasks": {
       "auto_start": false,
@@ -1425,14 +1948,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_schedule_tasks",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "total"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "total": {}
+        },
+        "required": [
+          "total"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "列出定时任务"
+      "model_validate": true,
+      "name": "列出定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:push_music_url": {
       "auto_start": false,
@@ -1440,6 +1984,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "push_music_url",
       "input_schema": {
         "properties": {
@@ -1475,8 +2020,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "pushed",
+        "chain",
+        "url"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "chain": {},
+          "pushed": {},
+          "url": {}
+        },
+        "required": [
+          "pushed",
+          "chain",
+          "url"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "推送音乐链接"
+      "model_validate": true,
+      "name": "推送音乐链接",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:report_playback_state": {
       "auto_start": false,
@@ -1484,6 +2055,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "report_playback_state",
       "input_schema": {
         "properties": {
@@ -1511,8 +2083,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "updated"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "updated": {}
+        },
+        "required": [
+          "updated"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "上报播放状态"
+      "model_validate": true,
+      "name": "上报播放状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:run": {
       "auto_start": false,
@@ -1520,6 +2112,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "run",
       "input_schema": {
         "properties": {
@@ -1553,8 +2146,37 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "pushed",
+        "url",
+        "title",
+        "artist"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "artist": {},
+          "pushed": {},
+          "title": {},
+          "url": {}
+        },
+        "required": [
+          "pushed",
+          "url",
+          "title",
+          "artist"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "通用推歌入口"
+      "model_validate": true,
+      "name": "通用推歌入口",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:run_schedule_task_now": {
       "auto_start": false,
@@ -1562,6 +2184,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "run_schedule_task_now",
       "input_schema": {
         "properties": {
@@ -1579,8 +2202,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "queued",
+        "task_id",
+        "started_immediately"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "queued": {},
+          "started_immediately": {},
+          "task_id": {}
+        },
+        "required": [
+          "queued",
+          "task_id",
+          "started_immediately"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "立即执行任务"
+      "model_validate": true,
+      "name": "立即执行任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:set_push_settings": {
       "auto_start": false,
@@ -1588,6 +2237,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_push_settings",
       "input_schema": {
         "properties": {
@@ -1601,8 +2251,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "attach_prompt_on_push"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "attach_prompt_on_push": {}
+        },
+        "required": [
+          "attach_prompt_on_push"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "设置推送开关"
+      "model_validate": true,
+      "name": "设置推送开关",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:skip_current_track": {
       "auto_start": false,
@@ -1610,6 +2280,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "skip_current_track",
       "input_schema": {
         "properties": {
@@ -1629,8 +2300,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "accepted",
+        "direction",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "accepted": {},
+          "direction": {},
+          "task_id": {}
+        },
+        "required": [
+          "accepted",
+          "direction",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "切换当前曲目"
+      "model_validate": true,
+      "name": "切换当前曲目",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:stop_schedule_task": {
       "auto_start": false,
@@ -1638,6 +2335,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "stop_schedule_task",
       "input_schema": {
         "properties": {
@@ -1649,8 +2347,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "stopped",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "stopped": {},
+          "task_id": {}
+        },
+        "required": [
+          "stopped",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "停止执行任务"
+      "model_validate": true,
+      "name": "停止执行任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:toggle_schedule_task": {
       "auto_start": false,
@@ -1658,6 +2379,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "toggle_schedule_task",
       "input_schema": {
         "properties": {
@@ -1671,8 +2393,34 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "action",
+        "task_id",
+        "ok"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "action": {},
+          "ok": {},
+          "task_id": {}
+        },
+        "required": [
+          "action",
+          "task_id",
+          "ok"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "切换运行或停止"
+      "model_validate": true,
+      "name": "切换运行或停止",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:update_schedule_task": {
       "auto_start": false,
@@ -1680,6 +2428,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "update_schedule_task",
       "input_schema": {
         "properties": {
@@ -1721,8 +2470,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "updated",
+        "task_id"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "task_id": {},
+          "updated": {}
+        },
+        "required": [
+          "updated",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "更新定时任务"
+      "model_validate": true,
+      "name": "更新定时任务",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "music_pusher:plugin_entry:upload_music_file": {
       "auto_start": false,
@@ -1730,6 +2502,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "upload_music_file",
       "input_schema": {
         "properties": {
@@ -1774,11 +2547,40 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "saved",
+        "pushed",
+        "music_url_absolute",
+        "duration_sec"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "duration_sec": {},
+          "music_url_absolute": {},
+          "pushed": {},
+          "saved": {}
+        },
+        "required": [
+          "saved",
+          "pushed",
+          "music_url_absolute",
+          "duration_sec"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "上传音乐并自动推送"
+      "model_validate": true,
+      "name": "上传音乐并自动推送",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 1206411,
   "source_files": [

--- a/plugin/plugins/netease_music/plugin.meta.json
+++ b/plugin/plugins/netease_music/plugin.meta.json
@@ -146,6 +146,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_music_u",
       "input_schema": {
         "additionalProperties": false,
@@ -162,11 +163,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.clear.name",
         "default": "清除网易云凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "netease_music.play_netease_music": {
       "auto_start": false,
@@ -177,6 +188,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "play_netease_music",
       "input_schema": {
         "additionalProperties": false,
@@ -200,11 +212,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.play.name",
         "default": "播放网易云歌曲"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": 20.0
     },
     "netease_music.save_music_u": {
       "auto_start": false,
@@ -215,6 +237,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_music_u",
       "input_schema": {
         "additionalProperties": false,
@@ -243,11 +266,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.save.name",
         "default": "保存网易云凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "netease_music:lifecycle:shutdown": {
       "auto_start": false,
@@ -255,14 +288,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "netease_music:lifecycle:startup": {
       "auto_start": false,
@@ -270,14 +314,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "netease_music:plugin_entry:clear_music_u": {
       "auto_start": false,
@@ -288,6 +343,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "clear_music_u",
       "input_schema": {
         "additionalProperties": false,
@@ -304,11 +360,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.clear.name",
         "default": "清除网易云凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "netease_music:plugin_entry:play_netease_music": {
       "auto_start": false,
@@ -319,6 +385,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "play_netease_music",
       "input_schema": {
         "additionalProperties": false,
@@ -342,11 +409,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.play.name",
         "default": "播放网易云歌曲"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": 20.0
     },
     "netease_music:plugin_entry:save_music_u": {
       "auto_start": false,
@@ -357,6 +434,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_music_u",
       "input_schema": {
         "additionalProperties": false,
@@ -385,14 +463,24 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entry.save.name",
         "default": "保存网易云凭据"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 68416,
   "source_files": [

--- a/plugin/plugins/netease_music/plugin.meta.json
+++ b/plugin/plugins/netease_music/plugin.meta.json
@@ -29,7 +29,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -71,7 +70,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -118,7 +116,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/plugins/proactive_controller/plugin.meta.json
+++ b/plugin/plugins/proactive_controller/plugin.meta.json
@@ -159,6 +159,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "command",
       "input_schema": {
         "properties": {
@@ -186,8 +187,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "主动搭话统一指令通道"
+      "model_validate": true,
+      "name": "主动搭话统一指令通道",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller.get_state": {
       "auto_start": false,
@@ -195,14 +206,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "mode"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "mode": {}
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "读取主动搭话状态"
+      "model_validate": true,
+      "name": "读取主动搭话状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller.set_mode": {
       "auto_start": false,
@@ -210,6 +242,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_mode",
       "input_schema": {
         "properties": {
@@ -230,8 +263,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "mode"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "mode": {}
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "切换主动搭话模式"
+      "model_validate": true,
+      "name": "切换主动搭话模式",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller.set_settings": {
       "auto_start": false,
@@ -239,6 +292,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_settings",
       "input_schema": {
         "properties": {
@@ -253,8 +307,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "细粒度调整主动搭话"
+      "model_validate": true,
+      "name": "细粒度调整主动搭话",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller:lifecycle:shutdown": {
       "auto_start": false,
@@ -262,14 +326,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller:lifecycle:startup": {
       "auto_start": false,
@@ -277,14 +352,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller:plugin_entry:command": {
       "auto_start": false,
@@ -292,6 +378,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "command",
       "input_schema": {
         "properties": {
@@ -319,8 +406,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "主动搭话统一指令通道"
+      "model_validate": true,
+      "name": "主动搭话统一指令通道",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller:plugin_entry:get_state": {
       "auto_start": false,
@@ -328,14 +425,35 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "mode"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "mode": {}
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "读取主动搭话状态"
+      "model_validate": true,
+      "name": "读取主动搭话状态",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller:plugin_entry:set_mode": {
       "auto_start": false,
@@ -343,6 +461,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_mode",
       "input_schema": {
         "properties": {
@@ -363,8 +482,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "mode"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "mode": {}
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "切换主动搭话模式"
+      "model_validate": true,
+      "name": "切换主动搭话模式",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "proactive_controller:plugin_entry:set_settings": {
       "auto_start": false,
@@ -372,6 +511,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_settings",
       "input_schema": {
         "properties": {
@@ -386,11 +526,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "细粒度调整主动搭话"
+      "model_validate": true,
+      "name": "细粒度调整主动搭话",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 15252,
   "source_files": [

--- a/plugin/plugins/proactive_controller/plugin.meta.json
+++ b/plugin/plugins/proactive_controller/plugin.meta.json
@@ -37,7 +37,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -136,7 +135,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/plugins/qq_auto_reply/plugin.meta.json
+++ b/plugin/plugins/qq_auto_reply/plugin.meta.json
@@ -1440,6 +1440,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_trusted_group",
       "input_schema": {
         "properties": {
@@ -1463,11 +1464,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.add_trusted_group.name",
         "default": "添加信任群聊"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.add_trusted_user": {
       "auto_start": false,
@@ -1478,6 +1489,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_trusted_user",
       "input_schema": {
         "properties": {
@@ -1502,11 +1514,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.add_trusted_user.name",
         "default": "添加信任用户"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.adjust_group_attention": {
       "auto_start": false,
@@ -1517,6 +1539,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "adjust_group_attention",
       "input_schema": {
         "additionalProperties": false,
@@ -1535,11 +1558,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.adjust_group_attention.name",
         "default": "手动调整群注意力"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.bind_identity_account": {
       "auto_start": false,
@@ -1550,6 +1583,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bind_identity_account",
       "input_schema": {
         "additionalProperties": false,
@@ -1568,11 +1602,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bind_identity_account.name",
         "default": "合并到已有身份"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.configure_onebot_nl": {
       "auto_start": false,
@@ -1583,6 +1627,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "configure_onebot_nl",
       "input_schema": {
         "additionalProperties": false,
@@ -1598,11 +1643,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.configure_onebot_nl.name",
         "default": "用自然语言配置 OneBot 连接"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.delete_group_prompt": {
       "auto_start": false,
@@ -1610,6 +1665,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_group_prompt",
       "input_schema": {
         "properties": {
@@ -1623,8 +1679,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "delete_group_prompt"
+      "model_validate": true,
+      "name": "delete_group_prompt",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.ensure_napcat": {
       "auto_start": false,
@@ -1635,6 +1701,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ensure_napcat",
       "input_schema": {
         "additionalProperties": false,
@@ -1642,11 +1709,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ensure_napcat.name",
         "default": "启动 NapCat 进程"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.forget_group_memory": {
       "auto_start": false,
@@ -1657,6 +1734,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "forget_group_memory",
       "input_schema": {
         "properties": {
@@ -1670,11 +1748,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.forget_group_memory.name",
         "default": "清除群记忆"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_attention_state": {
       "auto_start": false,
@@ -1685,6 +1773,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_attention_state",
       "input_schema": {
         "additionalProperties": false,
@@ -1692,11 +1781,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_attention_state.name",
         "default": "获取注意力状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_backlog_summary": {
       "auto_start": false,
@@ -1707,17 +1806,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_backlog_summary",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_backlog_summary.name",
         "default": "读取待审阅摘要"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_buffer_state": {
       "auto_start": false,
@@ -1725,14 +1835,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_buffer_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "get_buffer_state"
+      "model_validate": true,
+      "name": "get_buffer_state",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_dashboard_state": {
       "auto_start": false,
@@ -1743,17 +1864,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_dashboard_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_dashboard_state.name",
         "default": "获取控制面板状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_group_backlog_detail": {
       "auto_start": false,
@@ -1764,6 +1896,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_group_backlog_detail",
       "input_schema": {
         "properties": {
@@ -1777,11 +1910,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_group_backlog_detail.name",
         "default": "读取群聊待审阅详情"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_group_prompts": {
       "auto_start": false,
@@ -1789,14 +1932,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_group_prompts",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "get_group_prompts"
+      "model_validate": true,
+      "name": "get_group_prompts",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_napcat_webui": {
       "auto_start": false,
@@ -1807,6 +1961,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_napcat_webui",
       "input_schema": {
         "additionalProperties": false,
@@ -1814,11 +1969,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_napcat_webui.name",
         "default": "获取 NapCat WebUI 地址"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_prompt_editor_state": {
       "auto_start": false,
@@ -1829,6 +1994,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_prompt_editor_state",
       "input_schema": {
         "additionalProperties": false,
@@ -1840,11 +2006,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_prompt_editor_state.name",
         "default": "获取提示词编辑器状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_recent_logs": {
       "auto_start": false,
@@ -1855,6 +2031,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_recent_logs",
       "input_schema": {
         "additionalProperties": false,
@@ -1867,11 +2044,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_recent_logs.name",
         "default": "获取最近日志"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.get_user_profiles": {
       "auto_start": false,
@@ -1882,17 +2069,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_user_profiles",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_user_profiles.name",
         "default": "获取用户画像"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.init_config": {
       "auto_start": false,
@@ -1903,6 +2101,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "init_config",
       "input_schema": {
         "additionalProperties": false,
@@ -1914,11 +2113,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.init_config.name",
         "default": "初始化 QQ 配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.list_identity_claims": {
       "auto_start": false,
@@ -1929,6 +2138,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_identity_claims",
       "input_schema": {
         "additionalProperties": false,
@@ -1936,11 +2146,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.list_identity_claims.name",
         "default": "列出未认领的群内 ID"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.list_stickers": {
       "auto_start": false,
@@ -1951,6 +2171,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_stickers",
       "input_schema": {
         "additionalProperties": false,
@@ -1958,11 +2179,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.list_stickers.name",
         "default": "列出表情包"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.mark_group_backlog_reviewed": {
       "auto_start": false,
@@ -1973,6 +2204,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "mark_group_backlog_reviewed",
       "input_schema": {
         "properties": {
@@ -1986,11 +2218,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.mark_group_backlog_reviewed.name",
         "default": "标记群聊已处理"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.pick_directory": {
       "auto_start": false,
@@ -2001,6 +2243,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "pick_directory",
       "input_schema": {
         "additionalProperties": false,
@@ -2008,11 +2251,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.pick_directory.name",
         "default": "选择目录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.refresh_actual_contacts": {
       "auto_start": false,
@@ -2023,17 +2276,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "refresh_actual_contacts",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.refresh_actual_contacts.name",
         "default": "刷新实际联系人列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.register_sticker": {
       "auto_start": false,
@@ -2044,6 +2308,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "register_sticker",
       "input_schema": {
         "additionalProperties": false,
@@ -2064,11 +2329,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.register_sticker.name",
         "default": "注册表情包"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.remove_trusted_group": {
       "auto_start": false,
@@ -2079,6 +2354,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_trusted_group",
       "input_schema": {
         "properties": {
@@ -2092,11 +2368,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.remove_trusted_group.name",
         "default": "移除信任群聊"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.remove_trusted_user": {
       "auto_start": false,
@@ -2107,6 +2393,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_trusted_user",
       "input_schema": {
         "properties": {
@@ -2120,11 +2407,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.remove_trusted_user.name",
         "default": "移除信任用户"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.reset_prompt_override": {
       "auto_start": false,
@@ -2135,6 +2432,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "reset_prompt_override",
       "input_schema": {
         "additionalProperties": false,
@@ -2153,11 +2451,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.reset_prompt_override.name",
         "default": "重置提示词覆盖"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.save_group_prompt": {
       "auto_start": false,
@@ -2165,6 +2473,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_group_prompt",
       "input_schema": {
         "properties": {
@@ -2182,8 +2491,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "save_group_prompt"
+      "model_validate": true,
+      "name": "save_group_prompt",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.save_proactive_topics": {
       "auto_start": false,
@@ -2194,6 +2513,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_proactive_topics",
       "input_schema": {
         "additionalProperties": false,
@@ -2211,11 +2531,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_proactive_topics.name",
         "default": "保存主动发言话题"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.save_prompt_override": {
       "auto_start": false,
@@ -2226,6 +2556,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_prompt_override",
       "input_schema": {
         "additionalProperties": false,
@@ -2249,11 +2580,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_prompt_override.name",
         "default": "保存提示词覆盖"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.save_settings": {
       "auto_start": false,
@@ -2264,6 +2605,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_settings",
       "input_schema": {
         "additionalProperties": false,
@@ -2358,11 +2700,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_settings.name",
         "default": "保存 QQ 自动回复设置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.send_backlog_reply_direct": {
       "auto_start": false,
@@ -2373,6 +2725,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_backlog_reply_direct",
       "input_schema": {
         "additionalProperties": false,
@@ -2405,11 +2758,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_backlog_reply_direct.name",
         "default": "发送这条回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.send_group_proactive_message": {
       "auto_start": false,
@@ -2420,6 +2783,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_group_proactive_message",
       "input_schema": {
         "additionalProperties": false,
@@ -2438,13 +2802,23 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "timeout": 90
       },
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_group_proactive_message.name",
         "default": "主动发送群聊消息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.send_private_proactive_message": {
       "auto_start": false,
@@ -2455,6 +2829,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_private_proactive_message",
       "input_schema": {
         "additionalProperties": false,
@@ -2473,13 +2848,23 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "timeout": 90
       },
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_private_proactive_message.name",
         "default": "主动发送私聊消息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.set_user_nickname": {
       "auto_start": false,
@@ -2490,6 +2875,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_user_nickname",
       "input_schema": {
         "properties": {
@@ -2507,11 +2893,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_user_nickname.name",
         "default": "设置用户昵称"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.start_auto_reply": {
       "auto_start": false,
@@ -2522,17 +2918,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "start_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.start_auto_reply.name",
         "default": "启动自动回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.stop_auto_reply": {
       "auto_start": false,
@@ -2543,17 +2950,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "stop_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.stop_auto_reply.name",
         "default": "停止自动回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.sync_qrcode": {
       "auto_start": false,
@@ -2564,17 +2982,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "sync_qrcode",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.sync_qrcode.name",
         "default": "刷新二维码"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.unbind_identity_account": {
       "auto_start": false,
@@ -2585,6 +3014,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "unbind_identity_account",
       "input_schema": {
         "additionalProperties": false,
@@ -2599,11 +3029,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.unbind_identity_account.name",
         "default": "撤销合并"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply.upload_sticker": {
       "auto_start": false,
@@ -2614,6 +3054,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "upload_sticker",
       "input_schema": {
         "additionalProperties": false,
@@ -2639,13 +3080,23 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "timeout": 30
       },
+      "model_validate": true,
       "name": {
         "$i18n": "entries.upload_sticker.name",
         "default": "上传表情包"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:lifecycle:shutdown": {
       "auto_start": false,
@@ -2653,14 +3104,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:lifecycle:startup": {
       "auto_start": false,
@@ -2668,14 +3130,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:add_trusted_group": {
       "auto_start": false,
@@ -2686,6 +3159,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_trusted_group",
       "input_schema": {
         "properties": {
@@ -2709,11 +3183,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.add_trusted_group.name",
         "default": "添加信任群聊"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:add_trusted_user": {
       "auto_start": false,
@@ -2724,6 +3208,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "add_trusted_user",
       "input_schema": {
         "properties": {
@@ -2748,11 +3233,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.add_trusted_user.name",
         "default": "添加信任用户"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:adjust_group_attention": {
       "auto_start": false,
@@ -2763,6 +3258,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "adjust_group_attention",
       "input_schema": {
         "additionalProperties": false,
@@ -2781,11 +3277,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.adjust_group_attention.name",
         "default": "手动调整群注意力"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:bind_identity_account": {
       "auto_start": false,
@@ -2796,6 +3302,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "bind_identity_account",
       "input_schema": {
         "additionalProperties": false,
@@ -2814,11 +3321,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.bind_identity_account.name",
         "default": "合并到已有身份"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:configure_onebot_nl": {
       "auto_start": false,
@@ -2829,6 +3346,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "configure_onebot_nl",
       "input_schema": {
         "additionalProperties": false,
@@ -2844,11 +3362,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.configure_onebot_nl.name",
         "default": "用自然语言配置 OneBot 连接"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:delete_group_prompt": {
       "auto_start": false,
@@ -2856,6 +3384,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "delete_group_prompt",
       "input_schema": {
         "properties": {
@@ -2869,8 +3398,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "delete_group_prompt"
+      "model_validate": true,
+      "name": "delete_group_prompt",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:ensure_napcat": {
       "auto_start": false,
@@ -2881,6 +3420,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "ensure_napcat",
       "input_schema": {
         "additionalProperties": false,
@@ -2888,11 +3428,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.ensure_napcat.name",
         "default": "启动 NapCat 进程"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:forget_group_memory": {
       "auto_start": false,
@@ -2903,6 +3453,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "forget_group_memory",
       "input_schema": {
         "properties": {
@@ -2916,11 +3467,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.forget_group_memory.name",
         "default": "清除群记忆"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_attention_state": {
       "auto_start": false,
@@ -2931,6 +3492,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_attention_state",
       "input_schema": {
         "additionalProperties": false,
@@ -2938,11 +3500,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_attention_state.name",
         "default": "获取注意力状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_backlog_summary": {
       "auto_start": false,
@@ -2953,17 +3525,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_backlog_summary",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_backlog_summary.name",
         "default": "读取待审阅摘要"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_buffer_state": {
       "auto_start": false,
@@ -2971,14 +3554,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_buffer_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "get_buffer_state"
+      "model_validate": true,
+      "name": "get_buffer_state",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_dashboard_state": {
       "auto_start": false,
@@ -2989,17 +3583,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_dashboard_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_dashboard_state.name",
         "default": "获取控制面板状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_group_backlog_detail": {
       "auto_start": false,
@@ -3010,6 +3615,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_group_backlog_detail",
       "input_schema": {
         "properties": {
@@ -3023,11 +3629,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_group_backlog_detail.name",
         "default": "读取群聊待审阅详情"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_group_prompts": {
       "auto_start": false,
@@ -3035,14 +3651,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_group_prompts",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "get_group_prompts"
+      "model_validate": true,
+      "name": "get_group_prompts",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_napcat_webui": {
       "auto_start": false,
@@ -3053,6 +3680,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_napcat_webui",
       "input_schema": {
         "additionalProperties": false,
@@ -3060,11 +3688,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_napcat_webui.name",
         "default": "获取 NapCat WebUI 地址"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_prompt_editor_state": {
       "auto_start": false,
@@ -3075,6 +3713,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_prompt_editor_state",
       "input_schema": {
         "additionalProperties": false,
@@ -3086,11 +3725,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_prompt_editor_state.name",
         "default": "获取提示词编辑器状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_recent_logs": {
       "auto_start": false,
@@ -3101,6 +3750,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_recent_logs",
       "input_schema": {
         "additionalProperties": false,
@@ -3113,11 +3763,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_recent_logs.name",
         "default": "获取最近日志"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:get_user_profiles": {
       "auto_start": false,
@@ -3128,17 +3788,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_user_profiles",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_user_profiles.name",
         "default": "获取用户画像"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:init_config": {
       "auto_start": false,
@@ -3149,6 +3820,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "init_config",
       "input_schema": {
         "additionalProperties": false,
@@ -3160,11 +3832,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.init_config.name",
         "default": "初始化 QQ 配置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:list_identity_claims": {
       "auto_start": false,
@@ -3175,6 +3857,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_identity_claims",
       "input_schema": {
         "additionalProperties": false,
@@ -3182,11 +3865,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.list_identity_claims.name",
         "default": "列出未认领的群内 ID"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:list_stickers": {
       "auto_start": false,
@@ -3197,6 +3890,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "list_stickers",
       "input_schema": {
         "additionalProperties": false,
@@ -3204,11 +3898,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.list_stickers.name",
         "default": "列出表情包"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:mark_group_backlog_reviewed": {
       "auto_start": false,
@@ -3219,6 +3923,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "mark_group_backlog_reviewed",
       "input_schema": {
         "properties": {
@@ -3232,11 +3937,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.mark_group_backlog_reviewed.name",
         "default": "标记群聊已处理"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:pick_directory": {
       "auto_start": false,
@@ -3247,6 +3962,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "pick_directory",
       "input_schema": {
         "additionalProperties": false,
@@ -3254,11 +3970,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.pick_directory.name",
         "default": "选择目录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:refresh_actual_contacts": {
       "auto_start": false,
@@ -3269,17 +3995,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "refresh_actual_contacts",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.refresh_actual_contacts.name",
         "default": "刷新实际联系人列表"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:register_sticker": {
       "auto_start": false,
@@ -3290,6 +4027,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "register_sticker",
       "input_schema": {
         "additionalProperties": false,
@@ -3310,11 +4048,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.register_sticker.name",
         "default": "注册表情包"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:remove_trusted_group": {
       "auto_start": false,
@@ -3325,6 +4073,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_trusted_group",
       "input_schema": {
         "properties": {
@@ -3338,11 +4087,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.remove_trusted_group.name",
         "default": "移除信任群聊"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:remove_trusted_user": {
       "auto_start": false,
@@ -3353,6 +4112,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "remove_trusted_user",
       "input_schema": {
         "properties": {
@@ -3366,11 +4126,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.remove_trusted_user.name",
         "default": "移除信任用户"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:reset_prompt_override": {
       "auto_start": false,
@@ -3381,6 +4151,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "reset_prompt_override",
       "input_schema": {
         "additionalProperties": false,
@@ -3399,11 +4170,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.reset_prompt_override.name",
         "default": "重置提示词覆盖"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:save_group_prompt": {
       "auto_start": false,
@@ -3411,6 +4192,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_group_prompt",
       "input_schema": {
         "properties": {
@@ -3428,8 +4210,18 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "save_group_prompt"
+      "model_validate": true,
+      "name": "save_group_prompt",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:save_proactive_topics": {
       "auto_start": false,
@@ -3440,6 +4232,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_proactive_topics",
       "input_schema": {
         "additionalProperties": false,
@@ -3457,11 +4250,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_proactive_topics.name",
         "default": "保存主动发言话题"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:save_prompt_override": {
       "auto_start": false,
@@ -3472,6 +4275,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_prompt_override",
       "input_schema": {
         "additionalProperties": false,
@@ -3495,11 +4299,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_prompt_override.name",
         "default": "保存提示词覆盖"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:save_settings": {
       "auto_start": false,
@@ -3510,6 +4324,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_settings",
       "input_schema": {
         "additionalProperties": false,
@@ -3604,11 +4419,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_settings.name",
         "default": "保存 QQ 自动回复设置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:send_backlog_reply_direct": {
       "auto_start": false,
@@ -3619,6 +4444,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_backlog_reply_direct",
       "input_schema": {
         "additionalProperties": false,
@@ -3651,11 +4477,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_backlog_reply_direct.name",
         "default": "发送这条回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:send_group_proactive_message": {
       "auto_start": false,
@@ -3666,6 +4502,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_group_proactive_message",
       "input_schema": {
         "additionalProperties": false,
@@ -3684,13 +4521,23 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "timeout": 90
       },
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_group_proactive_message.name",
         "default": "主动发送群聊消息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:send_private_proactive_message": {
       "auto_start": false,
@@ -3701,6 +4548,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_private_proactive_message",
       "input_schema": {
         "additionalProperties": false,
@@ -3719,13 +4567,23 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "timeout": 90
       },
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_private_proactive_message.name",
         "default": "主动发送私聊消息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:set_user_nickname": {
       "auto_start": false,
@@ -3736,6 +4594,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "set_user_nickname",
       "input_schema": {
         "properties": {
@@ -3753,11 +4612,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.set_user_nickname.name",
         "default": "设置用户昵称"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:start_auto_reply": {
       "auto_start": false,
@@ -3768,17 +4637,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "start_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.start_auto_reply.name",
         "default": "启动自动回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:stop_auto_reply": {
       "auto_start": false,
@@ -3789,17 +4669,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "stop_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.stop_auto_reply.name",
         "default": "停止自动回复"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:sync_qrcode": {
       "auto_start": false,
@@ -3810,17 +4701,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "sync_qrcode",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.sync_qrcode.name",
         "default": "刷新二维码"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:unbind_identity_account": {
       "auto_start": false,
@@ -3831,6 +4733,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "unbind_identity_account",
       "input_schema": {
         "additionalProperties": false,
@@ -3845,11 +4748,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.unbind_identity_account.name",
         "default": "撤销合并"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "qq_auto_reply:plugin_entry:upload_sticker": {
       "auto_start": false,
@@ -3860,6 +4773,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "upload_sticker",
       "input_schema": {
         "additionalProperties": false,
@@ -3885,16 +4799,26 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {
         "timeout": 30
       },
+      "model_validate": true,
       "name": {
         "$i18n": "entries.upload_sticker.name",
         "default": "上传表情包"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 2470196,
   "source_files": [

--- a/plugin/plugins/qq_auto_reply/plugin.meta.json
+++ b/plugin/plugins/qq_auto_reply/plugin.meta.json
@@ -36,7 +36,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -79,7 +78,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -116,7 +114,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -153,7 +150,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -187,7 +183,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -216,7 +211,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -239,7 +233,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -271,7 +264,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -297,7 +289,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -322,7 +313,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -344,7 +334,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -366,7 +355,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -398,7 +386,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -420,7 +407,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -443,7 +429,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -473,7 +458,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -504,7 +488,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -529,7 +512,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -559,7 +541,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -585,7 +566,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -611,7 +591,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -643,7 +622,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -669,7 +647,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -694,7 +671,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -733,7 +709,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -765,7 +740,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -797,7 +771,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -834,7 +807,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -867,7 +839,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -900,7 +871,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -942,7 +912,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1055,7 +1024,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1106,7 +1074,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1143,7 +1110,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {
         "timeout": 90
@@ -1182,7 +1148,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {
         "timeout": 90
@@ -1220,7 +1185,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1245,7 +1209,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1270,7 +1233,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1295,7 +1257,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1328,7 +1289,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -1372,7 +1332,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {
         "timeout": 30

--- a/plugin/plugins/web_search/plugin.meta.json
+++ b/plugin/plugins/web_search/plugin.meta.json
@@ -124,6 +124,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "search",
       "input_schema": {
         "properties": {
@@ -154,8 +155,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "网络搜索"
+      "model_validate": true,
+      "name": "网络搜索",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": 30.0
     },
     "web_search.search_summary": {
       "auto_start": false,
@@ -163,6 +184,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "search_summary",
       "input_schema": {
         "properties": {
@@ -193,8 +215,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "搜索摘要"
+      "model_validate": true,
+      "name": "搜索摘要",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": 30.0
     },
     "web_search:lifecycle:shutdown": {
       "auto_start": false,
@@ -202,14 +244,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "web_search:lifecycle:startup": {
       "auto_start": false,
@@ -217,14 +270,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "web_search:plugin_entry:search": {
       "auto_start": false,
@@ -232,6 +296,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "search",
       "input_schema": {
         "properties": {
@@ -262,8 +327,28 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "网络搜索"
+      "model_validate": true,
+      "name": "网络搜索",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": 30.0
     },
     "web_search:plugin_entry:search_summary": {
       "auto_start": false,
@@ -271,6 +356,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "search_summary",
       "input_schema": {
         "properties": {
@@ -301,11 +387,31 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": [
+        "summary"
+      ],
+      "llm_result_schema": {
+        "properties": {
+          "summary": {}
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
       "metadata": {},
-      "name": "搜索摘要"
+      "model_validate": true,
+      "name": "搜索摘要",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": 30.0
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 72893,
   "source_files": [

--- a/plugin/plugins/wechat_integration/plugin.meta.json
+++ b/plugin/plugins/wechat_integration/plugin.meta.json
@@ -278,17 +278,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_dashboard_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_dashboard_state.name",
         "default": "获取控制面板状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.logout": {
       "auto_start": false,
@@ -299,17 +310,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "logout",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.logout.name",
         "default": "退出登录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.poll_login_status": {
       "auto_start": false,
@@ -320,17 +342,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "poll_login_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.poll_login_status.name",
         "default": "查询扫码状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.refresh_qrcode": {
       "auto_start": false,
@@ -341,17 +374,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "refresh_qrcode",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.refresh_qrcode.name",
         "default": "刷新二维码"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.save_settings": {
       "auto_start": false,
@@ -362,6 +406,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_settings",
       "input_schema": {
         "additionalProperties": false,
@@ -379,11 +424,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_settings.name",
         "default": "保存微信设置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.send_message": {
       "auto_start": false,
@@ -394,6 +449,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_message",
       "input_schema": {
         "additionalProperties": false,
@@ -414,11 +470,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_message.name",
         "default": "发送微信消息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.start_auto_reply": {
       "auto_start": false,
@@ -429,17 +495,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "start_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.start_auto_reply.name",
         "default": "开始消息监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.start_login": {
       "auto_start": false,
@@ -450,17 +527,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "start_login",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.start_login.name",
         "default": "开始扫码登录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration.stop_auto_reply": {
       "auto_start": false,
@@ -471,17 +559,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "stop_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.stop_auto_reply.name",
         "default": "停止消息监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:lifecycle:shutdown": {
       "auto_start": false,
@@ -489,14 +588,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "shutdown",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "shutdown"
+      "model_validate": true,
+      "name": "shutdown",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:lifecycle:startup": {
       "auto_start": false,
@@ -504,14 +614,25 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "lifecycle",
+      "extra": {},
       "id": "startup",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "lifecycle",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
-      "name": "startup"
+      "model_validate": true,
+      "name": "startup",
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:get_dashboard_state": {
       "auto_start": false,
@@ -522,17 +643,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "get_dashboard_state",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.get_dashboard_state.name",
         "default": "获取控制面板状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:logout": {
       "auto_start": false,
@@ -543,17 +675,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "logout",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.logout.name",
         "default": "退出登录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:poll_login_status": {
       "auto_start": false,
@@ -564,17 +707,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "poll_login_status",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.poll_login_status.name",
         "default": "查询扫码状态"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:refresh_qrcode": {
       "auto_start": false,
@@ -585,17 +739,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "refresh_qrcode",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.refresh_qrcode.name",
         "default": "刷新二维码"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:save_settings": {
       "auto_start": false,
@@ -606,6 +771,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "save_settings",
       "input_schema": {
         "additionalProperties": false,
@@ -623,11 +789,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.save_settings.name",
         "default": "保存微信设置"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:send_message": {
       "auto_start": false,
@@ -638,6 +814,7 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "send_message",
       "input_schema": {
         "additionalProperties": false,
@@ -658,11 +835,21 @@
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.send_message.name",
         "default": "发送微信消息"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:start_auto_reply": {
       "auto_start": false,
@@ -673,17 +860,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "start_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.start_auto_reply.name",
         "default": "开始消息监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:start_login": {
       "auto_start": false,
@@ -694,17 +892,28 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "start_login",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.start_login.name",
         "default": "开始扫码登录"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     },
     "wechat_integration:plugin_entry:stop_auto_reply": {
       "auto_start": false,
@@ -715,20 +924,31 @@
       "dynamic": false,
       "enabled": true,
       "event_type": "plugin_entry",
+      "extra": {},
       "id": "stop_auto_reply",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "kind": "action",
+      "llm_result_fields": null,
+      "llm_result_schema": null,
       "metadata": {},
+      "model_validate": true,
       "name": {
         "$i18n": "entries.stop_auto_reply.name",
         "default": "停止消息监听"
-      }
+      },
+      "persist": null,
+      "quick_action": false,
+      "quick_action_config": {
+        "icon": null,
+        "priority": 0
+      },
+      "timeout": null
     }
   },
-  "schema_version": 3,
+  "schema_version": 4,
   "sdk_version": "0.1.0",
   "source_bytes": 107766,
   "source_files": [

--- a/plugin/plugins/wechat_integration/plugin.meta.json
+++ b/plugin/plugins/wechat_integration/plugin.meta.json
@@ -19,7 +19,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -44,7 +43,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -69,7 +67,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -94,7 +91,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -130,7 +126,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -169,7 +164,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -194,7 +188,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -219,7 +212,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,
@@ -244,7 +236,6 @@
         "type": "object"
       },
       "kind": "action",
-      "llm_result_fields": [],
       "llm_result_schema": {},
       "metadata": {},
       "model_validate": true,

--- a/plugin/sdk/plugin/base.py
+++ b/plugin/sdk/plugin/base.py
@@ -260,6 +260,14 @@ class NekoPluginBase(_SharedNekoPluginBase):
         llm_fields = getattr(meta, "llm_result_fields", None)
         if llm_fields:
             meta_dict["llm_result_fields"] = list(llm_fields)
+        # 控制字段随注册一起过去，宿主才能按声明的预算调用、按声明的 schema 读结果。
+        for name in ("timeout", "model_validate", "persist"):
+            value = getattr(meta, name, None)
+            if value is not None:
+                meta_dict[name] = value
+        llm_schema = getattr(meta, "llm_result_schema", None)
+        if isinstance(llm_schema, Mapping):
+            meta_dict["llm_result_schema"] = dict(llm_schema)
         self._notify_host_comm({
             "type": "ENTRY_UPDATE",
             "action": "register",

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -157,12 +157,12 @@ def _read_packaged_isolated_metadata(
     worker in that case, since it mints keys under the id we pass it.
 
     An empty ``handlers`` mapping is an answer, not a gap: a background-only
-    plugin registers no entries, and schema v3 always writes the key. Treating
-    empty as "no metadata" sent exactly those plugins back through the worker —
+    plugin registers no entries, and the current schema always writes the key.
+    Treating empty as "no metadata" sent exactly those plugins back through the worker —
     one import for the scan, one for the host, so any module-level side effect
     (writing state, sending a notification, launching a helper) happened twice
-    (codex). There is no older package to protect: the version gate above only
-    accepts v3, and v1/v2 were never released.
+    (codex). The version gate rejects older artifacts whose handler contracts
+    may be incomplete; rebuilding or an explicit start derives current metadata.
 
     Returns ``None`` when there is no usable metadata at all.
     """

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -138,7 +138,16 @@ def _resolve_python_requirements(
 
 
 _MIN_CLAMPED_STOP_TIMEOUT = 1.0
+# 必须补齐的三个：宿主从 handler meta 投影进 /plugins，缺了就改变行为。
 _V3_RECOVERABLE_ENTRY_FIELDS = ("timeout", "llm_result_fields", "metadata")
+# llm_result_schema 也会被投影，但它缺席不改变行为——结果字段一旦恢复，那条
+# "从 schema 的 properties 推导"的兜底就走不到。所以带得出就补，补不出不回落。
+# 剩下的控制字段（model_validate / persist / quick_action / quick_action_config /
+# extra）宿主一处都不读：校验在子进程按真 SDK 元数据做，快捷操作也没有服务端消费
+# 者；而 preview 根本不带后四个，把它们要求成"补不齐就重扫"等于让每个 v3 包都重
+# 扫，这条兼容路径就白写了（greptile）。
+_V3_BEST_EFFORT_ENTRY_FIELDS = ("llm_result_schema",)
+_V3_RESTORED_ENTRY_FIELDS = _V3_RECOVERABLE_ENTRY_FIELDS + _V3_BEST_EFFORT_ENTRY_FIELDS
 
 
 def _restore_v3_packaged_handlers(
@@ -176,21 +185,21 @@ def _restore_v3_packaged_handlers(
                 return None
             controls = entry_contract_fields(configured[entry_id])
             if any(
-                key not in _V3_RECOVERABLE_ENTRY_FIELDS
+                key not in _V3_RESTORED_ENTRY_FIELDS
                 and (key not in meta or meta[key] != value)
                 for key, value in controls.items()
             ):
                 return None
-            for key in _V3_RECOVERABLE_ENTRY_FIELDS:
+            for key in _V3_RESTORED_ENTRY_FIELDS:
                 if key in controls:
                     meta[key] = deepcopy(controls[key])
                 elif key in previews.get(entry_id, {}):
                     meta[key] = deepcopy(previews[entry_id][key])
-                else:
+                elif key in _V3_RECOVERABLE_ENTRY_FIELDS:
                     return None
         else:
             preview = previews.get(entry_id, {})
-            for key in _V3_RECOVERABLE_ENTRY_FIELDS:
+            for key in _V3_RESTORED_ENTRY_FIELDS:
                 if key not in meta and key in preview:
                     meta[key] = deepcopy(preview[key])
             if any(key not in meta for key in _V3_RECOVERABLE_ENTRY_FIELDS):

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -10,6 +10,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
     import tomli as tomllib  # type: ignore[no-redef]
 from collections.abc import Mapping
+from copy import deepcopy
 from functools import partial
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,12 +19,14 @@ from typing import Any, Protocol, runtime_checkable
 from fastapi import HTTPException
 
 from plugin._types.exceptions import PluginError, PluginLifecycleError
+from plugin._types.entry_metadata import entry_contract_fields
 from plugin.core.host import PluginProcessHost
 from plugin.core.registry import (
     _collect_plugin_python_requirements,
     _collect_plugin_python_requirement_paths,
     _check_plugin_dependency,
     _find_missing_python_requirements,
+    _effective_entries,
     _parse_plugin_dependencies,
     _resolve_plugin_id_conflict,
 )
@@ -59,7 +62,10 @@ from plugin.server.application.plugins.metadata_scanner import (
     install_isolated_plugin_metadata,
     scan_plugin_metadata_isolated,
 )
-from plugin.server.infrastructure.packaged_metadata import read_packaged_metadata
+from plugin.server.infrastructure.packaged_metadata import (
+    PackagedPluginMetadata,
+    read_packaged_metadata,
+)
 from plugin.server.application.install_source import (
     InstallSourceError,
     get_install_source_manager,
@@ -131,6 +137,59 @@ def _resolve_python_requirements(
 
 
 _MIN_CLAMPED_STOP_TIMEOUT = 1.0
+_V3_RECOVERABLE_ENTRY_FIELDS = ("timeout", "llm_result_fields", "metadata")
+
+
+def _restore_v3_packaged_handlers(
+    packaged: PackagedPluginMetadata, conf: object, pdata: object,
+) -> dict[str, dict[str, object]] | None:
+    """Restore old controls only after the effective-config digest matches.
+
+    v3 dropped even explicitly cleared controls from configured entries. Their
+    decorator-first previews cannot recover that intent; use the configuration
+    instead. Decorator-only handlers can fill absent keys from their previews,
+    while existing values (including empty ones) remain authoritative.
+    Recovery is limited to timeout, result fields and metadata, not a general
+    schema migration. Other configured controls requiring changes need a scan.
+    """
+    configured: dict[str, dict[str, object]] = {}
+    for entry in _effective_entries(
+        dict(conf) if isinstance(conf, Mapping) else {},
+        dict(pdata) if isinstance(pdata, Mapping) else {},
+    ):
+        entry_id = entry.get("id") if isinstance(entry, dict) else str(entry)
+        if entry_id:
+            configured[str(entry_id)] = entry if isinstance(entry, dict) else {}
+    previews = {str(entry.get("id")): entry for entry in packaged.entries}
+    handlers = deepcopy(packaged.handlers)
+    for meta in handlers.values():
+        if meta.get("event_type", "plugin_entry") != "plugin_entry":
+            continue
+        entry_id = str(meta.get("id", ""))
+        if entry_id in configured:
+            # A configured id is resolved as a class attribute. An aliased
+            # decorator may have caused that declaration to be skipped; the
+            # artifact cannot tell us whether that attribute actually exists.
+            if packaged.entry_methods.get(entry_id, entry_id) != entry_id:
+                return None
+            controls = entry_contract_fields(configured[entry_id])
+            if any(
+                key not in _V3_RECOVERABLE_ENTRY_FIELDS
+                and (key not in meta or meta[key] != value)
+                for key, value in controls.items()
+            ):
+                return None
+            for key in _V3_RECOVERABLE_ENTRY_FIELDS:
+                if key in controls:
+                    meta[key] = deepcopy(controls[key])
+        else:
+            preview = previews.get(entry_id, {})
+            for key in _V3_RECOVERABLE_ENTRY_FIELDS:
+                if key not in meta and key in preview:
+                    meta[key] = deepcopy(preview[key])
+            if any(key not in meta for key in _V3_RECOVERABLE_ENTRY_FIELDS):
+                return None
+    return handlers
 
 
 def _read_packaged_isolated_metadata(
@@ -161,8 +220,8 @@ def _read_packaged_isolated_metadata(
     Treating empty as "no metadata" sent exactly those plugins back through the worker —
     one import for the scan, one for the host, so any module-level side effect
     (writing state, sending a notification, launching a helper) happened twice
-    (codex). The version gate rejects older artifacts whose handler contracts
-    may be incomplete; rebuilding or an explicit start derives current metadata.
+    (codex). v3 handler controls are restored in memory after the same source,
+    configuration, environment and ownership checks as current artifacts.
 
     Returns ``None`` when there is no usable metadata at all.
     """
@@ -196,9 +255,19 @@ def _read_packaged_isolated_metadata(
             plugin_id,
         )
         return None
+    handlers = (
+        _restore_v3_packaged_handlers(packaged, conf, pdata)
+        if packaged.schema_version == 3 else dict(packaged.handlers)
+    )
+    if handlers is None:
+        logger.info(
+            "v3 packaged controls cannot be restored unambiguously; rescanning: plugin_id={}",
+            plugin_id,
+        )
+        return None
     return IsolatedPluginMetadata(
         entries_preview=list(packaged.entries),
-        handlers=dict(packaged.handlers),
+        handlers=handlers,
         entry_methods=dict(packaged.entry_methods),
     )
 

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -27,7 +27,7 @@ from plugin.core.registry import (
     _check_plugin_dependency,
     _find_missing_python_requirements,
     _effective_entries,
-    _overlay_entry_controls,
+    _overlay_entry_declaration,
     _parse_plugin_dependencies,
     _resolve_plugin_id_conflict,
 )
@@ -281,7 +281,7 @@ def _read_packaged_isolated_metadata(
         )
         return None
     return IsolatedPluginMetadata(
-        entries_preview=_overlay_entry_controls(
+        entries_preview=_overlay_entry_declaration(
             packaged.entries,
             dict(conf) if isinstance(conf, Mapping) else {},
             dict(pdata) if isinstance(pdata, Mapping) else {},

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -27,6 +27,7 @@ from plugin.core.registry import (
     _check_plugin_dependency,
     _find_missing_python_requirements,
     _effective_entries,
+    _overlay_entry_controls,
     _parse_plugin_dependencies,
     _resolve_plugin_id_conflict,
 )
@@ -146,8 +147,9 @@ def _restore_v3_packaged_handlers(
     """Restore old controls only after the effective-config digest matches.
 
     v3 dropped even explicitly cleared controls from configured entries. Their
-    decorator-first previews cannot recover that intent; use the configuration
-    instead. Decorator-only handlers can fill absent keys from their previews,
+    decorator-first previews cannot recover that intent; overlay explicit
+    configuration on the preview, inheriting fields the configuration omits.
+    Decorator-only handlers can fill absent keys from their previews,
     while existing values (including empty ones) remain authoritative.
     Recovery is limited to timeout, result fields and metadata, not a general
     schema migration. Other configured controls requiring changes need a scan.
@@ -182,6 +184,10 @@ def _restore_v3_packaged_handlers(
             for key in _V3_RECOVERABLE_ENTRY_FIELDS:
                 if key in controls:
                     meta[key] = deepcopy(controls[key])
+                elif key in previews.get(entry_id, {}):
+                    meta[key] = deepcopy(previews[entry_id][key])
+                else:
+                    return None
         else:
             preview = previews.get(entry_id, {})
             for key in _V3_RECOVERABLE_ENTRY_FIELDS:
@@ -266,7 +272,11 @@ def _read_packaged_isolated_metadata(
         )
         return None
     return IsolatedPluginMetadata(
-        entries_preview=list(packaged.entries),
+        entries_preview=_overlay_entry_controls(
+            packaged.entries,
+            dict(conf) if isinstance(conf, Mapping) else {},
+            dict(pdata) if isinstance(pdata, Mapping) else {},
+        ),
         handlers=handlers,
         entry_methods=dict(packaged.entry_methods),
     )

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -150,6 +150,20 @@ _V3_BEST_EFFORT_ENTRY_FIELDS = ("llm_result_schema",)
 _V3_RESTORED_ENTRY_FIELDS = _V3_RECOVERABLE_ENTRY_FIELDS + _V3_BEST_EFFORT_ENTRY_FIELDS
 
 
+def _v3_entry_is_restored(meta: dict[str, object]) -> bool:
+    """Whether this handler now carries everything the host reads from it."""
+    for key in _V3_RECOVERABLE_ENTRY_FIELDS:
+        if key in meta:
+            continue
+        # 结果字段缺席但 schema 在，投影侧会按 schema 推，推出来的正是重扫会给的
+        # 那一份——不必为它把整个插件赶去重扫。v3 的 preview 把"没声明"规范化成
+        # 了 []，那份空列表已经在读取时被丢掉（packaged_metadata 里说明了原因）。
+        if key == "llm_result_fields" and meta.get("llm_result_schema"):
+            continue
+        return False
+    return True
+
+
 def _restore_v3_packaged_handlers(
     packaged: PackagedPluginMetadata, conf: object, pdata: object,
 ) -> dict[str, dict[str, object]] | None:
@@ -195,14 +209,14 @@ def _restore_v3_packaged_handlers(
                     meta[key] = deepcopy(controls[key])
                 elif key in previews.get(entry_id, {}):
                     meta[key] = deepcopy(previews[entry_id][key])
-                elif key in _V3_RECOVERABLE_ENTRY_FIELDS:
-                    return None
+            if not _v3_entry_is_restored(meta):
+                return None
         else:
             preview = previews.get(entry_id, {})
             for key in _V3_RESTORED_ENTRY_FIELDS:
                 if key not in meta and key in preview:
                     meta[key] = deepcopy(preview[key])
-            if any(key not in meta for key in _V3_RECOVERABLE_ENTRY_FIELDS):
+            if not _v3_entry_is_restored(meta):
                 return None
     return handlers
 

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -62,7 +62,6 @@ from plugin.server.application.plugins.metadata_scanner import (
     scan_plugin_metadata_isolated,
 )
 from plugin.server.infrastructure.packaged_metadata import (
-    PackagedPluginMetadata,
     read_packaged_metadata,
 )
 from plugin.server.application.install_source import (

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -10,7 +10,6 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
     import tomli as tomllib  # type: ignore[no-redef]
 from collections.abc import Mapping
-from copy import deepcopy
 from functools import partial
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,7 +18,6 @@ from typing import Any, Protocol, runtime_checkable
 from fastapi import HTTPException
 
 from plugin._types.exceptions import PluginError, PluginLifecycleError
-from plugin._types.entry_metadata import entry_contract_fields
 from plugin.core.host import PluginProcessHost
 from plugin.core.registry import (
     _collect_plugin_python_requirements,
@@ -138,87 +136,6 @@ def _resolve_python_requirements(
 
 
 _MIN_CLAMPED_STOP_TIMEOUT = 1.0
-# 必须补齐的三个：宿主从 handler meta 投影进 /plugins，缺了就改变行为。
-_V3_RECOVERABLE_ENTRY_FIELDS = ("timeout", "llm_result_fields", "metadata")
-# llm_result_schema 也会被投影，但它缺席不改变行为——结果字段一旦恢复，那条
-# "从 schema 的 properties 推导"的兜底就走不到。所以带得出就补，补不出不回落。
-# 剩下的控制字段（model_validate / persist / quick_action / quick_action_config /
-# extra）宿主一处都不读：校验在子进程按真 SDK 元数据做，快捷操作也没有服务端消费
-# 者；而 preview 根本不带后四个，把它们要求成"补不齐就重扫"等于让每个 v3 包都重
-# 扫，这条兼容路径就白写了（greptile）。
-_V3_BEST_EFFORT_ENTRY_FIELDS = ("llm_result_schema",)
-_V3_RESTORED_ENTRY_FIELDS = _V3_RECOVERABLE_ENTRY_FIELDS + _V3_BEST_EFFORT_ENTRY_FIELDS
-
-
-def _v3_entry_is_restored(meta: dict[str, object]) -> bool:
-    """Whether this handler now carries everything the host reads from it."""
-    for key in _V3_RECOVERABLE_ENTRY_FIELDS:
-        if key in meta:
-            continue
-        # 结果字段缺席但 schema 在，投影侧会按 schema 推，推出来的正是重扫会给的
-        # 那一份——不必为它把整个插件赶去重扫。v3 的 preview 把"没声明"规范化成
-        # 了 []，那份空列表已经在读取时被丢掉（packaged_metadata 里说明了原因）。
-        if key == "llm_result_fields" and meta.get("llm_result_schema"):
-            continue
-        return False
-    return True
-
-
-def _restore_v3_packaged_handlers(
-    packaged: PackagedPluginMetadata, conf: object, pdata: object,
-) -> dict[str, dict[str, object]] | None:
-    """Restore old controls only after the effective-config digest matches.
-
-    v3 dropped even explicitly cleared controls from configured entries. Their
-    decorator-first previews cannot recover that intent; overlay explicit
-    configuration on the preview, inheriting fields the configuration omits.
-    Decorator-only handlers can fill absent keys from their previews,
-    while existing values (including empty ones) remain authoritative.
-    Recovery is limited to timeout, result fields and metadata, not a general
-    schema migration. Other configured controls requiring changes need a scan.
-    """
-    configured: dict[str, dict[str, object]] = {}
-    for entry in _effective_entries(
-        dict(conf) if isinstance(conf, Mapping) else {},
-        dict(pdata) if isinstance(pdata, Mapping) else {},
-    ):
-        entry_id = entry.get("id") if isinstance(entry, dict) else str(entry)
-        if entry_id:
-            configured[str(entry_id)] = entry if isinstance(entry, dict) else {}
-    previews = {str(entry.get("id")): entry for entry in packaged.entries}
-    handlers = deepcopy(packaged.handlers)
-    for meta in handlers.values():
-        if meta.get("event_type", "plugin_entry") != "plugin_entry":
-            continue
-        entry_id = str(meta.get("id", ""))
-        if entry_id in configured:
-            # A configured id is resolved as a class attribute. An aliased
-            # decorator may have caused that declaration to be skipped; the
-            # artifact cannot tell us whether that attribute actually exists.
-            if packaged.entry_methods.get(entry_id, entry_id) != entry_id:
-                return None
-            controls = entry_contract_fields(configured[entry_id])
-            if any(
-                key not in _V3_RESTORED_ENTRY_FIELDS
-                and (key not in meta or meta[key] != value)
-                for key, value in controls.items()
-            ):
-                return None
-            for key in _V3_RESTORED_ENTRY_FIELDS:
-                if key in controls:
-                    meta[key] = deepcopy(controls[key])
-                elif key in previews.get(entry_id, {}):
-                    meta[key] = deepcopy(previews[entry_id][key])
-            if not _v3_entry_is_restored(meta):
-                return None
-        else:
-            preview = previews.get(entry_id, {})
-            for key in _V3_RESTORED_ENTRY_FIELDS:
-                if key not in meta and key in preview:
-                    meta[key] = deepcopy(preview[key])
-            if not _v3_entry_is_restored(meta):
-                return None
-    return handlers
 
 
 def _read_packaged_isolated_metadata(
@@ -249,8 +166,10 @@ def _read_packaged_isolated_metadata(
     Treating empty as "no metadata" sent exactly those plugins back through the worker —
     one import for the scan, one for the host, so any module-level side effect
     (writing state, sending a notification, launching a helper) happened twice
-    (codex). v3 handler controls are restored in memory after the same source,
-    configuration, environment and ownership checks as current artifacts.
+    (codex). An artifact written under an older schema is refused by the reader
+    and takes the worker path: one import per start until the plugin is
+    repackaged, which is what every plugin paid before packaged metadata
+    existed. Schema 3 never shipped in a release, so no in-memory migration.
 
     Returns ``None`` when there is no usable metadata at all.
     """
@@ -284,23 +203,13 @@ def _read_packaged_isolated_metadata(
             plugin_id,
         )
         return None
-    handlers = (
-        _restore_v3_packaged_handlers(packaged, conf, pdata)
-        if packaged.schema_version == 3 else dict(packaged.handlers)
-    )
-    if handlers is None:
-        logger.info(
-            "v3 packaged controls cannot be restored unambiguously; rescanning: plugin_id={}",
-            plugin_id,
-        )
-        return None
     return IsolatedPluginMetadata(
         entries_preview=_overlay_entry_declaration(
             packaged.entries,
             dict(conf) if isinstance(conf, Mapping) else {},
             dict(pdata) if isinstance(pdata, Mapping) else {},
         ),
-        handlers=handlers,
+        handlers=dict(packaged.handlers),
         entry_methods=dict(packaged.entry_methods),
     )
 

--- a/plugin/server/application/plugins/metadata_scanner.py
+++ b/plugin/server/application/plugins/metadata_scanner.py
@@ -18,12 +18,13 @@ import signal
 import subprocess
 import sys
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, Mapping
 
 import psutil
 
+from plugin._types.entry_metadata import entry_contract_fields
 from plugin._types.events import EventHandler, EventMeta
 from plugin.core import registry as registry_module
 from plugin.core.state import state
@@ -318,23 +319,30 @@ def _json_safe(value: Any) -> Any:
 
 def _event_meta_payload(meta: object) -> dict[str, object]:
     raw = getattr(meta, "__dict__", None)
-    if isinstance(raw, dict):
-        normalized = _json_safe(raw)
-        if isinstance(normalized, dict):
-            return normalized
-
-    return {
+    payload = dict(raw) if isinstance(raw, dict) else {
         "event_type": str(getattr(meta, "event_type", "plugin_entry") or "plugin_entry"),
         "id": str(getattr(meta, "id", "") or ""),
-        "name": _json_safe(getattr(meta, "name", "")),
-        "description": _json_safe(getattr(meta, "description", "")),
-        "input_schema": _json_safe(getattr(meta, "input_schema", None)),
+        "name": getattr(meta, "name", ""),
+        "description": getattr(meta, "description", ""),
+        "input_schema": getattr(meta, "input_schema", None),
         "kind": str(getattr(meta, "kind", "action") or "action"),
         "auto_start": bool(getattr(meta, "auto_start", False)),
         "enabled": bool(getattr(meta, "enabled", True)),
         "dynamic": bool(getattr(meta, "dynamic", False)),
-        "metadata": _json_safe(getattr(meta, "metadata", None)),
+        "metadata": getattr(meta, "metadata", None),
     }
+    # SDK v2 EventMeta is slotted. Its controls must survive just like legacy
+    # attributes; otherwise an isolated scan drops timeout/result projections.
+    payload.update(entry_contract_fields(meta))
+    quick_action_config = payload.get("quick_action_config")
+    if is_dataclass(quick_action_config) and not isinstance(quick_action_config, type):
+        # This SDK field has a structured wire contract. Do not change how the
+        # general JSON adapter handles unrelated custom dataclass values.
+        payload["quick_action_config"] = {
+            field.name: getattr(quick_action_config, field.name)
+            for field in fields(quick_action_config)
+        }
+    return _json_safe(payload)
 
 
 def _scan_in_worker(request: Mapping[str, object]) -> dict[str, object]:

--- a/plugin/server/application/plugins/metadata_scanner.py
+++ b/plugin/server/application/plugins/metadata_scanner.py
@@ -18,7 +18,7 @@ import signal
 import subprocess
 import sys
 import threading
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, Mapping
 
@@ -319,29 +319,29 @@ def _json_safe(value: Any) -> Any:
 
 def _event_meta_payload(meta: object) -> dict[str, object]:
     raw = getattr(meta, "__dict__", None)
-    payload = dict(raw) if isinstance(raw, dict) else {
-        "event_type": str(getattr(meta, "event_type", "plugin_entry") or "plugin_entry"),
-        "id": str(getattr(meta, "id", "") or ""),
-        "name": getattr(meta, "name", ""),
-        "description": getattr(meta, "description", ""),
-        "input_schema": getattr(meta, "input_schema", None),
-        "kind": str(getattr(meta, "kind", "action") or "action"),
-        "auto_start": bool(getattr(meta, "auto_start", False)),
-        "enabled": bool(getattr(meta, "enabled", True)),
-        "dynamic": bool(getattr(meta, "dynamic", False)),
-        "metadata": getattr(meta, "metadata", None),
-    }
-    # SDK v2 EventMeta is slotted. Its controls must survive just like legacy
-    # attributes; otherwise an isolated scan drops timeout/result projections.
+    if isinstance(raw, dict):
+        payload = dict(raw)
+    else:
+        # SDK v2 EventMeta is slotted. Only its identity and display fields are
+        # read by name here; every control comes from the shared contract below,
+        # so a control added to the SDK is transported by adding it there once.
+        # ``enabled`` / ``dynamic`` exist on the legacy EventMeta only, so the
+        # contract cannot supply them for an SDK meta: write their defaults.
+        payload = {
+            "event_type": str(getattr(meta, "event_type", "plugin_entry") or "plugin_entry"),
+            "id": str(getattr(meta, "id", "") or ""),
+            "name": getattr(meta, "name", ""),
+            "description": getattr(meta, "description", ""),
+            "input_schema": getattr(meta, "input_schema", None),
+            "enabled": True,
+            "dynamic": False,
+        }
     payload.update(entry_contract_fields(meta))
     quick_action_config = payload.get("quick_action_config")
     if is_dataclass(quick_action_config) and not isinstance(quick_action_config, type):
         # This SDK field has a structured wire contract. Do not change how the
         # general JSON adapter handles unrelated custom dataclass values.
-        payload["quick_action_config"] = {
-            field.name: getattr(quick_action_config, field.name)
-            for field in fields(quick_action_config)
-        }
+        payload["quick_action_config"] = asdict(quick_action_config)
     return _json_safe(payload)
 
 

--- a/plugin/server/application/plugins/query_service.py
+++ b/plugin/server/application/plugins/query_service.py
@@ -127,7 +127,7 @@ def _normalize_string_list(raw_value: object) -> list[str]:
 
 def _extract_llm_result_fields(raw_value: object, *, raw_schema: object = None) -> list[str]:
     fields = _normalize_string_list(raw_value)
-    if fields:
+    if isinstance(raw_value, list):
         return fields
     if isinstance(raw_schema, Mapping):
         properties_obj = raw_schema.get("properties")

--- a/plugin/server/application/plugins/registry_service.py
+++ b/plugin/server/application/plugins/registry_service.py
@@ -18,7 +18,7 @@ from plugin.core.registry import (
     _build_plugin_meta,
     _check_plugin_dependency,
     _extract_entries_preview,
-    _overlay_entry_controls,
+    _overlay_entry_declaration,
     _extract_plugin_ui_config,
     _find_missing_python_requirements,
     _parse_single_plugin_config,
@@ -613,7 +613,7 @@ def _packaged_entries_preview(
     ):
         return [
             _normalize_entry_input_schema(entry)
-            for entry in _overlay_entry_controls(packaged.entries, ctx.conf, ctx.pdata)
+            for entry in _overlay_entry_declaration(packaged.entries, ctx.conf, ctx.pdata)
         ]
     # 没有打包期元数据时，manifest 里静态声明的 entries 仍是一条完整通路——它只是
     # 拿不到从处理函数签名推出来的那部分 input_schema。这条通路一直都在：禁用的

--- a/plugin/server/application/plugins/registry_service.py
+++ b/plugin/server/application/plugins/registry_service.py
@@ -18,6 +18,7 @@ from plugin.core.registry import (
     _build_plugin_meta,
     _check_plugin_dependency,
     _extract_entries_preview,
+    _overlay_entry_controls,
     _extract_plugin_ui_config,
     _find_missing_python_requirements,
     _parse_single_plugin_config,
@@ -610,7 +611,10 @@ def _packaged_entries_preview(
         and packaged.entries
         and not config_overrides_packaged_entries(ctx.conf, ctx.pdata, packaged)
     ):
-        return [_normalize_entry_input_schema(entry) for entry in packaged.entries]
+        return [
+            _normalize_entry_input_schema(entry)
+            for entry in _overlay_entry_controls(packaged.entries, ctx.conf, ctx.pdata)
+        ]
     # 没有打包期元数据时，manifest 里静态声明的 entries 仍是一条完整通路——它只是
     # 拿不到从处理函数签名推出来的那部分 input_schema。这条通路一直都在：禁用的
     # 插件走的就是它。

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -57,7 +57,10 @@ PACKAGED_METADATA_FILENAME = "plugin.meta.json"
 # schema 变了就该换号，否则一份没有 source_files 的元数据仍会被当成合法的第 1 版
 # 接受，增删源文件时那道确定性的判据整个静默失效（coderabbit）。旧包因此回落到
 # manifest 声明的 entries，重新打包即可恢复。
-PACKAGED_METADATA_SCHEMA_VERSION = 3
+# 4: handlers retain the complete entry contract, including slotted SDK fields.
+# v3 artifacts may contain correct previews but incomplete handlers; rescan on
+# explicit start or rebuild the package, never import during discovery.
+PACKAGED_METADATA_SCHEMA_VERSION = 4
 
 # 解析之前先封顶。这份文件来自第三方包，而 json.loads 会把整份内容读进内存再建对象；
 # 一个几百 MB 的 plugin.meta.json 足以在刷新注册表时把进程撑爆，而刷新现在整段持锁
@@ -471,14 +474,14 @@ def entries_config_digest(conf: object, pdata: object) -> str:
 
 
 def _tables_are_well_formed(raw: Mapping[str, object]) -> bool:
-    """Whether the v3 tables are the shapes v3 promises.
+    """Whether the metadata tables have their required shapes.
 
     An empty ``handlers`` mapping is a real answer — a background-only plugin
     registers nothing — and the start path now trusts it instead of rescanning.
     That makes the difference between "empty" and "malformed" load-bearing:
     coercing a missing or non-object table into an empty one would let a broken
     package install *no* handlers while its ``entries`` advertise tools, leaving
-    the plugin running with nothing dispatchable (codex). v3 always writes all
+    the plugin running with nothing dispatchable (codex). The current schema writes all
     three tables, so anything else is a package to fall back on, not to believe.
     """
     handlers = raw.get("handlers")

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -58,8 +58,8 @@ PACKAGED_METADATA_FILENAME = "plugin.meta.json"
 # 接受，增删源文件时那道确定性的判据整个静默失效（coderabbit）。旧包因此回落到
 # manifest 声明的 entries，重新打包即可恢复。
 # 4: handlers retain the complete entry contract, including slotted SDK fields.
-# v3 artifacts may contain correct previews but incomplete handlers; rescan on
-# explicit start or rebuild the package, never import during discovery.
+# v3 previews remain readable; the start path restores their truncated handlers
+# using the preview and the matching effective entries configuration.
 PACKAGED_METADATA_SCHEMA_VERSION = 4
 
 # 解析之前先封顶。这份文件来自第三方包，而 json.loads 会把整份内容读进内存再建对象；
@@ -143,6 +143,7 @@ class PackagedPluginMetadata:
     source_sha256: str = ""
     # 打包机和这台机器是不是同一套 (os, python, arch)。
     built_in_this_environment: bool = False
+    schema_version: int = PACKAGED_METADATA_SCHEMA_VERSION
 
 
 def _stamp_metadata_verified(meta_path: Path, newest_source_ns: int) -> None:
@@ -560,7 +561,7 @@ def read_packaged_metadata(plugin_dir: Path) -> PackagedPluginMetadata | None:
         return None
 
     schema_version = raw.get("schema_version")
-    if schema_version != PACKAGED_METADATA_SCHEMA_VERSION:
+    if schema_version not in (3, PACKAGED_METADATA_SCHEMA_VERSION):
         logger.warning(
             "packaged plugin metadata schema mismatch, falling back to manifest: "
             "path={}, found={}, expected={}",
@@ -691,6 +692,7 @@ def read_packaged_metadata(plugin_dir: Path) -> PackagedPluginMetadata | None:
         _stamp_metadata_verified(meta_path, newest_source_ns)
 
     return PackagedPluginMetadata(
+        schema_version=schema_version,
         built_in_this_environment=_environment_matches(raw.get("build_env")),
         entries=_coerce_entries(raw.get("entries")),
         entries_config_sha256=str(raw.get("entries_config_sha256") or ""),

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -431,6 +431,26 @@ def _coerce_entries(raw: object) -> list[dict[str, object]]:
     return [dict(item) for item in raw if isinstance(item, Mapping)]
 
 
+def _drop_synthesized_result_fields(
+    entries: list[dict[str, object]], schema_version: object
+) -> list[dict[str, object]]:
+    """Drop a v3 preview's empty result-field list when a schema can supply it.
+
+    v3 generators normalized "not declared" into ``[]``, so an empty list there
+    carries no intent. Readers now take a list as the entry's final answer, and
+    an entry that only declares a result schema would lose its projection —
+    while a rescan of the same plugin derives the fields. v4 previews omit the
+    key when it was never declared, so an empty list there is a real choice and
+    must survive.
+    """
+    if schema_version != 3:
+        return entries
+    for entry in entries:
+        if entry.get("llm_result_fields") == [] and entry.get("llm_result_schema"):
+            entry.pop("llm_result_fields", None)
+    return entries
+
+
 def _coerce_handlers(raw: object) -> dict[str, dict[str, object]]:
     if not isinstance(raw, Mapping):
         return {}
@@ -694,7 +714,7 @@ def read_packaged_metadata(plugin_dir: Path) -> PackagedPluginMetadata | None:
     return PackagedPluginMetadata(
         schema_version=schema_version,
         built_in_this_environment=_environment_matches(raw.get("build_env")),
-        entries=_coerce_entries(raw.get("entries")),
+        entries=_drop_synthesized_result_fields(_coerce_entries(raw.get("entries")), schema_version),
         entries_config_sha256=str(raw.get("entries_config_sha256") or ""),
         handlers=_coerce_handlers(raw.get("handlers")),
         entry_methods=_coerce_entry_methods(raw.get("entry_methods")),

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -58,8 +58,11 @@ PACKAGED_METADATA_FILENAME = "plugin.meta.json"
 # 接受，增删源文件时那道确定性的判据整个静默失效（coderabbit）。旧包因此回落到
 # manifest 声明的 entries，重新打包即可恢复。
 # 4: handlers retain the complete entry contract, including slotted SDK fields.
-# v3 previews remain readable; the start path restores their truncated handlers
-# using the preview and the matching effective entries configuration.
+# 3 serialized slotted SDK metadata through a ten-field fallback and lost
+# timeout / result fields, so a v3 handler table describes an entry the host
+# would call with the wrong budget and read the wrong result from. Schema 3 was
+# only ever on nightly, so it is refused like any other stale schema and the
+# plugin takes the worker path until it is repackaged.
 PACKAGED_METADATA_SCHEMA_VERSION = 4
 
 # 解析之前先封顶。这份文件来自第三方包，而 json.loads 会把整份内容读进内存再建对象；
@@ -143,7 +146,6 @@ class PackagedPluginMetadata:
     source_sha256: str = ""
     # 打包机和这台机器是不是同一套 (os, python, arch)。
     built_in_this_environment: bool = False
-    schema_version: int = PACKAGED_METADATA_SCHEMA_VERSION
 
 
 def _stamp_metadata_verified(meta_path: Path, newest_source_ns: int) -> None:
@@ -431,26 +433,6 @@ def _coerce_entries(raw: object) -> list[dict[str, object]]:
     return [dict(item) for item in raw if isinstance(item, Mapping)]
 
 
-def _drop_synthesized_result_fields(
-    entries: list[dict[str, object]], schema_version: object
-) -> list[dict[str, object]]:
-    """Drop a v3 preview's empty result-field list when a schema can supply it.
-
-    v3 generators normalized "not declared" into ``[]``, so an empty list there
-    carries no intent. Readers now take a list as the entry's final answer, and
-    an entry that only declares a result schema would lose its projection —
-    while a rescan of the same plugin derives the fields. v4 previews omit the
-    key when it was never declared, so an empty list there is a real choice and
-    must survive.
-    """
-    if schema_version != 3:
-        return entries
-    for entry in entries:
-        if entry.get("llm_result_fields") == [] and entry.get("llm_result_schema"):
-            entry.pop("llm_result_fields", None)
-    return entries
-
-
 def _coerce_handlers(raw: object) -> dict[str, dict[str, object]]:
     if not isinstance(raw, Mapping):
         return {}
@@ -581,7 +563,7 @@ def read_packaged_metadata(plugin_dir: Path) -> PackagedPluginMetadata | None:
         return None
 
     schema_version = raw.get("schema_version")
-    if schema_version not in (3, PACKAGED_METADATA_SCHEMA_VERSION):
+    if schema_version != PACKAGED_METADATA_SCHEMA_VERSION:
         logger.warning(
             "packaged plugin metadata schema mismatch, falling back to manifest: "
             "path={}, found={}, expected={}",
@@ -712,9 +694,8 @@ def read_packaged_metadata(plugin_dir: Path) -> PackagedPluginMetadata | None:
         _stamp_metadata_verified(meta_path, newest_source_ns)
 
     return PackagedPluginMetadata(
-        schema_version=schema_version,
         built_in_this_environment=_environment_matches(raw.get("build_env")),
-        entries=_drop_synthesized_result_fields(_coerce_entries(raw.get("entries")), schema_version),
+        entries=_coerce_entries(raw.get("entries")),
         entries_config_sha256=str(raw.get("entries_config_sha256") or ""),
         handlers=_coerce_handlers(raw.get("handlers")),
         entry_methods=_coerce_entry_methods(raw.get("entry_methods")),

--- a/plugin/tests/unit/core/test_plugin_communication_shutdown.py
+++ b/plugin/tests/unit/core/test_plugin_communication_shutdown.py
@@ -488,6 +488,62 @@ async def test_entry_update_register_uses_outer_entry_id_for_meta() -> None:
             state._snapshot_cache = cache_backup
 
 
+@pytest.mark.asyncio
+async def test_entry_update_register_keeps_the_declared_controls() -> None:
+    """A runtime-registered entry carries the same contract as a static one.
+
+    Copying only the display fields left /plugins reporting timeout=null and
+    no result schema for dynamic entries, so the Agent used the default budget
+    on a long task the plugin had declared as slow.
+    """
+    manager = PluginCommunicationResourceManager(
+        plugin_id="demo",
+        transport=_Transport(),
+        logger=_Logger(),
+    )
+    schema = {"type": "object", "properties": {"summary": {"type": "string"}}}
+
+    handlers_backup = dict(state.event_handlers)
+    cache_backup = copy.deepcopy(state._snapshot_cache)
+    try:
+        with state.acquire_event_handlers_write_lock():
+            state.event_handlers.clear()
+        state.invalidate_snapshot_cache("handlers")
+
+        await manager._handle_entry_update({
+            "type": "ENTRY_UPDATE",
+            "action": "register",
+            "plugin_id": "demo",
+            "entry_id": "dyn",
+            "meta": {
+                "id": "dyn",
+                "name": "Dynamic",
+                "timeout": 42.0,
+                "model_validate": False,
+                "llm_result_fields": ["summary"],
+                "llm_result_schema": schema,
+                "metadata": {"agent_auto": False},
+                "dynamic": False,
+            },
+        })
+
+        with state.acquire_event_handlers_read_lock():
+            meta = state.event_handlers["demo.dyn"].meta
+        assert meta.timeout == 42.0
+        assert meta.model_validate is False
+        assert meta.llm_result_fields == ["summary"]
+        assert meta.llm_result_schema == schema
+        assert meta.metadata["agent_auto"] is False
+        assert meta.metadata["_dynamic"] is True
+        assert meta.dynamic is True
+    finally:
+        with state.acquire_event_handlers_write_lock():
+            state.event_handlers.clear()
+            state.event_handlers.update(handlers_backup)
+        with state._snapshot_cache_lock:
+            state._snapshot_cache = cache_backup
+
+
 # ---------------------------------------------------------------------------
 # push_message 的实际投递路径：message plane
 # ---------------------------------------------------------------------------

--- a/plugin/tests/unit/sdk/plugin/test_plugin_base_host_sync.py
+++ b/plugin/tests/unit/sdk/plugin/test_plugin_base_host_sync.py
@@ -82,3 +82,22 @@ def test_register_dynamic_entry_preserves_timeout_in_meta() -> None:
     event_handler = plugin.collect_entries()["dyn"]
     assert event_handler.meta.timeout == 42.0
     assert event_handler.meta.extra["timeout"] == 42.0
+
+
+def test_register_dynamic_entry_sends_its_controls_to_the_host() -> None:
+    ctx = _Ctx(Path(tempfile.mkdtemp()) / "plugin.toml")
+    plugin = _Plugin(ctx)
+
+    plugin.register_dynamic_entry(
+        "dyn", lambda **_: {"ok": True}, name="Dyn", timeout=42.0, llm_result_fields=["ok"],
+    )
+
+    register = next(
+        item for item in ctx.message_queue.items
+        if item.get("type") == "ENTRY_UPDATE" and item.get("action") == "register"
+    )
+    assert register["meta"]["timeout"] == 42.0
+    assert register["meta"]["model_validate"] is True
+    assert register["meta"]["llm_result_fields"] == ["ok"]
+    assert "llm_result_schema" not in register["meta"]
+    assert "persist" not in register["meta"]

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1535,6 +1535,7 @@ def test_v3_metadata_preserves_preview_and_restores_runtime_controls(
 
     preview = {
         "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
+        "llm_result_schema": {"type": "object", "properties": {"summary": {}}},
         "metadata": {"agent_auto": False}, "model_validate": True,
     }
     plugin_dir = _write_plugin(tmp_path, entries=[preview])
@@ -1564,7 +1565,10 @@ def test_v3_metadata_preserves_preview_and_restores_runtime_controls(
     static_entries = module._packaged_entries_preview(
         SimpleNamespace(toml_path=plugin_dir / "plugin.toml", conf=conf, pdata=pdata), "demo",
     )
-    expected = {key: preview[key] for key in ("timeout", "llm_result_fields", "metadata")}
+    expected = {
+        key: preview[key]
+        for key in ("timeout", "llm_result_fields", "llm_result_schema", "metadata")
+    }
     expected.update(configured or {})
     for key, value in expected.items():
         assert static_entries[0][key] == value

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1521,7 +1521,7 @@ def test_an_empty_directory_is_reported_before_packaging(tmp_path: Path) -> None
     )
 
 
-@pytest.mark.parametrize("configured", [None, {}, {
+@pytest.mark.parametrize("configured", [None, {}, {"timeout": 20}, {
     "timeout": None, "llm_result_fields": [], "metadata": {},
 }, {
     "timeout": 120, "llm_result_fields": ["configured"],
@@ -1560,25 +1560,26 @@ def test_v3_metadata_preserves_preview_and_restores_runtime_controls(
     packaged = packaged_metadata.read_packaged_metadata(plugin_dir)
     assert packaged is not None
     assert packaged.entries == [preview]
+    from types import SimpleNamespace
+    static_entries = module._packaged_entries_preview(
+        SimpleNamespace(toml_path=plugin_dir / "plugin.toml", conf=conf, pdata=pdata), "demo",
+    )
+    expected = {key: preview[key] for key in ("timeout", "llm_result_fields", "metadata")}
+    expected.update(configured or {})
+    for key, value in expected.items():
+        assert static_entries[0][key] == value
     for _ in range(2):
         loaded = lifecycle_service._read_packaged_isolated_metadata(
             plugin_dir / "plugin.toml", "demo", conf=conf, pdata=pdata,
         )
         assert loaded is not None
+        for key, value in expected.items():
+            assert loaded.entries_preview[0][key] == value
         for meta in loaded.handlers.values():
             assert "model_validate" not in meta
             assert meta["enabled"] is True
-            if configured is None:
-                assert meta["timeout"] == 100
-                assert meta["llm_result_fields"] == ["summary"]
-                assert meta["metadata"] == {"agent_auto": False}
-            else:
-                for key, value in configured.items():
-                    assert meta[key] == value
-                if not configured:
-                    assert "timeout" not in meta
-                    assert "llm_result_fields" not in meta
-                    assert meta["metadata"] is None
+            for key, value in expected.items():
+                assert meta[key] == value
     assert meta_path.read_bytes() == before
     assert _no_subprocess == []
 

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1519,3 +1519,128 @@ def test_an_empty_directory_is_reported_before_packaging(tmp_path: Path) -> None
     assert reported == ["runtime", "runtime/logs"], (
         f"空目录没被完整报出来（装不到用户机器上的正是它们）：{reported}"
     )
+
+
+@pytest.mark.parametrize("configured", [None, {}, {
+    "timeout": None, "llm_result_fields": [], "metadata": {},
+}, {
+    "timeout": 120, "llm_result_fields": ["configured"],
+    "metadata": {"agent_auto": False},
+}])
+@pytest.mark.parametrize("nested", [False, True])
+def test_v3_metadata_preserves_preview_and_restores_runtime_controls(
+    tmp_path, _no_subprocess, configured, nested,
+):
+    from plugin.server.application.plugins import lifecycle_service
+
+    preview = {
+        "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
+        "metadata": {"agent_auto": False}, "model_validate": True,
+    }
+    plugin_dir = _write_plugin(tmp_path, entries=[preview])
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    raw = json.loads(meta_path.read_text())
+    raw["schema_version"] = 3
+    # Actual v3 shapes: configured controls were never copied; decorator slots
+    # lost timeout/result fields but retained metadata.
+    handler = {
+        "event_type": "plugin_entry", "id": "go", "name": "Go",
+        "enabled": True, "metadata": None if configured is not None else preview["metadata"],
+    }
+    conf = {} if configured is None else {"entries": [{"id": "go", **configured}]}
+    if nested:
+        conf = {"plugin": conf}
+    pdata = conf.get("plugin", {})
+    raw["entries_config_sha256"] = packaged_metadata.entries_config_digest(conf, pdata)
+    raw["handlers"] = {"demo.go": handler, "demo:plugin_entry:go": handler}
+    raw["entry_methods"] = {"go": "go"}
+    meta_path.write_text(json.dumps(raw))
+    before = meta_path.read_bytes()
+
+    packaged = packaged_metadata.read_packaged_metadata(plugin_dir)
+    assert packaged is not None
+    assert packaged.entries == [preview]
+    for _ in range(2):
+        loaded = lifecycle_service._read_packaged_isolated_metadata(
+            plugin_dir / "plugin.toml", "demo", conf=conf, pdata=pdata,
+        )
+        assert loaded is not None
+        for meta in loaded.handlers.values():
+            assert "model_validate" not in meta
+            assert meta["enabled"] is True
+            if configured is None:
+                assert meta["timeout"] == 100
+                assert meta["llm_result_fields"] == ["summary"]
+                assert meta["metadata"] == {"agent_auto": False}
+            else:
+                for key, value in configured.items():
+                    assert meta[key] == value
+                if not configured:
+                    assert "timeout" not in meta
+                    assert "llm_result_fields" not in meta
+                    assert meta["metadata"] is None
+    assert meta_path.read_bytes() == before
+    assert _no_subprocess == []
+
+
+def test_v3_existing_empty_controls_are_not_replaced_by_preview(tmp_path):
+    from plugin.server.application.plugins import lifecycle_service
+
+    plugin_dir = _write_plugin(tmp_path, entries=[{
+        "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
+        "metadata": {"agent_auto": False},
+    }])
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    raw = json.loads(meta_path.read_text())
+    raw["schema_version"] = 3
+    raw["handlers"] = {"demo.go": {
+        "event_type": "plugin_entry", "id": "go", "timeout": None,
+        "llm_result_fields": [], "metadata": {},
+    }}
+    meta_path.write_text(json.dumps(raw))
+    loaded = lifecycle_service._read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "demo",
+    )
+    assert loaded is not None
+    assert loaded.handlers["demo.go"] == raw["handlers"]["demo.go"]
+    # The compatibility path must not bypass the effective-config digest gate.
+    assert lifecycle_service._read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "demo", conf={"entries": []},
+    ) is None
+
+
+@pytest.mark.parametrize("reason", ["environment", "owner", "source", "tables", "preview", "alias", "other_controls"])
+def test_v3_compatibility_retains_validation_and_ambiguous_fallback(tmp_path, reason):
+    from plugin.server.application.plugins import lifecycle_service
+
+    plugin_dir = _write_plugin(tmp_path, entries=[{
+        "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
+        "metadata": {"agent_auto": False},
+    }])
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    raw = json.loads(meta_path.read_text())
+    raw["schema_version"] = 3
+    raw["handlers"] = {"demo.go": {"event_type": "plugin_entry", "id": "go"}}
+    conf = {}
+    if reason == "environment":
+        raw["build_env"] = {}
+    elif reason == "owner":
+        raw["handlers"] = {"other.go": raw["handlers"]["demo.go"]}
+    elif reason == "source":
+        (plugin_dir / "main.py").write_text("VALUE = 12345\n")
+    elif reason == "tables":
+        raw.pop("handlers")
+    elif reason == "preview":
+        raw["entries"] = []
+    elif reason == "other_controls":
+        conf = {"entries": [{"id": "go", "enabled": False}]}
+        raw["handlers"]["demo.go"]["enabled"] = True
+        raw["entries_config_sha256"] = packaged_metadata.entries_config_digest(conf, {})
+    elif reason == "alias":
+        conf = {"entries": [{"id": "go", "timeout": 1}]}
+        raw["entries_config_sha256"] = packaged_metadata.entries_config_digest(conf, {})
+        raw["entry_methods"] = {"go": "invoke"}
+    meta_path.write_text(json.dumps(raw))
+    assert lifecycle_service._read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "demo", conf=conf,
+    ) is None

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -27,6 +27,12 @@ from plugin.server.application.plugins import registry_service as module
 from plugin.server.infrastructure import autostart_approvals, packaged_metadata
 from plugin.settings import BUILTIN_PLUGIN_CONFIG_ROOT
 
+# `platform` 第一次问操作系统版本时会 shell 出一个 `ver`，答案之后缓存在它自己的
+# 模块全局里。跑整个文件时这一下发生在某条更早的用例里，`_no_subprocess` 看不到；
+# 单跑任意一条用它的用例时却落进毒化窗口，报成"discovery 起了子进程"。在这里先问
+# 一次，让这些用例单跑和全量跑是同一个结果。
+packaged_metadata.build_environment()
+
 pytestmark = pytest.mark.plugin_unit
 
 
@@ -1649,3 +1655,48 @@ def test_v3_compatibility_retains_validation_and_ambiguous_fallback(tmp_path, re
     assert lifecycle_service._read_packaged_isolated_metadata(
         plugin_dir / "plugin.toml", "demo", conf=conf,
     ) is None
+
+
+@pytest.mark.parametrize("schema_version", [3, 4])
+def test_v3_synthesized_empty_result_fields_do_not_suppress_schema_derivation(
+    tmp_path, _no_subprocess, schema_version,
+):
+    from plugin.server.application.plugins import lifecycle_service, query_service
+
+    result_schema = {"type": "object", "properties": {"summary": {}, "detail": {}}}
+    # v3 生成器把"没声明"规范化成 []，v4 只有真声明才写这个键——所以同一份形状
+    # 在两个版本里意思相反。
+    plugin_dir = _write_plugin(tmp_path, entries=[{
+        "id": "go", "timeout": 100, "metadata": {},
+        "llm_result_fields": [], "llm_result_schema": result_schema,
+    }])
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    raw = json.loads(meta_path.read_text())
+    raw["schema_version"] = schema_version
+    raw["handlers"] = {"demo.go": {
+        "event_type": "plugin_entry", "id": "go", "name": "Go", "metadata": {},
+    }}
+    raw["entry_methods"] = {"go": "go"}
+    meta_path.write_text(json.dumps(raw))
+
+    loaded = lifecycle_service._read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "demo",
+    )
+    assert loaded is not None
+    entries: list = []
+    query_service._append_entries_from_preview(
+        plugin_id="demo",
+        plugin_meta={"entries_preview": loaded.entries_preview},
+        entries=entries,
+        seen=set(),
+    )
+    if schema_version == 3:
+        # 合成出来的空列表不表达任何意图，丢掉它、按 schema 推——推出来的正是重扫
+        # 会给的那一份。也不该为此把整个插件赶去重扫。
+        assert "llm_result_fields" not in loaded.entries_preview[0]
+        assert entries[0]["llm_result_fields"] == ["summary", "detail"]
+        assert "llm_result_fields" not in loaded.handlers["demo.go"]
+    else:
+        assert loaded.entries_preview[0]["llm_result_fields"] == []
+        assert entries[0]["llm_result_fields"] == []
+    assert _no_subprocess == []

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -159,7 +159,7 @@ def _write_plugin(tmp_path: Path, *, entries: list[dict], sdk_version: str | Non
             else packaged_metadata.build_environment()
         ),
         "entries": entries,
-        # v3 一定会写这三张表，缺哪张都算包坏了。
+        # 当前 schema 一定会写这三张表，缺哪张都算包坏了。
         "handlers": {},
         "entry_methods": {},
         "entries_config_sha256": packaged_metadata.entries_config_digest({}, {}),
@@ -1527,176 +1527,41 @@ def test_an_empty_directory_is_reported_before_packaging(tmp_path: Path) -> None
     )
 
 
-@pytest.mark.parametrize("configured", [None, {}, {"timeout": 20}, {
-    "timeout": None, "llm_result_fields": [], "metadata": {},
-}, {
-    "timeout": 120, "llm_result_fields": ["configured"],
-    "metadata": {"agent_auto": False},
-}])
-@pytest.mark.parametrize("nested", [False, True])
-def test_v3_metadata_preserves_preview_and_restores_runtime_controls(
-    tmp_path, _no_subprocess, configured, nested,
-):
-    from plugin.server.application.plugins import lifecycle_service
+def test_a_v3_package_is_refused_and_takes_the_worker_path(tmp_path, monkeypatch):
+    """Schema 3 handlers are truncated; the file is stale, not repairable.
 
-    preview = {
-        "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
-        "llm_result_schema": {"type": "object", "properties": {"summary": {}}},
-        "metadata": {"agent_auto": False}, "model_validate": True,
-    }
-    plugin_dir = _write_plugin(tmp_path, entries=[preview])
+    v3 serialized slotted SDK metadata through a ten-field fallback, so its
+    handler table has no timeout / result fields and configured entries carry a
+    blank input_schema. Patching that up in memory needs another hand-kept list
+    of "what the host reads" and still leaves the display fields wrong. Schema
+    3 only ever existed on nightly, so it is refused like schema 2: no import,
+    no rewrite, and the start path scans once until the plugin is repackaged.
+    """
+    from types import SimpleNamespace
+
+    from plugin.server.application.plugins import lifecycle_service, metadata_scanner
+
+    plugin_dir = _write_plugin(tmp_path, entries=[{"id": "go", "timeout": 100}])
     meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
     raw = json.loads(meta_path.read_text())
     raw["schema_version"] = 3
-    # Actual v3 shapes: configured controls were never copied; decorator slots
-    # lost timeout/result fields but retained metadata.
-    handler = {
-        "event_type": "plugin_entry", "id": "go", "name": "Go",
-        "enabled": True, "metadata": None if configured is not None else preview["metadata"],
-    }
-    conf = {} if configured is None else {"entries": [{"id": "go", **configured}]}
-    if nested:
-        conf = {"plugin": conf}
-    pdata = conf.get("plugin", {})
-    raw["entries_config_sha256"] = packaged_metadata.entries_config_digest(conf, pdata)
-    raw["handlers"] = {"demo.go": handler, "demo:plugin_entry:go": handler}
+    raw["handlers"] = {"demo.go": {"event_type": "plugin_entry", "id": "go", "name": "Go"}}
     raw["entry_methods"] = {"go": "go"}
     meta_path.write_text(json.dumps(raw))
     before = meta_path.read_bytes()
 
-    packaged = packaged_metadata.read_packaged_metadata(plugin_dir)
-    assert packaged is not None
-    assert packaged.entries == [preview]
-    from types import SimpleNamespace
-    static_entries = module._packaged_entries_preview(
-        SimpleNamespace(toml_path=plugin_dir / "plugin.toml", conf=conf, pdata=pdata), "demo",
+    def cannot_import(*args, **kwargs):
+        raise AssertionError("metadata reads must not import plugins")
+
+    monkeypatch.setattr(metadata_scanner, "scan_plugin_metadata_isolated", cannot_import)
+    assert packaged_metadata.read_packaged_metadata(plugin_dir) is None
+    assert lifecycle_service._read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "demo",
+    ) is None
+    # 发现侧照旧走 manifest 声明的那条通路，不会因为包过期就没有入口可列。
+    conf = {"entries": [{"id": "go", "name": "Declared"}]}
+    listed = module._packaged_entries_preview(
+        SimpleNamespace(toml_path=plugin_dir / "plugin.toml", conf=conf, pdata={}), "demo",
     )
-    expected = {
-        key: preview[key]
-        for key in ("timeout", "llm_result_fields", "llm_result_schema", "metadata")
-    }
-    expected.update(configured or {})
-    for key, value in expected.items():
-        assert static_entries[0][key] == value
-    for _ in range(2):
-        loaded = lifecycle_service._read_packaged_isolated_metadata(
-            plugin_dir / "plugin.toml", "demo", conf=conf, pdata=pdata,
-        )
-        assert loaded is not None
-        for key, value in expected.items():
-            assert loaded.entries_preview[0][key] == value
-        for meta in loaded.handlers.values():
-            assert "model_validate" not in meta
-            assert meta["enabled"] is True
-            for key, value in expected.items():
-                assert meta[key] == value
+    assert [(entry["id"], entry["name"]) for entry in listed] == [("go", "Declared")]
     assert meta_path.read_bytes() == before
-    assert _no_subprocess == []
-
-
-def test_v3_existing_empty_controls_are_not_replaced_by_preview(tmp_path):
-    from plugin.server.application.plugins import lifecycle_service
-
-    plugin_dir = _write_plugin(tmp_path, entries=[{
-        "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
-        "metadata": {"agent_auto": False},
-    }])
-    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
-    raw = json.loads(meta_path.read_text())
-    raw["schema_version"] = 3
-    raw["handlers"] = {"demo.go": {
-        "event_type": "plugin_entry", "id": "go", "timeout": None,
-        "llm_result_fields": [], "metadata": {},
-    }}
-    meta_path.write_text(json.dumps(raw))
-    loaded = lifecycle_service._read_packaged_isolated_metadata(
-        plugin_dir / "plugin.toml", "demo",
-    )
-    assert loaded is not None
-    assert loaded.handlers["demo.go"] == raw["handlers"]["demo.go"]
-    # The compatibility path must not bypass the effective-config digest gate.
-    assert lifecycle_service._read_packaged_isolated_metadata(
-        plugin_dir / "plugin.toml", "demo", conf={"entries": []},
-    ) is None
-
-
-@pytest.mark.parametrize("reason", ["environment", "owner", "source", "tables", "preview", "alias", "other_controls"])
-def test_v3_compatibility_retains_validation_and_ambiguous_fallback(tmp_path, reason):
-    from plugin.server.application.plugins import lifecycle_service
-
-    plugin_dir = _write_plugin(tmp_path, entries=[{
-        "id": "go", "timeout": 100, "llm_result_fields": ["summary"],
-        "metadata": {"agent_auto": False},
-    }])
-    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
-    raw = json.loads(meta_path.read_text())
-    raw["schema_version"] = 3
-    raw["handlers"] = {"demo.go": {"event_type": "plugin_entry", "id": "go"}}
-    conf = {}
-    if reason == "environment":
-        raw["build_env"] = {}
-    elif reason == "owner":
-        raw["handlers"] = {"other.go": raw["handlers"]["demo.go"]}
-    elif reason == "source":
-        (plugin_dir / "main.py").write_text("VALUE = 12345\n")
-    elif reason == "tables":
-        raw.pop("handlers")
-    elif reason == "preview":
-        raw["entries"] = []
-    elif reason == "other_controls":
-        conf = {"entries": [{"id": "go", "enabled": False}]}
-        raw["handlers"]["demo.go"]["enabled"] = True
-        raw["entries_config_sha256"] = packaged_metadata.entries_config_digest(conf, {})
-    elif reason == "alias":
-        conf = {"entries": [{"id": "go", "timeout": 1}]}
-        raw["entries_config_sha256"] = packaged_metadata.entries_config_digest(conf, {})
-        raw["entry_methods"] = {"go": "invoke"}
-    meta_path.write_text(json.dumps(raw))
-    assert lifecycle_service._read_packaged_isolated_metadata(
-        plugin_dir / "plugin.toml", "demo", conf=conf,
-    ) is None
-
-
-@pytest.mark.parametrize("schema_version", [3, 4])
-def test_v3_synthesized_empty_result_fields_do_not_suppress_schema_derivation(
-    tmp_path, _no_subprocess, schema_version,
-):
-    from plugin.server.application.plugins import lifecycle_service, query_service
-
-    result_schema = {"type": "object", "properties": {"summary": {}, "detail": {}}}
-    # v3 生成器把"没声明"规范化成 []，v4 只有真声明才写这个键——所以同一份形状
-    # 在两个版本里意思相反。
-    plugin_dir = _write_plugin(tmp_path, entries=[{
-        "id": "go", "timeout": 100, "metadata": {},
-        "llm_result_fields": [], "llm_result_schema": result_schema,
-    }])
-    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
-    raw = json.loads(meta_path.read_text())
-    raw["schema_version"] = schema_version
-    raw["handlers"] = {"demo.go": {
-        "event_type": "plugin_entry", "id": "go", "name": "Go", "metadata": {},
-    }}
-    raw["entry_methods"] = {"go": "go"}
-    meta_path.write_text(json.dumps(raw))
-
-    loaded = lifecycle_service._read_packaged_isolated_metadata(
-        plugin_dir / "plugin.toml", "demo",
-    )
-    assert loaded is not None
-    entries: list = []
-    query_service._append_entries_from_preview(
-        plugin_id="demo",
-        plugin_meta={"entries_preview": loaded.entries_preview},
-        entries=entries,
-        seen=set(),
-    )
-    if schema_version == 3:
-        # 合成出来的空列表不表达任何意图，丢掉它、按 schema 推——推出来的正是重扫
-        # 会给的那一份。也不该为此把整个插件赶去重扫。
-        assert "llm_result_fields" not in loaded.entries_preview[0]
-        assert entries[0]["llm_result_fields"] == ["summary", "detail"]
-        assert "llm_result_fields" not in loaded.handlers["demo.go"]
-    else:
-        assert loaded.entries_preview[0]["llm_result_fields"] == []
-        assert entries[0]["llm_result_fields"] == []
-    assert _no_subprocess == []

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -1,0 +1,374 @@
+"""Exercise metadata through registration/IPC/listing, not a hand-built Agent list."""
+
+from __future__ import annotations
+
+import copy
+import json
+import tomllib
+from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from plugin._types.events import EventMeta as LegacyEventMeta
+from plugin.core import registry
+from plugin.core.state import state
+from plugin.sdk.plugin import plugin_entry
+from plugin.server.application.plugins import metadata_scanner, query_service
+from plugin.server.routes.plugins import router
+
+
+class ContractPlugin:
+    @plugin_entry(
+        id="probe",
+        timeout=5,
+        llm_result_fields=["summary"],
+        metadata={"agent_auto": False},
+    )
+    async def probe(self):
+        pass
+
+    @plugin_entry(id="consult", timeout=100, llm_result_fields=["summary"])
+    async def consult(self):
+        pass
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    monkeypatch.setattr(state, "event_handlers", {})
+    monkeypatch.setattr(
+        state,
+        "_snapshot_cache",
+        {key: {"data": None, "timestamp": 0.0} for key in state._snapshot_cache},
+    )
+    monkeypatch.setattr(registry, "plugin_entry_method_map", {})
+
+
+def manifest_entries():
+    return [
+        {
+            "id": "probe",
+            "timeout": 5,
+            "llm_result_fields": ["summary"],
+            "metadata": {"agent_auto": False},
+        },
+        {
+            "id": "consult",
+            "timeout": 100,
+            "llm_result_fields": ["summary"],
+            "metadata": {},
+        },
+    ]
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_wire_payload_preserves_slotted_and_legacy_entry_contract(legacy):
+    source = ContractPlugin.probe.__neko_event_meta__
+    if legacy:
+        source = LegacyEventMeta(
+            "plugin_entry", "probe", "Probe", metadata={"agent_auto": False}
+        )
+        source.timeout = 5
+        source.llm_result_fields = ["summary"]
+        source.llm_result_schema = {
+            "type": "object",
+            "properties": {"summary": {"type": "string"}},
+        }
+        source.model_validate = False
+    payload = json.loads(json.dumps(metadata_scanner._event_meta_payload(source)))
+    for name in (
+        "timeout",
+        "llm_result_fields",
+        "llm_result_schema",
+        "model_validate",
+        "metadata",
+    ):
+        assert payload[name] == getattr(source, name)
+    payload["metadata"]["agent_auto"] = True
+    assert source.metadata["agent_auto"] is False
+
+
+@pytest.mark.parametrize("declared", [False, True])
+async def test_registered_entry_survives_ipc_http_listing_and_agent_projection(
+    isolated_registry, monkeypatch, declared
+):
+    from brain.task_executor import DirectTaskExecutor
+    from utils.result_parser import parse_plugin_result
+
+    config = {"entries": manifest_entries()} if declared else {}
+    registry.scan_static_metadata("contract", ContractPlugin, config, {})
+    preview = registry._extract_entries_preview("contract", ContractPlugin, config, {})
+    wire = json.loads(
+        json.dumps(
+            {
+                key: metadata_scanner._event_meta_payload(h.meta)
+                for key, h in state.event_handlers.items()
+            }
+        )
+    )
+    metadata_scanner.install_isolated_plugin_metadata(
+        "contract",
+        metadata_scanner.IsolatedPluginMetadata(
+            preview, wire, {"probe": "probe", "consult": "consult"}
+        ),
+    )
+    monkeypatch.setattr(
+        state,
+        "get_plugins_snapshot_cached",
+        lambda **_: {"contract": {"id": "contract", "entries_preview": preview}},
+    )
+    monkeypatch.setattr(
+        state,
+        "get_plugin_hosts_snapshot_cached",
+        lambda **_: {"contract": SimpleNamespace(is_alive=lambda: True)},
+    )
+    monkeypatch.setattr(query_service, "_install_source_index", lambda: ({}, {}))
+    app = FastAPI()
+    app.include_router(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/plugins?locale=en")
+    assert response.status_code == 200
+    plugin = response.json()["plugins"][0]
+    entries = {entry["id"]: entry for entry in plugin["entries"]}
+    assert entries["probe"]["metadata"]["agent_auto"] is False
+    assert entries["consult"]["timeout"] == 100
+    assert entries["consult"]["llm_result_fields"] == ["summary"]
+    executor = object.__new__(DirectTaskExecutor)
+    assert [e["id"] for e in executor._agent_visible_plugin_entries(plugin)] == [
+        "consult"
+    ]
+    assert (
+        parse_plugin_result(
+            {"summary": "New evidence", "response": {"private": True}},
+            llm_result_fields=entries["consult"]["llm_result_fields"],
+            plugin_message="done",
+        )
+        == "New evidence"
+    )
+
+
+def test_config_controls_are_preserved_without_reinterpreting_empty_values(
+    isolated_registry,
+):
+    entry = {
+        "id": "consult",
+        "name": "Configured",
+        "description": "Configured description",
+        "input_schema": {},
+        "metadata": {},
+        "timeout": 0,
+        "llm_result_fields": [],
+        "llm_result_schema": {},
+        "kind": "service",
+        "auto_start": False,
+        "enabled": False,
+        "dynamic": False,
+        "model_validate": False,
+        "persist": False,
+        "return_message": "",
+        "extra": {},
+    }
+    original = copy.deepcopy(entry)
+    registry.scan_static_metadata(
+        "contract",
+        ContractPlugin,
+        {"entries": [entry]},
+        {"entries": [{"id": "consult", "timeout": 999}]},
+    )
+    meta = state.event_handlers["contract.consult"].meta
+    for name, value in original.items():
+        assert getattr(meta, name) == value, name
+    meta.metadata["changed"] = True
+    meta.llm_result_fields.append("changed")
+    assert entry == original
+
+
+def test_config_only_registration_invalidates_handler_snapshot(isolated_registry):
+    class PlainPlugin:
+        async def invoke(self):
+            pass
+
+    assert state.get_event_handlers_snapshot_cached() == {}
+    registry.scan_static_metadata(
+        "plain",
+        PlainPlugin,
+        {"entries": [{"id": "invoke", "metadata": {"agent_auto": False}}]},
+        {},
+    )
+    assert state.get_event_handlers_snapshot_cached()["plain.invoke"].meta.metadata == {
+        "agent_auto": False
+    }
+
+
+def test_explicit_empty_entries_do_not_fall_back_to_manifest(isolated_registry):
+    class PlainPlugin:
+        async def invoke(self):
+            pass
+
+    registry.scan_static_metadata(
+        "plain", PlainPlugin, {"entries": []}, {"entries": [{"id": "invoke"}]}
+    )
+    assert state.event_handlers == {}
+
+
+def test_preview_does_not_restore_controls_explicitly_cleared_by_config(
+    isolated_registry,
+):
+    configured = {
+        "entries": [
+            {
+                "id": "probe",
+                "metadata": {},
+                "timeout": None,
+                "llm_result_fields": [],
+                "llm_result_schema": {},
+            }
+        ]
+    }
+    registry.scan_static_metadata("contract", ContractPlugin, configured, {})
+    entries, seen = query_service._build_entries_from_handlers(
+        plugin_id="contract", handlers_snapshot=dict(state.event_handlers)
+    )
+    preview = registry._extract_entries_preview(
+        "contract", ContractPlugin, configured, {}
+    )
+    query_service._append_entries_from_preview(
+        plugin_id="contract",
+        plugin_meta={"entries_preview": preview},
+        entries=entries,
+        seen=seen,
+    )
+    probe = next(entry for entry in entries if entry["id"] == "probe")
+    assert probe["metadata"] == {}
+    assert probe["timeout"] is None
+    assert probe["llm_result_fields"] == []
+
+
+def test_quick_action_config_survives_as_structured_metadata():
+    from plugin.sdk.shared.core.events import QuickActionConfig
+
+    source = copy.deepcopy(ContractPlugin.consult.__neko_event_meta__)
+    source.quick_action = True
+    source.quick_action_config = QuickActionConfig(icon="search", priority=7)
+    wire = metadata_scanner._event_meta_payload(source)
+    assert wire["quick_action"] is True
+    assert wire["quick_action_config"] == {"icon": "search", "priority": 7}
+
+
+def test_unrelated_dataclass_metadata_keeps_legacy_json_conversion():
+    from dataclasses import dataclass
+
+    @dataclass
+    class CustomDiagnostic:
+        value: int
+
+    diagnostic = CustomDiagnostic(7)
+    source = LegacyEventMeta(
+        "plugin_entry", "probe", "Probe", metadata={"custom": diagnostic}
+    )
+    wire = metadata_scanner._event_meta_payload(source)
+    assert wire["metadata"]["custom"] == str(diagnostic)
+
+
+def test_wire_payload_preserves_readonly_mapping_values_without_pickling():
+    original = {"agent_auto": False, "custom": {"values": [1, 2]}}
+    source = LegacyEventMeta(
+        "plugin_entry", "probe", "Probe", metadata=MappingProxyType(original)
+    )
+    source.llm_result_schema = MappingProxyType({"type": "object"})
+    wire = metadata_scanner._event_meta_payload(source)
+    assert wire["metadata"] == original
+    assert wire["llm_result_schema"] == {"type": "object"}
+    wire["metadata"]["custom"]["values"].append(3)
+    assert original["custom"]["values"] == [1, 2]
+
+
+def test_metadata_controls_remain_explicit_in_isolated_reconstruction(
+    isolated_registry,
+):
+    raw = {
+        "event_type": "plugin_entry",
+        "id": "consult",
+        "name": "Configured",
+        "metadata": {},
+        "timeout": None,
+        "llm_result_fields": [],
+        "llm_result_schema": {},
+        "auto_start": False,
+        "enabled": False,
+        "dynamic": False,
+        "model_validate": False,
+    }
+    metadata_scanner.install_isolated_plugin_metadata(
+        "contract",
+        metadata_scanner.IsolatedPluginMetadata(
+            [], {"contract.consult": raw}, {"consult": "consult"}
+        ),
+    )
+    installed = state.event_handlers["contract.consult"].meta
+    for name, value in raw.items():
+        assert getattr(installed, name) == value
+
+
+def test_packaging_uses_fixed_worker_and_rejects_old_contract_artifacts(
+    tmp_path: Path, isolated_registry, monkeypatch
+):
+    from plugin.neko_plugin_cli.core.metadata_probe import derive_plugin_metadata
+    from plugin.server.application.plugins.lifecycle_service import (
+        _read_packaged_isolated_metadata,
+    )
+    from plugin.server.infrastructure import packaged_metadata
+
+    plugin_dir = tmp_path / "contract"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.toml").write_text(
+        '[plugin]\nid="contract"\nname="Contract"\nversion="1.0.0"\ntype="plugin"\n'
+        'entry="plugin.plugins.contract:ContractPlugin"\n'
+        '[[entries]]\nid="consult"\ntimeout=100\nllm_result_fields=["summary"]\nmetadata={agent_auto=false}\n',
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "from plugin.sdk.plugin import NekoPluginBase, neko_plugin, plugin_entry\n"
+        "@neko_plugin\nclass ContractPlugin(NekoPluginBase):\n"
+        '    @plugin_entry(id="consult", timeout=5, llm_result_fields=["old"])\n'
+        '    async def consult(self): return {"summary":"New evidence"}\n',
+        encoding="utf-8",
+    )
+    payload = derive_plugin_metadata(plugin_dir)
+    handler = payload["handlers"]["contract.consult"]
+    assert handler["timeout"] == 100
+    assert handler["llm_result_fields"] == ["summary"]
+    assert handler["metadata"] == {"agent_auto": False}
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    meta_path.write_text(json.dumps(payload), encoding="utf-8")
+    config = tomllib.loads((plugin_dir / "plugin.toml").read_text(encoding="utf-8"))
+    loaded = _read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "contract", conf=config, pdata=config["plugin"]
+    )
+    assert loaded is not None
+    metadata_scanner.install_isolated_plugin_metadata("contract", loaded)
+    assert state.event_handlers["contract.consult"].meta.timeout == 100
+
+    # Old files may match all source fingerprints and still have truncated handlers.
+    payload["schema_version"] = 3
+    payload["handlers"]["contract.consult"].pop("timeout")
+    meta_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert (
+        _read_packaged_isolated_metadata(
+            plugin_dir / "plugin.toml", "contract", conf=config, pdata=config["plugin"]
+        )
+        is None
+    )
+
+    # Refusing the old format must keep discovery a read-only operation.
+    def cannot_import(*args, **kwargs):
+        raise AssertionError("metadata reads must not import plugins")
+
+    monkeypatch.setattr(
+        metadata_scanner, "scan_plugin_metadata_isolated", cannot_import
+    )
+    assert packaged_metadata.read_packaged_metadata(plugin_dir) is None

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -435,3 +435,94 @@ def test_partial_config_merges_decorator_and_matches_static_listing(
     assert source.metadata == original.metadata
     assert conf == original_conf
     assert "mutation" not in preview[0]["metadata"]
+
+
+@pytest.mark.parametrize("alias", [False, True])
+def test_partial_config_inherits_decorator_display_fields(isolated_registry, alias):
+    class Plugin:
+        @plugin_entry(id="probe", name="Decorated", description="Decorated description")
+        async def invoke(self, city: str):
+            pass
+
+    if not alias:
+        Plugin.probe = Plugin.invoke
+        del Plugin.invoke
+    decorated = getattr(Plugin, "invoke" if alias else "probe").__neko_event_meta__
+    assert decorated.input_schema, "the decorator must derive a schema for this test"
+
+    registry.scan_static_metadata("contract", Plugin, {"entries": [{"id": "probe", "timeout": 30}]}, {})
+    meta = state.event_handlers["contract.probe"].meta
+    # A declaration that only overrides a control must not blank the entry:
+    # the child still validates against the decorator schema.
+    assert meta.name == "Decorated"
+    assert meta.description == "Decorated description"
+    assert meta.input_schema == decorated.input_schema
+    assert meta.timeout == 30
+
+    # Writing an empty value is still a declaration.
+    registry.scan_static_metadata(
+        "contract",
+        Plugin,
+        {"entries": [{"id": "probe", "name": "", "input_schema": {}}]},
+        {},
+    )
+    cleared = state.event_handlers["contract.probe"].meta
+    assert cleared.name == ""
+    assert cleared.input_schema == {}
+
+    meta.input_schema["injected"] = True
+    assert "injected" not in decorated.input_schema
+
+
+def test_configured_result_schema_projects_the_same_before_and_after_start(
+    isolated_registry,
+):
+    class Plugin:
+        async def probe(self):
+            pass
+
+    def listed(previews):
+        entries: list = []
+        query_service._append_entries_from_preview(
+            plugin_id="contract",
+            plugin_meta={"entries_preview": previews},
+            entries=entries,
+            seen=set(),
+        )
+        return entries
+
+    def running():
+        entries, _ = query_service._build_entries_from_handlers(
+            plugin_id="contract", handlers_snapshot=dict(state.event_handlers)
+        )
+        return entries
+
+    conf = {
+        "entries": [
+            {
+                "id": "probe",
+                "llm_result_schema": {
+                    "type": "object",
+                    "properties": {"summary": {"type": "string"}},
+                },
+            }
+        ]
+    }
+    registry.scan_static_metadata("contract", Plugin, conf, {})
+    # Declaring only a result schema derives the fields; the listing must not
+    # depend on whether the plugin happens to be running.
+    assert listed(registry._extract_entries_preview("contract", Plugin, conf, {}))[0][
+        "llm_result_fields"
+    ] == ["summary"]
+    assert running()[0]["llm_result_fields"] == ["summary"]
+
+    cleared_conf = copy.deepcopy(conf)
+    cleared_conf["entries"][0]["llm_result_fields"] = []
+    registry.scan_static_metadata("contract", Plugin, cleared_conf, {})
+    assert (
+        listed(registry._extract_entries_preview("contract", Plugin, cleared_conf, {}))[0][
+            "llm_result_fields"
+        ]
+        == []
+    )
+    assert running()[0]["llm_result_fields"] == []

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -474,6 +474,34 @@ def test_partial_config_inherits_decorator_display_fields(isolated_registry, ali
     assert "injected" not in decorated.input_schema
 
 
+@pytest.mark.parametrize("alias", [False, True])
+def test_configured_display_fields_reach_the_static_listing(isolated_registry, alias):
+    class Plugin:
+        @plugin_entry(id="probe", name="Decorated", description="Decorated description")
+        async def invoke(self, city: str):
+            pass
+
+    if not alias:
+        Plugin.probe = Plugin.invoke
+        del Plugin.invoke
+    configured_schema = {"type": "object", "properties": {"query": {"type": "string"}}}
+    conf = {
+        "entries": [
+            {"id": "probe", "name": "Configured", "input_schema": configured_schema}
+        ]
+    }
+    preview = registry._extract_entries_preview("contract", Plugin, conf, {})
+    registry.scan_static_metadata("contract", Plugin, conf, {})
+    meta = state.event_handlers["contract.probe"].meta
+    # A stopped plugin is listed from the preview and a running one from the
+    # handler; a client must not build calls against two different schemas.
+    assert preview[0]["name"] == meta.name == "Configured"
+    assert preview[0]["input_schema"] == meta.input_schema == configured_schema
+    assert preview[0]["description"] == meta.description == "Decorated description"
+    preview[0]["input_schema"]["properties"]["injected"] = True
+    assert "injected" not in configured_schema["properties"]
+
+
 def test_configured_result_schema_projects_the_same_before_and_after_start(
     isolated_registry,
 ):

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -314,7 +314,7 @@ def test_metadata_controls_remain_explicit_in_isolated_reconstruction(
         assert getattr(installed, name) == value
 
 
-def test_packaging_uses_fixed_worker_and_rejects_old_contract_artifacts(
+def test_packaging_uses_fixed_worker_and_restores_v3_contract_artifacts(
     tmp_path: Path, isolated_registry, monkeypatch
 ):
     from plugin.neko_plugin_cli.core.metadata_probe import derive_plugin_metadata
@@ -355,20 +355,31 @@ def test_packaging_uses_fixed_worker_and_rejects_old_contract_artifacts(
 
     # Old files may match all source fingerprints and still have truncated handlers.
     payload["schema_version"] = 3
-    payload["handlers"]["contract.consult"].pop("timeout")
+    for old_handler in payload["handlers"].values():
+        old_handler.pop("timeout", None)
+        old_handler.pop("llm_result_fields", None)
+        old_handler["metadata"] = None
     meta_path.write_text(json.dumps(payload), encoding="utf-8")
-    assert (
-        _read_packaged_isolated_metadata(
-            plugin_dir / "plugin.toml", "contract", conf=config, pdata=config["plugin"]
-        )
-        is None
+    restored = _read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "contract", conf=config, pdata=config["plugin"]
     )
+    assert restored is not None
+    for old_handler in restored.handlers.values():
+        assert old_handler["timeout"] == 100
+        assert old_handler["llm_result_fields"] == ["summary"]
+        assert old_handler["metadata"] == {"agent_auto": False}
+    metadata_scanner.install_isolated_plugin_metadata("contract", restored)
+    assert state.event_handlers["contract.consult"].meta.timeout == 100
 
-    # Refusing the old format must keep discovery a read-only operation.
+    # Reading the old format must not import the plugin or rewrite the artifact.
     def cannot_import(*args, **kwargs):
         raise AssertionError("metadata reads must not import plugins")
 
     monkeypatch.setattr(
         metadata_scanner, "scan_plugin_metadata_isolated", cannot_import
     )
+    assert packaged_metadata.read_packaged_metadata(plugin_dir) is not None
+    assert json.loads(meta_path.read_text()) == payload
+    payload["schema_version"] = 2
+    meta_path.write_text(json.dumps(payload), encoding="utf-8")
     assert packaged_metadata.read_packaged_metadata(plugin_dir) is None

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -502,6 +502,43 @@ def test_configured_display_fields_reach_the_static_listing(isolated_registry, a
     assert "injected" not in configured_schema["properties"]
 
 
+def test_result_model_without_required_fields_projects_the_same_before_and_after_start(
+    isolated_registry,
+):
+    from pydantic import BaseModel
+
+    class AllDefaults(BaseModel):
+        summary: str = ""
+        detail: str = ""
+
+    class Plugin:
+        @plugin_entry(id="probe", name="Probe", llm_result_model=AllDefaults)
+        async def probe(self):
+            pass
+
+    source = Plugin.probe.__neko_event_meta__
+    # The SDK reverse-derives the field list from the schema's `required`, so a
+    # result model whose fields all have defaults keeps its schema and collapses
+    # the field list to None. The preview must not report that as "declared []".
+    assert source.llm_result_fields is None
+    assert list(source.llm_result_schema["properties"]) == ["summary", "detail"]
+
+    preview = registry._extract_entries_preview("contract", Plugin, {}, {})
+    registry.scan_static_metadata("contract", Plugin, {}, {})
+    listed: list = []
+    query_service._append_entries_from_preview(
+        plugin_id="contract",
+        plugin_meta={"entries_preview": preview},
+        entries=listed,
+        seen=set(),
+    )
+    running, _ = query_service._build_entries_from_handlers(
+        plugin_id="contract", handlers_snapshot=dict(state.event_handlers)
+    )
+    assert listed[0]["llm_result_fields"] == running[0]["llm_result_fields"]
+    assert running[0]["llm_result_fields"] == ["summary", "detail"]
+
+
 def test_configured_result_schema_projects_the_same_before_and_after_start(
     isolated_registry,
 ):

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -314,8 +314,9 @@ def test_metadata_controls_remain_explicit_in_isolated_reconstruction(
         assert getattr(installed, name) == value
 
 
+@pytest.mark.parametrize("partial", [False, True])
 def test_packaging_uses_fixed_worker_and_restores_v3_contract_artifacts(
-    tmp_path: Path, isolated_registry, monkeypatch
+    tmp_path: Path, isolated_registry, monkeypatch, partial
 ):
     from plugin.neko_plugin_cli.core.metadata_probe import derive_plugin_metadata
     from plugin.server.application.plugins.lifecycle_service import (
@@ -328,17 +329,22 @@ def test_packaging_uses_fixed_worker_and_restores_v3_contract_artifacts(
     (plugin_dir / "plugin.toml").write_text(
         '[plugin]\nid="contract"\nname="Contract"\nversion="1.0.0"\ntype="plugin"\n'
         'entry="plugin.plugins.contract:ContractPlugin"\n'
-        '[[entries]]\nid="consult"\ntimeout=100\nllm_result_fields=["summary"]\nmetadata={agent_auto=false}\n',
+        '[[entries]]\nid="consult"\nname="Configured"\n'
+        + ('' if partial else 'timeout=100\nllm_result_fields=["summary"]\nmetadata={agent_auto=false}\n'),
         encoding="utf-8",
     )
     (plugin_dir / "__init__.py").write_text(
         "from plugin.sdk.plugin import NekoPluginBase, neko_plugin, plugin_entry\n"
         "@neko_plugin\nclass ContractPlugin(NekoPluginBase):\n"
-        '    @plugin_entry(id="consult", timeout=5, llm_result_fields=["old"])\n'
+        '    @plugin_entry(id="consult", timeout=100, llm_result_fields=["summary"], metadata={"agent_auto":False})\n'
         '    async def consult(self): return {"summary":"New evidence"}\n',
         encoding="utf-8",
     )
     payload = derive_plugin_metadata(plugin_dir)
+    preview = next(entry for entry in payload["entries"] if entry["id"] == "consult")
+    assert preview["timeout"] == 100
+    assert preview["llm_result_fields"] == ["summary"]
+    assert preview["metadata"] == {"agent_auto": False}
     handler = payload["handlers"]["contract.consult"]
     assert handler["timeout"] == 100
     assert handler["llm_result_fields"] == ["summary"]
@@ -383,3 +389,49 @@ def test_packaging_uses_fixed_worker_and_restores_v3_contract_artifacts(
     payload["schema_version"] = 2
     meta_path.write_text(json.dumps(payload), encoding="utf-8")
     assert packaged_metadata.read_packaged_metadata(plugin_dir) is None
+
+
+@pytest.mark.parametrize("controls", [{}, {
+    "timeout": 20, "llm_result_fields": ["answer"], "metadata": {"agent_auto": True},
+}, {"timeout": None, "llm_result_fields": [], "metadata": {}}])
+@pytest.mark.parametrize("alias", [False, True])
+def test_partial_config_merges_decorator_and_matches_static_listing(
+    isolated_registry, controls, alias,
+):
+    class Plugin:
+        @plugin_entry(id="probe", name="Decorated", description="Description",
+                      timeout=100, llm_result_fields=["summary"],
+                      metadata={"agent_auto": False})
+        async def invoke(self):
+            pass
+
+    if not alias:
+        Plugin.probe = Plugin.invoke
+        del Plugin.invoke
+    configured = {"id": "probe", "name": "Configured", **controls}
+    conf = {"entries": [configured]}
+    original_conf = copy.deepcopy(conf)
+    source = getattr(Plugin, "invoke" if alias else "probe").__neko_event_meta__
+    original = copy.deepcopy(source)
+    preview = registry._extract_entries_preview("contract", Plugin, conf, {})
+    registry.scan_static_metadata("contract", Plugin, conf, {})
+    meta = state.event_handlers["contract.probe"].meta
+    expected = {"timeout": 100, "llm_result_fields": ["summary"],
+                "metadata": {"agent_auto": False}, **controls}
+    for key, value in expected.items():
+        assert getattr(meta, key) == value
+        assert preview[0][key] == value
+    assert meta.name == "Configured"
+    before = []
+    query_service._append_entries_from_preview(
+        plugin_id="contract", plugin_meta={"entries_preview": preview}, entries=before, seen=set(),
+    )
+    after, _ = query_service._build_entries_from_handlers(
+        plugin_id="contract", handlers_snapshot=dict(state.event_handlers),
+    )
+    for key in expected:
+        assert before[0][key] == after[0][key]
+    meta.metadata["mutation"] = True
+    assert source.metadata == original.metadata
+    assert conf == original_conf
+    assert "mutation" not in preview[0]["metadata"]

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -625,6 +625,35 @@ def test_configured_values_are_normalized_the_same_way_for_preview_and_handler(
     assert after["consult"]["llm_result_fields"] == ["a"]
 
 
+@pytest.mark.parametrize("declared, expected", [
+    ([], []),
+    (["a", 1, " a "], ["a"]),
+    # Not a list: not declared. The decorator's own ["summary"] is inherited,
+    # and a config-only entry falls back to deriving from its schema.
+    ("summary", ["summary"]),
+    (None, ["summary"]),
+])
+def test_only_a_list_declares_result_fields(isolated_registry, declared, expected):
+    """A mistyped ``llm_result_fields`` is not an explicit empty list.
+
+    ``[]`` switches schema derivation off on purpose; a string or null must
+    read as "not declared" on both sides so the decorator value or the schema
+    still supplies the fields.
+    """
+    schema = {"type": "object", "properties": {"summary": {}, "detail": {}}}
+    conf = {"entries": [
+        {"id": "consult", "llm_result_fields": declared},
+        {"id": "solo", "llm_result_schema": schema, "llm_result_fields": declared},
+    ]}
+    preview = registry._extract_entries_preview("contract", ContractPlugin, conf, {})
+    registry.scan_static_metadata("contract", ContractPlugin, conf, {})
+    before, after = _listed_before_and_after_start(preview)
+    assert before["consult"]["llm_result_fields"] == expected
+    assert after["consult"]["llm_result_fields"] == expected
+    solo_expected = expected if isinstance(declared, list) else ["summary", "detail"]
+    assert before["solo"]["llm_result_fields"] == solo_expected
+
+
 def test_config_only_entries_get_their_declared_fields_from_the_overlay(isolated_registry):
     conf = {"entries": [
         "bare",

--- a/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
+++ b/plugin/tests/unit/server/test_plugin_entry_metadata_contract.py
@@ -12,7 +12,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from plugin._types.events import EventMeta as LegacyEventMeta
+from plugin._types.events import EVENT_META_ATTR, EventMeta as LegacyEventMeta
 from plugin.core import registry
 from plugin.core.state import state
 from plugin.sdk.plugin import plugin_entry
@@ -315,7 +315,7 @@ def test_metadata_controls_remain_explicit_in_isolated_reconstruction(
 
 
 @pytest.mark.parametrize("partial", [False, True])
-def test_packaging_uses_fixed_worker_and_restores_v3_contract_artifacts(
+def test_packaging_uses_fixed_worker_and_refuses_v3_artifacts(
     tmp_path: Path, isolated_registry, monkeypatch, partial
 ):
     from plugin.neko_plugin_cli.core.metadata_probe import derive_plugin_metadata
@@ -359,36 +359,27 @@ def test_packaging_uses_fixed_worker_and_restores_v3_contract_artifacts(
     metadata_scanner.install_isolated_plugin_metadata("contract", loaded)
     assert state.event_handlers["contract.consult"].meta.timeout == 100
 
-    # Old files may match all source fingerprints and still have truncated handlers.
+    # A schema 3 file may match every source fingerprint and still carry
+    # truncated handlers. It is refused like any other stale schema: no
+    # in-memory repair, no plugin import, no rewrite of the artifact.
     payload["schema_version"] = 3
     for old_handler in payload["handlers"].values():
         old_handler.pop("timeout", None)
         old_handler.pop("llm_result_fields", None)
         old_handler["metadata"] = None
     meta_path.write_text(json.dumps(payload), encoding="utf-8")
-    restored = _read_packaged_isolated_metadata(
-        plugin_dir / "plugin.toml", "contract", conf=config, pdata=config["plugin"]
-    )
-    assert restored is not None
-    for old_handler in restored.handlers.values():
-        assert old_handler["timeout"] == 100
-        assert old_handler["llm_result_fields"] == ["summary"]
-        assert old_handler["metadata"] == {"agent_auto": False}
-    metadata_scanner.install_isolated_plugin_metadata("contract", restored)
-    assert state.event_handlers["contract.consult"].meta.timeout == 100
 
-    # Reading the old format must not import the plugin or rewrite the artifact.
     def cannot_import(*args, **kwargs):
         raise AssertionError("metadata reads must not import plugins")
 
     monkeypatch.setattr(
         metadata_scanner, "scan_plugin_metadata_isolated", cannot_import
     )
-    assert packaged_metadata.read_packaged_metadata(plugin_dir) is not None
-    assert json.loads(meta_path.read_text()) == payload
-    payload["schema_version"] = 2
-    meta_path.write_text(json.dumps(payload), encoding="utf-8")
     assert packaged_metadata.read_packaged_metadata(plugin_dir) is None
+    assert _read_packaged_isolated_metadata(
+        plugin_dir / "plugin.toml", "contract", conf=config, pdata=config["plugin"]
+    ) is None
+    assert json.loads(meta_path.read_text()) == payload
 
 
 @pytest.mark.parametrize("controls", [{}, {
@@ -591,3 +582,136 @@ def test_configured_result_schema_projects_the_same_before_and_after_start(
         == []
     )
     assert running()[0]["llm_result_fields"] == []
+
+
+def _listed_before_and_after_start(preview):
+    before: list = []
+    query_service._append_entries_from_preview(
+        plugin_id="contract", plugin_meta={"entries_preview": preview}, entries=before, seen=set(),
+    )
+    after, _ = query_service._build_entries_from_handlers(
+        plugin_id="contract", handlers_snapshot=dict(state.event_handlers),
+    )
+    return {entry["id"]: entry for entry in before}, {entry["id"]: entry for entry in after}
+
+
+def test_configured_values_are_normalized_the_same_way_for_preview_and_handler(
+    isolated_registry,
+):
+    """A manifest typo must not put a raw shape on the wire.
+
+    The overlay used to write the declaration verbatim over values the config
+    branch had just coerced, so ``metadata = "x"`` reached plugin.meta.json as
+    a string and ``["a", 1]`` reached /plugins with the integer in it.
+    """
+    conf = {"entries": [{
+        "id": "consult", "name": 7, "kind": "", "auto_start": "yes",
+        "metadata": "x", "llm_result_schema": "nope",
+        "llm_result_fields": ["a", 1, " a ", ""],
+    }]}
+    preview = registry._extract_entries_preview("contract", ContractPlugin, conf, {})
+    registry.scan_static_metadata("contract", ContractPlugin, conf, {})
+    meta = state.event_handlers["contract.consult"].meta
+    entry = next(item for item in preview if item["id"] == "consult")
+    expected = {
+        "name": "7", "kind": "action", "auto_start": True, "metadata": {},
+        "llm_result_schema": {}, "llm_result_fields": ["a"], "timeout": 100,
+    }
+    for key, value in expected.items():
+        assert entry[key] == value, key
+        assert getattr(meta, key) == value, key
+    before, after = _listed_before_and_after_start(preview)
+    assert before["consult"]["llm_result_fields"] == ["a"]
+    assert after["consult"]["llm_result_fields"] == ["a"]
+
+
+def test_config_only_entries_get_their_declared_fields_from_the_overlay(isolated_registry):
+    conf = {"entries": [
+        "bare",
+        {"id": "declared", "name": 7, "timeout": 9, "llm_result_fields": ["x"]},
+    ]}
+    preview = registry._extract_entries_preview(
+        "contract", type("UnscannedPluginStub", (), {}), conf, {},
+    )
+    by_id = {entry["id"]: entry for entry in preview}
+    assert by_id["bare"]["name"] == ""
+    assert by_id["bare"]["timeout"] is None
+    assert "llm_result_fields" not in by_id["bare"]
+    assert by_id["declared"]["name"] == "7"
+    assert by_id["declared"]["timeout"] == 9
+    assert by_id["declared"]["llm_result_fields"] == ["x"]
+    assert by_id["declared"]["event_key"] == "contract.declared"
+
+
+def test_unpicklable_decorator_metadata_keeps_the_configured_override(isolated_registry):
+    """Decorator values are referenced, not deep-copied.
+
+    A lock or a client handle stashed in decorator metadata made ``deepcopy``
+    raise TypeError inside the config loop, whose except clause swallowed it:
+    the decorator handler stayed registered and the configured timeout was
+    silently gone. The preview overlay copied the same object outside any
+    guard and failed the whole scan.
+    """
+    import threading
+
+    class Plugin:
+        async def locked(self):
+            pass
+
+    source = LegacyEventMeta(
+        "plugin_entry", "locked", "Locked", metadata={"lock": threading.Lock()}
+    )
+    setattr(Plugin.locked, EVENT_META_ATTR, source)
+    conf = {"entries": [{"id": "locked", "timeout": 5}]}
+
+    preview = registry._extract_entries_preview("contract", Plugin, conf, {})
+    assert preview[0]["timeout"] == 5
+    registry.scan_static_metadata("contract", Plugin, conf, {})
+    meta = state.event_handlers["contract.locked"].meta
+    assert meta.timeout == 5
+    assert meta.metadata is source.metadata
+    assert meta.name == "Locked"
+
+
+@pytest.mark.parametrize("replacement", [
+    {"agent_auto": False}, {"llm_result_fields": ["detail"]},
+])
+def test_config_metadata_replacement_projects_result_fields_the_same_way(
+    isolated_registry, replacement,
+):
+    """The legacy ``metadata={"llm_result_fields": [...]}`` lift follows the metadata.
+
+    The handler side reads that key from the effective metadata; once the
+    configuration replaces the mapping, the old lift is gone there. The preview
+    must not keep the value it lifted from the decorator's mapping.
+    """
+    class Plugin:
+        async def probe(self):
+            pass
+
+    setattr(
+        Plugin.probe,
+        EVENT_META_ATTR,
+        LegacyEventMeta(
+            "plugin_entry", "probe", "Probe", metadata={"llm_result_fields": ["summary"]}
+        ),
+    )
+    conf = {"entries": [{"id": "probe", "metadata": replacement}]}
+    preview = registry._extract_entries_preview("contract", Plugin, conf, {})
+    registry.scan_static_metadata("contract", Plugin, conf, {})
+    before, after = _listed_before_and_after_start(preview)
+    expected = replacement.get("llm_result_fields", [])
+    assert before["probe"]["llm_result_fields"] == expected
+    assert after["probe"]["llm_result_fields"] == expected
+
+
+def test_slotted_wire_payload_has_no_hand_copied_controls():
+    """Everything beyond identity and display comes from the shared contract."""
+    source = ContractPlugin.consult.__neko_event_meta__
+    payload = metadata_scanner._event_meta_payload(source)
+    identity = {"event_type", "id", "name", "description", "input_schema", "enabled", "dynamic"}
+    from plugin._types.entry_metadata import ENTRY_CONTRACT_FIELDS
+
+    assert set(payload) <= identity | set(ENTRY_CONTRACT_FIELDS)
+    assert payload["timeout"] == 100
+    assert payload["quick_action_config"] == {"icon": None, "priority": 0}

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -4069,3 +4069,130 @@ async def test_start_plugin_checks_python_requirements_off_the_event_loop(
         with module.state.acquire_plugin_hosts_write_lock():
             module.state.plugin_hosts.clear()
             module.state.plugin_hosts.update(hosts_backup)
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema_version", ["current", 3])
+async def test_start_plugin_scans_once_when_the_packaged_schema_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    schema_version: int,
+) -> None:
+    """A stale ``plugin.meta.json`` sends ``start_plugin`` through the worker.
+
+    Schema 3 handlers are truncated and are refused by the reader; the fallback
+    that turns that refusal into one isolated scan lives in ``start_plugin``,
+    not in the reader. A current artifact must still start without any scan.
+
+    Mutation: drop the ``isolated_metadata is None`` branch from ``start_plugin``.
+    """
+    import json
+    import tomllib
+
+    from plugin.server.infrastructure import packaged_metadata
+
+    if schema_version == "current":
+        schema_version = packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION
+    current = schema_version == packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION
+    plugin_dir = tmp_path / "packaged_adapter"
+    plugin_dir.mkdir(parents=True)
+    config_path = plugin_dir / "plugin.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[plugin]",
+                "id = 'packaged_adapter'",
+                "name = 'Packaged Adapter'",
+                "type = 'adapter'",
+                "entry = 'tests.fake_mcp:FakeAdapterPlugin'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    conf = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    handler = {"event_type": "plugin_entry", "id": "list_servers", "name": "List Servers"}
+    payload = {
+        "schema_version": schema_version,
+        "sdk_version": packaged_metadata.SDK_VERSION,
+        "source_sha256": packaged_metadata.compute_source_sha256(plugin_dir),
+        "source_files": packaged_metadata.source_file_names(plugin_dir)[0],
+        "source_bytes": packaged_metadata.source_stat_summary(plugin_dir).total_bytes,
+        "build_env": packaged_metadata.build_environment(),
+        "entries": [{"id": "list_servers", "name": "List Servers"}],
+        "handlers": {
+            "packaged_adapter.list_servers": handler,
+            "packaged_adapter:plugin_entry:list_servers": handler,
+        },
+        "entry_methods": {"list_servers": "list_servers"},
+        "entries_config_sha256": packaged_metadata.entries_config_digest(conf, conf["plugin"]),
+    }
+    (plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins["packaged_adapter"] = {
+                "id": "packaged_adapter",
+                "name": "Packaged Adapter",
+                "type": "adapter",
+                "config_path": str(config_path),
+                "entry_point": "tests.fake_mcp:FakeAdapterPlugin",
+            }
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+
+        monkeypatch.setattr(
+            module,
+            "resolve_plugin_config_from_path",
+            lambda *args, **kwargs: {
+                "effective_config": kwargs["base_config"],
+                "warnings": [],
+            },
+        )
+        monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
+        monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
+        inner_scan = _metadata_scan_for(_FakeAdapterPlugin)
+        scans: list[str] = []
+
+        def _recording_scan(**kwargs):
+            scans.append(str(kwargs["plugin_id"]))
+            kwargs.pop("timeout", None)
+            return inner_scan(**kwargs)
+
+        monkeypatch.setattr(module, "scan_plugin_metadata_isolated", _recording_scan)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+        response = await module.PluginLifecycleService().start_plugin(
+            "packaged_adapter", refresh_registry=False,
+        )
+
+        assert response["success"] is True
+        if current:
+            assert scans == [], "当前 schema 的包不该再起隔离扫描"
+            assert "packaged_adapter.list_servers" in module.state.event_handlers
+        else:
+            assert scans == ["packaged_adapter"], (
+                f"过期 schema 的包应该恰好回落扫描一次：{scans}"
+            )
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -4163,11 +4163,18 @@ async def test_start_plugin_scans_once_when_the_packaged_schema_is_stale(
         monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
         inner_scan = _metadata_scan_for(_FakeAdapterPlugin)
         scans: list[str] = []
+        scanned_handler = dict(handler, name="Scanned")
 
         def _recording_scan(**kwargs):
             scans.append(str(kwargs["plugin_id"]))
             kwargs.pop("timeout", None)
-            return inner_scan(**kwargs)
+            scanned = inner_scan(**kwargs)
+            # 扫描结果和包里那份只差一个 name，好分辨最终注册的是哪一份。
+            return IsolatedPluginMetadata(
+                entries_preview=scanned.entries_preview,
+                handlers={"packaged_adapter.list_servers": scanned_handler},
+                entry_methods={"list_servers": "list_servers"},
+            )
 
         monkeypatch.setattr(module, "scan_plugin_metadata_isolated", _recording_scan)
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
@@ -4177,13 +4184,15 @@ async def test_start_plugin_scans_once_when_the_packaged_schema_is_stale(
         )
 
         assert response["success"] is True
+        registered = module.state.event_handlers["packaged_adapter.list_servers"].meta
         if current:
             assert scans == [], "当前 schema 的包不该再起隔离扫描"
-            assert "packaged_adapter.list_servers" in module.state.event_handlers
+            assert registered.name == "List Servers", "注册的不是包里那份 handler"
         else:
             assert scans == ["packaged_adapter"], (
                 f"过期 schema 的包应该恰好回落扫描一次：{scans}"
             )
+            assert registered.name == "Scanned", "扫描结果没有被应用到注册表"
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()


### PR DESCRIPTION
## 改动概述 / Summary

修复插件入口在启动或重新加载后丢失设置的问题。这会导致两种用户可见的异常：原本只给面板调试使用的入口被 Agent 自动选中；插件已经返回了回答，传给本体的却只有 `done`。

### 原来为什么会这样

入口信息有两处会丢字段：

1. 同一个入口同时由装饰器和 manifest 声明时，注册器会用配置重新创建入口记录，但只复制名称、描述和输入 schema。`metadata`、超时和结果字段声明等信息没有被带过去。
2. 隔离扫描器通过 JSON 把入口信息送回宿主。SDK 的元数据对象使用 slots，没有 `__dict__`；这条后备序列化路径也漏掉了超时和结果字段。

所以，即使插件声明了 `metadata.agent_auto=false`，Agent 读取的入口列表仍可能没有这个标记。与此同时，`llm_result_fields` 丢失会让结果解析器回落到任务状态文字。平台会显示“调用成功”，但本体拿不到插件准备好的回答。

### 修复后的行为

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 调试入口声明 `metadata.agent_auto=false` | 标记可能在注册时丢失，Agent 会把它当作可选入口 | 标记能够经过注册、隔离传输和 `/plugins` 列表保留下来，自动路由会排除它 |
| 入口声明 `llm_result_fields=["summary"]` | 插件返回了 summary，本体仍可能只收到 `done` | 本体按声明取得 summary；未选中的原始 JSON 不会因此被自动塞入上下文 |
| 入口声明自己的超时，例如 100 秒 | 对外可能变成 `timeout=null`，下游使用默认预算 | 声明值保留，现有超时解析逻辑可以读到它 |
| 配置显式写入 false、空列表、空字典或 null | 部分字段没有进入注册记录 | 按已有配置覆盖规则保留这些值，不拿装饰器或 preview 的旧值补回来 |
| 只有配置声明的入口完成注册 | handler 快照可能短暂保持旧内容 | 两轮扫描写入结束后，使快照缓存失效 |

这次保留现有的配置覆盖优先级，以及运行时动态入口优先于静态记录的规则。没有修改 Agent 如何判断任务、结果解析器的提取策略，也没有改变本体先回答、随后接收插件回调的时序。

### 代码怎么改

- 用一个小型字段提取函数列出当前入口契约支持的控制字段，由配置注册和隔离序列化共用。
- 配置注册时复制这些字段，避免注册记录与可变配置对象互相影响。
- 隔离序列化继续通过现有 JSON 转换器生成独立数据，兼容只读 Mapping；不会为了复制元数据而要求对象支持 pickle。
- dataclass 的结构化转换只用于 SDK 的 `quick_action_config`。其他自定义元数据值仍使用原有转换方式。

### 为什么同时更新 14 份 plugin.meta.json

这些文件此前就被仓库跟踪。它们保存了打包时生成的入口预览和 handler 信息，运行时可以直接读取，避免为发现入口而导入插件代码。

旧 v3 文件可能出现“预览完整，handler 缺字段”的情况，即使源码指纹完全匹配也会继续复用错误信息。因此本次将元数据格式升级到 v4，并使用修复后的生成器重新生成了仓库内的 14 份文件。

已逐份核对：入口列表、源码指纹和原有 handler 字段值都没有改变；变化是补回缺失字段及更新格式版本。14 份文件重新生成后均与提交内容完全一致。大部分 diff 来自这些生成文件，并非修改了 14 个插件的业务逻辑。

### 兼容性与运行开销

- 新代码会拒绝旧 v3 元数据，使用已有的回落流程。尚未重新打包的第三方插件，在启动时可能需要隔离扫描；直到元数据更新前，再次启动仍可能扫描。
- 注册表刷新仍然只读取文件，不因旧格式失效而导入插件或创建扫描子进程。
- 这次没有增加模型请求，也没有在每次模型调用时增加扫描步骤。新增的字段处理发生在注册、扫描或构建元数据时。
- 本 PR 不包含 RimWorld 业务代码或 Mod 改动。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/`。本次验证集中于插件平台的元数据传递和消费链路。

## 不拆分理由 / Why Not Split

本次共 20 个文件，按项目规则计入上限的文件为 18 个，未超过限制。其中 14 个是已有的生成元数据。格式升级与这些文件的更新放在同一提交中，保证仓库内置产物能够被新代码直接读取。

## 测试 / Testing

- 251 项插件相关测试通过，覆盖注册、隔离扫描、打包元数据、静态发现、安装/启动规则、Hosted UI 查询和 SDK 入口契约。
- 2 项本体入口可见性测试通过。插件与本体测试按仓库 CI 的安排分进程运行。
- 新增回归实际经过：声明 → 注册 → JSON 序列化/重建 → HTTP `/plugins` → Agent 入口过滤 → 结果文本提取，避免只拿手工构造的完整字典测试过滤器。
- 覆盖 slotted/legacy 元数据、显式空值、只读 Mapping、quick-action 配置、配置覆盖、旧格式拒绝，以及真实隔离 worker 的打包/加载往返。
- 14 份生成元数据与当前生成器逐份比对一致。
- 模块分层检查、Ruff、异步阻塞检查和 `git diff --check` 通过。

以上为本地自动化验证；尚未部署到正在运行的桌面环境。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 插件条目元数据在注册、预览、列表及运行态展示中保持一致。
  - 支持结果字段、结果架构、模型校验、超时、持久化及快捷操作等配置。
  - 动态注册的插件条目可同步声明控制参数。

- **兼容性**
  - 元数据架构升级至 v4，相关插件配置已同步更新。
  - v3 打包元数据将被拒绝读取；需重新打包，否则使用工作进程路径。

- **问题修复**
  - 改进空结果字段、配置覆盖及快捷操作配置的处理。
  - 提升静态预览与运行态元数据的一致性和可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->