### PR TITLE
状态提示的 hover 保留改由指针轮询驱动，修复命中检测上线后 pin 时灵时不灵

### DIFF
--- a/templates/toast.html
+++ b/templates/toast.html
@@ -100,20 +100,49 @@
                 && point.y >= rect.top && point.y < rect.bottom;
         }
 
+        // 单次光标 IPC 的兜底期限。轮询周期 50ms，正常往返远小于此；超过即认为 IPC
+        // 悬挂，强制回到穿透态而不是把窗口无限期留在可命中态。
+        var STATUS_POINTER_IPC_TIMEOUT_MS = 1000;
+        var statusPointerWatchdogTimer = null;
+
+        function clearStatusPointerWatchdog() {
+            if (!statusPointerWatchdogTimer) return;
+            clearTimeout(statusPointerWatchdogTimer);
+            statusPointerWatchdogTimer = null;
+        }
+
+        function armStatusPointerWatchdog(generation) {
+            clearStatusPointerWatchdog();
+            statusPointerWatchdogTimer = setTimeout(function() {
+                statusPointerWatchdogTimer = null;
+                if (generation !== statusPointerPollGeneration) return;
+                stopStatusPointerTracking(false);
+            }, STATUS_POINTER_IPC_TIMEOUT_MS);
+        }
+
         function stopStatusPointerTracking(keepCurrentMouseState) {
             statusPointerPollGeneration += 1;
             if (statusPointerPollTimer) {
                 clearTimeout(statusPointerPollTimer);
                 statusPointerPollTimer = null;
             }
+            clearStatusPointerWatchdog();
             var wasPinnedByPointer = statusPointerInside;
             statusPointerTrackingActive = false;
             statusPointerInside = false;
             // 轮询驱动的 pin 只能由轮询自己解开：一旦停止追踪，窗口回到穿透态，
             // 再也不会有 mouseleave 到达。此处不恢复计时，被 pin 住的提示就会一直
-            // 挂在屏幕上（光标 IPC 失败、prominent notice 打断、页面转入后台都会走到
-            // 这里）。先清掉上面两个标志再调，_leave 才会按 DOM 语义重新判定。
-            if (wasPinnedByPointer && statusToast._leave) statusToast._leave();
+            // 挂在屏幕上（光标 IPC 失败/悬挂、prominent notice 打断、页面转入后台都会
+            // 走到这里）。
+            //
+            // 这里**不能**走 _leave：它会回落到 DOM :hover 判定，而如果之前真的来过
+            // 一次 mouseenter，:hover 此刻为真且再也不会被 mouseleave 纠正（窗口已穿透），
+            // 于是拒绝排程，提示照样滞留。只认键盘焦点。
+            if (wasPinnedByPointer
+                && statusToast._resumeAutoHide
+                && !statusToast.matches(':focus-within')) {
+                statusToast._resumeAutoHide();
+            }
             if (!keepCurrentMouseState && !prominentNoticeInteractive) {
                 setToastMouseThrough(true);
             }
@@ -160,7 +189,14 @@
                 return;
             }
 
