### PR TITLE
fix(licenses): 补齐 three-mmd 及内嵌依赖的 MIT 声明

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,6 +7,10 @@ This product is developed and maintained by the Project N.E.K.O. Team.
 Licensed under the Apache License, Version 2.0.
 See the LICENSE file for the full license text.
 
+Third-party components retain their respective copyrights and licenses.
+For the bundled three-mmd components and their embedded babylon-mmd portions,
+see static/libs/THIRD_PARTY_NOTICES.md and static/libs/licenses/.
+
 ------------------------------------------------------------
 
 我们种下了人与猫娘幸福共生的种子，我们的征途是星辰大海。

--- a/scripts/check_nuitka_dist.py
+++ b/scripts/check_nuitka_dist.py
@@ -63,6 +63,12 @@ _REQUIRED_ASSETS: tuple[tuple[str, str | None], ...] = (
     # 只编 .py 不带；守该目录里至少有一份 locale json，否则非默认语言用户的角色种子回退错语言。
     ("config/characters", "*.json"),
     ("static", None),
+    # Vendored MMD libraries must ship with their upstream license notices.
+    ("static/libs", "three-mmd.module.js"),
+    ("static/libs", "three-mmd-physics-ammo.module.js"),
+    ("static/libs", "THIRD_PARTY_NOTICES.md"),
+    ("static/libs/licenses", "THREE-MMD-LICENSE.txt"),
+    ("static/libs/licenses", "BABYLON-MMD-LICENSE.txt"),
     # 内置 Live2D 模型：源码打包在 assets/<name>.tar.gz，build_frontend 解到 static/<name>/。
     # 默认角色用 yui-lolita，加载失败的兜底与教程也指向它；yui-origin 仍随包发。
     # 只查 model3.json 挡不住半截解包——moc3 与纹理是加载硬依赖，一并断言。

--- a/static/libs/THIRD_PARTY_NOTICES.md
+++ b/static/libs/THIRD_PARTY_NOTICES.md
@@ -29,7 +29,7 @@ root Apache-2.0 license does not replace them.
 - Local changes: physics constraint limits and damping, rigid-body behavior,
   floor/distance handling, and model-rotation fixes. The existing implementation
   is preserved; this license update only prepends a comment.
-- Local history: introduced in N.E.K.O. commit `2800df92d`, subsequently modified
+- Local history: introduced in N.E.K.O. commit `450e78744`, subsequently modified
   in `665417441` and `3440b9bb7`.
 - License: MIT; full upstream text is in [THREE-MMD-LICENSE.txt](licenses/THREE-MMD-LICENSE.txt)
   and the file's leading comment, retaining both upstream copyright statements.

--- a/static/libs/THIRD_PARTY_NOTICES.md
+++ b/static/libs/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,60 @@
+# Third-party notices for the bundled MMD libraries
+
+These notices cover the two three-mmd bundles below and the babylon-mmd code
+embedded in the core bundle. This is not an inventory of every library in
+`static/libs`. These components retain their upstream licenses; the project's
+root Apache-2.0 license does not replace them.
+
+## @moeru/three-mmd
+
+- File: `three-mmd.module.js`
+- Source: <https://github.com/moeru-ai/three-mmd>
+- Version: `0.1.0-beta.3`. Before the license banners were added, this file
+  matched `package/dist/index.js` in the npm release after normalizing line
+  endings and the trailing newline.
+- Release: <https://registry.npmjs.org/@moeru/three-mmd/-/three-mmd-0.1.0-beta.3.tgz>
+- Local changes: license banners only; the JavaScript implementation is unchanged.
+- License: MIT; full upstream text is in [THREE-MMD-LICENSE.txt](licenses/THREE-MMD-LICENSE.txt)
+  and the file's leading comment, including the copyrights of the three.js
+  authors (2010-2024) and Moeru AI (2025).
+
+## @moeru/three-mmd-physics-ammo
+
+- File: `three-mmd-physics-ammo.module.js`
+- Source: <https://github.com/moeru-ai/three-mmd>
+- Version: locally modified `0.1.0-beta` series; the exact originating release
+  was not recorded and has not been established by a byte-for-byte match.
+- License reference: <https://registry.npmjs.org/@moeru/three-mmd-physics-ammo/-/three-mmd-physics-ammo-0.1.0-beta.3.tgz>
+  (`package/LICENSE.md`; the same MIT text is also present in beta.1 and beta.2).
+- Local changes: physics constraint limits and damping, rigid-body behavior,
+  floor/distance handling, and model-rotation fixes. The existing implementation
+  is preserved; this license update only prepends a comment.
+- Local history: introduced in N.E.K.O. commit `2800df92d`, subsequently modified
+  in `665417441` and `3440b9bb7`.
+- License: MIT; full upstream text is in [THREE-MMD-LICENSE.txt](licenses/THREE-MMD-LICENSE.txt)
+  and the file's leading comment, retaining both upstream copyright statements.
+
+## babylon-mmd (embedded portions)
+
+- File: `three-mmd.module.js` embeds parser utilities, PMD/PMX/VMD data and
+  readers, and shared toon texture data. The bundle's region markers identify
+  `babylon-mmd@1.0.0`.
+- Source: <https://github.com/noname0310/babylon-mmd>
+- Version: `1.0.0`.
+- Release: <https://registry.npmjs.org/babylon-mmd/-/babylon-mmd-1.0.0.tgz>
+- Copyright (c) 2024 noname.
+- License: MIT; full text from `package/LICENSE` is retained in
+  [BABYLON-MMD-LICENSE.txt](licenses/BABYLON-MMD-LICENSE.txt) and the core
+  bundle's leading comment.
+
+## Distribution and updates
+
+Keep these notices, the `licenses` directory, and the `/*! ... */` license
+comments when copying, patching, replacing, or minifying the bundles. Include
+them in both web deployments and desktop packages. The desktop workflows copy
+the entire `static` directory; `scripts/check_nuitka_dist.py` also checks for
+these files in the built package.
+
+When updating a bundle, recheck the licenses and embedded dependencies of the
+actual release and update this provenance record. Do not apply the root
+project license in place of a third-party license.

--- a/static/libs/THIRD_PARTY_NOTICES.md
+++ b/static/libs/THIRD_PARTY_NOTICES.md
@@ -30,9 +30,30 @@ root Apache-2.0 license does not replace them.
   floor/distance handling, and model-rotation fixes. The existing implementation
   is preserved; this license update only prepends a comment.
 - Local history: introduced in N.E.K.O. commit `450e78744`, subsequently modified
-  in `665417441` and `3440b9bb7`.
+  in `339bda9c0`, `9487b1136`, `665417441`, and `3440b9bb7` (in that order;
+  verified against the repository's full file history, not a shallow clone).
 - License: MIT; full upstream text is in [THREE-MMD-LICENSE.txt](licenses/THREE-MMD-LICENSE.txt)
   and the file's leading comment, retaining both upstream copyright statements.
+
+### Reproducing the locally patched physics bundle
+
+The exact pre-notice file is available at N.E.K.O. commit
+[`3440b9bb77ae6f02c966f6acb9a5f8804ba016a6`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/3440b9bb77ae6f02c966f6acb9a5f8804ba016a6/static/libs/three-mmd-physics-ammo.module.js).
+Its Git blob bytes (UTF-8, LF line endings, including the final newline) have
+SHA-256 `135190d7ff9618930bfb7accb89bf133fc805e013d11ac30e85970a2c5c1f11b`.
+This identifies our locally patched bundle, not an unmodified npm beta.3
+artifact. The beta.3 link above is a license reference only.
+
+To reconstruct its local modification history, start with this file at
+`450e78744d1367ebf4db9357304e469e0010d9be`, which already contains local changes,
+then apply only this file's diffs from `339bda9c0`, `9487b1136`, `665417441`, and
+`3440b9bb7`, in order, using the full Git history. Alternatively, retrieve the
+file directly at the full commit linked above. To compare the current bundle,
+remove only its leading `/*! ... */` license comment and the newline immediately
+following the closing `*/`, normalize CRLF to LF without trimming the final
+newline, and compute SHA-256. The result must match the digest above. These
+steps reproduce the known local artifact; they do not establish the missing
+original upstream release or its pre-import patch history.
 
 ## babylon-mmd (embedded portions)
 

--- a/static/libs/licenses/BABYLON-MMD-LICENSE.txt
+++ b/static/libs/licenses/BABYLON-MMD-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 noname
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/static/libs/licenses/THREE-MMD-LICENSE.txt
+++ b/static/libs/licenses/THREE-MMD-LICENSE.txt
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2010-2024 three.js authors
+
+Copyright (c) 2025 Moeru AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/static/libs/three-mmd-physics-ammo.module.js
+++ b/static/libs/three-mmd-physics-ammo.module.js
@@ -1,3 +1,31 @@
+/*!
+ * @moeru/three-mmd-physics-ammo - https://github.com/moeru-ai/three-mmd
+ * See THIRD_PARTY_NOTICES.md for provenance and local modifications.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2010-2024 three.js authors
+ *
+ * Copyright (c) 2025 Moeru AI
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import Ammo from 'ammojs-typed';
 import { Object3D, Matrix4, Vector3, Quaternion, MeshBasicMaterial, Color, Mesh, SphereGeometry, CapsuleGeometry, BoxGeometry, Euler, Bone } from 'three';
 import { PmxObject } from '@moeru/three-mmd';

--- a/static/libs/three-mmd.module.js
+++ b/static/libs/three-mmd.module.js
@@ -1,3 +1,56 @@
+/*!
+ * @moeru/three-mmd - https://github.com/moeru-ai/three-mmd
+ * See THIRD_PARTY_NOTICES.md for provenance and local modifications.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2010-2024 three.js authors
+ *
+ * Copyright (c) 2025 Moeru AI
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*!
+ * Bundled babylon-mmd 1.0.0 portions - https://github.com/noname0310/babylon-mmd
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 noname
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import { AddOperation, AnimationClip, Bone, BufferAttribute, BufferGeometry, Color, CustomBlending, DefaultLoadingManager, DoubleSide, DstAlphaFactor, Euler, FileLoader, FrontSide, Interpolant, Loader, LoaderUtils, MultiplyOperation, NearestFilter, NumberKeyframeTrack, OneMinusSrcAlphaFactor, Quaternion, QuaternionKeyframeTrack, RGB_ETC1_Format, RGB_ETC2_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGB_S3TC_DXT1_Format, RepeatWrapping, SRGBColorSpace, ShaderLib, ShaderMaterial, Skeleton, SkinnedMesh, SrcAlphaFactor, TangentSpaceNormalMap, TextureLoader, UniformsUtils, Vector3, VectorKeyframeTrack } from "three";
 import { TGALoader } from "three/addons/loaders/TGALoader.js";
 


### PR DESCRIPTION
## 改动概述 / Summary

当前直接分发的 three-mmd 核心及物理 JS 文件缺少上游 MIT 版权与许可文本，核心 bundle 内嵌的 babylon-mmd 代码也没有随附许可。本 PR 补齐这部分第三方声明，使源码、网页静态文件及桌面分发都能保留对应许可。

- 在两个 JS 文件头加入完整 MIT 文本，保留 three.js authors 与 Moeru AI 的版权；核心文件另保留内嵌 babylon-mmd 的版权与 MIT 文本。
- 新增 `static/libs/licenses/` 下的原始许可证，以及 `static/libs/THIRD_PARTY_NOTICES.md` 的来源、版本和本地修改记录；根 NOTICE 链接至这些文件。
- 为桌面打包检查加入两个 bundle、第三方说明和两份许可证，避免发布时漏带。

核心文件已与 npm `@moeru/three-mmd@0.1.0-beta.3` 比对一致（归一化换行后）；内嵌代码标记为 `babylon-mmd@1.0.0`。物理模块有本地补丁，未确认其精确原始版本，因此明确记录为 beta 系列，并说明所用许可证取自 beta.3、与 beta.1/beta.2 相同。两个 JS 的实现均保持不变。

感谢 @kwaa 在 #3065 中修复 MMD 动画计时问题，并提供 three-mmd 的上游升级建议；这也促使我们进一步核对并补齐了依赖的许可证声明。

## 回归报告 / Regression Report

不适用：未修改 app/、main_logic/ 或 memory/。

## 不拆分理由 / Why Not Split

不适用：同一组 vendored 依赖的许可证及分发检查，共 7 个文件。

## 测试 / Testing

- `uv run --no-sync pytest tests/unit/test_prepare_nuitka_plugins.py tests/unit/test_bilibili_sdk_packaging_contract.py -q`：21 passed。
- `uv run --no-sync ruff check scripts/check_nuitka_dist.py`：通过。
- 两个 JS 的 `node --check`：通过；去除新增注释后与修改前内容一致。
- 两份许可文件与对应 npm 发布包的 LICENSE 原文一致（归一化换行后）。
- 临时分发目录验证：完整 5 文件集合通过，逐个移除时均被现有打包检查检出。
- `git diff --check`：通过。

未重新构建完整桌面安装包；现有各平台工作流已整体打包 static 目录，新增文件位于该目录内。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 补充 MMD 相关组件的第三方版权、来源及 MIT 许可证说明。
  - 新增 Babylon MMD 与 three-mmd 的完整许可证文本。
  - 增加物理扩展修改记录及可复现、校验说明，便于审查与核验。
  - 在随附库文件中加入版权和许可证声明，便于随分发包查看。
- **改进**
  - 完善分发包完整性检查，确保 MMD 库及相关许可证文件不会遗漏。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->