### PR TITLE
fix(tests): 修复 Windows 单测的 Node 计时与话题重启偶发失败

### DIFF
--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -932,8 +932,10 @@ def test_another_preloads_dependency_does_not_start_the_budget(runner, tmp_path)
     before the harness script. Keying on "first compile" armed the deadline
     there, putting pre-main startup back inside the script's budget.
 
-    The witness is a preload slower than the whole budget: if its time is
-    charged to the script, an otherwise instant script comes back 87.
+    Advance a controlled clock past the whole budget inside the preload. If
+    that time is charged to the script, an otherwise instant script returns
+    87. A real 800ms busy loop against a 500ms deadline also measures Windows
+    scheduling and pipe shutdown, which made this test intermittently fail.
     """
     node_path = _node_or_skip()
 
@@ -941,13 +943,22 @@ def test_another_preloads_dependency_does_not_start_the_budget(runner, tmp_path)
     # instance delete the .mjs another is still loading.
     dependency = tmp_path / "neko-probe-dep.cjs"
     slow_import = tmp_path / "neko-probe-slow.mjs"
+    clock_preload = tmp_path / "neko-probe-clock.cjs"
+    # NODE_OPTIONS --require runs before the launcher's --require guard; the
+    # guard snapshots this clock before --import evaluates the dependency.
+    clock_preload.write_text(
+        "const clock = { now: 0n };\n"
+        "process.hrtime.bigint = () => clock.now;\n"
+        "module.exports = clock;\n",
+        encoding="utf-8",
+    )
     dependency.write_text("module.exports = 1;\n", encoding="utf-8")
     slow_import.write_text(
         "import { createRequire } from 'node:module';\n"
         "const require = createRequire(import.meta.url);\n"
+        f"const clock = require({clock_preload.as_posix()!r});\n"
         f"require({str(dependency)!r}.split('\\\\').join('/'));\n"
-        "const until = Date.now() + 800;\n"
-        "while (Date.now() < until) {}\n",
+        "clock.now += 20000000000n;\n",
         encoding="utf-8",
     )
     try:
@@ -956,12 +967,19 @@ def test_another_preloads_dependency_does_not_start_the_budget(runner, tmp_path)
             "process.stdout.write('ok');\n",
             capture_output=True,
             check=False,
-            timeout=0.5,
-            env={**os.environ, "NODE_OPTIONS": f"--import {slow_import.as_uri()}"},
+            timeout=10,
+            env={
+                **os.environ,
+                "NODE_OPTIONS": (
+                    f'--require "{clock_preload.as_posix()}" '
+                    f'--import "{slow_import.as_uri()}"'
+                ),
+            },
         )
     finally:
         dependency.unlink(missing_ok=True)
         slow_import.unlink(missing_ok=True)
+        clock_preload.unlink(missing_ok=True)
 
     assert result.returncode == 0, (
         "别人的预载花掉的时间被算进了脚本预算："

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1007,13 +1007,16 @@ async def test_topic_pool_restored_signals_respect_persisted_used_history(tmp_pa
     )
     pool.note_user_message("妮可", "先投递一次，建立今天已经用过 deep topic 的节流历史", lang="zh-CN")
     await pool.process_now("妮可", lang="zh-CN")
+    # A readable used-topics file is only an intermediate milestone: the old
+    # pool still has to clear and flush its signal snapshot. Finish that task
+    # before writing restart evidence, or its late flush can erase the new
+    # store's file and the restarted analyzer never runs (CI run 33599962541).
+    task = pool._trigger_tasks.get("妮可")
+    if task is not None:
+        await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+    assert not pool._trigger_tasks.get("妮可")
     used_path = path.with_name("topic_signals.used_topics.json")
-    # The trigger writes this file from a worker thread (to_thread), so a fixed
-    # sleep is a race: a loaded CI runner needs more than 20ms just to hand the
-    # write off. Polling `exists()` is not enough either — on Windows it flips
-    # True while os.replace is still in flight and the read right behind it
-    # loses with PermissionError (CI run 30549810820). Wait for readable, and
-    # read once: the two assertions below must see the same snapshot anyway.
+    # Read once so the privacy and history assertions share a disk snapshot.
     used_text = await read_text_when_readable(used_path)
 
     assert delivered == ["买车"]
@@ -1039,7 +1042,6 @@ async def test_topic_pool_restored_signals_respect_persisted_used_history(tmp_pa
         signal_store_path=path,
     )
     await restarted.process_ready_topics(now=time.time() + 120, lang="zh-CN")
-    await asyncio.sleep(0.02)
 
     assert analyzer_calls == 2
     assert delivered == ["买车"]


### PR DESCRIPTION
## 改动概述 / Summary

修复 Windows unit CI 的两处间歇性测试失败。相关 run 都已打印 pytest 汇总，退出原因是断言失败；当前工作流已使用 25 分钟上限。

- Node 预加载预算测试：用受控单调时钟在预加载期间推进 20 秒，验证这段时间不计入 10 秒脚本预算，替换原先 800ms 忙等与 500ms 真实截止时间的竞速。保留文件与 stdin 两种启动方式。原失败见 [9 月 3 日](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/33739030422)、[9 月 4 日](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/33881224280)、[9 月 6 日](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/34052403379)。
- 话题重启测试：先等待旧实例投递任务完成，包括 used-topics 落盘之后的 signal 清理与 flush，再创建重启候选数据。此前只等待 used-topics 文件可读，旧实例随后的 flush 会覆盖新数据，导致重启后 analyzer 未执行。原失败见 [run 33599962541](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/33599962541/job/100151260217)。

仅修改两个测试文件，保留生产逻辑和工作流设置。

## 回归报告 / Regression Report

不适用：未修改 app/、main_logic/ 或 memory/。

## 不拆分理由 / Why Not Split

不适用：仅修改两个测试文件。

## 测试 / Testing

- 本机 Windows：`uv run pytest tests/unit -q -n 4 --dist loadfile --durations=15`，24,838 passed、138 skipped、124 warnings，pytest 汇总耗时 255.33 秒。GitHub runner 结果待本 PR CI 验证。
- `uv run ruff check tests/unit/test_node_harness_contract.py tests/unit/test_topic_pipeline.py`、`git diff --check` 均通过。
- 在独立验证进程临时恢复 Node 护栏的“首次 compile 即开始计时”缺陷，文件与 stdin 两个测试均以预期的退出码 87 失败。
- 通过受控线程交错重放旧实例的延迟 flush：原话题测试失败，修复后的测试在相同交错下通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 优化预加载依赖计时测试，提升虚拟时钟验证的稳定性。
  * 调整测试超时与临时资源清理逻辑，确保参数化测试彼此隔离。
  * 改进重启后话题节流测试，减少异步处理时序导致的不稳定结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->