### PR TITLE
fix(build): 内置插件打包只收 Git 索引里的目录

### DIFF
--- a/scripts/prepare_nuitka_plugins.py
+++ b/scripts/prepare_nuitka_plugins.py
@@ -384,7 +384,8 @@ def main(argv: list[str] | None = None) -> int:
             f"{len(result.staged_files)} files; excluded {len(result.excluded_paths)} paths."
         )
         for entry in result.skipped_entries:
-            print(f"[WARNING] Not bundled, absent from the Git index: {entry}")
+            # ``entry`` already carries the reason it was left out.
+            print(f"[WARNING] Not bundled: {entry}")
         print(f"Plugin stage: {result.stage_dir}")
         print(f"Generated launcher: {result.generated_launcher}")
         return 0

--- a/scripts/prepare_nuitka_plugins.py
+++ b/scripts/prepare_nuitka_plugins.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +50,7 @@ class PrepareResult:
     staged_files: tuple[str, ...]
     excluded_paths: tuple[str, ...]
     excluded_modules: tuple[str, ...]
+    skipped_entries: tuple[str, ...]
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -80,6 +82,62 @@ def _module_name(plugin_dir_name: str, relative_path: Path, *, is_dir: bool) -> 
     if not parts or not all(part.isidentifier() for part in parts):
         return None
     return ".".join(parts)
