### PR TITLE
perf(avatar): Pet 窗口帧率总闸——配置低于刷新率时三后端整体改定时器驱动

### DIFF
--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -1256,6 +1256,18 @@
         S.hasSoundDetected = false;
     }
 
+    // 排下一次音量监测：Electron Pet 里渲染后端切到定时器驱动时，本循环也改走
+    // 定时器（frame-pacing.requestPacedFrame），否则这条 rAF 链会单独把 Blink 主帧
+    // 顶回显示器刷新率。非 Pet 页面没有 nekoFramePacing，保持 rAF。
+    function scheduleMonitorInputVolume() {
+        const pacing = window.nekoFramePacing;
+        if (pacing && typeof pacing.requestPacedFrame === 'function') {
+            pacing.requestPacedFrame(monitorInputVolume);
+            return;
+        }
+        requestAnimationFrame(monitorInputVolume);
+    }
+
     // 监测音频输入音量
     function monitorInputVolume() {
         if (!S.inputAnalyser || !S.isRecording) {
@@ -1268,7 +1280,7 @@
         // guard 把"本地噪声"误判成"用户在说话"导致语音模式 nudge 被静默
         // skip 卡死 (`_isUserRecentlySpeaking()` 8s 窗口拖尾)。
         if (S.isMicMuted) {
-            requestAnimationFrame(monitorInputVolume);
+            scheduleMonitorInputVolume();
             return;
         }
 
@@ -1307,7 +1319,7 @@
 
         // 持续监测
         if (S.isRecording) {
-            requestAnimationFrame(monitorInputVolume);
+            scheduleMonitorInputVolume();
         }
     }
 
@@ -2389,9 +2401,10 @@
                 return;
             }
 
-            // 检查弹出框是否仍然可见
+            // 检查弹出框是否仍然可见：不可见时只需低频探测它何时重新出现，
+            // 不必按刷新率排 rAF（弹窗关着也让 Blink 每 vsync 跑主帧）
             if (!cachedPopup || cachedPopup.style.display === 'none' || !cachedPopup.offsetParent) {
-                S.micVolumeAnimationId = requestAnimationFrame(updateVolumeDisplay);
+                scheduleMicVolumeFrame(MIC_VOLUME_HIDDEN_POLL_MS);
                 return;
             }
 
@@ -2506,19 +2519,49 @@
             }
 
             // 继续下一帧
+            scheduleMicVolumeFrame();
+        }
+
+        // 排下一帧：渲染后端在定时器驱动时跟随其周期（frame-pacing），否则 rAF；
+        // 传 delayMs 时固定用该延时（弹窗不可见的低频探测）
+        function scheduleMicVolumeFrame(delayMs) {
+            cancelMicVolumeFrame();
+            if (Number(delayMs) > 0) {
+                const id = setTimeout(updateVolumeDisplay, Number(delayMs));
+                _micVolumePacedCancel = () => clearTimeout(id);
+                return;
+            }
+            const pacing = window.nekoFramePacing;
+            if (pacing && typeof pacing.requestPacedFrame === 'function') {
+                _micVolumePacedCancel = pacing.requestPacedFrame(updateVolumeDisplay);
+                return;
+            }
             S.micVolumeAnimationId = requestAnimationFrame(updateVolumeDisplay);
         }
 
         // 启动动画循环
-        S.micVolumeAnimationId = requestAnimationFrame(updateVolumeDisplay);
+        scheduleMicVolumeFrame();
     }
 
-    // 停止麦克风音量可视化
-    function stopMicVolumeVisualization() {
+    // 弹窗不可见时探测它重新出现的周期
+    const MIC_VOLUME_HIDDEN_POLL_MS = 250;
+    // 定时器驱动路径的取消句柄（rAF 路径用 S.micVolumeAnimationId）
+    let _micVolumePacedCancel = null;
+
+    function cancelMicVolumeFrame() {
         if (S.micVolumeAnimationId) {
             cancelAnimationFrame(S.micVolumeAnimationId);
             S.micVolumeAnimationId = null;
         }
+        if (_micVolumePacedCancel) {
+            try { _micVolumePacedCancel(); } catch (_) {}
+            _micVolumePacedCancel = null;
+        }
+    }
+
+    // 停止麦克风音量可视化
+    function stopMicVolumeVisualization() {
+        cancelMicVolumeFrame();
     }
 
     // 立即更新音量显示状态（用于录音状态变化时立即反映）

--- a/static/app/app-audio-playback.js
+++ b/static/app/app-audio-playback.js
@@ -1481,11 +1481,39 @@
 
     // ======================== Lip-sync ========================
 
-    function startLipSync(model, analyser) {
-        console.log('[LipSync] 开始口型同步', { hasModel: !!model, hasAnalyser: !!analyser });
+    // 定时器驱动时的取消句柄（rAF 驱动时用 S.animationFrameId）
+    let _lipSyncPacedCancel = null;
+
+    // 取消已排的口型同步帧：rAF / 定时器两种驱动都覆盖
+    function cancelLipSyncFrame() {
         if (S.animationFrameId) {
             cancelAnimationFrame(S.animationFrameId);
+            S.animationFrameId = null;
         }
+        if (_lipSyncPacedCancel) {
+            try { _lipSyncPacedCancel(); } catch (_) {}
+            _lipSyncPacedCancel = null;
+        }
+    }
+
+    // 排下一帧：Electron Pet 里渲染后端切到定时器驱动时，本循环也走定时器（周期同渲染
+    // tick），否则这条 rAF 链会单独把 Blink 主帧顶回显示器刷新率。返回是否为定时器驱动。
+    function scheduleLipSyncFrame(animate) {
+        const pacing = window.nekoFramePacing;
+        if (pacing && typeof pacing.requestPacedFrame === 'function' &&
+            typeof pacing.currentTimerTickFps === 'function' && pacing.currentTimerTickFps() != null) {
+            S.animationFrameId = null;
+            _lipSyncPacedCancel = pacing.requestPacedFrame(animate);
+            return true;
+        }
+        _lipSyncPacedCancel = null;
+        S.animationFrameId = requestAnimationFrame(animate);
+        return false;
+    }
+
+    function startLipSync(model, analyser) {
+        console.log('[LipSync] 开始口型同步', { hasModel: !!model, hasAnalyser: !!analyser });
+        cancelLipSyncFrame();
 
         _lastMouthOpen = 0;
         _lipSyncSkipCounter = 0;
@@ -1494,9 +1522,11 @@
 
         function animate() {
             if (!analyser) return;
-            S.animationFrameId = requestAnimationFrame(animate);
+            const pacedByTimer = scheduleLipSyncFrame(animate);
 
-            if (++_lipSyncSkipCounter < LIP_SYNC_EVERY_N_FRAMES) return;
+            // 定时器驱动时周期已经是渲染 tick（≤ 配置帧率），不再隔帧；rAF 驱动才按
+            // LIP_SYNC_EVERY_N_FRAMES 隔帧采样
+            if (!pacedByTimer && ++_lipSyncSkipCounter < LIP_SYNC_EVERY_N_FRAMES) return;
             _lipSyncSkipCounter = 0;
 
             analyser.getByteTimeDomainData(dataArray);
@@ -1522,10 +1552,7 @@
 
     function stopLipSync(model) {
         console.log('[LipSync] 停止口型同步');
-        if (S.animationFrameId) {
-            cancelAnimationFrame(S.animationFrameId);
-            S.animationFrameId = null;
-        }
+        cancelLipSyncFrame();
         if (window.LanLan1 && typeof window.LanLan1.setMouth === 'function') {
             window.LanLan1.setMouth(0);
         } else if (model && model.internalModel && model.internalModel.coreModel) {

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -143,6 +143,18 @@
         return normalizeAvatarId(avatarId) + '\u0000' + String(capability || '').trim();
     }
 
+    // 排一帧舞台动画（tween / 漂浮 / 呼吸 / 姿态时间线）：Electron Pet 里渲染后端切到定时器
+    // 驱动时走同周期定时器（frame-pacing.requestPacedFrame），否则 rAF。返回取消函数。
+    // 这些循环在演出期间持续排帧，裸 rAF 会单独把 Blink 主帧顶回显示器刷新率。
+    function scheduleStageFrame(callback) {
+        const pacing = window.nekoFramePacing;
+        if (pacing && typeof pacing.requestPacedFrame === 'function') {
+            return pacing.requestPacedFrame(callback);
+        }
+        const id = window.requestAnimationFrame(callback);
+        return () => window.cancelAnimationFrame(id);
+    }
+
     function now() {
         return (window.performance && typeof window.performance.now === 'function')
             ? window.performance.now()
@@ -424,9 +436,9 @@
                         resolve(true);
                         return;
                     }
-                    tween.rafId = window.requestAnimationFrame(step);
+                    tween.cancelFrame = scheduleStageFrame(step);
                 };
-                tween.rafId = window.requestAnimationFrame(step);
+                tween.cancelFrame = scheduleStageFrame(step);
             });
         }
 
@@ -834,9 +846,9 @@
                     y: base.y + amplitudeY * wave
                 });
                 this.applyFrame(sessionId);
-                tween.rafId = window.requestAnimationFrame(step);
+                tween.cancelFrame = scheduleStageFrame(step);
             };
-            tween.rafId = window.requestAnimationFrame(step);
+            tween.cancelFrame = scheduleStageFrame(step);
             return true;
         }
 
@@ -1000,9 +1012,9 @@
                     scale: base.scale + scaleAmount * wave
                 });
                 this.applyFrame(sessionId);
-                tween.rafId = window.requestAnimationFrame(step);
+                tween.cancelFrame = scheduleStageFrame(step);
             };
-            tween.rafId = window.requestAnimationFrame(step);
+            tween.cancelFrame = scheduleStageFrame(step);
             return true;
         }
 
@@ -1085,8 +1097,9 @@
             this.tweens.forEach((tween, key) => {
                 if (!sessionId || key.indexOf(sessionId + ':') === 0) {
                     tween.done = true;
-                    if (tween.rafId) {
-                        window.cancelAnimationFrame(tween.rafId);
+                    if (tween.cancelFrame) {
+                        tween.cancelFrame();
+                        tween.cancelFrame = null;
                     }
                     this.tweens.delete(key);
                 }
@@ -1098,8 +1111,9 @@
             this.tweens.forEach((tween, key) => {
                 if (key.indexOf(prefix) === 0) {
                     tween.done = true;
-                    if (tween.rafId) {
-                        window.cancelAnimationFrame(tween.rafId);
+                    if (tween.cancelFrame) {
+                        tween.cancelFrame();
+                        tween.cancelFrame = null;
                     }
                     this.tweens.delete(key);
                 }
@@ -2342,7 +2356,7 @@
             const manager = context.manager;
             const source = 'avatar-performance-pose-' + (options && options.sessionId ? options.sessionId : 'session');
             const previousEyeBlinkSuspended = !!manager._suspendEyeBlinkOverride;
-            let frameId = 0;
+            let cancelFrame = null;
             let settled = false;
             let settleLoop = null;
             let usesTemporaryPoseOverride = false;
@@ -2353,9 +2367,9 @@
                     return;
                 }
                 settled = true;
-                if (frameId) {
-                    window.cancelAnimationFrame(frameId);
-                    frameId = 0;
+                if (cancelFrame) {
+                    cancelFrame();
+                    cancelFrame = null;
                 }
                 if (manager && normalized.suspendEyeBlink !== false) {
                     manager._suspendEyeBlinkOverride = previousEyeBlinkSuspended;
@@ -2492,10 +2506,10 @@
                             return;
                         }
                         if (!settled) {
-                            frameId = window.requestAnimationFrame(tick);
+                            cancelFrame = scheduleStageFrame(tick);
                         }
                     };
-                    frameId = window.requestAnimationFrame(tick);
+                    cancelFrame = scheduleStageFrame(tick);
                 });
                 return true;
             } catch (error) {

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -407,7 +407,7 @@
                     return;
                 }
 
-                const tween = { rafId: 0, done: false };
+                const tween = { cancelFrame: null, done: false };
                 const tweenKey = sessionId + ':' + now() + ':' + Math.random();
                 this.tweens.set(tweenKey, tween);
                 const startedAt = now();
@@ -828,7 +828,7 @@
             const periodMs = Math.max(1200, Number(normalized.periodMs || 5200));
             const phase = Number.isFinite(Number(normalized.phase)) ? Number(normalized.phase) : 0;
             const startedAt = now();
-            const tween = { rafId: 0, done: false };
+            const tween = { cancelFrame: null, done: false };
             const tweenKey = sessionId + ':preset:idleFloat:' + startedAt + ':' + Math.random();
             this.tweens.set(tweenKey, tween);
 
@@ -994,7 +994,7 @@
             const periodMs = Math.max(1600, Number(normalized.periodMs || 4200));
             const phase = Number.isFinite(Number(normalized.phase)) ? Number(normalized.phase) : 0;
             const startedAt = now();
-            const tween = { rafId: 0, done: false };
+            const tween = { cancelFrame: null, done: false };
             const tweenKey = sessionId + ':preset:breathe:' + startedAt + ':' + Math.random();
             this.tweens.set(tweenKey, tween);
 

--- a/static/avatar/avatar-reaction-bubble.js
+++ b/static/avatar/avatar-reaction-bubble.js
@@ -132,6 +132,7 @@
         turnEndedAt: 0,
         speechStartedAt: 0,
         followRafId: 0,
+        followPacedCancel: null,
         followUntilAt: 0,
         hideTimerId: 0,
         timeoutTimerId: 0,
@@ -312,11 +313,37 @@
         clearTimer('emotionSwapTimerId');
     }
 
-    function stopFollowLoop() {
+    // 取消已排的跟随帧：rAF / 定时器（frame-pacing）两种句柄都覆盖
+    function cancelFollowFrame() {
         if (state.followRafId) {
             cancelAnimationFrame(state.followRafId);
             state.followRafId = 0;
         }
+        if (state.followPacedCancel) {
+            try { state.followPacedCancel(); } catch (_) {}
+            state.followPacedCancel = null;
+        }
+    }
+
+    // 排下一帧跟随：Electron Pet 里渲染后端切到定时器驱动时，本循环也走同周期定时器
+    // （否则 10s 跟随窗口会单独把 Blink 主帧顶回显示器刷新率）；否则 rAF。
+    function scheduleFollowFrame(tick) {
+        var pacing = window.nekoFramePacing;
+        if (pacing && typeof pacing.requestPacedFrame === 'function') {
+            state.followRafId = 0;
+            state.followPacedCancel = pacing.requestPacedFrame(tick);
+            return;
+        }
+        state.followPacedCancel = null;
+        state.followRafId = requestAnimationFrame(tick);
+    }
+
+    function isFollowFrameScheduled() {
+        return !!(state.followRafId || state.followPacedCancel);
+    }
+
+    function stopFollowLoop() {
+        cancelFollowFrame();
         state.followUntilAt = 0;
         state.isAvatarPointerActive = false;
     }
@@ -2151,12 +2178,13 @@
         }
 
         state.followUntilAt = Math.max(state.followUntilAt, perfNow() + duration);
-        if (state.followRafId) {
+        if (isFollowFrameScheduled()) {
             return;
         }
 
         var tick = function () {
             state.followRafId = 0;
+            state.followPacedCancel = null;
             if (!state.visible) {
                 state.followUntilAt = 0;
                 return;
@@ -2164,13 +2192,13 @@
 
             updatePosition();
             if (state.followUntilAt > perfNow()) {
-                state.followRafId = requestAnimationFrame(tick);
+                scheduleFollowFrame(tick);
             } else {
                 state.followUntilAt = 0;
             }
         };
 
-        state.followRafId = requestAnimationFrame(tick);
+        scheduleFollowFrame(tick);
     }
 
     function syncPositionOnce() {

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -25,7 +25,7 @@
     // rAF（vsync 对齐更平滑，定时器也省不出东西），在 120/144Hz 屏上才切定时器。
     const TIMER_DRIVE_REFRESH_RATIO = 0.9;
 
-    const state = { refreshHz: null, sampling: false, resamplePending: false };
+    const state = { refreshHz: null, sampling: false, resamplePending: false, pendingCallbacks: [] };
     let startTimer = null;
 
     function isElectronPet() {
@@ -65,8 +65,9 @@
         if (typeof requestAnimationFrame !== 'function') return;
         if (state.sampling) {
             // 采样进行中又来一次请求（连续跨屏）：不能丢——当前这轮采到的可能是旧显示器
-            // 的时间戳，结束后紧接着再测一轮。
+            // 的时间戳，结束后紧接着再测一轮；排队请求的回调留到那一轮结束再调。
             state.resamplePending = true;
+            if (typeof onDone === 'function') state.pendingCallbacks.push(onDone);
             return;
         }
         state.sampling = true;
@@ -84,7 +85,10 @@
             }
             if (state.resamplePending) {
                 state.resamplePending = false;
-                measureDisplayRefreshRate();
+                const queued = state.pendingCallbacks.splice(0);
+                measureDisplayRefreshRate(queued.length === 0 ? undefined : (hz) => {
+                    queued.forEach((cb) => { try { cb(hz); } catch (_) {} });
+                });
             }
         };
         const timeout = setTimeout(() => finish(null), REFRESH_SAMPLE_TIMEOUT_MS);

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -67,7 +67,9 @@
             if (settled) return;
             settled = true;
             state.sampling = false;
-            if (hz > 0) state.refreshHz = hz;
+            // 测出就更新；测不出（超时/rAF 被挂起）则作废旧值——跨屏后旧显示器的刷新率
+            // 不能继续拿来决定驱动方式，回到「未知 → 保守走 rAF」。
+            state.refreshHz = hz > 0 ? hz : null;
             if (typeof onDone === 'function') {
                 try { onDone(state.refreshHz); } catch (_) {}
             }

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -1,0 +1,120 @@
+/**
+ * 帧率总闸（仅 Electron Pet 窗口生效）
+ *
+ * 背景：设置里的「帧率」只写 `window.targetFrameRate`，各渲染后端（Live2D / VRM / MMD）
+ * 原本各自用 rAF + 跳帧实现节流。跳帧只省掉 draw 本身，rAF 请求仍让 Blink 以显示器
+ * 刷新率跑完整主帧生命周期，CPU/GPU 降不下来。
+ *
+ * 本文件只做两件事：
+ *   1. 在 Pet 窗口里用 rAF 时间戳量出显示器刷新率；
+ *   2. 回答「活动态是否该改用定时器驱动、用多少帧」——配置帧率明显低于刷新率时，
+ *      各后端把 rAF 链整个停掉、改 setInterval 按配置帧率手动 tick（与现有
+ *      空闲低频 tick 模式同一套机制，只是频率换成配置值）。
+ *
+ * 非 Pet 页面（浏览器单窗口、模型管理器、角色卡等）不加载本文件，`window.nekoFramePacing`
+ * 不存在，各后端保持原有 rAF + 跳帧行为不变。
+ */
+(function () {
+    'use strict';
+    if (window.nekoFramePacing) return;
+
+    const REFRESH_SAMPLE_FRAMES = 24;        // 采样的 rAF 帧数
+    const REFRESH_SAMPLE_TIMEOUT_MS = 3000;  // 采样超时：测不到就一律走 rAF（保守）
+    const REFRESH_SAMPLE_START_DELAY_MS = 1500; // 页面 load 后延迟再采样，避开加载抖动
+    // 配置帧率必须低于「刷新率 × 该比例」才切定时器驱动：60fps 配置在 60Hz 屏上留在
+    // rAF（vsync 对齐更平滑，定时器也省不出东西），在 120/144Hz 屏上才切定时器。
+    const TIMER_DRIVE_REFRESH_RATIO = 0.9;
+
+    const state = { refreshHz: null, sampling: false };
+    let startTimer = null;
+
+    function isElectronPet() {
+        return window.__LANLAN_IS_ELECTRON_PET__ === true;
+    }
+
+    // 用户配置的目标帧率；0 = 不限帧（跟随 VSync）。与 live2d-core 的解析规则一致。
+    function configuredTargetFps() {
+        const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
+        return Number.isFinite(raw) && raw >= 0 ? raw : 60;
+    }
+
+    function getDisplayRefreshHz() {
+        return state.refreshHz;
+    }
+
+    /**
+     * 活动态应使用的定时器驱动帧率；返回 null 表示留在 rAF 驱动。
+     * 只有 Pet 窗口 + 配置帧率 > 0 + 已测出刷新率 + 配置明显低于刷新率时才给出数值。
+     */
+    function activeTimerTickFps() {
+        if (!isElectronPet()) return null;
+        const fps = configuredTargetFps();
+        if (!(fps > 0)) return null;
+        if (!(state.refreshHz > 0)) return null;
+        return fps < state.refreshHz * TIMER_DRIVE_REFRESH_RATIO ? fps : null;
+    }
+
+    /**
+     * 用连续 rAF 时间戳的中位数间隔估算刷新率。误差方向是保守的：加载期抖动只会让
+     * 间隔变长（刷新率被低估 → 更倾向留在 rAF），不会把刷新率估高。
+     */
+    function measureDisplayRefreshRate(onDone) {
+        if (state.sampling || typeof requestAnimationFrame !== 'function') return;
+        state.sampling = true;
+        const stamps = [];
+        let settled = false;
+        const finish = (hz) => {
+            if (settled) return;
+            settled = true;
+            state.sampling = false;
+            if (hz > 0) state.refreshHz = hz;
+            if (typeof onDone === 'function') {
+                try { onDone(state.refreshHz); } catch (_) {}
+            }
+        };
+        const timeout = setTimeout(() => finish(null), REFRESH_SAMPLE_TIMEOUT_MS);
+        const step = (t) => {
+            if (settled) return;
+            stamps.push(t);
+            if (stamps.length <= REFRESH_SAMPLE_FRAMES) {
+                requestAnimationFrame(step);
+                return;
+            }
+            clearTimeout(timeout);
+            const deltas = [];
+            for (let i = 1; i < stamps.length; i++) deltas.push(stamps[i] - stamps[i - 1]);
+            deltas.sort((a, b) => a - b);
+            const median = deltas[Math.floor(deltas.length / 2)];
+            finish(median > 0 ? Math.round(1000 / median) : null);
+        };
+        requestAnimationFrame(step);
+    }
+
+    function scheduleMeasure(delayMs) {
+        if (!isElectronPet()) return;
+        if (startTimer) clearTimeout(startTimer);
+        startTimer = setTimeout(() => {
+            startTimer = null;
+            measureDisplayRefreshRate();
+        }, Math.max(0, Number(delayMs) || 0));
+    }
+
+    window.nekoFramePacing = Object.freeze({
+        isElectronPet,
+        configuredTargetFps,
+        getDisplayRefreshHz,
+        activeTimerTickFps,
+        measureDisplayRefreshRate,
+        TIMER_DRIVE_REFRESH_RATIO,
+    });
+
+    if (isElectronPet()) {
+        if (document.readyState === 'complete') {
+            scheduleMeasure(REFRESH_SAMPLE_START_DELAY_MS);
+        } else {
+            window.addEventListener('load', () => scheduleMeasure(REFRESH_SAMPLE_START_DELAY_MS), { once: true });
+        }
+        // 跨屏 / 显示器热插拔后刷新率可能变化：重测（沿用各后端已在监听的同名事件）
+        window.addEventListener('electron-display-changed', () => scheduleMeasure(REFRESH_SAMPLE_START_DELAY_MS));
+    }
+})();

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -22,11 +22,12 @@
     'use strict';
     if (window.nekoFramePacing) return;
 
-    const REFRESH_SAMPLE_FRAMES = 24;        // 采样的 rAF 帧数
-    const REFRESH_SAMPLE_TIMEOUT_MS = 3000;  // 采样超时：测不到就一律走 rAF（保守）
-    const REFRESH_SAMPLE_START_DELAY_MS = 1500; // 页面 load 后延迟再采样，避开加载抖动
-    // 配置帧率必须低于「刷新率 × 该比例」才切定时器驱动：60fps 配置在 60Hz 屏上留在
-    // rAF（vsync 对齐更平滑，定时器也省不出东西），在 120/144Hz 屏上才切定时器。
+    const REFRESH_SAMPLE_FRAMES = 24;        // number of rAF frames to sample
+    const REFRESH_SAMPLE_TIMEOUT_MS = 3000;  // sampling timeout: unmeasurable -> stay on rAF (conservative)
+    const REFRESH_SAMPLE_START_DELAY_MS = 1500; // delay after load before sampling, to skip load-time jank
+    // The configured rate must be below "refresh rate x this ratio" to switch to timer
+    // driving: a 60fps setting stays on rAF on a 60Hz display (vsync-aligned is smoother
+    // and a timer would save nothing) and only switches on 120/144Hz displays.
     const TIMER_DRIVE_REFRESH_RATIO = 0.9;
 
     const state = { refreshHz: null, sampling: false, resamplePending: false, pendingCallbacks: [] };
@@ -36,7 +37,7 @@
         return window.__LANLAN_IS_ELECTRON_PET__ === true;
     }
 
-    // 用户配置的目标帧率；0 = 不限帧（跟随 VSync）。与 live2d-core 的解析规则一致。
+    // User-configured target frame rate; 0 = uncapped (follow VSync). Same parsing rules as live2d-core.
     function configuredTargetFps() {
         const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
         return Number.isFinite(raw) && raw >= 0 ? raw : 60;
@@ -47,10 +48,11 @@
     }
 
     /**
-     * 活动态应使用的定时器驱动帧率；返回 null 表示留在 rAF 驱动。
-     * 只有 Pet 窗口 + 配置帧率 > 0 + 已测出刷新率 + 配置明显低于刷新率时才给出数值。
-     * 调用方可传入自己解析出的目标帧率（如 MMD 在没有 window.targetFrameRate 时按
-     * performanceMode 回退），保证总闸与后端对「目标帧率」的理解一致。
+     * Timer-driving frame rate the active state should use; null means stay on rAF.
+     * A value is returned only for Pet window + configured rate > 0 + refresh rate measured
+     * + configured rate clearly below the refresh rate.
+     * Callers may pass their own resolved target rate (e.g. MMD falls back to performanceMode
+     * when window.targetFrameRate is absent) so the gate and the backend agree on "target rate".
      */
     function activeTimerTickFps(fpsOverride) {
         if (!isElectronPet()) return null;
@@ -62,14 +64,16 @@
     }
 
     /**
-     * 用连续 rAF 时间戳的中位数间隔估算刷新率。误差方向是保守的：加载期抖动只会让
-     * 间隔变长（刷新率被低估 → 更倾向留在 rAF），不会把刷新率估高。
+     * Estimate the refresh rate from the median interval of consecutive rAF timestamps.
+     * The error is conservative: load-time jank only lengthens intervals (refresh rate
+     * underestimated -> more likely to stay on rAF), it never overestimates it.
      */
     function measureDisplayRefreshRate(onDone) {
         if (typeof requestAnimationFrame !== 'function') return;
         if (state.sampling) {
-            // 采样进行中又来一次请求（连续跨屏）：不能丢——当前这轮采到的可能是旧显示器
-            // 的时间戳，结束后紧接着再测一轮；排队请求的回调留到那一轮结束再调。
+            // Another request while sampling (back-to-back display changes): must not be
+            // dropped -- the in-flight sample may hold timestamps from the previous display,
+            // so run one more round right after it settles; queued callbacks fire after that round.
             state.resamplePending = true;
             if (typeof onDone === 'function') state.pendingCallbacks.push(onDone);
             return;
@@ -81,8 +85,9 @@
             if (settled) return;
             settled = true;
             state.sampling = false;
-            // 测出就更新；测不出（超时/rAF 被挂起）则作废旧值——跨屏后旧显示器的刷新率
-            // 不能继续拿来决定驱动方式，回到「未知 → 保守走 rAF」。
+            // Measured -> update; unmeasurable (timeout / rAF suspended) -> invalidate the old
+            // value: after a display change the previous display's refresh rate must not keep
+            // deciding the driving mode, fall back to "unknown -> conservative rAF".
             state.refreshHz = hz > 0 ? hz : null;
             if (typeof onDone === 'function') {
                 try { onDone(state.refreshHz); } catch (_) {}
@@ -114,9 +119,11 @@
     }
 
     /**
-     * 当前是否有渲染后端在定时器驱动；是则返回其 tick 帧率，否则 null（rAF 驱动）。
-     * 供页面里其它每帧循环（麦克风音量监测、口型同步）对齐：渲染已经不排 rAF 了，
-     * 这些循环再排 rAF 会把 Blink 主帧顶回显示器刷新率，收益归零。
+     * Whether a renderer backend is currently timer-driven; if so returns its tick rate,
+     * otherwise null (rAF-driven). Lets the page's other per-frame loops (mic level monitor,
+     * lip-sync, ...) follow along: once rendering no longer schedules rAF, any of these loops
+     * scheduling rAF on their own would push Blink's main frame back to the display refresh
+     * rate and cancel the gain.
      */
     function currentTimerTickFps() {
         if (!isElectronPet()) return null;
@@ -134,8 +141,8 @@
     }
 
     /**
-     * 排一帧：渲染后端在定时器驱动时走 setTimeout（周期同渲染 tick），否则 rAF。
-     * 返回取消函数。
+     * Schedule one frame: setTimeout (same period as the render tick) while a backend is
+     * timer-driven, otherwise rAF. Returns a cancel function.
      */
     function requestPacedFrame(callback) {
         const fps = currentTimerTickFps();
@@ -173,7 +180,8 @@
         } else {
             window.addEventListener('load', () => scheduleMeasure(REFRESH_SAMPLE_START_DELAY_MS), { once: true });
         }
-        // 跨屏 / 显示器热插拔后刷新率可能变化：重测（沿用各后端已在监听的同名事件）
+        // Refresh rate may change after moving displays / hotplug: re-measure (same event the
+        // backends already listen to)
         window.addEventListener('electron-display-changed', () => scheduleMeasure(REFRESH_SAMPLE_START_DELAY_MS));
     }
 })();

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -95,6 +95,40 @@
         requestAnimationFrame(step);
     }
 
