### PR TITLE
feat(plugin): add per-plugin log export and log directory access

### DIFF
--- a/frontend/plugin-manager/env.d.ts
+++ b/frontend/plugin-manager/env.d.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
 
+// Vite 构建时注入的全局变量
+declare const __VITE_PROXY_TARGET_HOSTNAME__: string
+
 declare module 'element-plus/dist/locale/zh-cn.mjs'
 declare module 'element-plus/dist/locale/zh-tw.mjs'
 declare module 'element-plus/dist/locale/en.mjs'

--- a/frontend/plugin-manager/src/api/logs.ts
+++ b/frontend/plugin-manager/src/api/logs.ts
@@ -2,6 +2,7 @@
  * 日志相关 API
  */
 import { get } from './index'
+import { API_BASE_URL } from '@/utils/constants'
 import type { LogEntry, LogFile } from '@/types/api'
 
 /**
@@ -37,5 +38,23 @@ export function getPluginLogFiles(pluginId: string): Promise<{
   time: string
 }> {
   return get(`/plugin/${encodeURIComponent(pluginId)}/logs/files`)
+}
+
+/**
+ * 获取插件日志目录路径
+ */
+export function getPluginLogDirectory(pluginId: string): Promise<{
+  plugin_id: string
+  directory: string
+  time: string
+}> {
+  return get(`/plugin/${encodeURIComponent(pluginId)}/logs/directory`)
+}
+
+/**
+ * 导出插件日志文件（返回下载 URL）
+ */
+export function getPluginLogExportUrl(pluginId: string): string {
+  return `${API_BASE_URL}/plugin/${encodeURIComponent(pluginId)}/logs/export`
 }
 