+            // 光标 IPC 只要不 settle，下面两条分支一条都不会走：既不重排下一拍，也不
+            // 触发拒绝清理。而此时窗口可能已因上一拍的 inside 结果处于可命中态、自动
+            // 消失计时也已被清掉 —— 全屏透明窗口会一直吞掉整个桌面的输入。主进程侧的
+            // 空闲销毁救不了场：它在渲染端持有 ignore=false 时会主动推迟销毁。
+            armStatusPointerWatchdog(generation);
+
             Promise.resolve(cursorPointPromise).then(function(point) {
+                clearStatusPointerWatchdog();
                 if (generation !== statusPointerPollGeneration
                     || prominentNoticeInteractive
                     || !isStatusToastVisible()) return;
@@ -169,6 +205,7 @@
                 applyStatusPointerHover(inside);
             }).catch(function() {
                 // 光标 IPC 异常时立即回到穿透态，不能让透明全屏窗口留在桌面上拦截输入。
+                clearStatusPointerWatchdog();
                 if (generation === statusPointerPollGeneration) {
                     stopStatusPointerTracking(false);
                 }
@@ -288,6 +325,12 @@
             statusToast._leave = function() {
                 if (statusTimeout || statusToast.classList.contains('hide')) return;
                 if (!statusHoverHoldActive()) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+            };
+            // 追踪中断时的恢复入口：与 _leave 的区别是**不问 DOM :hover**。停止追踪后
+            // 窗口回到穿透态，陈旧的 :hover 再无 mouseleave 可纠正，问了就等于永不恢复。
+            statusToast._resumeAutoHide = function() {
+                if (statusTimeout || statusToast.classList.contains('hide')) return;
+                scheduleHide(toastRemaining!=null ? toastRemaining : duration);
             };
             statusToast._focusIn = function() {
                 if (!statusTimeout) return;

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -196,19 +196,21 @@
             armStatusPointerWatchdog(generation);
 
             Promise.resolve(cursorPointPromise).then(function(point) {
+                // 世代检查必须在清看门狗**之前**：旧世代的 Promise 可能在新一轮已经
+                // 武装好看门狗之后才 settle，抢先清掉就等于把新请求的兜底摘了 ——
+                // 新请求若随后悬挂，窗口会无限期停在可命中态拦截桌面输入。
+                if (generation !== statusPointerPollGeneration) return;
                 clearStatusPointerWatchdog();
-                if (generation !== statusPointerPollGeneration
-                    || prominentNoticeInteractive
-                    || !isStatusToastVisible()) return;
+                if (prominentNoticeInteractive || !isStatusToastVisible()) return;
                 var inside = isCursorInsideStatusToast(point);
                 setToastMouseThrough(!inside);
                 applyStatusPointerHover(inside);
             }).catch(function() {
-                // 光标 IPC 异常时立即回到穿透态，不能让透明全屏窗口留在桌面上拦截输入。
+                // 同上：先认世代，再动共享的看门狗。
+                if (generation !== statusPointerPollGeneration) return;
                 clearStatusPointerWatchdog();
-                if (generation === statusPointerPollGeneration) {
-                    stopStatusPointerTracking(false);
-                }
+                // 光标 IPC 异常时立即回到穿透态，不能让透明全屏窗口留在桌面上拦截输入。
+                stopStatusPointerTracking(false);
             }).then(function() {
                 if (generation !== statusPointerPollGeneration
                     || prominentNoticeInteractive

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -70,6 +70,12 @@
         var statusPointerPollTimer = null;
         var statusPointerPollGeneration = 0;
         var STATUS_POINTER_POLL_MS = 50;
+        // 命中检测开着时，轮询结果是「光标在不在提示上」的唯一权威。
+        // 窗口在穿透态收不到任何鼠标事件，所以「光标跨进矩形」这一刻必然发生在
+        // 渲染进程失聪期间：若用户在窗口恢复命中前就停稳，mouseenter 永远不会补发，
+        // DOM :hover 也不可信。hover 暂停自动消失因此不能再依赖 DOM 事件。
+        var statusPointerTrackingActive = false;
+        var statusPointerInside = false;
 
         function setToastMouseThrough(ignore, force) {
             if (!api || typeof api.setMouseThrough !== 'function') return;
@@ -100,8 +106,36 @@
                 clearTimeout(statusPointerPollTimer);
                 statusPointerPollTimer = null;
             }
+            statusPointerTrackingActive = false;
+            statusPointerInside = false;
             if (!keepCurrentMouseState && !prominentNoticeInteractive) {
                 setToastMouseThrough(true);
+            }
+        }
+
+        // 是否仍应按住自动消失。命中检测开着时不能信 DOM :hover —— 窗口在穿透态收不到
+        // 鼠标事件，:hover 可能从未置起（光标停稳型）或已经陈旧；此时以轮询结果为准。
+        // 键盘焦点两种模式下都要保留。
+        function statusHoverHoldActive() {
+            if (statusPointerTrackingActive) {
+                return statusPointerInside || statusToast.matches(':focus-within');
+            }
+            return statusToast.matches(':hover, :focus-within');
+        }
+
+        // 由轮询驱动 hover 暂停/恢复。DOM 的 mouseenter/mouseleave 仍然挂着，两条路
+        // 都调同一对幂等处理器（_enter 见 statusTimeout 已空即返回，_leave 见已排程即
+        // 返回），先到者生效，不会重复记账。
+        // 下面的边沿判定因此只是省掉每拍的无用调用，不承担正确性；真正必须的是
+        // stopStatusPointerTracking 里把 statusPointerInside 清零，否则光标停着不动时
+        // 第二条提示会被当成「状态未变」而漏掉 pin。
+        function applyStatusPointerHover(inside) {
+            if (inside === statusPointerInside) return;
+            statusPointerInside = inside;
+            if (inside) {
+                if (statusToast._enter) statusToast._enter();
+            } else if (statusToast._leave) {
+                statusToast._leave();
             }
         }
 
@@ -124,7 +158,9 @@
                 if (generation !== statusPointerPollGeneration
                     || prominentNoticeInteractive
                     || !isStatusToastVisible()) return;
-                setToastMouseThrough(!isCursorInsideStatusToast(point));
+                var inside = isCursorInsideStatusToast(point);
+                setToastMouseThrough(!inside);
+                applyStatusPointerHover(inside);
             }).catch(function() {
                 // 光标 IPC 异常时立即回到穿透态，不能让透明全屏窗口留在桌面上拦截输入。
                 if (generation === statusPointerPollGeneration) {
@@ -154,6 +190,7 @@
             }
 
             setToastMouseThrough(true);
+            statusPointerTrackingActive = true;
             var generation = statusPointerPollGeneration;
             pollStatusPointer(generation);
         }
@@ -244,7 +281,7 @@
             };
             statusToast._leave = function() {
                 if (statusTimeout || statusToast.classList.contains('hide')) return;
-                if (!statusToast.matches(':hover, :focus-within')) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+                if (!statusHoverHoldActive()) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
             };
             statusToast._focusIn = function() {
                 if (!statusTimeout) return;
@@ -255,7 +292,7 @@
             };
             statusToast._focusOut = function() {
                 if (statusTimeout || statusToast.classList.contains('hide')) return;
-                if (!statusToast.matches(':hover, :focus-within')) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
+                if (!statusHoverHoldActive()) scheduleHide(toastRemaining!=null ? toastRemaining : duration);
             };
             statusToast.addEventListener('mouseenter', statusToast._enter);
             statusToast.addEventListener('mouseleave', statusToast._leave);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -106,8 +106,14 @@
                 clearTimeout(statusPointerPollTimer);
                 statusPointerPollTimer = null;
             }
+            var wasPinnedByPointer = statusPointerInside;
             statusPointerTrackingActive = false;
             statusPointerInside = false;
+            // 轮询驱动的 pin 只能由轮询自己解开：一旦停止追踪，窗口回到穿透态，
+            // 再也不会有 mouseleave 到达。此处不恢复计时，被 pin 住的提示就会一直
+            // 挂在屏幕上（光标 IPC 失败、prominent notice 打断、页面转入后台都会走到
+            // 这里）。先清掉上面两个标志再调，_leave 才会按 DOM 语义重新判定。
+            if (wasPinnedByPointer && statusToast._leave) statusToast._leave();
             if (!keepCurrentMouseState && !prominentNoticeInteractive) {
                 setToastMouseThrough(true);
             }

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -485,3 +485,47 @@ test('a hung cursor IPC falls back to passthrough via the watchdog', async () =>
   );
   assert.equal(harness.hasAutoHideTimer(), true, '同时要恢复自动消失');
 });