+    /**
+     * 当前是否有渲染后端在定时器驱动；是则返回其 tick 帧率，否则 null（rAF 驱动）。
+     * 供页面里其它每帧循环（麦克风音量监测、口型同步）对齐：渲染已经不排 rAF 了，
+     * 这些循环再排 rAF 会把 Blink 主帧顶回显示器刷新率，收益归零。
+     */
+    function currentTimerTickFps() {
+        if (!isElectronPet()) return null;
+        const candidates = [
+            window.live2dManager,
+            window.vrmManager,
+            window.mmdManager && window.mmdManager.core,
+        ];
+        for (const backend of candidates) {
+            if (!backend || backend._idleTickMode !== true) continue;
+            const fps = Number(backend._idleTickFps);
+            if (fps > 0) return fps;
+        }
+        return null;
+    }
+
+    /**
+     * 排一帧：渲染后端在定时器驱动时走 setTimeout（周期同渲染 tick），否则 rAF。
+     * 返回取消函数。
+     */
+    function requestPacedFrame(callback) {
+        const fps = currentTimerTickFps();
+        if (fps != null) {
+            const id = setTimeout(() => callback(performance.now()), Math.max(4, Math.round(1000 / fps)));
+            return () => clearTimeout(id);
+        }
+        const id = requestAnimationFrame(callback);
+        return () => cancelAnimationFrame(id);
+    }
+
     function scheduleMeasure(delayMs) {
         if (!isElectronPet()) return;
         if (startTimer) clearTimeout(startTimer);
@@ -109,6 +143,8 @@
         configuredTargetFps,
         getDisplayRefreshHz,
         activeTimerTickFps,
+        currentTimerTickFps,
+        requestPacedFrame,
         measureDisplayRefreshRate,
         TIMER_DRIVE_REFRESH_RATIO,
     });

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -25,7 +25,7 @@
     // rAF（vsync 对齐更平滑，定时器也省不出东西），在 120/144Hz 屏上才切定时器。
     const TIMER_DRIVE_REFRESH_RATIO = 0.9;
 