--- a/frontend/plugin-manager/src/api/logs.ts
+++ b/frontend/plugin-manager/src/api/logs.ts
@@ -55,6 +55,8 @@ export function getPluginLogDirectory(pluginId: string): Promise<{
  * 导出插件日志文件（返回下载 URL）
  */
 export function getPluginLogExportUrl(pluginId: string): string {
-  return `${API_BASE_URL}/plugin/${encodeURIComponent(pluginId)}/logs/export`
+  // 移除尾部斜杠避免双斜杠路径
+  const baseUrl = API_BASE_URL.replace(/\/$/, '')
+  return `${baseUrl}/plugin/${encodeURIComponent(pluginId)}/logs/export`
 }
 

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -24,7 +24,7 @@
         {{ $t('logs.exportLog') }}
       </el-button>
 
-      <el-button data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
+      <el-button v-if="!isRemoteBackend" data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
         <el-icon><Folder /></el-icon>
         {{ $t('logs.openLogDirectory') }}
       </el-button>
@@ -77,6 +77,7 @@ import { useLogsStore } from '@/stores/logs'
 import { useLogStream } from '@/composables/useLogStream'
 import { getPluginLogDirectory, getPluginLogExportUrl } from '@/api/logs'
 import { openLocalPath } from '@/utils/openExternal'
+import { API_BASE_URL } from '@/utils/constants'
 
 const props = defineProps<{
   pluginId: string
@@ -86,6 +87,12 @@ const { t } = useI18n()
 const logsStore = useLogsStore()
 const pluginIdRef = toRef(props, 'pluginId')
 const { isConnected } = useLogStream(pluginIdRef)
+
+// 检测是否为远程后端（非本地）
+const isRemoteBackend = computed(() => {
+  const baseUrl = API_BASE_URL.replace(/\/$/, '')
+  return baseUrl && !baseUrl.match(/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/)
+})
 
 const levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 const levelFilter = ref('')

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -114,8 +114,20 @@ const isLocalBackend = computed(() => {
   // 空字符串表示通过 Vite 代理，但 VITE_BACKEND_URL 可能指向远程服务器，
   // 运行时无法获取构建时环境变量。为安全起见，开发模式下禁用目录打开功能。
   if (!baseUrl) return false
-  // 检测 localhost / 127.0.0.1 / 0.0.0.0
-  return !!baseUrl.match(/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/)
+
+  // 解析 URL 来提取 hostname，支持带路径的 URL（如 http://localhost:8000/api）
+  try {
+    const url = new URL(baseUrl, window.location.origin)
+    const hostname = url.hostname.toLowerCase()
+    // 只允许回环地址：localhost, 127.0.0.1, 0.0.0.0, ::1
+    return hostname === 'localhost' ||
+           hostname === '127.0.0.1' ||
+           hostname === '0.0.0.0' ||
+           hostname === '::1'
+  } catch {
+    // URL 解析失败，视为非本地
+    return false
+  }
 })
 
 // 只有同时满足：有桌面桥接 AND 后端是本地时，才能安全打开目录

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -111,8 +111,9 @@ const hasDesktopBridge = computed(() => {
 // 客户端无法打开或可能错误打开本地同名路径。
 const isLocalBackend = computed(() => {
   const baseUrl = API_BASE_URL.replace(/\/$/, '')
-  // 空字符串表示使用相对路径或 Vite 代理，假定为本地开发环境
-  if (!baseUrl) return true
+  // 空字符串表示通过 Vite 代理，但 VITE_BACKEND_URL 可能指向远程服务器，
+  // 运行时无法获取构建时环境变量。为安全起见，开发模式下禁用目录打开功能。
+  if (!baseUrl) return false
   // 检测 localhost / 127.0.0.1 / 0.0.0.0
   return !!baseUrl.match(/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/)
 })

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -111,23 +111,30 @@ const hasDesktopBridge = computed(() => {
 // 客户端无法打开或可能错误打开本地同名路径。
 const isLocalBackend = computed(() => {
   const baseUrl = API_BASE_URL.replace(/\/$/, '')
-  // 空字符串表示通过 Vite 代理，但 VITE_BACKEND_URL 可能指向远程服务器，
-  // 运行时无法获取构建时环境变量。为安全起见，开发模式下禁用目录打开功能。
-  if (!baseUrl) return false
 
-  // 解析 URL 来提取 hostname，支持带路径的 URL（如 http://localhost:8000/api）
-  try {
-    const url = new URL(baseUrl, window.location.origin)
-    const hostname = url.hostname.toLowerCase()
-    // 只允许回环地址：localhost, 127.0.0.1, 0.0.0.0, ::1
-    return hostname === 'localhost' ||
-           hostname === '127.0.0.1' ||
-           hostname === '0.0.0.0' ||
-           hostname === '::1'
-  } catch {
-    // URL 解析失败，视为非本地
-    return false
+  let hostname: string
+  if (!baseUrl) {
+    // 空字符串表示通过 Vite 代理。从构建时注入的变量获取代理目标的 hostname。
+    // 生产环境中该变量未定义，默认为 'localhost'（但生产环境 baseUrl 不会为空）。
+    hostname = (typeof __VITE_PROXY_TARGET_HOSTNAME__ !== 'undefined'
+                ? __VITE_PROXY_TARGET_HOSTNAME__
+                : 'localhost').toLowerCase()
+  } else {
+    // 有明确的 API_BASE_URL，解析它来提取 hostname
+    try {
+      const url = new URL(baseUrl, window.location.origin)
+      hostname = url.hostname.toLowerCase()
+    } catch {
+      // URL 解析失败，视为非本地
+      return false
+    }
   }
+
+  // 只允许回环地址：localhost, 127.0.0.1, 0.0.0.0, ::1
+  return hostname === 'localhost' ||
+         hostname === '127.0.0.1' ||
+         hostname === '0.0.0.0' ||
+         hostname === '::1'
 })
 
 // 只有同时满足：有桌面桥接 AND 后端是本地时，才能安全打开目录

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -211,7 +211,11 @@ async function handleExportLog() {
     console.error('Failed to export log:', error)
     ElMessage.error(t('logs.exportFailed'))
   } finally {
-    if (objectUrl) URL.revokeObjectURL(objectUrl)
+    // 延迟撤销 Blob URL，避免浏览器尚未解析 href 时就撤销导致下载失败
+    if (objectUrl) {
+      const urlToRevoke = objectUrl
+      setTimeout(() => URL.revokeObjectURL(urlToRevoke), 0)
+    }
   }
 }
 

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -19,6 +19,16 @@
 
       <el-button :loading="loading" data-yui-guide-id="log-refresh" @click="refreshLogs">{{ $t('common.refresh') }}</el-button>
 
+      <el-button data-yui-guide-id="log-export" @click="handleExportLog">
+        <el-icon><Download /></el-icon>
+        {{ $t('logs.exportLog') }}
+      </el-button>
+
+      <el-button data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
+        <el-icon><Folder /></el-icon>
+        {{ $t('logs.openLogDirectory') }}
+      </el-button>
+
       <el-switch v-model="autoScroll" data-yui-guide-id="log-auto-scroll" :active-text="$t('logs.autoScroll')" />
     </div>
 
@@ -61,8 +71,12 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ElMessage } from 'element-plus'
+import { Download, Folder } from '@element-plus/icons-vue'
 import { useLogsStore } from '@/stores/logs'
 import { useLogStream } from '@/composables/useLogStream'
+import { getPluginLogDirectory, getPluginLogExportUrl } from '@/api/logs'
+import { openLocalPath } from '@/utils/openExternal'
 
 const props = defineProps<{
   pluginId: string
@@ -137,6 +151,48 @@ async function scrollToBottom() {
   if (logContainerRef.value) {
     logContainerRef.value.scrollTop = logContainerRef.value.scrollHeight
   }
+}
+
+async function handleExportLog() {
+  let objectUrl = ''
+  try {
+    // 用 fetch 而不是直接 <a href> 触发下载：后者拿不到响应状态，
+    // 服务端返回 404（该插件没有日志）时也会弹成功提示。
+    const response = await fetch(getPluginLogExportUrl(props.pluginId))
+    if (!response.ok) {
+      ElMessage.error(response.status === 404 ? t('logs.noLogFileToExport') : t('logs.exportFailed'))
+      return
+    }
+    const blob = await response.blob()
+    objectUrl = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = objectUrl
+    link.download = `${props.pluginId}_logs.zip`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    ElMessage.success(t('logs.exportSuccess'))
+  } catch (error) {
+    console.error('Failed to export log:', error)
+    ElMessage.error(t('logs.exportFailed'))
+  } finally {
+    if (objectUrl) URL.revokeObjectURL(objectUrl)
+  }
+}
+
+function handleOpenDirectory() {
+  getPluginLogDirectory(props.pluginId)
+    .then((response) => {
+      if (!response.directory) {
+        ElMessage.warning(t('logs.noLogFileToExport'))
+        return
+      }
+      openLocalPath(response.directory)
+    })
+    .catch((error) => {
+      console.error('Failed to open log directory:', error)
+      ElMessage.error(t('logs.openDirectoryFailed'))
+    })
 }
 
 watch(

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -24,7 +24,7 @@
         {{ $t('logs.exportLog') }}
       </el-button>
 
-      <el-button v-if="hasDesktopBridge" data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
+      <el-button v-if="canOpenDirectory" data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
         <el-icon><Folder /></el-icon>
         {{ $t('logs.openLogDirectory') }}
       </el-button>
@@ -77,6 +77,7 @@ import { useLogsStore } from '@/stores/logs'
 import { useLogStream } from '@/composables/useLogStream'
 import { getPluginLogDirectory, getPluginLogExportUrl } from '@/api/logs'
 import { openLocalPath } from '@/utils/openExternal'
+import { API_BASE_URL } from '@/utils/constants'
 
 const props = defineProps<{
   pluginId: string
@@ -104,6 +105,20 @@ const hasDesktopBridge = computed(() => {
     ))
   )
 })
+
+// 检测后端是否为本地
+// 即使有桌面桥接，如果后端在远程机器上，返回的路径也是远程服务器的绝对路径，
+// 客户端无法打开或可能错误打开本地同名路径。
+const isLocalBackend = computed(() => {
+  const baseUrl = API_BASE_URL.replace(/\/$/, '')
+  // 空字符串表示使用相对路径或 Vite 代理，假定为本地开发环境
+  if (!baseUrl) return true
+  // 检测 localhost / 127.0.0.1 / 0.0.0.0
+  return !!baseUrl.match(/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/)
+})
+
+// 只有同时满足：有桌面桥接 AND 后端是本地时，才能安全打开目录
+const canOpenDirectory = computed(() => hasDesktopBridge.value && isLocalBackend.value)
 
 const levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 const levelFilter = ref('')

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -154,11 +154,13 @@ async function scrollToBottom() {
 }
 
 async function handleExportLog() {
+  // 在开始导出前捕获 pluginId，防止用户在下载期间切换插件导致文件名错误
+  const pluginId = props.pluginId
   let objectUrl = ''
   try {
     // 用 fetch 而不是直接 <a href> 触发下载：后者拿不到响应状态，
     // 服务端返回 404（该插件没有日志）时也会弹成功提示。
-    const response = await fetch(getPluginLogExportUrl(props.pluginId))
+    const response = await fetch(getPluginLogExportUrl(pluginId))
     if (!response.ok) {
       ElMessage.error(response.status === 404 ? t('logs.noLogFileToExport') : t('logs.exportFailed'))
       return
@@ -167,7 +169,7 @@ async function handleExportLog() {
     objectUrl = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = objectUrl
-    link.download = `${props.pluginId}_logs.zip`
+    link.download = `${pluginId}_logs.zip`
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -24,7 +24,7 @@
         {{ $t('logs.exportLog') }}
       </el-button>
 
-      <el-button v-if="!isRemoteBackend" data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
+      <el-button v-if="hasDesktopBridge" data-yui-guide-id="log-open-directory" @click="handleOpenDirectory">
         <el-icon><Folder /></el-icon>
         {{ $t('logs.openLogDirectory') }}
       </el-button>
@@ -77,7 +77,6 @@ import { useLogsStore } from '@/stores/logs'
 import { useLogStream } from '@/composables/useLogStream'
 import { getPluginLogDirectory, getPluginLogExportUrl } from '@/api/logs'
 import { openLocalPath } from '@/utils/openExternal'
-import { API_BASE_URL } from '@/utils/constants'
 
 const props = defineProps<{
   pluginId: string
@@ -88,10 +87,22 @@ const logsStore = useLogsStore()
 const pluginIdRef = toRef(props, 'pluginId')
 const { isConnected } = useLogStream(pluginIdRef)
 
-// 检测是否为远程后端（非本地）
-const isRemoteBackend = computed(() => {
-  const baseUrl = API_BASE_URL.replace(/\/$/, '')
-  return baseUrl && !baseUrl.match(/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/)
+// 检测是否有桌面桥接（Electron 环境）
+// 只有在桌面环境中才能打开本地路径；即使后端是本地的，
+// 如果运行在浏览器中也无法调用系统文件管理器。
+const hasDesktopBridge = computed(() => {
+  const w = window as unknown as {
+    nekoHost?: { openPath?: unknown }
+    electronShell?: { openPath?: unknown; showItemInFolder?: unknown; openExternal?: unknown }
+  }
+  return !!(
+    (w.nekoHost && typeof w.nekoHost.openPath === 'function') ||
+    (w.electronShell && (
+      typeof w.electronShell.openPath === 'function' ||
+      typeof w.electronShell.showItemInFolder === 'function' ||
+      typeof w.electronShell.openExternal === 'function'
+    ))
+  )
 })
 
 const levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -131,10 +131,12 @@ const isLocalBackend = computed(() => {
   }
 
   // 只允许回环地址：localhost, 127.0.0.1, 0.0.0.0, ::1
+  // 注意：URL 解析 IPv6 地址时会保留方括号，所以需要检查 [::1]
   return hostname === 'localhost' ||
          hostname === '127.0.0.1' ||
          hostname === '0.0.0.0' ||
-         hostname === '::1'
+         hostname === '::1' ||
+         hostname === '[::1]'
 })
 
 // 只有同时满足：有桌面桥接 AND 后端是本地时，才能安全打开目录

--- a/frontend/plugin-manager/src/components/logs/LogViewer.vue
+++ b/frontend/plugin-manager/src/components/logs/LogViewer.vue
@@ -187,7 +187,10 @@ function handleOpenDirectory() {
         ElMessage.warning(t('logs.noLogFileToExport'))
         return
       }
-      openLocalPath(response.directory)
+      return openLocalPath(response.directory)
+    })
+    .then(() => {
+      // 成功打开目录，不显示任何消息
     })
     .catch((error) => {
       console.error('Failed to open log directory:', error)

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -546,7 +546,7 @@ function handleMessage(event: MessageEvent) {
   }
   if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-open-path') {
     const path = typeof data.payload?.path === 'string' ? data.payload.path : ''
-    if (path) openLocalPath(path)
+    if (path) openLocalPath(path).catch(() => {}) // 宿主插件发起的打开请求，失败时静默处理
     return
   }
   if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-cancel') {

--- a/frontend/plugin-manager/src/i18n/locales/en-US.ts
+++ b/frontend/plugin-manager/src/i18n/locales/en-US.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: 'Returned Lines',
     connected: 'Connected',
     disconnected: 'Disconnected',
-    connectionFailed: 'Log stream connection failed'
+    connectionFailed: 'Log stream connection failed',
+    exportLog: 'Export Logs Archive',
+    openLogDirectory: 'Open Log Directory',
+    exportSuccess: 'Log exported successfully',
+    exportFailed: 'Failed to export log',
+    openDirectoryFailed: 'Failed to open directory',
+    noLogFileToExport: 'No log file to export'
   },
   runs: {
     title: 'Runs',

--- a/frontend/plugin-manager/src/i18n/locales/es.ts
+++ b/frontend/plugin-manager/src/i18n/locales/es.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: 'Líneas devueltas',
     connected: 'Conectado',
     disconnected: 'Desconectado',
-    connectionFailed: 'Error de conexión al flujo de registros'
+    connectionFailed: 'Error de conexión al flujo de registros',
+    exportLog: 'Exportar archivo de registros',
+    openLogDirectory: 'Abrir directorio de registros',
+    exportSuccess: 'Registro exportado con éxito',
+    exportFailed: 'Error al exportar el registro',
+    openDirectoryFailed: 'Error al abrir el directorio',
+    noLogFileToExport: 'No hay archivo de registro para exportar'
   },
   runs: {
     title: 'Ejecuciones',

--- a/frontend/plugin-manager/src/i18n/locales/ja.ts
+++ b/frontend/plugin-manager/src/i18n/locales/ja.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: '返却行数',
     connected: '接続済み',
     disconnected: '未接続',
-    connectionFailed: 'ログストリームの接続に失敗しました'
+    connectionFailed: 'ログストリームの接続に失敗しました',
+    exportLog: 'ログアーカイブをエクスポート',
+    openLogDirectory: 'ログディレクトリを開く',
+    exportSuccess: 'ログのエクスポートに成功しました',
+    exportFailed: 'ログのエクスポートに失敗しました',
+    openDirectoryFailed: 'ディレクトリを開けませんでした',
+    noLogFileToExport: 'エクスポートするログファイルがありません'
   },
   runs: {
     title: '実行履歴',

--- a/frontend/plugin-manager/src/i18n/locales/ko.ts
+++ b/frontend/plugin-manager/src/i18n/locales/ko.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: '반환된 줄 수',
     connected: '연결됨',
     disconnected: '연결 안 됨',
-    connectionFailed: '로그 스트림 연결에 실패했습니다'
+    connectionFailed: '로그 스트림 연결에 실패했습니다',
+    exportLog: '로그 아카이브 내보내기',
+    openLogDirectory: '로그 디렉터리 열기',
+    exportSuccess: '로그를 성공적으로 내보냈습니다',
+    exportFailed: '로그 내보내기에 실패했습니다',
+    openDirectoryFailed: '디렉터리를 열지 못했습니다',
+    noLogFileToExport: '내보낼 로그 파일이 없습니다'
   },
   runs: {
     title: '실행 기록',

--- a/frontend/plugin-manager/src/i18n/locales/pt.ts
+++ b/frontend/plugin-manager/src/i18n/locales/pt.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: 'Linhas retornadas',
     connected: 'Conectado',
     disconnected: 'Desconectado',
-    connectionFailed: 'Falha de conexão do fluxo de registros'
+    connectionFailed: 'Falha de conexão do fluxo de registros',
+    exportLog: 'Exportar arquivo de registros',
+    openLogDirectory: 'Abrir diretório de registros',
+    exportSuccess: 'Registro exportado com sucesso',
+    exportFailed: 'Falha ao exportar registro',
+    openDirectoryFailed: 'Falha ao abrir diretório',
+    noLogFileToExport: 'Nenhum arquivo de registro para exportar'
   },
   runs: {
     title: 'Execuções',

--- a/frontend/plugin-manager/src/i18n/locales/ru.ts
+++ b/frontend/plugin-manager/src/i18n/locales/ru.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: 'Возвращено строк',
     connected: 'Подключено',
     disconnected: 'Отключено',
-    connectionFailed: 'Ошибка подключения к потоку логов'
+    connectionFailed: 'Ошибка подключения к потоку логов',
+    exportLog: 'Экспортировать архив логов',
+    openLogDirectory: 'Открыть директорию логов',
+    exportSuccess: 'Лог успешно экспортирован',
+    exportFailed: 'Не удалось экспортировать лог',
+    openDirectoryFailed: 'Не удалось открыть директорию',
+    noLogFileToExport: 'Нет файла лога для экспорта'
   },
   runs: {
     title: 'Запуски',

--- a/frontend/plugin-manager/src/i18n/locales/zh-CN.ts
+++ b/frontend/plugin-manager/src/i18n/locales/zh-CN.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: '返回行数',
     connected: '已连接',
     disconnected: '未连接',
-    connectionFailed: '日志流连接失败'
+    connectionFailed: '日志流连接失败',
+    exportLog: '导出日志压缩包',
+    openLogDirectory: '打开日志目录',
+    exportSuccess: '日志导出成功',
+    exportFailed: '日志导出失败',
+    openDirectoryFailed: '打开目录失败',
+    noLogFileToExport: '没有可导出的日志文件'
   },
   runs: {
     title: '运行记录',

--- a/frontend/plugin-manager/src/i18n/locales/zh-TW.ts
+++ b/frontend/plugin-manager/src/i18n/locales/zh-TW.ts
@@ -648,7 +648,13 @@ export default {
     returnedLines: '返回行數',
     connected: '已連線',
     disconnected: '未連線',
-    connectionFailed: '日誌串流連線失敗'
+    connectionFailed: '日誌串流連線失敗',
+    exportLog: '匯出日誌壓縮包',
+    openLogDirectory: '開啟日誌目錄',
+    exportSuccess: '日誌匯出成功',
+    exportFailed: '日誌匯出失敗',
+    openDirectoryFailed: '開啟目錄失敗',
+    noLogFileToExport: '沒有可匯出的日誌檔案'
   },
   runs: {
     title: '執行記錄',

--- a/frontend/plugin-manager/src/utils/openExternal.ts
+++ b/frontend/plugin-manager/src/utils/openExternal.ts
@@ -81,7 +81,13 @@ export function openLocalPath(path: string): Promise<void> {
     })
   }
   if (host.electronShell && typeof host.electronShell.openPath === 'function') {
-    return Promise.resolve(host.electronShell.openPath(target)).then(() => undefined)
+    return Promise.resolve(host.electronShell.openPath(target)).then((result) => {
+      // Electron shell.openPath 返回 Promise<string>：空字符串表示成功，非空字符串是错误消息
+      if (typeof result === 'string' && result !== '') {
+        throw new Error(result)
+      }
+      return undefined
+    })
   }
   if (host.electronShell && typeof host.electronShell.showItemInFolder === 'function') {
     return Promise.resolve(host.electronShell.showItemInFolder(target)).then(() => undefined)

--- a/frontend/plugin-manager/src/utils/openExternal.ts
+++ b/frontend/plugin-manager/src/utils/openExternal.ts
@@ -58,9 +58,9 @@ export function openExternalUrl(url: string): void {
   window.open(href, '_blank', 'noopener,noreferrer')
 }
 
-export function openLocalPath(path: string): void {
+export function openLocalPath(path: string): Promise<void> {
   const raw = String(path || '').trim()
-  if (!isLocalPath(raw)) return
+  if (!isLocalPath(raw)) return Promise.reject(new Error('Not a valid local path'))
   const target = normalizeLocalPath(raw)
   const host = (window as unknown as {
     nekoHost?: { openPath?: (payload: { path: string }) => void | Promise<unknown> }
@@ -71,28 +71,19 @@ export function openLocalPath(path: string): void {
     }
   })
   if (host.nekoHost && typeof host.nekoHost.openPath === 'function') {
-    Promise.resolve(host.nekoHost.openPath({ path: target })).catch((err) => {
-      console.warn('[openLocalPath] nekoHost.openPath failed:', err)
-    })
-    return
+    return Promise.resolve(host.nekoHost.openPath({ path: target })).then(() => undefined)
   }
   if (host.electronShell && typeof host.electronShell.openPath === 'function') {
-    Promise.resolve(host.electronShell.openPath(target)).catch((err) => {
-      console.warn('[openLocalPath] electronShell.openPath failed:', err)
-    })
-    return
+    return Promise.resolve(host.electronShell.openPath(target)).then(() => undefined)
   }
   if (host.electronShell && typeof host.electronShell.showItemInFolder === 'function') {
-    Promise.resolve(host.electronShell.showItemInFolder(target)).catch((err) => {
-      console.warn('[openLocalPath] electronShell.showItemInFolder failed:', err)
-    })
-    return
+    return Promise.resolve(host.electronShell.showItemInFolder(target)).then(() => undefined)
   }
   if (host.electronShell && typeof host.electronShell.openExternal === 'function') {
-    Promise.resolve(host.electronShell.openExternal(localPathToFileUrl(target))).catch((err) => {
-      console.warn('[openLocalPath] electronShell.openExternal(file://) failed:', err)
-    })
+    return Promise.resolve(host.electronShell.openExternal(localPathToFileUrl(target))).then(() => undefined)
   }
+  // 纯浏览器环境：没有桌面桥接
+  return Promise.reject(new Error('No desktop bridge available'))
 }
 
 function isLocalPath(value: string): boolean {

--- a/frontend/plugin-manager/src/utils/openExternal.ts
+++ b/frontend/plugin-manager/src/utils/openExternal.ts
@@ -71,7 +71,14 @@ export function openLocalPath(path: string): Promise<void> {
     }
   })
   if (host.nekoHost && typeof host.nekoHost.openPath === 'function') {
-    return Promise.resolve(host.nekoHost.openPath({ path: target })).then(() => undefined)
+    return Promise.resolve(host.nekoHost.openPath({ path: target })).then((result) => {
+      // nekoHost.openPath 可能返回 {ok: false, error: ...} 结构化失败
+      if (result && typeof result === 'object' && 'ok' in result && result.ok === false) {
+        const error = 'error' in result && result.error ? String(result.error) : 'Failed to open path'
+        throw new Error(error)
+      }
+      return undefined
+    })
   }
   if (host.electronShell && typeof host.electronShell.openPath === 'function') {
     return Promise.resolve(host.electronShell.openPath(target)).then(() => undefined)

--- a/frontend/plugin-manager/vite.config.ts
+++ b/frontend/plugin-manager/vite.config.ts
@@ -10,6 +10,16 @@ const BACKEND_TARGET = process.env.VITE_BACKEND_URL || 'http://localhost:48916'
 const isVitest = process.env.VITEST === 'true'
 const elementPlusImportStyle = isVitest ? false : 'css'
 
+// 提取代理目标的 hostname 用于运行时检测
+// 当 API_BASE_URL 为空（通过 Vite 代理）时，前端需要知道代理目标是本地还是远程
+let PROXY_TARGET_HOSTNAME = 'localhost'
+try {
+  PROXY_TARGET_HOSTNAME = new URL(BACKEND_TARGET).hostname
+} catch {
+  // 解析失败，假定为本地
+  PROXY_TARGET_HOSTNAME = 'localhost'
+}
+
 // 组件测试普遍用 `app.component('el-tabs', stub)` 之类的全局桩替掉 Element Plus，
 // 断言再去查桩渲染出的标记（如 data-tab-name）。ElementPlusResolver 会把模板里的
 // <el-tabs> 编译成显式 `import { ElTabs } from 'element-plus'`，直接绕过全局注册，
@@ -26,6 +36,10 @@ const autoImportComponents = isVitest
 // https://vite.dev/config/
 export default defineConfig({
   base: '/ui/',
+  define: {
+    // 注入代理目标的 hostname，用于运行时检测本地/远程后端
+    __VITE_PROXY_TARGET_HOSTNAME__: JSON.stringify(PROXY_TARGET_HOSTNAME)
+  },
   plugins: [
     vue(),
     ...autoImportComponents,

--- a/plugin/server/application/logs/query_service.py
+++ b/plugin/server/application/logs/query_service.py
@@ -8,7 +8,7 @@ from plugin.logging_config import get_logger
 from plugin.server.domain import IO_RUNTIME_ERRORS
 from plugin.server.domain.errors import ServerDomainError
 from plugin.utils.time_utils import now_iso
-from plugin.server.logs import get_plugin_log_files, get_plugin_logs
+from plugin.server.logs import get_plugin_log_files, get_plugin_logs, get_plugin_log_directory_path
 
 logger = get_logger("server.application.logs.query")
 
@@ -161,6 +161,46 @@ class LogQueryService:
             raise ServerDomainError(
                 code="PLUGIN_LOG_FILES_QUERY_FAILED",
                 message="Failed to get plugin log files",
+                status_code=500,
+                details={
+                    "plugin_id": plugin_id,
+                    "error_type": type(exc).__name__,
+                },
+            ) from exc
+
+    def get_plugin_log_directory(self, plugin_id: str) -> dict[str, object]:
+        try:
+            directory_path = get_plugin_log_directory_path(plugin_id)
+            return {
+                "plugin_id": plugin_id,
+                "directory": directory_path,
+                "time": now_iso(),
+            }
+        except ServerDomainError:
+            raise
+        except HTTPException as exc:
+            logger.warning(
+                "get_plugin_log_directory failed with HTTPException: plugin_id={}, status_code={}, detail={}",
+                plugin_id,
+                exc.status_code,
+                str(exc.detail),
+            )
+            raise ServerDomainError(
+                code="PLUGIN_LOG_DIRECTORY_QUERY_FAILED",
+                message=_detail_to_message(exc.detail, default_message="Failed to get plugin log directory"),
+                status_code=exc.status_code,
+                details={"plugin_id": plugin_id, "error_type": "HTTPException"},
+            ) from exc
+        except IO_RUNTIME_ERRORS as exc:
+            logger.error(
+                "get_plugin_log_directory failed: plugin_id={}, err_type={}, err={}",
+                plugin_id,
+                type(exc).__name__,
+                str(exc),
+            )
+            raise ServerDomainError(
+                code="PLUGIN_LOG_DIRECTORY_QUERY_FAILED",
+                message="Failed to get plugin log directory",
                 status_code=500,
                 details={
                     "plugin_id": plugin_id,

--- a/plugin/server/logs.py
+++ b/plugin/server/logs.py
@@ -267,9 +267,10 @@ def list_plugin_log_files_for_export(log_dir: Path, plugin_id: str) -> list[Path
     if plugin_id != SERVER_LOG_ID:
         # 匹配 N.E.K.O_Plugin_{safe_id}_{YYYYMMDD}.log[.轮转后缀]
         # 或     N.E.K.O_Plugin_{safe_id}_error.log[.轮转后缀]
+        # 轮转后缀：RotatingFileHandler 使用 .1, .2, ... 纯数字后缀
         expected_prefix = f"N.E.K.O_Plugin_{safe_id}_"
-        date_pattern = re.compile(r"^\d{8}\.log")  # YYYYMMDD.log
-        error_pattern = re.compile(r"^error\.log")  # error.log
+        date_pattern = re.compile(r"^\d{8}\.log(?:\.\d+)?$")  # YYYYMMDD.log 或 YYYYMMDD.log.1
+        error_pattern = re.compile(r"^error\.log(?:\.\d+)?$")  # error.log 或 error.log.1
 
         filtered = []
         for p in candidates:

--- a/plugin/server/logs.py
+++ b/plugin/server/logs.py
@@ -237,6 +237,37 @@ def get_plugin_log_files(plugin_id: str) -> list[dict[str, object]]:
     return log_files
 
 
+def list_plugin_log_files_for_export(log_dir: Path, plugin_id: str) -> list[Path]:
+    """返回该 plugin 自己的全部日志文件，用于打包导出。
+
+    与 ``_list_plugin_log_files_for_tail`` 的区别：导出要保留 ``_error.log``
+    系列，用户排障时错误流往往才是关键。pattern 末尾的 ``*`` 覆盖轮转后缀。
+    """
+    if plugin_id == SERVER_LOG_ID:
+        pattern = "N.E.K.O_PluginServer_*.log*"
+    else:
+        pattern = f"N.E.K.O_Plugin_{plugin_id}_*.log*"
+
+    return [p for p in log_dir.glob(pattern) if p.is_file()]
+
+
+def get_plugin_log_directory_path(plugin_id: str) -> str:
+    """
+    获取插件日志目录的绝对路径
+
+    Args:
+        plugin_id: 插件ID（或 SERVER_LOG_ID 表示服务器日志）
+
+    Returns:
+        日志目录的绝对路径字符串
+
+    Raises:
+        HTTPException: 如果 plugin_id 不安全
+    """
+    log_dir = get_plugin_log_dir(plugin_id)
+    return str(log_dir.resolve())
+
+
 def parse_log_line(line: str) -> dict[str, object] | None:
     """
     解析日志行

--- a/plugin/server/logs.py
+++ b/plugin/server/logs.py
@@ -242,13 +242,48 @@ def list_plugin_log_files_for_export(log_dir: Path, plugin_id: str) -> list[Path
 
     与 ``_list_plugin_log_files_for_tail`` 的区别：导出要保留 ``_error.log``
     系列，用户排障时错误流往往才是关键。pattern 末尾的 ``*`` 覆盖轮转后缀。
+
+    注意：
+    1. plugin_id 必须先经过 sanitize，与实际写入日志时使用的 ID 一致
+    2. 文件名匹配精确到插件边界，防止 foo 匹配到 foo_bar 的日志
     """
+    from plugin.core.host import _sanitize_plugin_id
+    import re
+
+    # 与日志写入时保持一致：先 sanitize plugin_id
+    safe_id = _sanitize_plugin_id(plugin_id, max_len=64)
+
     if plugin_id == SERVER_LOG_ID:
         pattern = "N.E.K.O_PluginServer_*.log*"
     else:
-        pattern = f"N.E.K.O_Plugin_{plugin_id}_*.log*"
+        # 精确匹配插件边界：_后必须是 8位日期(YYYYMMDD) 或 error.log
+        # 正确匹配： N.E.K.O_Plugin_foo_20260906.log, N.E.K.O_Plugin_foo_error.log.1
+        # 拒绝匹配： N.E.K.O_Plugin_foo_bar_20260906.log
+        pattern = f"N.E.K.O_Plugin_{safe_id}_*.log*"
 
-    return [p for p in log_dir.glob(pattern) if p.is_file()]
+    candidates = [p for p in log_dir.glob(pattern) if p.is_file()]
+
+    # 二次过滤：确保 _ 后是日期或 error，防止前缀误匹配
+    if plugin_id != SERVER_LOG_ID:
+        # 匹配 N.E.K.O_Plugin_{safe_id}_{YYYYMMDD}.log[.轮转后缀]
+        # 或     N.E.K.O_Plugin_{safe_id}_error.log[.轮转后缀]
+        expected_prefix = f"N.E.K.O_Plugin_{safe_id}_"
+        date_pattern = re.compile(r"^\d{8}\.log")  # YYYYMMDD.log
+        error_pattern = re.compile(r"^error\.log")  # error.log
+
+        filtered = []
+        for p in candidates:
+            # 提取 prefix 之后的部分
+            if not p.name.startswith(expected_prefix):
+                continue
+            suffix = p.name[len(expected_prefix):]
+            # 必须是 YYYYMMDD.log* 或 error.log*
+            if date_pattern.match(suffix) or error_pattern.match(suffix):
+                filtered.append(p)
+
+        return filtered
+
+    return candidates
 
 
 def get_plugin_log_directory_path(plugin_id: str) -> str:

--- a/plugin/server/logs.py
+++ b/plugin/server/logs.py
@@ -268,9 +268,12 @@ def list_plugin_log_files_for_export(log_dir: Path, plugin_id: str) -> list[Path
         # 匹配 N.E.K.O_Plugin_{safe_id}_{YYYYMMDD}.log[.轮转后缀]
         # 或     N.E.K.O_Plugin_{safe_id}_error.log[.轮转后缀]
         # 轮转后缀：RotatingFileHandler 使用 .1, .2, ... 纯数字后缀
+        #           TimedRotatingFileHandler 使用 .YYYY-MM-DD 日期后缀
         expected_prefix = f"N.E.K.O_Plugin_{safe_id}_"
-        date_pattern = re.compile(r"^\d{8}\.log(?:\.\d+)?$")  # YYYYMMDD.log 或 YYYYMMDD.log.1
-        error_pattern = re.compile(r"^error\.log(?:\.\d+)?$")  # error.log 或 error.log.1
+        # YYYYMMDD.log 或 YYYYMMDD.log.1 或 YYYYMMDD.log.2026-04-21
+        date_pattern = re.compile(r"^\d{8}\.log(?:\.\d+|\.\d{4}-\d{2}-\d{2})?$")
+        # error.log 或 error.log.1 或 error.log.2026-04-21
+        error_pattern = re.compile(r"^error\.log(?:\.\d+|\.\d{4}-\d{2}-\d{2})?$")
 
         filtered = []
         for p in candidates:

--- a/plugin/server/routes/logs.py
+++ b/plugin/server/routes/logs.py
@@ -3,12 +3,18 @@
 """
 from __future__ import annotations
 
+import shutil
+import tempfile
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Query, WebSocket
+from fastapi.responses import StreamingResponse
+from starlette.background import BackgroundTask
 
 from plugin.logging_config import get_logger
 from plugin.server.application.logs import LogQueryService
+from plugin.server.logs import list_plugin_log_files_for_export
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure.auth import require_admin
 from plugin.server.logs import log_stream_endpoint
@@ -17,6 +23,26 @@ from plugin.server.infrastructure.error_mapping import raise_http_from_domain
 router = APIRouter()
 logger = get_logger("server.routes.logs")
 log_query_service = LogQueryService()
+
+
+def file_iterator(file_path: Path, chunk_size: int = 65536):
+    """流式读取文件，避免一次性加载到内存"""
+    with open(file_path, 'rb') as f:
+        while chunk := f.read(chunk_size):
+            yield chunk
+
+
+def cleanup_temp_path(path: str):
+    """清理临时文件或目录"""
+    try:
+        p = Path(path)
+        if p.is_file():
+            p.unlink(missing_ok=True)
+        elif p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+    except Exception as e:
+        logger.warning(f"Failed to cleanup temp path {path}: {e}")
+
 
 
 @router.get("/plugin/{plugin_id}/logs")
@@ -46,6 +72,62 @@ async def get_plugin_logs_endpoint(
 async def get_plugin_log_files_endpoint(plugin_id: str, _: str = require_admin) -> dict[str, object]:
     try:
         return log_query_service.get_plugin_log_files(plugin_id)
+    except ServerDomainError as error:
+        raise_http_from_domain(error, logger=logger)
+
+
+@router.get("/plugin/{plugin_id}/logs/directory")
+async def get_plugin_log_directory_endpoint(plugin_id: str, _: str = require_admin) -> dict[str, object]:
+    try:
+        return log_query_service.get_plugin_log_directory(plugin_id)
+    except ServerDomainError as error:
+        raise_http_from_domain(error, logger=logger)
+
+
+@router.get("/plugin/{plugin_id}/logs/export")
+async def export_plugin_log_endpoint(plugin_id: str, _: str = require_admin) -> StreamingResponse:
+    try:
+        # 获取日志目录
+        result = log_query_service.get_plugin_log_directory(plugin_id)
+        log_dir = Path(result["directory"])
+
+        # 创建临时目录用于存放日志文件副本和 zip
+        temp_dir = Path(tempfile.mkdtemp())
+        temp_log_dir = temp_dir / "logs"
+        temp_log_dir.mkdir()
+
+        # 只收集当前插件自己的日志文件：logs/plugin/ 是所有插件共享的，
+        # 直接打包整个目录会把别的插件日志一起泄漏出去。
+        copied_count = 0
+        for log_file in list_plugin_log_files_for_export(log_dir, plugin_id):
+            shutil.copy2(log_file, temp_log_dir / log_file.name)
+            copied_count += 1
+
+        if copied_count == 0:
+            cleanup_temp_path(str(temp_dir))
+            raise ServerDomainError(
+                code="NO_LOG_FILES",
+                message="No log files found for this plugin",
+                status_code=404,
+                details={"plugin_id": plugin_id}
+            )
+
+        # 打包临时日志目录
+        zip_filename = f"{plugin_id}_logs"
+        zip_path = temp_dir / zip_filename
+        archive_path = shutil.make_archive(
+            str(zip_path),
+            'zip',
+            temp_log_dir
+        )
+
+        # 使用流式响应 + 后台清理任务（复用主程序模式）
+        return StreamingResponse(
+            file_iterator(Path(archive_path)),
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="{plugin_id}_logs.zip"'},
+            background=BackgroundTask(cleanup_temp_path, str(temp_dir))
+        )
     except ServerDomainError as error:
         raise_http_from_domain(error, logger=logger)
 

--- a/plugin/server/routes/logs.py
+++ b/plugin/server/routes/logs.py
@@ -91,43 +91,64 @@ async def export_plugin_log_endpoint(plugin_id: str, _: str = require_admin) -> 
         result = log_query_service.get_plugin_log_directory(plugin_id)
         log_dir = Path(result["directory"])
 
-        # 创建临时目录用于存放日志文件副本和 zip
+        # 创建临时目录用于打包
         temp_dir = Path(tempfile.mkdtemp())
         temp_log_dir = temp_dir / "logs"
         temp_log_dir.mkdir()
 
-        # 只收集当前插件自己的日志文件：logs/plugin/ 是所有插件共享的，
-        # 直接打包整个目录会把别的插件日志一起泄漏出去。
-        copied_count = 0
-        for log_file in list_plugin_log_files_for_export(log_dir, plugin_id):
-            shutil.copy2(log_file, temp_log_dir / log_file.name)
-            copied_count += 1
+        # 确保异常路径也会清理临时目录
+        temp_needs_cleanup = True
 
-        if copied_count == 0:
-            cleanup_temp_path(str(temp_dir))
-            raise ServerDomainError(
-                code="NO_LOG_FILES",
-                message="No log files found for this plugin",
-                status_code=404,
-                details={"plugin_id": plugin_id}
+        try:
+            # 只收集当前插件自己的日志文件：logs/plugin/ 是所有插件共享的，
+            # 直接打包整个目录会把别的插件日志一起泄漏出去。
+            log_files = list_plugin_log_files_for_export(log_dir, plugin_id)
+
+            if not log_files:
+                raise ServerDomainError(
+                    code="NO_LOG_FILES",
+                    message="No log files found for this plugin",
+                    status_code=404,
+                    details={"plugin_id": plugin_id}
+                )
+
+            # 在线程池中执行文件复制和打包，避免阻塞事件循环
+            import asyncio
+            loop = asyncio.get_event_loop()
+
+            def _copy_and_archive():
+                """在线程池中执行同步文件操作"""
+                copied_count = 0
+                for log_file in log_files:
+                    shutil.copy2(log_file, temp_log_dir / log_file.name)
+                    copied_count += 1
+
+                # 打包临时日志目录
+                zip_filename = f"{plugin_id}_logs"
+                zip_path = temp_dir / zip_filename
+                archive_path = shutil.make_archive(
+                    str(zip_path),
+                    'zip',
+                    temp_log_dir
+                )
+                return archive_path
+
+            archive_path = await loop.run_in_executor(None, _copy_and_archive)
+
+            # 成功创建响应，清理责任移交给 BackgroundTask
+            temp_needs_cleanup = False
+
+            # 使用流式响应 + 后台清理任务（复用主程序模式）
+            return StreamingResponse(
+                file_iterator(Path(archive_path)),
+                media_type="application/zip",
+                headers={"Content-Disposition": f'attachment; filename="{plugin_id}_logs.zip"'},
+                background=BackgroundTask(cleanup_temp_path, str(temp_dir))
             )
-
-        # 打包临时日志目录
-        zip_filename = f"{plugin_id}_logs"
-        zip_path = temp_dir / zip_filename
-        archive_path = shutil.make_archive(
-            str(zip_path),
-            'zip',
-            temp_log_dir
-        )
-
-        # 使用流式响应 + 后台清理任务（复用主程序模式）
-        return StreamingResponse(
-            file_iterator(Path(archive_path)),
-            media_type="application/zip",
-            headers={"Content-Disposition": f'attachment; filename="{plugin_id}_logs.zip"'},
-            background=BackgroundTask(cleanup_temp_path, str(temp_dir))
-        )
+        finally:
+            # 如果在复制、打包或构造响应时失败，立即清理临时目录
+            if temp_needs_cleanup:
+                cleanup_temp_path(str(temp_dir))
     except ServerDomainError as error:
         raise_http_from_domain(error, logger=logger)
 

--- a/plugin/server/routes/logs.py
+++ b/plugin/server/routes/logs.py
@@ -87,6 +87,15 @@ async def get_plugin_log_directory_endpoint(plugin_id: str, _: str = require_adm
 @router.get("/plugin/{plugin_id}/logs/export")
 async def export_plugin_log_endpoint(plugin_id: str, _: str = require_admin) -> StreamingResponse:
     try:
+        # 拒绝包含换行符的 plugin_id，防止 HTTP 响应头注入
+        if '\n' in plugin_id or '\r' in plugin_id:
+            raise ServerDomainError(
+                code="INVALID_PLUGIN_ID",
+                message="Plugin ID cannot contain newline characters",
+                status_code=400,
+                details={"plugin_id": plugin_id}
+            )
+
         # 获取日志目录
         result = log_query_service.get_plugin_log_directory(plugin_id)
         log_dir = Path(result["directory"])

--- a/plugin/server/routes/logs.py
+++ b/plugin/server/routes/logs.py
@@ -133,8 +133,8 @@ async def export_plugin_log_endpoint(plugin_id: str, _: str = require_admin) -> 
                     copied_count += 1
 
                 # 打包临时日志目录
-                zip_filename = f"{plugin_id}_logs"
-                zip_path = temp_dir / zip_filename
+                # 使用固定文件名避免超长 plugin_id 导致超过文件系统 NAME_MAX 限制
+                zip_path = temp_dir / "export"
                 archive_path = shutil.make_archive(
                     str(zip_path),
                     'zip',

--- a/plugin/tests/unit/server/test_logs_export_filter.py
+++ b/plugin/tests/unit/server/test_logs_export_filter.py
@@ -62,6 +62,9 @@ def test_export_filter_rejects_invalid_suffix(tmp_path: Path):
     (tmp_path / "N.E.K.O_Plugin_demo_20260906.log").touch()
     (tmp_path / "N.E.K.O_Plugin_demo_badfile.txt").touch()  # 不符合规范
     (tmp_path / "N.E.K.O_Plugin_demo_20260906").touch()  # 缺少 .log
+    # 能通过 *.log* 初筛但会被二次过滤拒绝
+    (tmp_path / "N.E.K.O_Plugin_demo_20260906X.log").touch()  # 日期后有非法字符
+    (tmp_path / "N.E.K.O_Plugin_demo_errorX.log").touch()  # error 后有非法字符
 
     files = list_plugin_log_files_for_export(tmp_path, "demo")
     names = {f.name for f in files}
@@ -70,3 +73,5 @@ def test_export_filter_rejects_invalid_suffix(tmp_path: Path):
     assert "N.E.K.O_Plugin_demo_20260906.log" in names
     assert "N.E.K.O_Plugin_demo_badfile.txt" not in names
     assert "N.E.K.O_Plugin_demo_20260906" not in names
+    assert "N.E.K.O_Plugin_demo_20260906X.log" not in names
+    assert "N.E.K.O_Plugin_demo_errorX.log" not in names

--- a/plugin/tests/unit/server/test_logs_export_filter.py
+++ b/plugin/tests/unit/server/test_logs_export_filter.py
@@ -1,0 +1,72 @@
+"""测试日志导出文件过滤逻辑"""
+from pathlib import Path
+
+import pytest
+
+from plugin.server.logs import list_plugin_log_files_for_export
+
+
+def test_export_filter_prevents_prefix_leak(tmp_path: Path):
+    """插件 ID 前缀关系不应导致跨插件导出"""
+    # 创建两个插件的日志文件：foo 和 foo_bar
+    (tmp_path / "N.E.K.O_Plugin_foo_20260906.log").touch()
+    (tmp_path / "N.E.K.O_Plugin_foo_error.log").touch()
+    (tmp_path / "N.E.K.O_Plugin_foo_bar_20260906.log").touch()
+    (tmp_path / "N.E.K.O_Plugin_foo_bar_error.log").touch()
+
+    # 导出 foo 不应包含 foo_bar
+    foo_files = list_plugin_log_files_for_export(tmp_path, "foo")
+    foo_names = {f.name for f in foo_files}
+
+    assert "N.E.K.O_Plugin_foo_20260906.log" in foo_names
+    assert "N.E.K.O_Plugin_foo_error.log" in foo_names
+    assert "N.E.K.O_Plugin_foo_bar_20260906.log" not in foo_names
+    assert "N.E.K.O_Plugin_foo_bar_error.log" not in foo_names
+
+
+def test_export_filter_includes_rotated_logs(tmp_path: Path):
+    """导出应包含轮转日志和错误日志"""
+    (tmp_path / "N.E.K.O_Plugin_demo_20260906.log").touch()
+    (tmp_path / "N.E.K.O_Plugin_demo_20260905.log.1").touch()
+    (tmp_path / "N.E.K.O_Plugin_demo_error.log").touch()
+    (tmp_path / "N.E.K.O_Plugin_demo_error.log.2").touch()
+
+    files = list_plugin_log_files_for_export(tmp_path, "demo")
+    names = {f.name for f in files}
+
+    assert len(names) == 4
+    assert "N.E.K.O_Plugin_demo_20260906.log" in names
+    assert "N.E.K.O_Plugin_demo_20260905.log.1" in names
+    assert "N.E.K.O_Plugin_demo_error.log" in names
+    assert "N.E.K.O_Plugin_demo_error.log.2" in names
+
+
+def test_export_filter_uses_sanitized_id(tmp_path: Path):
+    """长 ID 应使用 sanitized 后的文件名匹配"""
+    # 模拟一个被截断哈希的长 ID
+    long_id = "a" * 70  # 超过 64 字符限制
+    from plugin.core.host import _sanitize_plugin_id
+    safe_id = _sanitize_plugin_id(long_id, max_len=64)
+
+    # 创建使用 safe_id 的日志文件
+    (tmp_path / f"N.E.K.O_Plugin_{safe_id}_20260906.log").touch()
+
+    # 使用原始 long_id 查询应能找到
+    files = list_plugin_log_files_for_export(tmp_path, long_id)
+    assert len(files) == 1
+    assert files[0].name == f"N.E.K.O_Plugin_{safe_id}_20260906.log"
+
+
+def test_export_filter_rejects_invalid_suffix(tmp_path: Path):
+    """拒绝不符合日志命名规范的文件"""
+    (tmp_path / "N.E.K.O_Plugin_demo_20260906.log").touch()
+    (tmp_path / "N.E.K.O_Plugin_demo_badfile.txt").touch()  # 不符合规范
+    (tmp_path / "N.E.K.O_Plugin_demo_20260906").touch()  # 缺少 .log
+
+    files = list_plugin_log_files_for_export(tmp_path, "demo")
+    names = {f.name for f in files}
+
+    assert len(names) == 1
+    assert "N.E.K.O_Plugin_demo_20260906.log" in names
+    assert "N.E.K.O_Plugin_demo_badfile.txt" not in names
+    assert "N.E.K.O_Plugin_demo_20260906" not in names

--- a/plugin/tests/unit/server/test_logs_export_filter.py
+++ b/plugin/tests/unit/server/test_logs_export_filter.py
@@ -65,6 +65,8 @@ def test_export_filter_rejects_invalid_suffix(tmp_path: Path):
     # 能通过 *.log* 初筛但会被二次过滤拒绝
     (tmp_path / "N.E.K.O_Plugin_demo_20260906X.log").touch()  # 日期后有非法字符
     (tmp_path / "N.E.K.O_Plugin_demo_errorX.log").touch()  # error 后有非法字符
+    (tmp_path / "N.E.K.O_Plugin_demo_20260906.log.tmp").touch()  # .log 后有非数字后缀
+    (tmp_path / "N.E.K.O_Plugin_demo_error.logX").touch()  # .log 后有非数字后缀
 
     files = list_plugin_log_files_for_export(tmp_path, "demo")
     names = {f.name for f in files}
@@ -75,3 +77,5 @@ def test_export_filter_rejects_invalid_suffix(tmp_path: Path):
     assert "N.E.K.O_Plugin_demo_20260906" not in names
     assert "N.E.K.O_Plugin_demo_20260906X.log" not in names
     assert "N.E.K.O_Plugin_demo_errorX.log" not in names
+    assert "N.E.K.O_Plugin_demo_20260906.log.tmp" not in names
+    assert "N.E.K.O_Plugin_demo_error.logX" not in names

--- a/plugin/tests/unit/server/test_logs_export_filter.py
+++ b/plugin/tests/unit/server/test_logs_export_filter.py
@@ -27,18 +27,22 @@ def test_export_filter_prevents_prefix_leak(tmp_path: Path):
 def test_export_filter_includes_rotated_logs(tmp_path: Path):
     """导出应包含轮转日志和错误日志"""
     (tmp_path / "N.E.K.O_Plugin_demo_20260906.log").touch()
-    (tmp_path / "N.E.K.O_Plugin_demo_20260905.log.1").touch()
+    (tmp_path / "N.E.K.O_Plugin_demo_20260905.log.1").touch()  # RotatingFileHandler 数字后缀
+    (tmp_path / "N.E.K.O_Plugin_demo_20260904.log.2026-09-04").touch()  # TimedRotatingFileHandler 日期后缀
     (tmp_path / "N.E.K.O_Plugin_demo_error.log").touch()
-    (tmp_path / "N.E.K.O_Plugin_demo_error.log.2").touch()
+    (tmp_path / "N.E.K.O_Plugin_demo_error.log.2").touch()  # RotatingFileHandler 数字后缀
+    (tmp_path / "N.E.K.O_Plugin_demo_error.log.2026-09-03").touch()  # TimedRotatingFileHandler 日期后缀
 
     files = list_plugin_log_files_for_export(tmp_path, "demo")
     names = {f.name for f in files}
 
-    assert len(names) == 4
+    assert len(names) == 6
     assert "N.E.K.O_Plugin_demo_20260906.log" in names
     assert "N.E.K.O_Plugin_demo_20260905.log.1" in names
+    assert "N.E.K.O_Plugin_demo_20260904.log.2026-09-04" in names
     assert "N.E.K.O_Plugin_demo_error.log" in names
     assert "N.E.K.O_Plugin_demo_error.log.2" in names
+    assert "N.E.K.O_Plugin_demo_error.log.2026-09-03" in names
 
 
 def test_export_filter_uses_sanitized_id(tmp_path: Path):

--- a/plugin/tests/unit/server/test_logs_export_routes.py
+++ b/plugin/tests/unit/server/test_logs_export_routes.py
@@ -1,0 +1,32 @@
+"""测试日志导出路由的安全性"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from plugin.server.routes.logs import export_plugin_log_endpoint
+
+
+pytestmark = pytest.mark.plugin_unit
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_newline_in_plugin_id():
+    """拒绝包含换行符的 plugin_id，防止 HTTP 响应头注入"""
+    # 测试 \n
+    with pytest.raises(HTTPException) as exc_info:
+        await export_plugin_log_endpoint("foo\n", _="test-admin")
+    assert exc_info.value.status_code == 400
+    assert "newline" in str(exc_info.value.detail).lower()
+
+    # 测试 \r
+    with pytest.raises(HTTPException) as exc_info:
+        await export_plugin_log_endpoint("foo\r", _="test-admin")
+    assert exc_info.value.status_code == 400
+    assert "newline" in str(exc_info.value.detail).lower()
+
+    # 测试 \r\n
+    with pytest.raises(HTTPException) as exc_info:
+        await export_plugin_log_endpoint("foo\r\n", _="test-admin")
+    assert exc_info.value.status_code == 400
+    assert "newline" in str(exc_info.value.detail).lower()


### PR DESCRIPTION
## Summary

- 插件管理器的日志页新增「导出日志压缩包」和「打开日志目录」两个入口
- 导出只打包该插件自己的日志文件：`logs/plugin/` 是所有插件共享的目录，直接打包整个目录会把其他插件的日志一并泄漏给使用者
- 8 个 locale（en / ja / ko / zh-CN / zh-TW / ru / pt / es）同步补齐新增文案

## Notes

- 文件筛选复用了既有的命名约定，并覆盖 `_server`（`N.E.K.O_PluginServer_*`）与轮转后缀（`.log.1` / `.log.2026-04-21`）两种情况
- 导出保留 `_error.log` 系列（排障时错误流通常是关键信息），这一点与 tail/WebSocket 用的筛选逻辑有意不同
- 下载走 `fetch` + blob 而不是直接 `<a href>`，否则拿不到响应状态，服务端返回 404 时前端也会弹「导出成功」
- 打包走临时目录 + 流式响应 + `BackgroundTask` 清理，与主程序既有的导出模式一致

## Test plan

- [x] `uv run pytest plugin/tests/unit/server/ plugin/tests/unit/test_plugin_logging_landing.py` — 889 passed, 8 skipped
- [x] `npm run type-check`（plugin-manager）无错误
- [x] 手动验证：导出 `custom_pngtuber` 得到 6 个文件、仅含该插件日志（修复前为 73 个文件 / 6.9MB，混入全部插件）
- [x] 脚本验证筛选逻辑：插件隔离、轮转后缀、`_server` 分支均正确

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 插件日志查看器支持导出日志压缩包。
  - 在桌面环境且连接本地后端时支持打开插件日志目录。
  - 导出或打开目录失败、无可用日志时显示明确提示。
- **本地化**
  - 为多种语言补充日志导出与目录访问相关文案。
- **问题修复**
  - 优化日志导出范围，避免包含其他插件或不规范文件。
  - 支持导出带日期后缀的轮转日志文件。
  - 改进本地路径打开失败时的错误处理，并提升日志下载稳定性。
  - 拒绝包含换行符的无效插件标识，增强导出安全性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->