+
+// 看门狗是全局单槽的。旧世代的光标 Promise 可能在新一轮已经武装好看门狗之后才
+// settle —— 若它抢先清掉，新请求悬挂时就再无兜底，透明全屏窗口会持续拦截桌面输入。
+test('a stale-generation cursor result must not clear the new watchdog', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  const first = createDeferred();
+  let call = 0;
+  harness.setCursorProvider(() => {
+    call += 1;
+    // 第一拍交出我们手动控制的 Promise，之后的拍永不 settle（模拟悬挂）。
+    return call === 1 ? first.promise : new Promise(() => {});
+  });
+
+  harness.emitStatus('first');
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasWatchdogTimer(), true, '第一拍已挂看门狗');
+
+  // 新提示到来 → stopStatusPointerTracking 提升世代 → 新一拍挂上新的看门狗。
+  harness.emitStatus('second');
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasWatchdogTimer(), true, '新世代已挂上自己的看门狗');
+
+  // 旧世代的 Promise 现在才落地。
+  first.resolve({ x: 150, y: 60 });
+  await flushPromises();
+
+  assert.equal(
+    harness.hasWatchdogTimer(),
+    true,
+    '旧世代的回调不得清掉新世代的看门狗',
+  );
+
+  harness.runTimer(1000);
+  await flushPromises();
+  assert.equal(
+    harness.mouseThrough[harness.mouseThrough.length - 1],
+    true,
+    '新请求悬挂时看门狗仍须把窗口拉回穿透态',
+  );
+});

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -379,3 +379,43 @@ test('a second toast re-pins with the cursor parked in place', async () => {
     '第二条提示同样必须被 pin：inside 标志位不得跨提示残留',
   );
 });
