### PR TITLE
feat(plugin): schema 过期的 plugin.meta.json 由首次启动原地升级

### DIFF
--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -237,6 +237,16 @@ def _upgrade_stale_packaged_metadata(
     except (OSError, ValueError):
         return
     manifest_pdata = manifest.get("plugin") if isinstance(manifest.get("plugin"), dict) else {}
+    if str(manifest_pdata.get("id") or "") != plugin_id:
+        # handler 键里嵌着运行时 id。id 冲突把这个插件改名成 foo_1 之后，扫描出的
+        # 键全是 foo_1.*；写进 foo 的包里，冲突一消失就再也对不上归属检查（coderabbit）。
+        logger.info(
+            "stale packaged metadata left as is; the runtime id differs from the "
+            "manifest id: plugin_id={}, manifest_id={}",
+            plugin_id,
+            manifest_pdata.get("id"),
+        )
+        return
     if entries_config_digest(conf, pdata) != entries_config_digest(manifest, manifest_pdata):
         logger.info(
             "stale packaged metadata left as is; the effective configuration "

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -62,7 +62,9 @@ from plugin.server.application.plugins.metadata_scanner import (
     scan_plugin_metadata_isolated,
 )
 from plugin.server.infrastructure.packaged_metadata import (
+    entries_config_digest,
     read_packaged_metadata,
+    refresh_stale_packaged_metadata,
 )
 from plugin.server.application.install_source import (
     InstallSourceError,
@@ -166,9 +168,9 @@ def _read_packaged_isolated_metadata(
     one import for the scan, one for the host, so any module-level side effect
     (writing state, sending a notification, launching a helper) happened twice
     (codex). An artifact written under an older schema is refused by the reader
-    and takes the worker path: one import per start until the plugin is
-    repackaged, which is what every plugin paid before packaged metadata
-    existed. Schema 3 never shipped in a release, so no in-memory migration.
+    and takes the worker path; ``start_plugin`` then rewrites it from that scan
+    (``_upgrade_stale_packaged_metadata``), so the cost is one import, not one
+    per start. Schema 3 never shipped in a release, so no in-memory migration.
 
     Returns ``None`` when there is no usable metadata at all.
     """
@@ -210,6 +212,45 @@ def _read_packaged_isolated_metadata(
         ),
         handlers=dict(packaged.handlers),
         entry_methods=dict(packaged.entry_methods),
+    )
+
+
+def _upgrade_stale_packaged_metadata(
+    config_path: Path,
+    plugin_id: str,
+    scanned: IsolatedPluginMetadata,
+    *,
+    conf: object,
+    pdata: object,
+) -> None:
+    """Turn the scan a stale package forced into the package's next fast path.
+
+    Only when the effective ``entries`` table is the manifest's own: the file
+    describes the package, and an active profile or runtime override that
+    rewrote the table would otherwise be frozen into it (the digest gate in
+    ``_read_packaged_isolated_metadata`` would then treat that machine's
+    overrides as the packaged baseline).
+    """
+    plugin_dir = Path(config_path).parent
+    try:
+        manifest = tomllib.loads(Path(config_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    manifest_pdata = manifest.get("plugin") if isinstance(manifest.get("plugin"), dict) else {}
+    if entries_config_digest(conf, pdata) != entries_config_digest(manifest, manifest_pdata):
+        logger.info(
+            "stale packaged metadata left as is; the effective configuration "
+            "overrides the entries table: plugin_id={}",
+            plugin_id,
+        )
+        return
+    refresh_stale_packaged_metadata(
+        plugin_dir,
+        entries=scanned.entries_preview,
+        handlers=scanned.handlers,
+        entry_methods=scanned.entry_methods,
+        conf=manifest,
+        pdata=manifest_pdata,
     )
 
 
@@ -1141,6 +1182,16 @@ class PluginLifecycleService:
                     pdata=pdata,
                     python_requirement_paths=python_requirement_paths,
                     timeout=scan_timeout,
+                )
+                # 包里那份元数据如果只是 schema 过期，这次扫描学到的就是打包器本
+                # 该写的那份。写回去，下次启动走快路径；写不成也不影响这次启动。
+                await asyncio.to_thread(
+                    _upgrade_stale_packaged_metadata,
+                    config_path,
+                    current_plugin_id,
+                    isolated_metadata,
+                    conf=conf,
+                    pdata=pdata,
                 )
 
             if start_deadline is not None and startup_timeout_value is not None:

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -62,9 +62,12 @@ from plugin.server.application.plugins.metadata_scanner import (
     scan_plugin_metadata_isolated,
 )
 from plugin.server.infrastructure.packaged_metadata import (
+    SourceTreeSnapshot,
     entries_config_digest,
     read_packaged_metadata,
     refresh_stale_packaged_metadata,
+    snapshot_source_tree,
+    stale_packaged_schema_version,
 )
 from plugin.server.application.install_source import (
     InstallSourceError,
@@ -215,11 +218,24 @@ def _read_packaged_isolated_metadata(
     )
 
 
+def _snapshot_stale_package_tree(config_path: Path) -> SourceTreeSnapshot | None:
+    """Fingerprint the tree before the scan imports it, if an upgrade is in prospect.
+
+    Only a stale-schema package can be upgraded, so only that case pays for
+    the snapshot; every other start skips this entirely.
+    """
+    plugin_dir = Path(config_path).parent
+    if stale_packaged_schema_version(plugin_dir) is None:
+        return None
+    return snapshot_source_tree(plugin_dir)
+
+
 def _upgrade_stale_packaged_metadata(
     config_path: Path,
     plugin_id: str,
     scanned: IsolatedPluginMetadata,
     *,
+    before_scan: SourceTreeSnapshot | None,
     conf: object,
     pdata: object,
 ) -> None:
@@ -231,6 +247,8 @@ def _upgrade_stale_packaged_metadata(
     ``_read_packaged_isolated_metadata`` would then treat that machine's
     overrides as the packaged baseline).
     """
+    if before_scan is None:
+        return
     plugin_dir = Path(config_path).parent
     try:
         manifest = tomllib.loads(Path(config_path).read_text(encoding="utf-8"))
@@ -256,6 +274,7 @@ def _upgrade_stale_packaged_metadata(
         return
     refresh_stale_packaged_metadata(
         plugin_dir,
+        before_scan=before_scan,
         entries=scanned.entries_preview,
         handlers=scanned.handlers,
         entry_methods=scanned.entry_methods,
@@ -1182,6 +1201,15 @@ class PluginLifecycleService:
                     _remaining_step_budget(start_deadline),
                     floor=_MIN_CLAMPED_START_TIMEOUT,
                 )
+                # 包里那份元数据如果只是 schema 过期，这次扫描学到的就是打包器本
+                # 该写的那份：写回去，下次启动走快路径。指纹在 import 之前先取一份，
+                # 之后比对，和打包器一样拒绝"import 改动了树"的情况。reload_all 有
+                # 总预算，可选的优化不放进去；应用启动的自动拉起没有截止期，在那里做。
+                before_scan = (
+                    await asyncio.to_thread(_snapshot_stale_package_tree, config_path)
+                    if start_deadline is None
+                    else None
+                )
                 isolated_metadata = await asyncio.to_thread(
                     scan_plugin_metadata_isolated,
                     plugin_id=current_plugin_id,
@@ -1193,13 +1221,12 @@ class PluginLifecycleService:
                     python_requirement_paths=python_requirement_paths,
                     timeout=scan_timeout,
                 )
-                # 包里那份元数据如果只是 schema 过期，这次扫描学到的就是打包器本
-                # 该写的那份。写回去，下次启动走快路径；写不成也不影响这次启动。
                 await asyncio.to_thread(
                     _upgrade_stale_packaged_metadata,
                     config_path,
                     current_plugin_id,
                     isolated_metadata,
+                    before_scan=before_scan,
                     conf=conf,
                     pdata=pdata,
                 )

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -518,9 +518,11 @@ def stale_packaged_schema_version(plugin_dir: Path) -> int | None:
     """The schema version of a real but outdated ``plugin.meta.json``, else ``None``.
 
     Only a regular, size-capped, well-formed JSON object whose integer
-    ``schema_version`` differs from the current one counts. A missing, broken
-    or current file is not "stale": the first two have nothing to upgrade and
-    the last one was refused for some other reason the upgrade cannot fix.
+    ``schema_version`` is *older* than the current one counts. A missing or
+    broken file has nothing to upgrade; a current one was refused for some
+    other reason the upgrade cannot fix; and a newer one was written by a
+    newer host, so rewriting it here would be a downgrade that throws away
+    fields this host does not know about (greptile).
     """
     meta_path = plugin_dir / PACKAGED_METADATA_FILENAME
     try:
@@ -538,7 +540,7 @@ def stale_packaged_schema_version(plugin_dir: Path) -> int | None:
     version = raw.get("schema_version")
     if isinstance(version, bool) or not isinstance(version, int):
         return None
-    return None if version == PACKAGED_METADATA_SCHEMA_VERSION else version
+    return version if version < PACKAGED_METADATA_SCHEMA_VERSION else None
 
 
 def refresh_stale_packaged_metadata(
@@ -565,34 +567,42 @@ def refresh_stale_packaged_metadata(
     guarantees that the effective ``entries`` table equals the manifest's,
     since the file must describe the package, not one machine's overrides.
 
-    Returns whether a file was written. Failing to write is not an error: the
-    directory may be read-only, and the plugin started fine without it.
+    Returns whether a file was written. Failing to fingerprint or write is not
+    an error: a source file can vanish between enumeration and hashing, the
+    directory may be read-only, and the plugin started fine without the file.
     """
     stale = stale_packaged_schema_version(plugin_dir)
     if stale is None:
         return False
-    summary = source_stat_summary(plugin_dir)
-    if summary.untrustworthy or empty_source_directories(plugin_dir) or unicode_renamed_source_files(plugin_dir):
-        logger.info(
-            "stale packaged metadata left as is; the tree cannot be fingerprinted: path={}",
-            plugin_dir,
-        )
-        return False
-    payload = {
-        "schema_version": PACKAGED_METADATA_SCHEMA_VERSION,
-        "sdk_version": SDK_VERSION,
-        "source_sha256": compute_source_sha256(plugin_dir),
-        "source_files": summary.names,
-        "source_bytes": summary.total_bytes,
-        "build_env": build_environment(),
-        "entries_config_sha256": entries_config_digest(conf, pdata),
-        "entries": list(entries),
-        "handlers": dict(handlers),
-        "entry_methods": dict(entry_methods),
-    }
     try:
+        summary = source_stat_summary(plugin_dir)
+        if (
+            summary.untrustworthy
+            or empty_source_directories(plugin_dir)
+            or unicode_renamed_source_files(plugin_dir)
+        ):
+            logger.info(
+                "stale packaged metadata left as is; the tree cannot be fingerprinted: path={}",
+                plugin_dir,
+            )
+            return False
+        payload = {
+            "schema_version": PACKAGED_METADATA_SCHEMA_VERSION,
+            "sdk_version": SDK_VERSION,
+            "source_sha256": compute_source_sha256(plugin_dir),
+            "source_files": summary.names,
+            "source_bytes": summary.total_bytes,
+            "build_env": build_environment(),
+            "entries_config_sha256": entries_config_digest(conf, pdata),
+            "entries": list(entries),
+            "handlers": dict(handlers),
+            "entry_methods": dict(entry_methods),
+        }
         atomic_write_json(plugin_dir / PACKAGED_METADATA_FILENAME, payload)
-    except OSError as exc:
+    except (OSError, PackagedMetadataError) as exc:
+        # compute_source_sha256 wraps its OSError in PackagedMetadataError (a
+        # ValueError); an optional optimisation must not turn that into a
+        # failed start (greptile).
         logger.info(
             "stale packaged metadata could not be rewritten; the plugin will rescan "
             "on every start until it is repackaged: path={}, err_type={}, err={}",

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -50,7 +50,7 @@ from typing import Any, Mapping
 
 from plugin._types.version import SDK_VERSION
 from plugin.logging_config import get_logger
-from utils.file_utils import atomic_write_text
+from utils.file_utils import atomic_write_bytes
 
 logger = get_logger("server.infrastructure.packaged_metadata")
 
@@ -636,17 +636,19 @@ def refresh_stale_packaged_metadata(
             "handlers": dict(handlers),
             "entry_methods": dict(entry_methods),
         }
-        text = json.dumps(payload, ensure_ascii=False, indent=2)
-        if len(text.encode("utf-8")) > MAX_PACKAGED_METADATA_BYTES:
+        # 量的就是写的：按字节落盘，文本模式在 Windows 上会把换行展开成 CRLF，
+        # 刚好卡在上限下的文件落到磁盘上就超了（codex）。打包器同样用 newline=""。
+        encoded = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        if len(encoded) > MAX_PACKAGED_METADATA_BYTES:
             logger.info(
                 "stale packaged metadata left as is; the upgraded file would exceed "
                 "the reader's size cap: path={}, bytes={}, cap={}",
                 plugin_dir,
-                len(text.encode("utf-8")),
+                len(encoded),
                 MAX_PACKAGED_METADATA_BYTES,
             )
             return False
-        atomic_write_text(plugin_dir / PACKAGED_METADATA_FILENAME, text)
+        atomic_write_bytes(plugin_dir / PACKAGED_METADATA_FILENAME, encoded)
     except (OSError, PackagedMetadataError) as exc:
         # compute_source_sha256 wraps its OSError in PackagedMetadataError (a
         # ValueError); an optional optimisation must not turn that into a

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -50,7 +50,7 @@ from typing import Any, Mapping
 
 from plugin._types.version import SDK_VERSION
 from plugin.logging_config import get_logger
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_text
 
 logger = get_logger("server.infrastructure.packaged_metadata")
 
@@ -543,9 +543,35 @@ def stale_packaged_schema_version(plugin_dir: Path) -> int | None:
     return version if version < PACKAGED_METADATA_SCHEMA_VERSION else None
 
 
+@dataclass(frozen=True, slots=True)
+class SourceTreeSnapshot:
+    """What a tree looked like before the plugin was imported.
+
+    The packager takes the same snapshot before its probe and refuses to write
+    metadata when the import changed the tree: handlers derived during the
+    import and a fingerprint taken after it can describe two different trees
+    (codex). ``None`` from :func:`snapshot_source_tree` means the tree could
+    not be read, which also refuses the upgrade.
+    """
+
+    sha256: str
+    directories: tuple[str, ...]
+
+
+def snapshot_source_tree(plugin_dir: Path) -> SourceTreeSnapshot | None:
+    try:
+        return SourceTreeSnapshot(
+            sha256=compute_source_sha256(plugin_dir),
+            directories=tuple(source_directory_names(plugin_dir)),
+        )
+    except (OSError, PackagedMetadataError):
+        return None
+
+
 def refresh_stale_packaged_metadata(
     plugin_dir: Path,
     *,
+    before_scan: SourceTreeSnapshot | None,
     entries: list[dict[str, object]],
     handlers: dict[str, dict[str, object]],
     entry_methods: dict[str, str],
@@ -563,16 +589,20 @@ def refresh_stale_packaged_metadata(
 
     The same refusals the packager applies (``metadata_probe``) apply here: a
     tree with symlinks, empty directories or names that change under NFC
-    cannot be described by a fingerprint, so it is left alone. The caller
-    guarantees that the effective ``entries`` table equals the manifest's,
-    since the file must describe the package, not one machine's overrides.
+    cannot be described by a fingerprint, and a tree the import itself changed
+    (``before_scan`` no longer matches) is one whose handlers and fingerprint
+    describe different states. Both are left alone. The caller guarantees that
+    the effective ``entries`` table equals the manifest's, since the file must
+    describe the package, not one machine's overrides.
 
     Returns whether a file was written. Failing to fingerprint or write is not
     an error: a source file can vanish between enumeration and hashing, the
     directory may be read-only, and the plugin started fine without the file.
+    A file the reader would refuse for its size is not written either: it would
+    be current-schema and oversized, so nothing could ever repair it (codex).
     """
     stale = stale_packaged_schema_version(plugin_dir)
-    if stale is None:
+    if stale is None or before_scan is None:
         return False
     try:
         summary = source_stat_summary(plugin_dir)
@@ -586,10 +616,18 @@ def refresh_stale_packaged_metadata(
                 plugin_dir,
             )
             return False
+        after_scan = snapshot_source_tree(plugin_dir)
+        if after_scan != before_scan:
+            logger.info(
+                "stale packaged metadata left as is; importing the plugin changed "
+                "its tree, so the scan and the fingerprint describe different states: path={}",
+                plugin_dir,
+            )
+            return False
         payload = {
             "schema_version": PACKAGED_METADATA_SCHEMA_VERSION,
             "sdk_version": SDK_VERSION,
-            "source_sha256": compute_source_sha256(plugin_dir),
+            "source_sha256": before_scan.sha256,
             "source_files": summary.names,
             "source_bytes": summary.total_bytes,
             "build_env": build_environment(),
@@ -598,7 +636,17 @@ def refresh_stale_packaged_metadata(
             "handlers": dict(handlers),
             "entry_methods": dict(entry_methods),
         }
-        atomic_write_json(plugin_dir / PACKAGED_METADATA_FILENAME, payload)
+        text = json.dumps(payload, ensure_ascii=False, indent=2)
+        if len(text.encode("utf-8")) > MAX_PACKAGED_METADATA_BYTES:
+            logger.info(
+                "stale packaged metadata left as is; the upgraded file would exceed "
+                "the reader's size cap: path={}, bytes={}, cap={}",
+                plugin_dir,
+                len(text.encode("utf-8")),
+                MAX_PACKAGED_METADATA_BYTES,
+            )
+            return False
+        atomic_write_text(plugin_dir / PACKAGED_METADATA_FILENAME, text)
     except (OSError, PackagedMetadataError) as exc:
         # compute_source_sha256 wraps its OSError in PackagedMetadataError (a
         # ValueError); an optional optimisation must not turn that into a

--- a/plugin/server/infrastructure/packaged_metadata.py
+++ b/plugin/server/infrastructure/packaged_metadata.py
@@ -21,8 +21,10 @@ get its module-level code run, and starting one plugin imported every other.
 
 The derivation now happens once, on the author's machine, at packaging time
 (see ``neko_plugin_cli.core.metadata_probe``), and the result ships inside the
-package as ``plugin.meta.json``. The host only ever reads that file. Nothing in
-this module imports, executes, or subprocesses plugin code.
+package as ``plugin.meta.json``. The host reads that file; the one thing it
+writes back is an upgrade of a file whose schema fell behind, and only from a
+scan the start path already had to run (see :func:`refresh_stale_packaged_metadata`).
+Nothing in this module imports, executes, or subprocesses plugin code.
 
 Entries whose schema is not available statically get
 :data:`PLACEHOLDER_INPUT_SCHEMA`, and that degradation is narrower than it
@@ -48,6 +50,7 @@ from typing import Any, Mapping
 
 from plugin._types.version import SDK_VERSION
 from plugin.logging_config import get_logger
+from utils.file_utils import atomic_write_json
 
 logger = get_logger("server.infrastructure.packaged_metadata")
 
@@ -509,6 +512,102 @@ def _tables_are_well_formed(raw: Mapping[str, object]) -> bool:
     ):
         return False
     return all(isinstance(item, Mapping) for item in entries)
+
+
+def stale_packaged_schema_version(plugin_dir: Path) -> int | None:
+    """The schema version of a real but outdated ``plugin.meta.json``, else ``None``.
+
+    Only a regular, size-capped, well-formed JSON object whose integer
+    ``schema_version`` differs from the current one counts. A missing, broken
+    or current file is not "stale": the first two have nothing to upgrade and
+    the last one was refused for some other reason the upgrade cannot fix.
+    """
+    meta_path = plugin_dir / PACKAGED_METADATA_FILENAME
+    try:
+        meta_stat = meta_path.stat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(meta_stat.st_mode) or meta_stat.st_size > MAX_PACKAGED_METADATA_BYTES:
+        return None
+    try:
+        raw: Any = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, RecursionError):
+        return None
+    if not isinstance(raw, Mapping):
+        return None
+    version = raw.get("schema_version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        return None
+    return None if version == PACKAGED_METADATA_SCHEMA_VERSION else version
+
+
+def refresh_stale_packaged_metadata(
+    plugin_dir: Path,
+    *,
+    entries: list[dict[str, object]],
+    handlers: dict[str, dict[str, object]],
+    entry_methods: dict[str, str],
+    conf: object,
+    pdata: object,
+) -> bool:
+    """Rewrite an outdated ``plugin.meta.json`` from a scan of this very tree.
+
+    A schema bump refuses every package built before it, and the plugin then
+    pays one isolated import per start until its author repackages — which,
+    for a plugin the author no longer touches, is forever. The start path has
+    just imported the tree anyway; what it learned is exactly what the
+    packager would have written, so write it, once, and the next start takes
+    the fast path again.
+
+    The same refusals the packager applies (``metadata_probe``) apply here: a
+    tree with symlinks, empty directories or names that change under NFC
+    cannot be described by a fingerprint, so it is left alone. The caller
+    guarantees that the effective ``entries`` table equals the manifest's,
+    since the file must describe the package, not one machine's overrides.
+
+    Returns whether a file was written. Failing to write is not an error: the
+    directory may be read-only, and the plugin started fine without it.
+    """
+    stale = stale_packaged_schema_version(plugin_dir)
+    if stale is None:
+        return False
+    summary = source_stat_summary(plugin_dir)
+    if summary.untrustworthy or empty_source_directories(plugin_dir) or unicode_renamed_source_files(plugin_dir):
+        logger.info(
+            "stale packaged metadata left as is; the tree cannot be fingerprinted: path={}",
+            plugin_dir,
+        )
+        return False
+    payload = {
+        "schema_version": PACKAGED_METADATA_SCHEMA_VERSION,
+        "sdk_version": SDK_VERSION,
+        "source_sha256": compute_source_sha256(plugin_dir),
+        "source_files": summary.names,
+        "source_bytes": summary.total_bytes,
+        "build_env": build_environment(),
+        "entries_config_sha256": entries_config_digest(conf, pdata),
+        "entries": list(entries),
+        "handlers": dict(handlers),
+        "entry_methods": dict(entry_methods),
+    }
+    try:
+        atomic_write_json(plugin_dir / PACKAGED_METADATA_FILENAME, payload)
+    except OSError as exc:
+        logger.info(
+            "stale packaged metadata could not be rewritten; the plugin will rescan "
+            "on every start until it is repackaged: path={}, err_type={}, err={}",
+            plugin_dir,
+            type(exc).__name__,
+            str(exc),
+        )
+        return False
+    logger.info(
+        "packaged metadata upgraded in place from schema {} to {}: path={}",
+        stale,
+        PACKAGED_METADATA_SCHEMA_VERSION,
+        plugin_dir,
+    )
+    return True
 
 
 def read_packaged_metadata(plugin_dir: Path) -> PackagedPluginMetadata | None:

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1634,7 +1634,10 @@ def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
         entry_methods={"go": "go"},
         conf={}, pdata={},
     ) is True
-    written = json.loads(meta_path.read_text(encoding="utf-8"))
+    written_bytes = meta_path.read_bytes()
+    # 落盘的字节就是量过的字节：不能经文本模式在 Windows 上被展开成 CRLF（codex）。
+    assert b"\r" not in written_bytes
+    written = json.loads(written_bytes.decode("utf-8"))
     # 键集合和打包器 derive_plugin_metadata 返回的字典一致：多一个少一个都算格式漂移。
     import ast as _ast
     import inspect as _inspect

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1675,13 +1675,16 @@ def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
     assert meta_path.read_bytes() == before
 
     # 写出来的文件读取器读不了（超过尺寸上限）就不写：它会是"当前版本且超大"，
-    # 之后没有任何路径能再修它。
+    # 之后没有任何路径能再修它。上限设成正好等于输入文件的大小：输入能过
+    # stale 判据，带缩进、多了指纹字段的输出一定超（coderabbit）。
     original_cap = packaged_metadata.MAX_PACKAGED_METADATA_BYTES
-    packaged_metadata.MAX_PACKAGED_METADATA_BYTES = 64
+    packaged_metadata.MAX_PACKAGED_METADATA_BYTES = len(before)
+    assert packaged_metadata.stale_packaged_schema_version(plugin_dir) == 3
     try:
         assert packaged_metadata.refresh_stale_packaged_metadata(
             plugin_dir, before_scan=before_scan,
-            entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
+            entries=[{"id": "go", "name": "Go"}], handlers={"demo.go": handler},
+            entry_methods={"go": "go"}, conf={}, pdata={},
         ) is False
     finally:
         packaged_metadata.MAX_PACKAGED_METADATA_BYTES = original_cap

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1625,8 +1625,10 @@ def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
     meta_path.write_text(json.dumps(raw), encoding="utf-8")
     handler = {"event_type": "plugin_entry", "id": "go", "name": "Go", "timeout": 4}
 
+    before_scan = packaged_metadata.snapshot_source_tree(plugin_dir)
     assert packaged_metadata.refresh_stale_packaged_metadata(
         plugin_dir,
+        before_scan=before_scan,
         entries=[{"id": "go", "name": "Go"}],
         handlers={"demo.go": handler},
         entry_methods={"go": "go"},
@@ -1665,10 +1667,24 @@ def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
     packaged_metadata.compute_source_sha256 = _vanished
     try:
         assert packaged_metadata.refresh_stale_packaged_metadata(
-            plugin_dir, entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
+            plugin_dir, before_scan=before_scan,
+            entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
         ) is False
     finally:
         packaged_metadata.compute_source_sha256 = original
+    assert meta_path.read_bytes() == before
+
+    # 写出来的文件读取器读不了（超过尺寸上限）就不写：它会是"当前版本且超大"，
+    # 之后没有任何路径能再修它。
+    original_cap = packaged_metadata.MAX_PACKAGED_METADATA_BYTES
+    packaged_metadata.MAX_PACKAGED_METADATA_BYTES = 64
+    try:
+        assert packaged_metadata.refresh_stale_packaged_metadata(
+            plugin_dir, before_scan=before_scan,
+            entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
+        ) is False
+    finally:
+        packaged_metadata.MAX_PACKAGED_METADATA_BYTES = original_cap
     assert meta_path.read_bytes() == before
     raw["schema_version"] = packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION
     meta_path.write_text(json.dumps(raw), encoding="utf-8")
@@ -1676,6 +1692,7 @@ def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
     # 第二次没有过期文件可升，什么都不写。
     before = meta_path.read_bytes()
     assert packaged_metadata.refresh_stale_packaged_metadata(
-        plugin_dir, entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
+        plugin_dir, before_scan=before_scan,
+        entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
     ) is False
     assert meta_path.read_bytes() == before

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1565,3 +1565,92 @@ def test_a_v3_package_is_refused_and_takes_the_worker_path(tmp_path, monkeypatch
     )
     assert [(entry["id"], entry["name"]) for entry in listed] == [("go", "Declared")]
     assert meta_path.read_bytes() == before
+
+
+@pytest.mark.parametrize("shape, expected", [
+    ("missing", None),
+    ("current", None),
+    ("v3", 3),
+    ("v2", 2),
+    ("string_version", None),
+    ("bool_version", None),
+    ("not_json", None),
+    ("not_object", None),
+    ("oversized", None),
+])
+def test_only_a_real_outdated_file_counts_as_stale(tmp_path, shape, expected):
+    """Stale means "an upgrade would fix it", nothing looser.
+
+    A missing or broken file has nothing to upgrade; a current-schema file was
+    refused for a reason a rewrite cannot fix; a version that is not an int is
+    a malformed file, not an old one.
+    """
+    plugin_dir = _write_plugin(tmp_path, entries=[{"id": "go"}])
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    raw = json.loads(meta_path.read_text(encoding="utf-8"))
+    if shape == "missing":
+        meta_path.unlink()
+    elif shape == "v3":
+        raw["schema_version"] = 3
+    elif shape == "v2":
+        raw["schema_version"] = 2
+    elif shape == "string_version":
+        raw["schema_version"] = "3"
+    elif shape == "bool_version":
+        raw["schema_version"] = True
+    elif shape == "not_json":
+        meta_path.write_text("{not json", encoding="utf-8")
+    elif shape == "not_object":
+        meta_path.write_text("[3]", encoding="utf-8")
+    elif shape == "oversized":
+        raw["schema_version"] = 3
+        raw["padding"] = "x" * (packaged_metadata.MAX_PACKAGED_METADATA_BYTES + 1)
+    if shape not in ("missing", "not_json", "not_object"):
+        meta_path.write_text(json.dumps(raw), encoding="utf-8")
+    assert packaged_metadata.stale_packaged_schema_version(plugin_dir) == expected
+
+
+def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
+    """Same keys, same fingerprint, accepted by the same reader."""
+    from plugin.neko_plugin_cli.core import metadata_probe
+
+    plugin_dir = _write_plugin(tmp_path, entries=[{"id": "go"}])
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    raw = json.loads(meta_path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 3
+    meta_path.write_text(json.dumps(raw), encoding="utf-8")
+    handler = {"event_type": "plugin_entry", "id": "go", "name": "Go", "timeout": 4}
+
+    assert packaged_metadata.refresh_stale_packaged_metadata(
+        plugin_dir,
+        entries=[{"id": "go", "name": "Go"}],
+        handlers={"demo.go": handler},
+        entry_methods={"go": "go"},
+        conf={}, pdata={},
+    ) is True
+    written = json.loads(meta_path.read_text(encoding="utf-8"))
+    # 键集合和打包器 derive_plugin_metadata 返回的字典一致：多一个少一个都算格式漂移。
+    import ast as _ast
+    import inspect as _inspect
+
+    tree = _ast.parse(_inspect.getsource(metadata_probe.derive_plugin_metadata))
+    packager_keys = {
+        key.value
+        for node in _ast.walk(tree)
+        if isinstance(node, _ast.Return) and isinstance(node.value, _ast.Dict)
+        for key in node.value.keys
+        if isinstance(key, _ast.Constant)
+    }
+    assert packager_keys, "没找到打包器的返回字典，测试自身失效"
+    assert set(written) == packager_keys
+    assert written["source_sha256"] == packaged_metadata.compute_source_sha256(plugin_dir)
+    assert written["handlers"]["demo.go"] == handler
+    packaged = packaged_metadata.read_packaged_metadata(plugin_dir)
+    assert packaged is not None
+    assert packaged.handlers["demo.go"]["timeout"] == 4
+    # 第二次没有过期文件可升，什么都不写。
+    before = meta_path.read_bytes()
+    assert packaged_metadata.refresh_stale_packaged_metadata(
+        plugin_dir, entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
+    ) is False
+    assert meta_path.read_bytes() == before

--- a/plugin/tests/unit/server/test_plugin_discovery_static.py
+++ b/plugin/tests/unit/server/test_plugin_discovery_static.py
@@ -1572,6 +1572,7 @@ def test_a_v3_package_is_refused_and_takes_the_worker_path(tmp_path, monkeypatch
     ("current", None),
     ("v3", 3),
     ("v2", 2),
+    ("newer", None),
     ("string_version", None),
     ("bool_version", None),
     ("not_json", None),
@@ -1583,7 +1584,8 @@ def test_only_a_real_outdated_file_counts_as_stale(tmp_path, shape, expected):
 
     A missing or broken file has nothing to upgrade; a current-schema file was
     refused for a reason a rewrite cannot fix; a version that is not an int is
-    a malformed file, not an old one.
+    a malformed file, not an old one; a newer version came from a newer host
+    and rewriting it would be a downgrade (greptile).
     """
     plugin_dir = _write_plugin(tmp_path, entries=[{"id": "go"}])
     meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
@@ -1594,6 +1596,8 @@ def test_only_a_real_outdated_file_counts_as_stale(tmp_path, shape, expected):
         raw["schema_version"] = 3
     elif shape == "v2":
         raw["schema_version"] = 2
+    elif shape == "newer":
+        raw["schema_version"] = packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION + 1
     elif shape == "string_version":
         raw["schema_version"] = "3"
     elif shape == "bool_version":
@@ -1648,6 +1652,27 @@ def test_an_upgraded_file_is_what_the_packager_would_have_written(tmp_path):
     packaged = packaged_metadata.read_packaged_metadata(plugin_dir)
     assert packaged is not None
     assert packaged.handlers["demo.go"]["timeout"] == 4
+    # 指纹阶段出错（文件在枚举和哈希之间消失）不能变成启动失败：只记日志、不写。
+    raw = json.loads(meta_path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 3
+    meta_path.write_text(json.dumps(raw), encoding="utf-8")
+    before = meta_path.read_bytes()
+
+    def _vanished(_plugin_dir):
+        raise packaged_metadata.PackagedMetadataError("source file vanished mid-hash")
+
+    original = packaged_metadata.compute_source_sha256
+    packaged_metadata.compute_source_sha256 = _vanished
+    try:
+        assert packaged_metadata.refresh_stale_packaged_metadata(
+            plugin_dir, entries=[], handlers={}, entry_methods={}, conf={}, pdata={},
+        ) is False
+    finally:
+        packaged_metadata.compute_source_sha256 = original
+    assert meta_path.read_bytes() == before
+    raw["schema_version"] = packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION
+    meta_path.write_text(json.dumps(raw), encoding="utf-8")
+
     # 第二次没有过期文件可升，什么都不写。
     before = meta_path.read_bytes()
     assert packaged_metadata.refresh_stale_packaged_metadata(

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -4413,7 +4413,7 @@ async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
         def _refuse(*args, **kwargs):
             raise PermissionError("read-only plugin directory")
 
-        monkeypatch.setattr(packaged_metadata, "atomic_write_text", _refuse)
+        monkeypatch.setattr(packaged_metadata, "atomic_write_bytes", _refuse)
     else:
         config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
     before = meta_path.read_bytes() if meta_path.exists() else None

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -4233,6 +4233,7 @@ def _write_stale_package(plugin_dir: Path, *, schema_version: object, handler: d
 
 async def _start_packaged_adapter(
     monkeypatch, config_path: Path, *, scanned_handler: dict, effective_overlay: dict | None = None,
+    runtime_id: str = "packaged_adapter",
 ) -> list[str]:
     """Run start_plugin against a fake host and return the plugin ids that were scanned."""
     with module.state.acquire_plugins_write_lock():
@@ -4256,7 +4257,7 @@ async def _start_packaged_adapter(
             "warnings": [],
         },
     )
-    monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
+    monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: runtime_id)
     monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
     monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
     inner_scan = _metadata_scan_for(_FakeAdapterPlugin)
@@ -4268,7 +4269,7 @@ async def _start_packaged_adapter(
         scanned = inner_scan(**kwargs)
         return IsolatedPluginMetadata(
             entries_preview=scanned.entries_preview,
-            handlers={"packaged_adapter.list_servers": scanned_handler},
+            handlers={f"{runtime_id}.list_servers": scanned_handler},
             entry_methods={"list_servers": "list_servers"},
         )
 
@@ -4365,7 +4366,7 @@ async def test_a_stale_package_is_upgraded_in_place_by_its_first_start(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize("reason", ["no_file", "current_schema", "config_overrides", "unwritable"])
+@pytest.mark.parametrize("reason", ["no_file", "current_schema", "config_overrides", "unwritable", "renamed"])
 async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _isolated_plugin_state, reason,
 ) -> None:
@@ -4375,8 +4376,10 @@ async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
     must not start growing one. A current-schema file that was refused for
     another reason (a foreign build environment here) is not fixed by a
     rewrite. An effective configuration that overrides the entries table would
-    freeze one machine's overrides into the package. And a directory the host
-    cannot write to is not a failed start.
+    freeze one machine's overrides into the package. A directory the host
+    cannot write to is not a failed start. And a plugin renamed by an id
+    conflict scans handler keys under the runtime id, which must not land in
+    the package of the manifest id (coderabbit).
     """
     from plugin.server.infrastructure import packaged_metadata
 
@@ -4396,19 +4399,22 @@ async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
     elif reason == "config_overrides":
         config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
         conf_overlay = {"entries": [{"id": "list_servers", "timeout": 5}]}
-    else:
+    elif reason == "unwritable":
         config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
 
         def _refuse(*args, **kwargs):
             raise PermissionError("read-only plugin directory")
 
         monkeypatch.setattr(packaged_metadata, "atomic_write_json", _refuse)
+    else:
+        config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
     before = meta_path.read_bytes() if meta_path.exists() else None
 
     scans = await _start_packaged_adapter(
         monkeypatch, config_path, scanned_handler=scanned, effective_overlay=conf_overlay,
+        runtime_id="packaged_adapter_1" if reason == "renamed" else "packaged_adapter",
     )
-    assert scans == ["packaged_adapter"]
+    assert scans == ["packaged_adapter_1" if reason == "renamed" else "packaged_adapter"]
     if before is None:
         assert not meta_path.exists(), "没有元数据文件的插件不该被凭空造出一份"
     elif reason == "config_overrides":

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -4205,3 +4205,215 @@ async def test_start_plugin_scans_once_when_the_packaged_schema_is_stale(
             module.state.event_handlers.update(handlers_backup)
         with module.state._snapshot_cache_lock:
             module.state._snapshot_cache = cache_backup
+
+
+def _write_stale_package(plugin_dir: Path, *, schema_version: object, handler: dict) -> Path:
+    """A plugin.meta.json that matches this tree except for its schema version."""
+    import json
+
+    from plugin.server.infrastructure import packaged_metadata
+
+    config_path = plugin_dir / "plugin.toml"
+    payload = {
+        "schema_version": schema_version,
+        "sdk_version": packaged_metadata.SDK_VERSION,
+        "source_sha256": packaged_metadata.compute_source_sha256(plugin_dir),
+        "source_files": packaged_metadata.source_file_names(plugin_dir)[0],
+        "source_bytes": packaged_metadata.source_stat_summary(plugin_dir).total_bytes,
+        "build_env": packaged_metadata.build_environment(),
+        "entries": [{"id": "list_servers", "name": "List Servers"}],
+        "handlers": {"packaged_adapter.list_servers": handler},
+        "entry_methods": {"list_servers": "list_servers"},
+        "entries_config_sha256": packaged_metadata.entries_config_digest({}, {}),
+    }
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    meta_path.write_text(json.dumps(payload), encoding="utf-8")
+    return config_path
+
+
+async def _start_packaged_adapter(
+    monkeypatch, config_path: Path, *, scanned_handler: dict, effective_overlay: dict | None = None,
+) -> list[str]:
+    """Run start_plugin against a fake host and return the plugin ids that were scanned."""
+    with module.state.acquire_plugins_write_lock():
+        module.state.plugins.clear()
+        module.state.plugins["packaged_adapter"] = {
+            "id": "packaged_adapter",
+            "name": "Packaged Adapter",
+            "type": "adapter",
+            "config_path": str(config_path),
+            "entry_point": "tests.fake_mcp:FakeAdapterPlugin",
+        }
+    with module.state.acquire_plugin_hosts_write_lock():
+        module.state.plugin_hosts.clear()
+    with module.state.acquire_event_handlers_write_lock():
+        module.state.event_handlers.clear()
+    monkeypatch.setattr(
+        module,
+        "resolve_plugin_config_from_path",
+        lambda *args, **kwargs: {
+            "effective_config": {**kwargs["base_config"], **(effective_overlay or {})},
+            "warnings": [],
+        },
+    )
+    monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
+    monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
+    monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+    inner_scan = _metadata_scan_for(_FakeAdapterPlugin)
+    scans: list[str] = []
+
+    def _recording_scan(**kwargs):
+        scans.append(str(kwargs["plugin_id"]))
+        kwargs.pop("timeout", None)
+        scanned = inner_scan(**kwargs)
+        return IsolatedPluginMetadata(
+            entries_preview=scanned.entries_preview,
+            handlers={"packaged_adapter.list_servers": scanned_handler},
+            entry_methods={"list_servers": "list_servers"},
+        )
+
+    monkeypatch.setattr(module, "scan_plugin_metadata_isolated", _recording_scan)
+    response = await module.PluginLifecycleService().start_plugin(
+        "packaged_adapter", refresh_registry=False,
+    )
+    assert response["success"] is True
+    return scans
+
+
+@pytest.fixture
+def _isolated_plugin_state():
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+    try:
+        yield
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+def _packaged_adapter_dir(tmp_path: Path) -> Path:
+    plugin_dir = tmp_path / "packaged_adapter"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.toml").write_text(
+        "\n".join(
+            [
+                "[plugin]",
+                "id = 'packaged_adapter'",
+                "name = 'Packaged Adapter'",
+                "type = 'adapter'",
+                "entry = 'tests.fake_mcp:FakeAdapterPlugin'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_a_stale_package_is_upgraded_in_place_by_its_first_start(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _isolated_plugin_state,
+) -> None:
+    """One scan, then the fast path — instead of one scan per start forever.
+
+    A schema bump refuses every package built before it. Nothing rewrote the
+    file, so a plugin whose author never repackages paid an isolated import on
+    every start. The start path has just imported the tree; what it learned is
+    what the packager would have written.
+
+    Mutation: drop the ``_upgrade_stale_packaged_metadata`` call.
+    """
+    import json
+
+    from plugin.server.infrastructure import packaged_metadata
+
+    plugin_dir = _packaged_adapter_dir(tmp_path)
+    old_handler = {"event_type": "plugin_entry", "id": "list_servers", "name": "Old"}
+    config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
+    scanned = {"event_type": "plugin_entry", "id": "list_servers", "name": "Scanned", "timeout": 7}
+
+    scans = await _start_packaged_adapter(monkeypatch, config_path, scanned_handler=scanned)
+    assert scans == ["packaged_adapter"]
+
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    written = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert written["schema_version"] == packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION
+    assert written["handlers"]["packaged_adapter.list_servers"] == scanned
+    assert written["entries"][0]["id"] == "list_servers"
+    # 写出来的文件要能被读取器原样接受，下次启动才真的不再扫描。
+    packaged = packaged_metadata.read_packaged_metadata(plugin_dir)
+    assert packaged is not None
+    assert packaged.handlers["packaged_adapter.list_servers"]["name"] == "Scanned"
+    manifest = {"plugin": {"id": "packaged_adapter"}}
+    reused = module._read_packaged_isolated_metadata(
+        config_path, "packaged_adapter", conf=manifest, pdata=manifest["plugin"],
+    )
+    assert reused is not None
+    assert reused.handlers["packaged_adapter.list_servers"]["timeout"] == 7
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ["no_file", "current_schema", "config_overrides", "unwritable"])
+async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _isolated_plugin_state, reason,
+) -> None:
+    """The upgrade is for a stale file, nothing else.
+
+    No file means a hand-dropped or dev-mode plugin, which never had one and
+    must not start growing one. A current-schema file that was refused for
+    another reason (a foreign build environment here) is not fixed by a
+    rewrite. An effective configuration that overrides the entries table would
+    freeze one machine's overrides into the package. And a directory the host
+    cannot write to is not a failed start.
+    """
+    from plugin.server.infrastructure import packaged_metadata
+
+    plugin_dir = _packaged_adapter_dir(tmp_path)
+    meta_path = plugin_dir / packaged_metadata.PACKAGED_METADATA_FILENAME
+    old_handler = {"event_type": "plugin_entry", "id": "list_servers", "name": "Old"}
+    scanned = {"event_type": "plugin_entry", "id": "list_servers", "name": "Scanned"}
+    conf_overlay = None
+    if reason == "no_file":
+        config_path = plugin_dir / "plugin.toml"
+    elif reason == "current_schema":
+        config_path = _write_stale_package(
+            plugin_dir, schema_version=packaged_metadata.PACKAGED_METADATA_SCHEMA_VERSION,
+            handler=old_handler,
+        )
+        monkeypatch.setattr(packaged_metadata, "_environment_matches", lambda raw: False)
+    elif reason == "config_overrides":
+        config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
+        conf_overlay = {"entries": [{"id": "list_servers", "timeout": 5}]}
+    else:
+        config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
+
+        def _refuse(*args, **kwargs):
+            raise PermissionError("read-only plugin directory")
+
+        monkeypatch.setattr(packaged_metadata, "atomic_write_json", _refuse)
+    before = meta_path.read_bytes() if meta_path.exists() else None
+
+    scans = await _start_packaged_adapter(
+        monkeypatch, config_path, scanned_handler=scanned, effective_overlay=conf_overlay,
+    )
+    assert scans == ["packaged_adapter"]
+    if before is None:
+        assert not meta_path.exists(), "没有元数据文件的插件不该被凭空造出一份"
+    elif reason == "config_overrides":
+        assert meta_path.read_bytes() == before, "生效配置改过 entries 表，不能把这台机器的覆盖冻进包里"
+    elif reason == "unwritable":
+        assert meta_path.read_bytes() == before
+    else:
+        assert meta_path.read_bytes() == before, "当前 schema 的文件被拒是别的原因，重写修不了它"

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -4233,7 +4233,7 @@ def _write_stale_package(plugin_dir: Path, *, schema_version: object, handler: d
 
 async def _start_packaged_adapter(
     monkeypatch, config_path: Path, *, scanned_handler: dict, effective_overlay: dict | None = None,
-    runtime_id: str = "packaged_adapter",
+    runtime_id: str = "packaged_adapter", scan_side_effect=None, start_deadline: float | None = None,
 ) -> list[str]:
     """Run start_plugin against a fake host and return the plugin ids that were scanned."""
     with module.state.acquire_plugins_write_lock():
@@ -4266,6 +4266,8 @@ async def _start_packaged_adapter(
     def _recording_scan(**kwargs):
         scans.append(str(kwargs["plugin_id"]))
         kwargs.pop("timeout", None)
+        if scan_side_effect is not None:
+            scan_side_effect()
         scanned = inner_scan(**kwargs)
         return IsolatedPluginMetadata(
             entries_preview=scanned.entries_preview,
@@ -4275,7 +4277,7 @@ async def _start_packaged_adapter(
 
     monkeypatch.setattr(module, "scan_plugin_metadata_isolated", _recording_scan)
     response = await module.PluginLifecycleService().start_plugin(
-        "packaged_adapter", refresh_registry=False,
+        "packaged_adapter", refresh_registry=False, start_deadline=start_deadline,
     )
     assert response["success"] is True
     return scans
@@ -4366,7 +4368,10 @@ async def test_a_stale_package_is_upgraded_in_place_by_its_first_start(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize("reason", ["no_file", "current_schema", "config_overrides", "unwritable", "renamed"])
+@pytest.mark.parametrize("reason", [
+    "no_file", "current_schema", "config_overrides", "unwritable", "renamed",
+    "import_mutates_tree", "reload_budget",
+])
 async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _isolated_plugin_state, reason,
 ) -> None:
@@ -4377,9 +4382,12 @@ async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
     another reason (a foreign build environment here) is not fixed by a
     rewrite. An effective configuration that overrides the entries table would
     freeze one machine's overrides into the package. A directory the host
-    cannot write to is not a failed start. And a plugin renamed by an id
+    cannot write to is not a failed start. A plugin renamed by an id
     conflict scans handler keys under the runtime id, which must not land in
-    the package of the manifest id (coderabbit).
+    the package of the manifest id (coderabbit). An import that changes its
+    own tree leaves handlers and fingerprint describing different states, the
+    case the packager refuses too (codex). And under a reload_all deadline the
+    optional work is skipped rather than charged to the round (codex).
     """
     from plugin.server.infrastructure import packaged_metadata
 
@@ -4405,14 +4413,19 @@ async def test_a_scan_does_not_write_metadata_it_has_no_business_writing(
         def _refuse(*args, **kwargs):
             raise PermissionError("read-only plugin directory")
 
-        monkeypatch.setattr(packaged_metadata, "atomic_write_json", _refuse)
+        monkeypatch.setattr(packaged_metadata, "atomic_write_text", _refuse)
     else:
         config_path = _write_stale_package(plugin_dir, schema_version=3, handler=old_handler)
     before = meta_path.read_bytes() if meta_path.exists() else None
 
+    def _import_writes_a_cache_file():
+        (plugin_dir / "cache.json").write_text("{}", encoding="utf-8")
+
     scans = await _start_packaged_adapter(
         monkeypatch, config_path, scanned_handler=scanned, effective_overlay=conf_overlay,
         runtime_id="packaged_adapter_1" if reason == "renamed" else "packaged_adapter",
+        scan_side_effect=_import_writes_a_cache_file if reason == "import_mutates_tree" else None,
+        start_deadline=time.monotonic() + 20.0 if reason == "reload_budget" else None,
     )
     assert scans == ["packaged_adapter_1" if reason == "renamed" else "packaged_adapter"]
     if before is None:


### PR DESCRIPTION
## 改动概述 / Summary

接在 #3054（已合并）之后。

#3054 把打包元数据 schema 从 3 升到 4，旧包被读取器拒绝、走 worker 回落。回落是对的，但代价不该是永久的：插件从此每次启动都多一次隔离 import，直到作者重新打包；作者不再维护的插件就是永远。而启动路径本来就已经 import 过这棵树，扫描学到的正是打包器该写的那份。

本 PR 让 `start_plugin` 在回落扫描成功后，把**已存在且仅 schema 过期**的 `plugin.meta.json` 原地重写成当前版本。之后的启动走快路径，和作者重新打包一个效果。

### 行为

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| 目录里有 schema 3 的文件，源码指纹一致 | 每次启动都隔离扫描 | 第一次启动扫描一次并重写为 v4，之后直接读文件 |
| 没有 `plugin.meta.json`（手放 / dev 插件） | 每次扫描 | 不变，不会凭空造文件 |
| 当前 schema 的文件因别的原因被拒（打包环境不同、源码变了） | 扫描 | 不变，重写修不了它 |
| 生效配置（profile / 运行时覆盖）改过 `entries` 表 | 扫描 | 不变，不把某台机器的覆盖冻进包里 |
| 插件目录只读 | 扫描 | 记一条 info 日志，本次启动照常成功 |
| 树里有符号链接 / 空目录 / NFC 改名 | 扫描 | 不写，沿用打包器同一套拒收判据 |

### 代码

- `packaged_metadata.stale_packaged_schema_version`：只认"真实存在、能解析、整数 `schema_version` 且不等于当前版本"。
- `packaged_metadata.refresh_stale_packaged_metadata`：键集合与 `neko_plugin_cli.core.metadata_probe.derive_plugin_metadata` 的返回字典一致，用 `utils.file_utils.atomic_write_json` 落盘。
- `lifecycle_service._upgrade_stale_packaged_metadata`：读 manifest 算 `entries` 摘要，与生效配置一致才写；在 `start_plugin` 回落扫描之后以 `to_thread` 调用。

宿主此前对这个文件只做过一件写操作：内容校验通过后盖 mtime。这次是第二件，且限定在"文件已在、只是版本旧"这一种情况。注册表刷新路径不动，仍然只读文件、不 import。

### 实测

隔离扫描一次的时长（本机，Windows）：web_search 0.75s、lifekit 0.75s、qq_auto_reply 1.3s（84 条 handler）。扫描上限 10s，reload_all 单步下界 3s。所以这个 PR 省的是每次启动一次 import 及其副作用，不是在救超时。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/`。

## 不拆分理由 / Why Not Split

4 个文件，一个功能点。

## 测试 / Testing

- 新增：首次启动升级后读取器原样接受、二次读不再扫描；无文件 / 当前版本被拒 / 配置覆盖 / 目录只读四种情况不写且启动成功；stale 判据九向参数化；写出的键集合按 AST 与打包器返回字典比对；同一目录第二次调用不再写。
- 变异验证：删掉 `start_plugin` 里的升级调用，升级测试转红。
- `plugin/tests/unit/server` 全量、CLI 打包相关测试、docstring 门、分层门、ruff 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 插件启动扫描时，可自动将过期的打包元数据升级为当前版本。
  - 升级后的扫描结果会保存并复用，避免后续启动重复扫描。

- **错误修复**
  - 检测到插件源码或目录在扫描期间发生变化时，不再回写元数据。
  - 高于当前支持版本的元数据不会被误判为可升级。
  - 超出大小限制或指纹计算失败时，保留原文件且不影响启动流程。
  - 元数据采用原子方式写入，降低文件损坏风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->