-    const state = { refreshHz: null, sampling: false };
+    const state = { refreshHz: null, sampling: false, resamplePending: false };
     let startTimer = null;
 
     function isElectronPet() {
@@ -62,7 +62,13 @@
      * 间隔变长（刷新率被低估 → 更倾向留在 rAF），不会把刷新率估高。
      */
     function measureDisplayRefreshRate(onDone) {
-        if (state.sampling || typeof requestAnimationFrame !== 'function') return;
+        if (typeof requestAnimationFrame !== 'function') return;
+        if (state.sampling) {
+            // 采样进行中又来一次请求（连续跨屏）：不能丢——当前这轮采到的可能是旧显示器
+            // 的时间戳，结束后紧接着再测一轮。
+            state.resamplePending = true;
+            return;
+        }
         state.sampling = true;
         const stamps = [];
         let settled = false;
@@ -75,6 +81,10 @@
             state.refreshHz = hz > 0 ? hz : null;
             if (typeof onDone === 'function') {
                 try { onDone(state.refreshHz); } catch (_) {}
+            }
+            if (state.resamplePending) {
+                state.resamplePending = false;
+                measureDisplayRefreshRate();
             }
         };
         const timeout = setTimeout(() => finish(null), REFRESH_SAMPLE_TIMEOUT_MS);

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -1,18 +1,22 @@
 /**
- * 帧率总闸（仅 Electron Pet 窗口生效）
+ * Frame pacing gate (Electron Pet window only).
  *
- * 背景：设置里的「帧率」只写 `window.targetFrameRate`，各渲染后端（Live2D / VRM / MMD）
- * 原本各自用 rAF + 跳帧实现节流。跳帧只省掉 draw 本身，rAF 请求仍让 Blink 以显示器
- * 刷新率跑完整主帧生命周期，CPU/GPU 降不下来。
+ * Background: the "frame rate" setting only writes `window.targetFrameRate`, and each
+ * renderer backend (Live2D / VRM / MMD) used to throttle on its own with rAF + frame
+ * skipping. Skipping only saves the draw itself; the pending rAF request still makes
+ * Blink run a full main-frame lifecycle at the display refresh rate, so CPU/GPU never
+ * actually go down.
  *
- * 本文件只做两件事：
- *   1. 在 Pet 窗口里用 rAF 时间戳量出显示器刷新率；
- *   2. 回答「活动态是否该改用定时器驱动、用多少帧」——配置帧率明显低于刷新率时，
- *      各后端把 rAF 链整个停掉、改 setInterval 按配置帧率手动 tick（与现有
- *      空闲低频 tick 模式同一套机制，只是频率换成配置值）。
+ * This file does two things:
+ *   1. measures the display refresh rate from rAF timestamps inside the Pet window;
+ *   2. answers "should the active state switch to timer driving, and at what rate" —
+ *      when the configured frame rate is clearly below the refresh rate, backends stop
+ *      their rAF chain entirely and tick manually via setInterval at the configured rate
+ *      (same mechanism as the existing idle low-rate tick mode, just at a different rate).
  *
- * 非 Pet 页面（浏览器单窗口、模型管理器、角色卡等）不加载本文件，`window.nekoFramePacing`
- * 不存在，各后端保持原有 rAF + 跳帧行为不变。
+ * Non-Pet pages (browser single window, model manager, character cards, ...) do not load
+ * this file, `window.nekoFramePacing` does not exist there, and every backend keeps its
+ * original rAF + frame-skipping behaviour.
  */
 (function () {
     'use strict';

--- a/static/frame-pacing.js
+++ b/static/frame-pacing.js
@@ -45,10 +45,13 @@
     /**
      * 活动态应使用的定时器驱动帧率；返回 null 表示留在 rAF 驱动。
      * 只有 Pet 窗口 + 配置帧率 > 0 + 已测出刷新率 + 配置明显低于刷新率时才给出数值。
+     * 调用方可传入自己解析出的目标帧率（如 MMD 在没有 window.targetFrameRate 时按
+     * performanceMode 回退），保证总闸与后端对「目标帧率」的理解一致。
      */
-    function activeTimerTickFps() {
+    function activeTimerTickFps(fpsOverride) {
         if (!isElectronPet()) return null;
-        const fps = configuredTargetFps();
+        const override = Number(fpsOverride);
+        const fps = Number.isFinite(override) && override >= 0 ? override : configuredTargetFps();
         if (!(fps > 0)) return null;
         if (!(state.refreshHz > 0)) return null;
         return fps < state.refreshHz * TIMER_DRIVE_REFRESH_RATIO ? fps : null;

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -383,8 +383,10 @@ class Live2DManager {
                     const origStart = ticker.start.bind(ticker);
                     this._tickerOrigStop = origStop;
                     this._tickerOrigStart = origStart;
-                    ticker.stop = function () { mgr._exitIdleTickMode(); return origStop(); };
-                    ticker.start = function () { mgr._exitIdleTickMode(); return origStart(); };
+                    // stop：退出定时器模式但不拉起全局 ticker（Live2D 停了就不该让 PIXI 的
+                    // rAF 链继续跑）；start：退出定时器模式并把全局 ticker 一并拉回来。
+                    ticker.stop = function () { mgr._exitIdleTickMode({ restartGlobals: false }); return origStop(); };
+                    ticker.start = function () { mgr._exitIdleTickMode(); mgr._releaseGlobalTickers(); return origStart(); };
                 }
                 // 启动自适应帧率守护：静止时降到地板（LIVE2D_IDLE_FPS），活动时升回配置帧率。
                 this._startIdleFpsGovernor();
@@ -933,36 +935,48 @@ class Live2DManager {
         }, intervalMs);
     }
 
-    _exitIdleTickMode() {
+    /**
+     * 退出定时器驱动模式。默认把定时器模式停掉的全局 shared/system ticker 一并拉起
+     * （回到 rAF 驱动）；`restartGlobals: false` 用于外部 ticker.stop() 路径（切到
+     * VRM/MMD、pauseRendering）：Live2D 本身都不渲染了，全局 ticker 拉起来只会让
+     * PIXI 的 rAF 链继续按刷新率空跑，之后由 ticker.start() 包装再 _releaseGlobalTickers。
+     */
+    _exitIdleTickMode(options) {
         if (!this._idleTickMode) return;
+        const restartGlobals = !(options && options.restartGlobals === false);
         this._idleTickMode = false;
         if (this._idleTickTimer) {
             clearInterval(this._idleTickTimer);
             this._idleTickTimer = null;
         }
-        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
-        try {
-            if (PixiTicker) {
-                if (this._idleTickSharedWasStarted && !PixiTicker.shared.started) PixiTicker.shared.start();
-                if (this._idleTickSystemWasStarted && !PixiTicker.system.started) PixiTicker.system.start();
-            }
-        } catch (_) {}
         const app = this.pixi_app;
         if (app && app.ticker && typeof this._idleTickSavedMaxFPS === 'number') {
             app.ticker.maxFPS = this._idleTickSavedMaxFPS;
         }
-        if (PixiTicker && typeof this._idleTickSavedGlobalMaxFPS === 'number') {
-            try {
-                PixiTicker.shared.maxFPS = this._idleTickSavedGlobalMaxFPS;
-                PixiTicker.system.maxFPS = this._idleTickSavedGlobalMaxFPS;
-            } catch (_) {}
-        }
+        if (restartGlobals) this._releaseGlobalTickers();
         if (app && app.ticker && app.ticker.started === false && this._tickerOrigStart) {
             try { this._tickerOrigStart(); } catch (_) {}
         }
         this._idleTickSavedMaxFPS = null;
-        this._idleTickSavedGlobalMaxFPS = null;
         this._idleTickFps = null;
+    }
+
+    // 把定时器模式接管（停掉）的全局 shared/system ticker 拉回来并恢复它们的帧率上限。
+    // 幂等：没接管过就什么都不做。
+    _releaseGlobalTickers() {
+        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
+        if (!PixiTicker) return;
+        try {
+            if (typeof this._idleTickSavedGlobalMaxFPS === 'number') {
+                PixiTicker.shared.maxFPS = this._idleTickSavedGlobalMaxFPS;
+                PixiTicker.system.maxFPS = this._idleTickSavedGlobalMaxFPS;
+            }
+            if (this._idleTickSharedWasStarted && !PixiTicker.shared.started) PixiTicker.shared.start();
+            if (this._idleTickSystemWasStarted && !PixiTicker.system.started) PixiTicker.system.start();
+        } catch (_) {}
+        this._idleTickSharedWasStarted = false;
+        this._idleTickSystemWasStarted = false;
+        this._idleTickSavedGlobalMaxFPS = null;
     }
 
     // 向后兼容旧调用名（live2d-interaction.js 的交互升帧），现已推广到全平台。
@@ -977,7 +991,11 @@ class Live2DManager {
                 return true;
             }
         } catch (_) {}
-        if (this._isDraggingModel || this.isFocusing) return true;
+        if (this._isDraggingModel) return true;
+        // 光标停在模型悬停范围内时 isFocusing 会一直为 true；只有光标最近真的动过才算活动，
+        // 否则视线目标已收敛、却永远进不了空闲低频 tick。
+        if (this.isFocusing && this._lastPointerMoveAt &&
+            (performance.now() - this._lastPointerMoveAt) < LIVE2D_INTERACTIVE_FPS_HOLD_MS) return true;
         const appState = window.appState;
         if (appState && appState.lipSyncActive) return true;
         return false;

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -385,8 +385,21 @@ class Live2DManager {
                     this._tickerOrigStart = origStart;
                     // stop：退出定时器模式但不拉起全局 ticker（Live2D 停了就不该让 PIXI 的
                     // rAF 链继续跑）；start：退出定时器模式并把全局 ticker 一并拉回来。
-                    ticker.stop = function () { mgr._exitIdleTickMode({ restartGlobals: false }); return origStop(); };
-                    ticker.start = function () { mgr._exitIdleTickMode(); mgr._releaseGlobalTickers(); return origStart(); };
+                    // 身份检查：PIXI 重建后外部残留的旧 ticker 再调包装，不能去动当前实例
+                    // 与全局 ticker 的调度状态，只操作旧 ticker 自己。
+                    ticker.stop = function () {
+                        if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) {
+                            mgr._exitIdleTickMode({ restartGlobals: false });
+                        }
+                        return origStop();
+                    };
+                    ticker.start = function () {
+                        if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) {
+                            mgr._exitIdleTickMode();
+                            mgr._releaseGlobalTickers();
+                        }
+                        return origStart();
+                    };
                 }
                 // 启动自适应帧率守护：静止时降到地板（LIVE2D_IDLE_FPS），活动时升回配置帧率。
                 this._startIdleFpsGovernor();
@@ -994,7 +1007,7 @@ class Live2DManager {
         if (this._isDraggingModel) return true;
         // 光标停在模型悬停范围内时 isFocusing 会一直为 true；只有光标最近真的动过才算活动，
         // 否则视线目标已收敛、却永远进不了空闲低频 tick。
-        if (this.isFocusing && this._lastPointerMoveAt &&
+        if (this.isFocusing && Number.isFinite(this._lastPointerMoveAt) &&
             (performance.now() - this._lastPointerMoveAt) < LIVE2D_INTERACTIVE_FPS_HOLD_MS) return true;
         const appState = window.appState;
         if (appState && appState.lipSyncActive) return true;

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -387,9 +387,13 @@ class Live2DManager {
                     // rAF 链继续跑）；start：退出定时器模式并把全局 ticker 一并拉回来。
                     // 身份检查：PIXI 重建后外部残留的旧 ticker 再调包装，不能去动当前实例
                     // 与全局 ticker 的调度状态，只操作旧 ticker 自己。
+                    // stop 在 Pet 窗口下无论此前是否在定时器模式都扣住全局 ticker：切角色的真实
+                    // 序列是 stop → removeModel 里 start（放开）→ 最终 stop，最后这一下不在
+                    // 定时器模式，只靠 _exitIdleTickMode 不会再把全局 ticker 停回去。
                     ticker.stop = function () {
                         if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) {
                             mgr._exitIdleTickMode({ restartGlobals: false });
+                            if (mgr._resolveGlobalTickers()) mgr._holdGlobalTickers();
                         }
                         return origStop();
                     };
@@ -891,26 +895,40 @@ class Live2DManager {
         const ticker = this.pixi_app.ticker;
         // 外部已显式暂停（pauseRendering / 角色切换）：不接管
         if (ticker.started === false) return;
-        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
         this._idleTickMode = true;
-        this._idleTickSharedWasStarted = !!(PixiTicker && PixiTicker.shared.started);
-        this._idleTickSystemWasStarted = !!(PixiTicker && PixiTicker.system.started);
         // 定时器本身就是节流器：清掉 maxFPS 限制，避免 interval 抖动（33ms < minElapsed
         // 33.33ms）导致 update() 被 maxFPS 丢帧、实际帧率减半。
         this._idleTickSavedMaxFPS = ticker.maxFPS;
         ticker.maxFPS = 0;
-        // Pet 窗口下 shared/system 的 maxFPS 也由本 manager 接管（见 _applyRafMaxFps），
-        // 手动 update() 同样不能被它们的 maxFPS 丢帧：一并清零并记住恢复值。
+        this._tickerOrigStop();
+        this._holdGlobalTickers();
+        this._idleTickTimer = this._startTimerTick(tickFps);
+    }
+
+    /**
+     * 扣住全局 PIXI.Ticker.shared/system：记录它们原本是否在跑并停掉（幂等，已扣住则不动）。
+     * 定时器模式下由 _startTimerTick 手动 update 它们；Pet 窗口外部 ticker.stop()（切
+     * VRM/MMD、pauseRendering）也扣住——Live2D 不渲染时没人需要 PIXI 的 rAF 链继续跑。
+     * Pet 窗口下 shared/system 的 maxFPS 也由本 manager 接管（见 _applyRafMaxFps），
+     * 手动 update() 同样不能被它们的 maxFPS 丢帧：一并清零并记住恢复值。
+     */
+    _holdGlobalTickers() {
+        if (this._globalTickersHeld) return;
+        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
+        if (!PixiTicker || !PixiTicker.shared || !PixiTicker.system) return;
+        this._globalTickersHeld = true;
+        this._idleTickSharedWasStarted = !!PixiTicker.shared.started;
+        this._idleTickSystemWasStarted = !!PixiTicker.system.started;
         const globals = this._resolveGlobalTickers();
         if (globals) {
             this._idleTickSavedGlobalMaxFPS = globals.shared.maxFPS;
             globals.shared.maxFPS = 0;
             globals.system.maxFPS = 0;
         }
-        this._tickerOrigStop();
-        if (this._idleTickSharedWasStarted) PixiTicker.shared.stop();
-        if (this._idleTickSystemWasStarted) PixiTicker.system.stop();
-        this._idleTickTimer = this._startTimerTick(tickFps);
+        try {
+            if (this._idleTickSharedWasStarted) PixiTicker.shared.stop();
+            if (this._idleTickSystemWasStarted) PixiTicker.system.stop();
+        } catch (_) {}
     }
 
     // 定时器驱动的 tick 循环：按 fps 手动 update() app + shared/system 三个 ticker。
@@ -978,6 +996,8 @@ class Live2DManager {
     // 把定时器模式接管（停掉）的全局 shared/system ticker 拉回来并恢复它们的帧率上限。
     // 幂等：没接管过就什么都不做。
     _releaseGlobalTickers() {
+        if (!this._globalTickersHeld) return;
+        this._globalTickersHeld = false;
         const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
         if (!PixiTicker) return;
         try {

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -369,7 +369,8 @@ class Live2DManager {
                 this.isInitialized = true;
                 this._lastPIXIContext = { ...requestedInitContext };
                 if (typeof window.targetFrameRate === 'number' && this.pixi_app.ticker) {
-                    this.pixi_app.ticker.maxFPS = window.targetFrameRate;
+                    // 经归一化再写：已存的负数/非法配置不能直接进 PIXI maxFPS
+                    this.pixi_app.ticker.maxFPS = this._resolveConfiguredTargetFps();
                 }
                 // 包装 ticker.stop/start：外部代码（app-character / live2d-model 等）直接
                 // 操作 ticker 时先退出空闲低频 tick 模式，避免空闲定时器与外部暂停意图打架。
@@ -753,7 +754,8 @@ class Live2DManager {
         // setTargetFPS 是「目标帧率」配置的权威应用点：先同步配置源，确保 governor 的
         // boost/restore 读到的是新值而非旧值（调用方一般已设过 window.targetFrameRate，这里兜底自洽）。
         const resolved = Number(fps);
-        window.targetFrameRate = Number.isFinite(resolved) ? resolved : 60;
+        // 负数/非法值一律按 60：否则豁免分支会把负数直接写进 PIXI maxFPS，被钳到 minFPS=10
+        window.targetFrameRate = Number.isFinite(resolved) && resolved >= 0 ? resolved : 60;
         if (this._idleFpsRestoreTimer) {
             clearTimeout(this._idleFpsRestoreTimer);
             this._idleFpsRestoreTimer = null;
@@ -763,7 +765,7 @@ class Live2DManager {
         if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
             // 页面级豁免：直接落配置帧率，不进入空闲地板/低频模式
             this._exitIdleTickMode();
-            this._applyRafMaxFps(window.targetFrameRate);
+            this._applyRafMaxFps(this._resolveConfiguredTargetFps());
         } else if (this._hasRenderActivity()) {
             this.boostInteractiveFPS();
         } else {

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -1050,6 +1050,9 @@ class Live2DManager {
         // teardown 时必须退出空闲低频 tick 模式：全局 PIXI.Ticker.shared/system 是
         // 我们停的，不恢复的话销毁重建后模型 autoUpdate（挂在 shared 上）会被冻住。
         this._exitIdleTickMode();
+        // 先 ticker.stop()（不拉起全局 ticker）再销毁的路径：上面已不在定时器模式，
+        // 全局 ticker 仍被本 manager 扣着——销毁时必须无条件释放（幂等）。
+        this._releaseGlobalTickers();
     }
 
     /**

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -821,14 +821,19 @@ class Live2DManager {
         const globals = this._resolveGlobalTickers();
         if (this._idleTickMode) {
             this._idleTickSavedMaxFPS = resolved;
-            if (globals) this._idleTickSavedGlobalMaxFPS = resolved;
+        } else if (ticker.maxFPS !== resolved) {
+            ticker.maxFPS = resolved;
+        }
+        if (!globals) return;
+        // 全局 ticker 被扣住（定时器模式 / 外部 stop 期间）时只更新待恢复值，放开时才生效；
+        // 否则直接写——两者分开存，虽然本 manager 总是给同一个值，但恢复时不互相串
+        if (this._globalTickersHeld) {
+            this._idleTickSavedSharedMaxFPS = resolved;
+            this._idleTickSavedSystemMaxFPS = resolved;
             return;
         }
-        if (ticker.maxFPS !== resolved) ticker.maxFPS = resolved;
-        if (globals) {
-            if (globals.shared.maxFPS !== resolved) globals.shared.maxFPS = resolved;
-            if (globals.system.maxFPS !== resolved) globals.system.maxFPS = resolved;
-        }
+        if (globals.shared.maxFPS !== resolved) globals.shared.maxFPS = resolved;
+        if (globals.system.maxFPS !== resolved) globals.system.maxFPS = resolved;
     }
 
     // 有渲染活动时升回配置帧率，并安排在 durationMs 后衰减回静止地板（全平台）。
@@ -923,7 +928,8 @@ class Live2DManager {
         this._idleTickSystemWasStarted = !!PixiTicker.system.started;
         const globals = this._resolveGlobalTickers();
         if (globals) {
-            this._idleTickSavedGlobalMaxFPS = globals.shared.maxFPS;
+            this._idleTickSavedSharedMaxFPS = globals.shared.maxFPS;
+            this._idleTickSavedSystemMaxFPS = globals.system.maxFPS;
             globals.shared.maxFPS = 0;
             globals.system.maxFPS = 0;
         }
@@ -1003,16 +1009,15 @@ class Live2DManager {
         const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
         if (!PixiTicker) return;
         try {
-            if (typeof this._idleTickSavedGlobalMaxFPS === 'number') {
-                PixiTicker.shared.maxFPS = this._idleTickSavedGlobalMaxFPS;
-                PixiTicker.system.maxFPS = this._idleTickSavedGlobalMaxFPS;
-            }
+            if (typeof this._idleTickSavedSharedMaxFPS === 'number') PixiTicker.shared.maxFPS = this._idleTickSavedSharedMaxFPS;
+            if (typeof this._idleTickSavedSystemMaxFPS === 'number') PixiTicker.system.maxFPS = this._idleTickSavedSystemMaxFPS;
             if (this._idleTickSharedWasStarted && !PixiTicker.shared.started) PixiTicker.shared.start();
             if (this._idleTickSystemWasStarted && !PixiTicker.system.started) PixiTicker.system.start();
         } catch (_) {}
         this._idleTickSharedWasStarted = false;
         this._idleTickSystemWasStarted = false;
-        this._idleTickSavedGlobalMaxFPS = null;
+        this._idleTickSavedSharedMaxFPS = null;
+        this._idleTickSavedSystemMaxFPS = null;
     }
 
     // 向后兼容旧调用名（live2d-interaction.js 的交互升帧），现已推广到全平台。

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -774,7 +774,7 @@ class Live2DManager {
     _resolveActiveTimerTickFps() {
         const pacing = window.nekoFramePacing;
         if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
-        const fps = Number(pacing.activeTimerTickFps());
+        const fps = Number(pacing.activeTimerTickFps(this._resolveConfiguredTargetFps()));
         return Number.isFinite(fps) && fps > 0 ? fps : null;
     }
 

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -775,7 +775,8 @@ class Live2DManager {
     // 用户配置的目标帧率（活动时的上限），默认 60；0 表示不限帧（跟随 VSync）。
     _resolveConfiguredTargetFps() {
         const configured = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
-        return Number.isFinite(configured) ? configured : 60;
+        // 负数/非法值一律按 60（否则地板会变成负数、定时器周期算出秒级）
+        return Number.isFinite(configured) && configured >= 0 ? configured : 60;
     }
 
     // 静止地板帧率：不超过用户配置；配置为 0（不限帧）时仍压到地板省 CPU。

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -744,16 +744,15 @@ class Live2DManager {
         if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
             // 页面级豁免：直接落配置帧率，不进入空闲地板/低频模式
             this._exitIdleTickMode();
-            this.pixi_app.ticker.maxFPS = window.targetFrameRate;
+            this._applyRafMaxFps(window.targetFrameRate);
         } else if (this._hasRenderActivity()) {
             this.boostInteractiveFPS();
         } else {
-            // 改配置时如果正处于空闲低频 tick 模式，先退出再按新地板重新进入，
+            // 无活动：直接按新地板落到空闲低频 tick。已在定时器模式则只换周期，
             // 让 interval 周期与新的地板帧率一致。
-            const wasIdleTickMode = this._idleTickMode;
-            if (wasIdleTickMode) this._exitIdleTickMode();
-            this.pixi_app.ticker.maxFPS = this._resolveIdleFps();
-            if (wasIdleTickMode) this._enterIdleTickMode();
+            const idleFps = this._resolveIdleFps();
+            this._applyRafMaxFps(idleFps);
+            this._enterIdleTickMode(idleFps);
         }
         console.log(`[Live2D Core] 目标帧率设置为 ${window.targetFrameRate === 0 ? 'VSync (无限制)' : window.targetFrameRate + 'fps'}`);
     }
@@ -770,18 +769,64 @@ class Live2DManager {
         return configured === 0 ? LIVE2D_IDLE_FPS : Math.min(LIVE2D_IDLE_FPS, configured);
     }
 
+    // 活动态应改用定时器驱动的帧率（Pet 窗口且配置帧率明显低于显示器刷新率时由
+    // frame-pacing.js 给出）；null = 留在 rAF 驱动。非 Pet 页面没有 nekoFramePacing，恒为 null。
+    _resolveActiveTimerTickFps() {
+        const pacing = window.nekoFramePacing;
+        if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
+        const fps = Number(pacing.activeTimerTickFps());
+        return Number.isFinite(fps) && fps > 0 ? fps : null;
+    }
+
+    // Pet 窗口进程里只有一个 Live2DManager，可以安全接管全局 PIXI.Ticker.shared/system
+    // 的帧率上限（模型 motion/physics 的 autoUpdate 挂在 shared 上，不接管的话它仍按
+    // 显示器刷新率跑）。其它页面（模型管理器/角色卡预览可能多个 manager 共存）不碰。
+    _resolveGlobalTickers() {
+        const pacing = window.nekoFramePacing;
+        if (!pacing || typeof pacing.isElectronPet !== 'function' || !pacing.isElectronPet()) return null;
+        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
+        if (!PixiTicker || !PixiTicker.shared || !PixiTicker.system) return null;
+        return { shared: PixiTicker.shared, system: PixiTicker.system };
+    }
+
+    // rAF 驱动下的帧率上限：写到 app.ticker，Pet 窗口还一并写到 shared/system。
+    // 定时器驱动模式下三个 ticker 的 maxFPS 必须保持 0（定时器周期本身就是节流器，
+    // interval 抖动会被 maxFPS 丢帧、实际帧率减半），此时只更新退出定时器模式时要恢复的值。
+    _applyRafMaxFps(fps) {
+        const resolved = Number.isFinite(Number(fps)) ? Number(fps) : 0;
+        const ticker = this.pixi_app && this.pixi_app.ticker;
+        if (!ticker) return;
+        const globals = this._resolveGlobalTickers();
+        if (this._idleTickMode) {
+            this._idleTickSavedMaxFPS = resolved;
+            if (globals) this._idleTickSavedGlobalMaxFPS = resolved;
+            return;
+        }
+        if (ticker.maxFPS !== resolved) ticker.maxFPS = resolved;
+        if (globals) {
+            if (globals.shared.maxFPS !== resolved) globals.shared.maxFPS = resolved;
+            if (globals.system.maxFPS !== resolved) globals.system.maxFPS = resolved;
+        }
+    }
+
     // 有渲染活动时升回配置帧率，并安排在 durationMs 后衰减回静止地板（全平台）。
     boostInteractiveFPS(durationMs = LIVE2D_INTERACTIVE_FPS_HOLD_MS) {
         if (!this.pixi_app || !this.pixi_app.ticker) return;
-        // 有活动：先退出空闲低频 tick 模式，恢复 rAF 驱动的满帧管线。
-        this._exitIdleTickMode();
         const ticker = this.pixi_app.ticker;
         const configured = this._resolveConfiguredTargetFps();
         // 活动时升回用户配置上限（0=不限帧）。不再 Math.max(IDLE,...)，否则会把刻意设到
         // 低于地板的配置（如低端机 24fps）反而抬到 30，超过用户上限。
         const activeFps = configured === 0 ? 0 : configured;
-        if (ticker.maxFPS !== activeFps) {
-            ticker.maxFPS = activeFps;
+        const timerFps = this._resolveActiveTimerTickFps();
+        if (timerFps != null) {
+            // Pet 窗口且配置帧率低于刷新率：活动态也留在定时器驱动，只把周期换成配置帧率。
+            // 回到 rAF 只会让 Blink 按刷新率跑主帧再跳掉一半，省不出 CPU/GPU。
+            this._applyRafMaxFps(activeFps);
+            this._enterIdleTickMode(timerFps);
+        } else {
+            // 有活动：退出定时器驱动，恢复 rAF 驱动的满帧管线。
+            this._exitIdleTickMode();
+            this._applyRafMaxFps(activeFps);
         }
         const originalTicker = ticker;
         if (this._idleFpsRestoreTimer) {
@@ -793,11 +838,13 @@ class Live2DManager {
         this._idleFpsRestoreTimer = setTimeout(() => {
             this._idleFpsRestoreTimer = null;
             if (this.pixi_app && this.pixi_app.ticker === originalTicker) {
-                originalTicker.maxFPS = this._resolveIdleFps();
+                const idleFps = this._resolveIdleFps();
+                this._applyRafMaxFps(idleFps);
                 // 无活动衰减到地板后，进一步切换到定时器驱动的低频 tick：
                 // rAF 驱动下即使 maxFPS 已限 30，三个 ticker 的 rAF 请求仍会让
                 // Blink 以显示器刷新率（如 120Hz）跑完整主帧生命周期，空耗 CPU/GPU。
-                this._enterIdleTickMode();
+                // 已在定时器模式（活动态定时器驱动）则只把周期换成地板帧率。
+                this._enterIdleTickMode(idleFps);
             }
         }, Math.max(100, Number(durationMs) || LIVE2D_INTERACTIVE_FPS_HOLD_MS));
     }
@@ -814,8 +861,16 @@ class Live2DManager {
      * （模型 motion/physics 的 autoUpdate）降到自己的地板频率——届时需要把
      * shared/system 的接管改成跨实例引用计数。
      */
-    _enterIdleTickMode() {
-        if (this._idleTickMode) return;
+    _enterIdleTickMode(fps) {
+        const requested = Number(fps);
+        const tickFps = Number.isFinite(requested) && requested > 0 ? requested : this._resolveIdleFps();
+        if (this._idleTickMode) {
+            // 已在定时器模式（空闲地板 ↔ 活动态定时器驱动之间切换）：只换周期，不经过 rAF
+            if (this._idleTickFps === tickFps) return;
+            if (this._idleTickTimer) clearInterval(this._idleTickTimer);
+            this._idleTickTimer = this._startTimerTick(tickFps);
+            return;
+        }
         if (!this.pixi_app || !this.pixi_app.ticker || !this._tickerOrigStop) return;
         const ticker = this.pixi_app.ticker;
         // 外部已显式暂停（pauseRendering / 角色切换）：不接管
@@ -828,11 +883,27 @@ class Live2DManager {
         // 33.33ms）导致 update() 被 maxFPS 丢帧、实际帧率减半。
         this._idleTickSavedMaxFPS = ticker.maxFPS;
         ticker.maxFPS = 0;
+        // Pet 窗口下 shared/system 的 maxFPS 也由本 manager 接管（见 _applyRafMaxFps），
+        // 手动 update() 同样不能被它们的 maxFPS 丢帧：一并清零并记住恢复值。
+        const globals = this._resolveGlobalTickers();
+        if (globals) {
+            this._idleTickSavedGlobalMaxFPS = globals.shared.maxFPS;
+            globals.shared.maxFPS = 0;
+            globals.system.maxFPS = 0;
+        }
         this._tickerOrigStop();
         if (this._idleTickSharedWasStarted) PixiTicker.shared.stop();
         if (this._idleTickSystemWasStarted) PixiTicker.system.stop();
-        const intervalMs = Math.max(16, Math.round(1000 / Math.max(1, this._resolveIdleFps())));
-        this._idleTickTimer = setInterval(() => {
+        this._idleTickTimer = this._startTimerTick(tickFps);
+    }
+
+    // 定时器驱动的 tick 循环：按 fps 手动 update() app + shared/system 三个 ticker。
+    // 空闲地板（30）和活动态定时器驱动（配置帧率）共用，只有周期不同。
+    _startTimerTick(fps) {
+        this._idleTickFps = fps;
+        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
+        const intervalMs = Math.max(4, Math.round(1000 / Math.max(1, fps)));
+        return setInterval(() => {
             if (!this._idleTickMode) return;
             const app = this.pixi_app;
             if (!app || !app.ticker) { this._exitIdleTickMode(); return; }
@@ -880,10 +951,18 @@ class Live2DManager {
         if (app && app.ticker && typeof this._idleTickSavedMaxFPS === 'number') {
             app.ticker.maxFPS = this._idleTickSavedMaxFPS;
         }
+        if (PixiTicker && typeof this._idleTickSavedGlobalMaxFPS === 'number') {
+            try {
+                PixiTicker.shared.maxFPS = this._idleTickSavedGlobalMaxFPS;
+                PixiTicker.system.maxFPS = this._idleTickSavedGlobalMaxFPS;
+            } catch (_) {}
+        }
         if (app && app.ticker && app.ticker.started === false && this._tickerOrigStart) {
             try { this._tickerOrigStart(); } catch (_) {}
         }
         this._idleTickSavedMaxFPS = null;
+        this._idleTickSavedGlobalMaxFPS = null;
+        this._idleTickFps = null;
     }
 
     // 向后兼容旧调用名（live2d-interaction.js 的交互升帧），现已推广到全平台。
@@ -933,8 +1012,9 @@ class Live2DManager {
                 // 自愈：外部「确保渲染」路径（model-display / universal-manager 等的
                 // `!started && start()`）会把 ticker 拉回 rAF 模式并解除空闲低频 tick，
                 // 且不会再有 boost 衰减计时器带我们回来。无活动、无待衰减时直接重新进入。
-                this.pixi_app.ticker.maxFPS = this._resolveIdleFps();
-                this._enterIdleTickMode();
+                const idleFps = this._resolveIdleFps();
+                this._applyRafMaxFps(idleFps);
+                this._enterIdleTickMode(idleFps);
             }
         }, LIVE2D_IDLE_FPS_GOVERNOR_INTERVAL_MS);
     }

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2662,6 +2662,8 @@ Live2DManager.prototype.enableMouseTracking = function (model, options = {}) {
         // 静止时也周期性派发合成 pointermove，不加这道闸它会把升帧的 hold 窗口无限续命，
         // 空闲低频 tick 永远进不去。其余悬停/淡化状态逻辑照常执行，不受影响。
         const pointerMoved = pointer.x !== this._lastMouseX || pointer.y !== this._lastMouseY;
+        // 供 live2d-core 的活动判定：isFocusing 只在光标最近真的动过时才算活动
+        if (pointerMoved) this._lastPointerMoveAt = performance.now();
         this._lastMouseX = pointer.x;
         this._lastMouseY = pointer.y;
         this._lastMouseLocalX = localPointer.x;

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2658,6 +2658,10 @@ Live2DManager.prototype.enableMouseTracking = function (model, options = {}) {
         const pointerCoords = getLive2DNiriPetPointerCoordinates(event);
         const pointer = pointerCoords.virtual;
         const localPointer = pointerCoords.local;
+        // 只有坐标真的变了才算「交互活动」去升帧。Electron Pet 的 preload 轮询会在光标
+        // 静止时也周期性派发合成 pointermove，不加这道闸它会把升帧的 hold 窗口无限续命，
+        // 空闲低频 tick 永远进不去。其余悬停/淡化状态逻辑照常执行，不受影响。
+        const pointerMoved = pointer.x !== this._lastMouseX || pointer.y !== this._lastMouseY;
         this._lastMouseX = pointer.x;
         this._lastMouseY = pointer.y;
         this._lastMouseLocalX = localPointer.x;
@@ -2813,7 +2817,7 @@ Live2DManager.prototype.enableMouseTracking = function (model, options = {}) {
             };
 
             if (distance < threshold) {
-                if (typeof this.boostLinuxX11InteractiveFPS === 'function') {
+                if (pointerMoved && typeof this.boostLinuxX11InteractiveFPS === 'function') {
                     this.boostLinuxX11InteractiveFPS();
                 }
                 showButtons();
@@ -2842,7 +2846,7 @@ Live2DManager.prototype.enableMouseTracking = function (model, options = {}) {
                     }
                 }
             } else if (isFullscreenTracking) {
-                if (typeof this.boostLinuxX11InteractiveFPS === 'function') {
+                if (pointerMoved && typeof this.boostLinuxX11InteractiveFPS === 'function') {
                     this.boostLinuxX11InteractiveFPS();
                 }
                 if (canvasEl && !this.isLocked && !(model.interactive && model.dragging)) {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -1673,6 +1673,17 @@ Live2DManager.prototype._checkSnapRequired = async function (model, options = {}
     }
 };
 
+// 排一帧吸附动画：Electron Pet 里渲染后端切到定时器驱动时走同周期定时器
+// （frame-pacing.requestPacedFrame），否则 rAF；裸 rAF 会在动画期间把 Blink 主帧顶回刷新率
+function scheduleLive2DSnapFrame(callback) {
+    const pacing = window.nekoFramePacing;
+    if (pacing && typeof pacing.requestPacedFrame === 'function') {
+        return pacing.requestPacedFrame(callback);
+    }
+    const id = requestAnimationFrame(callback);
+    return () => cancelAnimationFrame(id);
+}
+
 /**
  * 执行平滑吸附动画
  * @param {PIXI.DisplayObject} model - Live2D 模型对象
@@ -1725,7 +1736,7 @@ Live2DManager.prototype._performSnapAnimation = function (model, snapInfo, optio
             model.y = startY + (targetY - startY) * easedProgress;
 
             if (progress < 1) {
-                requestAnimationFrame(animate);
+                scheduleLive2DSnapFrame(animate);
             } else {
                 // 确保最终位置精确
                 model.x = targetX;
@@ -1737,7 +1748,7 @@ Live2DManager.prototype._performSnapAnimation = function (model, snapInfo, optio
         };
 
         console.debug('[Live2D] 开始吸附动画:', { from: { x: startX, y: startY }, to: { x: targetX, y: targetY } });
-        requestAnimationFrame(animate);
+        scheduleLive2DSnapFrame(animate);
     });
 };
 

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -1186,6 +1186,13 @@ class MMDCore {
         // 由 interval 直接调用 _renderFrame，不经过这里）
         this._refreshTargetFps();
         const now = performance.now();
+        if (!(this.frameTime > 0)) {
+            // 不限帧：每个 rAF 都渲染。不能走下面的取模（elapsed % 0 = NaN 会把
+            // lastFrameTime 污染成 NaN，之后切回有限帧率也永远节流不了）。
+            this.lastFrameTime = now;
+            this._renderFrame(now);
+            return;
+        }
         const elapsed = now - this.lastFrameTime;
         if (elapsed < this.frameTime) return;
         this.lastFrameTime = now - (elapsed % this.frameTime);

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -15,8 +15,9 @@ class MMDCore {
     constructor(manager) {
         this.manager = manager;
         this.performanceMode = this.detectPerformanceMode();
-        this.targetFPS = this.performanceMode === 'low' ? 30 : (this.performanceMode === 'medium' ? 45 : 60);
+        this.targetFPS = 60;
         this.frameTime = 1000 / this.targetFPS;
+        this._refreshTargetFps();
         this.lastFrameTime = 0;
 
         // 缓存的模块引用
@@ -957,8 +958,59 @@ class MMDCore {
 
     // ═══════════════════ 空闲低频 tick 模式（对齐 live2d-core.js round-1 模式）═══════════════════
 
-    _enterIdleTickMode() {
-        if (this._idleTickMode) return;
+    // 用户配置的目标帧率（设置里的「帧率」滑块，与 Live2D/VRM 同源）；0 = 不限帧。
+    // 没有该配置（独立预览页等）时退回 performanceMode 的档位值。
+    _resolveConfiguredTargetFps() {
+        const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : NaN;
+        if (Number.isFinite(raw) && raw >= 0) return raw;
+        return this.performanceMode === 'low' ? 30 : (this.performanceMode === 'medium' ? 45 : 60);
+    }
+
+    // 同步 targetFPS/frameTime 到当前配置；rAF 路径每帧调用，配置变更立即生效。
+    _refreshTargetFps() {
+        const fps = this._resolveConfiguredTargetFps();
+        if (fps === this.targetFPS) return;
+        this.targetFPS = fps;
+        this.frameTime = fps > 0 ? 1000 / fps : 0;
+    }
+
+    // 静止地板帧率：不超过用户配置；配置为 0（不限帧）时仍压到地板省 CPU。
+    _resolveIdleFps() {
+        const configured = this._resolveConfiguredTargetFps();
+        return configured === 0 ? MMD_IDLE_FPS : Math.min(MMD_IDLE_FPS, configured);
+    }
+
+    // 活动态应改用定时器驱动的帧率（Pet 窗口且配置帧率明显低于显示器刷新率时由
+    // frame-pacing.js 给出）；null = 留在 rAF 驱动。非 Pet 页面没有 nekoFramePacing，恒为 null。
+    _resolveActiveTimerTickFps() {
+        const pacing = window.nekoFramePacing;
+        if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
+        const fps = Number(pacing.activeTimerTickFps());
+        return Number.isFinite(fps) && fps > 0 ? fps : null;
+    }
+
+    // 帧率设置变更：有活动按新配置重新升帧；空闲定时器模式按新地板换周期。
+    applyTargetFrameRate() {
+        this._refreshTargetFps();
+        const m = this.manager;
+        if (!m || !m._shouldRender || m._isDisposed || !m.renderer) return;
+        if (this._hasRenderActivity()) {
+            this._boostInteractiveFPS();
+        } else if (this._idleTickMode) {
+            this._enterIdleTickMode(this._resolveIdleFps());
+        }
+    }
+
+    _enterIdleTickMode(fps) {
+        const requested = Number(fps);
+        const tickFps = Number.isFinite(requested) && requested > 0 ? requested : this._resolveIdleFps();
+        if (this._idleTickMode) {
+            // 已在定时器模式（空闲地板 ↔ 活动态定时器驱动之间切换）：只换周期，不经过 rAF
+            if (this._idleTickFps === tickFps) return;
+            if (this._idleTickTimer) clearInterval(this._idleTickTimer);
+            this._idleTickTimer = this._startTimerTick(tickFps);
+            return;
+        }
         const manager = this.manager;
         if (!manager || !manager._shouldRender || manager._isDisposed || !manager.renderer) return;
         this._idleTickMode = true;
@@ -966,9 +1018,14 @@ class MMDCore {
             cancelAnimationFrame(manager._animationFrameId);
             manager._animationFrameId = null;
         }
-        const idleFps = Math.min(MMD_IDLE_FPS, this.targetFPS || MMD_IDLE_FPS);
-        const intervalMs = Math.max(16, Math.round(1000 / Math.max(1, idleFps)));
-        this._idleTickTimer = setInterval(() => {
+        this._idleTickTimer = this._startTimerTick(tickFps);
+    }
+
+    // 定时器驱动的 tick 循环：空闲地板（30）和活动态定时器驱动（配置帧率）共用，只有周期不同。
+    _startTimerTick(fps) {
+        this._idleTickFps = fps;
+        const intervalMs = Math.max(4, Math.round(1000 / Math.max(1, fps)));
+        return setInterval(() => {
             if (!this._idleTickMode) return;
             const m = this.manager;
             if (!m || !m._shouldRender || m._isDisposed || !m.renderer) { this._exitIdleTickMode(false); return; }
@@ -990,6 +1047,7 @@ class MMDCore {
     _exitIdleTickMode(restartRaf = true) {
         if (!this._idleTickMode) return;
         this._idleTickMode = false;
+        this._idleTickFps = null;
         if (this._idleTickTimer) {
             clearInterval(this._idleTickTimer);
             this._idleTickTimer = null;
@@ -1003,7 +1061,14 @@ class MMDCore {
 
     // 有交互/活动时升回 rAF 满帧，并安排在 durationMs 后无活动则回落空闲模式
     _boostInteractiveFPS(durationMs = MMD_INTERACTIVE_FPS_HOLD_MS) {
-        this._exitIdleTickMode();
+        const timerFps = this._resolveActiveTimerTickFps();
+        if (timerFps != null) {
+            // Pet 窗口且配置帧率低于刷新率：活动态也留在定时器驱动，只把周期换成配置帧率。
+            // 回到 rAF 只会让 Blink 按刷新率跑主帧再跳掉一半，省不出 CPU/GPU。
+            this._enterIdleTickMode(timerFps);
+        } else {
+            this._exitIdleTickMode();
+        }
         if (this._idleDecayTimer) clearTimeout(this._idleDecayTimer);
         // 豁免页：只升频、不安排衰减——衰减会在 governor 缺席时把渲染拖回空闲模式
         if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
@@ -1119,6 +1184,7 @@ class MMDCore {
 
         // 帧率限制（仅 rAF 驱动路径；空闲低频模式下 interval 周期本身就是节流器，
         // 由 interval 直接调用 _renderFrame，不经过这里）
+        this._refreshTargetFps();
         const now = performance.now();
         const elapsed = now - this.lastFrameTime;
         if (elapsed < this.frameTime) return;
@@ -1628,3 +1694,11 @@ class MMDCore {
 }
 
 window.MMDCore = MMDCore;
+
+// 监听帧率变更事件（与 live2d-core.js 同名事件对齐）
+window.addEventListener('neko-frame-rate-changed', () => {
+    const core = window.mmdManager && window.mmdManager.core;
+    if (core && typeof core.applyTargetFrameRate === 'function') {
+        try { core.applyTargetFrameRate(); } catch (_) {}
+    }
+});

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -985,7 +985,9 @@ class MMDCore {
     _resolveActiveTimerTickFps() {
         const pacing = window.nekoFramePacing;
         if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
-        const fps = Number(pacing.activeTimerTickFps());
+        // 传入本后端解析出的目标帧率：没有 window.targetFrameRate 时 MMD 按 performanceMode
+        // 回退 30/45/60，总闸不能自己按 60 算
+        const fps = Number(pacing.activeTimerTickFps(this._resolveConfiguredTargetFps()));
         return Number.isFinite(fps) && fps > 0 ? fps : null;
     }
 

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -1099,14 +1099,15 @@ class MMDCore {
         try {
             const cf = m.cursorFollow;
             if (cf && cf.enabled) {
-                if (cf._lastPointerMoveTs && (performance.now() - cf._lastPointerMoveTs) < MMD_INTERACTIVE_FPS_HOLD_MS) return true;
+                // 时间戳 0 是合法值（performance.now() 起点），不能用真值判断
+                if (Number.isFinite(cf._lastPointerMoveTs) && (performance.now() - cf._lastPointerMoveTs) < MMD_INTERACTIVE_FPS_HOLD_MS) return true;
                 // 头部朝向还没收敛完：保持满帧到位
                 if (Math.abs((cf._targetYaw || 0) - (cf._currentYaw || 0)) > 0.02 ||
                     Math.abs((cf._targetPitch || 0) - (cf._currentPitch || 0)) > 0.02) return true;
             }
         } catch (_) {}
         try {
-            if (m._lastInteractionBoostTs && (performance.now() - m._lastInteractionBoostTs) < MMD_INTERACTIVE_FPS_HOLD_MS) return true;
+            if (Number.isFinite(m._lastInteractionBoostTs) && (performance.now() - m._lastInteractionBoostTs) < MMD_INTERACTIVE_FPS_HOLD_MS) return true;
         } catch (_) {}
         return false;
     }

--- a/static/mmd/mmd-cursor-follow.js
+++ b/static/mmd/mmd-cursor-follow.js
@@ -190,8 +190,11 @@ class MMDCursorFollow {
     _setupEventListeners() {
         this._pointerMoveHandler = (e) => {
             const now = performance.now();
-            // 供 mmd-core 空闲低频 governor 判定"光标最近在动"（活动 → 满帧）
-            this._lastPointerMoveTs = now;
+            // 供 mmd-core 空闲低频 governor 判定"光标最近在动"（活动 → 满帧）。
+            // 坐标没变的重复事件（Electron Pet 的 preload 轮询在光标静止时也会转发）不算。
+            if (e.clientX !== this._rawMouseX || e.clientY !== this._rawMouseY) {
+                this._lastPointerMoveTs = now;
+            }
             // 去重：pointermove 后常跟随合成 mousemove（Electron 透明窗口）
             if (e.type === 'mousemove' && now < this._ignoreMouseMoveUntil) return;
             if (e.type === 'pointermove') {

--- a/static/mmd/mmd-interaction.js
+++ b/static/mmd/mmd-interaction.js
@@ -40,7 +40,7 @@ class MMDInteraction {
             duration: 260,
             easingType: 'easeOutBack'
         };
-        this._snapAnimationFrameId = null;
+        this._snapCancelFrame = null;
         this._isSnappingModel = false;
         this._snapResolve = null;
 
@@ -348,9 +348,9 @@ class MMDInteraction {
             if (this.checkLocked()) return;
             if (isYuiGuideDragLocked()) return;
 
-            if (this._snapAnimationFrameId) {
-                cancelAnimationFrame(this._snapAnimationFrameId);
-                this._snapAnimationFrameId = null;
+            if (this._snapCancelFrame) {
+                this._snapCancelFrame();
+                this._snapCancelFrame = null;
                 if (this._snapResolve) {
                     this._snapResolve(false);
                     this._snapResolve = null;
@@ -943,9 +943,9 @@ class MMDInteraction {
             return Promise.resolve(false);
         }
 
-        if (this._snapAnimationFrameId) {
-            cancelAnimationFrame(this._snapAnimationFrameId);
-            this._snapAnimationFrameId = null;
+        if (this._snapCancelFrame) {
+            this._snapCancelFrame();
+            this._snapCancelFrame = null;
             if (this._snapResolve) {
                 this._snapResolve(false);
                 this._snapResolve = null;
@@ -972,17 +972,17 @@ class MMDInteraction {
                 );
 
                 if (progress < 1) {
-                    this._snapAnimationFrameId = requestAnimationFrame(animate);
+                    this._snapCancelFrame = this._scheduleSnapFrame(animate);
                 } else {
                     mesh.position.copy(targetPosition);
                     this._isSnappingModel = false;
-                    this._snapAnimationFrameId = null;
+                    this._snapCancelFrame = null;
                     this._snapResolve = null;
                     resolve(true);
                 }
             };
 
-            this._snapAnimationFrameId = requestAnimationFrame(animate);
+            this._snapCancelFrame = this._scheduleSnapFrame(animate);
         });
     }
 
@@ -1094,12 +1094,23 @@ class MMDInteraction {
         }, 500);
     }
 
+    // 排一帧回弹动画：Electron Pet 里渲染后端切到定时器驱动时走同周期定时器
+    // （frame-pacing.requestPacedFrame），否则 rAF。返回取消函数（存到 _snapCancelFrame）。
+    _scheduleSnapFrame(callback) {
+        const pacing = window.nekoFramePacing;
+        if (pacing && typeof pacing.requestPacedFrame === 'function') {
+            return pacing.requestPacedFrame(callback);
+        }
+        const id = requestAnimationFrame(callback);
+        return () => cancelAnimationFrame(id);
+    }
+
     dispose() {
         this.cleanupDragAndZoom();
 
-        if (this._snapAnimationFrameId) {
-            cancelAnimationFrame(this._snapAnimationFrameId);
-            this._snapAnimationFrameId = null;
+        if (this._snapCancelFrame) {
+            this._snapCancelFrame();
+            this._snapCancelFrame = null;
         }
         if (this._snapResolve) {
             this._snapResolve(false);

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -595,11 +595,13 @@ MMDManager.prototype._startUIUpdateLoop = function() {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
         if (this.core && this.core._idleTickMode) {
             if (this._uiLoopIdleTimeout) clearTimeout(this._uiLoopIdleTimeout);
+            // 周期跟随渲染 tick 频率：活动态定时器驱动（配置帧率）下按钮跟手，空闲地板下 ~33ms
+            const tickFps = Number(this.core._idleTickFps) > 0 ? Number(this.core._idleTickFps) : 30;
             this._uiLoopIdleTimeout = setTimeout(() => {
                 this._uiLoopIdleTimeout = null;
                 if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
                 this._uiUpdateLoopId = requestAnimationFrame(update);
-            }, 33);
+            }, Math.max(4, Math.round(1000 / tickFps)));
             return;
         }
         this._uiUpdateLoopId = requestAnimationFrame(update);

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -595,12 +595,13 @@ MMDManager.prototype._startUIUpdateLoop = function() {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
         if (this.core && this.core._idleTickMode) {
             if (this._uiLoopIdleTimeout) clearTimeout(this._uiLoopIdleTimeout);
-            // 周期跟随渲染 tick 频率：活动态定时器驱动（配置帧率）下按钮跟手，空闲地板下 ~33ms
+            // 周期跟随渲染 tick 频率：活动态定时器驱动（配置帧率）下按钮跟手，空闲地板下 ~33ms。
+            // 定时器到点直接调 update，不再转一次性 rAF——那会再等一个 vsync，按钮比模型慢半拍
             const tickFps = Number(this.core._idleTickFps) > 0 ? Number(this.core._idleTickFps) : 30;
             this._uiLoopIdleTimeout = setTimeout(() => {
                 this._uiLoopIdleTimeout = null;
                 if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
-                this._uiUpdateLoopId = requestAnimationFrame(update);
+                update();
             }, Math.max(4, Math.round(1000 / tickFps)));
             return;
         }

--- a/static/vrm/vrm-cursor-follow.js
+++ b/static/vrm/vrm-cursor-follow.js
@@ -333,10 +333,13 @@ class CursorFollowController {
                 // macOS / Safari 等环境下，pointermove 后常跟随合成 mousemove，短窗口去重即可。
                 this._ignoreMouseMoveUntil = now + 40;
             }
+            // 坐标没变的重复事件（Electron Pet 的 preload 轮询在光标静止时也会转发）不算
+            // 「光标在动」，否则空闲低频 governor 永远看到活动、降不下帧。
+            const moved = e.clientX !== this._rawMouseX || e.clientY !== this._rawMouseY;
             this._rawMouseX = e.clientX;
             this._rawMouseY = e.clientY;
             this._hasPointerInput = true;
-            this._lastPointerMoveAt = now;
+            if (moved) this._lastPointerMoveAt = now;
         };
 
         // 同时监听 pointermove + mousemove，绑定到 window（非 document）

--- a/static/vrm/vrm-interaction.js
+++ b/static/vrm/vrm-interaction.js
@@ -101,7 +101,7 @@ class VRMInteraction {
             duration: 260,
             easingType: 'easeOutBack'
         };
-        this._snapAnimationFrameId = null;
+        this._snapCancelFrame = null;
         this._isSnappingModel = false;
         this._snapResolve = null;
         this._lastPanDragPointerScreen = null;
@@ -365,9 +365,9 @@ class VRMInteraction {
             if (isYuiGuideDragLocked()) return;
 
             // 如果正在回弹动画，优先取消，避免拖拽冲突
-            if (this._snapAnimationFrameId) {
-                cancelAnimationFrame(this._snapAnimationFrameId);
-                this._snapAnimationFrameId = null;
+            if (this._snapCancelFrame) {
+                this._snapCancelFrame();
+                this._snapCancelFrame = null;
                 if (this._snapResolve) {
                     this._snapResolve(false);
                     this._snapResolve = null;
@@ -1018,9 +1018,9 @@ class VRMInteraction {
             return Promise.resolve(false);
         }
 
-        if (this._snapAnimationFrameId) {
-            cancelAnimationFrame(this._snapAnimationFrameId);
-            this._snapAnimationFrameId = null;
+        if (this._snapCancelFrame) {
+            this._snapCancelFrame();
+            this._snapCancelFrame = null;
             if (this._snapResolve) {
                 this._snapResolve(false);
                 this._snapResolve = null;
@@ -1049,17 +1049,17 @@ class VRMInteraction {
                 scene.position.set(newX, newY, newZ);
 
                 if (progress < 1) {
-                    this._snapAnimationFrameId = requestAnimationFrame(animate);
+                    this._snapCancelFrame = this._scheduleSnapFrame(animate);
                 } else {
                     scene.position.copy(targetPosition);
                     this._isSnappingModel = false;
-                    this._snapAnimationFrameId = null;
+                    this._snapCancelFrame = null;
                     this._snapResolve = null;
                     resolve(true);
                 }
             };
 
-            this._snapAnimationFrameId = requestAnimationFrame(animate);
+            this._snapCancelFrame = this._scheduleSnapFrame(animate);
         });
     }
 
@@ -2034,6 +2034,17 @@ class VRMInteraction {
     /**
      * 清理交互资源
      */
+    // 排一帧回弹动画：Electron Pet 里渲染后端切到定时器驱动时走同周期定时器
+    // （frame-pacing.requestPacedFrame），否则 rAF。返回取消函数（存到 _snapCancelFrame）。
+    _scheduleSnapFrame(callback) {
+        const pacing = window.nekoFramePacing;
+        if (pacing && typeof pacing.requestPacedFrame === 'function') {
+            return pacing.requestPacedFrame(callback);
+        }
+        const id = requestAnimationFrame(callback);
+        return () => cancelAnimationFrame(id);
+    }
+
     dispose() {
         this.enableMouseTracking(false);
         this.cleanupDragAndZoom();
@@ -2057,9 +2068,9 @@ class VRMInteraction {
         }
 
         // 清理回弹动画
-        if (this._snapAnimationFrameId) {
-            cancelAnimationFrame(this._snapAnimationFrameId);
-            this._snapAnimationFrameId = null;
+        if (this._snapCancelFrame) {
+            this._snapCancelFrame();
+            this._snapCancelFrame = null;
         }
         if (this._snapResolve) {
             this._snapResolve(false);

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -9,6 +9,8 @@
 const VRM_IDLE_FPS = 30;
 const VRM_INTERACTIVE_FPS_HOLD_MS = 900;
 const VRM_IDLE_FPS_GOVERNOR_INTERVAL_MS = 300;
+// medium 画质隔帧物理允许的最低 tick 频率：2×(1000/40) = 50ms，正好是物理 delta 的防爆 clamp
+const VRM_PHYSICS_FRAME_SKIP_MIN_FPS = 40;
 
 const COMPRESSED_BUNDLED_VRMA_NAMES = new Set([
     'liked',
@@ -926,12 +928,14 @@ class VRMManager {
         return Number.isFinite(fps) && fps > 0 ? fps : null;
     }
 
-    // 当前是否以「地板级」低频 tick 在跑（≤ VRM_IDLE_FPS）。与 _idleTickMode 区分：
-    // 活动态定时器驱动也置 _idleTickMode，但频率是配置帧率，不算低频。
+    // 当前定时器 tick 频率是否低到不能再隔帧做物理：隔帧后的步长 2×(1000/fps) 必须
+    // 落在 50ms 防爆 clamp 之内，即 fps ≥ 40；再低（含 30 地板、以及 31~39 的非
+    // 标准配置）就每 tick 全量物理。与 _idleTickMode 区分：活动态定时器驱动也置
+    // 该标志，但频率是配置帧率，45/60 仍按 medium 隔帧。
     _isLowTickRate() {
         if (!this._idleTickMode) return false;
         const fps = Number(this._idleTickFps);
-        return !(fps > VRM_IDLE_FPS);
+        return !(fps >= VRM_PHYSICS_FRAME_SKIP_MIN_FPS);
     }
 
     _enterIdleTickMode(fps) {

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -1043,19 +1043,20 @@ class VRMManager {
         try { if (this.interaction && this.interaction.isDragging) return true; } catch (_) {}
         try {
             const cf = this._cursorFollow;
+            // 时间戳 0 是合法值（performance.now() 起点），不能用真值判断
             if (cf && typeof cf.isEnabled === 'function' && cf.isEnabled() &&
-                cf._lastPointerMoveAt && (performance.now() - cf._lastPointerMoveAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
+                Number.isFinite(cf._lastPointerMoveAt) && (performance.now() - cf._lastPointerMoveAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
         } catch (_) {}
         try {
-            if (this._lastLookAtPointerMoveAt &&
+            if (Number.isFinite(this._lastLookAtPointerMoveAt) &&
                 (performance.now() - this._lastLookAtPointerMoveAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
         } catch (_) {}
         try {
-            if (this._lastCameraChangeAt &&
+            if (Number.isFinite(this._lastCameraChangeAt) &&
                 (performance.now() - this._lastCameraChangeAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
         } catch (_) {}
         try {
-            if (this._lastInteractionBoostTs &&
+            if (Number.isFinite(this._lastInteractionBoostTs) &&
                 (performance.now() - this._lastInteractionBoostTs) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
         } catch (_) {}
         try {

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -806,7 +806,10 @@ class VRMManager {
                     const pendingDelta = this._physicsPendingDelta || 0;
                     // 补上累计时间后的步长仍受 50ms 防爆 clamp
                     const physicsStep = Math.min(delta + pendingDelta, VRM_PHYSICS_MAX_STEP_S);
-                    if (quality === 'medium' && !this._isLowTickRate() && delta * 2 <= VRM_PHYSICS_MAX_STEP_S) {
+                    // 隔帧只在能把弹簧骨物理单独更新时启用；旧版 three-vrm 只有整体 vrm.update(t)，
+                    // 累计步长会一并喂给 lookAt/材质，所以旧版一律每帧 update(delta)
+                    const canSplitPhysics = this._canSplitVrmPhysicsUpdate(this.currentModel.vrm);
+                    if (quality === 'medium' && canSplitPhysics && !this._isLowTickRate() && delta * 2 <= VRM_PHYSICS_MAX_STEP_S) {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
                             this._physicsPendingDelta = 0;
@@ -968,9 +971,13 @@ class VRMManager {
     // 材质，直接传累计步长会让视线/材质动画在一帧里多走一倍。顺序与 VRM.update 一致：
     // humanoid → 约束 → 弹簧骨 → lookAt → 表情 → 材质。没有分量 API（旧版 three-vrm）时
     // 退回整体 update。
+    _canSplitVrmPhysicsUpdate(vrm) {
+        return !!(vrm && vrm.springBoneManager && typeof vrm.springBoneManager.update === 'function');
+    }
+
     _updateVrmWithPhysicsStep(vrm, delta, physicsStep) {
-        const springBones = vrm.springBoneManager;
-        if (springBones && typeof springBones.update === 'function') {
+        if (this._canSplitVrmPhysicsUpdate(vrm)) {
+            const springBones = vrm.springBoneManager;
             if (vrm.humanoid && typeof vrm.humanoid.update === 'function') vrm.humanoid.update();
             if (vrm.nodeConstraintManager && typeof vrm.nodeConstraintManager.update === 'function') vrm.nodeConstraintManager.update();
             springBones.update(physicsStep);

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -970,21 +970,21 @@ class VRMManager {
 
     // 分量更新：只有弹簧骨物理吃「当前帧 + 上一跳过帧」的累计步长，LookAt / 表情 / 材质
     // 仍按当前帧 delta 推进——three-vrm 的 VRM.update(t) 会把 t 一并喂给 lookAt 和 MToon
-    // 材质，直接传累计步长会让视线/材质动画在一帧里多走一倍。顺序与 VRM.update 一致：
-    // humanoid → 约束 → 弹簧骨 → lookAt → 表情 → 材质。没有分量 API（旧版 three-vrm）时
-    // 退回整体 update。
+    // 材质，直接传累计步长会让视线/材质动画在一帧里多走一倍。顺序与 three-vrm 的
+    // VRM.update 完全一致（VRMCore.update：humanoid → lookAt → 表情；再 约束 → 弹簧骨 → 材质），
+    // 约束/弹簧骨必须在 LookAt 驱动的姿态之后跑，否则拿到的是上一帧的骨骼变换。
+    // 没有分量 API（旧版 three-vrm）时退回整体 update。
     _canSplitVrmPhysicsUpdate(vrm) {
         return !!(vrm && vrm.springBoneManager && typeof vrm.springBoneManager.update === 'function');
     }
 
     _updateVrmWithPhysicsStep(vrm, delta, physicsStep) {
         if (this._canSplitVrmPhysicsUpdate(vrm)) {
-            const springBones = vrm.springBoneManager;
             if (vrm.humanoid && typeof vrm.humanoid.update === 'function') vrm.humanoid.update();
-            if (vrm.nodeConstraintManager && typeof vrm.nodeConstraintManager.update === 'function') vrm.nodeConstraintManager.update();
-            springBones.update(physicsStep);
             if (vrm.lookAt) vrm.lookAt.update(delta);
             if (vrm.expressionManager) vrm.expressionManager.update(delta);
+            if (vrm.nodeConstraintManager && typeof vrm.nodeConstraintManager.update === 'function') vrm.nodeConstraintManager.update();
+            vrm.springBoneManager.update(physicsStep);
             this._updateVrmMaterials(vrm, delta);
             return;
         }

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -779,10 +779,11 @@ class VRMManager {
                 // low: 仅 lookAt + expressions；medium: 隔帧物理；high: 每帧物理
                 const quality = window.renderQuality || 'medium';
                 if (this.enablePhysics && quality !== 'low') {
-                    // 空闲低频模式下绕过 medium 的隔帧物理：30fps 地板上再隔帧会让
-                    // 弹簧骨物理退化到 15Hz/66.7ms 步长，超出 50ms 防爆 clamp 的设计
-                    // 意图且发丝/裙摆可见抖动；30Hz 全帧物理成本 ≈ medium@60 不变
-                    if (quality === 'medium' && !this._idleTickMode) {
+                    // 30fps 地板上绕过 medium 的隔帧物理：再隔帧会让弹簧骨物理退化到
+                    // 15Hz/66.7ms 步长，超出 50ms 防爆 clamp 的设计意图且发丝/裙摆可见抖动；
+                    // 30Hz 全帧物理成本 ≈ medium@60 不变。判据是 tick 频率而不是「是否定时器
+                    // 驱动」：活动态定时器驱动（45/60fps）仍按 medium 隔帧，物理成本不翻倍。
+                    if (quality === 'medium' && !this._isLowTickRate()) {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
                             this.currentModel.vrm.update(delta * 2);
@@ -923,6 +924,14 @@ class VRMManager {
         if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
         const fps = Number(pacing.activeTimerTickFps());
         return Number.isFinite(fps) && fps > 0 ? fps : null;
+    }
+
+    // 当前是否以「地板级」低频 tick 在跑（≤ VRM_IDLE_FPS）。与 _idleTickMode 区分：
+    // 活动态定时器驱动也置 _idleTickMode，但频率是配置帧率，不算低频。
+    _isLowTickRate() {
+        if (!this._idleTickMode) return false;
+        const fps = Number(this._idleTickFps);
+        return !(fps > VRM_IDLE_FPS);
     }
 
     _enterIdleTickMode(fps) {

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -908,7 +908,8 @@ class VRMManager {
             // VMC 启用时使用累计目标时间，避免 144Hz 等非整数倍刷新率
             // 下发送速率退化；关闭时保留原渲染节流行为，隔离功能影响。
             const now = performance.now();
-            const targetFps = typeof window.targetFrameRate === 'number' ? window.targetFrameRate : 60;
+            // 与定时器路径同一套解析：负数/NaN/Infinity 一律按 60，0 = 不限帧
+            const targetFps = this._resolveConfiguredTargetFps();
             if (targetFps > 0) {
                 const frameInterval = 1000 / targetFps;
                 if (window.__NEKO_VMC_ACTIVE__ === true) {

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -11,6 +11,8 @@ const VRM_INTERACTIVE_FPS_HOLD_MS = 900;
 const VRM_IDLE_FPS_GOVERNOR_INTERVAL_MS = 300;
 // medium 画质隔帧物理允许的最低 tick 频率：2×(1000/40) = 50ms，正好是物理 delta 的防爆 clamp
 const VRM_PHYSICS_FRAME_SKIP_MIN_FPS = 40;
+// 隔帧物理允许的最大步长（秒）：与 renderFrame 里 delta 的 50ms 防爆 clamp 一致
+const VRM_PHYSICS_MAX_STEP_S = 0.05;
 
 const COMPRESSED_BUNDLED_VRMA_NAMES = new Set([
     'liked',
@@ -785,7 +787,9 @@ class VRMManager {
                     // 15Hz/66.7ms 步长，超出 50ms 防爆 clamp 的设计意图且发丝/裙摆可见抖动；
                     // 30Hz 全帧物理成本 ≈ medium@60 不变。判据是 tick 频率而不是「是否定时器
                     // 驱动」：活动态定时器驱动（45/60fps）仍按 medium 隔帧，物理成本不翻倍。
-                    if (quality === 'medium' && !this._isLowTickRate()) {
+                    // 再按实际 delta 兜底：rAF 路径被配置限到 30~39fps、或定时器抖动时，
+                    // 隔帧后的步长 2×delta 超过 50ms clamp 也走全量物理
+                    if (quality === 'medium' && !this._isLowTickRate() && delta * 2 <= VRM_PHYSICS_MAX_STEP_S) {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
                             this.currentModel.vrm.update(delta * 2);
@@ -913,9 +917,14 @@ class VRMManager {
 
     // ═══════ 空闲低频 tick 模式（对齐 live2d-core.js / mmd-core.js 的同名机制）═══════
 
-    _resolveIdleFps() {
+    // 用户配置的目标帧率；负数/非法值一律按 60，0 = 不限帧
+    _resolveConfiguredTargetFps() {
         const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
-        const configured = Number.isFinite(raw) ? raw : 60;
+        return Number.isFinite(raw) && raw >= 0 ? raw : 60;
+    }
+
+    _resolveIdleFps() {
+        const configured = this._resolveConfiguredTargetFps();
         return configured === 0 ? VRM_IDLE_FPS : Math.min(VRM_IDLE_FPS, configured);
     }
 
@@ -924,9 +933,7 @@ class VRMManager {
     _resolveActiveTimerTickFps() {
         const pacing = window.nekoFramePacing;
         if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
-        const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
-        const configured = Number.isFinite(raw) ? raw : 60;
-        const fps = Number(pacing.activeTimerTickFps(configured));
+        const fps = Number(pacing.activeTimerTickFps(this._resolveConfiguredTargetFps()));
         return Number.isFinite(fps) && fps > 0 ? fps : null;
     }
 

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -345,8 +345,13 @@ class VRMManager {
         if (!this._mouseMoveHandler) {
             this._mouseMoveHandler = (event) => {
                 if (!this.isMouseTrackingEnabled()) return;
-                // 供空闲低频 governor 判定"光标最近在动"（legacy 视线跟随路径）
-                this._lastLookAtPointerMoveAt = performance.now();
+                // 供空闲低频 governor 判定"光标最近在动"（legacy 视线跟随路径）。
+                // 坐标没变的重复事件（Electron Pet 的 preload 轮询在光标静止时也会转发）不算，
+                // 否则 VRM 永远降不到空闲帧率。
+                const moved = event.clientX !== this._lastLookAtMouseX || event.clientY !== this._lastLookAtMouseY;
+                this._lastLookAtMouseX = event.clientX;
+                this._lastLookAtMouseY = event.clientY;
+                if (moved) this._lastLookAtPointerMoveAt = performance.now();
                 this._setLookAtTargetByMouse(event.clientX, event.clientY);
             };
             document.addEventListener('mousemove', this._mouseMoveHandler, { passive: true });

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -818,6 +818,8 @@ class VRMManager {
                             this._physicsPendingDelta = pendingDelta + delta;
                             if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);
                             if (this.currentModel.vrm.expressionManager) this.currentModel.vrm.expressionManager.update(delta);
+                            // 跳过的只是弹簧骨物理；MToon 材质的 UV 动画按 delta 累积，每帧都要推进
+                            this._updateVrmMaterials(this.currentModel.vrm, delta);
                         }
                     } else {
                         this._physicsFrameSkip = 0;
@@ -983,14 +985,18 @@ class VRMManager {
             springBones.update(physicsStep);
             if (vrm.lookAt) vrm.lookAt.update(delta);
             if (vrm.expressionManager) vrm.expressionManager.update(delta);
-            if (Array.isArray(vrm.materials)) {
-                vrm.materials.forEach((material) => {
-                    if (material && typeof material.update === 'function') material.update(delta);
-                });
-            }
+            this._updateVrmMaterials(vrm, delta);
             return;
         }
         vrm.update(physicsStep);
+    }
+
+    // MToon 等材质的逐帧推进（three-vrm VRM.update 的最后一步）；跳过物理的帧也要调
+    _updateVrmMaterials(vrm, delta) {
+        if (!vrm || !Array.isArray(vrm.materials)) return;
+        vrm.materials.forEach((material) => {
+            if (material && typeof material.update === 'function') material.update(delta);
+        });
     }
 
     // 当前定时器 tick 频率是否低到不能再隔帧做物理：隔帧后的步长 2×(1000/fps) 必须

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -963,10 +963,11 @@ class VRMManager {
         return Number.isFinite(fps) && fps > 0 ? fps : null;
     }
 
-    // 分量更新：只有弹簧骨物理吃「当前帧 + 上一跳过帧」的累计步长，LookAt / 表情仍按
-    // 当前帧 delta 推进——three-vrm 的 VRM.update(t) 会把 t 一并喂给 lookAt，直接传累计
-    // 步长会让视线在一帧里多走一倍。顺序与 VRM.update 一致：humanoid → 约束 → 弹簧骨 →
-    // lookAt → 表情。没有分量 API（旧版 three-vrm）时退回整体 update。
+    // 分量更新：只有弹簧骨物理吃「当前帧 + 上一跳过帧」的累计步长，LookAt / 表情 / 材质
+    // 仍按当前帧 delta 推进——three-vrm 的 VRM.update(t) 会把 t 一并喂给 lookAt 和 MToon
+    // 材质，直接传累计步长会让视线/材质动画在一帧里多走一倍。顺序与 VRM.update 一致：
+    // humanoid → 约束 → 弹簧骨 → lookAt → 表情 → 材质。没有分量 API（旧版 three-vrm）时
+    // 退回整体 update。
     _updateVrmWithPhysicsStep(vrm, delta, physicsStep) {
         const springBones = vrm.springBoneManager;
         if (springBones && typeof springBones.update === 'function') {
@@ -975,6 +976,11 @@ class VRMManager {
             springBones.update(physicsStep);
             if (vrm.lookAt) vrm.lookAt.update(delta);
             if (vrm.expressionManager) vrm.expressionManager.update(delta);
+            if (Array.isArray(vrm.materials)) {
+                vrm.materials.forEach((material) => {
+                    if (material && typeof material.update === 'function') material.update(delta);
+                });
+            }
             return;
         }
         vrm.update(physicsStep);

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -816,10 +816,9 @@ class VRMManager {
                             this._updateVrmWithPhysicsStep(this.currentModel.vrm, delta, physicsStep);
                         } else {
                             this._physicsPendingDelta = pendingDelta + delta;
-                            if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);
-                            if (this.currentModel.vrm.expressionManager) this.currentModel.vrm.expressionManager.update(delta);
-                            // 跳过的只是弹簧骨物理；MToon 材质的 UV 动画按 delta 累积，每帧都要推进
-                            this._updateVrmMaterials(this.currentModel.vrm, delta);
+                            // 跳过的只是弹簧骨物理：其余分量（humanoid / lookAt / 表情 / 约束 / 材质）
+                            // 仍按库顺序每帧推进，受约束的骨骼不会显示上一帧姿态
+                            this._updateVrmWithoutPhysics(this.currentModel.vrm, delta);
                         }
                     } else {
                         this._physicsFrameSkip = 0;
@@ -980,15 +979,27 @@ class VRMManager {
 
     _updateVrmWithPhysicsStep(vrm, delta, physicsStep) {
         if (this._canSplitVrmPhysicsUpdate(vrm)) {
-            if (vrm.humanoid && typeof vrm.humanoid.update === 'function') vrm.humanoid.update();
-            if (vrm.lookAt) vrm.lookAt.update(delta);
-            if (vrm.expressionManager) vrm.expressionManager.update(delta);
-            if (vrm.nodeConstraintManager && typeof vrm.nodeConstraintManager.update === 'function') vrm.nodeConstraintManager.update();
+            this._updateVrmPoseComponents(vrm, delta);
             vrm.springBoneManager.update(physicsStep);
             this._updateVrmMaterials(vrm, delta);
             return;
         }
         vrm.update(physicsStep);
+    }
+
+    // 跳过弹簧骨物理的帧：除 springBoneManager 外的分量全部按当前 delta 推进（库顺序不变）
+    _updateVrmWithoutPhysics(vrm, delta) {
+        this._updateVrmPoseComponents(vrm, delta);
+        this._updateVrmMaterials(vrm, delta);
+    }
+
+    // VRM.update 里弹簧骨之前的部分：humanoid → lookAt → 表情 → 约束
+    _updateVrmPoseComponents(vrm, delta) {
+        if (!vrm) return;
+        if (vrm.humanoid && typeof vrm.humanoid.update === 'function') vrm.humanoid.update();
+        if (vrm.lookAt) vrm.lookAt.update(delta);
+        if (vrm.expressionManager) vrm.expressionManager.update(delta);
+        if (vrm.nodeConstraintManager && typeof vrm.nodeConstraintManager.update === 'function') vrm.nodeConstraintManager.update();
     }
 
     // MToon 等材质的逐帧推进（three-vrm VRM.update 的最后一步）；跳过物理的帧也要调

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -924,7 +924,9 @@ class VRMManager {
     _resolveActiveTimerTickFps() {
         const pacing = window.nekoFramePacing;
         if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
-        const fps = Number(pacing.activeTimerTickFps());
+        const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
+        const configured = Number.isFinite(raw) ? raw : 60;
+        const fps = Number(pacing.activeTimerTickFps(configured));
         return Number.isFinite(fps) && fps > 0 ? fps : null;
     }
 

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -789,16 +789,24 @@ class VRMManager {
                     // 驱动」：活动态定时器驱动（45/60fps）仍按 medium 隔帧，物理成本不翻倍。
                     // 再按实际 delta 兜底：rAF 路径被配置限到 30~39fps、或定时器抖动时，
                     // 隔帧后的步长 2×delta 超过 50ms clamp 也走全量物理
+                    // 被跳过那一帧的时间累计在 _physicsPendingDelta 里，下一次物理更新把它一起
+                    // 补上；隔帧/全量两种模式之间切换时不丢时间也不重复计时（全量分支同样
+                    // 冲掉累计值并重置奇偶计数，重新进入隔帧模式从"跳过"一帧开始）。
+                    const pendingDelta = this._physicsPendingDelta || 0;
                     if (quality === 'medium' && !this._isLowTickRate() && delta * 2 <= VRM_PHYSICS_MAX_STEP_S) {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
-                            this.currentModel.vrm.update(delta * 2);
+                            this._physicsPendingDelta = 0;
+                            this.currentModel.vrm.update(delta + pendingDelta);
                         } else {
+                            this._physicsPendingDelta = pendingDelta + delta;
                             if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);
                             if (this.currentModel.vrm.expressionManager) this.currentModel.vrm.expressionManager.update(delta);
                         }
                     } else {
-                        this.currentModel.vrm.update(delta);
+                        this._physicsFrameSkip = 0;
+                        this._physicsPendingDelta = 0;
+                        this.currentModel.vrm.update(delta + pendingDelta);
                     }
                 } else {
                     if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -810,7 +810,7 @@ class VRMManager {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
                             this._physicsPendingDelta = 0;
-                            this.currentModel.vrm.update(physicsStep);
+                            this._updateVrmWithPhysicsStep(this.currentModel.vrm, delta, physicsStep);
                         } else {
                             this._physicsPendingDelta = pendingDelta + delta;
                             if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);
@@ -819,7 +819,7 @@ class VRMManager {
                     } else {
                         this._physicsFrameSkip = 0;
                         this._physicsPendingDelta = 0;
-                        this.currentModel.vrm.update(physicsStep);
+                        this._updateVrmWithPhysicsStep(this.currentModel.vrm, delta, physicsStep);
                     }
                 } else {
                     // 物理关闭 / low 画质：清掉隔帧状态，重新开启时从干净状态起步，
@@ -961,6 +961,23 @@ class VRMManager {
         if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
         const fps = Number(pacing.activeTimerTickFps(this._resolveConfiguredTargetFps()));
         return Number.isFinite(fps) && fps > 0 ? fps : null;
+    }
+
+    // 分量更新：只有弹簧骨物理吃「当前帧 + 上一跳过帧」的累计步长，LookAt / 表情仍按
+    // 当前帧 delta 推进——three-vrm 的 VRM.update(t) 会把 t 一并喂给 lookAt，直接传累计
+    // 步长会让视线在一帧里多走一倍。顺序与 VRM.update 一致：humanoid → 约束 → 弹簧骨 →
+    // lookAt → 表情。没有分量 API（旧版 three-vrm）时退回整体 update。
+    _updateVrmWithPhysicsStep(vrm, delta, physicsStep) {
+        const springBones = vrm.springBoneManager;
+        if (springBones && typeof springBones.update === 'function') {
+            if (vrm.humanoid && typeof vrm.humanoid.update === 'function') vrm.humanoid.update();
+            if (vrm.nodeConstraintManager && typeof vrm.nodeConstraintManager.update === 'function') vrm.nodeConstraintManager.update();
+            springBones.update(physicsStep);
+            if (vrm.lookAt) vrm.lookAt.update(delta);
+            if (vrm.expressionManager) vrm.expressionManager.update(delta);
+            return;
+        }
+        vrm.update(physicsStep);
     }
 
     // 当前定时器 tick 频率是否低到不能再隔帧做物理：隔帧后的步长 2×(1000/fps) 必须

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -916,16 +916,39 @@ class VRMManager {
         return configured === 0 ? VRM_IDLE_FPS : Math.min(VRM_IDLE_FPS, configured);
     }
 
-    _enterIdleTickMode() {
-        if (this._idleTickMode) return;
+    // 活动态应改用定时器驱动的帧率（Pet 窗口且配置帧率明显低于显示器刷新率时由
+    // frame-pacing.js 给出）；null = 留在 rAF 驱动。非 Pet 页面没有 nekoFramePacing，恒为 null。
+    _resolveActiveTimerTickFps() {
+        const pacing = window.nekoFramePacing;
+        if (!pacing || typeof pacing.activeTimerTickFps !== 'function') return null;
+        const fps = Number(pacing.activeTimerTickFps());
+        return Number.isFinite(fps) && fps > 0 ? fps : null;
+    }
+
+    _enterIdleTickMode(fps) {
+        const requested = Number(fps);
+        const tickFps = Number.isFinite(requested) && requested > 0 ? requested : this._resolveIdleFps();
+        if (this._idleTickMode) {
+            // 已在定时器模式（空闲地板 ↔ 活动态定时器驱动之间切换）：只换周期，不经过 rAF
+            if (this._idleTickFps === tickFps) return;
+            if (this._idleTickTimer) clearInterval(this._idleTickTimer);
+            this._idleTickTimer = this._startTimerTick(tickFps);
+            return;
+        }
         if (!this.renderer || !this.scene || !this.camera) return;
         // 外部已暂停（pauseRendering 后 rAF 链不存在）：不接管
         if (!this._animationFrameId) return;
         this._idleTickMode = true;
         cancelAnimationFrame(this._animationFrameId);
         this._animationFrameId = null;
-        const intervalMs = Math.max(16, Math.round(1000 / Math.max(1, this._resolveIdleFps())));
-        this._idleTickTimer = setInterval(() => {
+        this._idleTickTimer = this._startTimerTick(tickFps);
+    }
+
+    // 定时器驱动的 tick 循环：空闲地板（30）和活动态定时器驱动（配置帧率）共用，只有周期不同。
+    _startTimerTick(fps) {
+        this._idleTickFps = fps;
+        const intervalMs = Math.max(4, Math.round(1000 / Math.max(1, fps)));
+        return setInterval(() => {
             if (!this._idleTickMode) return;
             if (!this.renderer || !this.scene || !this.camera) { this._exitIdleTickMode(false); return; }
             // 外部代码绕过 startAnimateLoop 拉起了 rAF 链：让位
@@ -946,6 +969,7 @@ class VRMManager {
     _exitIdleTickMode(restartRaf = true) {
         if (!this._idleTickMode) return;
         this._idleTickMode = false;
+        this._idleTickFps = null;
         if (this._idleTickTimer) {
             clearInterval(this._idleTickTimer);
             this._idleTickTimer = null;
@@ -958,9 +982,27 @@ class VRMManager {
         }
     }
 
+    // 帧率设置变更：有活动按新配置重新升帧；空闲定时器模式按新地板换周期。
+    // rAF 驱动路径每帧自己读 window.targetFrameRate，不需要在这里处理。
+    applyTargetFrameRate() {
+        if (!this.renderer || !this.scene || !this.camera) return;
+        if (this._hasRenderActivity()) {
+            this._boostInteractiveFPS();
+        } else if (this._idleTickMode) {
+            this._enterIdleTickMode(this._resolveIdleFps());
+        }
+    }
+
     // 有交互/活动时升回 rAF 满帧，并安排在 durationMs 后无活动则回落空闲低频
     _boostInteractiveFPS(durationMs = VRM_INTERACTIVE_FPS_HOLD_MS) {
-        this._exitIdleTickMode();
+        const timerFps = this._resolveActiveTimerTickFps();
+        if (timerFps != null) {
+            // Pet 窗口且配置帧率低于刷新率：活动态也留在定时器驱动，只把周期换成配置帧率。
+            // 回到 rAF 只会让 Blink 按刷新率跑主帧再跳掉一半，省不出 CPU/GPU。
+            this._enterIdleTickMode(timerFps);
+        } else {
+            this._exitIdleTickMode();
+        }
         if (this._idleFpsRestoreTimer) clearTimeout(this._idleFpsRestoreTimer);
         // 豁免页：只升频、不安排衰减——衰减会在 governor 缺席时把渲染拖回空闲模式
         if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
@@ -2118,3 +2160,11 @@ class VRMManager {
 }
 
 window.VRMManager = VRMManager;
+
+// 监听帧率变更事件（与 live2d-core.js 同名事件对齐）
+window.addEventListener('neko-frame-rate-changed', () => {
+    const manager = window.vrmManager;
+    if (manager && typeof manager.applyTargetFrameRate === 'function') {
+        try { manager.applyTargetFrameRate(); } catch (_) {}
+    }
+});

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -1043,8 +1043,9 @@ class VRMManager {
         try { if (this.interaction && this.interaction.isDragging) return true; } catch (_) {}
         try {
             const cf = this._cursorFollow;
-            // 时间戳 0 是合法值（performance.now() 起点），不能用真值判断
-            if (cf && typeof cf.isEnabled === 'function' && cf.isEnabled() &&
+            // 时间戳 0 是合法值（performance.now() 起点），不能用真值判断；但 CursorFollow
+            // 构造/重置时把 _lastPointerMoveAt 置 0 当「尚无指针输入」，要靠 _hasPointerInput 区分
+            if (cf && typeof cf.isEnabled === 'function' && cf.isEnabled() && cf._hasPointerInput === true &&
                 Number.isFinite(cf._lastPointerMoveAt) && (performance.now() - cf._lastPointerMoveAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
         } catch (_) {}
         try {

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -792,12 +792,20 @@ class VRMManager {
                     // 被跳过那一帧的时间累计在 _physicsPendingDelta 里，下一次物理更新把它一起
                     // 补上；隔帧/全量两种模式之间切换时不丢时间也不重复计时（全量分支同样
                     // 冲掉累计值并重置奇偶计数，重新进入隔帧模式从"跳过"一帧开始）。
+                    // 换了模型：上一模型残留的累计时间/奇偶计数不能带到新模型
+                    if (this._physicsStateModel !== this.currentModel.vrm) {
+                        this._physicsStateModel = this.currentModel.vrm;
+                        this._physicsFrameSkip = 0;
+                        this._physicsPendingDelta = 0;
+                    }
                     const pendingDelta = this._physicsPendingDelta || 0;
+                    // 补上累计时间后的步长仍受 50ms 防爆 clamp
+                    const physicsStep = Math.min(delta + pendingDelta, VRM_PHYSICS_MAX_STEP_S);
                     if (quality === 'medium' && !this._isLowTickRate() && delta * 2 <= VRM_PHYSICS_MAX_STEP_S) {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
                             this._physicsPendingDelta = 0;
-                            this.currentModel.vrm.update(delta + pendingDelta);
+                            this.currentModel.vrm.update(physicsStep);
                         } else {
                             this._physicsPendingDelta = pendingDelta + delta;
                             if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);
@@ -806,9 +814,13 @@ class VRMManager {
                     } else {
                         this._physicsFrameSkip = 0;
                         this._physicsPendingDelta = 0;
-                        this.currentModel.vrm.update(delta + pendingDelta);
+                        this.currentModel.vrm.update(physicsStep);
                     }
                 } else {
+                    // 物理关闭 / low 画质：清掉隔帧状态，重新开启时从干净状态起步，
+                    // 不把旧会话的累计时间套到当前（甚至新）模型上
+                    this._physicsFrameSkip = 0;
+                    this._physicsPendingDelta = 0;
                     if (this.currentModel.vrm.lookAt) this.currentModel.vrm.lookAt.update(delta);
                     if (this.currentModel.vrm.expressionManager) this.currentModel.vrm.expressionManager.update(delta);
                 }

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -548,11 +548,13 @@ VRMManager.prototype._startUIUpdateLoop = function() {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
         if (this._idleTickMode) {
             if (this._uiLoopIdleTimeout) clearTimeout(this._uiLoopIdleTimeout);
+            // 周期跟随渲染 tick 频率：活动态定时器驱动（配置帧率）下按钮跟手，空闲地板下 ~33ms
+            const tickFps = Number(this._idleTickFps) > 0 ? Number(this._idleTickFps) : 30;
             this._uiLoopIdleTimeout = setTimeout(() => {
                 this._uiLoopIdleTimeout = null;
                 if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
                 this._uiUpdateLoopId = requestAnimationFrame(update);
-            }, 33);
+            }, Math.max(4, Math.round(1000 / tickFps)));
             return;
         }
         this._uiUpdateLoopId = requestAnimationFrame(update);

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -541,19 +541,19 @@ VRMManager.prototype._startUIUpdateLoop = function() {
     let lastMobileUpdate = 0;
     const MOBILE_UPDATE_INTERVAL = 100;
 
-    // 空闲低频模式下改用 ~33ms 定时器转一次性 rAF：一次性 rAF 不形成连续
-    // vsync 链，Blink 主帧调度随渲染循环一起降到地板频率。否则本循环单独
-    // 就能把 BeginMainFrame 顶回显示器刷新率，渲染侧的空闲化收益归零。
+    // 定时器驱动模式下本循环也改走定时器、周期跟随渲染 tick（活动态=配置帧率、空闲=地板 30）：
+    // 不排 rAF，Blink 主帧调度才能随渲染循环一起降下来；否则本循环单独就能把
+    // BeginMainFrame 顶回显示器刷新率，渲染侧的收益归零。定时器到点直接调 update，
+    // 不再转一次性 rAF——那会再等一个 vsync，按钮位置比模型慢半拍。
     const scheduleNext = () => {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
         if (this._idleTickMode) {
             if (this._uiLoopIdleTimeout) clearTimeout(this._uiLoopIdleTimeout);
-            // 周期跟随渲染 tick 频率：活动态定时器驱动（配置帧率）下按钮跟手，空闲地板下 ~33ms
             const tickFps = Number(this._idleTickFps) > 0 ? Number(this._idleTickFps) : 30;
             this._uiLoopIdleTimeout = setTimeout(() => {
                 this._uiLoopIdleTimeout = null;
                 if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
-                this._uiUpdateLoopId = requestAnimationFrame(update);
+                update();
             }, Math.max(4, Math.round(1000 / tickFps)));
             return;
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,10 @@
          timer，业务代码之后加载就抓不到早期注册的那些。默认关，靠
          localStorage.NEKO_DEBUG_HEALTH=1 + 刷新启用。详见 static/debug-health.js。 -->
     <script src="/static/debug-health.js?v={{ static_asset_version }}"></script>
+    <!-- 帧率总闸（仅 Electron Pet 窗口生效）：量显示器刷新率，决定 Live2D/VRM/MMD 在
+         配置帧率低于刷新率时改用定时器驱动而非 rAF 跳帧。只在本页加载；其它页面不加载
+         即保持原行为。详见 static/frame-pacing.js。 -->
+    <script src="/static/frame-pacing.js?v={{ static_asset_version }}"></script>
     <!-- i18next 加载器（统一处理 CDN 加载和初始化） -->
     <script src="/static/i18n-i18next.js?v={{ static_asset_version }}"></script>
     <script src="/static/common_dialogs.js?v={{ static_asset_version }}"></script>

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -155,6 +155,24 @@ test('frame-pacing：Pet 窗口先量出刷新率，配置明显低于刷新率�
     assert.equal(pacing.activeTimerTickFps(), 30);
 }));
 
+test('frame-pacing：重测超时要作废旧刷新率，回到保守 rAF', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    sb.measureRefresh(60);
+    assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), 45);
+    // 跨屏事件触发重测，但 rAF 一帧都不来 → 3s 超时
+    sb.window.dispatchEvent({ type: 'electron-display-changed' });
+    // mock timers 不会在同一次 tick 里跑 tick 期间新排的定时器：先到采样起点，再跨过超时
+    mock.timers.tick(1500);
+    mock.timers.tick(3000);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), null, '超时后旧值作废');
+    assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), null, '未知刷新率 → rAF');
+    // 再来一次重测成功 → 恢复
+    sb.window.dispatchEvent({ type: 'electron-display-changed' });
+    sb.measureRefresh(120);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), 120);
+    assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), 45);
+}));
+
 test('frame-pacing：144Hz 屏上 60fps 配置也切定时器驱动', withMockTimers(() => {
     const sb = createSandbox({ pet: true, targetFrameRate: 60 });
     sb.measureRefresh(144);
@@ -293,12 +311,14 @@ test('VRM Pet + 配置低于刷新率：活动态定时器驱动，衰减只换�
     mgr._boostInteractiveFPS();
     assert.equal(mgr._idleTickMode, true);
     assert.equal(mgr._idleTickFps, 45);
+    assert.equal(mgr._isLowTickRate(), false, '活动态 45fps 定时器驱动不算低频：medium 隔帧物理照常');
     assert.equal(mgr._animationFrameId, null, 'rAF 链已停');
     mock.timers.tick(22 * 5);
     assert.ok(mgr.renders >= 4, '按 45fps 定时渲染');
     mock.timers.tick(1000);
     assert.equal(mgr._idleTickMode, true);
     assert.equal(mgr._idleTickFps, 30);
+    assert.equal(mgr._isLowTickRate(), true, '30fps 地板才绕过隔帧物理');
     assert.equal(sb.rafQueue.length, 0, '从未重新排 rAF');
     // 设置变更事件驱动换周期
     sb.window.targetFrameRate = 24;

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -377,8 +377,11 @@ test('MMD：目标帧率接到设置里的帧率滑块，0 = 不限帧', withMoc
     assert.equal(core.frameTime, 1000 / 24);
     assert.equal(core._resolveIdleFps(), 24);
     delete sb.window.targetFrameRate;
-    core._refreshTargetFps();
-    assert.ok([30, 45, 60].includes(core.targetFPS), '没有该配置时退回 performanceMode 档位');
+    for (const [mode, expected] of [['low', 30], ['medium', 45], ['high', 60]]) {
+        core.performanceMode = mode;
+        core._refreshTargetFps();
+        assert.equal(core.targetFPS, expected, `没有该配置时退回 performanceMode=${mode} 的档位`);
+    }
 }));
 
 test('MMD rAF 路径：不限帧后切回有限帧率，节流状态不能被 NaN 污染', withMockTimers(() => {
@@ -405,12 +408,14 @@ test('MMD Pet 没有 window.targetFrameRate 时，总闸按 MMD 自己的 perfor
     delete sb.window.targetFrameRate;
     sb.measureRefresh(144);
     const { core } = setupMMD(sb);
-    const fallback = core._resolveConfiguredTargetFps();
-    assert.ok([30, 45, 60].includes(fallback));
     assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), 60, '总闸自己的缺省是 60');
-    assert.equal(core._resolveActiveTimerTickFps(), fallback, 'MMD 把自己解析的帧率交给总闸');
-    core._boostInteractiveFPS();
-    assert.equal(core._idleTickFps, fallback, '活动态定时器周期 = MMD 回退值');
+    for (const [mode, expected] of [['low', 30], ['medium', 45], ['high', 60]]) {
+        core.performanceMode = mode;
+        assert.equal(core._resolveConfiguredTargetFps(), expected);
+        assert.equal(core._resolveActiveTimerTickFps(), expected, `MMD 把自己解析的 ${mode} 档帧率交给总闸`);
+        core._boostInteractiveFPS();
+        assert.equal(core._idleTickFps, expected, `活动态定时器周期 = ${mode} 档回退值`);
+    }
 }));
 
 test('MMD：交互升帧的 900ms 保持期到期后活动判定失效', withMockTimers(() => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -102,7 +102,7 @@ function createSandbox({ pet, targetFrameRate }) {
     // （_hasRenderActivity 的 900ms 窗口）也随时间失效
     const tick = (ms) => {
         frameClock += ms;
-        sb.tick(ms);
+        mock.timers.tick(ms);
     };
     const measureRefresh = (hz) => {
         // frame-pacing：load 后延迟 1500ms 才开始采样，采 24 帧

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -262,8 +262,14 @@ test('契约：VRM / MMD 浮动按钮循环在定时器模式下到点直接 upd
         assert.ok(start > 0 && end > start, file + ' scheduleNext 定位失败');
         const body = src.slice(start, end);
         assert.match(body, new RegExp('const tickFps = Number\\(' + fpsExpr + '\\) > 0 \\? Number\\(' + fpsExpr + '\\) : 30;'), file + ' 周期跟随渲染 tick');
-        assert.match(body, /this\._uiLoopIdleTimeout = setTimeout\(\(\) => \{[\s\S]*?update\(\);\s*\}, Math\.max\(4, Math\.round\(1000 \/ tickFps\)\)\);/, file + ' 定时器到点直接 update');
-        assert.equal((body.match(/requestAnimationFrame\(update\)/g) || []).length, 1, file + ' 只有 rAF 模式那一处排 rAF');
+        const cbStart = body.indexOf('this._uiLoopIdleTimeout = setTimeout(() => {');
+        const cbEnd = body.indexOf('}, Math.max(4, Math.round(1000 / tickFps)));', cbStart);
+        assert.ok(cbStart >= 0 && cbEnd > cbStart, file + ' 定时器回调定位失败');
+        const timerCallback = body.slice(cbStart, cbEnd);
+        assert.match(timerCallback, /update\(\);\s*$/, file + ' 定时器到点直接 update');
+        assert.doesNotMatch(timerCallback, /requestAnimationFrame/, file + ' 定时器回调里不允许再排任何 rAF');
+        const outsideTimer = body.slice(0, cbStart) + body.slice(cbEnd);
+        assert.equal((outsideTimer.match(/requestAnimationFrame\(/g) || []).length, 1, file + ' 只有 rAF 模式那一处排 rAF');
     }
 });
 

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -597,8 +597,11 @@ test('MMD / VRM：时间戳 0 是合法的活动时间戳，不能被当成未�
         assert.equal(vrm._hasRenderActivity(), true, `VRM ${key} = 0 在保持期内算活动`);
         vrm[key] = undefined;
     }
-    vrm._cursorFollow = { isEnabled: () => true, _lastPointerMoveAt: 0 };
-    assert.equal(vrm._hasRenderActivity(), true, 'VRM 光标时间戳 0 在保持期内算活动');
+    // CursorFollow 构造/重置时 _lastPointerMoveAt = 0 表示「尚无指针输入」，必须靠 _hasPointerInput 区分
+    vrm._cursorFollow = { isEnabled: () => true, _lastPointerMoveAt: 0, _hasPointerInput: false };
+    assert.equal(vrm._hasRenderActivity(), false, '尚无指针输入时 0 不算活动');
+    vrm._cursorFollow = { isEnabled: () => true, _lastPointerMoveAt: 0, _hasPointerInput: true };
+    assert.equal(vrm._hasRenderActivity(), true, '有过指针输入时时间戳 0 在保持期内算活动');
     sb2.tick(901);
     assert.equal(vrm._hasRenderActivity(), false);
 }));

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -588,7 +588,7 @@ test('负数 targetFrameRate 一律归一为 60：Live2D / VRM / MMD 地板都�
 test('契约：VRM medium 隔帧物理按实际 delta 兜底，且模式切换不丢/不重复物理时间', () => {
     const src = read('static/vrm/vrm-manager.js');
     assert.match(src, /const VRM_PHYSICS_MAX_STEP_S = 0\.05;/);
-    assert.match(src, /if \(quality === 'medium' && !this\._isLowTickRate\(\) && delta \* 2 <= VRM_PHYSICS_MAX_STEP_S\) \{/);
+    assert.match(src, /if \(quality === 'medium' && canSplitPhysics && !this\._isLowTickRate\(\) && delta \* 2 <= VRM_PHYSICS_MAX_STEP_S\) \{/);
     // 跳过帧累计时间，物理更新时补上（受 clamp）；全量分支冲掉累计并重置奇偶计数
     assert.match(src, /this\._physicsPendingDelta = pendingDelta \+ delta;/);
     assert.match(src, /const physicsStep = Math\.min\(delta \+ pendingDelta, VRM_PHYSICS_MAX_STEP_S\);/);
@@ -607,7 +607,11 @@ function loadVrmPhysicsStep() {
     const helperStart = src.indexOf('_updateVrmWithPhysicsStep(vrm, delta, physicsStep) {');
     const helperEnd = src.indexOf('\n    }\n', helperStart) + 7;
     assert.ok(helperStart > 0 && helperEnd > helperStart, '_updateVrmWithPhysicsStep 定位失败');
-    const helperSrc = 'this._updateVrmWithPhysicsStep = function ' + src.slice(helperStart, helperEnd) + ';';
+    const canSplitStart = src.indexOf('_canSplitVrmPhysicsUpdate(vrm) {');
+    const canSplitEnd = src.indexOf('\n    }\n', canSplitStart) + 7;
+    assert.ok(canSplitStart > 0 && canSplitEnd > canSplitStart, '_canSplitVrmPhysicsUpdate 定位失败');
+    const helperSrc = 'this._canSplitVrmPhysicsUpdate = function ' + src.slice(canSplitStart, canSplitEnd) + ';'
+        + 'this._updateVrmWithPhysicsStep = function ' + src.slice(helperStart, helperEnd) + ';';
     return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', helperSrc + src.slice(start, end));
 }
 function makeVrmPhysicsCtx({ componentApi = true } = {}) {
@@ -637,10 +641,14 @@ test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt / MToon 材质每 
     assert.deepEqual(ctx.lookAtTime, frames, 'LookAt 每帧只拿当前 delta，不吃累计');
     // 跳过帧不更新材质（与旧行为一致），更新帧材质拿当前 delta 而不是累计步长
     assert.deepEqual(ctx.materialTime, [0.0167, 0.0333, 0.0167], '材质只在物理更新帧按当前 delta 推进');
-    // 旧版 three-vrm（无 springBoneManager.update）退回整体 update
+    // 旧版 three-vrm（无 springBoneManager.update）：不隔帧，每帧整体 update(delta)，
+    // 累计步长不会喂给 lookAt/材质
     const legacy = makeVrmPhysicsCtx({ componentApi: false });
-    for (const d of [0.0167, 0.0167]) run.call(legacy, d, { renderQuality: 'medium' }, 0.05);
-    assert.ok(Math.abs(legacy.simulated - 0.0334) < 1e-9, '退回整体 update 时物理时间仍守恒');
+    const legacyFrames = [0.0167, 0.0167, 0.0167];
+    for (const d of legacyFrames) run.call(legacy, d, { renderQuality: 'medium' }, 0.05);
+    assert.ok(Math.abs(legacy.simulated - 0.0501) < 1e-9, '旧版每帧都整体 update');
+    assert.deepEqual(legacy.lookAtTime, legacyFrames, '旧版 lookAt 每帧只拿当前 delta');
+    assert.equal(legacy._physicsPendingDelta, 0, '旧版从不累计跳帧时间');
 });
 
 test('VRM 物理隔帧：隔帧↔全量切换时物理时间总和 = 实际经过时间', () => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -542,29 +542,73 @@ test('契约：VRM medium 隔帧物理按实际 delta 兜底，且模式切换�
     const src = read('static/vrm/vrm-manager.js');
     assert.match(src, /const VRM_PHYSICS_MAX_STEP_S = 0\.05;/);
     assert.match(src, /if \(quality === 'medium' && !this\._isLowTickRate\(\) && delta \* 2 <= VRM_PHYSICS_MAX_STEP_S\) \{/);
-    // 跳过帧累计时间，物理更新时补上；全量分支冲掉累计并重置奇偶计数
+    // 跳过帧累计时间，物理更新时补上（受 clamp）；全量分支冲掉累计并重置奇偶计数
     assert.match(src, /this\._physicsPendingDelta = pendingDelta \+ delta;/);
-    assert.match(src, /this\._physicsPendingDelta = 0;\s*this\.currentModel\.vrm\.update\(delta \+ pendingDelta\);/);
-    assert.match(src, /\} else \{\s*this\._physicsFrameSkip = 0;\s*this\._physicsPendingDelta = 0;\s*this\.currentModel\.vrm\.update\(delta \+ pendingDelta\);/);
+    assert.match(src, /const physicsStep = Math\.min\(delta \+ pendingDelta, VRM_PHYSICS_MAX_STEP_S\);/);
+    assert.match(src, /\} else \{\s*this\._physicsFrameSkip = 0;\s*this\._physicsPendingDelta = 0;\s*this\.currentModel\.vrm\.update\(physicsStep\);/);
     assert.doesNotMatch(src, /vrm\.update\(delta \* 2\)/, '不再盲目用 delta*2，改用实际累计时间');
 });
 
-test('VRM 物理隔帧：隔帧↔全量切换时物理时间总和 = 实际经过时间', () => {
-    // 把源码里的物理分支抠出来单独执行，验证时间守恒
+// 把源码里「5. VRM 核心更新」整段抠出来单独执行（含 enablePhysics / 画质 / 换模型 / 隔帧分支）
+function loadVrmPhysicsStep() {
     const src = read('static/vrm/vrm-manager.js');
-    const start = src.indexOf('const pendingDelta = this._physicsPendingDelta || 0;');
-    const end = src.indexOf('} else {', src.indexOf('this.currentModel.vrm.update(delta + pendingDelta);', src.indexOf('this._physicsFrameSkip = 0;', start)));
-    assert.ok(start > 0 && end > start, '物理分支定位失败');
-    const branch = src.slice(start, end);
-    const VRM_PHYSICS_MAX_STEP_S = 0.05;
-    let simulated = 0;
-    const ctx = { _isLowTickRate: () => false, currentModel: { vrm: { update: (d) => { simulated += d; }, lookAt: { update() {} }, expressionManager: { update() {} } } } };
-    const run = new Function('delta', 'quality', 'VRM_PHYSICS_MAX_STEP_S', branch);
+    const start = src.indexOf("const quality = window.renderQuality || 'medium';");
+    const end = src.indexOf('// 6. CursorFollow', start);
+    assert.ok(start > 0 && end > start, 'VRM 物理段定位失败');
+    return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', src.slice(start, end));
+}
+function makeVrmPhysicsCtx() {
+    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, currentModel: null };
+    ctx.newModel = () => { ctx.currentModel = { vrm: { update: (d) => { ctx.simulated += d; }, lookAt: { update() {} }, expressionManager: { update() {} } } }; };
+    ctx.newModel();
+    return ctx;
+}
+
+test('VRM 物理隔帧：隔帧↔全量切换时物理时间总和 = 实际经过时间', () => {
+    const run = loadVrmPhysicsStep();
+    const ctx = makeVrmPhysicsCtx();
     // 60fps 隔帧 4 帧 → 切到 30fps 全量 3 帧 → 回 60fps 隔帧 4 帧
     const frames = [0.0167, 0.0167, 0.0167, 0.0167, 0.0333, 0.0333, 0.0333, 0.0167, 0.0167, 0.0167, 0.0167];
     let elapsed = 0;
-    for (const d of frames) { elapsed += d; run.call(ctx, d, 'medium', VRM_PHYSICS_MAX_STEP_S); }
-    assert.ok(Math.abs(simulated - elapsed) < 1e-9, `物理累计 ${simulated} 应等于实际 ${elapsed}`);
+    for (const d of frames) { elapsed += d; run.call(ctx, d, { renderQuality: 'medium' }, 0.05); }
+    assert.ok(Math.abs(ctx.simulated - elapsed) < 1e-9, `物理累计 ${ctx.simulated} 应等于实际 ${elapsed}`);
+});
+
+test('VRM 物理隔帧：关物理 / 切 low / 换模型都清掉累计时间，不把旧会话的 pending 套到新模型', () => {
+    const run = loadVrmPhysicsStep();
+    // 奇数帧后关闭物理 → pending 必须被清
+    let ctx = makeVrmPhysicsCtx();
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.equal(ctx._physicsPendingDelta, 0.0167, '奇数帧累计了一帧');
+    ctx.enablePhysics = false;
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.equal(ctx._physicsPendingDelta, 0, '关物理时清掉累计');
+    assert.equal(ctx._physicsFrameSkip, 0);
+    ctx.enablePhysics = true;
+    ctx.simulated = 0;
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.equal(ctx.simulated, 0, '重新开启后首帧是干净的「跳过」帧，不会套旧 pending');
+    // 奇数帧后切 low 画质 → 同样清
+    ctx = makeVrmPhysicsCtx();
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    run.call(ctx, 0.0167, { renderQuality: 'low' }, 0.05);
+    assert.equal(ctx._physicsPendingDelta, 0, 'low 画质清掉累计');
+    // 奇数帧后换模型 → 新模型不吃旧 pending
+    ctx = makeVrmPhysicsCtx();
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    ctx.newModel();
+    ctx.simulated = 0;
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.equal(ctx.simulated, 0, '换模型后首帧不套旧 pending');
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.ok(Math.abs(ctx.simulated - 0.0334) < 1e-9, '新模型自己的两帧才合并更新');
+    // 累计后的步长仍受 50ms clamp
+    ctx = makeVrmPhysicsCtx();
+    run.call(ctx, 0.0167, { renderQuality: 'medium' }, 0.05); // 绑定模型 + 奇数帧
+    ctx._physicsPendingDelta = 0.05; // 模拟极端累计
+    ctx.simulated = 0;
+    run.call(ctx, 0.02, { renderQuality: 'medium' }, 0.05);
+    assert.equal(ctx.simulated, 0.05, '步长不超过防爆上限');
 });
 
 test('MMD：目标帧率接到设置里的帧率滑块，0 = 不限帧', withMockTimers(() => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -619,9 +619,16 @@ function setupMMD(sb) {
 
 test('负数 targetFrameRate 一律归一为 60：Live2D / VRM / MMD 地板都不会算成负数', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: -1 });
-    const { mgr } = setupLive2D(sb);
+    const { mgr, app } = setupLive2D(sb);
     assert.equal(mgr._resolveConfiguredTargetFps(), 60);
     assert.equal(mgr._resolveIdleFps(), 30);
+    // setTargetFPS(-1) 不能把负数写进配置 / PIXI maxFPS（豁免分支直接落 maxFPS，PIXI 会钳到 minFPS=10）
+    sb.window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;
+    mgr.setTargetFPS(-1);
+    assert.equal(sb.window.targetFrameRate, 60, '负数配置归一为 60 再写入');
+    assert.equal(app.ticker.maxFPS, 60, '豁免分支写进 PIXI 的是归一化后的值');
+    delete sb.window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__;
+    assert.doesNotMatch(LIVE2D_CORE_SRC, /this\.pixi_app\.ticker\.maxFPS = window\.targetFrameRate;/, 'initPIXI 也不允许裸写配置进 maxFPS');
     const sb2 = createSandbox({ pet: false, targetFrameRate: -1 });
     const vrm = setupVRM(sb2);
     assert.equal(vrm._resolveConfiguredTargetFps(), 60);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -66,12 +66,14 @@ function createSandbox({ pet, targetFrameRate }) {
         createElement() { return { style: {} }; },
         body: { classList: { contains() { return false; } } },
     };
+    // 沙盒时钟：随 pumpFrames 推进；rAF 时间戳与 performance.now() 同源
+    let frameClock = 0;
     const sandbox = {
         window,
         document,
         PIXI,
         console: { log() {}, warn() {}, error() {}, info() {}, debug() {} },
-        performance,
+        performance: { now: () => frameClock },
         navigator: window.navigator,
         localStorage: window.localStorage,
         // 走 globalThis 间接调用，让 node:test 的 mock timers 生效
@@ -88,7 +90,6 @@ function createSandbox({ pet, targetFrameRate }) {
     vm.createContext(sandbox);
     vm.runInContext(FRAME_PACING_SRC, sandbox, { filename: 'frame-pacing.js' });
 
-    let frameClock = 0;
     // 手动推 n 个 rAF 帧，时间戳按 hz 递增
     const pumpFrames = (n, hz) => {
         for (let i = 0; i < n; i++) {
@@ -347,6 +348,25 @@ test('MMD：目标帧率接到设置里的帧率滑块，0 = 不限帧', withMoc
     delete sb.window.targetFrameRate;
     core._refreshTargetFps();
     assert.ok([30, 45, 60].includes(core.targetFPS), '没有该配置时退回 performanceMode 档位');
+}));
+
+test('MMD rAF 路径：不限帧后切回有限帧率，节流状态不能被 NaN 污染', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 0 });
+    const { core, manager } = setupMMD(sb);
+    manager._animationFrameId = null;
+    // 不限帧：连续 rAF 全部渲染
+    core._render();
+    sb.pumpFrames(1, 60);
+    sb.pumpFrames(1, 60);
+    assert.equal(core.renders, 3, '不限帧时每个 rAF 都渲染');
+    assert.ok(Number.isFinite(core.lastFrameTime), 'lastFrameTime 必须是有限数');
+    // 切回 45fps：60Hz 推 60 帧应只渲染约 45 帧
+    sb.window.targetFrameRate = 45;
+    const before = core.renders;
+    sb.pumpFrames(60, 60);
+    const rendered = core.renders - before;
+    assert.ok(rendered >= 40 && rendered <= 50, `切回 45fps 后应重新节流，实际渲染 ${rendered}/60`);
+    assert.ok(Number.isFinite(core.lastFrameTime));
 }));
 
 test('MMD Pet + 配置低于刷新率：活动态定时器驱动，衰减只换周期', withMockTimers(() => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -538,10 +538,33 @@ test('负数 targetFrameRate 一律归一为 60：Live2D / VRM / MMD 地板都�
     assert.equal(core._resolveIdleFps(), Math.min(30, core._resolveConfiguredTargetFps()));
 }));
 
-test('契约：VRM medium 隔帧物理还要按实际 delta 兜底（2×delta ≤ 50ms 才隔帧）', () => {
+test('契约：VRM medium 隔帧物理按实际 delta 兜底，且模式切换不丢/不重复物理时间', () => {
     const src = read('static/vrm/vrm-manager.js');
     assert.match(src, /const VRM_PHYSICS_MAX_STEP_S = 0\.05;/);
     assert.match(src, /if \(quality === 'medium' && !this\._isLowTickRate\(\) && delta \* 2 <= VRM_PHYSICS_MAX_STEP_S\) \{/);
+    // 跳过帧累计时间，物理更新时补上；全量分支冲掉累计并重置奇偶计数
+    assert.match(src, /this\._physicsPendingDelta = pendingDelta \+ delta;/);
+    assert.match(src, /this\._physicsPendingDelta = 0;\s*this\.currentModel\.vrm\.update\(delta \+ pendingDelta\);/);
+    assert.match(src, /\} else \{\s*this\._physicsFrameSkip = 0;\s*this\._physicsPendingDelta = 0;\s*this\.currentModel\.vrm\.update\(delta \+ pendingDelta\);/);
+    assert.doesNotMatch(src, /vrm\.update\(delta \* 2\)/, '不再盲目用 delta*2，改用实际累计时间');
+});
+
+test('VRM 物理隔帧：隔帧↔全量切换时物理时间总和 = 实际经过时间', () => {
+    // 把源码里的物理分支抠出来单独执行，验证时间守恒
+    const src = read('static/vrm/vrm-manager.js');
+    const start = src.indexOf('const pendingDelta = this._physicsPendingDelta || 0;');
+    const end = src.indexOf('} else {', src.indexOf('this.currentModel.vrm.update(delta + pendingDelta);', src.indexOf('this._physicsFrameSkip = 0;', start)));
+    assert.ok(start > 0 && end > start, '物理分支定位失败');
+    const branch = src.slice(start, end);
+    const VRM_PHYSICS_MAX_STEP_S = 0.05;
+    let simulated = 0;
+    const ctx = { _isLowTickRate: () => false, currentModel: { vrm: { update: (d) => { simulated += d; }, lookAt: { update() {} }, expressionManager: { update() {} } } } };
+    const run = new Function('delta', 'quality', 'VRM_PHYSICS_MAX_STEP_S', branch);
+    // 60fps 隔帧 4 帧 → 切到 30fps 全量 3 帧 → 回 60fps 隔帧 4 帧
+    const frames = [0.0167, 0.0167, 0.0167, 0.0167, 0.0333, 0.0333, 0.0333, 0.0167, 0.0167, 0.0167, 0.0167];
+    let elapsed = 0;
+    for (const d of frames) { elapsed += d; run.call(ctx, d, 'medium', VRM_PHYSICS_MAX_STEP_S); }
+    assert.ok(Math.abs(simulated - elapsed) < 1e-9, `物理累计 ${simulated} 应等于实际 ${elapsed}`);
 });
 
 test('MMD：目标帧率接到设置里的帧率滑块，0 = 不限帧', withMockTimers(() => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -574,24 +574,53 @@ test('契约：VRM medium 隔帧物理按实际 delta 兜底，且模式切换�
     // 跳过帧累计时间，物理更新时补上（受 clamp）；全量分支冲掉累计并重置奇偶计数
     assert.match(src, /this\._physicsPendingDelta = pendingDelta \+ delta;/);
     assert.match(src, /const physicsStep = Math\.min\(delta \+ pendingDelta, VRM_PHYSICS_MAX_STEP_S\);/);
-    assert.match(src, /\} else \{\s*this\._physicsFrameSkip = 0;\s*this\._physicsPendingDelta = 0;\s*this\.currentModel\.vrm\.update\(physicsStep\);/);
+    assert.match(src, /\} else \{\s*this\._physicsFrameSkip = 0;\s*this\._physicsPendingDelta = 0;\s*this\._updateVrmWithPhysicsStep\(this\.currentModel\.vrm, delta, physicsStep\);/);
     assert.doesNotMatch(src, /vrm\.update\(delta \* 2\)/, '不再盲目用 delta*2，改用实际累计时间');
+    assert.doesNotMatch(src.slice(src.indexOf("const quality = window.renderQuality"), src.indexOf('// 6. CursorFollow')), /currentModel\.vrm\.update\(/, '物理段不再直接整体 vrm.update，累计步长只喂弹簧骨');
 });
 
-// 把源码里「5. VRM 核心更新」整段抠出来单独执行（含 enablePhysics / 画质 / 换模型 / 隔帧分支）
+// 把源码里「5. VRM 核心更新」整段 + _updateVrmWithPhysicsStep 抠出来单独执行
+// （含 enablePhysics / 画质 / 换模型 / 隔帧分支）
 function loadVrmPhysicsStep() {
     const src = read('static/vrm/vrm-manager.js');
     const start = src.indexOf("const quality = window.renderQuality || 'medium';");
     const end = src.indexOf('// 6. CursorFollow', start);
     assert.ok(start > 0 && end > start, 'VRM 物理段定位失败');
-    return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', src.slice(start, end));
+    const helperStart = src.indexOf('_updateVrmWithPhysicsStep(vrm, delta, physicsStep) {');
+    const helperEnd = src.indexOf('\n    }\n', helperStart) + 7;
+    assert.ok(helperStart > 0 && helperEnd > helperStart, '_updateVrmWithPhysicsStep 定位失败');
+    const helperSrc = 'this._updateVrmWithPhysicsStep = function ' + src.slice(helperStart, helperEnd) + ';';
+    return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', helperSrc + src.slice(start, end));
 }
-function makeVrmPhysicsCtx() {
-    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, currentModel: null };
-    ctx.newModel = () => { ctx.currentModel = { vrm: { update: (d) => { ctx.simulated += d; }, lookAt: { update() {} }, expressionManager: { update() {} } } }; };
+function makeVrmPhysicsCtx({ componentApi = true } = {}) {
+    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, lookAtTime: [], currentModel: null };
+    ctx.newModel = () => {
+        const vrm = {
+            update: (d) => { ctx.simulated += d; ctx.lookAtTime.push(d); },
+            lookAt: { update: (d) => { ctx.lookAtTime.push(d); } },
+            expressionManager: { update() {} },
+            humanoid: { update() {} },
+        };
+        if (componentApi) vrm.springBoneManager = { update: (d) => { ctx.simulated += d; } };
+        ctx.currentModel = { vrm };
+    };
     ctx.newModel();
     return ctx;
 }
+
+test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt 每 tick 只推进当前 delta', () => {
+    const run = loadVrmPhysicsStep();
+    const ctx = makeVrmPhysicsCtx();
+    const frames = [0.0167, 0.0167, 0.0333, 0.0167, 0.0167];
+    let elapsed = 0;
+    for (const d of frames) { elapsed += d; run.call(ctx, d, { renderQuality: 'medium' }, 0.05); }
+    assert.ok(Math.abs(ctx.simulated - elapsed) < 1e-9, '弹簧骨物理时间守恒');
+    assert.deepEqual(ctx.lookAtTime, frames, 'LookAt 每帧只拿当前 delta，不吃累计');
+    // 旧版 three-vrm（无 springBoneManager.update）退回整体 update
+    const legacy = makeVrmPhysicsCtx({ componentApi: false });
+    for (const d of [0.0167, 0.0167]) run.call(legacy, d, { renderQuality: 'medium' }, 0.05);
+    assert.ok(Math.abs(legacy.simulated - 0.0334) < 1e-9, '退回整体 update 时物理时间仍守恒');
+});
 
 test('VRM 物理隔帧：隔帧↔全量切换时物理时间总和 = 实际经过时间', () => {
     const run = loadVrmPhysicsStep();

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -138,10 +138,16 @@ function setupLive2D(sb) {
     const origStart = app.ticker.start.bind(app.ticker);
     mgr._tickerOrigStop = origStop;
     mgr._tickerOrigStart = origStart;
-    app.ticker.stop = function () { mgr._exitIdleTickMode(); return origStop(); };
-    app.ticker.start = function () { mgr._exitIdleTickMode(); return origStart(); };
+    // 与 live2d-core.js initPIXI 里的包装保持一致（下面有契约断言防漂移）
+    app.ticker.stop = function () { mgr._exitIdleTickMode({ restartGlobals: false }); return origStop(); };
+    app.ticker.start = function () { mgr._exitIdleTickMode(); mgr._releaseGlobalTickers(); return origStart(); };
     return { mgr, app, shared: sb.PIXI.Ticker.shared, system: sb.PIXI.Ticker.system };
 }
+
+test('契约：initPIXI 的 ticker.stop/start 包装语义与测试复刻一致', () => {
+    assert.match(LIVE2D_CORE_SRC, /ticker\.stop = function \(\) \{ mgr\._exitIdleTickMode\(\{ restartGlobals: false \}\); return origStop\(\); \};/);
+    assert.match(LIVE2D_CORE_SRC, /ticker\.start = function \(\) \{ mgr\._exitIdleTickMode\(\); mgr\._releaseGlobalTickers\(\); return origStart\(\); \};/);
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // frame-pacing.js
@@ -339,6 +345,47 @@ test('Live2D Pet + 配置 = 刷新率：rAF 模式接管 shared/system 的 maxFP
     assert.equal(app.ticker.maxFPS, 0);
     assert.equal(shared.maxFPS, 0);
 }));
+
+test('Live2D：外部 ticker.stop()（切 VRM/MMD、pauseRendering）退出定时器模式时不拉起全局 ticker；start() 再拉回', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 30 });
+    sb.measureRefresh(60);
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    shared.maxFPS = 0;
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true);
+    assert.equal(shared.started, false);
+    app.ticker.stop(); // 切角色 / pauseRendering 走的是包装后的 stop
+    assert.ok(!mgr._idleTickMode);
+    assert.equal(app.ticker.started, false);
+    assert.equal(shared.started, false, 'Live2D 停了，shared 不能被拉起来空跑 rAF');
+    assert.equal(system.started, false, 'system 同理');
+    app.ticker.start(); // 切回 Live2D
+    assert.equal(app.ticker.started, true);
+    assert.equal(shared.started, true, '回到 Live2D 时全局 ticker 一并恢复');
+    assert.equal(system.started, true);
+    assert.equal(shared.maxFPS, 30, '恢复时帧率上限也恢复到配置值');
+}));
+
+test('Live2D：光标停在悬停范围内（isFocusing 常驻）不算持续活动，保持期过后可进空闲', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 60 });
+    const { mgr } = setupLive2D(sb);
+    sb.tick(1000);
+    mgr.isFocusing = true;
+    assert.equal(mgr._hasRenderActivity(), false, '没有任何指针位移记录时 isFocusing 不算活动');
+    mgr._lastPointerMoveAt = sb.sandbox.performance.now();
+    assert.equal(mgr._hasRenderActivity(), true, '刚动过算活动');
+    sb.tick(899);
+    assert.equal(mgr._hasRenderActivity(), true);
+    sb.tick(2);
+    assert.equal(mgr._hasRenderActivity(), false, '保持期过后视线目标已收敛，不再算活动');
+    mgr._isDraggingModel = true;
+    assert.equal(mgr._hasRenderActivity(), true, '拖拽仍无条件算活动');
+}));
+
+test('契约：Live2D 交互层在坐标变化时记录 _lastPointerMoveAt', () => {
+    const src = read('static/live2d/live2d-interaction.js');
+    assert.match(src, /if \(pointerMoved\) this\._lastPointerMoveAt = performance\.now\(\);/);
+});
 
 test('Live2D：外部 pauseRendering 时不接管；ticker.start() 让位后 governor 自愈回定时器', withMockTimers(() => {
     const sb = createSandbox({ pet: true, targetFrameRate: 30 });

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -366,6 +366,22 @@ test('Live2D：外部 ticker.stop()（切 VRM/MMD、pauseRendering）退出定�
     assert.equal(shared.maxFPS, 30, '恢复时帧率上限也恢复到配置值');
 }));
 
+test('Live2D：stop() 后直接销毁（不经 start）也必须释放全局 ticker，否则重建后模型 autoUpdate 冻住', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 30 });
+    sb.measureRefresh(60);
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    mgr._startIdleFpsGovernor();
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true);
+    app.ticker.stop();
+    assert.equal(shared.started, false);
+    mgr._stopIdleFpsGovernor(); // destroy / 重建路径
+    assert.equal(shared.started, true, '销毁时释放被扣住的 shared');
+    assert.equal(system.started, true, '销毁时释放被扣住的 system');
+    mgr._stopIdleFpsGovernor();
+    assert.equal(shared.startCalls, 1, '释放幂等，不重复 start');
+}));
+
 test('Live2D：光标停在悬停范围内（isFocusing 常驻）不算持续活动，保持期过后可进空闲', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: 60 });
     const { mgr } = setupLive2D(sb);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -276,6 +276,26 @@ test('契约：麦克风音量监测与口型同步循环通过 frame-pacing 排
     assert.doesNotMatch(lipSyncBody, /S\.animationFrameId = requestAnimationFrame\(animate\)/, 'startLipSync 内不允许直接排 rAF');
 });
 
+test('frame-pacing：采样进行中再来一次重测请求不丢，当前轮结束后紧接着再测', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    sb.measureRefresh(60);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), 60);
+    // 第一次跨屏：采样开始但一帧没推（慢采样中）
+    sb.window.dispatchEvent({ type: 'electron-display-changed' });
+    sb.tick(1500);
+    assert.equal(sb.rafQueue.length, 1, '采样已开始');
+    // 第二次跨屏在采样中到达
+    sb.window.dispatchEvent({ type: 'electron-display-changed' });
+    sb.tick(1500);
+    // 当前轮在 120Hz 屏上采完
+    sb.pumpFrames(25, 120);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), 120, '当前轮结果先落地');
+    assert.equal(sb.rafQueue.length, 1, '排队的第二轮紧接着开始，而不是被丢掉');
+    sb.pumpFrames(25, 144);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), 144, '第二轮结果覆盖');
+    assert.equal(sb.rafQueue.length, 0, '没有第三轮');
+}));
+
 test('frame-pacing：144Hz 屏上 60fps 配置也切定时器驱动', withMockTimers(() => {
     const sb = createSandbox({ pet: true, targetFrameRate: 60 });
     sb.measureRefresh(144);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -276,6 +276,18 @@ test('契约：VRM / MMD 浮动按钮循环在定时器模式下到点直接 upd
     }
 });
 
+test('契约：演出舞台的 tween / 漂浮 / 呼吸 / 姿态时间线循环通过 frame-pacing 排帧', () => {
+    const src = read('static/avatar/avatar-performance-stage.js');
+    assert.match(src, /function scheduleStageFrame\(callback\)[\s\S]*?return pacing\.requestPacedFrame\(callback\);/);
+    assert.equal((src.match(/tween\.cancelFrame = scheduleStageFrame\(step\);/g) || []).length, 6, 'transition/idleFloat/breathe 三条循环各两处排帧');
+    assert.equal((src.match(/cancelFrame = scheduleStageFrame\(tick\);/g) || []).length, 2, '姿态时间线两处排帧');
+    assert.doesNotMatch(src, /tween\.rafId/, 'tween 不再持有裸 rAF id');
+    assert.doesNotMatch(src, /frameId = window\.requestAnimationFrame\(tick\)/, '姿态时间线不再裸排 rAF');
+    // 允许残留的裸 rAF 只剩等待 Live2D 上下文那条有界短循环（check）
+    const remaining = (src.match(/window\.requestAnimationFrame\(/g) || []).length;
+    assert.equal(remaining, 3, `裸 rAF 只剩 scheduleStageFrame 内一处 + check 两处，实际 ${remaining}`);
+});
+
 test('契约：反应气泡跟随循环通过 frame-pacing 排帧', () => {
     const src = read('static/avatar/avatar-reaction-bubble.js');
     assert.match(src, /function scheduleFollowFrame\(tick\)[\s\S]*?state\.followPacedCancel = pacing\.requestPacedFrame\(tick\);/);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -141,7 +141,10 @@ function setupLive2D(sb) {
     // 与 live2d-core.js initPIXI 里的包装保持一致（下面有契约断言防漂移）
     const ticker = app.ticker;
     ticker.stop = function () {
-        if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) mgr._exitIdleTickMode({ restartGlobals: false });
+        if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) {
+            mgr._exitIdleTickMode({ restartGlobals: false });
+            if (mgr._resolveGlobalTickers()) mgr._holdGlobalTickers();
+        }
         return origStop();
     };
     ticker.start = function () {
@@ -152,7 +155,7 @@ function setupLive2D(sb) {
 }
 
 test('契约：initPIXI 的 ticker.stop/start 包装语义与测试复刻一致（含旧 ticker 身份检查）', () => {
-    assert.match(LIVE2D_CORE_SRC, /ticker\.stop = function \(\) \{\s*if \(mgr\.pixi_app && mgr\.pixi_app\.ticker === ticker\) \{\s*mgr\._exitIdleTickMode\(\{ restartGlobals: false \}\);\s*\}\s*return origStop\(\);\s*\};/);
+    assert.match(LIVE2D_CORE_SRC, /ticker\.stop = function \(\) \{\s*if \(mgr\.pixi_app && mgr\.pixi_app\.ticker === ticker\) \{\s*mgr\._exitIdleTickMode\(\{ restartGlobals: false \}\);\s*if \(mgr\._resolveGlobalTickers\(\)\) mgr\._holdGlobalTickers\(\);\s*\}\s*return origStop\(\);\s*\};/);
     assert.match(LIVE2D_CORE_SRC, /ticker\.start = function \(\) \{\s*if \(mgr\.pixi_app && mgr\.pixi_app\.ticker === ticker\) \{\s*mgr\._exitIdleTickMode\(\);\s*mgr\._releaseGlobalTickers\(\);\s*\}\s*return origStart\(\);\s*\};/);
 });
 
@@ -460,6 +463,29 @@ test('Live2D：外部 ticker.stop()（切 VRM/MMD、pauseRendering）退出定�
     assert.equal(shared.started, true, '回到 Live2D 时全局 ticker 一并恢复');
     assert.equal(system.started, true);
     assert.equal(shared.maxFPS, 30, '恢复时帧率上限也恢复到配置值');
+}));
+
+test('Live2D：真实切角色序列 stop → removeModel 的 start → 最终 stop，最后全局 ticker 仍是停的', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 30 });
+    sb.measureRefresh(60);
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true);
+    app.ticker.stop();          // app-character：切走前先停
+    assert.equal(shared.started, false);
+    app.ticker.start();         // removeModel()：拉起来做清理渲染 → 放开全局 ticker
+    assert.equal(shared.started, true);
+    assert.ok(!mgr._idleTickMode, '此时不在定时器模式');
+    app.ticker.stop();          // app-character：最终停掉 Live2D 给 VRM/MMD 让路
+    assert.equal(shared.started, false, '不在定时器模式的 stop 也必须把 Pet 全局 ticker 扣住');
+    assert.equal(system.started, false);
+    app.ticker.start();         // 切回 Live2D
+    assert.equal(shared.started, true, 'start 再放开');
+    // 非 Pet：stop 不扣全局 ticker（保持既有行为）
+    const sb2 = createSandbox({ pet: false, targetFrameRate: 30 });
+    const l2 = setupLive2D(sb2);
+    l2.app.ticker.stop();
+    assert.equal(l2.shared.started, true, '非 Pet 页面 stop 不动全局 ticker');
 }));
 
 test('Live2D：stop() 后直接销毁（不经 start）也必须释放全局 ticker，否则重建后模型 autoUpdate 冻住', withMockTimers(() => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -532,6 +532,15 @@ test('负数 targetFrameRate 一律归一为 60：Live2D / VRM / MMD 地板都�
     assert.equal(vrm._resolveIdleFps(), 30);
     vrm._enterIdleTickMode();
     assert.equal(vrm._idleTickFps, 30, '空闲周期不会被负数配置拖到 1fps');
+    // rAF 路径也走同一解析，不再直接读 window.targetFrameRate
+    const vrmSrc = read('static/vrm/vrm-manager.js');
+    const loopBody = vrmSrc.slice(vrmSrc.indexOf('startAnimateLoop() {'), vrmSrc.indexOf('_resolveActiveTimerTickFps() {'));
+    assert.match(loopBody, /const targetFps = this\._resolveConfiguredTargetFps\(\);/);
+    assert.doesNotMatch(loopBody, /typeof window\.targetFrameRate === 'number' \? window\.targetFrameRate : 60/, 'rAF 路径不允许绕过归一化直接读配置');
+    sb2.window.targetFrameRate = Infinity;
+    assert.equal(vrm._resolveConfiguredTargetFps(), 60, 'Infinity 也归一为 60');
+    sb2.window.targetFrameRate = NaN;
+    assert.equal(vrm._resolveConfiguredTargetFps(), 60, 'NaN 归一为 60');
     const sb3 = createSandbox({ pet: false, targetFrameRate: -1 });
     const { core } = setupMMD(sb3);
     assert.ok([30, 45, 60].includes(core._resolveConfiguredTargetFps()), 'MMD 负数配置退回档位值');

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -760,6 +760,33 @@ test('契约：Live2D 交互层只有坐标真变了才升帧', () => {
     );
 });
 
+test('VRM legacy 视线跟随（CursorFollow 未加载）：重复坐标不续期活动保持期', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 60 });
+    const vrm = setupVRM(sb);
+    vrm.isMouseTrackingEnabled = () => true;
+    vrm._setLookAtTargetByMouse = () => {};
+    // 从源码抠出 legacy handler 的闭包体，避免依赖 THREE 初始化
+    const src = VRM_MANAGER_SRC;
+    const start = src.indexOf('this._mouseMoveHandler = (event) => {');
+    const end = src.indexOf('document.addEventListener(\'mousemove\', this._mouseMoveHandler', start);
+    assert.ok(start > 0 && end > start, 'legacy handler 定位失败');
+    // 必须在沙盒 realm 里构造，handler 读到的才是沙盒的 performance.now()
+    const install = vm.runInContext('(function () {' + src.slice(start, end) + '})', sb.sandbox);
+    install.call(vrm);
+    sb.tick(1000);
+    vrm._mouseMoveHandler({ clientX: 10, clientY: 20 });
+    const first = vrm._lastLookAtPointerMoveAt;
+    assert.equal(first, sb.sandbox.performance.now(), '首次坐标记录时间戳');
+    sb.tick(500);
+    vrm._mouseMoveHandler({ clientX: 10, clientY: 20 });
+    assert.equal(vrm._lastLookAtPointerMoveAt, first, '同坐标重复事件不刷新时间戳');
+    sb.tick(500);
+    assert.equal(vrm._hasRenderActivity(), false, '保持期过后可进空闲');
+    vrm._mouseMoveHandler({ clientX: 11, clientY: 20 });
+    assert.equal(vrm._lastLookAtPointerMoveAt, sb.sandbox.performance.now(), '坐标一变立即刷新');
+    assert.equal(vrm._hasRenderActivity(), true);
+}));
+
 test('契约：VRM / MMD 光标跟随对坐标没变的事件不刷新活动时间戳', () => {
     const vrm = read('static/vrm/vrm-cursor-follow.js');
     assert.match(vrm, /const moved = e\.clientX !== this\._rawMouseX \|\| e\.clientY !== this\._rawMouseY;/);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -186,6 +186,64 @@ test('frame-pacing：重测超时要作废旧刷新率，回到保守 rAF', with
     assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), 45);
 }));
 
+test('frame-pacing：渲染后端定时器驱动时，requestPacedFrame 走定时器而非 rAF', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 30 });
+    const pacing = sb.window.nekoFramePacing;
+    let calls = 0;
+    // 无后端 / 后端在 rAF 模式：走 rAF
+    sb.window.live2dManager = { _idleTickMode: false, _idleTickFps: null };
+    assert.equal(pacing.currentTimerTickFps(), null);
+    pacing.requestPacedFrame(() => { calls++; });
+    assert.equal(sb.rafQueue.length, 1, 'rAF 模式下排 rAF');
+    sb.pumpFrames(1, 60);
+    assert.equal(calls, 1);
+    // 后端定时器驱动 30fps：走 setTimeout(33ms)，不排 rAF
+    sb.window.live2dManager = { _idleTickMode: true, _idleTickFps: 30 };
+    assert.equal(pacing.currentTimerTickFps(), 30);
+    const cancel = pacing.requestPacedFrame(() => { calls++; });
+    assert.equal(sb.rafQueue.length, 0, '定时器驱动下不排 rAF');
+    sb.tick(32);
+    assert.equal(calls, 1, '33ms 前不触发');
+    sb.tick(2);
+    assert.equal(calls, 2, '按 30fps 周期触发');
+    const cancel2 = pacing.requestPacedFrame(() => { calls++; });
+    cancel2();
+    sb.tick(100);
+    assert.equal(calls, 2, '取消函数生效');
+    assert.equal(typeof cancel, 'function');
+}));
+
+test('frame-pacing：非 Pet 页面 currentTimerTickFps 恒为 null', () => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 30 });
+    sb.window.live2dManager = { _idleTickMode: true, _idleTickFps: 30 };
+    assert.equal(sb.window.nekoFramePacing.currentTimerTickFps(), null);
+});
+
+test('契约：麦克风音量监测与口型同步循环通过 frame-pacing 排帧', () => {
+    const capture = read('static/app/app-audio-capture.js');
+    assert.match(capture, /function scheduleMonitorInputVolume\(\)[\s\S]*?pacing\.requestPacedFrame\(monitorInputVolume\)/);
+    const monitorBody = capture.slice(capture.indexOf('function monitorInputVolume()'), capture.indexOf('// ======================== AudioWorklet'));
+    assert.doesNotMatch(monitorBody, /requestAnimationFrame\(monitorInputVolume\)/, 'monitorInputVolume 内不允许直接排 rAF');
+    assert.equal((monitorBody.match(/scheduleMonitorInputVolume\(\);/g) || []).length, 2, 'mute 分支与常规分支都走 paced 排帧');
+    // 麦克风音量可视化：弹窗不可见低频探测、可见时跟随渲染 tick、stop 同时取消两种句柄
+    const volumeStart = capture.indexOf('function updateVolumeDisplay()');
+    const volumeEnd = capture.indexOf('// 立即更新音量显示状态（用于录音状态变化时立即反映）', volumeStart);
+    assert.ok(volumeStart >= 0 && volumeEnd > volumeStart, 'updateVolumeDisplay 区块定位失败');
+    const volumeBody = capture.slice(volumeStart, volumeEnd);
+    assert.doesNotMatch(volumeBody, /S\.micVolumeAnimationId = requestAnimationFrame\(updateVolumeDisplay\);\s*return;/, '弹窗不可见分支不允许按刷新率排 rAF');
+    assert.match(volumeBody, /scheduleMicVolumeFrame\(MIC_VOLUME_HIDDEN_POLL_MS\);/);
+    assert.match(volumeBody, /function scheduleMicVolumeFrame\(delayMs\)[\s\S]*?_micVolumePacedCancel = pacing\.requestPacedFrame\(updateVolumeDisplay\);/);
+    assert.match(volumeBody, /function stopMicVolumeVisualization\(\) \{\s*cancelMicVolumeFrame\(\);/);
+    assert.match(capture, /const MIC_VOLUME_HIDDEN_POLL_MS = 250;/);
+    const playback = read('static/app/app-audio-playback.js');
+    assert.match(playback, /function scheduleLipSyncFrame\(animate\)[\s\S]*?_lipSyncPacedCancel = pacing\.requestPacedFrame\(animate\);/);
+    assert.match(playback, /const pacedByTimer = scheduleLipSyncFrame\(animate\);/);
+    assert.match(playback, /if \(!pacedByTimer && \+\+_lipSyncSkipCounter < LIP_SYNC_EVERY_N_FRAMES\) return;/);
+    assert.match(playback, /function stopLipSync\(model\) \{[\s\S]*?cancelLipSyncFrame\(\);/);
+    const lipSyncBody = playback.slice(playback.indexOf('function startLipSync('), playback.indexOf('function stopLipSync('));
+    assert.doesNotMatch(lipSyncBody, /S\.animationFrameId = requestAnimationFrame\(animate\)/, 'startLipSync 内不允许直接排 rAF');
+});
+
 test('frame-pacing：144Hz 屏上 60fps 配置也切定时器驱动', withMockTimers(() => {
     const sb = createSandbox({ pet: true, targetFrameRate: 60 });
     sb.measureRefresh(144);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -576,10 +576,37 @@ test('MMD Pet 没有 window.targetFrameRate 时，总闸按 MMD 自己的 perfor
     }
 }));
 
+test('MMD / VRM：时间戳 0 是合法的活动时间戳，不能被当成未设置', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 45 });
+    const { core, manager } = setupMMD(sb);
+    assert.equal(sb.sandbox.performance.now(), 0);
+    assert.equal(core._hasRenderActivity(), false, '未设置时不算活动');
+    manager._lastInteractionBoostTs = 0;
+    assert.equal(core._hasRenderActivity(), true, 'MMD 交互时间戳 0 在保持期内算活动');
+    manager._lastInteractionBoostTs = undefined;
+    manager.cursorFollow = { enabled: true, _lastPointerMoveTs: 0, _targetYaw: 0, _currentYaw: 0, _targetPitch: 0, _currentPitch: 0 };
+    assert.equal(core._hasRenderActivity(), true, 'MMD 光标时间戳 0 在保持期内算活动');
+    sb.tick(901);
+    assert.equal(core._hasRenderActivity(), false);
+
+    const sb2 = createSandbox({ pet: false, targetFrameRate: 45 });
+    const vrm = setupVRM(sb2);
+    assert.equal(vrm._hasRenderActivity(), false);
+    for (const key of ['_lastLookAtPointerMoveAt', '_lastCameraChangeAt', '_lastInteractionBoostTs']) {
+        vrm[key] = 0;
+        assert.equal(vrm._hasRenderActivity(), true, `VRM ${key} = 0 在保持期内算活动`);
+        vrm[key] = undefined;
+    }
+    vrm._cursorFollow = { isEnabled: () => true, _lastPointerMoveAt: 0 };
+    assert.equal(vrm._hasRenderActivity(), true, 'VRM 光标时间戳 0 在保持期内算活动');
+    sb2.tick(901);
+    assert.equal(vrm._hasRenderActivity(), false);
+}));
+
 test('MMD：交互升帧的 900ms 保持期到期后活动判定失效', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: 45 });
     const { core, manager } = setupMMD(sb);
-    sb.tick(1000); // 让 performance.now() 离开 0，时间戳判定才不会被当成未设置
+    sb.tick(1000);
     manager._lastInteractionBoostTs = sb.sandbox.performance.now();
     assert.equal(core._hasRenderActivity(), true);
     sb.tick(899);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -288,6 +288,21 @@ test('契约：演出舞台的 tween / 漂浮 / 呼吸 / 姿态时间线循环�
     assert.equal(remaining, 3, `裸 rAF 只剩 scheduleStageFrame 内一处 + check 两处，实际 ${remaining}`);
 });
 
+test('契约：Live2D / VRM / MMD 拖拽回弹（吸附）动画通过 frame-pacing 排帧', () => {
+    const l2d = read('static/live2d/live2d-interaction.js');
+    assert.match(l2d, /function scheduleLive2DSnapFrame\(callback\)[\s\S]*?return pacing\.requestPacedFrame\(callback\);/);
+    const snap = l2d.slice(l2d.indexOf('Live2DManager.prototype._performSnapAnimation = function'), l2d.indexOf('检测并执行自动吸附'));
+    assert.equal((snap.match(/scheduleLive2DSnapFrame\(animate\);/g) || []).length, 2, 'Live2D 首帧与续帧都走 paced');
+    assert.doesNotMatch(snap, /requestAnimationFrame\(animate\)/, 'Live2D 吸附动画不允许裸排 rAF');
+    for (const file of ['static/vrm/vrm-interaction.js', 'static/mmd/mmd-interaction.js']) {
+        const src = read(file);
+        assert.match(src, /_scheduleSnapFrame\(callback\) \{[\s\S]*?return pacing\.requestPacedFrame\(callback\);/, file + ' 有 paced 排帧 helper');
+        assert.equal((src.match(/this\._snapCancelFrame = this\._scheduleSnapFrame\(animate\);/g) || []).length, 2, file + ' 首帧与续帧都走 paced');
+        assert.doesNotMatch(src, /_snapAnimationFrameId/, file + ' 不再持有裸 rAF id');
+        assert.ok((src.match(/this\._snapCancelFrame\(\);/g) || []).length >= 3, file + ' 取消路径用取消函数');
+    }
+});
+
 test('契约：反应气泡跟随循环通过 frame-pacing 排帧', () => {
     const src = read('static/avatar/avatar-reaction-bubble.js');
     assert.match(src, /function scheduleFollowFrame\(tick\)[\s\S]*?state\.followPacedCancel = pacing\.requestPacedFrame\(tick\);/);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -98,13 +98,19 @@ function createSandbox({ pet, targetFrameRate }) {
             batch.forEach((e) => e.fn(frameClock));
         }
     };
+    // 推进 mock 定时器的同时推进沙盒时钟，让 performance.now() 依赖的保持期判定
+    // （_hasRenderActivity 的 900ms 窗口）也随时间失效
+    const tick = (ms) => {
+        frameClock += ms;
+        sb.tick(ms);
+    };
     const measureRefresh = (hz) => {
         // frame-pacing：load 后延迟 1500ms 才开始采样，采 24 帧
-        mock.timers.tick(1500);
+        tick(1500);
         pumpFrames(30, hz);
     };
     const load = (src, name) => vm.runInContext(src, sandbox, { filename: name });
-    return { sandbox, window, PIXI, pumpFrames, measureRefresh, load, rafQueue, listeners };
+    return { sandbox, window, PIXI, pumpFrames, measureRefresh, tick, load, rafQueue, listeners };
 }
 
 function withMockTimers(fn) {
@@ -162,8 +168,8 @@ test('frame-pacing：重测超时要作废旧刷新率，回到保守 rAF', with
     // 跨屏事件触发重测，但 rAF 一帧都不来 → 3s 超时
     sb.window.dispatchEvent({ type: 'electron-display-changed' });
     // mock timers 不会在同一次 tick 里跑 tick 期间新排的定时器：先到采样起点，再跨过超时
-    mock.timers.tick(1500);
-    mock.timers.tick(3000);
+    sb.tick(1500);
+    sb.tick(3000);
     assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), null, '超时后旧值作废');
     assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), null, '未知刷新率 → rAF');
     // 再来一次重测成功 → 恢复
@@ -194,7 +200,7 @@ test('Live2D 非 Pet：行为不变——活动态 rAF + maxFPS，只碰 app.tic
     assert.equal(app.ticker.maxFPS, 45);
     assert.equal(shared.maxFPS, 999, '非 Pet 不接管 shared');
     assert.equal(system.maxFPS, 999, '非 Pet 不接管 system');
-    mock.timers.tick(1000); // 衰减
+    sb.tick(1000); // 衰减
     assert.equal(mgr._idleTickMode, true, '无活动衰减到空闲低频 tick');
     assert.equal(mgr._idleTickFps, 30);
     assert.equal(app.ticker.started, false);
@@ -217,12 +223,12 @@ test('Live2D Pet + 配置低于刷新率：活动态也走定时器驱动，衰�
     assert.equal(system.maxFPS, 0);
 
     const before = { app: app.ticker.updates, shared: shared.updates, system: system.updates };
-    mock.timers.tick(22 * 5);
+    sb.tick(22 * 5);
     assert.ok(app.ticker.updates - before.app >= 4, 'app ticker 按 45fps 手动 update');
     assert.ok(shared.updates - before.shared >= 4, 'shared ticker 一起被手动 update');
     assert.ok(system.updates - before.system >= 4, 'system ticker 一起被手动 update');
 
-    mock.timers.tick(1000); // 衰减
+    sb.tick(1000); // 衰减
     assert.equal(mgr._idleTickMode, true);
     assert.equal(mgr._idleTickFps, 30, '衰减到地板 30');
     assert.equal(app.ticker.startCalls, 0, '整个过程从未回到 rAF 模式');
@@ -245,7 +251,7 @@ test('Live2D Pet + 配置 = 刷新率：rAF 模式接管 shared/system 的 maxFP
     assert.equal(shared.maxFPS, 60, 'Pet 下 shared 也被限到配置帧率');
     assert.equal(system.maxFPS, 60);
 
-    mock.timers.tick(1000); // 衰减 → 空闲定时器
+    sb.tick(1000); // 衰减 → 空闲定时器
     assert.equal(mgr._idleTickMode, true);
     assert.equal(mgr._idleTickFps, 30);
     assert.equal(app.ticker.maxFPS, 0);
@@ -283,7 +289,7 @@ test('Live2D：外部 pauseRendering 时不接管；ticker.start() 让位后 gov
     app.ticker.start(); // 外部「确保渲染」路径
     assert.equal(mgr._idleTickMode, false, '外部 start() 让位给 rAF');
     mgr._startIdleFpsGovernor();
-    mock.timers.tick(1500);
+    sb.tick(1500);
     assert.equal(mgr._idleTickMode, true, 'governor 自愈回定时器模式');
     mgr._stopIdleFpsGovernor();
 }));
@@ -313,9 +319,9 @@ test('VRM Pet + 配置低于刷新率：活动态定时器驱动，衰减只换�
     assert.equal(mgr._idleTickFps, 45);
     assert.equal(mgr._isLowTickRate(), false, '活动态 45fps 定时器驱动不算低频：medium 隔帧物理照常');
     assert.equal(mgr._animationFrameId, null, 'rAF 链已停');
-    mock.timers.tick(22 * 5);
+    sb.tick(22 * 5);
     assert.ok(mgr.renders >= 4, '按 45fps 定时渲染');
-    mock.timers.tick(1000);
+    sb.tick(1000);
     assert.equal(mgr._idleTickMode, true);
     assert.equal(mgr._idleTickFps, 30);
     assert.equal(mgr._isLowTickRate(), true, '30fps 地板才绕过隔帧物理');
@@ -330,7 +336,7 @@ test('VRM Pet + 配置低于刷新率：活动态定时器驱动，衰减只换�
 test('VRM 非 Pet：行为不变——活动态回 rAF', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: 45 });
     const mgr = setupVRM(sb);
-    mock.timers.tick(0);
+    sb.tick(0);
     mgr._enterIdleTickMode();
     assert.equal(mgr._idleTickMode, true);
     mgr._boostInteractiveFPS();
@@ -389,6 +395,23 @@ test('MMD rAF 路径：不限帧后切回有限帧率，节流状态不能被 Na
     assert.ok(Number.isFinite(core.lastFrameTime));
 }));
 
+test('MMD：交互升帧的 900ms 保持期到期后活动判定失效', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 45 });
+    const { core, manager } = setupMMD(sb);
+    sb.tick(1000); // 让 performance.now() 离开 0，时间戳判定才不会被当成未设置
+    manager._lastInteractionBoostTs = sb.sandbox.performance.now();
+    assert.equal(core._hasRenderActivity(), true);
+    sb.tick(899);
+    assert.equal(core._hasRenderActivity(), true, '保持期内仍算活动');
+    sb.tick(2);
+    assert.equal(core._hasRenderActivity(), false, '过了 900ms 保持期失效');
+    // 光标跟随时间戳同一套窗口
+    manager.cursorFollow = { enabled: true, _lastPointerMoveTs: sb.sandbox.performance.now(), _targetYaw: 0, _currentYaw: 0, _targetPitch: 0, _currentPitch: 0 };
+    assert.equal(core._hasRenderActivity(), true);
+    sb.tick(901);
+    assert.equal(core._hasRenderActivity(), false);
+}));
+
 test('MMD Pet + 配置低于刷新率：活动态定时器驱动，衰减只换周期', withMockTimers(() => {
     const sb = createSandbox({ pet: true, targetFrameRate: 45 });
     sb.measureRefresh(60);
@@ -397,9 +420,9 @@ test('MMD Pet + 配置低于刷新率：活动态定时器驱动，衰减只换�
     assert.equal(core._idleTickMode, true);
     assert.equal(core._idleTickFps, 45);
     assert.equal(manager._animationFrameId, null);
-    mock.timers.tick(22 * 5);
+    sb.tick(22 * 5);
     assert.ok(core.renders >= 4);
-    mock.timers.tick(1000);
+    sb.tick(1000);
     assert.equal(core._idleTickMode, true);
     assert.equal(core._idleTickFps, 30);
     assert.equal(sb.rafQueue.length, 0, '从未重新排 rAF');

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -139,15 +139,41 @@ function setupLive2D(sb) {
     mgr._tickerOrigStop = origStop;
     mgr._tickerOrigStart = origStart;
     // 与 live2d-core.js initPIXI 里的包装保持一致（下面有契约断言防漂移）
-    app.ticker.stop = function () { mgr._exitIdleTickMode({ restartGlobals: false }); return origStop(); };
-    app.ticker.start = function () { mgr._exitIdleTickMode(); mgr._releaseGlobalTickers(); return origStart(); };
+    const ticker = app.ticker;
+    ticker.stop = function () {
+        if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) mgr._exitIdleTickMode({ restartGlobals: false });
+        return origStop();
+    };
+    ticker.start = function () {
+        if (mgr.pixi_app && mgr.pixi_app.ticker === ticker) { mgr._exitIdleTickMode(); mgr._releaseGlobalTickers(); }
+        return origStart();
+    };
     return { mgr, app, shared: sb.PIXI.Ticker.shared, system: sb.PIXI.Ticker.system };
 }
 
-test('契约：initPIXI 的 ticker.stop/start 包装语义与测试复刻一致', () => {
-    assert.match(LIVE2D_CORE_SRC, /ticker\.stop = function \(\) \{ mgr\._exitIdleTickMode\(\{ restartGlobals: false \}\); return origStop\(\); \};/);
-    assert.match(LIVE2D_CORE_SRC, /ticker\.start = function \(\) \{ mgr\._exitIdleTickMode\(\); mgr\._releaseGlobalTickers\(\); return origStart\(\); \};/);
+test('契约：initPIXI 的 ticker.stop/start 包装语义与测试复刻一致（含旧 ticker 身份检查）', () => {
+    assert.match(LIVE2D_CORE_SRC, /ticker\.stop = function \(\) \{\s*if \(mgr\.pixi_app && mgr\.pixi_app\.ticker === ticker\) \{\s*mgr\._exitIdleTickMode\(\{ restartGlobals: false \}\);\s*\}\s*return origStop\(\);\s*\};/);
+    assert.match(LIVE2D_CORE_SRC, /ticker\.start = function \(\) \{\s*if \(mgr\.pixi_app && mgr\.pixi_app\.ticker === ticker\) \{\s*mgr\._exitIdleTickMode\(\);\s*mgr\._releaseGlobalTickers\(\);\s*\}\s*return origStart\(\);\s*\};/);
 });
+
+test('Live2D：PIXI 重建后旧 ticker 的包装不再动当前实例的调度状态', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 30 });
+    sb.measureRefresh(60);
+    const { mgr, app: oldApp } = setupLive2D(sb);
+    const oldTicker = oldApp.ticker;
+    // 模拟 rebuildPIXI：换成新实例并进入定时器模式
+    const newApp = new sb.PIXI.Application();
+    mgr.pixi_app = newApp;
+    mgr._tickerOrigStop = newApp.ticker.stop.bind(newApp.ticker);
+    mgr._tickerOrigStart = newApp.ticker.start.bind(newApp.ticker);
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true);
+    oldTicker.stop(); // 外部残留引用
+    assert.equal(mgr._idleTickMode, true, '旧 ticker 的 stop 不能把当前实例踢出定时器模式');
+    oldTicker.start();
+    assert.equal(mgr._idleTickMode, true, '旧 ticker 的 start 同理');
+    assert.equal(oldTicker.started, true, '旧 ticker 自己的 start/stop 照常生效');
+}));
 
 // ─────────────────────────────────────────────────────────────────────────────
 // frame-pacing.js
@@ -385,9 +411,13 @@ test('Live2D：stop() 后直接销毁（不经 start）也必须释放全局 tic
 test('Live2D：光标停在悬停范围内（isFocusing 常驻）不算持续活动，保持期过后可进空闲', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: 60 });
     const { mgr } = setupLive2D(sb);
-    sb.tick(1000);
     mgr.isFocusing = true;
     assert.equal(mgr._hasRenderActivity(), false, '没有任何指针位移记录时 isFocusing 不算活动');
+    // 时间戳 0 是合法值（页面刚加载时 performance.now() 可以是 0），不能被当成"未设置"
+    mgr._lastPointerMoveAt = 0;
+    assert.equal(mgr._hasRenderActivity(), true, '时间戳为 0 时保持期内仍算活动');
+    sb.tick(1000);
+    assert.equal(mgr._hasRenderActivity(), false);
     mgr._lastPointerMoveAt = sb.sandbox.performance.now();
     assert.equal(mgr._hasRenderActivity(), true, '刚动过算活动');
     sb.tick(899);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -251,6 +251,16 @@ test('frame-pacing：非 Pet 页面 currentTimerTickFps 恒为 null', () => {
     assert.equal(sb.window.nekoFramePacing.currentTimerTickFps(), null);
 });
 
+test('契约：反应气泡跟随循环通过 frame-pacing 排帧', () => {
+    const src = read('static/avatar/avatar-reaction-bubble.js');
+    assert.match(src, /function scheduleFollowFrame\(tick\)[\s\S]*?state\.followPacedCancel = pacing\.requestPacedFrame\(tick\);/);
+    assert.match(src, /function stopFollowLoop\(\) \{\s*cancelFollowFrame\(\);/);
+    const follow = src.slice(src.indexOf('function extendFollowLoop('), src.indexOf('function syncPositionOnce('));
+    assert.doesNotMatch(follow, /requestAnimationFrame\(tick\)/, 'extendFollowLoop 内不允许直接排 rAF');
+    assert.equal((follow.match(/scheduleFollowFrame\(tick\);/g) || []).length, 2, '首帧与续帧都走 paced 排帧');
+    assert.match(follow, /if \(isFollowFrameScheduled\(\)\) \{\s*return;/, '已排帧判定要同时认 rAF 与定时器句柄');
+});
+
 test('契约：麦克风音量监测与口型同步循环通过 frame-pacing 排帧', () => {
     const capture = read('static/app/app-audio-capture.js');
     assert.match(capture, /function scheduleMonitorInputVolume\(\)[\s\S]*?pacing\.requestPacedFrame\(monitorInputVolume\)/);
@@ -619,21 +629,33 @@ function loadVrmPhysicsStep() {
     return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', helperSrc + src.slice(start, end));
 }
 function makeVrmPhysicsCtx({ componentApi = true } = {}) {
-    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, lookAtTime: [], materialTime: [], currentModel: null };
+    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, lookAtTime: [], materialTime: [], order: [], currentModel: null };
     ctx.newModel = () => {
         const vrm = {
-            update: (d) => { ctx.simulated += d; ctx.lookAtTime.push(d); ctx.materialTime.push(d); },
-            lookAt: { update: (d) => { ctx.lookAtTime.push(d); } },
-            expressionManager: { update() {} },
-            humanoid: { update() {} },
-            materials: [{ update: (d) => { ctx.materialTime.push(d); } }, {}],
+            update: (d) => { ctx.simulated += d; ctx.lookAtTime.push(d); ctx.materialTime.push(d); ctx.order.push('whole'); },
+            lookAt: { update: (d) => { ctx.lookAtTime.push(d); ctx.order.push('lookAt'); } },
+            expressionManager: { update() { ctx.order.push('expression'); } },
+            humanoid: { update() { ctx.order.push('humanoid'); } },
+            nodeConstraintManager: { update() { ctx.order.push('constraint'); } },
+            materials: [{ update: (d) => { ctx.materialTime.push(d); ctx.order.push('material'); } }, {}],
         };
-        if (componentApi) vrm.springBoneManager = { update: (d) => { ctx.simulated += d; } };
+        if (componentApi) vrm.springBoneManager = { update: (d) => { ctx.simulated += d; ctx.order.push('spring'); } };
         ctx.currentModel = { vrm };
     };
     ctx.newModel();
     return ctx;
 }
+
+test('VRM 分量更新顺序与 three-vrm VRM.update 一致：humanoid → lookAt → 表情 → 约束 → 弹簧骨 → 材质', () => {
+    const run = loadVrmPhysicsStep();
+    const ctx = makeVrmPhysicsCtx();
+    run.call(ctx, 0.0167, { renderQuality: 'high' }, 0.05);
+    assert.deepEqual(ctx.order, ['humanoid', 'lookAt', 'expression', 'constraint', 'spring', 'material'],
+        '约束/弹簧骨必须在 LookAt 驱动的姿态之后');
+    // 打包版 three-vrm 里 VRM.update 的真实顺序，防止库升级后两边漂移
+    const lib = read('static/libs/three-vrm.module.min.js');
+    assert.match(lib, /update\(e\)\{super\.update\(e\),this\.nodeConstraintManager&&this\.nodeConstraintManager\.update\(\),this\.springBoneManager&&this\.springBoneManager\.update\(e\),this\.materials&&this\.materials\.forEach/);
+});
 
 test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt / MToon 材质每 tick 只推进当前 delta', () => {
     const run = loadVrmPhysicsStep();

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -100,9 +100,16 @@ function createSandbox({ pet, targetFrameRate }) {
     };
     // 推进 mock 定时器的同时推进沙盒时钟，让 performance.now() 依赖的保持期判定
     // （_hasRenderActivity 的 900ms 窗口）也随时间失效
+    // 按 1ms 步进，让每个定时器回调看到的 performance.now() 是它自己的到期时刻，
+    // 而不是本次 tick 的终点（跨多个到期点时保持期判定才准确）
     const tick = (ms) => {
-        frameClock += ms;
-        mock.timers.tick(ms);
+        let remaining = Math.max(0, Number(ms) || 0);
+        while (remaining > 0) {
+            const step = Math.min(1, remaining);
+            frameClock += step;
+            mock.timers.tick(step);
+            remaining -= step;
+        }
     };
     const measureRefresh = (hz) => {
         // frame-pacing：load 后延迟 1500ms 才开始采样，采 24 帧

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -325,6 +325,11 @@ test('VRM Pet + 配置低于刷新率：活动态定时器驱动，衰减只换�
     assert.equal(mgr._idleTickMode, true);
     assert.equal(mgr._idleTickFps, 30);
     assert.equal(mgr._isLowTickRate(), true, '30fps 地板才绕过隔帧物理');
+    // 非标准配置 35fps：隔帧后步长 57ms 超出 50ms clamp，同样按低频全量物理
+    mgr._enterIdleTickMode(35);
+    assert.equal(mgr._isLowTickRate(), true, '35fps 隔帧步长会超 clamp，不隔帧');
+    mgr._enterIdleTickMode(40);
+    assert.equal(mgr._isLowTickRate(), false, '40fps 隔帧步长恰为 50ms，允许隔帧');
     assert.equal(sb.rafQueue.length, 0, '从未重新排 rAF');
     // 设置变更事件驱动换周期
     sb.window.targetFrameRate = 24;

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -1,0 +1,406 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test, mock } = require('node:test');
+const vm = require('node:vm');
+
+// pytest 包装层把本文件内容写到临时路径再交给 node 跑，__dirname 不是仓库根。
+const fileRoot = path.resolve(__dirname, '..', '..');
+const PROJECT_ROOT = fs.existsSync(path.join(fileRoot, 'static')) ? fileRoot : process.cwd();
+const read = (rel) => fs.readFileSync(path.join(PROJECT_ROOT, ...rel.split('/')), 'utf8');
+
+const FRAME_PACING_SRC = read('static/frame-pacing.js');
+const LIVE2D_CORE_SRC = read('static/live2d/live2d-core.js');
+const VRM_MANAGER_SRC = read('static/vrm/vrm-manager.js');
+const MMD_CORE_SRC = read('static/mmd/mmd-core.js');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 沙盒：真实加载 frame-pacing.js + 目标后端源码；rAF 由测试手动推帧（可指定刷新率），
+// setTimeout/setInterval 走 node:test 的 mock timers。
+// ─────────────────────────────────────────────────────────────────────────────
+function makeTicker(name) {
+    return {
+        name,
+        started: true,
+        maxFPS: 0,
+        updates: 0,
+        startCalls: 0,
+        stopCalls: 0,
+        update() { this.updates++; },
+        start() { this.started = true; this.startCalls++; },
+        stop() { this.started = false; this.stopCalls++; },
+    };
+}
+
+function createSandbox({ pet, targetFrameRate }) {
+    const rafQueue = [];
+    let rafId = 0;
+    const listeners = {};
+    const PIXI = {
+        live2d: { Live2DModel: class Live2DModel {} },
+        Ticker: { shared: makeTicker('shared'), system: makeTicker('system') },
+        Application: class Application {
+            constructor() { this.ticker = makeTicker('app'); this.stage = {}; this.renderer = {}; }
+        },
+    };
+    const window = {
+        PIXI,
+        targetFrameRate,
+        __LANLAN_IS_ELECTRON_PET__: pet === true,
+        innerWidth: 1920,
+        innerHeight: 1080,
+        screen: { width: 1920, height: 1080 },
+        devicePixelRatio: 1,
+        location: { hostname: 'localhost', pathname: '/' },
+        navigator: { userAgent: 'node' },
+        localStorage: { getItem() { return null; }, setItem() {} },
+        addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+        removeEventListener() {},
+        dispatchEvent(evt) { (listeners[evt.type] || []).forEach((fn) => fn(evt)); return true; },
+    };
+    const document = {
+        hidden: false,
+        readyState: 'complete',
+        getElementById() { return null; },
+        addEventListener() {},
+        createElement() { return { style: {} }; },
+        body: { classList: { contains() { return false; } } },
+    };
+    const sandbox = {
+        window,
+        document,
+        PIXI,
+        console: { log() {}, warn() {}, error() {}, info() {}, debug() {} },
+        performance,
+        navigator: window.navigator,
+        localStorage: window.localStorage,
+        // 走 globalThis 间接调用，让 node:test 的 mock timers 生效
+        setTimeout: (...a) => globalThis.setTimeout(...a),
+        clearTimeout: (...a) => globalThis.clearTimeout(...a),
+        setInterval: (...a) => globalThis.setInterval(...a),
+        clearInterval: (...a) => globalThis.clearInterval(...a),
+        requestAnimationFrame(fn) { rafId += 1; rafQueue.push({ id: rafId, fn }); return rafId; },
+        cancelAnimationFrame(id) { const i = rafQueue.findIndex((e) => e.id === id); if (i >= 0) rafQueue.splice(i, 1); },
+        CustomEvent: class CustomEvent { constructor(type, init) { this.type = type; this.detail = init && init.detail; } },
+    };
+    sandbox.globalThis = sandbox;
+    sandbox.self = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(FRAME_PACING_SRC, sandbox, { filename: 'frame-pacing.js' });
+
+    let frameClock = 0;
+    // 手动推 n 个 rAF 帧，时间戳按 hz 递增
+    const pumpFrames = (n, hz) => {
+        for (let i = 0; i < n; i++) {
+            frameClock += 1000 / hz;
+            const batch = rafQueue.splice(0, rafQueue.length);
+            batch.forEach((e) => e.fn(frameClock));
+        }
+    };
+    const measureRefresh = (hz) => {
+        // frame-pacing：load 后延迟 1500ms 才开始采样，采 24 帧
+        mock.timers.tick(1500);
+        pumpFrames(30, hz);
+    };
+    const load = (src, name) => vm.runInContext(src, sandbox, { filename: name });
+    return { sandbox, window, PIXI, pumpFrames, measureRefresh, load, rafQueue, listeners };
+}
+
+function withMockTimers(fn) {
+    return () => {
+        mock.timers.enable({ apis: ['setTimeout', 'setInterval'] });
+        try { fn(); } finally { mock.timers.reset(); }
+    };
+}
+
+function setupLive2D(sb) {
+    sb.load(LIVE2D_CORE_SRC, 'live2d-core.js');
+    const mgr = new sb.window.Live2DManager();
+    const app = new sb.PIXI.Application();
+    mgr.pixi_app = app;
+    mgr.isInitialized = true;
+    // 复刻 initPIXI 里对 ticker.stop/start 的包装
+    const origStop = app.ticker.stop.bind(app.ticker);
+    const origStart = app.ticker.start.bind(app.ticker);
+    mgr._tickerOrigStop = origStop;
+    mgr._tickerOrigStart = origStart;
+    app.ticker.stop = function () { mgr._exitIdleTickMode(); return origStop(); };
+    app.ticker.start = function () { mgr._exitIdleTickMode(); return origStart(); };
+    return { mgr, app, shared: sb.PIXI.Ticker.shared, system: sb.PIXI.Ticker.system };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// frame-pacing.js
+// ─────────────────────────────────────────────────────────────────────────────
+test('frame-pacing：非 Pet 页面永远不给定时器驱动帧率', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 30 });
+    sb.measureRefresh(60);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), null, '非 Pet 不采样刷新率');
+    assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), null);
+}));
+
+test('frame-pacing：Pet 窗口先量出刷新率，配置明显低于刷新率才切定时器驱动', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    const pacing = sb.window.nekoFramePacing;
+    assert.equal(pacing.activeTimerTickFps(), null, '刷新率未测出前保守走 rAF');
+    sb.measureRefresh(60);
+    assert.equal(pacing.getDisplayRefreshHz(), 60);
+    assert.equal(pacing.activeTimerTickFps(), 45, '45 < 60×0.9 → 定时器驱动 45fps');
+    sb.window.targetFrameRate = 60;
+    assert.equal(pacing.activeTimerTickFps(), null, '60fps 配置在 60Hz 屏留在 rAF（vsync 对齐）');
+    sb.window.targetFrameRate = 0;
+    assert.equal(pacing.activeTimerTickFps(), null, '0=不限帧 留在 rAF');
+    sb.window.targetFrameRate = 30;
+    assert.equal(pacing.activeTimerTickFps(), 30);
+}));
+
+test('frame-pacing：144Hz 屏上 60fps 配置也切定时器驱动', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 60 });
+    sb.measureRefresh(144);
+    assert.equal(sb.window.nekoFramePacing.getDisplayRefreshHz(), 144);
+    assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), 60);
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live2D
+// ─────────────────────────────────────────────────────────────────────────────
+test('Live2D 非 Pet：行为不变——活动态 rAF + maxFPS，只碰 app.ticker，不碰全局 shared/system', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 45 });
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    shared.maxFPS = 999;
+    system.maxFPS = 999;
+    mgr.boostInteractiveFPS();
+    assert.ok(!mgr._idleTickMode);
+    assert.equal(app.ticker.started, true);
+    assert.equal(app.ticker.maxFPS, 45);
+    assert.equal(shared.maxFPS, 999, '非 Pet 不接管 shared');
+    assert.equal(system.maxFPS, 999, '非 Pet 不接管 system');
+    mock.timers.tick(1000); // 衰减
+    assert.equal(mgr._idleTickMode, true, '无活动衰减到空闲低频 tick');
+    assert.equal(mgr._idleTickFps, 30);
+    assert.equal(app.ticker.started, false);
+    assert.equal(shared.maxFPS, 999);
+    assert.equal(system.maxFPS, 999);
+}));
+
+test('Live2D Pet + 配置低于刷新率：活动态也走定时器驱动，衰减只换周期、不回 rAF', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    sb.measureRefresh(60);
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true, '活动态直接进定时器模式');
+    assert.equal(mgr._idleTickFps, 45, '周期 = 配置帧率');
+    assert.equal(app.ticker.started, false, 'app ticker 的 rAF 链已停');
+    assert.equal(shared.started, false, 'shared ticker 已停');
+    assert.equal(system.started, false, 'system ticker 已停');
+    assert.equal(app.ticker.maxFPS, 0, '定时器模式下 maxFPS 清零，避免抖动丢帧');
+    assert.equal(shared.maxFPS, 0);
+    assert.equal(system.maxFPS, 0);
+
+    const before = { app: app.ticker.updates, shared: shared.updates, system: system.updates };
+    mock.timers.tick(22 * 5);
+    assert.ok(app.ticker.updates - before.app >= 4, 'app ticker 按 45fps 手动 update');
+    assert.ok(shared.updates - before.shared >= 4, 'shared ticker 一起被手动 update');
+    assert.ok(system.updates - before.system >= 4, 'system ticker 一起被手动 update');
+
+    mock.timers.tick(1000); // 衰减
+    assert.equal(mgr._idleTickMode, true);
+    assert.equal(mgr._idleTickFps, 30, '衰减到地板 30');
+    assert.equal(app.ticker.startCalls, 0, '整个过程从未回到 rAF 模式');
+
+    // 空闲态改设置：只换周期
+    sb.window.targetFrameRate = 24;
+    mgr.setTargetFPS(24);
+    assert.equal(mgr._idleTickMode, true);
+    assert.equal(mgr._idleTickFps, 24, '地板不超过用户配置');
+    assert.equal(app.ticker.startCalls, 0);
+}));
+
+test('Live2D Pet + 配置 = 刷新率：rAF 模式接管 shared/system 的 maxFPS，进出定时器模式正确保存/恢复', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 60 });
+    sb.measureRefresh(60);
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    mgr.boostInteractiveFPS();
+    assert.ok(!mgr._idleTickMode, '60@60Hz 留在 rAF');
+    assert.equal(app.ticker.maxFPS, 60);
+    assert.equal(shared.maxFPS, 60, 'Pet 下 shared 也被限到配置帧率');
+    assert.equal(system.maxFPS, 60);
+
+    mock.timers.tick(1000); // 衰减 → 空闲定时器
+    assert.equal(mgr._idleTickMode, true);
+    assert.equal(mgr._idleTickFps, 30);
+    assert.equal(app.ticker.maxFPS, 0);
+    assert.equal(shared.maxFPS, 0);
+    assert.equal(system.maxFPS, 0);
+
+    mgr.boostInteractiveFPS(); // 活动 → 回 rAF
+    assert.equal(mgr._idleTickMode, false);
+    assert.equal(app.ticker.started, true);
+    assert.equal(shared.started, true);
+    assert.equal(system.started, true);
+    assert.equal(app.ticker.maxFPS, 60);
+    assert.equal(shared.maxFPS, 60, '退出定时器模式后恢复到配置值而不是旧的地板值');
+    assert.equal(system.maxFPS, 60);
+
+    sb.window.targetFrameRate = 0;
+    mgr.setTargetFPS(0);
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, false, '0=不限帧 留在 rAF');
+    assert.equal(app.ticker.maxFPS, 0);
+    assert.equal(shared.maxFPS, 0);
+}));
+
+test('Live2D：外部 pauseRendering 时不接管；ticker.start() 让位后 governor 自愈回定时器', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 30 });
+    sb.measureRefresh(60);
+    const { mgr, app } = setupLive2D(sb);
+    mgr.pauseRendering();
+    mgr.boostInteractiveFPS();
+    assert.ok(!mgr._idleTickMode, '外部暂停时不进定时器模式');
+    assert.equal(app.ticker.started, false);
+    mgr.resumeRendering();
+    mgr.boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true);
+    app.ticker.start(); // 外部「确保渲染」路径
+    assert.equal(mgr._idleTickMode, false, '外部 start() 让位给 rAF');
+    mgr._startIdleFpsGovernor();
+    mock.timers.tick(1500);
+    assert.equal(mgr._idleTickMode, true, 'governor 自愈回定时器模式');
+    mgr._stopIdleFpsGovernor();
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VRM
+// ─────────────────────────────────────────────────────────────────────────────
+function setupVRM(sb) {
+    sb.load(VRM_MANAGER_SRC, 'vrm-manager.js');
+    const mgr = new sb.window.VRMManager();
+    mgr.renderer = {};
+    mgr.scene = {};
+    mgr.camera = {};
+    mgr.renders = 0;
+    mgr._renderFrame = () => { mgr.renders++; };
+    mgr._rafDriver = () => {};
+    mgr._animationFrameId = sb.sandbox.requestAnimationFrame(mgr._rafDriver);
+    return mgr;
+}
+
+test('VRM Pet + 配置低于刷新率：活动态定时器驱动，衰减只换周期', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    sb.measureRefresh(60);
+    const mgr = setupVRM(sb);
+    mgr._boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, true);
+    assert.equal(mgr._idleTickFps, 45);
+    assert.equal(mgr._animationFrameId, null, 'rAF 链已停');
+    mock.timers.tick(22 * 5);
+    assert.ok(mgr.renders >= 4, '按 45fps 定时渲染');
+    mock.timers.tick(1000);
+    assert.equal(mgr._idleTickMode, true);
+    assert.equal(mgr._idleTickFps, 30);
+    assert.equal(sb.rafQueue.length, 0, '从未重新排 rAF');
+    // 设置变更事件驱动换周期
+    sb.window.targetFrameRate = 24;
+    sb.window.vrmManager = mgr;
+    sb.window.dispatchEvent({ type: 'neko-frame-rate-changed', detail: { fps: 24 } });
+    assert.equal(mgr._idleTickFps, 24);
+}));
+
+test('VRM 非 Pet：行为不变——活动态回 rAF', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 45 });
+    const mgr = setupVRM(sb);
+    mock.timers.tick(0);
+    mgr._enterIdleTickMode();
+    assert.equal(mgr._idleTickMode, true);
+    mgr._boostInteractiveFPS();
+    assert.equal(mgr._idleTickMode, false);
+    assert.ok(mgr._animationFrameId, '活动态重新排 rAF');
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MMD
+// ─────────────────────────────────────────────────────────────────────────────
+function setupMMD(sb) {
+    sb.load(MMD_CORE_SRC, 'mmd-core.js');
+    const manager = { _shouldRender: true, _isDisposed: false, renderer: {}, _animationFrameId: null, clock: null, _renderWaiters: [] };
+    const core = new sb.window.MMDCore(manager);
+    core.renders = 0;
+    core._renderFrame = () => { core.renders++; };
+    manager._animationFrameId = sb.sandbox.requestAnimationFrame(() => {});
+    manager.core = core;
+    return { core, manager };
+}
+
+test('MMD：目标帧率接到设置里的帧率滑块，0 = 不限帧', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: 45 });
+    const { core } = setupMMD(sb);
+    assert.equal(core.targetFPS, 45);
+    sb.window.targetFrameRate = 0;
+    core._refreshTargetFps();
+    assert.equal(core.targetFPS, 0);
+    assert.equal(core.frameTime, 0, '不限帧时 rAF 路径不再跳帧');
+    assert.equal(core._resolveIdleFps(), 30);
+    sb.window.targetFrameRate = 24;
+    core._refreshTargetFps();
+    assert.equal(core.frameTime, 1000 / 24);
+    assert.equal(core._resolveIdleFps(), 24);
+    delete sb.window.targetFrameRate;
+    core._refreshTargetFps();
+    assert.ok([30, 45, 60].includes(core.targetFPS), '没有该配置时退回 performanceMode 档位');
+}));
+
+test('MMD Pet + 配置低于刷新率：活动态定时器驱动，衰减只换周期', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    sb.measureRefresh(60);
+    const { core, manager } = setupMMD(sb);
+    core._boostInteractiveFPS();
+    assert.equal(core._idleTickMode, true);
+    assert.equal(core._idleTickFps, 45);
+    assert.equal(manager._animationFrameId, null);
+    mock.timers.tick(22 * 5);
+    assert.ok(core.renders >= 4);
+    mock.timers.tick(1000);
+    assert.equal(core._idleTickMode, true);
+    assert.equal(core._idleTickFps, 30);
+    assert.equal(sb.rafQueue.length, 0, '从未重新排 rAF');
+    sb.window.targetFrameRate = 24;
+    sb.window.mmdManager = manager;
+    sb.window.dispatchEvent({ type: 'neko-frame-rate-changed', detail: { fps: 24 } });
+    assert.equal(core._idleTickFps, 24);
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 契约：页面侧对「坐标没变的 pointermove」不再升帧 / 不再算作光标活动
+// ─────────────────────────────────────────────────────────────────────────────
+test('契约：Live2D 交互层只有坐标真变了才升帧', () => {
+    const src = read('static/live2d/live2d-interaction.js');
+    const movedDecl = src.indexOf('const pointerMoved = pointer.x !== this._lastMouseX || pointer.y !== this._lastMouseY;');
+    const lastAssign = src.indexOf('this._lastMouseX = pointer.x;');
+    assert.ok(movedDecl >= 0, 'pointerMoved 判定缺失');
+    assert.ok(movedDecl < lastAssign, 'pointerMoved 必须在覆盖 _lastMouseX 之前计算');
+    const guarded = src.match(/pointerMoved && typeof this\.boostLinuxX11InteractiveFPS === 'function'/g) || [];
+    assert.equal(guarded.length, 2, '悬停范围内 + 全屏跟踪 两处升帧都必须受 pointerMoved 门控');
+    assert.doesNotMatch(
+        src.slice(src.indexOf('const onPointerMove = '), src.indexOf('const onBlur = ')),
+        /\n\s+if \(typeof this\.boostLinuxX11InteractiveFPS === 'function'\) \{\n\s+this\.boostLinuxX11InteractiveFPS\(\);/,
+        'onPointerMove 内不允许残留无门控的升帧'
+    );
+});
+
+test('契约：VRM / MMD 光标跟随对坐标没变的事件不刷新活动时间戳', () => {
+    const vrm = read('static/vrm/vrm-cursor-follow.js');
+    assert.match(vrm, /const moved = e\.clientX !== this\._rawMouseX \|\| e\.clientY !== this\._rawMouseY;/);
+    assert.match(vrm, /if \(moved\) this\._lastPointerMoveAt = now;/);
+    assert.doesNotMatch(vrm, /\n\s+this\._lastPointerMoveAt = now;\n/, '不允许无条件刷新');
+    const mmd = read('static/mmd/mmd-cursor-follow.js');
+    assert.match(mmd, /if \(e\.clientX !== this\._rawMouseX \|\| e\.clientY !== this\._rawMouseY\) \{\n\s+this\._lastPointerMoveTs = now;/);
+    assert.equal((mmd.match(/this\._lastPointerMoveTs = now;/g) || []).length, 1, '时间戳只在坐标变化门控内刷新一处');
+});
+
+test('契约：frame-pacing.js 只在 index.html（Pet 窗口页面）加载', () => {
+    const index = read('templates/index.html');
+    assert.match(index, /<script src="\/static\/frame-pacing\.js\?v=\{\{ static_asset_version \}\}"><\/script>/);
+    for (const tpl of ['model_manager.html', 'character_card_manager.html', 'card_maker.html', 'chat.html']) {
+        assert.doesNotMatch(read('templates/' + tpl), /frame-pacing\.js/, tpl + ' 不应加载帧率总闸');
+    }
+});

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -251,6 +251,22 @@ test('frame-pacing：非 Pet 页面 currentTimerTickFps 恒为 null', () => {
     assert.equal(sb.window.nekoFramePacing.currentTimerTickFps(), null);
 });
 
+test('契约：VRM / MMD 浮动按钮循环在定时器模式下到点直接 update，不再转一次性 rAF 多等一个 vsync', () => {
+    for (const [file, fpsExpr] of [
+        ['static/vrm/vrm-ui-buttons.js', 'this\\._idleTickFps'],
+        ['static/mmd/mmd-ui-buttons.js', 'this\\.core\\._idleTickFps'],
+    ]) {
+        const src = read(file);
+        const start = src.indexOf('const scheduleNext = () => {');
+        const end = src.indexOf('const update = () => {', start);
+        assert.ok(start > 0 && end > start, file + ' scheduleNext 定位失败');
+        const body = src.slice(start, end);
+        assert.match(body, new RegExp('const tickFps = Number\\(' + fpsExpr + '\\) > 0 \\? Number\\(' + fpsExpr + '\\) : 30;'), file + ' 周期跟随渲染 tick');
+        assert.match(body, /this\._uiLoopIdleTimeout = setTimeout\(\(\) => \{[\s\S]*?update\(\);\s*\}, Math\.max\(4, Math\.round\(1000 \/ tickFps\)\)\);/, file + ' 定时器到点直接 update');
+        assert.equal((body.match(/requestAnimationFrame\(update\)/g) || []).length, 1, file + ' 只有 rAF 模式那一处排 rAF');
+    }
+});
+
 test('契约：反应气泡跟随循环通过 frame-pacing 排帧', () => {
     const src = read('static/avatar/avatar-reaction-bubble.js');
     assert.match(src, /function scheduleFollowFrame\(tick\)[\s\S]*?state\.followPacedCancel = pacing\.requestPacedFrame\(tick\);/);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -400,6 +400,19 @@ test('MMD rAF 路径：不限帧后切回有限帧率，节流状态不能被 Na
     assert.ok(Number.isFinite(core.lastFrameTime));
 }));
 
+test('MMD Pet 没有 window.targetFrameRate 时，总闸按 MMD 自己的 performanceMode 回退值走，不按 60', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: undefined });
+    delete sb.window.targetFrameRate;
+    sb.measureRefresh(144);
+    const { core } = setupMMD(sb);
+    const fallback = core._resolveConfiguredTargetFps();
+    assert.ok([30, 45, 60].includes(fallback));
+    assert.equal(sb.window.nekoFramePacing.activeTimerTickFps(), 60, '总闸自己的缺省是 60');
+    assert.equal(core._resolveActiveTimerTickFps(), fallback, 'MMD 把自己解析的帧率交给总闸');
+    core._boostInteractiveFPS();
+    assert.equal(core._idleTickFps, fallback, '活动态定时器周期 = MMD 回退值');
+}));
+
 test('MMD：交互升帧的 900ms 保持期到期后活动判定失效', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: 45 });
     const { core, manager } = setupMMD(sb);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -479,13 +479,34 @@ test('Live2D：真实切角色序列 stop → removeModel 的 start → 最终 s
     app.ticker.stop();          // app-character：最终停掉 Live2D 给 VRM/MMD 让路
     assert.equal(shared.started, false, '不在定时器模式的 stop 也必须把 Pet 全局 ticker 扣住');
     assert.equal(system.started, false);
+    // 扣住期间改帧率设置：放开时全局 ticker 拿到的是新上限，且 shared/system 各自独立恢复
+    system.maxFPS = 45; // 模拟两者原本不同（放开后应各回各的，不互相串）
+    sb.window.targetFrameRate = 24;
+    mgr.setTargetFPS(24);
     app.ticker.start();         // 切回 Live2D
     assert.equal(shared.started, true, 'start 再放开');
+    assert.equal(shared.maxFPS, 24, '扣住期间改的设置在放开时生效');
+    assert.equal(system.maxFPS, 24, 'system 同样拿到新上限');
     // 非 Pet：stop 不扣全局 ticker（保持既有行为）
     const sb2 = createSandbox({ pet: false, targetFrameRate: 30 });
     const l2 = setupLive2D(sb2);
     l2.app.ticker.stop();
     assert.equal(l2.shared.started, true, '非 Pet 页面 stop 不动全局 ticker');
+}));
+
+test('Live2D：shared/system 的帧率上限分别保存、分别恢复，不互相串', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 60 });
+    sb.measureRefresh(60);
+    const { mgr, app, shared, system } = setupLive2D(sb);
+    mgr.boostInteractiveFPS(); // rAF 模式，shared/system = 60
+    shared.maxFPS = 50; // 外部把两者改成不同值
+    system.maxFPS = 20;
+    app.ticker.stop();  // 扣住：各自记下
+    assert.equal(shared.maxFPS, 0);
+    assert.equal(system.maxFPS, 0);
+    app.ticker.start(); // 放开：各回各的
+    assert.equal(shared.maxFPS, 50);
+    assert.equal(system.maxFPS, 20, 'system 不能被 shared 的保存值覆盖');
 }));
 
 test('Live2D：stop() 后直接销毁（不经 start）也必须释放全局 ticker，否则重建后模型 autoUpdate 冻住', withMockTimers(() => {

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -296,6 +296,24 @@ test('frame-pacing：采样进行中再来一次重测请求不丢，当前轮�
     assert.equal(sb.rafQueue.length, 0, '没有第三轮');
 }));
 
+test('frame-pacing：采样中排队的 measureDisplayRefreshRate(onDone) 回调在最后一轮结束后拿到最终结果', withMockTimers(() => {
+    const sb = createSandbox({ pet: true, targetFrameRate: 45 });
+    const pacing = sb.window.nekoFramePacing;
+    const firstResults = [];
+    const queuedResults = [];
+    pacing.measureDisplayRefreshRate((hz) => firstResults.push(hz));
+    assert.equal(sb.rafQueue.length, 1, '第一轮采样开始');
+    pacing.measureDisplayRefreshRate((hz) => queuedResults.push(hz));
+    pacing.measureDisplayRefreshRate((hz) => queuedResults.push(hz * 10));
+    assert.equal(queuedResults.length, 0, '排队请求的回调不会被提前调用');
+    sb.pumpFrames(25, 60);
+    assert.deepEqual(firstResults, [60], '首轮回调拿到首轮结果');
+    assert.deepEqual(queuedResults, [], '排队回调要等最后一轮');
+    sb.pumpFrames(25, 120);
+    assert.deepEqual(queuedResults, [120, 1200], '排队回调都拿到最终轮结果');
+    assert.equal(sb.rafQueue.length, 0);
+}));
+
 test('frame-pacing：144Hz 屏上 60fps 配置也切定时器驱动', withMockTimers(() => {
     const sb = createSandbox({ pet: true, targetFrameRate: 60 });
     sb.measureRefresh(144);
@@ -593,13 +611,14 @@ function loadVrmPhysicsStep() {
     return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', helperSrc + src.slice(start, end));
 }
 function makeVrmPhysicsCtx({ componentApi = true } = {}) {
-    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, lookAtTime: [], currentModel: null };
+    const ctx = { enablePhysics: true, _isLowTickRate: () => false, simulated: 0, lookAtTime: [], materialTime: [], currentModel: null };
     ctx.newModel = () => {
         const vrm = {
-            update: (d) => { ctx.simulated += d; ctx.lookAtTime.push(d); },
+            update: (d) => { ctx.simulated += d; ctx.lookAtTime.push(d); ctx.materialTime.push(d); },
             lookAt: { update: (d) => { ctx.lookAtTime.push(d); } },
             expressionManager: { update() {} },
             humanoid: { update() {} },
+            materials: [{ update: (d) => { ctx.materialTime.push(d); } }, {}],
         };
         if (componentApi) vrm.springBoneManager = { update: (d) => { ctx.simulated += d; } };
         ctx.currentModel = { vrm };
@@ -608,7 +627,7 @@ function makeVrmPhysicsCtx({ componentApi = true } = {}) {
     return ctx;
 }
 
-test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt 每 tick 只推进当前 delta', () => {
+test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt / MToon 材质每 tick 只推进当前 delta', () => {
     const run = loadVrmPhysicsStep();
     const ctx = makeVrmPhysicsCtx();
     const frames = [0.0167, 0.0167, 0.0333, 0.0167, 0.0167];
@@ -616,6 +635,8 @@ test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt 每 tick 只推进
     for (const d of frames) { elapsed += d; run.call(ctx, d, { renderQuality: 'medium' }, 0.05); }
     assert.ok(Math.abs(ctx.simulated - elapsed) < 1e-9, '弹簧骨物理时间守恒');
     assert.deepEqual(ctx.lookAtTime, frames, 'LookAt 每帧只拿当前 delta，不吃累计');
+    // 跳过帧不更新材质（与旧行为一致），更新帧材质拿当前 delta 而不是累计步长
+    assert.deepEqual(ctx.materialTime, [0.0167, 0.0333, 0.0167], '材质只在物理更新帧按当前 delta 推进');
     // 旧版 three-vrm（无 springBoneManager.update）退回整体 update
     const legacy = makeVrmPhysicsCtx({ componentApi: false });
     for (const d of [0.0167, 0.0167]) run.call(legacy, d, { renderQuality: 'medium' }, 0.05);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -521,6 +521,29 @@ function setupMMD(sb) {
     return { core, manager };
 }
 
+test('负数 targetFrameRate 一律归一为 60：Live2D / VRM / MMD 地板都不会算成负数', withMockTimers(() => {
+    const sb = createSandbox({ pet: false, targetFrameRate: -1 });
+    const { mgr } = setupLive2D(sb);
+    assert.equal(mgr._resolveConfiguredTargetFps(), 60);
+    assert.equal(mgr._resolveIdleFps(), 30);
+    const sb2 = createSandbox({ pet: false, targetFrameRate: -1 });
+    const vrm = setupVRM(sb2);
+    assert.equal(vrm._resolveConfiguredTargetFps(), 60);
+    assert.equal(vrm._resolveIdleFps(), 30);
+    vrm._enterIdleTickMode();
+    assert.equal(vrm._idleTickFps, 30, '空闲周期不会被负数配置拖到 1fps');
+    const sb3 = createSandbox({ pet: false, targetFrameRate: -1 });
+    const { core } = setupMMD(sb3);
+    assert.ok([30, 45, 60].includes(core._resolveConfiguredTargetFps()), 'MMD 负数配置退回档位值');
+    assert.equal(core._resolveIdleFps(), Math.min(30, core._resolveConfiguredTargetFps()));
+}));
+
+test('契约：VRM medium 隔帧物理还要按实际 delta 兜底（2×delta ≤ 50ms 才隔帧）', () => {
+    const src = read('static/vrm/vrm-manager.js');
+    assert.match(src, /const VRM_PHYSICS_MAX_STEP_S = 0\.05;/);
+    assert.match(src, /if \(quality === 'medium' && !this\._isLowTickRate\(\) && delta \* 2 <= VRM_PHYSICS_MAX_STEP_S\) \{/);
+});
+
 test('MMD：目标帧率接到设置里的帧率滑块，0 = 不限帧', withMockTimers(() => {
     const sb = createSandbox({ pet: false, targetFrameRate: 45 });
     const { core } = setupMMD(sb);

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -610,7 +610,11 @@ function loadVrmPhysicsStep() {
     const canSplitStart = src.indexOf('_canSplitVrmPhysicsUpdate(vrm) {');
     const canSplitEnd = src.indexOf('\n    }\n', canSplitStart) + 7;
     assert.ok(canSplitStart > 0 && canSplitEnd > canSplitStart, '_canSplitVrmPhysicsUpdate 定位失败');
+    const matStart = src.indexOf('_updateVrmMaterials(vrm, delta) {');
+    const matEnd = src.indexOf('\n    }\n', matStart) + 7;
+    assert.ok(matStart > 0 && matEnd > matStart, '_updateVrmMaterials 定位失败');
     const helperSrc = 'this._canSplitVrmPhysicsUpdate = function ' + src.slice(canSplitStart, canSplitEnd) + ';'
+        + 'this._updateVrmMaterials = function ' + src.slice(matStart, matEnd) + ';'
         + 'this._updateVrmWithPhysicsStep = function ' + src.slice(helperStart, helperEnd) + ';';
     return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', helperSrc + src.slice(start, end));
 }
@@ -639,8 +643,8 @@ test('VRM 物理隔帧：累计步长只喂弹簧骨，LookAt / MToon 材质每 
     for (const d of frames) { elapsed += d; run.call(ctx, d, { renderQuality: 'medium' }, 0.05); }
     assert.ok(Math.abs(ctx.simulated - elapsed) < 1e-9, '弹簧骨物理时间守恒');
     assert.deepEqual(ctx.lookAtTime, frames, 'LookAt 每帧只拿当前 delta，不吃累计');
-    // 跳过帧不更新材质（与旧行为一致），更新帧材质拿当前 delta 而不是累计步长
-    assert.deepEqual(ctx.materialTime, [0.0167, 0.0333, 0.0167], '材质只在物理更新帧按当前 delta 推进');
+    // MToon 材质 UV 动画按 delta 累积：跳过物理的帧也要推进，每帧拿当前 delta 而不是累计步长
+    assert.deepEqual(ctx.materialTime, frames, '材质每帧按当前 delta 推进，动画不会变成半速');
     // 旧版 three-vrm（无 springBoneManager.update）：不隔帧，每帧整体 update(delta)，
     // 累计步长不会喂给 lookAt/材质
     const legacy = makeVrmPhysicsCtx({ componentApi: false });

--- a/tests/frontend/pet_frame_pacing_gate.test.cjs
+++ b/tests/frontend/pet_frame_pacing_gate.test.cjs
@@ -620,11 +620,16 @@ function loadVrmPhysicsStep() {
     const canSplitStart = src.indexOf('_canSplitVrmPhysicsUpdate(vrm) {');
     const canSplitEnd = src.indexOf('\n    }\n', canSplitStart) + 7;
     assert.ok(canSplitStart > 0 && canSplitEnd > canSplitStart, '_canSplitVrmPhysicsUpdate 定位失败');
-    const matStart = src.indexOf('_updateVrmMaterials(vrm, delta) {');
-    const matEnd = src.indexOf('\n    }\n', matStart) + 7;
-    assert.ok(matStart > 0 && matEnd > matStart, '_updateVrmMaterials 定位失败');
+    const sliceMethod = (name) => {
+        const s = src.indexOf(name + '(vrm, delta) {');
+        const e = src.indexOf('\n    }\n', s) + 7;
+        assert.ok(s > 0 && e > s, name + ' 定位失败');
+        return 'this.' + name + ' = function ' + src.slice(s, e) + ';';
+    };
     const helperSrc = 'this._canSplitVrmPhysicsUpdate = function ' + src.slice(canSplitStart, canSplitEnd) + ';'
-        + 'this._updateVrmMaterials = function ' + src.slice(matStart, matEnd) + ';'
+        + sliceMethod('_updateVrmMaterials')
+        + sliceMethod('_updateVrmPoseComponents')
+        + sliceMethod('_updateVrmWithoutPhysics')
         + 'this._updateVrmWithPhysicsStep = function ' + src.slice(helperStart, helperEnd) + ';';
     return new Function('delta', 'window', 'VRM_PHYSICS_MAX_STEP_S', helperSrc + src.slice(start, end));
 }
@@ -652,6 +657,12 @@ test('VRM 分量更新顺序与 three-vrm VRM.update 一致：humanoid → lookA
     run.call(ctx, 0.0167, { renderQuality: 'high' }, 0.05);
     assert.deepEqual(ctx.order, ['humanoid', 'lookAt', 'expression', 'constraint', 'spring', 'material'],
         '约束/弹簧骨必须在 LookAt 驱动的姿态之后');
+    // medium 跳过物理的帧：除弹簧骨外全部分量照常按库顺序推进（约束不能只在另一帧跑）
+    const skipCtx = makeVrmPhysicsCtx();
+    run.call(skipCtx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.deepEqual(skipCtx.order, ['humanoid', 'lookAt', 'expression', 'constraint', 'material'], '跳过帧只少弹簧骨');
+    run.call(skipCtx, 0.0167, { renderQuality: 'medium' }, 0.05);
+    assert.deepEqual(skipCtx.order.slice(5), ['humanoid', 'lookAt', 'expression', 'constraint', 'spring', 'material'], '更新帧完整顺序');
     // 打包版 three-vrm 里 VRM.update 的真实顺序，防止库升级后两边漂移
     const lib = read('static/libs/three-vrm.module.min.js');
     assert.match(lib, /update\(e\)\{super\.update\(e\),this\.nodeConstraintManager&&this\.nodeConstraintManager\.update\(\),this\.springBoneManager&&this\.springBoneManager\.update\(e\),this\.materials&&this\.materials\.forEach/);

--- a/tests/unit/test_pet_frame_pacing_gate.py
+++ b/tests/unit/test_pet_frame_pacing_gate.py
@@ -1,0 +1,35 @@
+"""Electron Pet window frame pacing gate: Live2D / VRM / MMD switch to timer-driven
+ticks when the configured frame rate is below the display refresh rate.
+
+The behavioural suite lives in ``tests/frontend/pet_frame_pacing_gate.test.cjs``
+(node:test; it loads the real ``static/frame-pacing.js`` plus the three renderer
+backends). This file is only the pytest entry point.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pet_frame_pacing_gate_node_suite() -> None:
+    from tests.node_harness import run_node_script
+
+    node_path = shutil.which("node")
+    if not node_path:
+        pytest.skip("node not found")
+
+    test_path = ROOT / "tests" / "frontend" / "pet_frame_pacing_gate.test.cjs"
+    result = run_node_script(
+        node_path,
+        test_path.read_text(encoding="utf-8"),
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## 背景

设置里的「帧率」滑块降不下 Pet 窗口的 CPU/GPU，原因是帧的"发动机"有多个，滑块只接到其中一个：

| 驱动源 | 改前 |
|---|---|
| Live2D `app.ticker`（draw + UI 按钮 ticker） | 听设置 |
| `PIXI.Ticker.shared`（模型 motion/physics 参数合成） | 不听，按显示器刷新率跑 |
| rAF 排程本身 | 不听，maxFPS 只跳回调体，Blink 仍每 vsync 跑主帧 |
| VRM 自建 rAF | 跳过 render，rAF 不停 |
| MMD | 完全没接线（`targetFPS` 来自 `performanceMode`） |
| Electron preload 光标轮询 | 光标静止也周期性派发合成 pointermove，页面侧无条件升帧把空闲低频 tick 的 hold 无限续命 |

## 改动（只覆盖 Electron Pet 窗口）

- **新增 `static/frame-pacing.js`**：仅 `index.html` 加载、仅 `__LANLAN_IS_ELECTRON_PET__` 时生效。用 rAF 时间戳量显示器刷新率；配置帧率 < 刷新率×0.9 时给出「活动态定时器驱动帧率」，否则留在 rAF。非 Pet 页面没有这个全局，各后端保持原有行为。
- **Live2D**：活动态按该帧率走现有定时器 tick 模式（停 app/shared/system 三条 rAF），衰减到地板只换周期、不回 rAF。rAF 模式下 Pet 一并接管 `shared/system.maxFPS`；定时器模式下三者 maxFPS 清零并保存/恢复。
- **VRM / MMD**：同一套活动态定时器驱动；MMD 的 `targetFPS` 改读 `window.targetFrameRate`（0 = 不限帧）并监听 `neko-frame-rate-changed`。
- **页面侧只有坐标真变了才升帧 / 才算光标活动**（`live2d-interaction`、`vrm/mmd-cursor-follow`），与 preload 侧的合成事件去重（N.E.K.O.-PC 配套 PR）互为兜底。

## 回归风险

- 定时器驱动不与 vsync 对齐：60fps 配置在 60Hz 屏上刻意留在 rAF（0.9 比例），只有 30/45 或高刷屏才切；刷新率测不出时保守走 rAF。
- Pet 进程只有一个 Live2DManager，接管全局 `Ticker.shared/system` 安全；其它页面不加载 frame-pacing.js，不接管。
- 外部 `ticker.start()`/`pauseRendering` 路径：定时器模式让位给 rAF，governor 300ms 内自愈。
- VRM 定时器驱动时 VMC 发送速率 = 配置帧率（原来 = rAF 累计目标时间）。

## 验证

- `tests/frontend/pet_frame_pacing_gate.test.cjs`（真实加载三后端源码 + frame-pacing，14 条，已做变异验证：去掉 gate / 去掉 shared 接管各自被抓）+ pytest 入口 `tests/unit/test_pet_frame_pacing_gate.py`。
- 既有 12 个碰 live2d/vrm/mmd 源码的静态契约测试全过（227 passed）。
- 真机判据：Pet 窗 DevTools 里 `live2dManager._idleTickMode` / `_idleTickFps`，配 30fps 设置在 60Hz 屏静止 2s 后应为 `true / 30`，鼠标划过模型时仍为 `true / 30`（不回 rAF）；任务管理器 GPU% 对比改前。

配套：N.E.K.O.-PC 侧 preload 合成 pointermove 全平台去重（Project-N-E-K-O/N.E.K.O.-PC PR 见评论）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Electron 宠物窗口可根据显示器刷新率智能调度帧率。
  * Live2D、MMD 和 VRM 支持活动与空闲状态动态切换帧率。
  * 音量监测、口型同步、反应气泡、舞台动画及拖拽回弹支持统一帧调度。

* **性能优化**
  * 静止指针事件不再延长活动状态。
  * 空闲 UI 更新按目标帧率执行，减少额外等待。
  * 音量弹窗不可见时降低检测频率。
  * 优化 VRM 低帧率下的物理更新表现。

* **Bug 修复**
  * 非法帧率配置统一回退至 60 FPS，并支持不限帧设置。

* **测试**
  * 新增帧率调度与渲染切换自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->