+
+// 轮询把提示 pin 住之后，窗口回到穿透态就再也不会有 mouseleave 到达。
+// 所以任何中断追踪的路径都必须自己解开 pin，否则提示一直挂在屏幕上。
+test('cursor IPC failure releases a poll-driven pin instead of stranding the toast', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasAutoHideTimer(), false, '前置条件：轮询已 pin 住提示');
+
+  // 下一拍光标 IPC 失败 —— stopStatusPointerTracking 会停掉轮询。
+  harness.setCursorProvider(() => Promise.reject(new Error('ipc down')));
+  harness.runTimer(50);
+  await flushPromises();
+
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    true,
+    '追踪中断后必须恢复自动消失，否则被 pin 住的提示永远不会消失',
+  );
+});
+
+test('a prominent notice interrupting a pinned toast still leaves auto-hide armed', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  harness.emitProminent();
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    true,
+    'prominent notice 打断追踪时同样要把 pin 解开',
+  );
+});

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -58,7 +58,11 @@ function createElement(tagName = 'div') {
       const listener = listeners.get(type);
       if (listener) listener(event);
     },
-    matches() { return false; },
+    _pseudo: new Set(),
+    matches(selector) {
+      // 支持 ':hover, :focus-within' 这类逗号选择器：任一命中即为真。
+      return String(selector).split(',').some((part) => this._pseudo.has(part.trim()));
+    },
     focus() { document.activeElement = this; },
     blur() { if (document.activeElement === this) document.activeElement = null; },
     getBoundingClientRect() {
@@ -192,7 +196,14 @@ function createHarness(options = {}) {
     // 自动消失计时器是唯一延迟大于 1s 的：show=10ms、轮询=50ms、cleanup=400ms。
     // 按区间而不是精确值判定，因为暂停/恢复会把剩余时长按实际经过时间扣掉。
     hasAutoHideTimer() {
-      return Array.from(timers.values()).some((timer) => timer.delay > 1000);
+      return Array.from(timers.values()).some((timer) => timer.delay >= 2000);
+    },
+    hasWatchdogTimer() {
+      return Array.from(timers.values()).some((timer) => timer.delay === 1000);
+    },
+    setHover(on) {
+      if (on) statusToast._pseudo.add(':hover');
+      else statusToast._pseudo.delete(':hover');
     },
     getProminentButton() {
       const overlay = document.getElementById('prominent-notice-overlay');
@@ -418,4 +429,59 @@ test('a prominent notice interrupting a pinned toast still leaves auto-hide arme
     true,
     'prominent notice 打断追踪时同样要把 pin 解开',
   );
+});
+
+// 追踪停止后窗口回到穿透态，陈旧的 :hover 再也不会被 mouseleave 纠正。
+// 恢复自动消失时若还去问 DOM :hover，提示就会永久滞留。
+test('a stale DOM :hover does not block auto-hide resume when tracking stops', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasAutoHideTimer(), false, '前置条件：轮询已 pin 住提示');
+
+  // 光标确实进来过，DOM :hover 已经置起。
+  harness.setHover(true);
+
+  harness.setCursorProvider(() => Promise.reject(new Error('ipc down')));
+  harness.runTimer(50);
+  await flushPromises();
+
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    true,
+    '停止追踪时必须无视陈旧 :hover 恢复自动消失，否则提示永久滞留',
+  );
+});
+
+// 光标 IPC 悬挂（既不 resolve 也不 reject）时，轮询两条分支都走不到。
+// 此时窗口可能已处可命中态，全屏透明层会一直吞掉桌面输入。
+test('a hung cursor IPC falls back to passthrough via the watchdog', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.deepEqual(harness.mouseThrough, [true, false], '前置条件：窗口已因命中变为可交互');
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  // 下一拍的 IPC 永不 settle。
+  harness.setCursorProvider(() => new Promise(() => {}));
+  harness.runTimer(50);
+  await flushPromises();
+
+  assert.equal(harness.hasWatchdogTimer(), true, '飞行中的光标 IPC 必须挂看门狗');
+
+  harness.runTimer(1000);
+  await flushPromises();
+
+  assert.deepEqual(
+    harness.mouseThrough,
+    [true, false, true],
+    '看门狗超时后必须强制回到穿透态，不能让全屏透明窗口继续拦截桌面输入',
+  );
+  assert.equal(harness.hasAutoHideTimer(), true, '同时要恢复自动消失');
 });

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -90,7 +90,7 @@ function createDeferred() {
   return { promise, resolve, reject };
 }
 