+
+
+def _git_tracked_top_level_names(plugins_root: Path) -> set[str] | None:
+    """Names Git tracks directly under ``plugins_root``.
+
+    Returns ``None`` when Git is unavailable or the tree is not a checkout, in
+    which case the caller falls back to the ``plugin.toml`` requirement alone.
+    """
+
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=str(plugins_root),
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+
+    names: set[str] = set()
+    for entry in completed.stdout.split(bytes([0])):
+        if not entry:
+            continue
+        relative = entry.decode("utf-8", errors="replace")
+        head = relative.split("/", 1)[0]
+        if head:
+            names.add(head)
+    # An empty index for a directory that is supposed to hold the built-in
+    # plugins means the query answered about some unrelated checkout (a temp
+    # tree nested in a repository, for example).  Fall back rather than treat
+    # every plugin as untracked.
+    return names or None
+
+
+def _skip_reason(entry: Path, *, tracked_names: set[str] | None) -> str | None:
+    """Why ``entry`` must stay out of the desktop payload, or ``None`` to keep it.
+
+    Local-only plugin directories (private experiments, plugins already moved to
+    the marketplace and deleted from the index) stay on a developer machine long
+    after Git stops tracking them.  Copying whatever ``plugin/plugins`` happens
+    to contain shipped those directories in desktop builds, so the stage now
+    mirrors the index instead of the working tree.
+    """
+
+    if tracked_names is not None and entry.name not in tracked_names:
+        return "untracked by git"
+    if not entry.is_dir():
+        return None
+    # ``_shared`` and friends are runtime helper packages, not plugins.
+    if entry.name.startswith("_"):
+        return None
+    if not (entry / "plugin.toml").is_file():
+        return "missing plugin.toml"
+    return None
 
 
 def _copy_plugin_tree(
@@ -196,11 +254,21 @@ def prepare_plugins(
     staged_files: list[str] = []
     excluded_paths: list[str] = []
     excluded_modules: set[str] = set()
+    skipped_entries: list[str] = []
+    tracked_names = _git_tracked_top_level_names(plugins_root)
 
     for source_file in sorted(path for path in plugins_root.iterdir() if path.is_file()):
+        reason = _skip_reason(source_file, tracked_names=tracked_names)
+        if reason is not None:
+            skipped_entries.append(f"{source_file.name} ({reason})")
+            continue
         shutil.copy2(source_file, stage_dir / source_file.name)
 
     for source_dir in sorted(path for path in plugins_root.iterdir() if path.is_dir()):
+        reason = _skip_reason(source_dir, tracked_names=tracked_names)
+        if reason is not None:
+            skipped_entries.append(f"{source_dir.name}/ ({reason})")
+            continue
         plugin_dirs.append(source_dir.name)
         destination_dir = stage_dir / source_dir.name
         destination_dir.mkdir(parents=True, exist_ok=True)
@@ -230,6 +298,7 @@ def prepare_plugins(
         "staged_files": staged_files,
         "excluded_paths": sorted(excluded_paths),
         "excluded_modules": sorted(excluded_modules),
+        "skipped_entries": sorted(skipped_entries),
     }
     (stage_dir.parent / "nuitka-plugin-stage.json").write_text(
         json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
@@ -244,6 +313,7 @@ def prepare_plugins(
         staged_files=tuple(staged_files),
         excluded_paths=tuple(sorted(excluded_paths)),
         excluded_modules=tuple(sorted(excluded_modules)),
+        skipped_entries=tuple(sorted(skipped_entries)),
     )
 
 
@@ -313,6 +383,8 @@ def main(argv: list[str] | None = None) -> int:
             f"Prepared {len(result.plugin_dirs)} built-in plugin directories with "
             f"{len(result.staged_files)} files; excluded {len(result.excluded_paths)} paths."
         )
+        for entry in result.skipped_entries:
+            print(f"[WARNING] Not bundled, absent from the Git index: {entry}")
         print(f"Plugin stage: {result.stage_dir}")
         print(f"Generated launcher: {result.generated_launcher}")
         return 0

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 
@@ -95,6 +96,82 @@ def test_prepare_and_install_plugins_apply_neko_build_rules(tmp_path: Path) -> N
     assert not (destination / "stale_plugin").exists()
     assert (destination / "demo_plugin" / "runtime.py").is_file()
     assert not (destination / ".nuitka-stage.json").exists()
+
+
+def test_prepare_skips_plugin_directory_missing_plugin_toml(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    plugins_root = project_root / "plugin" / "plugins"
+    _write(project_root / "launcher.py")
+    _write(plugins_root / "demo" / "plugin.toml", '[plugin]\nid = "demo"\n')
+    _write(plugins_root / "demo" / "runtime.py")
+    # A plugin dropped from the index leaves its __pycache__ behind; the husk
+    # used to reach the payload and trip the dist gate at the end of the build.
+    _write(plugins_root / "husk" / "__pycache__" / "runtime.pyc")
+
+    result = prepare_plugins(
+        project_root=project_root,
+        plugins_root=Path("plugin") / "plugins",
+        stage_dir=Path("build") / "stage",
+        source_launcher=Path("launcher.py"),
+        generated_launcher=Path("build") / "launcher_gen.py",
+    )
+
+    assert result.plugin_dirs == ("demo",)
+    assert not (result.stage_dir / "husk").exists()
+    assert "husk/ (missing plugin.toml)" in result.skipped_entries
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required")
+def test_prepare_skips_entries_absent_from_the_git_index(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    plugins_root = project_root / "plugin" / "plugins"
+    _write(project_root / "launcher.py")
+    _write(plugins_root / "__init__.py")
+    _write(plugins_root / "_shared" / "helper.py")
+    _write(plugins_root / "demo" / "plugin.toml", '[plugin]\nid = "demo"\n')
+    _write(plugins_root / "demo" / "runtime.py")
+    # Complete, loadable and local-only: a private experiment, or a plugin that
+    # moved to the marketplace.  Only the index separates it from a built-in.
+    _write(plugins_root / "local_only" / "plugin.toml", '[plugin]\nid = "local_only"\n')
+    _write(plugins_root / "local_only" / "runtime.py")
+    _write(plugins_root / "scratch.txt")
+
+    subprocess.run(["git", "init"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(
+        [
+            "git",
+            "add",
+            "launcher.py",
+            "plugin/plugins/__init__.py",
+            "plugin/plugins/_shared",
+            "plugin/plugins/demo",
+        ],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+    )
+
+    result = prepare_plugins(
+        project_root=project_root,
+        plugins_root=Path("plugin") / "plugins",
+        stage_dir=Path("build") / "stage",
+        source_launcher=Path("launcher.py"),
+        generated_launcher=Path("build") / "launcher_gen.py",
+    )
+
+    assert result.plugin_dirs == ("_shared", "demo")
+    assert not (result.stage_dir / "local_only").exists()
+    assert not (result.stage_dir / "scratch.txt").exists()
+    assert (result.stage_dir / "demo" / "runtime.py").is_file()
+    assert (result.stage_dir / "_shared" / "helper.py").is_file()
+    assert (result.stage_dir / "__init__.py").is_file()
+    assert set(result.skipped_entries) == {
+        "local_only/ (untracked by git)",
+        "scratch.txt (untracked by git)",
+    }
+    manifest_path = result.stage_dir.parent / "nuitka-plugin-stage.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["skipped_entries"] == sorted(result.skipped_entries)
 
 
 def test_prepare_keeps_shared_plugin_runtime_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## 问题

打包的 stage 阶段直接 `iterdir()` 复制 `plugin/plugins` 下的一切，不看 Git 是否跟踪：

```python
for source_dir in sorted(path for path in plugins_root.iterdir() if path.is_dir()):
```

本地留下的插件目录——私有实验、已迁到插件市场但工作区还没清干净的——会被原样打进桌面包，装出来是加载失败的残件。`check_nuitka_dist.py` 只按硬编码的 `_MARKETPLACE_ONLY_PLUGIN_IDS` 名单拦住了其中两个（`neko_warthunder`、`study_companion`），其余带 `plugin.toml` 的一律静默通过。

这不是假想：本仓库每移除一个内置插件（#3039 伴学、#3041 Galgame），所有已 clone 的工作区就多一份未跟踪残留。

## 改动

stage 从「复制工作区里有什么」改成「复制索引里有什么」，两条闸门：

1. **Git 索引过滤** — `git ls-files -z` 查出 `plugin/plugins` 下被跟踪的顶层名，其余目录和文件不进 stage。索引查不动（无 git、非 checkout，例如从 tarball 打包）时回落；空结果同样按回落处理，避免嵌套在别的仓库里的临时目录把全部插件误判成未跟踪。
2. **`plugin.toml` 必需** — 目录名不以 `_` 开头（`_shared` 是运行时共享包，不是插件）却没有 `plugin.toml` 的一律跳过。这条不依赖 git，tarball 打包时仍然生效，专门挡只剩 `__pycache__` 的空壳。

被跳过的条目写进 stage manifest 的 `skipped_entries`，并在 prepare 输出打 `[WARNING]` —— 静默排除比静默包含更难查。

`check_nuitka_dist.py` 的 marketplace-only 名单原样保留，作为第二层。

## 验证

在一台留有残留的开发机上实跑 `prepare`，18 → 16 个目录，文件数 566 不变（没误伤任何真插件）：

```
Prepared 16 built-in plugin directories with 566 files; excluded 35 paths.
[WARNING] Not bundled, absent from the Git index: __pycache__/ (untracked by git)
[WARNING] Not bundled, absent from the Git index: study_companion/ (untracked by git)
```

新增两条单测：一条建真 git 仓库，验证被跟踪的 `_shared` / `demo` / 顶层 `__init__.py` 保留、本地独有的 `local_only/` 和 `scratch.txt` 被排除并记进 manifest；一条在无 git 环境下验证只剩 `__pycache__` 的空壳目录被跳过。

`tests/unit/test_prepare_nuitka_plugins.py` 17 passed。

CI 产物不变：runner 上是干净 checkout，索引与工作区一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 插件准备阶段现在仅处理 Git 索引中记录的顶层插件或文件。
  - 缺少 `plugin.toml` 的插件目录将被跳过，避免进入打包内容。
  - Git 不可用时保留原有处理规则。

- **提示**
  - 被跳过的条目及原因会记录在结果和阶段清单中，并通过命令行发出警告。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->