-function createHarness() {
+function createHarness(options = {}) {
   const callbacks = {};
   const mouseThrough = [];
   const timers = new Map();
@@ -137,7 +137,7 @@ function createHarness() {
   };
 
   const api = {
-    supportsStatusPointerTracking: true,
+    supportsStatusPointerTracking: options.supportsStatusPointerTracking !== false,
     getCursorPoint() { return cursorProvider(); },
     setMouseThrough(ignore) { mouseThrough.push(ignore); },
     onShowStatusToast(callback) { callbacks.status = callback; },
@@ -188,6 +188,11 @@ function createHarness() {
     },
     hasTimer(delay) {
       return Array.from(timers.values()).some((timer) => timer.delay === delay);
+    },
+    // 自动消失计时器是唯一延迟大于 1s 的：show=10ms、轮询=50ms、cleanup=400ms。
+    // 按区间而不是精确值判定，因为暂停/恢复会把剩余时长按实际经过时间扣掉。
+    hasAutoHideTimer() {
+      return Array.from(timers.values()).some((timer) => timer.delay > 1000);
     },
     getProminentButton() {
       const overlay = document.getElementById('prominent-notice-overlay');
@@ -269,4 +274,108 @@ test('page teardown force-restores desktop passthrough', () => {
   assert.deepEqual(harness.mouseThrough, [false]);
   harness.dispatchBeforeUnload();
   assert.deepEqual(harness.mouseThrough, [false, true]);
+});
+
+// 窗口从穿透态起步，且渲染进程在穿透期间收不到任何鼠标事件。harness 的
+// matches() 恒为 false 正是这个语义：DOM :hover 从不置起、mouseenter 从不派发。
+// 于是「hover 保留」必须由轮询自己驱动，不能等 DOM 事件。
+test('poll-driven hover pin pauses auto-hide without any DOM mouseenter', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 }); // 光标本就压在提示矩形上，全程不移动
+
+  harness.emitStatus();
+  assert.equal(harness.hasAutoHideTimer(), true, '前置条件：显示时应排定自动消失');
+
+  harness.runTimer(10);
+  await flushPromises();
+
+  assert.deepEqual(harness.mouseThrough, [true, false]);
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    false,
+    '轮询判定光标在提示上时必须暂停自动消失，而不是等一个永远不会来的 mouseenter',
+  );
+});
+
+test('poll-driven hover release resumes auto-hide', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  harness.setCursor({ x: 20, y: 20 }); // 光标移出矩形
+  harness.runTimer(50);
+  await flushPromises();
+
+  assert.deepEqual(harness.mouseThrough, [true, false, true]);
+  assert.equal(harness.hasAutoHideTimer(), true, '光标离开后必须恢复自动消失');
+});
+
+test('a real DOM mouseenter does not double-count the poll-driven pause', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  // 光标随后真的动了一下，DOM 事件补到：处理器幂等，不得重复记账或复活计时器。
+  harness.statusToast.dispatch('mouseenter', {});
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  harness.statusToast.dispatch('mouseleave', {});
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    false,
+    '轮询仍判定光标在提示内时，DOM mouseleave 不得抢先恢复自动消失',
+  );
+});
+
+// Niri 小窗与非 Electron 环境走 supportsStatusPointerTracking === false，
+// 此时轮询不启动，hover 判定必须退回纯 DOM 语义。
+test('with pointer tracking unsupported the DOM hover path still governs', async () => {
+  const harness = createHarness({ supportsStatusPointerTracking: false });
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  await flushPromises();
+
+  assert.deepEqual(harness.mouseThrough, [true], '不支持时应全程穿透，不发起轮询');
+  assert.equal(harness.hasTimer(50), false);
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    true,
+    '没有轮询权威时，光标位置不该凭空暂停自动消失',
+  );
+
+  harness.statusToast.dispatch('mouseenter', {});
+  assert.equal(harness.hasAutoHideTimer(), false, 'DOM hover 仍应能暂停');
+});
+
+// 连发场景：光标全程停在矩形上不动。第二条提示必须重新 pin —— 若 inside 标志位
+// 跨提示残留，边沿判定会认为「没变化」而跳过 _enter，第二条照旧 3s 后消失。
+test('a second toast re-pins with the cursor parked in place', async () => {
+  const harness = createHarness();
+  harness.setCursor({ x: 150, y: 60 });
+
+  harness.emitStatus('first');
+  harness.runTimer(10);
+  await flushPromises();
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  harness.emitStatus('second');
+  assert.equal(harness.hasAutoHideTimer(), true, '新提示会重新排定自动消失');
+  harness.runTimer(10);
+  await flushPromises();
+
+  assert.equal(
+    harness.hasAutoHideTimer(),
+    false,
+    '第二条提示同样必须被 pin：inside 标志位不得跨提示残留',
+  );
 });

--- a/tests/unit/test_toast_pointer_passthrough.py
+++ b/tests/unit/test_toast_pointer_passthrough.py
@@ -26,8 +26,14 @@ def test_status_toast_uses_precise_pointer_tracking_instead_of_fullscreen_captur
     # 命中结果必须同时驱动 hover 暂停：窗口在穿透态收不到 mouseenter，
     # 光标停稳时 DOM 事件永不到达，pin 只能由轮询自己驱动。
     assert "applyStatusPointerHover(inside);" in status_section
-    # 停止追踪时必须解开轮询驱动的 pin，否则提示会一直挂在屏幕上。
-    assert "if (wasPinnedByPointer && statusToast._leave) statusToast._leave();" in status_section
+    # 停止追踪时必须解开轮询驱动的 pin，否则提示会一直挂在屏幕上；
+    # 且必须走不问 DOM :hover 的恢复入口（穿透态下陈旧 :hover 再无 mouseleave 可纠正）。
+    assert "statusToast._resumeAutoHide();" in status_section
+    assert "statusToast._resumeAutoHide = function()" in status_section
+    # 飞行中的光标 IPC 必须有兜底：悬挂时强制回到穿透态，
+    # 否则全屏透明窗口会一直拦截桌面输入（主进程空闲销毁会主动推迟，救不了场）。
+    assert "armStatusPointerWatchdog(generation);" in status_section
+    assert "clearStatusPointerWatchdog();" in status_section
     assert "if (api && api.setMouseThrough) api.setMouseThrough(false);" not in status_section
     assert "stopStatusPointerTracking(false);" in status_section
 

--- a/tests/unit/test_toast_pointer_passthrough.py
+++ b/tests/unit/test_toast_pointer_passthrough.py
@@ -21,7 +21,13 @@ def test_status_toast_uses_precise_pointer_tracking_instead_of_fullscreen_captur
 
     assert "getBoundingClientRect()" in status_section
     assert "api.getCursorPoint()" in status_section
-    assert "setToastMouseThrough(!isCursorInsideStatusToast(point));" in status_section
+    assert "var inside = isCursorInsideStatusToast(point);" in status_section
+    assert "setToastMouseThrough(!inside);" in status_section
+    # 命中结果必须同时驱动 hover 暂停：窗口在穿透态收不到 mouseenter，
+    # 光标停稳时 DOM 事件永不到达，pin 只能由轮询自己驱动。
+    assert "applyStatusPointerHover(inside);" in status_section
+    # 停止追踪时必须解开轮询驱动的 pin，否则提示会一直挂在屏幕上。
+    assert "if (wasPinnedByPointer && statusToast._leave) statusToast._leave();" in status_section
     assert "if (api && api.setMouseThrough) api.setMouseThrough(false);" not in status_section
     assert "stopStatusPointerTracking(false);" in status_section
 


### PR DESCRIPTION
配套 Project-N-E-K-O/N.E.K.O.-PC#473（已合并）。两者独立可合，合起来才完整。

## 问题

#3053 给状态提示加了精确命中检测：窗口只在光标落在提示矩形内时才可命中，其余时间穿透。这让 #3002 的「hover 时可保留」从**可靠工作**退化成**时灵时不灵** —— 这是回归。

改动前 `showStatusToast` 里有一句无条件的 `api.setMouseThrough(false)`，窗口在整条提示显示期间都可命中，鼠标移上去必然产生 `mouseenter` → pin 住。该行在 #3053 中被移除。

## 成因

窗口从穿透态起步（PC 侧 `createToastWindow` 建窗即 `setIgnoreMouseEvents(true)`，且该窗口刻意不用 `{ forward: true }`），所以**「光标跨进矩形」这一刻必然发生在渲染进程收不到任何鼠标事件的时候**。轮询要到下一拍才把窗口切成可命中；此时光标若已停稳，Windows 撤掉 `WS_EX_TRANSPARENT` / macOS `setIgnoresMouseEvents:NO` 都不会补发鼠标消息 —— `mouseenter` 永不触发，`statusTimeout` 不被清，提示照旧自动消失。DOM `:hover` 出于同样原因也不可信。

用户观感：把鼠标移到提示上想多看两眼，有时 pin 得住有时 pin 不住；抖一下鼠标才生效。

## 改动

轮询每拍已经算出 `isCursorInsideStatusToast`，把它作为指针位置的唯一权威。

- `applyStatusPointerHover(inside)` 在 inside 变化时调用既有的 `_enter` / `_leave`。两者本就幂等（`_enter` 见 `statusTimeout` 已空即返回，`_leave` 见已排程即返回），所以 DOM 事件仍挂着、先到者生效，不会重复记账。
- `statusHoverHoldActive()` 在命中检测开启时以轮询结果判断，不看 `:hover`；键盘焦点（`:focus-within`）两种模式下都保留。**命中检测未开启时（Niri 小窗、非 Electron 环境）完全走回原来的纯 DOM 语义。**
- `stopStatusPointerTracking` 清零 `statusPointerInside` —— 否则光标停着不动时，第二条提示会被边沿判定当成「状态未变」而漏掉 pin。

## 验证

在既有 DOM harness 上从 3 条加到 8 条（harness 的 `matches()` 恒为 false，正是「穿透期间 `:hover` 从未置起」的语义）。

变异验证：去掉轮询驱动 pin / 让 hover 判定忽略轮询 / 不清 inside 标志 / 不置 tracking 标志 —— 全部被捕获。

`tests/frontend/` 全量 279 条：274 pass、5 fail，5 个失败全在 `api_key_secret_masking.test.cjs`，在**未改动的上游代码**上同样失败（4 pass / 5 fail），与本次无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 状态提示可根据光标位置识别悬停状态，并暂停或恢复自动隐藏。
  * 支持时，鼠标穿透状态可随光标位置动态切换；不支持时保持兼容行为。
  * 悬停判断兼顾光标位置和键盘焦点，提升交互一致性。

* **稳定性**
  * 优化鼠标离开、焦点移出及连续提示场景下的状态处理。
  * 增加追踪超时保护；追踪失败、请求挂起或提示被打断时，可恢复自动隐藏并保持正确的鼠标穿透状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->