### PR TITLE
修复“请她离开”状态下从系统托盘恢复默认模型后模型消失的问题

### DIFF
--- a/main_routers/characters_router/live2d_models.py
+++ b/main_routers/characters_router/live2d_models.py
@@ -653,6 +653,118 @@ async def update_catgirl_l2d(name: str, request: Request):
                 'applied_runtime': apply_runtime,
             })
 
+        # Runtime drag/return persistence only owns PNGTuber placement. Keep it
+        # separate from model selection so a delayed position save cannot bind
+        # an old PNGTuber again after the user has selected another model.
+        placement_only_keys = {
+            'pngtuber_placement',
+            'expected_pngtuber_binding',
+            'apply_runtime',
+        }
+        is_pngtuber_placement_only_update = (
+            isinstance(data.get('pngtuber_placement'), dict)
+            and set(data).issubset(placement_only_keys)
+        )
+        if is_pngtuber_placement_only_update:
+            placement = data['pngtuber_placement']
+            allowed_placement_keys = {
+                'scale',
+                'offset_x',
+                'offset_y',
+                'mobile_scale',
+                'mobile_offset_x',
+                'mobile_offset_y',
+                'position_anchor',
+                'mirror',
+            }
+            unexpected_keys = set(placement) - allowed_placement_keys
+            if unexpected_keys:
+                return JSONResponse(
+                    content={
+                        'success': False,
+                        'error': 'PNGTuber placement 包含不支持的字段',
+                    },
+                    status_code=400,
+                )
+
+            _config_manager = get_config_manager()
+            characters = await _config_manager.aload_characters()
+            catgirls = characters.get('猫娘')
+            if not isinstance(catgirls, dict) or name not in catgirls:
+                return JSONResponse(
+                    content={'success': False, 'error': '猫娘不存在'},
+                    status_code=404,
+                )
+
+            catgirl = catgirls[name]
+            saved_pngtuber = get_reserved(
+                catgirl,
+                'avatar',
+                'pngtuber',
+                default={},
+            )
+            if not isinstance(saved_pngtuber, dict) or not saved_pngtuber:
+                return JSONResponse(content={
+                    'success': True,
+                    'pngtuber_placement_updated': False,
+                    'skipped': 'pngtuber_config_missing',
+                    'applied_runtime': False,
+                })
+
+            expected_binding = str(data.get('expected_pngtuber_binding') or '').strip()
+            current_binding = str(
+                saved_pngtuber.get('layered_metadata')
+                or saved_pngtuber.get('idle_image')
+                or ''
+            ).strip()
+            if not expected_binding or expected_binding != current_binding:
+                return JSONResponse(content={
+                    'success': True,
+                    'pngtuber_placement_updated': False,
+                    'skipped': 'pngtuber_binding_changed',
+                    'applied_runtime': False,
+                })
+
+            number_bounds = {
+                'scale': (1, 0.1, 5),
+                'offset_x': (0, -5000, 5000),
+                'offset_y': (0, -5000, 5000),
+                'mobile_scale': (1, 0.1, 5),
+                'mobile_offset_x': (0, -5000, 5000),
+                'mobile_offset_y': (0, -5000, 5000),
+            }
+            normalized_placement = {}
+            try:
+                for key, (default, min_value, max_value) in number_bounds.items():
+                    if key not in placement:
+                        continue
+                    value = float(placement.get(key, default))
+                    if not math.isfinite(value):
+                        raise ValueError('数值字段必须是有限值')
+                    normalized_placement[key] = max(min_value, min(max_value, value))
+            except (TypeError, ValueError) as exc:
+                return JSONResponse(
+                    content={'success': False, 'error': str(exc)},
+                    status_code=400,
+                )
+            if 'position_anchor' in placement:
+                anchor = str(placement.get('position_anchor') or '').strip().lower()
+                normalized_placement['position_anchor'] = (
+                    anchor if anchor in {'center', 'bottom_right'} else 'bottom_right'
+                )
+            if 'mirror' in placement:
+                normalized_placement['mirror'] = _config_value_is_enabled(placement.get('mirror'))
+
+            updated_pngtuber = dict(saved_pngtuber)
+            updated_pngtuber.update(normalized_placement)
+            set_reserved(catgirl, 'avatar', 'pngtuber', updated_pngtuber)
+            await _config_manager.asave_characters(characters)
+            return JSONResponse(content={
+                'success': True,
+                'pngtuber_placement_updated': True,
+                'applied_runtime': False,
+            })
+
         live2d_model = data.get('live2d')
         vrm_model = data.get('vrm')
         mmd_model = data.get('mmd')

--- a/main_routers/characters_router/live2d_models.py
+++ b/main_routers/characters_router/live2d_models.py
@@ -22,9 +22,11 @@ Split out of the former monolithic ``main_routers/characters_router.py``.
 from ._shared import logger, router
 from .voice_providers import _config_value_is_enabled
 
+import asyncio
 import re
 import os
 import math
+import time
 from urllib.parse import unquote, urlparse
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -43,6 +45,49 @@ from utils.character_memory import character_config_mutation_lock
 from config import (
     DEFAULT_LIVE2D_MODEL_NAME,
 )
+
+
+_MODEL_PERSISTENCE_OPERATION_ID_RE = re.compile(r"^[A-Za-z0-9._-]{8,128}$")
+_MODEL_PERSISTENCE_OPERATION_LIMIT = 64
+_model_persistence_operations = {}
+
+
+def _record_model_persistence_operation(operation_id: str, state: str, error: str = ""):
+    if not operation_id:
+        return
+    _model_persistence_operations[operation_id] = {
+        "state": state,
+        "error": str(error or ""),
+        "updated_at": time.monotonic(),
+    }
+    while len(_model_persistence_operations) > _MODEL_PERSISTENCE_OPERATION_LIMIT:
+        oldest_operation_id = min(
+            _model_persistence_operations,
+            key=lambda key: _model_persistence_operations[key]["updated_at"],
+        )
+        _model_persistence_operations.pop(oldest_operation_id, None)
+
+
+@router.get('/catgirl/l2d/persistence/{operation_id}')
+async def get_model_persistence_operation(operation_id: str):
+    """Return the authoritative completion state of a renderer persistence request."""
+    if not _MODEL_PERSISTENCE_OPERATION_ID_RE.fullmatch(operation_id or ""):
+        return JSONResponse(
+            content={"success": False, "error": "无效的持久化操作 ID"},
+            status_code=400,
+        )
+    operation = _model_persistence_operations.get(operation_id)
+    if operation is None:
+        return JSONResponse(
+            content={"success": False, "state": "unknown"},
+            status_code=404,
+        )
+    return JSONResponse(content={
+        "success": True,
+        "operation_id": operation_id,
+        "state": operation["state"],
+        "error": operation["error"],
+    })
 
 
 def _derive_live2d_model_name(model_ref: str) -> str:
@@ -592,8 +637,17 @@ async def get_current_live2d_model(catgirl_name: str = "", item_id: str = ""):
 async def update_catgirl_l2d(name: str, request: Request):
     """Update the specified catgirl's model settings (supports Live2D and VRM)."""
     mutation_lock_acquired = False
+    persistence_operation_id = ""
     try:
         data = await request.json()
+        persistence_operation_id = str(data.get('persistence_operation_id') or '').strip()
+        if persistence_operation_id:
+            if not _MODEL_PERSISTENCE_OPERATION_ID_RE.fullmatch(persistence_operation_id):
+                return JSONResponse(
+                    content={'success': False, 'error': '无效的持久化操作 ID'},
+                    status_code=400,
+                )
+            _record_model_persistence_operation(persistence_operation_id, 'running')
         apply_runtime = _config_value_is_enabled(data.get('apply_runtime', True))
         query_params = getattr(request, 'query_params', {})
         if 'apply_runtime' in query_params:
@@ -1135,8 +1189,37 @@ async def update_catgirl_l2d(name: str, request: Request):
                 set_reserved(characters['猫娘'][name], 'avatar', 'asset_source', resolved_asset_source or 'local_imported')
                 logger.debug(f"已保存角色 {name} 的模型 {live2d_model}，asset_source={resolved_asset_source or 'local_imported'}")
 
-        # 保存配置
-        await _config_manager.asave_characters(characters)
+        # 保存配置。带 operation id 的请求必须在客户端断开后仍等待底层线程
+        # 真正结束，再通过状态接口公布确定结果；AbortController 不能撤销
+        # asyncio.to_thread 中已经开始的原子写入。
+        if persistence_operation_id:
+            persistence_save_task = asyncio.create_task(
+                _config_manager.asave_characters(characters)
+            )
+            try:
+                await asyncio.shield(persistence_save_task)
+            except asyncio.CancelledError:
+                try:
+                    await persistence_save_task
+                except Exception as persistence_error:
+                    _record_model_persistence_operation(
+                        persistence_operation_id,
+                        'failed',
+                        str(persistence_error),
+                    )
+                    raise
+                _record_model_persistence_operation(
+                    persistence_operation_id,
+                    'succeeded',
+                )
+                raise
+            else:
+                _record_model_persistence_operation(
+                    persistence_operation_id,
+                    'succeeded',
+                )
+        else:
+            await _config_manager.asave_characters(characters)
         character_config_mutation_lock.release()
         mutation_lock_acquired = False
         # Fast path：只刷新被编辑角色的 session_manager（avatar 配置），不遍历其它 N-1 个。
@@ -1160,9 +1243,22 @@ async def update_catgirl_l2d(name: str, request: Request):
             'applied_runtime': apply_runtime,
         })
 
-    except MaintenanceModeError:
+    except asyncio.CancelledError:
+        operation = _model_persistence_operations.get(persistence_operation_id)
+        if persistence_operation_id and (
+            operation is None or operation.get('state') != 'succeeded'
+        ):
+            _record_model_persistence_operation(
+                persistence_operation_id,
+                'failed',
+                'request_cancelled_before_save_completed',
+            )
+        raise
+    except MaintenanceModeError as e:
+        _record_model_persistence_operation(persistence_operation_id, 'failed', str(e))
         raise
     except Exception as e:
+        _record_model_persistence_operation(persistence_operation_id, 'failed', str(e))
         logger.exception("更新角色模型设置失败")
         return JSONResponse(content={
             'success': False,
@@ -1186,6 +1282,7 @@ async def update_catgirl_touch_set(name: str, request: Request):
         }
     }
     """
+    mutation_lock_acquired = False
     try:
         data = await request.json()
 
@@ -1212,6 +1309,8 @@ async def update_catgirl_touch_set(name: str, request: Request):
             )
 
         _config_manager = get_config_manager()
+        await character_config_mutation_lock.acquire()
+        mutation_lock_acquired = True
         characters = await _config_manager.aload_characters()
 
         if '猫娘' not in characters or name not in characters['猫娘']:
@@ -1229,6 +1328,8 @@ async def update_catgirl_touch_set(name: str, request: Request):
 
         set_reserved(characters['猫娘'][name], 'touch_set', existing_touch_set)
         await _config_manager.asave_characters(characters)
+        character_config_mutation_lock.release()
+        mutation_lock_acquired = False
 
         # Fast path：只刷新被编辑角色的 session_manager（touch_set），不遍历其它 N-1 个。
         init_one_catgirl = get_init_one_catgirl()
@@ -1249,6 +1350,9 @@ async def update_catgirl_touch_set(name: str, request: Request):
             'success': False,
             'error': str(e)
         }, status_code=500)
+    finally:
+        if mutation_lock_acquired:
+            character_config_mutation_lock.release()
 
 
 @router.put('/catgirl/{name}/lighting')
@@ -1260,6 +1364,7 @@ async def update_catgirl_lighting(name: str, request: Request):
         request: body containing lighting (dict) and an optional apply_runtime (bool);
                  apply_runtime can also be passed as a query param, which takes precedence
     """
+    mutation_lock_acquired = False
     try:
         data = await request.json()
         lighting = data.get('lighting')
@@ -1270,6 +1375,8 @@ async def update_catgirl_lighting(name: str, request: Request):
             apply_runtime = query_params.get('apply_runtime', '').lower() in ('true', '1', 'yes')
 
         _config_manager = get_config_manager()
+        await character_config_mutation_lock.acquire()
+        mutation_lock_acquired = True
         characters = await _config_manager.aload_characters()
 
         if '猫娘' not in characters or name not in characters['猫娘']:
@@ -1347,6 +1454,8 @@ async def update_catgirl_lighting(name: str, request: Request):
         )
 
         await _config_manager.asave_characters(characters)
+        character_config_mutation_lock.release()
+        mutation_lock_acquired = False
 
         if apply_runtime:
             # Fast path：只刷新被编辑角色的 session_manager（lighting），不遍历其它 N-1 个。
@@ -1375,6 +1484,9 @@ async def update_catgirl_lighting(name: str, request: Request):
             'success': False,
             'error': str(e)
         }, status_code=500)
+    finally:
+        if mutation_lock_acquired:
+            character_config_mutation_lock.release()
 
 
 @router.put('/catgirl/{name}/mmd_settings')
@@ -1387,10 +1499,13 @@ async def update_catgirl_mmd_settings(name: str, request: Request):
             return val.lower() in ('true', '1', 'yes')
         return bool(val)
 
+    mutation_lock_acquired = False
     try:
         data = await request.json()
 
         _config_manager = get_config_manager()
+        await character_config_mutation_lock.acquire()
+        mutation_lock_acquired = True
         characters = await _config_manager.aload_characters()
 
         if '猫娘' not in characters or name not in characters['猫娘']:
@@ -1458,6 +1573,8 @@ async def update_catgirl_mmd_settings(name: str, request: Request):
             set_reserved(characters['猫娘'][name], 'avatar', 'mmd', 'cursor_follow', cursor_follow)
 
         await _config_manager.asave_characters(characters)
+        character_config_mutation_lock.release()
+        mutation_lock_acquired = False
 
         logger.info("已保存角色 %s 的MMD模型设置", name)
         return JSONResponse(content={
@@ -1471,6 +1588,9 @@ async def update_catgirl_mmd_settings(name: str, request: Request):
             'success': False,
             'error': str(e)
         }, status_code=500)
+    finally:
+        if mutation_lock_acquired:
+            character_config_mutation_lock.release()
 
 
 @router.get('/catgirl/{name}/mmd_settings')

--- a/main_routers/characters_router/live2d_models.py
+++ b/main_routers/characters_router/live2d_models.py
@@ -39,6 +39,7 @@ from utils.config_manager import (
 from utils.frontend_utils import find_models, find_model_directory
 from utils.url_utils import encode_url_path
 from utils.cloudsave_runtime import MaintenanceModeError
+from utils.character_memory import character_config_mutation_lock
 from config import (
     DEFAULT_LIVE2D_MODEL_NAME,
 )
@@ -590,6 +591,7 @@ async def get_current_live2d_model(catgirl_name: str = "", item_id: str = ""):
 @router.put('/catgirl/l2d/{name}')
 async def update_catgirl_l2d(name: str, request: Request):
     """Update the specified catgirl's model settings (supports Live2D and VRM)."""
+    mutation_lock_acquired = False
     try:
         data = await request.json()
         apply_runtime = _config_value_is_enabled(data.get('apply_runtime', True))
@@ -616,6 +618,8 @@ async def update_catgirl_l2d(name: str, request: Request):
                 )
 
             _config_manager = get_config_manager()
+            await character_config_mutation_lock.acquire()
+            mutation_lock_acquired = True
             characters = await _config_manager.aload_characters()
             catgirls = characters.get('猫娘')
             if not isinstance(catgirls, dict) or name not in catgirls:
@@ -642,6 +646,8 @@ async def update_catgirl_l2d(name: str, request: Request):
                 live2d_idle_animation,
             )
             await _config_manager.asave_characters(characters)
+            character_config_mutation_lock.release()
+            mutation_lock_acquired = False
 
             if apply_runtime:
                 init_one_catgirl = get_init_one_catgirl()
@@ -688,6 +694,8 @@ async def update_catgirl_l2d(name: str, request: Request):
                 )
 
             _config_manager = get_config_manager()
+            await character_config_mutation_lock.acquire()
+            mutation_lock_acquired = True
             characters = await _config_manager.aload_characters()
             catgirls = characters.get('猫娘')
             if not isinstance(catgirls, dict) or name not in catgirls:
@@ -759,6 +767,8 @@ async def update_catgirl_l2d(name: str, request: Request):
             updated_pngtuber.update(normalized_placement)
             set_reserved(catgirl, 'avatar', 'pngtuber', updated_pngtuber)
             await _config_manager.asave_characters(characters)
+            character_config_mutation_lock.release()
+            mutation_lock_acquired = False
             return JSONResponse(content={
                 'success': True,
                 'pngtuber_placement_updated': True,
@@ -945,6 +955,8 @@ async def update_catgirl_l2d(name: str, request: Request):
 
         # 加载当前角色配置
         _config_manager = get_config_manager()
+        await character_config_mutation_lock.acquire()
+        mutation_lock_acquired = True
         characters = await _config_manager.aload_characters()
 
         # 确保猫娘配置存在
@@ -1125,6 +1137,8 @@ async def update_catgirl_l2d(name: str, request: Request):
 
         # 保存配置
         await _config_manager.asave_characters(characters)
+        character_config_mutation_lock.release()
+        mutation_lock_acquired = False
         # Fast path：只刷新被编辑角色的 session_manager（avatar 配置），不遍历其它 N-1 个。
         init_one_catgirl = get_init_one_catgirl()
         if apply_runtime:
@@ -1154,6 +1168,9 @@ async def update_catgirl_l2d(name: str, request: Request):
             'success': False,
             'error': str(e)
         })
+    finally:
+        if mutation_lock_acquired:
+            character_config_mutation_lock.release()
 
 
 @router.patch('/catgirl/{name}/touch_set')

--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -169,10 +169,14 @@
     }
 
     function isGoodbyeActive() {
+        if (typeof window.isNekoGoodbyeModeActive === 'function') {
+            return window.isNekoGoodbyeModeActive();
+        }
         return !!(
             (window.live2dManager && window.live2dManager._goodbyeClicked)
             || (window.vrmManager && window.vrmManager._goodbyeClicked)
             || (window.mmdManager && window.mmdManager._goodbyeClicked)
+            || (window.pngtuberManager && window.pngtuberManager._goodbyeClicked)
         );
     }
 

--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -995,8 +995,14 @@
             });
             noteUserInteraction('return-click');
         };
+        const handleReturnAbort = () => {
+            if (!state.pendingReturnSnapshot || !isGoodbyeActive()) return;
+            state.pendingReturnSnapshot = null;
+            syncGoodbyeSilentState(true, 'return-abort');
+        };
         window.addEventListener('neko:cat-return-commit', handleReturnCommit);
         window.addEventListener('neko:cat-return-complete', handleReturnComplete);
+        window.addEventListener('neko:cat-return-abort', handleReturnAbort);
         window.addEventListener('neko:goodbye-state-cleared', () => {
             state.pendingReturnSnapshot = null;
         });

--- a/static/app/app-character.js
+++ b/static/app/app-character.js
@@ -194,9 +194,11 @@
                 window.live2dManager && window.live2dManager._returnButtonContainer,
                 window.vrmManager && window.vrmManager._returnButtonContainer,
                 window.mmdManager && window.mmdManager._returnButtonContainer,
+                window.pngtuberManager && window.pngtuberManager._returnButtonContainer,
                 document.getElementById('live2d-return-button-container'),
                 document.getElementById('vrm-return-button-container'),
-                document.getElementById('mmd-return-button-container')
+                document.getElementById('mmd-return-button-container'),
+                document.getElementById('pngtuber-return-button-container')
             ].forEach(hideReturnButtonContainer);
         };
 
@@ -212,6 +214,7 @@
             clearManagerReturnState(window.live2dManager);
             clearManagerReturnState(window.vrmManager);
             clearManagerReturnState(window.mmdManager);
+            clearManagerReturnState(window.pngtuberManager);
             hideAllReturnButtonContainers();
 
             window.__nekoGoodbyeSilentState = {
@@ -2062,6 +2065,9 @@
             }
             if (window.mmdManager) {
                 window.mmdManager._goodbyeClicked = false;
+            }
+            if (window.pngtuberManager) {
+                window.pngtuberManager._goodbyeClicked = false;
             }
         }
     }

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -851,6 +851,7 @@ I.mod = window.appInterpage;
         var skipPersistentExpressions = !!reloadOptions.skipPersistentExpressions;
         var deferRevealPrepared = !!reloadOptions.deferRevealPrepared;
         var throwOnError = !!reloadOptions.throwOnError;
+        var bypassRecentDedup = !!reloadOptions.bypassRecentDedup;
         var queueHoldToken = typeof reloadOptions.queueHoldToken === 'string'
             ? reloadOptions.queueHoldToken
             : '';
@@ -862,7 +863,7 @@ I.mod = window.appInterpage;
             deferRevealPrepared: deferRevealPrepared
         });
 
-        if (!queueHoldToken && window._lastModelReloadKey === reloadKey && Date.now() - (window._lastModelReloadAt || 0) < 1000) {
+        if (!bypassRecentDedup && !queueHoldToken && window._lastModelReloadKey === reloadKey && Date.now() - (window._lastModelReloadAt || 0) < 1000) {
             console.log('[Model] 忽略短时间内重复的模型重载请求');
             return window._lastModelReloadResult;
         }

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1654,6 +1654,7 @@ I.mod = window.appInterpage;
                 }, 100);
             }
         }
+        return window._lastModelReloadResult === true;
     }
 
     I.handleReloadModelParametersMessage = async function handleReloadModelParametersMessage(message) {

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -803,6 +803,34 @@ I.mod = window.appInterpage;
         }
     }
 
+    function schedulePendingModelReload() {
+        if (!window._pendingModelReload) return false;
+        console.log('[Model] 执行待处理的模型重载请求');
+        var pendingReload = window._pendingModelReload;
+        window._pendingModelReload = null;
+        setTimeout(function () {
+            I.handleModelReload(pendingReload.targetLanlanName, pendingReload.reloadOptions)
+                .then(function (result) {
+                    if (typeof pendingReload.resolve === 'function') pendingReload.resolve(result);
+                })
+                .catch(function (error) {
+                    if (typeof pendingReload.reject === 'function') pendingReload.reject(error);
+                });
+        }, 100);
+        return true;
+    }
+
+    I.releaseModelReloadQueueHold = function releaseModelReloadQueueHold(queueHoldToken) {
+        if (!queueHoldToken || window._modelReloadQueueHoldToken !== queueHoldToken) {
+            return false;
+        }
+        window._modelReloadQueueHoldToken = '';
+        window._modelReloadInFlight = false;
+        window._modelReloadKey = '';
+        schedulePendingModelReload();
+        return true;
+    };
+
     /**
      * Handle model hot-swap triggered from another tab (model_manager).
      *
@@ -823,6 +851,9 @@ I.mod = window.appInterpage;
         var skipPersistentExpressions = !!reloadOptions.skipPersistentExpressions;
         var deferRevealPrepared = !!reloadOptions.deferRevealPrepared;
         var throwOnError = !!reloadOptions.throwOnError;
+        var queueHoldToken = typeof reloadOptions.queueHoldToken === 'string'
+            ? reloadOptions.queueHoldToken
+            : '';
         var reloadKey = JSON.stringify({
             lanlan_name: targetLanlanName,
             temporaryConfig: temporaryConfig || null,
@@ -831,7 +862,7 @@ I.mod = window.appInterpage;
             deferRevealPrepared: deferRevealPrepared
         });
 
-        if (window._lastModelReloadKey === reloadKey && Date.now() - (window._lastModelReloadAt || 0) < 1000) {
+        if (!queueHoldToken && window._lastModelReloadKey === reloadKey && Date.now() - (window._lastModelReloadAt || 0) < 1000) {
             console.log('[Model] 忽略短时间内重复的模型重载请求');
             return window._lastModelReloadResult;
         }
@@ -853,7 +884,7 @@ I.mod = window.appInterpage;
         // Concurrency: wait if another reload is in-flight
         if (window._modelReloadInFlight) {
             console.log('[Model] 模型重载已在进行中，等待完成后重试');
-            if (window._modelReloadKey === reloadKey) {
+            if (!queueHoldToken && window._modelReloadKey === reloadKey) {
                 console.log('[Model] 模型重载已在进行，复用当前重载请求');
                 return window._modelReloadPromise;
             }
@@ -1611,8 +1642,12 @@ I.mod = window.appInterpage;
                 throw error;
             }
         } finally {
-            // Clear in-flight flag
-            window._modelReloadInFlight = false;
+            // A transactional caller may keep the queue reserved after the
+            // runtime load succeeds, so queued reloads cannot observe stale
+            // persistence before the caller commits its matching config.
+            var keepReloadQueueHeld = reloadSucceeded && !!queueHoldToken;
+            window._modelReloadInFlight = keepReloadQueueHeld;
+            window._modelReloadQueueHoldToken = keepReloadQueueHeld ? queueHoldToken : '';
             activeMMDReloadCanvasSessionId = '';
             if (reloadSucceeded) {
                 window._lastModelReloadKey = reloadKey;
@@ -1622,7 +1657,7 @@ I.mod = window.appInterpage;
             } else {
                 window._lastModelReloadResult = false;
             }
-            window._modelReloadKey = '';
+            window._modelReloadKey = keepReloadQueueHeld ? reloadKey : '';
             resolveReload(window._lastModelReloadResult);
 
             // If the model manager is still open, keep the Pet UI hidden even
@@ -1638,21 +1673,7 @@ I.mod = window.appInterpage;
                 I.handleShowMainUI(deferredShowOptions);
             }
 
-            // Process any queued reload request
-            if (window._pendingModelReload) {
-                console.log('[Model] 执行待处理的模型重载请求');
-                var pendingReload = window._pendingModelReload;
-                window._pendingModelReload = null;
-                setTimeout(function () {
-                    I.handleModelReload(pendingReload.targetLanlanName, pendingReload.reloadOptions)
-                        .then(function (result) {
-                            if (typeof pendingReload.resolve === 'function') pendingReload.resolve(result);
-                        })
-                        .catch(function (error) {
-                            if (typeof pendingReload.reject === 'function') pendingReload.reject(error);
-                        });
-                }, 100);
-            }
+            if (!keepReloadQueueHeld) schedulePendingModelReload();
         }
         return window._lastModelReloadResult === true;
     }

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -356,7 +356,45 @@
         _resetToDefaultModelInFlight = true;
 
         var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+        var previousModelConfig = null;
+        var reloadModel = null;
+        var returnWasNeeded = false;
+        var returnedFromGoodbye = false;
         try {
+            previousModelConfig = window.lanlan_config && typeof window.lanlan_config === 'object'
+                ? Object.assign({}, window.lanlan_config)
+                : null;
+            if (previousModelConfig) {
+                var previousModelType = String(previousModelConfig.model_type || 'live2d').toLowerCase();
+                var previousLive3dSubType = String(previousModelConfig.live3d_sub_type || '').toLowerCase();
+                if (previousModelType === 'pngtuber') {
+                    previousModelConfig.pngtuber = previousModelConfig.pngtuber
+                        ? Object.assign({}, previousModelConfig.pngtuber)
+                        : null;
+                    previousModelConfig.model_path = previousModelConfig.pngtuber
+                        ? String(previousModelConfig.pngtuber.idle_image || '')
+                        : '';
+                } else if (previousModelType === 'live3d' && previousLive3dSubType === 'mmd') {
+                    previousModelConfig.model_path = String(window.mmdModel || previousModelConfig.mmd || '');
+                } else if (previousModelType === 'live3d' || previousModelType === 'vrm') {
+                    previousModelConfig.model_path = String(window.vrmModel || previousModelConfig.vrm || '');
+                } else if (previousModelType === 'mmd') {
+                    previousModelConfig.model_path = String(window.mmdModel || previousModelConfig.mmd || '');
+                } else {
+                    previousModelConfig.model_path = String(window.cubism4Model || previousModelConfig.live2d || '');
+                }
+            }
+            reloadModel = typeof I.handleModelReload === 'function'
+                ? I.handleModelReload
+                : (typeof window.handleModelReload === 'function' ? window.handleModelReload : null);
+            var visibleReturnBallBeforeReset = document.querySelector(
+                '[id$="-return-button-container"][data-neko-return-visible="true"]'
+            );
+            returnWasNeeded = !!(
+                visibleReturnBallBeforeReset
+                || (window.__appUiParts && window.__appUiParts.nekoCatReturnLifecycle)
+                || (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive())
+            );
             // Fail-fast when there is no character context. This happens if the
             // tray IPC fires before `neko:config-injected`, or on a sub-window
             // that never received the injection. Without lanlan_name we cannot
@@ -366,6 +404,9 @@
                 console.warn('[Model] resetToDefaultModel: 当前没有 lanlan_name，无法持久化默认模型设置');
                 throw new Error('missing_lanlan_name');
             }
+            if (!reloadModel) {
+                throw new Error('model_reload_unavailable');
+            }
 
             // “恢复默认模型”的目标固定为内置 Live2D。先退出 goodbye 并恢复
             // Electron Pet 的完整 viewport，但不要重新显示即将被替换的旧模型；
@@ -373,7 +414,7 @@
             // helper 即使当前不在 goodbye 也会立即成功；无条件调用还能加入一个
             // 已清除 manager 标志、但尚未完整结束的现有 return lifecycle。
             if (window.appUi && typeof window.appUi.returnFromGoodbye === 'function') {
-                var returnedFromGoodbye = await window.appUi.returnFromGoodbye({
+                returnedFromGoodbye = await window.appUi.returnFromGoodbye({
                     source: 'reset-to-default-model',
                     retryViewportRestore: true,
                     restoreCurrentModel: false
@@ -418,13 +459,7 @@
             // need them surfaced so the reset doesn't report success after a
             // failed hot-swap.
             var reloadOpts = { suppressToast: true, throwOnError: true };
-            if (typeof I.handleModelReload === 'function') {
-                await I.handleModelReload(lanlanName, reloadOpts);
-            } else if (typeof window.handleModelReload === 'function') {
-                await window.handleModelReload(lanlanName, reloadOpts);
-            } else {
-                console.warn('[Model] handleModelReload 不可用，跳过热切换');
-            }
+            await reloadModel(lanlanName, reloadOpts);
 
             try {
                 if (typeof window.showStatusToast === 'function') {
@@ -438,6 +473,17 @@
             return { success: true };
         } catch (e) {
             console.error('[Model] 恢复默认模型失败:', e);
+            if (returnWasNeeded && returnedFromGoodbye && previousModelConfig && reloadModel) {
+                try {
+                    await reloadModel(lanlanName, {
+                        temporaryConfig: Object.assign({ success: true }, previousModelConfig),
+                        suppressToast: true,
+                        throwOnError: true
+                    });
+                } catch (restoreError) {
+                    console.error('[Model] 默认模型恢复失败后回退旧模型也失败:', restoreError);
+                }
+            }
             try {
                 if (typeof window.showStatusToast === 'function') {
                     window.showStatusToast(

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -360,6 +360,7 @@
         var defaultReloadAttempted = false;
         var defaultPersisted = false;
         var persistenceOutcomeUnknown = false;
+        var reloadQueueReleasedBeforePersistenceResult = false;
         var reloadQueueHoldToken = 'reset-default-model-' + Date.now() + '-' + Math.random();
         var reloadQueueHeld = false;
         var reloadModel = typeof I.handleModelReload === 'function'
@@ -440,7 +441,8 @@
             }
             async function waitForPersistenceResult() {
                 var statusDeadline = Date.now() + DEFAULT_MODEL_PERSIST_TIMEOUT_MS;
-                while (Date.now() < statusDeadline) {
+                var observedRunningOperation = false;
+                while (observedRunningOperation || Date.now() < statusDeadline) {
                     var statusAbortController = new window.AbortController();
                     var statusTimeoutId = window.setTimeout(function () {
                         statusAbortController.abort();
@@ -457,6 +459,13 @@
                             statusData.state === 'succeeded' || statusData.state === 'failed'
                         )) {
                             return statusData;
+                        }
+                        if (statusResponse.ok && statusData && statusData.state === 'running') {
+                            // Once the server has acknowledged the operation,
+                            // keep observing it until the real save reaches a
+                            // terminal state. The reload queue is released
+                            // separately, so this cannot block model changes.
+                            observedRunningOperation = true;
                         }
                     } catch (_) {
                         // The original PUT may still be reaching the server, or
@@ -501,6 +510,7 @@
                 if (reloadQueueHeld && typeof I.releaseModelReloadQueueHold === 'function') {
                     I.releaseModelReloadQueueHold(reloadQueueHoldToken);
                     reloadQueueHeld = false;
+                    reloadQueueReleasedBeforePersistenceResult = true;
                 }
                 var persistenceResult = await waitForPersistenceResult();
                 if (persistenceResult.state === 'succeeded') {
@@ -527,6 +537,17 @@
                 throw new Error('HTTP ' + putResp.status + (errorDetail ? (': ' + errorDetail) : ''));
             }
             defaultPersisted = true;
+            if (reloadQueueReleasedBeforePersistenceResult) {
+                // A queued reload may have fetched the old page_config while
+                // the backend save was still running. Re-fetch after the
+                // terminal result; handleModelReload queues this behind any
+                // active reload, so the last rendered model is authoritative.
+                await reloadModel(lanlanName, {
+                    suppressToast: true,
+                    throwOnError: true,
+                    bypassRecentDedup: true
+                });
+            }
             if (reloadQueueHeld) {
                 I.releaseModelReloadQueueHold(reloadQueueHoldToken);
                 reloadQueueHeld = false;

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -359,6 +359,7 @@
         var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
         var defaultReloadAttempted = false;
         var defaultPersisted = false;
+        var persistenceOutcomeUnknown = false;
         var reloadQueueHoldToken = 'reset-default-model-' + Date.now() + '-' + Math.random();
         var reloadQueueHeld = false;
         var reloadModel = typeof I.handleModelReload === 'function'
@@ -431,8 +432,43 @@
 
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
+            var persistenceOperationId = 'default-model-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+            var persistenceStatusUrl = '/api/characters/catgirl/l2d/persistence/'
+                + encodeURIComponent(persistenceOperationId);
             if (typeof window.AbortController !== 'function') {
                 throw new Error('model_persist_abort_unavailable');
+            }
+            async function waitForPersistenceResult() {
+                var statusDeadline = Date.now() + DEFAULT_MODEL_PERSIST_TIMEOUT_MS;
+                while (Date.now() < statusDeadline) {
+                    var statusAbortController = new window.AbortController();
+                    var statusTimeoutId = window.setTimeout(function () {
+                        statusAbortController.abort();
+                    }, Math.min(1000, Math.max(1, statusDeadline - Date.now())));
+                    try {
+                        var statusResponse = await fetch(persistenceStatusUrl, {
+                            signal: statusAbortController.signal
+                        });
+                        var statusData = null;
+                        try {
+                            statusData = await statusResponse.json();
+                        } catch (_) {}
+                        if (statusResponse.ok && statusData && (
+                            statusData.state === 'succeeded' || statusData.state === 'failed'
+                        )) {
+                            return statusData;
+                        }
+                    } catch (_) {
+                        // The original PUT may still be reaching the server, or
+                        // this individual status request may have timed out.
+                    } finally {
+                        window.clearTimeout(statusTimeoutId);
+                    }
+                    await new Promise(function (resolve) {
+                        window.setTimeout(resolve, 100);
+                    });
+                }
+                return { state: 'unknown' };
             }
             var persistenceAbortController = new window.AbortController();
             var persistenceTimeoutId = window.setTimeout(function () {
@@ -448,6 +484,7 @@
                         model_type: 'live2d',
                         live2d: DEFAULT_LIVE2D_MODEL_NAME,
                         live2d_idle_animation: null,
+                        persistence_operation_id: persistenceOperationId,
                         // The frontend already loaded and validated the target.
                         // Avoid a post-save init_one_catgirl failure being reported
                         // after the persistent binding has already changed.
@@ -455,18 +492,33 @@
                     }),
                     signal: persistenceAbortController.signal
                 });
-                try {
-                    putData = await putResp.json();
-                } catch (putBodyError) {
-                    // A malformed response is handled by the success check below;
-                    // an aborted body must retain the explicit timeout result.
-                    if (persistenceAbortController.signal.aborted) throw putBodyError;
-                }
+                putData = await putResp.json();
             } catch (persistenceError) {
-                if (persistenceAbortController.signal.aborted) {
-                    throw new Error('default_model_persist_timeout');
+                // A browser abort or lost response cannot cancel/undo an
+                // already-started ConfigManager save. Release queued model
+                // changes, then ask the backend for the authoritative result
+                // before deciding whether the previous model may be restored.
+                if (reloadQueueHeld && typeof I.releaseModelReloadQueueHold === 'function') {
+                    I.releaseModelReloadQueueHold(reloadQueueHoldToken);
+                    reloadQueueHeld = false;
                 }
-                throw persistenceError;
+                var persistenceResult = await waitForPersistenceResult();
+                if (persistenceResult.state === 'succeeded') {
+                    putResp = { ok: true, status: 200 };
+                    putData = { success: true };
+                } else if (persistenceResult.state === 'failed') {
+                    throw new Error(
+                        'default_model_persist_failed'
+                        + (persistenceResult.error ? (': ' + persistenceResult.error) : '')
+                    );
+                } else {
+                    persistenceOutcomeUnknown = true;
+                    throw new Error(
+                        persistenceAbortController.signal.aborted
+                            ? 'default_model_persist_pending'
+                            : 'default_model_persist_unconfirmed'
+                    );
+                }
             } finally {
                 window.clearTimeout(persistenceTimeoutId);
             }
@@ -497,11 +549,12 @@
             }
             // 临时热切换失败，或模型已切换但 PUT 失败时，服务端通常仍保留
             // 原 page_config。重新走标准热重载，避免旧模型容器保持隐藏。
-            if (defaultReloadAttempted && !defaultPersisted && reloadModel) {
+            if (defaultReloadAttempted && !defaultPersisted && !persistenceOutcomeUnknown && reloadModel) {
                 try {
                     await reloadModel(lanlanName, {
                         suppressToast: true,
-                        throwOnError: true
+                        throwOnError: true,
+                        bypassRecentDedup: true
                     });
                 } catch (restoreError) {
                     console.error('[Model] 默认模型恢复失败后回退原模型也失败:', restoreError);

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -363,6 +363,21 @@
         var returnedFromGoodbye = false;
         var defaultModelPersisted = false;
         try {
+            reloadModel = typeof I.handleModelReload === 'function'
+                ? I.handleModelReload
+                : (typeof window.handleModelReload === 'function' ? window.handleModelReload : null);
+            // Fail-fast when there is no character context. This happens if the
+            // tray IPC fires before `neko:config-injected`, or on a sub-window
+            // that never received the injection. Without lanlan_name we cannot
+            // PUT the persistence change, and handleModelReload('') would
+            // simply re-fetch the unchanged config — masking a no-op as success.
+            if (!lanlanName) {
+                console.warn('[Model] resetToDefaultModel: 当前没有 lanlan_name，无法持久化默认模型设置');
+                throw new Error('missing_lanlan_name');
+            }
+            if (!reloadModel) {
+                throw new Error('model_reload_unavailable');
+            }
             previousModelConfig = window.lanlan_config && typeof window.lanlan_config === 'object'
                 ? Object.assign({}, window.lanlan_config)
                 : null;
@@ -399,11 +414,36 @@
                 } else {
                     previousModelPersistencePayload.model_type = 'live2d';
                     previousModelPersistencePayload.live2d = previousModelConfig.model_path;
+                    // page_config does not expose the saved idle motion. Read the
+                    // authoritative character record before changing it so a
+                    // failed reset can restore both the Live2D binding and motion.
+                    var charactersResp = await fetch('/api/characters');
+                    if (!charactersResp.ok) {
+                        throw new Error('previous_model_config_unavailable');
+                    }
+                    var charactersData = await charactersResp.json();
+                    var previousCharacterData = charactersData
+                        && charactersData['猫娘']
+                        && charactersData['猫娘'][lanlanName];
+                    var previousReservedLive2D = previousCharacterData
+                        && previousCharacterData._reserved
+                        && previousCharacterData._reserved.avatar
+                        && previousCharacterData._reserved.avatar.live2d;
+                    var previousAvatarLive2D = previousCharacterData
+                        && previousCharacterData.avatar
+                        && previousCharacterData.avatar.live2d;
+                    var hasOwn = Object.prototype.hasOwnProperty;
+                    if (previousReservedLive2D && hasOwn.call(previousReservedLive2D, 'idle_animation')) {
+                        previousModelPersistencePayload.live2d_idle_animation = previousReservedLive2D.idle_animation;
+                    } else if (previousCharacterData && hasOwn.call(previousCharacterData, 'live2d_idle_animation')) {
+                        previousModelPersistencePayload.live2d_idle_animation = previousCharacterData.live2d_idle_animation;
+                    } else if (previousAvatarLive2D && hasOwn.call(previousAvatarLive2D, 'idle_animation')) {
+                        previousModelPersistencePayload.live2d_idle_animation = previousAvatarLive2D.idle_animation;
+                    } else {
+                        previousModelPersistencePayload.live2d_idle_animation = null;
+                    }
                 }
             }
-            reloadModel = typeof I.handleModelReload === 'function'
-                ? I.handleModelReload
-                : (typeof window.handleModelReload === 'function' ? window.handleModelReload : null);
             var visibleReturnBallBeforeReset = document.querySelector(
                 '[id$="-return-button-container"][data-neko-return-visible="true"]'
             );
@@ -412,19 +452,6 @@
                 || (window.__appUiParts && window.__appUiParts.nekoCatReturnLifecycle)
                 || (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive())
             );
-            // Fail-fast when there is no character context. This happens if the
-            // tray IPC fires before `neko:config-injected`, or on a sub-window
-            // that never received the injection. Without lanlan_name we cannot
-            // PUT the persistence change, and handleModelReload('') would
-            // simply re-fetch the unchanged config — masking a no-op as success.
-            if (!lanlanName) {
-                console.warn('[Model] resetToDefaultModel: 当前没有 lanlan_name，无法持久化默认模型设置');
-                throw new Error('missing_lanlan_name');
-            }
-            if (!reloadModel) {
-                throw new Error('model_reload_unavailable');
-            }
-
             // “恢复默认模型”的目标固定为内置 Live2D。先退出 goodbye 并恢复
             // Electron Pet 的完整 viewport，但不要重新显示即将被替换的旧模型；
             // 后面的 PUT + handleModelReload 会直接加载目标 Live2D。

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -356,16 +356,7 @@
         _resetToDefaultModelInFlight = true;
 
         var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
-        var previousModelConfig = null;
-        var previousModelPersistencePayload = null;
-        var reloadModel = null;
-        var returnWasNeeded = false;
-        var returnedFromGoodbye = false;
-        var defaultModelPersisted = false;
         try {
-            reloadModel = typeof I.handleModelReload === 'function'
-                ? I.handleModelReload
-                : (typeof window.handleModelReload === 'function' ? window.handleModelReload : null);
             // Fail-fast when there is no character context. This happens if the
             // tray IPC fires before `neko:config-injected`, or on a sub-window
             // that never received the injection. Without lanlan_name we cannot
@@ -375,90 +366,14 @@
                 console.warn('[Model] resetToDefaultModel: 当前没有 lanlan_name，无法持久化默认模型设置');
                 throw new Error('missing_lanlan_name');
             }
-            if (!reloadModel) {
-                throw new Error('model_reload_unavailable');
-            }
-            previousModelConfig = window.lanlan_config && typeof window.lanlan_config === 'object'
-                ? Object.assign({}, window.lanlan_config)
-                : null;
-            if (previousModelConfig) {
-                var previousModelType = String(previousModelConfig.model_type || 'live2d').toLowerCase();
-                var previousLive3dSubType = String(previousModelConfig.live3d_sub_type || '').toLowerCase();
-                if (previousModelType === 'pngtuber') {
-                    previousModelConfig.pngtuber = previousModelConfig.pngtuber
-                        ? Object.assign({}, previousModelConfig.pngtuber)
-                        : null;
-                    previousModelConfig.model_path = previousModelConfig.pngtuber
-                        ? String(previousModelConfig.pngtuber.idle_image || '')
-                        : '';
-                } else if (previousModelType === 'live3d' && previousLive3dSubType === 'mmd') {
-                    previousModelConfig.model_path = String(window.mmdModel || previousModelConfig.mmd || '');
-                } else if (previousModelType === 'live3d' || previousModelType === 'vrm') {
-                    previousModelConfig.model_path = String(window.vrmModel || previousModelConfig.vrm || '');
-                } else if (previousModelType === 'mmd') {
-                    previousModelConfig.model_path = String(window.mmdModel || previousModelConfig.mmd || '');
-                } else {
-                    previousModelConfig.model_path = String(window.cubism4Model || previousModelConfig.live2d || '');
-                }
-                previousModelPersistencePayload = { model_type: previousModelType };
-                if (previousModelType === 'pngtuber') {
-                    previousModelPersistencePayload.pngtuber = previousModelConfig.pngtuber;
-                } else if (previousModelType === 'live3d' && previousLive3dSubType === 'mmd') {
-                    previousModelPersistencePayload.mmd = previousModelConfig.model_path;
-                } else if (previousModelType === 'live3d' || previousModelType === 'vrm') {
-                    previousModelPersistencePayload.model_type = 'live3d';
-                    previousModelPersistencePayload.vrm = previousModelConfig.model_path;
-                } else if (previousModelType === 'mmd') {
-                    previousModelPersistencePayload.model_type = 'live3d';
-                    previousModelPersistencePayload.mmd = previousModelConfig.model_path;
-                } else {
-                    previousModelPersistencePayload.model_type = 'live2d';
-                    previousModelPersistencePayload.live2d = previousModelConfig.model_path;
-                    // page_config does not expose the saved idle motion. Read the
-                    // authoritative character record before changing it so a
-                    // failed reset can restore both the Live2D binding and motion.
-                    var charactersResp = await fetch('/api/characters');
-                    if (!charactersResp.ok) {
-                        throw new Error('previous_model_config_unavailable');
-                    }
-                    var charactersData = await charactersResp.json();
-                    var previousCharacterData = charactersData
-                        && charactersData['猫娘']
-                        && charactersData['猫娘'][lanlanName];
-                    var previousReservedLive2D = previousCharacterData
-                        && previousCharacterData._reserved
-                        && previousCharacterData._reserved.avatar
-                        && previousCharacterData._reserved.avatar.live2d;
-                    var previousAvatarLive2D = previousCharacterData
-                        && previousCharacterData.avatar
-                        && previousCharacterData.avatar.live2d;
-                    var hasOwn = Object.prototype.hasOwnProperty;
-                    if (previousReservedLive2D && hasOwn.call(previousReservedLive2D, 'idle_animation')) {
-                        previousModelPersistencePayload.live2d_idle_animation = previousReservedLive2D.idle_animation;
-                    } else if (previousCharacterData && hasOwn.call(previousCharacterData, 'live2d_idle_animation')) {
-                        previousModelPersistencePayload.live2d_idle_animation = previousCharacterData.live2d_idle_animation;
-                    } else if (previousAvatarLive2D && hasOwn.call(previousAvatarLive2D, 'idle_animation')) {
-                        previousModelPersistencePayload.live2d_idle_animation = previousAvatarLive2D.idle_animation;
-                    } else {
-                        previousModelPersistencePayload.live2d_idle_animation = null;
-                    }
-                }
-            }
-            var visibleReturnBallBeforeReset = document.querySelector(
-                '[id$="-return-button-container"][data-neko-return-visible="true"]'
-            );
-            returnWasNeeded = !!(
-                visibleReturnBallBeforeReset
-                || (window.__appUiParts && window.__appUiParts.nekoCatReturnLifecycle)
-                || (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive())
-            );
+
             // “恢复默认模型”的目标固定为内置 Live2D。先退出 goodbye 并恢复
             // Electron Pet 的完整 viewport，但不要重新显示即将被替换的旧模型；
             // 后面的 PUT + handleModelReload 会直接加载目标 Live2D。
             // helper 即使当前不在 goodbye 也会立即成功；无条件调用还能加入一个
             // 已清除 manager 标志、但尚未完整结束的现有 return lifecycle。
             if (window.appUi && typeof window.appUi.returnFromGoodbye === 'function') {
-                returnedFromGoodbye = await window.appUi.returnFromGoodbye({
+                var returnedFromGoodbye = await window.appUi.returnFromGoodbye({
                     source: 'reset-to-default-model',
                     retryViewportRestore: true,
                     restoreCurrentModel: false
@@ -494,7 +409,6 @@
                 try { errText = await putResp.text(); } catch (_) {}
                 throw new Error('HTTP ' + putResp.status + (errText ? (': ' + errText) : ''));
             }
-            defaultModelPersisted = true;
 
             // Trigger the live model swap. handleModelReload re-fetches the
             // page_config, so it will pick up the freshly-saved default Live2D
@@ -504,7 +418,13 @@
             // need them surfaced so the reset doesn't report success after a
             // failed hot-swap.
             var reloadOpts = { suppressToast: true, throwOnError: true };
-            await reloadModel(lanlanName, reloadOpts);
+            if (typeof I.handleModelReload === 'function') {
+                await I.handleModelReload(lanlanName, reloadOpts);
+            } else if (typeof window.handleModelReload === 'function') {
+                await window.handleModelReload(lanlanName, reloadOpts);
+            } else {
+                console.warn('[Model] handleModelReload 不可用，跳过热切换');
+            }
 
             try {
                 if (typeof window.showStatusToast === 'function') {
@@ -518,33 +438,6 @@
             return { success: true };
         } catch (e) {
             console.error('[Model] 恢复默认模型失败:', e);
-            if (defaultModelPersisted && previousModelPersistencePayload) {
-                try {
-                    var rollbackResp = await fetch(putUrl, {
-                        method: 'PUT',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(previousModelPersistencePayload)
-                    });
-                    if (!rollbackResp.ok) {
-                        var rollbackErrText = '';
-                        try { rollbackErrText = await rollbackResp.text(); } catch (_) {}
-                        throw new Error('HTTP ' + rollbackResp.status + (rollbackErrText ? (': ' + rollbackErrText) : ''));
-                    }
-                } catch (persistenceRestoreError) {
-                    console.error('[Model] 默认模型恢复失败后回滚持久化配置也失败:', persistenceRestoreError);
-                }
-            }
-            if (returnWasNeeded && returnedFromGoodbye && previousModelConfig && reloadModel) {
-                try {
-                    await reloadModel(lanlanName, {
-                        temporaryConfig: Object.assign({ success: true }, previousModelConfig),
-                        suppressToast: true,
-                        throwOnError: true
-                    });
-                } catch (restoreError) {
-                    console.error('[Model] 默认模型恢复失败后回退旧模型也失败:', restoreError);
-                }
-            }
             try {
                 if (typeof window.showStatusToast === 'function') {
                     window.showStatusToast(

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -367,32 +367,29 @@
                 throw new Error('missing_lanlan_name');
             }
 
-            // “恢复默认模型”是一次显式回到模型态的操作。若仍在“请她离开”状态，
-            // 必须先走完整的回来链：Electron 的 return-ball 模式可能已把 Pet 窗口
-            // 缩成 160x160；直接热重载会移除回来控件，却把新模型留在小窗口外。
-            var goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
-                ? window.isNekoGoodbyeModeActive()
-                : !!(
-                    (window.live2dManager && window.live2dManager._goodbyeClicked)
-                    || (window.vrmManager && window.vrmManager._goodbyeClicked)
-                    || (window.mmdManager && window.mmdManager._goodbyeClicked)
-                );
-            if (goodbyeActive) {
-                if (!window.appUi || typeof window.appUi.returnFromGoodbye !== 'function') {
-                    throw new Error('goodbye_return_unavailable');
-                }
+            // “恢复默认模型”的目标固定为内置 Live2D。先退出 goodbye 并恢复
+            // Electron Pet 的完整 viewport，但不要重新显示即将被替换的旧模型；
+            // 后面的 PUT + handleModelReload 会直接加载目标 Live2D。
+            // helper 即使当前不在 goodbye 也会立即成功；无条件调用还能加入一个
+            // 已清除 manager 标志、但尚未完整结束的现有 return lifecycle。
+            if (window.appUi && typeof window.appUi.returnFromGoodbye === 'function') {
                 var returnedFromGoodbye = await window.appUi.returnFromGoodbye({
-                    source: 'reset-to-default-model'
+                    source: 'reset-to-default-model',
+                    retryViewportRestore: true,
+                    restoreCurrentModel: false
                 });
-                var goodbyeStillActive = typeof window.isNekoGoodbyeModeActive === 'function'
-                    ? window.isNekoGoodbyeModeActive()
-                    : !!(
-                        (window.live2dManager && window.live2dManager._goodbyeClicked)
-                        || (window.vrmManager && window.vrmManager._goodbyeClicked)
-                        || (window.mmdManager && window.mmdManager._goodbyeClicked)
-                    );
-                if (!returnedFromGoodbye || goodbyeStillActive) {
+                if (!returnedFromGoodbye) {
                     throw new Error('goodbye_return_failed');
+                }
+            } else {
+                var visibleReturnBall = document.querySelector(
+                    '[id$="-return-button-container"][data-neko-return-visible="true"]'
+                );
+                var goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
+                    ? window.isNekoGoodbyeModeActive()
+                    : false;
+                if (goodbyeActive || visibleReturnBall) {
+                    throw new Error('goodbye_return_unavailable');
                 }
             }
 

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -357,9 +357,11 @@
 
         var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
         var previousModelConfig = null;
+        var previousModelPersistencePayload = null;
         var reloadModel = null;
         var returnWasNeeded = false;
         var returnedFromGoodbye = false;
+        var defaultModelPersisted = false;
         try {
             previousModelConfig = window.lanlan_config && typeof window.lanlan_config === 'object'
                 ? Object.assign({}, window.lanlan_config)
@@ -382,6 +384,21 @@
                     previousModelConfig.model_path = String(window.mmdModel || previousModelConfig.mmd || '');
                 } else {
                     previousModelConfig.model_path = String(window.cubism4Model || previousModelConfig.live2d || '');
+                }
+                previousModelPersistencePayload = { model_type: previousModelType };
+                if (previousModelType === 'pngtuber') {
+                    previousModelPersistencePayload.pngtuber = previousModelConfig.pngtuber;
+                } else if (previousModelType === 'live3d' && previousLive3dSubType === 'mmd') {
+                    previousModelPersistencePayload.mmd = previousModelConfig.model_path;
+                } else if (previousModelType === 'live3d' || previousModelType === 'vrm') {
+                    previousModelPersistencePayload.model_type = 'live3d';
+                    previousModelPersistencePayload.vrm = previousModelConfig.model_path;
+                } else if (previousModelType === 'mmd') {
+                    previousModelPersistencePayload.model_type = 'live3d';
+                    previousModelPersistencePayload.mmd = previousModelConfig.model_path;
+                } else {
+                    previousModelPersistencePayload.model_type = 'live2d';
+                    previousModelPersistencePayload.live2d = previousModelConfig.model_path;
                 }
             }
             reloadModel = typeof I.handleModelReload === 'function'
@@ -450,6 +467,7 @@
                 try { errText = await putResp.text(); } catch (_) {}
                 throw new Error('HTTP ' + putResp.status + (errText ? (': ' + errText) : ''));
             }
+            defaultModelPersisted = true;
 
             // Trigger the live model swap. handleModelReload re-fetches the
             // page_config, so it will pick up the freshly-saved default Live2D
@@ -473,6 +491,22 @@
             return { success: true };
         } catch (e) {
             console.error('[Model] 恢复默认模型失败:', e);
+            if (defaultModelPersisted && previousModelPersistencePayload) {
+                try {
+                    var rollbackResp = await fetch(putUrl, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(previousModelPersistencePayload)
+                    });
+                    if (!rollbackResp.ok) {
+                        var rollbackErrText = '';
+                        try { rollbackErrText = await rollbackResp.text(); } catch (_) {}
+                        throw new Error('HTTP ' + rollbackResp.status + (rollbackErrText ? (': ' + rollbackErrText) : ''));
+                    }
+                } catch (persistenceRestoreError) {
+                    console.error('[Model] 默认模型恢复失败后回滚持久化配置也失败:', persistenceRestoreError);
+                }
+            }
             if (returnWasNeeded && returnedFromGoodbye && previousModelConfig && reloadModel) {
                 try {
                     await reloadModel(lanlanName, {

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -367,6 +367,35 @@
                 throw new Error('missing_lanlan_name');
             }
 
+            // “恢复默认模型”是一次显式回到模型态的操作。若仍在“请她离开”状态，
+            // 必须先走完整的回来链：Electron 的 return-ball 模式可能已把 Pet 窗口
+            // 缩成 160x160；直接热重载会移除回来控件，却把新模型留在小窗口外。
+            var goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
+                ? window.isNekoGoodbyeModeActive()
+                : !!(
+                    (window.live2dManager && window.live2dManager._goodbyeClicked)
+                    || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                    || (window.mmdManager && window.mmdManager._goodbyeClicked)
+                );
+            if (goodbyeActive) {
+                if (!window.appUi || typeof window.appUi.returnFromGoodbye !== 'function') {
+                    throw new Error('goodbye_return_unavailable');
+                }
+                var returnedFromGoodbye = await window.appUi.returnFromGoodbye({
+                    source: 'reset-to-default-model'
+                });
+                var goodbyeStillActive = typeof window.isNekoGoodbyeModeActive === 'function'
+                    ? window.isNekoGoodbyeModeActive()
+                    : !!(
+                        (window.live2dManager && window.live2dManager._goodbyeClicked)
+                        || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                        || (window.mmdManager && window.mmdManager._goodbyeClicked)
+                    );
+                if (!returnedFromGoodbye || goodbyeStillActive) {
+                    throw new Error('goodbye_return_failed');
+                }
+            }
+
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
             var putResp = await fetch(putUrl, {

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -340,12 +340,12 @@
     // Reset current avatar to the built-in default Live2D model
     //
     // Triggered from the Electron tray "Advanced Settings → Reset to Default
-    // Avatar" menu via the `reset-to-default-model` IPC. Persists the change
-    // through the standard PUT /api/characters/catgirl/l2d/<name> endpoint so
-    // the choice survives a reload, then triggers handleModelReload to swap
-    // the current MMD/VRM/Live2D model live.
+    // Avatar" menu via the `reset-to-default-model` IPC. It first validates the
+    // built-in Live2D model through the existing temporary hot-reload path, then
+    // persists the choice through PUT /api/characters/catgirl/l2d/<name>.
     // =====================================================================
     var DEFAULT_LIVE2D_MODEL_NAME = 'yui-lolita';
+    var DEFAULT_LIVE2D_MODEL_PATH = '/static/yui-lolita/yui-lolita.model3.json';
     var _resetToDefaultModelInFlight = false;
 
     async function resetToDefaultModel() {
@@ -356,6 +356,11 @@
         _resetToDefaultModelInFlight = true;
 
         var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+        var defaultReloadAttempted = false;
+        var defaultPersisted = false;
+        var reloadModel = typeof I.handleModelReload === 'function'
+            ? I.handleModelReload
+            : (typeof window.handleModelReload === 'function' ? window.handleModelReload : null);
         try {
             // Fail-fast when there is no character context. This happens if the
             // tray IPC fires before `neko:config-injected`, or on a sub-window
@@ -365,6 +370,9 @@
             if (!lanlanName) {
                 console.warn('[Model] resetToDefaultModel: 当前没有 lanlan_name，无法持久化默认模型设置');
                 throw new Error('missing_lanlan_name');
+            }
+            if (!reloadModel) {
+                throw new Error('model_reload_unavailable');
             }
 
             // “恢复默认模型”的目标固定为内置 Live2D。先退出 goodbye 并恢复
@@ -393,6 +401,22 @@
                 }
             }
 
+            // 先验证内置 Live2D 能在当前页面成功加载。临时配置不会改写服务端，
+            // 因此加载或后续 PUT 失败时，仍可从 page_config 恢复原模型。
+            defaultReloadAttempted = true;
+            await reloadModel(lanlanName, {
+                temporaryConfig: {
+                    success: true,
+                    model_type: 'live2d',
+                    model_path: DEFAULT_LIVE2D_MODEL_PATH,
+                    live3d_sub_type: ''
+                },
+                skipIdleRestore: true,
+                skipPersistentExpressions: true,
+                suppressToast: true,
+                throwOnError: true
+            });
+
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
             var putResp = await fetch(putUrl, {
@@ -404,27 +428,13 @@
                     live2d_idle_animation: null
                 })
             });
-            if (!putResp.ok) {
-                var errText = '';
-                try { errText = await putResp.text(); } catch (_) {}
-                throw new Error('HTTP ' + putResp.status + (errText ? (': ' + errText) : ''));
+            var putData = null;
+            try { putData = await putResp.json(); } catch (_) {}
+            if (!putResp.ok || !putData || putData.success !== true) {
+                var errorDetail = (putData && putData.error) || '';
+                throw new Error('HTTP ' + putResp.status + (errorDetail ? (': ' + errorDetail) : ''));
             }
-
-            // Trigger the live model swap. handleModelReload re-fetches the
-            // page_config, so it will pick up the freshly-saved default Live2D
-            // model and recycle the VRM/MMD overlays as needed.
-            // suppressToast: this caller owns the success/failure toast.
-            // throwOnError: handleModelReload's own catch swallows errors; we
-            // need them surfaced so the reset doesn't report success after a
-            // failed hot-swap.
-            var reloadOpts = { suppressToast: true, throwOnError: true };
-            if (typeof I.handleModelReload === 'function') {
-                await I.handleModelReload(lanlanName, reloadOpts);
-            } else if (typeof window.handleModelReload === 'function') {
-                await window.handleModelReload(lanlanName, reloadOpts);
-            } else {
-                console.warn('[Model] handleModelReload 不可用，跳过热切换');
-            }
+            defaultPersisted = true;
 
             try {
                 if (typeof window.showStatusToast === 'function') {
@@ -437,6 +447,18 @@
 
             return { success: true };
         } catch (e) {
+            // 临时热切换失败，或模型已切换但 PUT 失败时，服务端通常仍保留
+            // 原 page_config。重新走标准热重载，避免旧模型容器保持隐藏。
+            if (defaultReloadAttempted && !defaultPersisted && reloadModel) {
+                try {
+                    await reloadModel(lanlanName, {
+                        suppressToast: true,
+                        throwOnError: true
+                    });
+                } catch (restoreError) {
+                    console.error('[Model] 默认模型恢复失败后回退原模型也失败:', restoreError);
+                }
+            }
             console.error('[Model] 恢复默认模型失败:', e);
             try {
                 if (typeof window.showStatusToast === 'function') {

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -358,6 +358,8 @@
         var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
         var defaultReloadAttempted = false;
         var defaultPersisted = false;
+        var reloadQueueHoldToken = 'reset-default-model-' + Date.now() + '-' + Math.random();
+        var reloadQueueHeld = false;
         var reloadModel = typeof I.handleModelReload === 'function'
             ? I.handleModelReload
             : (typeof window.handleModelReload === 'function' ? window.handleModelReload : null);
@@ -414,7 +416,8 @@
                 skipIdleRestore: true,
                 skipPersistentExpressions: true,
                 suppressToast: true,
-                throwOnError: true
+                throwOnError: true,
+                queueHoldToken: reloadQueueHoldToken
             });
             if (defaultReloadResult !== true) {
                 // A queued reload can be displaced by a newer request and
@@ -423,6 +426,7 @@
                 defaultReloadAttempted = false;
                 throw new Error('default_model_reload_not_applied');
             }
+            reloadQueueHeld = typeof I.releaseModelReloadQueueHold === 'function';
 
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
@@ -446,6 +450,10 @@
                 throw new Error('HTTP ' + putResp.status + (errorDetail ? (': ' + errorDetail) : ''));
             }
             defaultPersisted = true;
+            if (reloadQueueHeld) {
+                I.releaseModelReloadQueueHold(reloadQueueHoldToken);
+                reloadQueueHeld = false;
+            }
 
             try {
                 if (typeof window.showStatusToast === 'function') {
@@ -458,6 +466,10 @@
 
             return { success: true };
         } catch (e) {
+            if (reloadQueueHeld && typeof I.releaseModelReloadQueueHold === 'function') {
+                I.releaseModelReloadQueueHold(reloadQueueHoldToken);
+                reloadQueueHeld = false;
+            }
             // 临时热切换失败，或模型已切换但 PUT 失败时，服务端通常仍保留
             // 原 page_config。重新走标准热重载，避免旧模型容器保持隐藏。
             if (defaultReloadAttempted && !defaultPersisted && reloadModel) {
@@ -481,6 +493,9 @@
             } catch (_) {}
             return { success: false, error: (e && e.message) || String(e) };
         } finally {
+            if (reloadQueueHeld && typeof I.releaseModelReloadQueueHold === 'function') {
+                I.releaseModelReloadQueueHold(reloadQueueHoldToken);
+            }
             _resetToDefaultModelInFlight = false;
         }
     }
@@ -491,6 +506,7 @@
 
     I.mod.nekoBroadcastChannel = I.nekoBroadcastChannel;
     I.mod.handleModelReload = I.handleModelReload;
+    I.mod.releaseModelReloadQueueHold = I.releaseModelReloadQueueHold;
     I.mod.resetToDefaultModel = resetToDefaultModel;
     I.mod.handleHideMainUI = I.handleHideMainUI;
     I.mod.handleShowMainUI = I.handleShowMainUI;

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -404,7 +404,7 @@
             // 先验证内置 Live2D 能在当前页面成功加载。临时配置不会改写服务端，
             // 因此加载或后续 PUT 失败时，仍可从 page_config 恢复原模型。
             defaultReloadAttempted = true;
-            await reloadModel(lanlanName, {
+            var defaultReloadResult = await reloadModel(lanlanName, {
                 temporaryConfig: {
                     success: true,
                     model_type: 'live2d',
@@ -416,6 +416,13 @@
                 suppressToast: true,
                 throwOnError: true
             });
+            if (defaultReloadResult !== true) {
+                // A queued reload can be displaced by a newer request and
+                // resolve false without throwing. It did not validate the
+                // default model, so it must not be persisted or rolled back.
+                defaultReloadAttempted = false;
+                throw new Error('default_model_reload_not_applied');
+            }
 
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
@@ -425,7 +432,11 @@
                 body: JSON.stringify({
                     model_type: 'live2d',
                     live2d: DEFAULT_LIVE2D_MODEL_NAME,
-                    live2d_idle_animation: null
+                    live2d_idle_animation: null,
+                    // The frontend already loaded and validated the target.
+                    // Avoid a post-save init_one_catgirl failure being reported
+                    // after the persistent binding has already changed.
+                    apply_runtime: false
                 })
             });
             var putData = null;

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -346,6 +346,7 @@
     // =====================================================================
     var DEFAULT_LIVE2D_MODEL_NAME = 'yui-lolita';
     var DEFAULT_LIVE2D_MODEL_PATH = '/static/yui-lolita/yui-lolita.model3.json';
+    var DEFAULT_MODEL_PERSIST_TIMEOUT_MS = 10000;
     var _resetToDefaultModelInFlight = false;
 
     async function resetToDefaultModel() {
@@ -430,21 +431,45 @@
 
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
-            var putResp = await fetch(putUrl, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    model_type: 'live2d',
-                    live2d: DEFAULT_LIVE2D_MODEL_NAME,
-                    live2d_idle_animation: null,
-                    // The frontend already loaded and validated the target.
-                    // Avoid a post-save init_one_catgirl failure being reported
-                    // after the persistent binding has already changed.
-                    apply_runtime: false
-                })
-            });
+            if (typeof window.AbortController !== 'function') {
+                throw new Error('model_persist_abort_unavailable');
+            }
+            var persistenceAbortController = new window.AbortController();
+            var persistenceTimeoutId = window.setTimeout(function () {
+                persistenceAbortController.abort();
+            }, DEFAULT_MODEL_PERSIST_TIMEOUT_MS);
+            var putResp;
             var putData = null;
-            try { putData = await putResp.json(); } catch (_) {}
+            try {
+                putResp = await fetch(putUrl, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        model_type: 'live2d',
+                        live2d: DEFAULT_LIVE2D_MODEL_NAME,
+                        live2d_idle_animation: null,
+                        // The frontend already loaded and validated the target.
+                        // Avoid a post-save init_one_catgirl failure being reported
+                        // after the persistent binding has already changed.
+                        apply_runtime: false
+                    }),
+                    signal: persistenceAbortController.signal
+                });
+                try {
+                    putData = await putResp.json();
+                } catch (putBodyError) {
+                    // A malformed response is handled by the success check below;
+                    // an aborted body must retain the explicit timeout result.
+                    if (persistenceAbortController.signal.aborted) throw putBodyError;
+                }
+            } catch (persistenceError) {
+                if (persistenceAbortController.signal.aborted) {
+                    throw new Error('default_model_persist_timeout');
+                }
+                throw persistenceError;
+            } finally {
+                window.clearTimeout(persistenceTimeoutId);
+            }
             if (!putResp.ok || !putData || putData.success !== true) {
                 var errorDetail = (putData && putData.error) || '';
                 throw new Error('HTTP ' + putResp.status + (errorDetail ? (': ' + errorDetail) : ''));

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -300,6 +300,7 @@
             (window.live2dManager && window.live2dManager._goodbyeClicked)
             || (window.vrmManager && window.vrmManager._goodbyeClicked)
             || (window.mmdManager && window.mmdManager._goodbyeClicked)
+            || (window.pngtuberManager && window.pngtuberManager._goodbyeClicked)
         );
     };
 

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -330,8 +330,25 @@ I.mod = window.appUi;
         }
     }
 
+    I.reapplyGoodbyeResourceSuspend = function reapplyGoodbyeResourceSuspend(previousSnapshot) {
+        const prior = previousSnapshot && typeof previousSnapshot === 'object'
+            ? previousSnapshot
+            : null;
+        const token = I.beginGoodbyeResourceSuspend({
+            activeModelType: prior && prior.activeModelType ? prior.activeModelType : ''
+        });
+        const snapshot = getGoodbyeResourceSnapshot();
+        if (snapshot && prior) {
+            snapshot.subtitleWindowWasVisible = !!prior.subtitleWindowWasVisible;
+            snapshot.agentHudWasVisible = !!prior.agentHudWasVisible;
+        }
+        I.completeGoodbyeResourceSuspend(token);
+        return token;
+    }
+
     I.mod.restoreGoodbyeResourceSuspend = I.restoreGoodbyeResourceSuspend;
     I.mod.completeGoodbyeResourceSuspend = I.completeGoodbyeResourceSuspend;
+    I.mod.reapplyGoodbyeResourceSuspend = I.reapplyGoodbyeResourceSuspend;
     window.addEventListener('neko:goodbye-state-cleared', (event) => {
         const detail = event && event.detail ? event.detail : {};
         const reason = detail.reason || 'goodbye-state-cleared';

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -675,11 +675,6 @@
 
     // --- showCurrentModel ---
     I.showCurrentModel = async function showCurrentModel() {
-        const returnLifecycle = I.nekoCatReturnLifecycle;
-        const returnSignal = returnLifecycle && returnLifecycle.signal
-            ? returnLifecycle.signal
-            : null;
-        const isReturnCancelled = () => !!(returnSignal && returnSignal.aborted);
         // 检查"请她离开"状态
         if (window.live2dManager && window.live2dManager._goodbyeClicked) {
             console.log('[showCurrentModel] 当前处于"请她离开"状态，跳过显示逻辑');
@@ -698,7 +693,6 @@
         if (!modelViewportReady.ready) {
             return false;
         }
-        if (isReturnCancelled()) return false;
 
         // 重置 goodbye 标志
         if (window.live2dManager) {
@@ -721,10 +715,7 @@
             const isMmdCurrentlyActive = window.mmdManager && window.mmdManager.currentModel
                 && _mmdEl && _mmdEl.style.display !== 'none' && !_mmdEl.classList.contains('hidden');
 
-            const charResponse = await fetch(
-                '/api/characters',
-                returnSignal ? { signal: returnSignal } : undefined
-            );
+            const charResponse = await fetch('/api/characters');
             if (!charResponse.ok) {
                 console.warn('[showCurrentModel] 无法获取角色配置');
                 // 如果当前已有 VRM/MMD 模型在运行，保持当前状态而非回退到 Live2D
@@ -737,7 +728,6 @@
             }
 
             const charactersData = await charResponse.json();
-            if (isReturnCancelled()) return false;
             const currentCatgirl = lanlan_config.lanlan_name;
             const catgirlConfig = charactersData['猫娘']?.[currentCatgirl];
 
@@ -1072,12 +1062,8 @@
                 I.pendingPngtuberReturnConfig = null;
 
                 if (window.loadPNGTuberAvatar) {
-                    await window.loadPNGTuberAvatar(
-                        pngtuberConfig,
-                        returnSignal ? { signal: returnSignal } : undefined
-                    );
+                    await window.loadPNGTuberAvatar(pngtuberConfig);
                 }
-                if (isReturnCancelled()) return false;
                 if (window.pngtuberManager && typeof window.pngtuberManager.show === 'function') {
                     window.pngtuberManager.show();
                 } else if (pngtuberContainer) {
@@ -1161,10 +1147,6 @@
                 if (mmdLockIconL2d) { mmdLockIconL2d.style.display = 'none'; }
             }
         } catch (error) {
-            if (isReturnCancelled()) {
-                console.warn('[showCurrentModel] 模型返回生命周期已取消');
-                return false;
-            }
             console.error('[showCurrentModel] 失败:', error);
             // 出错时检查是否有 VRM/MMD 正在运行且可见，如果有则保持当前状态
             const vrmEl = document.getElementById('vrm-container');

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -675,6 +675,11 @@
 
     // --- showCurrentModel ---
     I.showCurrentModel = async function showCurrentModel() {
+        const returnLifecycle = I.nekoCatReturnLifecycle;
+        const returnSignal = returnLifecycle && returnLifecycle.signal
+            ? returnLifecycle.signal
+            : null;
+        const isReturnCancelled = () => !!(returnSignal && returnSignal.aborted);
         // 检查"请她离开"状态
         if (window.live2dManager && window.live2dManager._goodbyeClicked) {
             console.log('[showCurrentModel] 当前处于"请她离开"状态，跳过显示逻辑');
@@ -693,6 +698,7 @@
         if (!modelViewportReady.ready) {
             return false;
         }
+        if (isReturnCancelled()) return false;
 
         // 重置 goodbye 标志
         if (window.live2dManager) {
@@ -715,7 +721,10 @@
             const isMmdCurrentlyActive = window.mmdManager && window.mmdManager.currentModel
                 && _mmdEl && _mmdEl.style.display !== 'none' && !_mmdEl.classList.contains('hidden');
 
-            const charResponse = await fetch('/api/characters');
+            const charResponse = await fetch(
+                '/api/characters',
+                returnSignal ? { signal: returnSignal } : undefined
+            );
             if (!charResponse.ok) {
                 console.warn('[showCurrentModel] 无法获取角色配置');
                 // 如果当前已有 VRM/MMD 模型在运行，保持当前状态而非回退到 Live2D
@@ -728,6 +737,7 @@
             }
 
             const charactersData = await charResponse.json();
+            if (isReturnCancelled()) return false;
             const currentCatgirl = lanlan_config.lanlan_name;
             const catgirlConfig = charactersData['猫娘']?.[currentCatgirl];
 
@@ -1147,6 +1157,10 @@
                 if (mmdLockIconL2d) { mmdLockIconL2d.style.display = 'none'; }
             }
         } catch (error) {
+            if (isReturnCancelled()) {
+                console.warn('[showCurrentModel] 模型返回生命周期已取消');
+                return false;
+            }
             console.error('[showCurrentModel] 失败:', error);
             // 出错时检查是否有 VRM/MMD 正在运行且可见，如果有则保持当前状态
             const vrmEl = document.getElementById('vrm-container');

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -1104,7 +1104,6 @@
                 const pngtuberConfig = I.pendingPngtuberReturnConfig
                     ? Object.assign({}, basePngtuberConfig, I.pendingPngtuberReturnConfig)
                     : basePngtuberConfig;
-                I.pendingPngtuberReturnConfig = null;
 
                 if (window.loadPNGTuberAvatar) {
                     await window.loadPNGTuberAvatar(

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -1072,8 +1072,12 @@
                 I.pendingPngtuberReturnConfig = null;
 
                 if (window.loadPNGTuberAvatar) {
-                    await window.loadPNGTuberAvatar(pngtuberConfig);
+                    await window.loadPNGTuberAvatar(
+                        pngtuberConfig,
+                        returnSignal ? { signal: returnSignal } : undefined
+                    );
                 }
+                if (isReturnCancelled()) return false;
                 if (window.pngtuberManager && typeof window.pngtuberManager.show === 'function') {
                     window.pngtuberManager.show();
                 } else if (pngtuberContainer) {

--- a/static/app/app-ui/model-display.js
+++ b/static/app/app-ui/model-display.js
@@ -622,7 +622,29 @@
         return null;
     }
 
-    I.ensureModelViewportReadyBeforeShowCurrentModel = async function ensureModelViewportReadyBeforeShowCurrentModel() {
+    function waitForReturnOperation(operation, signal) {
+        if (!signal) return Promise.resolve(operation);
+        if (signal.aborted) return Promise.reject(new DOMException('Return cancelled', 'AbortError'));
+        return new Promise((resolve, reject) => {
+            const handleAbort = () => reject(new DOMException('Return cancelled', 'AbortError'));
+            signal.addEventListener('abort', handleAbort, { once: true });
+            Promise.resolve(operation).then(
+                (value) => {
+                    signal.removeEventListener('abort', handleAbort);
+                    resolve(value);
+                },
+                (error) => {
+                    signal.removeEventListener('abort', handleAbort);
+                    reject(error);
+                }
+            );
+        });
+    }
+
+    I.ensureModelViewportReadyBeforeShowCurrentModel = async function ensureModelViewportReadyBeforeShowCurrentModel(options = {}) {
+        const returnSignal = options && options.signal ? options.signal : null;
+        const cancelledResult = () => ({ ready: false, restored: false, cancelled: true });
+        if (returnSignal && returnSignal.aborted) return cancelledResult();
         const restoreBounds = I.getPendingModelViewportRestoreBounds();
         if (!restoreBounds) {
             if (I.isNativeReturnBallViewportSize(window.innerWidth, window.innerHeight)) {
@@ -644,18 +666,34 @@
 
         if (window.nekoPetDrag && typeof window.nekoPetDrag.reveal === 'function') {
             try {
-                const revealResult = await Promise.resolve(window.nekoPetDrag.reveal());
+                const revealResult = await waitForReturnOperation(
+                    Promise.resolve(window.nekoPetDrag.reveal()),
+                    returnSignal
+                );
                 if (revealResult === false) {
-                    await waitForModelViewportRestore(restoreBounds, {
-                        timeoutMs: NEKO_MODEL_VIEWPORT_RESTORE_RETRY_MS
-                    });
+                    await waitForReturnOperation(
+                        waitForModelViewportRestore(restoreBounds, {
+                            timeoutMs: NEKO_MODEL_VIEWPORT_RESTORE_RETRY_MS
+                        }),
+                        returnSignal
+                    );
                 }
             } catch (error) {
+                if (returnSignal && returnSignal.aborted) return cancelledResult();
                 console.warn('[showCurrentModel] restore model viewport reveal retry failed:', error);
             }
         }
 
-        const viewportWait = await waitForModelViewportRestore(restoreBounds);
+        let viewportWait;
+        try {
+            viewportWait = await waitForReturnOperation(
+                waitForModelViewportRestore(restoreBounds),
+                returnSignal
+            );
+        } catch (error) {
+            if (returnSignal && returnSignal.aborted) return cancelledResult();
+            throw error;
+        }
         if (viewportWait.restored) {
             pendingNativeModelViewportRestoreBounds = null;
             recoverLive2DRendererFromReturnBallViewport('ensure-model-viewport-ready:after-wait');
@@ -674,7 +712,9 @@
     }
 
     // --- showCurrentModel ---
-    I.showCurrentModel = async function showCurrentModel() {
+    I.showCurrentModel = async function showCurrentModel(options = {}) {
+        const returnSignal = options && options.signal ? options.signal : null;
+        const isReturnCancelled = () => !!(returnSignal && returnSignal.aborted);
         // 检查"请她离开"状态
         if (window.live2dManager && window.live2dManager._goodbyeClicked) {
             console.log('[showCurrentModel] 当前处于"请她离开"状态，跳过显示逻辑');
@@ -689,10 +729,11 @@
             return;
         }
 
-        const modelViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+        const modelViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel({ signal: returnSignal });
         if (!modelViewportReady.ready) {
             return false;
         }
+        if (isReturnCancelled()) return false;
 
         // 重置 goodbye 标志
         if (window.live2dManager) {
@@ -715,7 +756,10 @@
             const isMmdCurrentlyActive = window.mmdManager && window.mmdManager.currentModel
                 && _mmdEl && _mmdEl.style.display !== 'none' && !_mmdEl.classList.contains('hidden');
 
-            const charResponse = await fetch('/api/characters');
+            const charResponse = await fetch(
+                '/api/characters',
+                returnSignal ? { signal: returnSignal } : undefined
+            );
             if (!charResponse.ok) {
                 console.warn('[showCurrentModel] 无法获取角色配置');
                 // 如果当前已有 VRM/MMD 模型在运行，保持当前状态而非回退到 Live2D
@@ -728,6 +772,7 @@
             }
 
             const charactersData = await charResponse.json();
+            if (isReturnCancelled()) return false;
             const currentCatgirl = lanlan_config.lanlan_name;
             const catgirlConfig = charactersData['猫娘']?.[currentCatgirl];
 
@@ -1062,8 +1107,12 @@
                 I.pendingPngtuberReturnConfig = null;
 
                 if (window.loadPNGTuberAvatar) {
-                    await window.loadPNGTuberAvatar(pngtuberConfig);
+                    await window.loadPNGTuberAvatar(
+                        pngtuberConfig,
+                        returnSignal ? { signal: returnSignal } : undefined
+                    );
                 }
+                if (isReturnCancelled()) return false;
                 if (window.pngtuberManager && typeof window.pngtuberManager.show === 'function') {
                     window.pngtuberManager.show();
                 } else if (pngtuberContainer) {
@@ -1147,6 +1196,10 @@
                 if (mmdLockIconL2d) { mmdLockIconL2d.style.display = 'none'; }
             }
         } catch (error) {
+            if (isReturnCancelled()) {
+                console.warn('[showCurrentModel] 模型返回生命周期已取消');
+                return false;
+            }
             console.error('[showCurrentModel] 失败:', error);
             // 出错时检查是否有 VRM/MMD 正在运行且可见，如果有则保持当前状态
             const vrmEl = document.getElementById('vrm-container');

--- a/static/app/app-ui/return-transitions.js
+++ b/static/app/app-ui/return-transitions.js
@@ -239,10 +239,10 @@
                 if (interaction && typeof interaction._snapModelIntoScreen === 'function') {
                     const snapped = await interaction._snapModelIntoScreen({ animate: true });
                     if (!snapped && shouldSaveWhenUnchanged) {
-                        await saveReturnModelPosition('mmd');
+                        void saveReturnModelPosition('mmd');
                     }
                 } else if (shouldSaveWhenUnchanged) {
-                    await saveReturnModelPosition('mmd');
+                    void saveReturnModelPosition('mmd');
                 }
                 return;
             }
@@ -254,12 +254,12 @@
                     const snapped = await interaction._snapModelIntoScreen({ animate: true });
                     if (snapped) {
                         // VRM 的回弹方法只负责动画，最终位置需要由外层保存。
-                        await saveReturnModelPosition('vrm');
+                        void saveReturnModelPosition('vrm');
                     } else if (shouldSaveWhenUnchanged) {
-                        await saveReturnModelPosition('vrm');
+                        void saveReturnModelPosition('vrm');
                     }
                 } else if (shouldSaveWhenUnchanged) {
-                    await saveReturnModelPosition('vrm');
+                    void saveReturnModelPosition('vrm');
                 }
                 return;
             }
@@ -270,7 +270,7 @@
                 activeModelType = 'pngtuber';
                 const snapped = await snapPngtuberIntoScreen();
                 if (snapped || shouldSaveWhenUnchanged) {
-                    await saveReturnModelPosition('pngtuber');
+                    void saveReturnModelPosition('pngtuber');
                 }
                 return;
             }
@@ -282,16 +282,16 @@
                 if (liveModel && !liveModel.destroyed && typeof window.live2dManager._checkAndPerformSnap === 'function') {
                     const snapped = await window.live2dManager._checkAndPerformSnap(liveModel, { allowWhenNotReady: true });
                     if (!snapped && shouldSaveWhenUnchanged) {
-                        await saveReturnModelPosition('live2d');
+                        void saveReturnModelPosition('live2d');
                     }
                 } else if (shouldSaveWhenUnchanged) {
-                    await saveReturnModelPosition('live2d');
+                    void saveReturnModelPosition('live2d');
                 }
             }
         } catch (error) {
             console.warn('[App] 回来后的边界回弹计算失败:', error);
             if (shouldSaveWhenUnchanged && activeModelType) {
-                await saveReturnModelPosition(activeModelType);
+                void saveReturnModelPosition(activeModelType);
             }
         }
     }

--- a/static/app/app-ui/return-transitions.js
+++ b/static/app/app-ui/return-transitions.js
@@ -226,10 +226,39 @@
         }
     }
 
-    I.settleReturnedModelBounds = async function settleReturnedModelBounds(shouldSaveWhenUnchanged) {
+    function waitForReturnTransitionOperation(operation, signal) {
+        if (!signal) return Promise.resolve(operation).then(value => ({ cancelled: false, value }));
+        if (signal.aborted) return Promise.resolve({ cancelled: true, value: undefined });
+        return new Promise((resolve, reject) => {
+            const handleAbort = () => resolve({ cancelled: true, value: undefined });
+            signal.addEventListener('abort', handleAbort, { once: true });
+            Promise.resolve(operation).then(
+                (value) => {
+                    signal.removeEventListener('abort', handleAbort);
+                    resolve({ cancelled: false, value });
+                },
+                (error) => {
+                    signal.removeEventListener('abort', handleAbort);
+                    reject(error);
+                }
+            );
+        });
+    }
+
+    I.settleReturnedModelBounds = async function settleReturnedModelBounds(shouldSaveWhenUnchanged, options = {}) {
+        const returnSignal = options && options.signal ? options.signal : null;
+        const isCancelled = () => !!(returnSignal && returnSignal.aborted);
         // showCurrentModel 会恢复容器和 canvas；等布局提交后再读边界，避免拿到隐藏态尺寸。
-        await waitForModelReturnEnterToSettle();
-        await I.waitForAnimationFrames(2);
+        let operationResult = await waitForReturnTransitionOperation(
+            waitForModelReturnEnterToSettle(),
+            returnSignal
+        );
+        if (operationResult.cancelled || isCancelled()) return false;
+        operationResult = await waitForReturnTransitionOperation(
+            I.waitForAnimationFrames(2),
+            returnSignal
+        );
+        if (operationResult.cancelled || isCancelled()) return false;
 
         let activeModelType = null;
         try {
@@ -237,42 +266,56 @@
                 activeModelType = 'mmd';
                 const interaction = window.mmdManager.interaction;
                 if (interaction && typeof interaction._snapModelIntoScreen === 'function') {
-                    const snapped = await interaction._snapModelIntoScreen({ animate: true });
-                    if (!snapped && shouldSaveWhenUnchanged) {
+                    operationResult = await waitForReturnTransitionOperation(
+                        interaction._snapModelIntoScreen({ animate: true }),
+                        returnSignal
+                    );
+                    if (operationResult.cancelled || isCancelled()) return false;
+                    if (!operationResult.value && shouldSaveWhenUnchanged) {
                         void saveReturnModelPosition('mmd');
                     }
                 } else if (shouldSaveWhenUnchanged) {
+                    if (isCancelled()) return false;
                     void saveReturnModelPosition('mmd');
                 }
-                return;
+                return true;
             }
 
             if (window.vrmManager && window.vrmManager.currentModel && isModelContainerVisible('vrm-container')) {
                 activeModelType = 'vrm';
                 const interaction = window.vrmManager.interaction;
                 if (interaction && typeof interaction._snapModelIntoScreen === 'function') {
-                    const snapped = await interaction._snapModelIntoScreen({ animate: true });
-                    if (snapped) {
+                    operationResult = await waitForReturnTransitionOperation(
+                        interaction._snapModelIntoScreen({ animate: true }),
+                        returnSignal
+                    );
+                    if (operationResult.cancelled || isCancelled()) return false;
+                    if (operationResult.value) {
                         // VRM 的回弹方法只负责动画，最终位置需要由外层保存。
                         void saveReturnModelPosition('vrm');
                     } else if (shouldSaveWhenUnchanged) {
                         void saveReturnModelPosition('vrm');
                     }
                 } else if (shouldSaveWhenUnchanged) {
+                    if (isCancelled()) return false;
                     void saveReturnModelPosition('vrm');
                 }
-                return;
+                return true;
             }
 
             if ((window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber'
                 && getPngtuberManager()
                 && isModelContainerVisible('pngtuber-container')) {
                 activeModelType = 'pngtuber';
-                const snapped = await snapPngtuberIntoScreen();
-                if (snapped || shouldSaveWhenUnchanged) {
+                operationResult = await waitForReturnTransitionOperation(
+                    snapPngtuberIntoScreen(),
+                    returnSignal
+                );
+                if (operationResult.cancelled || isCancelled()) return false;
+                if (operationResult.value || shouldSaveWhenUnchanged) {
                     void saveReturnModelPosition('pngtuber');
                 }
-                return;
+                return true;
             }
 
             if (window.live2dManager) {
@@ -280,20 +323,26 @@
                 const liveModel = typeof window.live2dManager.getCurrentModel === 'function'
                     ? window.live2dManager.getCurrentModel() : null;
                 if (liveModel && !liveModel.destroyed && typeof window.live2dManager._checkAndPerformSnap === 'function') {
-                    const snapped = await window.live2dManager._checkAndPerformSnap(liveModel, { allowWhenNotReady: true });
-                    if (!snapped && shouldSaveWhenUnchanged) {
+                    operationResult = await waitForReturnTransitionOperation(
+                        window.live2dManager._checkAndPerformSnap(liveModel, { allowWhenNotReady: true }),
+                        returnSignal
+                    );
+                    if (operationResult.cancelled || isCancelled()) return false;
+                    if (!operationResult.value && shouldSaveWhenUnchanged) {
                         void saveReturnModelPosition('live2d');
                     }
                 } else if (shouldSaveWhenUnchanged) {
+                    if (isCancelled()) return false;
                     void saveReturnModelPosition('live2d');
                 }
             }
         } catch (error) {
             console.warn('[App] 回来后的边界回弹计算失败:', error);
-            if (shouldSaveWhenUnchanged && activeModelType) {
+            if (!isCancelled() && shouldSaveWhenUnchanged && activeModelType) {
                 void saveReturnModelPosition(activeModelType);
             }
         }
+        return !isCancelled();
     }
 
     function cancelReturnBallReveal(container) {

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -1597,6 +1597,38 @@
         }
     });
 
+        function hideReturnedModelForRetry() {
+            [window.live2dManager, window.vrmManager, window.mmdManager].forEach((manager) => {
+                if (manager) manager._goodbyeClicked = true;
+            });
+            if (window.live2d) window.live2d._goodbyeClicked = true;
+            if (window.pngtuberManager && typeof window.pngtuberManager.hide === 'function') {
+                window.pngtuberManager.hide();
+            }
+            ['live2d', 'vrm', 'mmd', 'pngtuber'].forEach((modelType) => {
+                const container = document.getElementById(`${modelType}-container`);
+                if (container) {
+                    container.classList.add('hidden');
+                    container.style.setProperty('display', 'none', 'important');
+                    container.style.setProperty('visibility', 'hidden', 'important');
+                    container.style.setProperty('pointer-events', 'none', 'important');
+                }
+                const canvas = document.getElementById(`${modelType}-canvas`);
+                if (canvas) {
+                    canvas.style.setProperty('visibility', 'hidden', 'important');
+                    canvas.style.setProperty('pointer-events', 'none', 'important');
+                }
+                [`${modelType}-floating-buttons`, `${modelType}-lock-icon`].forEach((controlId) => {
+                    const control = document.getElementById(controlId);
+                    if (!control) return;
+                    control.style.setProperty('display', 'none', 'important');
+                    control.style.setProperty('visibility', 'hidden', 'important');
+                    control.style.setProperty('opacity', '0', 'important');
+                });
+            });
+            window._nekoModelReturnEnterRect = null;
+        }
+
         function restoreReturnBallAfterBlockedModelViewport(event) {
             const eventType = String(event && event.type || '');
             const match = eventType.match(/^([a-z0-9-]+)-return-click$/i);
@@ -1635,7 +1667,11 @@
                 console.log('[App] 请她回来流程已在执行，忽略重复事件');
                 return;
             }
-            returnLifecycle.restoreRetryState = () => restoreReturnBallAfterBlockedModelViewport(event);
+            let returnedModelShown = false;
+            returnLifecycle.restoreRetryState = () => {
+                if (returnedModelShown) hideReturnedModelForRetry();
+                restoreReturnBallAfterBlockedModelViewport(event);
+            };
             let returnTerminalPublished = false;
             let returnAbortReason = 'return-incomplete';
             try {
@@ -1805,13 +1841,16 @@
                 if (modelDisplayReady === false) {
                     return;
                 }
+                returnedModelShown = true;
                 if (returnLifecycle.cancelled) {
                     returnAbortReason = 'return-lifecycle-cancelled';
                     return;
                 }
 
-                await I.settleReturnedModelBounds(returnModelWasMoved);
-                if (returnLifecycle.cancelled) {
+                const modelBoundsSettled = await I.settleReturnedModelBounds(returnModelWasMoved, {
+                    signal: returnLifecycle.signal
+                });
+                if (modelBoundsSettled === false || returnLifecycle.cancelled) {
                     returnAbortReason = 'return-lifecycle-cancelled';
                     return;
                 }

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -16,7 +16,6 @@
 
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
-    const NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS = 15000;
 
     I.beginNekoCatReturnLifecycle = function beginNekoCatReturnLifecycle(options = {}) {
         if (I.nekoCatReturnLifecycle) return null;
@@ -106,12 +105,13 @@
         const activeType = visibleTypeMatch ? visibleTypeMatch[1] : configuredActiveType;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS;
+            : 15000;
 
         return new Promise((resolve) => {
             let settled = false;
             let timeoutId = null;
             let joinedReturnLifecycle = null;
+            let ownsJoinedReturnLifecycle = false;
             const finish = (restored) => {
                 if (settled) return;
                 settled = true;
@@ -127,7 +127,7 @@
             window.addEventListener('neko:cat-return-abort', handleAbort);
             timeoutId = window.setTimeout(() => {
                 console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
-                if (joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
+                if (ownsJoinedReturnLifecycle && joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
                     I.abortNekoCatReturnLifecycle(joinedReturnLifecycle, 'programmatic-return-timeout');
                 }
                 finish(false);
@@ -188,6 +188,7 @@
                 // dispatchEvent 会同步进入 canonical handler 并创建 lifecycle。
                 if (!joinedReturnLifecycle && I.nekoCatReturnLifecycle) {
                     joinedReturnLifecycle = I.nekoCatReturnLifecycle;
+                    ownsJoinedReturnLifecycle = true;
                 }
             };
             dispatchReturnWhenReady().catch((error) => {

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -16,6 +16,7 @@
 
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
+    const NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS = 15000;
 
     I.beginNekoCatReturnLifecycle = function beginNekoCatReturnLifecycle(options = {}) {
         if (I.nekoCatReturnLifecycle) return null;
@@ -23,7 +24,7 @@
         let resolveLifecycle;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : null;
+            : NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS;
         const lifecycle = {
             settled: false,
             cancelled: false,
@@ -36,11 +37,9 @@
         };
         lifecycle.resolve = resolveLifecycle;
         I.nekoCatReturnLifecycle = lifecycle;
-        if (timeoutMs !== null) {
-            lifecycle.timeoutId = window.setTimeout(() => {
-                I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
-            }, timeoutMs);
-        }
+        lifecycle.timeoutId = window.setTimeout(() => {
+            I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
+        }, timeoutMs);
         return lifecycle;
     };
 
@@ -105,13 +104,12 @@
         const activeType = visibleTypeMatch ? visibleTypeMatch[1] : configuredActiveType;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : 15000;
+            : NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS;
 
         return new Promise((resolve) => {
             let settled = false;
             let timeoutId = null;
             let joinedReturnLifecycle = null;
-            let ownsJoinedReturnLifecycle = false;
             const finish = (restored) => {
                 if (settled) return;
                 settled = true;
@@ -127,7 +125,7 @@
             window.addEventListener('neko:cat-return-abort', handleAbort);
             timeoutId = window.setTimeout(() => {
                 console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
-                if (ownsJoinedReturnLifecycle && joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
+                if (joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
                     I.abortNekoCatReturnLifecycle(joinedReturnLifecycle, 'programmatic-return-timeout');
                 }
                 finish(false);
@@ -188,7 +186,6 @@
                 // dispatchEvent 会同步进入 canonical handler 并创建 lifecycle。
                 if (!joinedReturnLifecycle && I.nekoCatReturnLifecycle) {
                     joinedReturnLifecycle = I.nekoCatReturnLifecycle;
-                    ownsJoinedReturnLifecycle = true;
                 }
             };
             dispatchReturnWhenReady().catch((error) => {

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -16,6 +16,73 @@
 
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
+
+    I.returnFromGoodbye = function returnFromGoodbye(options = {}) {
+        options = options && typeof options === 'object' ? options : {};
+        const goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
+            ? window.isNekoGoodbyeModeActive()
+            : !!(
+                (window.live2dManager && window.live2dManager._goodbyeClicked)
+                || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                || (window.mmdManager && window.mmdManager._goodbyeClicked)
+            );
+        if (!goodbyeActive) return Promise.resolve(true);
+
+        const visibleReturnContainer = typeof I.getVisibleIdleReturnBallContainer === 'function'
+            ? I.getVisibleIdleReturnBallContainer()
+            : null;
+        const visibleTypeMatch = visibleReturnContainer && String(visibleReturnContainer.id || '')
+            .match(/^(live2d|vrm|mmd|pngtuber)-return-button-container$/);
+        const configuredType = String(window.lanlan_config?.model_type || 'live2d').toLowerCase();
+        const live3dSubType = String(window.lanlan_config?.live3d_sub_type || '').toLowerCase();
+        const configuredActiveType = configuredType === 'live3d'
+            ? (live3dSubType === 'mmd' ? 'mmd' : 'vrm')
+            : (['live2d', 'vrm', 'mmd', 'pngtuber'].includes(configuredType) ? configuredType : 'live2d');
+        // 可见的回来控件比配置更权威：配置可能正被其它模型切换请求更新，
+        // 而 restore viewport 的失败兜底必须重新显示实际那一个控件。
+        const activeType = visibleTypeMatch ? visibleTypeMatch[1] : configuredActiveType;
+        const timeoutMs = Number.isFinite(Number(options.timeoutMs))
+            ? Math.max(1000, Number(options.timeoutMs))
+            : 15000;
+
+        return new Promise((resolve) => {
+            let settled = false;
+            let timeoutId = null;
+            const finish = (restored) => {
+                if (settled) return;
+                settled = true;
+                if (timeoutId !== null) window.clearTimeout(timeoutId);
+                window.removeEventListener('neko:cat-return-complete', handleComplete);
+                window.removeEventListener('neko:cat-return-abort', handleAbort);
+                resolve(restored);
+            };
+            const handleComplete = () => finish(true);
+            const handleAbort = () => finish(false);
+
+            window.addEventListener('neko:cat-return-complete', handleComplete);
+            window.addEventListener('neko:cat-return-abort', handleAbort);
+            timeoutId = window.setTimeout(() => {
+                console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
+                finish(false);
+            }, timeoutMs);
+
+            try {
+                // 复用唯一的“请她回来”事件链。它会先恢复 Electron Pet 的完整
+                // viewport，再清理猫咪/呼吸球、资源暂停和三个模型管理器的离开标志。
+                // 直接清标志后热重载会把 return-ball 清掉，却仍留下 160x160 的 Pet
+                // carrier，正是托盘恢复默认模型后整个模型消失的根因。
+                window.dispatchEvent(new CustomEvent(`${activeType}-return-click`, {
+                    detail: {
+                        source: options.source || 'programmatic-return'
+                    }
+                }));
+            } catch (error) {
+                console.error('[App] 程序化恢复模型失败:', error);
+                finish(false);
+            }
+        });
+    };
+
     function initFloatingButtonListeners() {
         // DOM refs from orchestrator
         const micButton = I.S.dom.micButton;
@@ -1978,6 +2045,7 @@
     }
 
     I.mod.initFloatingButtonListeners = initFloatingButtonListeners;
+    I.mod.returnFromGoodbye = I.returnFromGoodbye;
 
     // ================================================================
     //  5. ensureHiddenElements & final UI init  (app.js lines 11354-11420)

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -2277,6 +2277,9 @@
                     window.nekoLive2DPeek.restoreAnchor(live2DPeekRestoreAnchor).catch(() => {});
                 } catch (_) {}
             }
+            if (isReturningToPngtuber) {
+                I.pendingPngtuberReturnConfig = null;
+            }
             window.dispatchEvent(new CustomEvent('neko:cat-return-complete', {
                 detail: {
                     source: event && event.type ? event.type : 'return-click',

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -21,19 +21,13 @@
         if (I.nekoCatReturnLifecycle) return null;
         options = options && typeof options === 'object' ? options : {};
         let resolveLifecycle;
-        const AbortControllerCtor = window.AbortController;
-        const abortController = typeof AbortControllerCtor === 'function'
-            ? new AbortControllerCtor()
-            : null;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : 15000;
+            : null;
         const lifecycle = {
             settled: false,
             cancelled: false,
             abortPublished: false,
-            abortController,
-            signal: abortController ? abortController.signal : null,
             source: options.source || 'return-click',
             timeoutId: null,
             promise: new Promise((resolve) => {
@@ -42,9 +36,11 @@
         };
         lifecycle.resolve = resolveLifecycle;
         I.nekoCatReturnLifecycle = lifecycle;
-        lifecycle.timeoutId = window.setTimeout(() => {
-            I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
-        }, timeoutMs);
+        if (timeoutMs !== null) {
+            lifecycle.timeoutId = window.setTimeout(() => {
+                I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
+            }, timeoutMs);
+        }
         return lifecycle;
     };
 
@@ -64,11 +60,6 @@
     I.abortNekoCatReturnLifecycle = function abortNekoCatReturnLifecycle(lifecycle, reason) {
         if (!lifecycle || lifecycle.settled) return false;
         lifecycle.cancelled = true;
-        if (lifecycle.abortController) {
-            try {
-                lifecycle.abortController.abort();
-            } catch (_) {}
-        }
         I.finishNekoCatReturnLifecycle(lifecycle, false);
         if (!lifecycle.abortPublished) {
             lifecycle.abortPublished = true;
@@ -86,6 +77,9 @@
     I.returnFromGoodbye = function returnFromGoodbye(options = {}) {
         options = options && typeof options === 'object' ? options : {};
         const activeReturnLifecycle = I.nekoCatReturnLifecycle;
+        const visibleReturnContainer = typeof I.getVisibleIdleReturnBallContainer === 'function'
+            ? I.getVisibleIdleReturnBallContainer()
+            : null;
         const goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
             ? window.isNekoGoodbyeModeActive()
             : !!(
@@ -93,11 +87,12 @@
                 || (window.vrmManager && window.vrmManager._goodbyeClicked)
                 || (window.mmdManager && window.mmdManager._goodbyeClicked)
             );
-        if (!goodbyeActive && !activeReturnLifecycle) return Promise.resolve(true);
-
-        const visibleReturnContainer = typeof I.getVisibleIdleReturnBallContainer === 'function'
-            ? I.getVisibleIdleReturnBallContainer()
-            : null;
+        // PNGTuber 在全新启动时没有 Live2D/VRM/MMD manager，离开态由可见的
+        // return-ball 表示。这里以实际 UI 为准，避免把目标固定为 Live2D 误当成
+        // 当前模型也一定是 Live2D。
+        if (!goodbyeActive && !visibleReturnContainer && !activeReturnLifecycle) {
+            return Promise.resolve(true);
+        }
         const visibleTypeMatch = visibleReturnContainer && String(visibleReturnContainer.id || '')
             .match(/^(live2d|vrm|mmd|pngtuber)-return-button-container$/);
         const configuredType = String(window.lanlan_config?.model_type || 'live2d').toLowerCase();
@@ -116,6 +111,7 @@
             let settled = false;
             let timeoutId = null;
             let joinedReturnLifecycle = null;
+            let ownsJoinedReturnLifecycle = false;
             const finish = (restored) => {
                 if (settled) return;
                 settled = true;
@@ -131,7 +127,7 @@
             window.addEventListener('neko:cat-return-abort', handleAbort);
             timeoutId = window.setTimeout(() => {
                 console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
-                if (joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
+                if (ownsJoinedReturnLifecycle && joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
                     I.abortNekoCatReturnLifecycle(joinedReturnLifecycle, 'programmatic-return-timeout');
                 }
                 finish(false);
@@ -184,12 +180,15 @@
                 window.dispatchEvent(new CustomEvent(`${activeType}-return-click`, {
                     detail: {
                         source: options.source || 'programmatic-return',
-                        timeoutMs
+                        timeoutMs,
+                        retryViewportRestore: options.retryViewportRestore === true,
+                        restoreCurrentModel: options.restoreCurrentModel !== false
                     }
                 }));
                 // dispatchEvent 会同步进入 canonical handler 并创建 lifecycle。
                 if (!joinedReturnLifecycle && I.nekoCatReturnLifecycle) {
                     joinedReturnLifecycle = I.nekoCatReturnLifecycle;
+                    ownsJoinedReturnLifecycle = true;
                 }
             };
             dispatchReturnWhenReady().catch((error) => {
@@ -1611,7 +1610,7 @@
                 ? event.detail
                 : {};
             const returnLifecycle = I.beginNekoCatReturnLifecycle({
-                source: event && event.type ? event.type : 'return-click',
+                source: returnDetail.source || (event && event.type ? event.type : 'return-click'),
                 timeoutMs: returnDetail.timeoutMs
             });
             if (!returnLifecycle) {
@@ -1631,7 +1630,16 @@
                 window._goodbyeHideTimerId = null;
                 console.log('[App] handleReturnClick: 已取消 goodbye 延迟隐藏定时器');
             }
-            const preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+            let preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+            while (
+                !preReturnViewportReady.ready
+                && returnDetail.retryViewportRestore === true
+                && !returnLifecycle.cancelled
+            ) {
+                await new Promise((resume) => window.setTimeout(resume, 50));
+                if (returnLifecycle.cancelled) break;
+                preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+            }
             if (!preReturnViewportReady.ready) {
                 console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
                 restoreReturnBallAfterBlockedModelViewport(event);
@@ -1759,26 +1767,35 @@
                 ? window.isMobileWidth()
                 : (window.innerWidth <= 768);
 
-            // 使用 showCurrentModel() 做最终裁决
-            let modelDisplayReady = true;
-            try {
-                modelDisplayReady = await I.showCurrentModel();
-            } catch (error) {
-                console.error('[App] showCurrentModel 失败:', error);
-                I.showLive2d();
-            }
-            if (modelDisplayReady === false) {
-                return;
-            }
-            if (returnLifecycle.cancelled) {
-                returnAbortReason = 'return-lifecycle-cancelled';
-                return;
-            }
+            const restoreCurrentModel = returnDetail.restoreCurrentModel !== false;
+            if (restoreCurrentModel) {
+                // 普通“请她回来”仍恢复当前模型；恢复默认模型会跳过这一步，
+                // 由紧随其后的 handleModelReload 直接加载目标 Live2D，避免先把
+                // 即将被替换的 VRM/MMD/PNGTuber 再加载一遍。
+                let modelDisplayReady = true;
+                try {
+                    modelDisplayReady = await I.showCurrentModel();
+                } catch (error) {
+                    console.error('[App] showCurrentModel 失败:', error);
+                    I.showLive2d();
+                }
+                if (modelDisplayReady === false) {
+                    return;
+                }
+                if (returnLifecycle.cancelled) {
+                    returnAbortReason = 'return-lifecycle-cancelled';
+                    return;
+                }
 
-            await I.settleReturnedModelBounds(returnModelWasMoved);
-            if (returnLifecycle.cancelled) {
-                returnAbortReason = 'return-lifecycle-cancelled';
-                return;
+                await I.settleReturnedModelBounds(returnModelWasMoved);
+                if (returnLifecycle.cancelled) {
+                    returnAbortReason = 'return-lifecycle-cancelled';
+                    return;
+                }
+            } else {
+                // showCurrentModel() normally consumes this one-shot rect.
+                // Skipping the old model must not leak it into a later return.
+                window._nekoModelReturnEnterRect = null;
             }
 
             // 恢复 VRM canvas 的可见性

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -24,7 +24,7 @@
         let resolveLifecycle;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS;
+            : null;
         const lifecycle = {
             settled: false,
             cancelled: false,
@@ -37,9 +37,11 @@
         };
         lifecycle.resolve = resolveLifecycle;
         I.nekoCatReturnLifecycle = lifecycle;
-        lifecycle.timeoutId = window.setTimeout(() => {
-            I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
-        }, timeoutMs);
+        if (timeoutMs !== null) {
+            lifecycle.timeoutId = window.setTimeout(() => {
+                I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
+            }, timeoutMs);
+        }
         return lifecycle;
     };
 

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -106,6 +106,7 @@
                 (window.live2dManager && window.live2dManager._goodbyeClicked)
                 || (window.vrmManager && window.vrmManager._goodbyeClicked)
                 || (window.mmdManager && window.mmdManager._goodbyeClicked)
+                || (window.pngtuberManager && window.pngtuberManager._goodbyeClicked)
             );
         // PNGTuber 在全新启动时没有 Live2D/VRM/MMD manager，离开态由可见的
         // return-ball 表示。这里以实际 UI 为准，避免把目标固定为 Live2D 误当成
@@ -1088,6 +1089,9 @@
             if (window.mmdManager) {
                 window.mmdManager._goodbyeClicked = true;
             }
+            if (window.pngtuberManager) {
+                window.pngtuberManager._goodbyeClicked = true;
+            }
             if (window.appInterpage && typeof window.appInterpage.postGoodbyeChatComposerHiddenState === 'function') {
                 window.appInterpage.postGoodbyeChatComposerHiddenState(true, 'live2d-goodbye-click');
             } else if (typeof window.postGoodbyeChatComposerHiddenState === 'function') {
@@ -1571,7 +1575,8 @@
                 const goodbyeStillActive = !!(
                     (window.live2dManager && window.live2dManager._goodbyeClicked) ||
                     (window.vrmManager && window.vrmManager._goodbyeClicked) ||
-                    (window.mmdManager && window.mmdManager._goodbyeClicked)
+                    (window.mmdManager && window.mmdManager._goodbyeClicked) ||
+                    (window.pngtuberManager && window.pngtuberManager._goodbyeClicked)
                 );
                 if (!goodbyeStillActive) {
                     console.log('[App] 跳过过期的 resetSessionButton.click()：当前已不在 goodbye 状态', reason || '');
@@ -1598,7 +1603,7 @@
     });
 
         function hideReturnedModelForRetry(goodbyeResourceSnapshot) {
-            [window.live2dManager, window.vrmManager, window.mmdManager].forEach((manager) => {
+            [window.live2dManager, window.vrmManager, window.mmdManager, window.pngtuberManager].forEach((manager) => {
                 if (manager) manager._goodbyeClicked = true;
             });
             if (window.live2d) window.live2d._goodbyeClicked = true;
@@ -1805,6 +1810,9 @@
             }
             if (window.mmdManager) {
                 window.mmdManager._goodbyeClicked = false;
+            }
+            if (window.pngtuberManager) {
+                window.pngtuberManager._goodbyeClicked = false;
             }
             console.log('[App] 标志清除后 - live2dManager._goodbyeClicked:', window.live2dManager?._goodbyeClicked);
             console.log('[App] 标志清除后 - vrmManager._goodbyeClicked:', window.vrmManager?._goodbyeClicked);

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -16,31 +16,38 @@
 
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
+    const NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS = 15000;
 
     I.beginNekoCatReturnLifecycle = function beginNekoCatReturnLifecycle(options = {}) {
         if (I.nekoCatReturnLifecycle) return null;
         options = options && typeof options === 'object' ? options : {};
         let resolveLifecycle;
+        const AbortControllerCtor = window.AbortController;
+        const abortController = typeof AbortControllerCtor === 'function'
+            ? new AbortControllerCtor()
+            : null;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : null;
+            : NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS;
         const lifecycle = {
             settled: false,
             cancelled: false,
             abortPublished: false,
+            abortController,
+            signal: abortController ? abortController.signal : null,
             source: options.source || 'return-click',
             timeoutId: null,
+            retryStateRestored: false,
+            restoreRetryState: null,
             promise: new Promise((resolve) => {
                 resolveLifecycle = resolve;
             })
         };
         lifecycle.resolve = resolveLifecycle;
         I.nekoCatReturnLifecycle = lifecycle;
-        if (timeoutMs !== null) {
-            lifecycle.timeoutId = window.setTimeout(() => {
-                I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
-            }, timeoutMs);
-        }
+        lifecycle.timeoutId = window.setTimeout(() => {
+            I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
+        }, timeoutMs);
         return lifecycle;
     };
 
@@ -60,6 +67,19 @@
     I.abortNekoCatReturnLifecycle = function abortNekoCatReturnLifecycle(lifecycle, reason) {
         if (!lifecycle || lifecycle.settled) return false;
         lifecycle.cancelled = true;
+        if (lifecycle.abortController) {
+            try {
+                lifecycle.abortController.abort();
+            } catch (_) {}
+        }
+        if (!lifecycle.retryStateRestored && typeof lifecycle.restoreRetryState === 'function') {
+            lifecycle.retryStateRestored = true;
+            try {
+                lifecycle.restoreRetryState(reason || 'return-incomplete');
+            } catch (restoreError) {
+                console.warn('[App] 恢复可重试的 return 状态失败:', restoreError);
+            }
+        }
         I.finishNekoCatReturnLifecycle(lifecycle, false);
         if (!lifecycle.abortPublished) {
             lifecycle.abortPublished = true;
@@ -105,13 +125,12 @@
         const activeType = visibleTypeMatch ? visibleTypeMatch[1] : configuredActiveType;
         const timeoutMs = Number.isFinite(Number(options.timeoutMs))
             ? Math.max(1000, Number(options.timeoutMs))
-            : 15000;
+            : NEKO_CAT_RETURN_LIFECYCLE_TIMEOUT_MS;
 
         return new Promise((resolve) => {
             let settled = false;
             let timeoutId = null;
             let joinedReturnLifecycle = null;
-            let ownsJoinedReturnLifecycle = false;
             const finish = (restored) => {
                 if (settled) return;
                 settled = true;
@@ -127,7 +146,7 @@
             window.addEventListener('neko:cat-return-abort', handleAbort);
             timeoutId = window.setTimeout(() => {
                 console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
-                if (ownsJoinedReturnLifecycle && joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
+                if (joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
                     I.abortNekoCatReturnLifecycle(joinedReturnLifecycle, 'programmatic-return-timeout');
                 }
                 finish(false);
@@ -188,7 +207,6 @@
                 // dispatchEvent 会同步进入 canonical handler 并创建 lifecycle。
                 if (!joinedReturnLifecycle && I.nekoCatReturnLifecycle) {
                     joinedReturnLifecycle = I.nekoCatReturnLifecycle;
-                    ownsJoinedReturnLifecycle = true;
                 }
             };
             dispatchReturnWhenReady().catch((error) => {
@@ -1617,6 +1635,7 @@
                 console.log('[App] 请她回来流程已在执行，忽略重复事件');
                 return;
             }
+            returnLifecycle.restoreRetryState = () => restoreReturnBallAfterBlockedModelViewport(event);
             let returnTerminalPublished = false;
             let returnAbortReason = 'return-incomplete';
             try {
@@ -1630,7 +1649,9 @@
                 window._goodbyeHideTimerId = null;
                 console.log('[App] handleReturnClick: 已取消 goodbye 延迟隐藏定时器');
             }
-            let preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+            let preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel({
+                signal: returnLifecycle.signal
+            });
             while (
                 !preReturnViewportReady.ready
                 && returnDetail.retryViewportRestore === true
@@ -1638,7 +1659,9 @@
             ) {
                 await new Promise((resume) => window.setTimeout(resume, 50));
                 if (returnLifecycle.cancelled) break;
-                preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+                preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel({
+                    signal: returnLifecycle.signal
+                });
             }
             if (!preReturnViewportReady.ready) {
                 console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
@@ -1774,7 +1797,7 @@
                 // 即将被替换的 VRM/MMD/PNGTuber 再加载一遍。
                 let modelDisplayReady = true;
                 try {
-                    modelDisplayReady = await I.showCurrentModel();
+                    modelDisplayReady = await I.showCurrentModel({ signal: returnLifecycle.signal });
                 } catch (error) {
                     console.error('[App] showCurrentModel 失败:', error);
                     I.showLive2d();

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -17,8 +17,32 @@
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
 
+    I.beginNekoCatReturnLifecycle = function beginNekoCatReturnLifecycle() {
+        if (I.nekoCatReturnLifecycle) return null;
+        let resolveLifecycle;
+        const lifecycle = {
+            settled: false,
+            promise: new Promise((resolve) => {
+                resolveLifecycle = resolve;
+            })
+        };
+        lifecycle.resolve = resolveLifecycle;
+        I.nekoCatReturnLifecycle = lifecycle;
+        return lifecycle;
+    };
+
+    I.finishNekoCatReturnLifecycle = function finishNekoCatReturnLifecycle(lifecycle, restored) {
+        if (!lifecycle || lifecycle.settled) return;
+        lifecycle.settled = true;
+        if (I.nekoCatReturnLifecycle === lifecycle) {
+            I.nekoCatReturnLifecycle = null;
+        }
+        lifecycle.resolve(restored === true);
+    };
+
     I.returnFromGoodbye = function returnFromGoodbye(options = {}) {
         options = options && typeof options === 'object' ? options : {};
+        const activeReturnLifecycle = I.nekoCatReturnLifecycle;
         const goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
             ? window.isNekoGoodbyeModeActive()
             : !!(
@@ -26,7 +50,7 @@
                 || (window.vrmManager && window.vrmManager._goodbyeClicked)
                 || (window.mmdManager && window.mmdManager._goodbyeClicked)
             );
-        if (!goodbyeActive) return Promise.resolve(true);
+        if (!goodbyeActive && !activeReturnLifecycle) return Promise.resolve(true);
 
         const visibleReturnContainer = typeof I.getVisibleIdleReturnBallContainer === 'function'
             ? I.getVisibleIdleReturnBallContainer()
@@ -66,7 +90,23 @@
                 finish(false);
             }, timeoutMs);
 
+            const joinActiveReturnLifecycle = () => {
+                const lifecycle = I.nekoCatReturnLifecycle;
+                if (!lifecycle || !lifecycle.promise || typeof lifecycle.promise.then !== 'function') {
+                    return false;
+                }
+                lifecycle.promise.then(
+                    (restored) => finish(restored === true),
+                    () => finish(false)
+                );
+                return true;
+            };
+
             const dispatchReturnWhenReady = async () => {
+                // manager flags 会在完整 return 结束前被清除。若已有标准返回链，
+                // 必须加入其生命周期，不能把“标志已清除”误判成恢复已完成。
+                if (joinActiveReturnLifecycle()) return;
+
                 // goodbye 标志会在 model-to-cat 动画开始时立即置位，但普通 return
                 // handler 会忽略动画尚未结束时的点击。等待同一个 transition token
                 // 释放后再派发，避免一次合法的托盘点击白等 15 秒后失败。
@@ -81,6 +121,9 @@
                     }
                 }
                 if (settled) return;
+
+                // 等待离开动画期间，用户也可能先触发标准返回链。
+                if (joinActiveReturnLifecycle()) return;
 
                 // 若另一条“请她回来”链已经在执行，只等待上面安装好的 terminal
                 // event，不能再次派发造成两条恢复流程并发。
@@ -1511,6 +1554,14 @@
                 console.log('[App] 模型正在切换为猫形态，忽略本次请她回来事件');
                 return;
             }
+            const returnLifecycle = I.beginNekoCatReturnLifecycle();
+            if (!returnLifecycle) {
+                console.log('[App] 请她回来流程已在执行，忽略重复事件');
+                return;
+            }
+            let returnTerminalPublished = false;
+            let returnAbortReason = 'return-incomplete';
+            try {
             const hadPendingGoodbyeReset = !!window._goodbyeResetClickTimerId;
             if (hadPendingGoodbyeReset) {
                 clearTimeout(window._goodbyeResetClickTimerId);
@@ -1528,15 +1579,7 @@
                 if (hadPendingGoodbyeReset) {
                     runGoodbyeResetClickIfActive('return-viewport-blocked');
                 }
-                // 这次恢复尝试已经结束；程序化恢复可能正在加入同一条
-                // cat-to-model 链，必须收到明确的终止信号，不能只能等超时。
-                window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
-                    detail: {
-                        source: event && event.type ? event.type : 'return-click',
-                        reason: 'model-viewport-not-ready',
-                        timestamp: Date.now()
-                    }
-                }));
+                returnAbortReason = 'model-viewport-not-ready';
                 return;
             }
             let hadCatCycle = false;
@@ -1568,8 +1611,6 @@
                     timestamp: Date.now()
                 }
             }));
-            let returnTerminalPublished = false;
-            try {
             const isReturningToPngtuber = (window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber';
             if (I.multiWindowReturnBallDragState) {
                 I.multiWindowReturnBallDragState.dragSessionToken += 1;
@@ -2054,11 +2095,12 @@
 
             console.log('[App] 请她回来完成，未自动开始会话，等待用户主动发起对话');
             } finally {
+                I.finishNekoCatReturnLifecycle(returnLifecycle, returnTerminalPublished);
                 if (!returnTerminalPublished) {
                     window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
                         detail: {
                             source: event && event.type ? event.type : 'return-click',
-                            reason: 'return-incomplete',
+                            reason: returnAbortReason,
                             timestamp: Date.now()
                         }
                     }));

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -17,27 +17,70 @@
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
 
-    I.beginNekoCatReturnLifecycle = function beginNekoCatReturnLifecycle() {
+    I.beginNekoCatReturnLifecycle = function beginNekoCatReturnLifecycle(options = {}) {
         if (I.nekoCatReturnLifecycle) return null;
+        options = options && typeof options === 'object' ? options : {};
         let resolveLifecycle;
+        const AbortControllerCtor = window.AbortController;
+        const abortController = typeof AbortControllerCtor === 'function'
+            ? new AbortControllerCtor()
+            : null;
+        const timeoutMs = Number.isFinite(Number(options.timeoutMs))
+            ? Math.max(1000, Number(options.timeoutMs))
+            : 15000;
         const lifecycle = {
             settled: false,
+            cancelled: false,
+            abortPublished: false,
+            abortController,
+            signal: abortController ? abortController.signal : null,
+            source: options.source || 'return-click',
+            timeoutId: null,
             promise: new Promise((resolve) => {
                 resolveLifecycle = resolve;
             })
         };
         lifecycle.resolve = resolveLifecycle;
         I.nekoCatReturnLifecycle = lifecycle;
+        lifecycle.timeoutId = window.setTimeout(() => {
+            I.abortNekoCatReturnLifecycle(lifecycle, 'return-lifecycle-timeout');
+        }, timeoutMs);
         return lifecycle;
     };
 
     I.finishNekoCatReturnLifecycle = function finishNekoCatReturnLifecycle(lifecycle, restored) {
         if (!lifecycle || lifecycle.settled) return;
         lifecycle.settled = true;
+        if (lifecycle.timeoutId !== null) {
+            window.clearTimeout(lifecycle.timeoutId);
+            lifecycle.timeoutId = null;
+        }
         if (I.nekoCatReturnLifecycle === lifecycle) {
             I.nekoCatReturnLifecycle = null;
         }
         lifecycle.resolve(restored === true);
+    };
+
+    I.abortNekoCatReturnLifecycle = function abortNekoCatReturnLifecycle(lifecycle, reason) {
+        if (!lifecycle || lifecycle.settled) return false;
+        lifecycle.cancelled = true;
+        if (lifecycle.abortController) {
+            try {
+                lifecycle.abortController.abort();
+            } catch (_) {}
+        }
+        I.finishNekoCatReturnLifecycle(lifecycle, false);
+        if (!lifecycle.abortPublished) {
+            lifecycle.abortPublished = true;
+            window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
+                detail: {
+                    source: lifecycle.source || 'return-click',
+                    reason: reason || 'return-incomplete',
+                    timestamp: Date.now()
+                }
+            }));
+        }
+        return true;
     };
 
     I.returnFromGoodbye = function returnFromGoodbye(options = {}) {
@@ -72,6 +115,7 @@
         return new Promise((resolve) => {
             let settled = false;
             let timeoutId = null;
+            let joinedReturnLifecycle = null;
             const finish = (restored) => {
                 if (settled) return;
                 settled = true;
@@ -87,6 +131,9 @@
             window.addEventListener('neko:cat-return-abort', handleAbort);
             timeoutId = window.setTimeout(() => {
                 console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
+                if (joinedReturnLifecycle && !joinedReturnLifecycle.settled) {
+                    I.abortNekoCatReturnLifecycle(joinedReturnLifecycle, 'programmatic-return-timeout');
+                }
                 finish(false);
             }, timeoutMs);
 
@@ -95,6 +142,7 @@
                 if (!lifecycle || !lifecycle.promise || typeof lifecycle.promise.then !== 'function') {
                     return false;
                 }
+                joinedReturnLifecycle = lifecycle;
                 lifecycle.promise.then(
                     (restored) => finish(restored === true),
                     () => finish(false)
@@ -135,9 +183,14 @@
                 // carrier，正是托盘恢复默认模型后整个模型消失的根因。
                 window.dispatchEvent(new CustomEvent(`${activeType}-return-click`, {
                     detail: {
-                        source: options.source || 'programmatic-return'
+                        source: options.source || 'programmatic-return',
+                        timeoutMs
                     }
                 }));
+                // dispatchEvent 会同步进入 canonical handler 并创建 lifecycle。
+                if (!joinedReturnLifecycle && I.nekoCatReturnLifecycle) {
+                    joinedReturnLifecycle = I.nekoCatReturnLifecycle;
+                }
             };
             dispatchReturnWhenReady().catch((error) => {
                 console.error('[App] 程序化恢复模型失败:', error);
@@ -1554,7 +1607,13 @@
                 console.log('[App] 模型正在切换为猫形态，忽略本次请她回来事件');
                 return;
             }
-            const returnLifecycle = I.beginNekoCatReturnLifecycle();
+            const returnDetail = event && event.detail && typeof event.detail === 'object'
+                ? event.detail
+                : {};
+            const returnLifecycle = I.beginNekoCatReturnLifecycle({
+                source: event && event.type ? event.type : 'return-click',
+                timeoutMs: returnDetail.timeoutMs
+            });
             if (!returnLifecycle) {
                 console.log('[App] 请她回来流程已在执行，忽略重复事件');
                 return;
@@ -1580,6 +1639,10 @@
                     runGoodbyeResetClickIfActive('return-viewport-blocked');
                 }
                 returnAbortReason = 'model-viewport-not-ready';
+                return;
+            }
+            if (returnLifecycle.cancelled) {
+                returnAbortReason = 'return-lifecycle-cancelled';
                 return;
             }
             let hadCatCycle = false;
@@ -1707,8 +1770,16 @@
             if (modelDisplayReady === false) {
                 return;
             }
+            if (returnLifecycle.cancelled) {
+                returnAbortReason = 'return-lifecycle-cancelled';
+                return;
+            }
 
             await I.settleReturnedModelBounds(returnModelWasMoved);
+            if (returnLifecycle.cancelled) {
+                returnAbortReason = 'return-lifecycle-cancelled';
+                return;
+            }
 
             // 恢复 VRM canvas 的可见性
             const vrmCanvas = document.getElementById('vrm-canvas');
@@ -2095,15 +2166,10 @@
 
             console.log('[App] 请她回来完成，未自动开始会话，等待用户主动发起对话');
             } finally {
-                I.finishNekoCatReturnLifecycle(returnLifecycle, returnTerminalPublished);
-                if (!returnTerminalPublished) {
-                    window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
-                        detail: {
-                            source: event && event.type ? event.type : 'return-click',
-                            reason: returnAbortReason,
-                            timestamp: Date.now()
-                        }
-                    }));
+                if (returnTerminalPublished) {
+                    I.finishNekoCatReturnLifecycle(returnLifecycle, true);
+                } else {
+                    I.abortNekoCatReturnLifecycle(returnLifecycle, returnAbortReason);
                 }
             }
         };

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -1597,7 +1597,7 @@
         }
     });
 
-        function hideReturnedModelForRetry() {
+        function hideReturnedModelForRetry(goodbyeResourceSnapshot) {
             [window.live2dManager, window.vrmManager, window.mmdManager].forEach((manager) => {
                 if (manager) manager._goodbyeClicked = true;
             });
@@ -1626,6 +1626,25 @@
                     control.style.setProperty('opacity', '0', 'important');
                 });
             });
+            if (window.live2dManager && typeof window.live2dManager.setLocked === 'function') {
+                window.live2dManager.setLocked(true, { updateFloatingButtons: false });
+            }
+            if (window.vrmManager && window.vrmManager.core && typeof window.vrmManager.core.setLocked === 'function') {
+                window.vrmManager.core.setLocked(true);
+            }
+            if (window.mmdManager && window.mmdManager.core && typeof window.mmdManager.core.setLocked === 'function') {
+                window.mmdManager.core.setLocked(true);
+            }
+            if (goodbyeResourceSnapshot && goodbyeResourceSnapshot.activeModelType === 'mmd' && window.mmdManager) {
+                window.mmdManager.enablePhysics = false;
+            }
+            if (goodbyeResourceSnapshot && goodbyeResourceSnapshot.activeModelType === 'pngtuber'
+                && window.pngtuberManager && typeof window.pngtuberManager.setLocked === 'function') {
+                window.pngtuberManager.setLocked(true, { updateFloatingButtons: false });
+            }
+            if (typeof I.reapplyGoodbyeResourceSuspend === 'function') {
+                I.reapplyGoodbyeResourceSuspend(goodbyeResourceSnapshot);
+            }
             window._nekoModelReturnEnterRect = null;
         }
 
@@ -1647,6 +1666,7 @@
                 }
             }
             I.revealReturnBallContainer(container, 'return-ball-model-viewport-blocked');
+            return container;
         }
 
         // 请她回来按钮（统一处理函数）
@@ -1667,10 +1687,24 @@
                 console.log('[App] 请她回来流程已在执行，忽略重复事件');
                 return;
             }
-            let returnedModelShown = false;
+            const retryGoodbyeResourceSnapshot = window.__nekoGoodbyeResourceSuspendSnapshot || null;
+            let returnStateCommitted = false;
             returnLifecycle.restoreRetryState = () => {
-                if (returnedModelShown) hideReturnedModelForRetry();
-                restoreReturnBallAfterBlockedModelViewport(event);
+                if (returnStateCommitted) {
+                    hideReturnedModelForRetry(retryGoodbyeResourceSnapshot);
+                }
+                const restoredReturnContainer = restoreReturnBallAfterBlockedModelViewport(event);
+                if (returnStateCommitted && restoredReturnContainer) {
+                    const restoredAppearance = I.getReturnButtonAppearance(restoredReturnContainer);
+                    I.publishCatLocalActive(
+                        restoredAppearance === I.NEKO_GOODBYE_IDLE_APPEARANCE_CAT,
+                        {
+                            source: event && event.type ? event.type : 'return-click',
+                            reason: 'return-abort-rollback',
+                            appearance: restoredAppearance
+                        }
+                    );
+                }
             };
             let returnTerminalPublished = false;
             let returnAbortReason = 'return-incomplete';
@@ -1728,6 +1762,7 @@
                     live2DPeekRestoreAnchor = returnContainer.__nekoLive2DPeekEdgeAnchor;
                 }
             } catch (_) {}
+            returnStateCommitted = true;
             I.publishCatLocalActive(false, {
                 source: event && event.type ? event.type : 'return-click',
                 reason: 'return-commit',
@@ -1841,7 +1876,6 @@
                 if (modelDisplayReady === false) {
                     return;
                 }
-                returnedModelShown = true;
                 if (returnLifecycle.cancelled) {
                     returnAbortReason = 'return-lifecycle-cancelled';
                     return;

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -1528,6 +1528,15 @@
                 if (hadPendingGoodbyeReset) {
                     runGoodbyeResetClickIfActive('return-viewport-blocked');
                 }
+                // 这次恢复尝试已经结束；程序化恢复可能正在加入同一条
+                // cat-to-model 链，必须收到明确的终止信号，不能只能等超时。
+                window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
+                    detail: {
+                        source: event && event.type ? event.type : 'return-click',
+                        reason: 'model-viewport-not-ready',
+                        timestamp: Date.now()
+                    }
+                }));
                 return;
             }
             let hadCatCycle = false;

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -66,7 +66,26 @@
                 finish(false);
             }, timeoutMs);
 
-            try {
+            const dispatchReturnWhenReady = async () => {
+                // goodbye 标志会在 model-to-cat 动画开始时立即置位，但普通 return
+                // handler 会忽略动画尚未结束时的点击。等待同一个 transition token
+                // 释放后再派发，避免一次合法的托盘点击白等 15 秒后失败。
+                while (!settled && I.isNekoModelCatTransitionActive('model-to-cat')) {
+                    const transition = I.nekoModelCatTransitionActive;
+                    if (transition && transition.promise && typeof transition.promise.then === 'function') {
+                        try {
+                            await transition.promise;
+                        } catch (_) { /* 继续按当前 transition 状态裁决 */ }
+                    } else {
+                        await new Promise((resume) => window.setTimeout(resume, 16));
+                    }
+                }
+                if (settled) return;
+
+                // 若另一条“请她回来”链已经在执行，只等待上面安装好的 terminal
+                // event，不能再次派发造成两条恢复流程并发。
+                if (I.isNekoModelCatTransitionActive('cat-to-model')) return;
+
                 // 复用唯一的“请她回来”事件链。它会先恢复 Electron Pet 的完整
                 // viewport，再清理猫咪/呼吸球、资源暂停和三个模型管理器的离开标志。
                 // 直接清标志后热重载会把 return-ball 清掉，却仍留下 160x160 的 Pet
@@ -76,10 +95,11 @@
                         source: options.source || 'programmatic-return'
                     }
                 }));
-            } catch (error) {
+            };
+            dispatchReturnWhenReady().catch((error) => {
                 console.error('[App] 程序化恢复模型失败:', error);
                 finish(false);
-            }
+            });
         });
     };
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -878,7 +878,6 @@
 
         async setupLayeredAdapter(options = {}) {
             const config = options.config || this.config;
-            const signal = options.signal || null;
             const isCurrentLoad = typeof options.isCurrentLoad === 'function'
                 ? options.isCurrentLoad
                 : () => true;
@@ -907,10 +906,7 @@
             this.layeredAssetActionActive = false;
             if (config.adapter !== 'layered_canvas_v1' || !config.layered_metadata) return false;
             try {
-                const response = await fetch(config.layered_metadata, {
-                    cache: 'no-cache',
-                    ...(signal ? { signal } : {})
-                });
+                const response = await fetch(config.layered_metadata, { cache: 'no-cache' });
                 if (!isCurrentLoad()) return false;
                 if (!response.ok) throw new Error(`metadata ${response.status}`);
                 const metadata = await response.json();
@@ -3630,14 +3626,12 @@
 
         async load(config, options = {}) {
             const loadToken = Number(options.loadToken) || 0;
-            const signal = options.signal || null;
             if (loadToken && loadToken < this._latestLifecycleLoadToken) return false;
             if (loadToken) this._latestLifecycleLoadToken = loadToken;
             const loadGeneration = ++this._loadGeneration;
             const isCurrentLoad = () => (
                 loadGeneration === this._loadGeneration
                 && (!loadToken || loadToken === this._latestLifecycleLoadToken)
-                && !(signal && signal.aborted)
             );
             this.detachDragListeners();
             this.clearEmotion({ render: false });
@@ -3647,7 +3641,7 @@
             window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
                 detail: { loadToken }
             }));
-            await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad, signal });
+            await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad });
             if (!isCurrentLoad()) return false;
             this.ensureContainer();
             this.preloadImages();
@@ -4799,27 +4793,19 @@
             });
     }
 
-    async function loadPNGTuberAvatar(config, options = {}) {
+    async function loadPNGTuberAvatar(config) {
         const loadToken = ++pngtuberLoadSequence;
-        const returnSignal = options && options.signal ? options.signal : null;
-        const isReturnCancelled = () => !!(returnSignal && returnSignal.aborted);
         window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
             detail: { loadToken }
         }));
         try {
-            if (isReturnCancelled()) return window.pngtuberManager || null;
             await hideOtherAvatarRuntimesForPNGTuber();
             if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager || null;
-            if (isReturnCancelled()) return window.pngtuberManager || null;
             if (!window.pngtuberManager) {
                 window.pngtuberManager = new PNGTuberManager();
             }
-            const loaded = await window.pngtuberManager.load(config || {}, {
-                loadToken,
-                signal: returnSignal
-            });
+            const loaded = await window.pngtuberManager.load(config || {}, { loadToken });
             if (!loaded || loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
-            if (isReturnCancelled()) return window.pngtuberManager;
             if (document.body?.classList.contains('model-manager-page')
                 && window._modelManagerCurrentAvatarType
                 && window._modelManagerCurrentAvatarType !== 'pngtuber') {
@@ -4828,11 +4814,9 @@
             }
             await hideOtherAvatarRuntimesForPNGTuber();
             if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
-            if (isReturnCancelled()) return window.pngtuberManager;
             window.pngtuberManager.show();
             await hideOtherAvatarRuntimesForPNGTuber();
             if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
-            if (isReturnCancelled()) return window.pngtuberManager;
             window.dispatchEvent(new CustomEvent('pngtuber-model-loaded', {
                 detail: { loadToken }
             }));

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -878,6 +878,7 @@
 
         async setupLayeredAdapter(options = {}) {
             const config = options.config || this.config;
+            const signal = options.signal || null;
             const isCurrentLoad = typeof options.isCurrentLoad === 'function'
                 ? options.isCurrentLoad
                 : () => true;
@@ -906,7 +907,10 @@
             this.layeredAssetActionActive = false;
             if (config.adapter !== 'layered_canvas_v1' || !config.layered_metadata) return false;
             try {
-                const response = await fetch(config.layered_metadata, { cache: 'no-cache' });
+                const response = await fetch(config.layered_metadata, {
+                    cache: 'no-cache',
+                    ...(signal ? { signal } : {})
+                });
                 if (!isCurrentLoad()) return false;
                 if (!response.ok) throw new Error(`metadata ${response.status}`);
                 const metadata = await response.json();
@@ -3626,12 +3630,14 @@
 
         async load(config, options = {}) {
             const loadToken = Number(options.loadToken) || 0;
+            const signal = options.signal || null;
             if (loadToken && loadToken < this._latestLifecycleLoadToken) return false;
             if (loadToken) this._latestLifecycleLoadToken = loadToken;
             const loadGeneration = ++this._loadGeneration;
             const isCurrentLoad = () => (
                 loadGeneration === this._loadGeneration
                 && (!loadToken || loadToken === this._latestLifecycleLoadToken)
+                && !(signal && signal.aborted)
             );
             this.detachDragListeners();
             this.clearEmotion({ render: false });
@@ -3641,7 +3647,7 @@
             window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
                 detail: { loadToken }
             }));
-            await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad });
+            await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad, signal });
             if (!isCurrentLoad()) return false;
             this.ensureContainer();
             this.preloadImages();
@@ -4793,19 +4799,27 @@
             });
     }
 
-    async function loadPNGTuberAvatar(config) {
+    async function loadPNGTuberAvatar(config, options = {}) {
         const loadToken = ++pngtuberLoadSequence;
+        const returnSignal = options && options.signal ? options.signal : null;
+        const isReturnCancelled = () => !!(returnSignal && returnSignal.aborted);
         window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {
             detail: { loadToken }
         }));
         try {
+            if (isReturnCancelled()) return window.pngtuberManager || null;
             await hideOtherAvatarRuntimesForPNGTuber();
             if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager || null;
+            if (isReturnCancelled()) return window.pngtuberManager || null;
             if (!window.pngtuberManager) {
                 window.pngtuberManager = new PNGTuberManager();
             }
-            const loaded = await window.pngtuberManager.load(config || {}, { loadToken });
+            const loaded = await window.pngtuberManager.load(config || {}, {
+                loadToken,
+                signal: returnSignal
+            });
             if (!loaded || loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
+            if (isReturnCancelled()) return window.pngtuberManager;
             if (document.body?.classList.contains('model-manager-page')
                 && window._modelManagerCurrentAvatarType
                 && window._modelManagerCurrentAvatarType !== 'pngtuber') {
@@ -4814,9 +4828,11 @@
             }
             await hideOtherAvatarRuntimesForPNGTuber();
             if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
+            if (isReturnCancelled()) return window.pngtuberManager;
             window.pngtuberManager.show();
             await hideOtherAvatarRuntimesForPNGTuber();
             if (loadToken !== pngtuberLoadSequence) return window.pngtuberManager;
+            if (isReturnCancelled()) return window.pngtuberManager;
             window.dispatchEvent(new CustomEvent('pngtuber-model-loaded', {
                 detail: { loadToken }
             }));

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -88,11 +88,38 @@
         return base ? `${base}/${path}` : path;
     }
 
-    function loadImageElement(src) {
+    function loadImageElement(src, signal = null) {
         return new Promise((resolve, reject) => {
             const img = new Image();
-            img.onload = () => resolve(img);
-            img.onerror = reject;
+            let settled = false;
+            const cleanup = () => {
+                img.onload = null;
+                img.onerror = null;
+                if (signal) signal.removeEventListener('abort', handleAbort);
+            };
+            const finish = (callback, value) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                callback(value);
+            };
+            const handleAbort = () => {
+                const error = new Error('Image load aborted');
+                error.name = 'AbortError';
+                finish(reject, error);
+                try {
+                    img.removeAttribute?.('src');
+                } catch (_) {}
+            };
+            img.onload = () => finish(resolve, img);
+            img.onerror = (error) => finish(reject, error);
+            if (signal) {
+                signal.addEventListener('abort', handleAbort, { once: true });
+                if (signal.aborted) {
+                    handleAbort();
+                    return;
+                }
+            }
             assignImageSource(img, src);
         });
     }
@@ -923,7 +950,7 @@
                 await Promise.all(layers.map(async (layer, index) => {
                     const src = resolveSiblingAsset(config.layered_metadata, layer.image);
                     if (!src) return;
-                    const img = await loadImageElement(src);
+                    const img = await loadImageElement(src, signal);
                     if (!isCurrentLoad()) return;
                     layeredImages.set(index, img);
                     layer._imageIndex = index;

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3593,14 +3593,29 @@
             ].join(':');
             if (saveKey === this._lastSavedPositionKey) return true;
             const runSave = async () => {
+                if ((window.lanlan_config?.model_type || '').toLowerCase() !== 'pngtuber') {
+                    return false;
+                }
                 const name = await this.resolveCurrentLanlanName();
                 if (!name) {
                     console.warn('[PNGTuber] 无法解析当前角色名，跳过位置保存');
                     return false;
                 }
+                if ((window.lanlan_config?.model_type || '').toLowerCase() !== 'pngtuber') {
+                    return false;
+                }
                 const payload = {
-                    model_type: 'pngtuber',
-                    pngtuber: Object.assign({}, this.config),
+                    pngtuber_placement: {
+                        offset_x: this.config.offset_x,
+                        offset_y: this.config.offset_y,
+                        scale: this.config.scale,
+                        mobile_offset_x: this.config.mobile_offset_x,
+                        mobile_offset_y: this.config.mobile_offset_y,
+                        mobile_scale: this.config.mobile_scale,
+                        position_anchor: this.config.position_anchor,
+                        mirror: this.config.mirror
+                    },
+                    expected_pngtuber_binding: this.config.layered_metadata || this.config.idle_image || '',
                     apply_runtime: false
                 };
                 const response = await fetch(`/api/characters/catgirl/l2d/${encodeURIComponent(name)}`, {
@@ -3613,6 +3628,7 @@
                     console.warn('[PNGTuber] 保存位置失败:', result.error || response.statusText);
                     return false;
                 }
+                if (result.pngtuber_placement_updated !== true) return false;
                 this._lastSavedPositionKey = saveKey;
                 return true;
             };

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -52,6 +52,9 @@ function createResetHarness({
   temporaryReloadResult = true,
   putOk = true,
   putData = { success: true },
+  putNeverResolves = false,
+  persistenceTimeoutMs = 10_000,
+  hasQueueHoldRelease = false,
 } = {}) {
   const functionStart = resetSource.indexOf('async function resetToDefaultModel() {');
   const functionEnd = resetSource.indexOf('    // =====================================================================\n    // Public API', functionStart);
@@ -67,6 +70,11 @@ function createResetHarness({
       return options.temporaryConfig ? temporaryReloadResult : true;
     };
   }
+  if (hasQueueHoldRelease) {
+    parts.releaseModelReloadQueueHold = (token) => {
+      calls.push({ type: 'release', token });
+    };
+  }
   const window = {
     lanlan_config: { lanlan_name: 'Test Character' },
     appUi: {
@@ -78,10 +86,18 @@ function createResetHarness({
     showStatusToast(message) {
       calls.push({ type: 'toast', message });
     },
+    AbortController,
+    setTimeout,
+    clearTimeout,
   };
   const document = { querySelector: () => null };
   const fetch = async (url, options) => {
     calls.push({ type: 'put', url, options });
+    if (putNeverResolves) {
+      return new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+    }
     return {
       ok: putOk,
       status: putOk ? 200 : 500,
@@ -92,6 +108,7 @@ function createResetHarness({
   vm.runInNewContext(`
     var DEFAULT_LIVE2D_MODEL_NAME = 'yui-lolita';
     var DEFAULT_LIVE2D_MODEL_PATH = '/static/yui-lolita/yui-lolita.model3.json';
+    var DEFAULT_MODEL_PERSIST_TIMEOUT_MS = ${persistenceTimeoutMs};
     var _resetToDefaultModelInFlight = false;
     ${resetFunction}
     window.runResetToDefaultModel = resetToDefaultModel;
@@ -469,7 +486,7 @@ test('position persistence cannot block return completion', () => {
 test('default-model reset validates Live2D before persisting and restores on failure', () => {
   const returnCall = resetSource.indexOf('await window.appUi.returnFromGoodbye({');
   const reloadCall = resetSource.indexOf('await reloadModel(lanlanName, {', returnCall);
-  const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", reloadCall);
+  const persistenceCall = resetSource.indexOf('putResp = await fetch(putUrl', reloadCall);
   const catchBlock = resetSource.indexOf('} catch (e) {', persistenceCall);
   const restoreCall = resetSource.indexOf('await reloadModel(lanlanName, {', catchBlock);
 
@@ -538,6 +555,23 @@ test('default-model persistence keeps queued reloads behind the validated transa
   assert.match(modelReloadSource, /I\.releaseModelReloadQueueHold = function releaseModelReloadQueueHold/);
   assert.match(handler, /var keepReloadQueueHeld = reloadSucceeded && !!queueHoldToken;/);
   assert.match(handler, /if \(!keepReloadQueueHeld\) schedulePendingModelReload\(\);/);
+});
+
+test('default-model persistence timeout releases the reload queue before rollback', async () => {
+  const harness = createResetHarness({
+    putNeverResolves: true,
+    persistenceTimeoutMs: 5,
+    hasQueueHoldRelease: true,
+  });
+  const result = await harness.window.runResetToDefaultModel();
+  const operationTypes = harness.calls
+    .filter((call) => call.type !== 'toast')
+    .map((call) => call.type);
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'default_model_persist_timeout');
+  assert.deepEqual(operationTypes, ['return', 'reload', 'put', 'release', 'reload']);
+  assert.equal(harness.calls.find((call) => call.type === 'put').options.signal.aborted, true);
 });
 
 test('default-model reset restores the persisted prior model when PUT reports failure', async () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -16,6 +16,10 @@ const modelDisplaySource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-ui/model-display.js'),
   'utf8',
 );
+const pngtuberSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/pngtuber-core.js'),
+  'utf8',
+);
 
 function createDeferred() {
   let resolve;
@@ -279,6 +283,10 @@ test('return model lookup is cancelled with the shared lifecycle', () => {
   assert.match(modelDisplaySource, /const returnSignal = returnLifecycle && returnLifecycle\.signal/);
   assert.match(modelDisplaySource, /returnSignal \? \{ signal: returnSignal \} : undefined/);
   assert.match(modelDisplaySource, /if \(isReturnCancelled\(\)\) \{[\s\S]*?return false;/);
+  assert.match(modelDisplaySource, /await window\.loadPNGTuberAvatar\([\s\S]*?returnSignal \? \{ signal: returnSignal \} : undefined/);
+  assert.match(pngtuberSource, /async function loadPNGTuberAvatar\(config, options = \{\}\)/);
+  assert.match(pngtuberSource, /const isReturnCancelled = \(\) => !!\(returnSignal && returnSignal\.aborted\)/);
+  assert.match(pngtuberSource, /await this\.setupLayeredAdapter\(\{ config: normalizedConfig, isCurrentLoad, signal \}\)/);
 });
 
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -426,6 +426,11 @@ test('position persistence cannot block return completion', () => {
   assert.doesNotMatch(returnTransitionsSource, /await saveReturnModelPosition\(/);
   assert.match(returnTransitionsSource, /void saveReturnModelPosition\('pngtuber'\)/);
   assert.match(returnTransitionsSource, /void saveReturnModelPosition\('live2d'\)/);
+  assert.match(returnTransitionsSource, /async function settleReturnedModelBounds\(shouldSaveWhenUnchanged, options = \{\}\)/);
+  assert.match(returnTransitionsSource, /waitForReturnTransitionOperation\([\s\S]*?returnSignal/);
+  assert.match(surfaceSource, /settleReturnedModelBounds\(returnModelWasMoved, \{[\s\S]*?signal: returnLifecycle\.signal/);
+  assert.match(surfaceSource, /if \(returnedModelShown\) hideReturnedModelForRetry\(\);/);
+  assert.match(surfaceSource, /\['live2d', 'vrm', 'mmd', 'pngtuber'\]\.forEach/);
 });
 
 test('default-model reset validates Live2D before persisting and restores on failure', () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -57,6 +57,8 @@ function createResetHarness({
   putOk = true,
   putData = { success: true },
   putNeverResolves = false,
+  putRejects = false,
+  persistenceStatusData = { success: true, state: 'succeeded' },
   persistenceTimeoutMs = 10_000,
   hasQueueHoldRelease = false,
 } = {}) {
@@ -96,12 +98,21 @@ function createResetHarness({
   };
   const document = { querySelector: () => null };
   const fetch = async (url, options) => {
-    calls.push({ type: 'put', url, options });
+    const isPersistenceStatus = url.includes('/catgirl/l2d/persistence/');
+    calls.push({ type: isPersistenceStatus ? 'status' : 'put', url, options });
+    if (isPersistenceStatus) {
+      return {
+        ok: persistenceStatusData.success === true,
+        status: persistenceStatusData.success === true ? 200 : 404,
+        async json() { return persistenceStatusData; },
+      };
+    }
     if (putNeverResolves) {
       return new Promise((resolve, reject) => {
         options.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
       });
     }
+    if (putRejects) throw new Error('response_lost');
     return {
       ok: putOk,
       status: putOk ? 200 : 500,
@@ -470,6 +481,22 @@ test('PNGTuber retry state participates in the canonical goodbye predicate', () 
   assert.match(autoGoodbyeSource, /return window\.isNekoGoodbyeModeActive\(\);/);
 });
 
+test('PNGTuber dragged placement is consumed only after return settlement succeeds', () => {
+  const completeDispatch = surfaceSource.indexOf("new CustomEvent('neko:cat-return-complete'");
+  const pendingClear = surfaceSource.lastIndexOf(
+    'I.pendingPngtuberReturnConfig = null;',
+    completeDispatch,
+  );
+
+  assert.doesNotMatch(modelDisplaySource, /I\.pendingPngtuberReturnConfig = null;/);
+  assert.notEqual(pendingClear, -1);
+  assert.ok(pendingClear < completeDispatch);
+  assert.match(
+    surfaceSource.slice(pendingClear - 80, completeDispatch),
+    /if \(isReturningToPngtuber\) \{[\s\S]*?I\.pendingPngtuberReturnConfig = null;/,
+  );
+});
+
 test('default-model return skips restoring the model that is about to be replaced', () => {
   const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
   const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
@@ -520,7 +547,9 @@ test('default-model reset validates Live2D before persisting and restores on fai
   assert.match(resetSource, /if \(defaultReloadResult !== true\)/);
   assert.match(resetSource, /apply_runtime: false/);
   assert.match(resetSource, /putData\.success !== true/);
-  assert.match(resetSource, /if \(defaultReloadAttempted && !defaultPersisted && reloadModel\)/);
+  assert.match(resetSource, /persistence_operation_id: persistenceOperationId/);
+  assert.match(resetSource, /await waitForPersistenceResult\(\)/);
+  assert.match(resetSource, /if \(defaultReloadAttempted && !defaultPersisted && !persistenceOutcomeUnknown && reloadModel\)/);
 });
 
 test('default-model reset loads the built-in Live2D before persisting it', async () => {
@@ -575,7 +604,7 @@ test('default-model persistence keeps queued reloads behind the validated transa
   assert.match(handler, /if \(!keepReloadQueueHeld\) schedulePendingModelReload\(\);/);
 });
 
-test('default-model persistence timeout releases the reload queue before rollback', async () => {
+test('default-model persistence timeout releases the reload queue and reconciles server success', async () => {
   const harness = createResetHarness({
     putNeverResolves: true,
     persistenceTimeoutMs: 5,
@@ -586,10 +615,51 @@ test('default-model persistence timeout releases the reload queue before rollbac
     .filter((call) => call.type !== 'toast')
     .map((call) => call.type);
 
-  assert.equal(result.success, false);
-  assert.equal(result.error, 'default_model_persist_timeout');
-  assert.deepEqual(operationTypes, ['return', 'reload', 'put', 'release', 'reload']);
+  assert.equal(result.success, true);
+  assert.deepEqual(operationTypes, ['return', 'reload', 'put', 'release', 'status']);
   assert.equal(harness.calls.find((call) => call.type === 'put').options.signal.aborted, true);
+});
+
+test('confirmed persistence failure rolls back with recent reload deduplication bypassed', async () => {
+  const harness = createResetHarness({
+    putNeverResolves: true,
+    persistenceStatusData: { success: true, state: 'failed', error: 'save_failed' },
+    persistenceTimeoutMs: 5,
+    hasQueueHoldRelease: true,
+  });
+  const result = await harness.window.runResetToDefaultModel();
+  const reloads = harness.calls.filter((call) => call.type === 'reload');
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /^default_model_persist_failed/);
+  assert.equal(reloads.length, 2);
+  assert.equal(reloads[1].options.bypassRecentDedup, true);
+});
+
+test('lost persistence response reconciles the server result before rollback', async () => {
+  const harness = createResetHarness({
+    putRejects: true,
+    persistenceStatusData: { success: true, state: 'succeeded' },
+    hasQueueHoldRelease: true,
+  });
+  const result = await harness.window.runResetToDefaultModel();
+
+  assert.equal(result.success, true);
+  assert.deepEqual(
+    harness.calls.filter((call) => call.type !== 'toast').map((call) => call.type),
+    ['return', 'reload', 'put', 'release', 'status'],
+  );
+  assert.equal(harness.calls.filter((call) => call.type === 'reload').length, 1);
+});
+
+test('rollback reload bypasses the one-second completed-request deduplication path', () => {
+  const handlerStart = modelReloadSource.indexOf('I.handleModelReload = async function handleModelReload');
+  const handlerEnd = modelReloadSource.indexOf('I.handleReloadModelParametersMessage =', handlerStart);
+  const handler = modelReloadSource.slice(handlerStart, handlerEnd);
+
+  assert.match(handler, /var bypassRecentDedup = !!reloadOptions\.bypassRecentDedup;/);
+  assert.match(handler, /if \(!bypassRecentDedup && !queueHoldToken && window\._lastModelReloadKey === reloadKey/);
+  assert.match(resetSource, /bypassRecentDedup: true/);
 });
 
 test('default-model reset restores the persisted prior model when PUT reports failure', async () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -188,15 +188,14 @@ test('a timed-out return lifecycle aborts and releases the canonical handler loc
   assert.ok(parts.beginNekoCatReturnLifecycle());
 });
 
-test('a standard return lifecycle has a finite default timeout', async () => {
+test('a standard user return remains untimed unless a caller supplies a deadline', () => {
   const harness = createReturnHarness();
   const parts = harness.window.__appUiParts;
   const lifecycle = parts.beginNekoCatReturnLifecycle({ source: 'live2d-return-click' });
 
-  assert.ok(lifecycle.timeoutId, 'standard returns must not hold the handler lock forever');
-  harness.fireTimer(lifecycle.timeoutId);
-  assert.equal(await lifecycle.promise, false);
-  assert.equal(parts.nekoCatReturnLifecycle, null);
+  assert.equal(lifecycle.timeoutId, null);
+  assert.deepEqual(harness.activeTimerIds(), []);
+  parts.finishNekoCatReturnLifecycle(lifecycle, true);
 });
 
 for (const [modelType, subType, expectedEvent] of [
@@ -358,4 +357,11 @@ test('default-model reset restores the previous runtime model after a failed res
   assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.mmdModel/);
   assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.cubism4Model/);
   assert.match(resetSource, /throw new Error\('model_reload_unavailable'\)/);
+  assert.match(resetSource, /defaultModelPersisted = true/);
+  assert.match(resetSource, /if \(defaultModelPersisted && previousModelPersistencePayload\)/);
+  assert.match(resetSource, /body: JSON\.stringify\(previousModelPersistencePayload\)/);
+  assert.ok(
+    resetSource.indexOf('body: JSON.stringify(previousModelPersistencePayload)') < rollbackCall,
+    'persistent binding must be rolled back before the previous runtime model is restored',
+  );
 });

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -26,6 +26,7 @@ function createReturnHarness({
   subType = '',
   visibleReturnType = '',
   transitionDirection = '',
+  returnInProgress = false,
 } = {}) {
   const listeners = new Map();
   const dispatched = [];
@@ -39,6 +40,13 @@ function createReturnHarness({
     });
   }
   const transition = transitionDirection ? createDeferred() : null;
+  const returnLifecycle = returnInProgress ? createDeferred() : null;
+  if (returnLifecycle) {
+    parts.nekoCatReturnLifecycle = {
+      settled: false,
+      promise: returnLifecycle.promise,
+    };
+  }
   if (transition) {
     parts.nekoModelCatTransitionActive = {
       direction: transitionDirection,
@@ -119,6 +127,11 @@ function createReturnHarness({
       parts.nekoModelCatTransitionActive = null;
       transition.resolve({ completed: true, direction: transitionDirection });
     },
+    completeReturnLifecycle(restored) {
+      assert.ok(returnLifecycle, 'the harness has no active return lifecycle');
+      parts.nekoCatReturnLifecycle = null;
+      returnLifecycle.resolve(restored === true);
+    },
   };
 }
 
@@ -127,6 +140,22 @@ test('programmatic goodbye return is a no-op when the model is already present',
   harness.setGoodbyeActive(false);
   assert.equal(await harness.window.appUi.returnFromGoodbye(), true);
   assert.equal(harness.dispatched.length, 0);
+});
+
+test('canonical return lifecycle admits only one handler until it settles', async () => {
+  const harness = createReturnHarness();
+  const parts = harness.window.__appUiParts;
+  const first = parts.beginNekoCatReturnLifecycle();
+
+  assert.ok(first);
+  assert.equal(parts.beginNekoCatReturnLifecycle(), null);
+  parts.finishNekoCatReturnLifecycle(first, false);
+  assert.equal(await first.promise, false);
+
+  const next = parts.beginNekoCatReturnLifecycle();
+  assert.ok(next);
+  parts.finishNekoCatReturnLifecycle(next, true);
+  assert.equal(await next.promise, true);
 });
 
 for (const [modelType, subType, expectedEvent] of [
@@ -190,15 +219,28 @@ test('programmatic return joins an existing cat-to-model transition without redi
   assert.equal(await result, true);
 });
 
-test('blocked viewport aborts joined programmatic returns instead of leaving them to time out', () => {
-  const guardStart = surfaceSource.indexOf('if (!preReturnViewportReady.ready) {');
-  const guardEnd = surfaceSource.indexOf('let hadCatCycle = false;', guardStart);
-  const blockedViewportGuard = surfaceSource.slice(guardStart, guardEnd);
+test('programmatic return joins the active return lifecycle after goodbye flags are cleared', async () => {
+  const harness = createReturnHarness({ returnInProgress: true });
+  harness.setGoodbyeActive(false);
+  const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+  await Promise.resolve();
 
-  assert.notEqual(guardStart, -1);
-  assert.notEqual(guardEnd, -1);
-  assert.match(blockedViewportGuard, /new CustomEvent\('neko:cat-return-abort'/);
-  assert.match(blockedViewportGuard, /reason:\s*'model-viewport-not-ready'/);
+  assert.equal(harness.dispatched.length, 0);
+  harness.completeReturnLifecycle(true);
+  assert.equal(await result, true);
+});
+
+test('the canonical return lifecycle serializes handlers and aborts a blocked viewport', () => {
+  const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
+  const lifecycleStart = surfaceSource.indexOf('const returnLifecycle = I.beginNekoCatReturnLifecycle();', handlerStart);
+  const viewportWait = surfaceSource.indexOf('await I.ensureModelViewportReadyBeforeShowCurrentModel()', handlerStart);
+  const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
+  const handlerSource = surfaceSource.slice(handlerStart, handlerEnd);
+
+  assert.ok(handlerStart < lifecycleStart && lifecycleStart < viewportWait);
+  assert.match(handlerSource, /if \(!returnLifecycle\) \{[\s\S]*?return;/);
+  assert.match(handlerSource, /returnAbortReason = 'model-viewport-not-ready';/);
+  assert.match(handlerSource, /new CustomEvent\('neko:cat-return-abort'/);
 });
 
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -16,6 +16,14 @@ const modelReloadSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-interpage/bootstrap-resources-and-model-reload.js'),
   'utf8',
 );
+const goodbyeResourceSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-ui/bootstrap-goodbye-and-toasts.js'),
+  'utf8',
+);
+const autoGoodbyeSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-auto-goodbye.js'),
+  'utf8',
+);
 const modelDisplaySource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-ui/model-display.js'),
   'utf8',
@@ -406,6 +414,27 @@ test('the canonical return lifecycle serializes handlers and aborts a blocked vi
   assert.match(surfaceSource, /new CustomEvent\('neko:cat-return-abort'/);
 });
 
+test('a cancelled committed return restores the complete suspended goodbye state', () => {
+  const retryStart = surfaceSource.indexOf('function hideReturnedModelForRetry(goodbyeResourceSnapshot)');
+  const retryEnd = surfaceSource.indexOf('function restoreReturnBallAfterBlockedModelViewport', retryStart);
+  const retrySource = surfaceSource.slice(retryStart, retryEnd);
+  const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
+  const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
+  const handlerSource = surfaceSource.slice(handlerStart, handlerEnd);
+
+  assert.match(retrySource, /live2dManager\.setLocked\(true/);
+  assert.match(retrySource, /vrmManager\.core\.setLocked\(true\)/);
+  assert.match(retrySource, /mmdManager\.core\.setLocked\(true\)/);
+  assert.match(retrySource, /I\.reapplyGoodbyeResourceSuspend\(goodbyeResourceSnapshot\)/);
+  assert.match(handlerSource, /if \(returnStateCommitted\) \{\s*hideReturnedModelForRetry\(retryGoodbyeResourceSnapshot\)/);
+  assert.match(handlerSource, /reason: 'return-abort-rollback'/);
+  assert.match(goodbyeResourceSource, /I\.reapplyGoodbyeResourceSuspend = function reapplyGoodbyeResourceSuspend/);
+  assert.match(goodbyeResourceSource, /snapshot\.subtitleWindowWasVisible = !!prior\.subtitleWindowWasVisible/);
+  assert.match(goodbyeResourceSource, /snapshot\.agentHudWasVisible = !!prior\.agentHudWasVisible/);
+  assert.match(autoGoodbyeSource, /window\.addEventListener\('neko:cat-return-abort', handleReturnAbort\)/);
+  assert.match(autoGoodbyeSource, /syncGoodbyeSilentState\(true, 'return-abort'\)/);
+});
+
 test('default-model return skips restoring the model that is about to be replaced', () => {
   const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
   const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
@@ -433,7 +462,7 @@ test('position persistence cannot block return completion', () => {
   assert.match(returnTransitionsSource, /async function settleReturnedModelBounds\(shouldSaveWhenUnchanged, options = \{\}\)/);
   assert.match(returnTransitionsSource, /waitForReturnTransitionOperation\([\s\S]*?returnSignal/);
   assert.match(surfaceSource, /settleReturnedModelBounds\(returnModelWasMoved, \{[\s\S]*?signal: returnLifecycle\.signal/);
-  assert.match(surfaceSource, /if \(returnedModelShown\) hideReturnedModelForRetry\(\);/);
+  assert.match(surfaceSource, /if \(returnStateCommitted\) \{\s*hideReturnedModelForRetry\(retryGoodbyeResourceSnapshot\)/);
   assert.match(surfaceSource, /\['live2d', 'vrm', 'mmd', 'pngtuber'\]\.forEach/);
 });
 

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -12,6 +12,10 @@ const resetSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-interpage/listeners-and-api.js'),
   'utf8',
 );
+const modelReloadSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-interpage/bootstrap-resources-and-model-reload.js'),
+  'utf8',
+);
 const modelDisplaySource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-ui/model-display.js'),
   'utf8',
@@ -481,6 +485,15 @@ test('default-model reset does not persist a superseded temporary reload', async
     harness.calls.filter((call) => call.type !== 'toast').map((call) => call.type),
     ['return', 'reload'],
   );
+});
+
+test('direct model reloads publish their final success result to callers', () => {
+  const handlerStart = modelReloadSource.indexOf('I.handleModelReload = async function handleModelReload');
+  const handlerEnd = modelReloadSource.indexOf('I.handleReloadModelParametersMessage =', handlerStart);
+  const handler = modelReloadSource.slice(handlerStart, handlerEnd);
+
+  assert.match(handler, /resolveReload\(window\._lastModelReloadResult\);/);
+  assert.match(handler, /return window\._lastModelReloadResult === true;\s*}/);
 });
 
 test('default-model reset restores the persisted prior model when PUT reports failure', async () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -598,7 +598,7 @@ test('default-model persistence keeps queued reloads behind the validated transa
   const handler = modelReloadSource.slice(handlerStart, handlerEnd);
 
   assert.match(reset, /queueHoldToken: reloadQueueHoldToken/);
-  assert.match(reset, /defaultPersisted = true;\s*if \(reloadQueueHeld\) \{\s*I\.releaseModelReloadQueueHold/);
+  assert.match(reset, /defaultPersisted = true;[\s\S]*?if \(reloadQueueHeld\) \{\s*I\.releaseModelReloadQueueHold/);
   assert.match(modelReloadSource, /I\.releaseModelReloadQueueHold = function releaseModelReloadQueueHold/);
   assert.match(handler, /var keepReloadQueueHeld = reloadSucceeded && !!queueHoldToken;/);
   assert.match(handler, /if \(!keepReloadQueueHeld\) schedulePendingModelReload\(\);/);
@@ -616,7 +616,9 @@ test('default-model persistence timeout releases the reload queue and reconciles
     .map((call) => call.type);
 
   assert.equal(result.success, true);
-  assert.deepEqual(operationTypes, ['return', 'reload', 'put', 'release', 'status']);
+  assert.deepEqual(operationTypes, ['return', 'reload', 'put', 'release', 'status', 'reload']);
+  const reloads = harness.calls.filter((call) => call.type === 'reload');
+  assert.equal(reloads[1].options.bypassRecentDedup, true);
   assert.equal(harness.calls.find((call) => call.type === 'put').options.signal.aborted, true);
 });
 
@@ -647,9 +649,9 @@ test('lost persistence response reconciles the server result before rollback', a
   assert.equal(result.success, true);
   assert.deepEqual(
     harness.calls.filter((call) => call.type !== 'toast').map((call) => call.type),
-    ['return', 'reload', 'put', 'release', 'status'],
+    ['return', 'reload', 'put', 'release', 'status', 'reload'],
   );
-  assert.equal(harness.calls.filter((call) => call.type === 'reload').length, 1);
+  assert.equal(harness.calls.filter((call) => call.type === 'reload').length, 2);
 });
 
 test('rollback reload bypasses the one-second completed-request deduplication path', () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -1,0 +1,145 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const surfaceSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-ui/surface-floating-controls.js'),
+  'utf8',
+);
+const resetSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-interpage/listeners-and-api.js'),
+  'utf8',
+);
+
+function createReturnHarness({ modelType = 'live2d', subType = '', visibleReturnType = '' } = {}) {
+  const listeners = new Map();
+  const dispatched = [];
+  let goodbyeActive = true;
+  let nextTimerId = 1;
+
+  const parts = { mod: {} };
+  if (visibleReturnType) {
+    parts.getVisibleIdleReturnBallContainer = () => ({
+      id: `${visibleReturnType}-return-button-container`,
+    });
+  }
+
+  const window = {
+    appUi: {},
+    __appUiParts: parts,
+    lanlan_config: {
+      model_type: modelType,
+      live3d_sub_type: subType,
+    },
+    isNekoGoodbyeModeActive: () => goodbyeActive,
+    addEventListener(type, listener) {
+      const bucket = listeners.get(type) || [];
+      bucket.push(listener);
+      listeners.set(type, bucket);
+    },
+    removeEventListener(type, listener) {
+      const bucket = listeners.get(type) || [];
+      listeners.set(type, bucket.filter((entry) => entry !== listener));
+    },
+    dispatchEvent(event) {
+      dispatched.push(event);
+      for (const listener of [...(listeners.get(event.type) || [])]) listener(event);
+      return true;
+    },
+    setTimeout() {
+      nextTimerId += 1;
+      return nextTimerId;
+    },
+    clearTimeout() {},
+  };
+
+  class CustomEvent {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.detail = init.detail;
+    }
+  }
+
+  vm.runInNewContext(surfaceSource, {
+    window,
+    document: {},
+    CustomEvent,
+    console,
+    Promise,
+    Number,
+    String,
+    Object,
+    Array,
+    Math,
+  }, { filename: 'surface-floating-controls.js' });
+
+  return {
+    window,
+    dispatched,
+    setGoodbyeActive(value) {
+      goodbyeActive = value === true;
+    },
+    complete() {
+      goodbyeActive = false;
+      window.dispatchEvent(new CustomEvent('neko:cat-return-complete'));
+    },
+    abort() {
+      window.dispatchEvent(new CustomEvent('neko:cat-return-abort'));
+    },
+  };
+}
+
+test('programmatic goodbye return is a no-op when the model is already present', async () => {
+  const harness = createReturnHarness();
+  harness.setGoodbyeActive(false);
+  assert.equal(await harness.window.appUi.returnFromGoodbye(), true);
+  assert.equal(harness.dispatched.length, 0);
+});
+
+for (const [modelType, subType, expectedEvent] of [
+  ['live2d', '', 'live2d-return-click'],
+  ['vrm', '', 'vrm-return-click'],
+  ['live3d', 'vrm', 'vrm-return-click'],
+  ['live3d', 'mmd', 'mmd-return-click'],
+  ['mmd', '', 'mmd-return-click'],
+  ['pngtuber', '', 'pngtuber-return-click'],
+]) {
+  test(`programmatic goodbye return follows the ${modelType}/${subType || '-'} model path`, async () => {
+    const harness = createReturnHarness({ modelType, subType });
+    const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+
+    assert.equal(harness.dispatched[0].type, expectedEvent);
+    assert.equal(harness.dispatched[0].detail.source, 'reset-to-default-model');
+
+    harness.complete();
+    assert.equal(await result, true);
+  });
+}
+
+test('programmatic goodbye return reports an aborted canonical return', async () => {
+  const harness = createReturnHarness({ modelType: 'live3d', subType: 'mmd' });
+  const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+  harness.abort();
+  assert.equal(await result, false);
+});
+
+test('visible return control wins over a stale configured model type', async () => {
+  const harness = createReturnHarness({ modelType: 'vrm', visibleReturnType: 'mmd' });
+  const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+  assert.equal(harness.dispatched[0].type, 'mmd-return-click');
+  harness.complete();
+  assert.equal(await result, true);
+});
+
+test('default-model reset returns from goodbye before persisting or hot-reloading', () => {
+  const returnCall = resetSource.indexOf('await window.appUi.returnFromGoodbye({');
+  const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);
+  const reloadCall = resetSource.indexOf('await I.handleModelReload(lanlanName, reloadOpts)', persistenceCall);
+
+  assert.notEqual(returnCall, -1);
+  assert.ok(returnCall < persistenceCall, 'the full return path must restore the Pet viewport before persistence');
+  assert.ok(persistenceCall < reloadCall, 'the saved default must be visible to the hot reload');
+  assert.match(resetSource, /if \(!returnedFromGoodbye \|\| goodbyeStillActive\)/);
+});

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -190,6 +190,17 @@ test('programmatic return joins an existing cat-to-model transition without redi
   assert.equal(await result, true);
 });
 
+test('blocked viewport aborts joined programmatic returns instead of leaving them to time out', () => {
+  const guardStart = surfaceSource.indexOf('if (!preReturnViewportReady.ready) {');
+  const guardEnd = surfaceSource.indexOf('let hadCatCycle = false;', guardStart);
+  const blockedViewportGuard = surfaceSource.slice(guardStart, guardEnd);
+
+  assert.notEqual(guardStart, -1);
+  assert.notEqual(guardEnd, -1);
+  assert.match(blockedViewportGuard, /new CustomEvent\('neko:cat-return-abort'/);
+  assert.match(blockedViewportGuard, /reason:\s*'model-viewport-not-ready'/);
+});
+
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {
   const returnCall = resetSource.indexOf('await window.appUi.returnFromGoodbye({');
   const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -13,7 +13,20 @@ const resetSource = fs.readFileSync(
   'utf8',
 );
 
-function createReturnHarness({ modelType = 'live2d', subType = '', visibleReturnType = '' } = {}) {
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createReturnHarness({
+  modelType = 'live2d',
+  subType = '',
+  visibleReturnType = '',
+  transitionDirection = '',
+} = {}) {
   const listeners = new Map();
   const dispatched = [];
   let goodbyeActive = true;
@@ -24,6 +37,19 @@ function createReturnHarness({ modelType = 'live2d', subType = '', visibleReturn
     parts.getVisibleIdleReturnBallContainer = () => ({
       id: `${visibleReturnType}-return-button-container`,
     });
+  }
+  const transition = transitionDirection ? createDeferred() : null;
+  if (transition) {
+    parts.nekoModelCatTransitionActive = {
+      direction: transitionDirection,
+      promise: transition.promise,
+    };
+    parts.isNekoModelCatTransitionActive = (direction = '') => {
+      const active = parts.nekoModelCatTransitionActive;
+      return !!(active && (!direction || active.direction === direction));
+    };
+  } else {
+    parts.isNekoModelCatTransitionActive = () => false;
   }
 
   const window = {
@@ -88,6 +114,11 @@ function createReturnHarness({ modelType = 'live2d', subType = '', visibleReturn
     abort() {
       window.dispatchEvent(new CustomEvent('neko:cat-return-abort'));
     },
+    completeTransition() {
+      assert.ok(transition, 'the harness has no active transition');
+      parts.nekoModelCatTransitionActive = null;
+      transition.resolve({ completed: true, direction: transitionDirection });
+    },
   };
 }
 
@@ -129,6 +160,32 @@ test('visible return control wins over a stale configured model type', async () 
   const harness = createReturnHarness({ modelType: 'vrm', visibleReturnType: 'mmd' });
   const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
   assert.equal(harness.dispatched[0].type, 'mmd-return-click');
+  harness.complete();
+  assert.equal(await result, true);
+});
+
+test('programmatic return waits for an in-flight model-to-cat transition', async () => {
+  const harness = createReturnHarness({
+    modelType: 'live3d',
+    subType: 'mmd',
+    transitionDirection: 'model-to-cat',
+  });
+  const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+
+  assert.equal(harness.dispatched.length, 0, 'return must not be dropped into the active transition');
+  harness.completeTransition();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(harness.dispatched[0].type, 'mmd-return-click');
+
+  harness.complete();
+  assert.equal(await result, true);
+});
+
+test('programmatic return joins an existing cat-to-model transition without redispatching', async () => {
+  const harness = createReturnHarness({ transitionDirection: 'cat-to-model' });
+  const result = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+  await Promise.resolve();
+  assert.equal(harness.dispatched.length, 0);
   harness.complete();
   assert.equal(await result, true);
 });

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -360,6 +360,11 @@ test('default-model reset restores the previous runtime model after a failed res
   assert.match(resetSource, /defaultModelPersisted = true/);
   assert.match(resetSource, /if \(defaultModelPersisted && previousModelPersistencePayload\)/);
   assert.match(resetSource, /body: JSON\.stringify\(previousModelPersistencePayload\)/);
+  assert.match(resetSource, /var charactersResp = await fetch\('\/api\/characters'\)/);
+  assert.match(resetSource, /hasOwn\.call\(previousReservedLive2D, 'idle_animation'\)/);
+  assert.match(resetSource, /previousModelPersistencePayload\.live2d_idle_animation = previousReservedLive2D\.idle_animation/);
+  assert.match(resetSource, /previousModelPersistencePayload\.live2d_idle_animation = previousCharacterData\.live2d_idle_animation/);
+  assert.match(resetSource, /previousModelPersistencePayload\.live2d_idle_animation = previousAvatarLive2D\.idle_animation/);
   assert.ok(
     resetSource.indexOf('body: JSON.stringify(previousModelPersistencePayload)') < rollbackCall,
     'persistent binding must be rolled back before the previous runtime model is restored',

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -525,6 +525,21 @@ test('direct model reloads publish their final success result to callers', () =>
   assert.match(handler, /return window\._lastModelReloadResult === true;\s*}/);
 });
 
+test('default-model persistence keeps queued reloads behind the validated transaction', () => {
+  const resetStart = resetSource.indexOf('async function resetToDefaultModel() {');
+  const resetEnd = resetSource.indexOf('// Public API', resetStart);
+  const reset = resetSource.slice(resetStart, resetEnd);
+  const handlerStart = modelReloadSource.indexOf('I.handleModelReload = async function handleModelReload');
+  const handlerEnd = modelReloadSource.indexOf('I.handleReloadModelParametersMessage =', handlerStart);
+  const handler = modelReloadSource.slice(handlerStart, handlerEnd);
+
+  assert.match(reset, /queueHoldToken: reloadQueueHoldToken/);
+  assert.match(reset, /defaultPersisted = true;\s*if \(reloadQueueHeld\) \{\s*I\.releaseModelReloadQueueHold/);
+  assert.match(modelReloadSource, /I\.releaseModelReloadQueueHold = function releaseModelReloadQueueHold/);
+  assert.match(handler, /var keepReloadQueueHeld = reloadSucceeded && !!queueHoldToken;/);
+  assert.match(handler, /if \(!keepReloadQueueHeld\) schedulePendingModelReload\(\);/);
+});
+
 test('default-model reset restores the persisted prior model when PUT reports failure', async () => {
   const harness = createResetHarness({ putData: { success: false, error: 'save_failed' } });
   const result = await harness.window.runResetToDefaultModel();

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -8,6 +8,10 @@ const surfaceSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-ui/surface-floating-controls.js'),
   'utf8',
 );
+const appStateSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-state.js'),
+  'utf8',
+);
 const resetSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-interpage/listeners-and-api.js'),
   'utf8',
@@ -442,6 +446,7 @@ test('a cancelled committed return restores the complete suspended goodbye state
   assert.match(retrySource, /live2dManager\.setLocked\(true/);
   assert.match(retrySource, /vrmManager\.core\.setLocked\(true\)/);
   assert.match(retrySource, /mmdManager\.core\.setLocked\(true\)/);
+  assert.match(retrySource, /window\.pngtuberManager\]\.forEach/);
   assert.match(retrySource, /I\.reapplyGoodbyeResourceSuspend\(goodbyeResourceSnapshot\)/);
   assert.match(handlerSource, /if \(returnStateCommitted\) \{\s*hideReturnedModelForRetry\(retryGoodbyeResourceSnapshot\)/);
   assert.match(handlerSource, /reason: 'return-abort-rollback'/);
@@ -450,6 +455,19 @@ test('a cancelled committed return restores the complete suspended goodbye state
   assert.match(goodbyeResourceSource, /snapshot\.agentHudWasVisible = !!prior\.agentHudWasVisible/);
   assert.match(autoGoodbyeSource, /window\.addEventListener\('neko:cat-return-abort', handleReturnAbort\)/);
   assert.match(autoGoodbyeSource, /syncGoodbyeSilentState\(true, 'return-abort'\)/);
+});
+
+test('PNGTuber retry state participates in the canonical goodbye predicate', () => {
+  const window = {
+    pngtuberManager: { _goodbyeClicked: true },
+  };
+
+  vm.runInNewContext(appStateSource, { window }, { filename: 'app-state.js' });
+
+  assert.equal(window.isNekoGoodbyeModeActive(), true);
+  assert.match(surfaceSource, /window\.pngtuberManager\._goodbyeClicked = true;/);
+  assert.match(surfaceSource, /window\.pngtuberManager\._goodbyeClicked = false;/);
+  assert.match(autoGoodbyeSource, /return window\.isNekoGoodbyeModeActive\(\);/);
 });
 
 test('default-model return skips restoring the model that is about to be replaced', () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -37,6 +37,7 @@ function createResetHarness({
   hasReloadHandler = true,
   returnResult = true,
   temporaryReloadFails = false,
+  temporaryReloadResult = true,
   putOk = true,
   putData = { success: true },
 } = {}) {
@@ -51,7 +52,7 @@ function createResetHarness({
       if (options.temporaryConfig && temporaryReloadFails) {
         throw new Error('temporary_reload_failed');
       }
-      return true;
+      return options.temporaryConfig ? temporaryReloadResult : true;
     };
   }
   const window = {
@@ -443,6 +444,8 @@ test('default-model reset validates Live2D before persisting and restores on fai
   assert.match(resetSource, /if \(!returnedFromGoodbye\)/);
   assert.match(resetSource, /model_path: DEFAULT_LIVE2D_MODEL_PATH/);
   assert.match(resetSource, /skipIdleRestore: true/);
+  assert.match(resetSource, /if \(defaultReloadResult !== true\)/);
+  assert.match(resetSource, /apply_runtime: false/);
   assert.match(resetSource, /putData\.success !== true/);
   assert.match(resetSource, /if \(defaultReloadAttempted && !defaultPersisted && reloadModel\)/);
 });
@@ -459,6 +462,20 @@ test('default-model reset loads the built-in Live2D before persisting it', async
   const reload = harness.calls.find((call) => call.type === 'reload');
   assert.equal(reload.options.temporaryConfig.model_type, 'live2d');
   assert.equal(reload.options.temporaryConfig.model_path, '/static/yui-lolita/yui-lolita.model3.json');
+  const put = harness.calls.find((call) => call.type === 'put');
+  assert.equal(JSON.parse(put.options.body).apply_runtime, false);
+});
+
+test('default-model reset does not persist a superseded temporary reload', async () => {
+  const harness = createResetHarness({ temporaryReloadResult: false });
+  const result = await harness.window.runResetToDefaultModel();
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'default_model_reload_not_applied');
+  assert.deepEqual(
+    harness.calls.filter((call) => call.type !== 'toast').map((call) => call.type),
+    ['return', 'reload'],
+  );
 });
 
 test('default-model reset restores the persisted prior model when PUT reports failure', async () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -12,6 +12,10 @@ const resetSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-interpage/listeners-and-api.js'),
   'utf8',
 );
+const modelDisplaySource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-ui/model-display.js'),
+  'utf8',
+);
 
 function createDeferred() {
   let resolve;
@@ -32,6 +36,7 @@ function createReturnHarness({
   const dispatched = [];
   let goodbyeActive = true;
   let nextTimerId = 1;
+  const timers = new Map();
 
   const parts = { mod: {} };
   if (visibleReturnType) {
@@ -82,11 +87,15 @@ function createReturnHarness({
       for (const listener of [...(listeners.get(event.type) || [])]) listener(event);
       return true;
     },
-    setTimeout() {
+    setTimeout(callback) {
+      const timerId = nextTimerId;
       nextTimerId += 1;
-      return nextTimerId;
+      timers.set(timerId, callback);
+      return timerId;
     },
-    clearTimeout() {},
+    clearTimeout(timerId) {
+      timers.delete(timerId);
+    },
   };
 
   class CustomEvent {
@@ -132,6 +141,12 @@ function createReturnHarness({
       parts.nekoCatReturnLifecycle = null;
       returnLifecycle.resolve(restored === true);
     },
+    fireTimer(timerId) {
+      const callback = timers.get(timerId);
+      assert.equal(typeof callback, 'function', `timer ${timerId} is not active`);
+      timers.delete(timerId);
+      callback();
+    },
   };
 }
 
@@ -156,6 +171,22 @@ test('canonical return lifecycle admits only one handler until it settles', asyn
   assert.ok(next);
   parts.finishNekoCatReturnLifecycle(next, true);
   assert.equal(await next.promise, true);
+});
+
+test('a timed-out return lifecycle aborts and releases the canonical handler lock', async () => {
+  const harness = createReturnHarness();
+  const parts = harness.window.__appUiParts;
+  const lifecycle = parts.beginNekoCatReturnLifecycle({
+    source: 'live2d-return-click',
+    timeoutMs: 1000,
+  });
+
+  harness.fireTimer(lifecycle.timeoutId);
+  assert.equal(await lifecycle.promise, false);
+  assert.equal(parts.nekoCatReturnLifecycle, null);
+  assert.equal(harness.dispatched.at(-1).type, 'neko:cat-return-abort');
+  assert.equal(harness.dispatched.at(-1).detail.reason, 'return-lifecycle-timeout');
+  assert.ok(parts.beginNekoCatReturnLifecycle());
 });
 
 for (const [modelType, subType, expectedEvent] of [
@@ -232,7 +263,7 @@ test('programmatic return joins the active return lifecycle after goodbye flags 
 
 test('the canonical return lifecycle serializes handlers and aborts a blocked viewport', () => {
   const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
-  const lifecycleStart = surfaceSource.indexOf('const returnLifecycle = I.beginNekoCatReturnLifecycle();', handlerStart);
+  const lifecycleStart = surfaceSource.indexOf('const returnLifecycle = I.beginNekoCatReturnLifecycle({', handlerStart);
   const viewportWait = surfaceSource.indexOf('await I.ensureModelViewportReadyBeforeShowCurrentModel()', handlerStart);
   const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
   const handlerSource = surfaceSource.slice(handlerStart, handlerEnd);
@@ -240,7 +271,14 @@ test('the canonical return lifecycle serializes handlers and aborts a blocked vi
   assert.ok(handlerStart < lifecycleStart && lifecycleStart < viewportWait);
   assert.match(handlerSource, /if \(!returnLifecycle\) \{[\s\S]*?return;/);
   assert.match(handlerSource, /returnAbortReason = 'model-viewport-not-ready';/);
-  assert.match(handlerSource, /new CustomEvent\('neko:cat-return-abort'/);
+  assert.match(handlerSource, /I\.abortNekoCatReturnLifecycle\(returnLifecycle, returnAbortReason\)/);
+  assert.match(surfaceSource, /new CustomEvent\('neko:cat-return-abort'/);
+});
+
+test('return model lookup is cancelled with the shared lifecycle', () => {
+  assert.match(modelDisplaySource, /const returnSignal = returnLifecycle && returnLifecycle\.signal/);
+  assert.match(modelDisplaySource, /returnSignal \? \{ signal: returnSignal \} : undefined/);
+  assert.match(modelDisplaySource, /if \(isReturnCancelled\(\)\) \{[\s\S]*?return false;/);
 });
 
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -137,6 +137,9 @@ function createReturnHarness({
       parts.nekoCatReturnLifecycle = null;
       returnLifecycle.resolve(restored === true);
     },
+    activeTimerIds() {
+      return [...timers.keys()];
+    },
     fireTimer(timerId) {
       const callback = timers.get(timerId);
       assert.equal(typeof callback, 'function', `timer ${timerId} is not active`);
@@ -183,6 +186,17 @@ test('a timed-out return lifecycle aborts and releases the canonical handler loc
   assert.equal(harness.dispatched.at(-1).type, 'neko:cat-return-abort');
   assert.equal(harness.dispatched.at(-1).detail.reason, 'return-lifecycle-timeout');
   assert.ok(parts.beginNekoCatReturnLifecycle());
+});
+
+test('a standard return lifecycle has a finite default timeout', async () => {
+  const harness = createReturnHarness();
+  const parts = harness.window.__appUiParts;
+  const lifecycle = parts.beginNekoCatReturnLifecycle({ source: 'live2d-return-click' });
+
+  assert.ok(lifecycle.timeoutId, 'standard returns must not hold the handler lock forever');
+  harness.fireTimer(lifecycle.timeoutId);
+  assert.equal(await lifecycle.promise, false);
+  assert.equal(parts.nekoCatReturnLifecycle, null);
 });
 
 for (const [modelType, subType, expectedEvent] of [
@@ -271,6 +285,27 @@ test('programmatic return joins the active return lifecycle after goodbye flags 
   assert.equal(await result, true);
 });
 
+test('programmatic timeout aborts a joined return lifecycle', async () => {
+  const harness = createReturnHarness();
+  const parts = harness.window.__appUiParts;
+  const lifecycle = parts.beginNekoCatReturnLifecycle({
+    source: 'live2d-return-click',
+    timeoutMs: 5000,
+  });
+  harness.setGoodbyeActive(false);
+  const result = harness.window.appUi.returnFromGoodbye({
+    source: 'reset-to-default-model',
+    timeoutMs: 1000,
+  });
+  const helperTimerId = harness.activeTimerIds().find((timerId) => timerId !== lifecycle.timeoutId);
+
+  harness.fireTimer(helperTimerId);
+  assert.equal(await result, false);
+  assert.equal(await lifecycle.promise, false);
+  assert.equal(parts.nekoCatReturnLifecycle, null);
+  assert.equal(harness.dispatched.at(-1).detail.reason, 'programmatic-return-timeout');
+});
+
 test('the canonical return lifecycle serializes handlers and aborts a blocked viewport', () => {
   const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
   const lifecycleStart = surfaceSource.indexOf('const returnLifecycle = I.beginNekoCatReturnLifecycle({', handlerStart);
@@ -299,7 +334,7 @@ test('default-model return skips restoring the model that is about to be replace
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {
   const returnCall = resetSource.indexOf('await window.appUi.returnFromGoodbye({');
   const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);
-  const reloadCall = resetSource.indexOf('await I.handleModelReload(lanlanName, reloadOpts)', persistenceCall);
+  const reloadCall = resetSource.indexOf('await reloadModel(lanlanName, reloadOpts)', persistenceCall);
 
   assert.notEqual(returnCall, -1);
   assert.ok(returnCall < persistenceCall, 'the full return path must restore the Pet viewport before persistence');
@@ -307,4 +342,20 @@ test('default-model reset returns from goodbye before persisting or hot-reloadin
   assert.match(resetSource, /retryViewportRestore: true/);
   assert.match(resetSource, /restoreCurrentModel: false/);
   assert.match(resetSource, /if \(!returnedFromGoodbye\)/);
+});
+
+test('default-model reset restores the previous runtime model after a failed reset', () => {
+  const returnCall = resetSource.indexOf('returnedFromGoodbye = await window.appUi.returnFromGoodbye({');
+  const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);
+  const reloadCall = resetSource.indexOf('await reloadModel(lanlanName, reloadOpts)', persistenceCall);
+  const catchBlock = resetSource.indexOf('} catch (e) {', reloadCall);
+  const rollbackCall = resetSource.indexOf('temporaryConfig: Object.assign({ success: true }, previousModelConfig)', catchBlock);
+
+  assert.ok(returnCall < persistenceCall && persistenceCall < reloadCall && reloadCall < catchBlock);
+  assert.ok(catchBlock < rollbackCall, 'failure must reload the previous in-memory model config');
+  assert.match(resetSource, /if \(returnWasNeeded && returnedFromGoodbye && previousModelConfig && reloadModel\)/);
+  assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.vrmModel/);
+  assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.mmdModel/);
+  assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.cubism4Model/);
+  assert.match(resetSource, /throw new Error\('model_reload_unavailable'\)/);
 });

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -137,9 +137,6 @@ function createReturnHarness({
       parts.nekoCatReturnLifecycle = null;
       returnLifecycle.resolve(restored === true);
     },
-    activeTimerIds() {
-      return [...timers.keys()];
-    },
     fireTimer(timerId) {
       const callback = timers.get(timerId);
       assert.equal(typeof callback, 'function', `timer ${timerId} is not active`);
@@ -186,16 +183,6 @@ test('a timed-out return lifecycle aborts and releases the canonical handler loc
   assert.equal(harness.dispatched.at(-1).type, 'neko:cat-return-abort');
   assert.equal(harness.dispatched.at(-1).detail.reason, 'return-lifecycle-timeout');
   assert.ok(parts.beginNekoCatReturnLifecycle());
-});
-
-test('a standard user return remains untimed unless a caller supplies a deadline', () => {
-  const harness = createReturnHarness();
-  const parts = harness.window.__appUiParts;
-  const lifecycle = parts.beginNekoCatReturnLifecycle({ source: 'live2d-return-click' });
-
-  assert.equal(lifecycle.timeoutId, null);
-  assert.deepEqual(harness.activeTimerIds(), []);
-  parts.finishNekoCatReturnLifecycle(lifecycle, true);
 });
 
 for (const [modelType, subType, expectedEvent] of [
@@ -284,27 +271,6 @@ test('programmatic return joins the active return lifecycle after goodbye flags 
   assert.equal(await result, true);
 });
 
-test('programmatic timeout aborts a joined return lifecycle', async () => {
-  const harness = createReturnHarness();
-  const parts = harness.window.__appUiParts;
-  const lifecycle = parts.beginNekoCatReturnLifecycle({
-    source: 'live2d-return-click',
-    timeoutMs: 5000,
-  });
-  harness.setGoodbyeActive(false);
-  const result = harness.window.appUi.returnFromGoodbye({
-    source: 'reset-to-default-model',
-    timeoutMs: 1000,
-  });
-  const helperTimerId = harness.activeTimerIds().find((timerId) => timerId !== lifecycle.timeoutId);
-
-  harness.fireTimer(helperTimerId);
-  assert.equal(await result, false);
-  assert.equal(await lifecycle.promise, false);
-  assert.equal(parts.nekoCatReturnLifecycle, null);
-  assert.equal(harness.dispatched.at(-1).detail.reason, 'programmatic-return-timeout');
-});
-
 test('the canonical return lifecycle serializes handlers and aborts a blocked viewport', () => {
   const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
   const lifecycleStart = surfaceSource.indexOf('const returnLifecycle = I.beginNekoCatReturnLifecycle({', handlerStart);
@@ -333,7 +299,7 @@ test('default-model return skips restoring the model that is about to be replace
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {
   const returnCall = resetSource.indexOf('await window.appUi.returnFromGoodbye({');
   const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);
-  const reloadCall = resetSource.indexOf('await reloadModel(lanlanName, reloadOpts)', persistenceCall);
+  const reloadCall = resetSource.indexOf('await I.handleModelReload(lanlanName, reloadOpts)', persistenceCall);
 
   assert.notEqual(returnCall, -1);
   assert.ok(returnCall < persistenceCall, 'the full return path must restore the Pet viewport before persistence');
@@ -341,32 +307,4 @@ test('default-model reset returns from goodbye before persisting or hot-reloadin
   assert.match(resetSource, /retryViewportRestore: true/);
   assert.match(resetSource, /restoreCurrentModel: false/);
   assert.match(resetSource, /if \(!returnedFromGoodbye\)/);
-});
-
-test('default-model reset restores the previous runtime model after a failed reset', () => {
-  const returnCall = resetSource.indexOf('returnedFromGoodbye = await window.appUi.returnFromGoodbye({');
-  const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);
-  const reloadCall = resetSource.indexOf('await reloadModel(lanlanName, reloadOpts)', persistenceCall);
-  const catchBlock = resetSource.indexOf('} catch (e) {', reloadCall);
-  const rollbackCall = resetSource.indexOf('temporaryConfig: Object.assign({ success: true }, previousModelConfig)', catchBlock);
-
-  assert.ok(returnCall < persistenceCall && persistenceCall < reloadCall && reloadCall < catchBlock);
-  assert.ok(catchBlock < rollbackCall, 'failure must reload the previous in-memory model config');
-  assert.match(resetSource, /if \(returnWasNeeded && returnedFromGoodbye && previousModelConfig && reloadModel\)/);
-  assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.vrmModel/);
-  assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.mmdModel/);
-  assert.match(resetSource, /previousModelConfig\.model_path = String\(window\.cubism4Model/);
-  assert.match(resetSource, /throw new Error\('model_reload_unavailable'\)/);
-  assert.match(resetSource, /defaultModelPersisted = true/);
-  assert.match(resetSource, /if \(defaultModelPersisted && previousModelPersistencePayload\)/);
-  assert.match(resetSource, /body: JSON\.stringify\(previousModelPersistencePayload\)/);
-  assert.match(resetSource, /var charactersResp = await fetch\('\/api\/characters'\)/);
-  assert.match(resetSource, /hasOwn\.call\(previousReservedLive2D, 'idle_animation'\)/);
-  assert.match(resetSource, /previousModelPersistencePayload\.live2d_idle_animation = previousReservedLive2D\.idle_animation/);
-  assert.match(resetSource, /previousModelPersistencePayload\.live2d_idle_animation = previousCharacterData\.live2d_idle_animation/);
-  assert.match(resetSource, /previousModelPersistencePayload\.live2d_idle_animation = previousAvatarLive2D\.idle_animation/);
-  assert.ok(
-    resetSource.indexOf('body: JSON.stringify(previousModelPersistencePayload)') < rollbackCall,
-    'persistent binding must be rolled back before the previous runtime model is restored',
-  );
 });

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -12,6 +12,18 @@ const resetSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-interpage/listeners-and-api.js'),
   'utf8',
 );
+const modelDisplaySource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-ui/model-display.js'),
+  'utf8',
+);
+const returnTransitionsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/app/app-ui/return-transitions.js'),
+  'utf8',
+);
+const pngtuberSource = fs.readFileSync(
+  path.resolve(__dirname, '../../static/pngtuber-core.js'),
+  'utf8',
+);
 
 function createDeferred() {
   let resolve;
@@ -19,6 +31,69 @@ function createDeferred() {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+function createResetHarness({
+  hasReloadHandler = true,
+  returnResult = true,
+  temporaryReloadFails = false,
+  putOk = true,
+  putData = { success: true },
+} = {}) {
+  const functionStart = resetSource.indexOf('async function resetToDefaultModel() {');
+  const functionEnd = resetSource.indexOf('    // =====================================================================\n    // Public API', functionStart);
+  const resetFunction = resetSource.slice(functionStart, functionEnd);
+  const calls = [];
+  const parts = {};
+  if (hasReloadHandler) {
+    parts.handleModelReload = async (name, options = {}) => {
+      calls.push({ type: 'reload', name, options });
+      if (options.temporaryConfig && temporaryReloadFails) {
+        throw new Error('temporary_reload_failed');
+      }
+      return true;
+    };
+  }
+  const window = {
+    lanlan_config: { lanlan_name: 'Test Character' },
+    appUi: {
+      async returnFromGoodbye(options) {
+        calls.push({ type: 'return', options });
+        return returnResult;
+      },
+    },
+    showStatusToast(message) {
+      calls.push({ type: 'toast', message });
+    },
+  };
+  const document = { querySelector: () => null };
+  const fetch = async (url, options) => {
+    calls.push({ type: 'put', url, options });
+    return {
+      ok: putOk,
+      status: putOk ? 200 : 500,
+      async json() { return putData; },
+    };
+  };
+
+  vm.runInNewContext(`
+    var DEFAULT_LIVE2D_MODEL_NAME = 'yui-lolita';
+    var DEFAULT_LIVE2D_MODEL_PATH = '/static/yui-lolita/yui-lolita.model3.json';
+    var _resetToDefaultModelInFlight = false;
+    ${resetFunction}
+    window.runResetToDefaultModel = resetToDefaultModel;
+  `, {
+    window,
+    document,
+    fetch,
+    I: parts,
+    console,
+    JSON,
+    String,
+    encodeURIComponent,
+  }, { filename: 'reset-to-default-model.js' });
+
+  return { window, calls };
 }
 
 function createReturnHarness({
@@ -45,6 +120,9 @@ function createReturnHarness({
   if (returnLifecycle) {
     parts.nekoCatReturnLifecycle = {
       settled: false,
+      cancelled: false,
+      source: 'live2d-return-click',
+      resolve: returnLifecycle.resolve,
       promise: returnLifecycle.promise,
     };
   }
@@ -68,6 +146,7 @@ function createReturnHarness({
       model_type: modelType,
       live3d_sub_type: subType,
     },
+    AbortController,
     isNekoGoodbyeModeActive: () => goodbyeActive,
     addEventListener(type, listener) {
       const bucket = listeners.get(type) || [];
@@ -137,6 +216,9 @@ function createReturnHarness({
       parts.nekoCatReturnLifecycle = null;
       returnLifecycle.resolve(restored === true);
     },
+    activeTimerIds() {
+      return [...timers.keys()];
+    },
     fireTimer(timerId) {
       const callback = timers.get(timerId);
       assert.equal(typeof callback, 'function', `timer ${timerId} is not active`);
@@ -183,6 +265,21 @@ test('a timed-out return lifecycle aborts and releases the canonical handler loc
   assert.equal(harness.dispatched.at(-1).type, 'neko:cat-return-abort');
   assert.equal(harness.dispatched.at(-1).detail.reason, 'return-lifecycle-timeout');
   assert.ok(parts.beginNekoCatReturnLifecycle());
+});
+
+test('an ordinary return has a finite timeout and restores a retryable state', async () => {
+  const harness = createReturnHarness();
+  const parts = harness.window.__appUiParts;
+  const lifecycle = parts.beginNekoCatReturnLifecycle({ source: 'live2d-return-click' });
+  let retryRestores = 0;
+  lifecycle.restoreRetryState = () => { retryRestores += 1; };
+
+  assert.notEqual(lifecycle.timeoutId, null);
+  harness.fireTimer(lifecycle.timeoutId);
+  assert.equal(await lifecycle.promise, false);
+  assert.equal(retryRestores, 1);
+  assert.equal(lifecycle.signal.aborted, true);
+  assert.equal(parts.nekoCatReturnLifecycle, null);
 });
 
 for (const [modelType, subType, expectedEvent] of [
@@ -271,10 +368,28 @@ test('programmatic return joins the active return lifecycle after goodbye flags 
   assert.equal(await result, true);
 });
 
+test('programmatic timeout aborts a joined return lifecycle', async () => {
+  const harness = createReturnHarness({ returnInProgress: true });
+  const parts = harness.window.__appUiParts;
+  const lifecycle = parts.nekoCatReturnLifecycle;
+  harness.setGoodbyeActive(false);
+  const result = harness.window.appUi.returnFromGoodbye({
+    source: 'reset-to-default-model',
+    timeoutMs: 1000,
+  });
+  const helperTimerId = harness.activeTimerIds()[0];
+
+  harness.fireTimer(helperTimerId);
+  assert.equal(await result, false);
+  assert.equal(await lifecycle.promise, false);
+  assert.equal(parts.nekoCatReturnLifecycle, null);
+  assert.equal(harness.dispatched.at(-1).detail.reason, 'programmatic-return-timeout');
+});
+
 test('the canonical return lifecycle serializes handlers and aborts a blocked viewport', () => {
   const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
   const lifecycleStart = surfaceSource.indexOf('const returnLifecycle = I.beginNekoCatReturnLifecycle({', handlerStart);
-  const viewportWait = surfaceSource.indexOf('await I.ensureModelViewportReadyBeforeShowCurrentModel()', handlerStart);
+  const viewportWait = surfaceSource.indexOf('await I.ensureModelViewportReadyBeforeShowCurrentModel({', handlerStart);
   const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
   const handlerSource = surfaceSource.slice(handlerStart, handlerEnd);
 
@@ -292,19 +407,77 @@ test('default-model return skips restoring the model that is about to be replace
   const handlerSource = surfaceSource.slice(handlerStart, handlerEnd);
 
   assert.match(handlerSource, /const restoreCurrentModel = returnDetail\.restoreCurrentModel !== false;/);
-  assert.match(handlerSource, /if \(restoreCurrentModel\) \{[\s\S]*?await I\.showCurrentModel\(\);/);
+  assert.match(handlerSource, /if \(restoreCurrentModel\) \{[\s\S]*?await I\.showCurrentModel\(\{ signal: returnLifecycle\.signal \}\);/);
   assert.match(handlerSource, /else \{[\s\S]*?window\._nekoModelReturnEnterRect = null;/);
 });
 
-test('default-model reset returns from goodbye before persisting or hot-reloading', () => {
+test('return cancellation reaches model lookup and PNGTuber loading', () => {
+  assert.match(modelDisplaySource, /async function showCurrentModel\(options = \{\}\)/);
+  assert.match(surfaceSource, /ensureModelViewportReadyBeforeShowCurrentModel\(\{[\s\S]*?signal: returnLifecycle\.signal/);
+  assert.match(modelDisplaySource, /returnSignal \? \{ signal: returnSignal \} : undefined/);
+  assert.match(modelDisplaySource, /await window\.loadPNGTuberAvatar\([\s\S]*?signal: returnSignal/);
+  assert.match(pngtuberSource, /async function loadPNGTuberAvatar\(config, options = \{\}\)/);
+  assert.match(pngtuberSource, /await this\.setupLayeredAdapter\(\{ config: normalizedConfig, isCurrentLoad, signal \}\)/);
+  assert.match(pngtuberSource, /&& !\(signal && signal\.aborted\)/);
+});
+
+test('position persistence cannot block return completion', () => {
+  assert.doesNotMatch(returnTransitionsSource, /await saveReturnModelPosition\(/);
+  assert.match(returnTransitionsSource, /void saveReturnModelPosition\('pngtuber'\)/);
+  assert.match(returnTransitionsSource, /void saveReturnModelPosition\('live2d'\)/);
+});
+
+test('default-model reset validates Live2D before persisting and restores on failure', () => {
   const returnCall = resetSource.indexOf('await window.appUi.returnFromGoodbye({');
-  const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", returnCall);
-  const reloadCall = resetSource.indexOf('await I.handleModelReload(lanlanName, reloadOpts)', persistenceCall);
+  const reloadCall = resetSource.indexOf('await reloadModel(lanlanName, {', returnCall);
+  const persistenceCall = resetSource.indexOf("var putResp = await fetch(putUrl", reloadCall);
+  const catchBlock = resetSource.indexOf('} catch (e) {', persistenceCall);
+  const restoreCall = resetSource.indexOf('await reloadModel(lanlanName, {', catchBlock);
 
   assert.notEqual(returnCall, -1);
-  assert.ok(returnCall < persistenceCall, 'the full return path must restore the Pet viewport before persistence');
-  assert.ok(persistenceCall < reloadCall, 'the saved default must be visible to the hot reload');
+  assert.ok(returnCall < reloadCall, 'the full return path must restore the Pet viewport before hot reload');
+  assert.ok(reloadCall < persistenceCall, 'the default Live2D must load before persistence');
+  assert.ok(catchBlock < restoreCall, 'failure must re-fetch and restore the persisted previous model');
   assert.match(resetSource, /retryViewportRestore: true/);
   assert.match(resetSource, /restoreCurrentModel: false/);
   assert.match(resetSource, /if \(!returnedFromGoodbye\)/);
+  assert.match(resetSource, /model_path: DEFAULT_LIVE2D_MODEL_PATH/);
+  assert.match(resetSource, /skipIdleRestore: true/);
+  assert.match(resetSource, /putData\.success !== true/);
+  assert.match(resetSource, /if \(defaultReloadAttempted && !defaultPersisted && reloadModel\)/);
+});
+
+test('default-model reset loads the built-in Live2D before persisting it', async () => {
+  const harness = createResetHarness();
+  const result = await harness.window.runResetToDefaultModel();
+  const operationTypes = harness.calls
+    .filter((call) => call.type !== 'toast')
+    .map((call) => call.type);
+
+  assert.deepEqual(operationTypes, ['return', 'reload', 'put']);
+  assert.equal(result.success, true);
+  const reload = harness.calls.find((call) => call.type === 'reload');
+  assert.equal(reload.options.temporaryConfig.model_type, 'live2d');
+  assert.equal(reload.options.temporaryConfig.model_path, '/static/yui-lolita/yui-lolita.model3.json');
+});
+
+test('default-model reset restores the persisted prior model when PUT reports failure', async () => {
+  const harness = createResetHarness({ putData: { success: false, error: 'save_failed' } });
+  const result = await harness.window.runResetToDefaultModel();
+  const reloads = harness.calls.filter((call) => call.type === 'reload');
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'HTTP 200: save_failed');
+  assert.equal(reloads.length, 2);
+  assert.ok(reloads[0].options.temporaryConfig);
+  assert.equal(reloads[1].options.temporaryConfig, undefined);
+});
+
+test('default-model reset fails before leaving goodbye when hot reload is unavailable', async () => {
+  const harness = createResetHarness({ hasReloadHandler: false });
+  const result = await harness.window.runResetToDefaultModel();
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'model_reload_unavailable');
+  assert.deepEqual(harness.calls.map((call) => call.type), ['toast']);
 });

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -12,14 +12,6 @@ const resetSource = fs.readFileSync(
   path.resolve(__dirname, '../../static/app/app-interpage/listeners-and-api.js'),
   'utf8',
 );
-const modelDisplaySource = fs.readFileSync(
-  path.resolve(__dirname, '../../static/app/app-ui/model-display.js'),
-  'utf8',
-);
-const pngtuberSource = fs.readFileSync(
-  path.resolve(__dirname, '../../static/pngtuber-core.js'),
-  'utf8',
-);
 
 function createDeferred() {
   let resolve;
@@ -228,6 +220,20 @@ test('visible return control wins over a stale configured model type', async () 
   assert.equal(await result, true);
 });
 
+test('a visible PNGTuber return control is sufficient to detect goodbye state', async () => {
+  const harness = createReturnHarness({ modelType: 'pngtuber', visibleReturnType: 'pngtuber' });
+  harness.setGoodbyeActive(false);
+  const result = harness.window.appUi.returnFromGoodbye({
+    source: 'reset-to-default-model',
+    restoreCurrentModel: false,
+  });
+
+  assert.equal(harness.dispatched[0].type, 'pngtuber-return-click');
+  assert.equal(harness.dispatched[0].detail.restoreCurrentModel, false);
+  harness.complete();
+  assert.equal(await result, true);
+});
+
 test('programmatic return waits for an in-flight model-to-cat transition', async () => {
   const harness = createReturnHarness({
     modelType: 'live3d',
@@ -274,19 +280,20 @@ test('the canonical return lifecycle serializes handlers and aborts a blocked vi
 
   assert.ok(handlerStart < lifecycleStart && lifecycleStart < viewportWait);
   assert.match(handlerSource, /if \(!returnLifecycle\) \{[\s\S]*?return;/);
+  assert.match(handlerSource, /while \([\s\S]*?returnDetail\.retryViewportRestore === true[\s\S]*?!returnLifecycle\.cancelled[\s\S]*?\)/);
   assert.match(handlerSource, /returnAbortReason = 'model-viewport-not-ready';/);
   assert.match(handlerSource, /I\.abortNekoCatReturnLifecycle\(returnLifecycle, returnAbortReason\)/);
   assert.match(surfaceSource, /new CustomEvent\('neko:cat-return-abort'/);
 });
 
-test('return model lookup is cancelled with the shared lifecycle', () => {
-  assert.match(modelDisplaySource, /const returnSignal = returnLifecycle && returnLifecycle\.signal/);
-  assert.match(modelDisplaySource, /returnSignal \? \{ signal: returnSignal \} : undefined/);
-  assert.match(modelDisplaySource, /if \(isReturnCancelled\(\)\) \{[\s\S]*?return false;/);
-  assert.match(modelDisplaySource, /await window\.loadPNGTuberAvatar\([\s\S]*?returnSignal \? \{ signal: returnSignal \} : undefined/);
-  assert.match(pngtuberSource, /async function loadPNGTuberAvatar\(config, options = \{\}\)/);
-  assert.match(pngtuberSource, /const isReturnCancelled = \(\) => !!\(returnSignal && returnSignal\.aborted\)/);
-  assert.match(pngtuberSource, /await this\.setupLayeredAdapter\(\{ config: normalizedConfig, isCurrentLoad, signal \}\)/);
+test('default-model return skips restoring the model that is about to be replaced', () => {
+  const handlerStart = surfaceSource.indexOf('const handleReturnClick = async (event) => {');
+  const handlerEnd = surfaceSource.indexOf("window.addEventListener('live2d-return-click'", handlerStart);
+  const handlerSource = surfaceSource.slice(handlerStart, handlerEnd);
+
+  assert.match(handlerSource, /const restoreCurrentModel = returnDetail\.restoreCurrentModel !== false;/);
+  assert.match(handlerSource, /if \(restoreCurrentModel\) \{[\s\S]*?await I\.showCurrentModel\(\);/);
+  assert.match(handlerSource, /else \{[\s\S]*?window\._nekoModelReturnEnterRect = null;/);
 });
 
 test('default-model reset returns from goodbye before persisting or hot-reloading', () => {
@@ -297,5 +304,7 @@ test('default-model reset returns from goodbye before persisting or hot-reloadin
   assert.notEqual(returnCall, -1);
   assert.ok(returnCall < persistenceCall, 'the full return path must restore the Pet viewport before persistence');
   assert.ok(persistenceCall < reloadCall, 'the saved default must be visible to the hot reload');
-  assert.match(resetSource, /if \(!returnedFromGoodbye \|\| goodbyeStillActive\)/);
+  assert.match(resetSource, /retryViewportRestore: true/);
+  assert.match(resetSource, /restoreCurrentModel: false/);
+  assert.match(resetSource, /if \(!returnedFromGoodbye\)/);
 });

--- a/tests/unit/test_app_character_static.py
+++ b/tests/unit/test_app_character_static.py
@@ -45,6 +45,9 @@ def test_character_switch_clears_goodbye_state_only_after_commit():
     assert "channel.postMessage(payload)" in source
     assert "manager._goodbyeClicked = false" in source
     assert "manager._isInReturnState = false" in source
+    assert "clearManagerReturnState(window.pngtuberManager);" in source
+    assert "window.pngtuberManager && window.pngtuberManager._returnButtonContainer" in source
+    assert "document.getElementById('pngtuber-return-button-container')" in source
     assert "window.__nekoGoodbyeSilentState = {" in source
     assert "action: 'goodbye_state'" in source
     assert "active: false" in source

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -953,7 +953,7 @@ def test_model_cat_transition_contract_is_present():
         return_handler_start:
         source.index("await settleReturnedModelBounds(returnModelWasMoved);", return_handler_start)
     ]
-    pre_return_guard_start = return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();")
+    pre_return_guard_start = return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();")
     return_handler_start_block = return_handler_full_block[
         pre_return_guard_start:
         return_handler_full_block.index("const isReturningToPngtuber")
@@ -961,7 +961,7 @@ def test_model_cat_transition_contract_is_present():
     _assert_source_order(
         return_handler_start_block,
         "return handler preserves cat state until viewport can restore",
-        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
         "if (!preReturnViewportReady.ready) {",
         "restoreReturnBallAfterBlockedModelViewport(event);",
         "return;",
@@ -981,7 +981,7 @@ def test_model_cat_transition_contract_is_present():
         "if (window._goodbyeHideTimerId) {",
         "clearTimeout(window._goodbyeHideTimerId);",
         "window._goodbyeHideTimerId = null;",
-        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
     )
     return_handler_after_viewport_guard_block = return_handler_full_block[
         pre_return_guard_start:
@@ -995,7 +995,7 @@ def test_model_cat_transition_contract_is_present():
         "runGoodbyeResetClickIfActive('return-viewport-blocked');",
         "return;",
     )
-    assert return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
+    assert return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
     restore_block = source[
         source.index("function restoreReturnBallAfterBlockedModelViewport(event)"):
         source.index("// 请她回来按钮（统一处理函数）")

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -938,7 +938,7 @@ def test_model_cat_transition_contract_is_present():
     return_handler_guard_start = source.index("let modelDisplayReady = true;")
     return_handler_block = source[
         return_handler_guard_start:
-        source.index("await settleReturnedModelBounds(returnModelWasMoved);", return_handler_guard_start)
+        source.index("const modelBoundsSettled = await settleReturnedModelBounds(", return_handler_guard_start)
     ]
     _assert_source_order(
         return_handler_block,
@@ -951,7 +951,7 @@ def test_model_cat_transition_contract_is_present():
     return_handler_start = source.index("const handleReturnClick = async (event) => {")
     return_handler_full_block = source[
         return_handler_start:
-        source.index("await settleReturnedModelBounds(returnModelWasMoved);", return_handler_start)
+        source.index("const modelBoundsSettled = await settleReturnedModelBounds(", return_handler_start)
     ]
     pre_return_guard_start = return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({")
     return_handler_start_block = return_handler_full_block[
@@ -1008,14 +1008,21 @@ def test_model_cat_transition_contract_is_present():
     assert "revealReturnBallContainer(container, 'return-ball-model-viewport-blocked')" in restore_block
     assert "showReturnBallContainer(container, returnRect)" in restore_block
     settle_block = source[
-        source.index("async function settleReturnedModelBounds(shouldSaveWhenUnchanged)"):
+        source.index("async function settleReturnedModelBounds(shouldSaveWhenUnchanged, options = {})"):
         source.index("function cancelReturnBallReveal(container)")
     ]
+    assert "waitForReturnTransitionOperation(" in settle_block
+    assert "if (operationResult.cancelled || isCancelled()) return false;" in settle_block
+    assert "if (!isCancelled() && shouldSaveWhenUnchanged && activeModelType)" in settle_block
+    assert "signal: returnLifecycle.signal" in return_handler_full_block
+    assert "if (modelBoundsSettled === false || returnLifecycle.cancelled)" in source
+    assert "function hideReturnedModelForRetry()" in source
+    assert "if (returnedModelShown) hideReturnedModelForRetry();" in source
     _assert_source_order(
         settle_block,
         "return settle waits for model enter animation before snap/save",
-        "await waitForModelReturnEnterToSettle();",
-        "await waitForAnimationFrames(2);",
+        "waitForModelReturnEnterToSettle(),",
+        "waitForAnimationFrames(2),",
         "if (window.mmdManager && window.mmdManager.currentModel",
         "if (window.vrmManager && window.vrmManager.currentModel",
         "if (window.live2dManager) {",

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -795,10 +795,10 @@ def test_model_cat_transition_contract_is_present():
     assert "function playModelReturnEnter(container, rect)" in source
     assert "window._nekoModelReturnEnterRect = returnRect || savedRect || null" in source
     assert "consumeModelReturnEnterRect()" in source
-    assert "function ensureModelViewportReadyBeforeShowCurrentModel()" in source
+    assert "function ensureModelViewportReadyBeforeShowCurrentModel(options = {})" in source
     assert "function restoreReturnBallAfterBlockedModelViewport(event)" in source
     assert "function shouldBlockCatToModelTransitionForModelViewport(direction)" in source
-    assert "const modelViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();" in source
+    assert "const modelViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({ signal: returnSignal });" in source
     assert "blocked model display because Pet viewport is still return-ball sized" in source
     assert "function setPendingNativeModelViewportRestoreBounds(bounds)" in source
     assert "if (isNativeReturnBallViewportSize(width, height)) {" in source
@@ -921,7 +921,7 @@ def test_model_cat_transition_contract_is_present():
         "if (nekoModelCatTransitionActive) {",
         "container.setAttribute('data-neko-model-cat-transitioning', direction);",
     )
-    viewport_guard_start = source.index("const modelViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();")
+    viewport_guard_start = source.index("const modelViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({ signal: returnSignal });")
     show_current_model_block = source[
         viewport_guard_start:
         source.index("try {", viewport_guard_start)
@@ -929,7 +929,7 @@ def test_model_cat_transition_contract_is_present():
     _assert_source_order(
         show_current_model_block,
         "showCurrentModel viewport guard ordering",
-        "const modelViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "const modelViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({ signal: returnSignal });",
         "if (!modelViewportReady.ready) {",
         "return false;",
     )
@@ -944,7 +944,7 @@ def test_model_cat_transition_contract_is_present():
         return_handler_block,
         "return handler stops when model viewport is still shrunken",
         "let modelDisplayReady = true;",
-        "modelDisplayReady = await showCurrentModel();",
+        "modelDisplayReady = await showCurrentModel({ signal: returnLifecycle.signal });",
         "if (modelDisplayReady === false) {",
         "return;",
     )
@@ -953,7 +953,7 @@ def test_model_cat_transition_contract_is_present():
         return_handler_start:
         source.index("await settleReturnedModelBounds(returnModelWasMoved);", return_handler_start)
     ]
-    pre_return_guard_start = return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();")
+    pre_return_guard_start = return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({")
     return_handler_start_block = return_handler_full_block[
         pre_return_guard_start:
         return_handler_full_block.index("const isReturningToPngtuber")
@@ -961,7 +961,10 @@ def test_model_cat_transition_contract_is_present():
     _assert_source_order(
         return_handler_start_block,
         "return handler preserves cat state until viewport can restore",
-        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({",
+        "signal: returnLifecycle.signal",
+        "while (",
+        "returnDetail.retryViewportRestore === true",
         "if (!preReturnViewportReady.ready) {",
         "restoreReturnBallAfterBlockedModelViewport(event);",
         "return;",
@@ -981,7 +984,7 @@ def test_model_cat_transition_contract_is_present():
         "if (window._goodbyeHideTimerId) {",
         "clearTimeout(window._goodbyeHideTimerId);",
         "window._goodbyeHideTimerId = null;",
-        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({",
     )
     return_handler_after_viewport_guard_block = return_handler_full_block[
         pre_return_guard_start:
@@ -995,7 +998,7 @@ def test_model_cat_transition_contract_is_present():
         "runGoodbyeResetClickIfActive('return-viewport-blocked');",
         "return;",
     )
-    assert return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
+    assert return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel({") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
     restore_block = source[
         source.index("function restoreReturnBallAfterBlockedModelViewport(event)"):
         source.index("// 请她回来按钮（统一处理函数）")
@@ -1018,11 +1021,15 @@ def test_model_cat_transition_contract_is_present():
         "if (window.live2dManager) {",
     )
     viewport_ready_block = source[
-        source.index("async function ensureModelViewportReadyBeforeShowCurrentModel()"):
+        source.index("async function ensureModelViewportReadyBeforeShowCurrentModel(options = {})"):
         source.index("// --- showCurrentModel ---")
     ]
+    missing_restore_bounds_block = viewport_ready_block[
+        viewport_ready_block.index("if (!restoreBounds) {"):
+        viewport_ready_block.index("if (isModelViewportRestored(restoreBounds))")
+    ]
     _assert_source_order(
-        viewport_ready_block,
+        missing_restore_bounds_block,
         "model viewport guard blocks raw return-ball viewport without trusting invalid target",
         "if (!restoreBounds) {",
         "isNativeReturnBallViewportSize(window.innerWidth, window.innerHeight)",
@@ -1186,7 +1193,7 @@ def test_pngtuber_return_replays_model_enter_animation_after_preparing_container
 
     assert "const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;" in branch
     assert branch.count("consumeModelReturnEnterRect()") == 1
-    assert branch.index("await window.loadPNGTuberAvatar(pngtuberConfig);") < branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
+    assert branch.index("await window.loadPNGTuberAvatar(") < branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
     assert "prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });" in branch
     assert "if (modelReturnEnterRect) {" in branch
     assert "playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);" in branch

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -953,7 +953,7 @@ def test_model_cat_transition_contract_is_present():
         return_handler_start:
         source.index("await settleReturnedModelBounds(returnModelWasMoved);", return_handler_start)
     ]
-    pre_return_guard_start = return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();")
+    pre_return_guard_start = return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();")
     return_handler_start_block = return_handler_full_block[
         pre_return_guard_start:
         return_handler_full_block.index("const isReturningToPngtuber")
@@ -961,7 +961,7 @@ def test_model_cat_transition_contract_is_present():
     _assert_source_order(
         return_handler_start_block,
         "return handler preserves cat state until viewport can restore",
-        "let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
         "if (!preReturnViewportReady.ready) {",
         "restoreReturnBallAfterBlockedModelViewport(event);",
         "return;",
@@ -981,7 +981,7 @@ def test_model_cat_transition_contract_is_present():
         "if (window._goodbyeHideTimerId) {",
         "clearTimeout(window._goodbyeHideTimerId);",
         "window._goodbyeHideTimerId = null;",
-        "let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
     )
     return_handler_after_viewport_guard_block = return_handler_full_block[
         pre_return_guard_start:
@@ -995,7 +995,7 @@ def test_model_cat_transition_contract_is_present():
         "runGoodbyeResetClickIfActive('return-viewport-blocked');",
         "return;",
     )
-    assert return_handler_full_block.index("let preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
+    assert return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
     restore_block = source[
         source.index("function restoreReturnBallAfterBlockedModelViewport(event)"):
         source.index("// 请她回来按钮（统一处理函数）")

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1016,8 +1016,10 @@ def test_model_cat_transition_contract_is_present():
     assert "if (!isCancelled() && shouldSaveWhenUnchanged && activeModelType)" in settle_block
     assert "signal: returnLifecycle.signal" in return_handler_full_block
     assert "if (modelBoundsSettled === false || returnLifecycle.cancelled)" in source
-    assert "function hideReturnedModelForRetry()" in source
-    assert "if (returnedModelShown) hideReturnedModelForRetry();" in source
+    assert "function hideReturnedModelForRetry(goodbyeResourceSnapshot)" in source
+    assert "if (returnStateCommitted) {" in source
+    assert "hideReturnedModelForRetry(retryGoodbyeResourceSnapshot);" in source
+    assert "reapplyGoodbyeResourceSuspend(goodbyeResourceSnapshot);" in source
     _assert_source_order(
         settle_block,
         "return settle waits for model enter animation before snap/save",

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1186,10 +1186,7 @@ def test_pngtuber_return_replays_model_enter_animation_after_preparing_container
 
     assert "const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;" in branch
     assert branch.count("consumeModelReturnEnterRect()") == 1
-    load_index = branch.index("await window.loadPNGTuberAvatar(")
-    cancel_guard_index = branch.index("if (isReturnCancelled()) return false;", load_index)
-    enter_rect_index = branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
-    assert load_index < cancel_guard_index < enter_rect_index
+    assert branch.index("await window.loadPNGTuberAvatar(pngtuberConfig);") < branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
     assert "prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });" in branch
     assert "if (modelReturnEnterRect) {" in branch
     assert "playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);" in branch

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1186,7 +1186,10 @@ def test_pngtuber_return_replays_model_enter_animation_after_preparing_container
 
     assert "const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;" in branch
     assert branch.count("consumeModelReturnEnterRect()") == 1
-    assert branch.index("await window.loadPNGTuberAvatar(pngtuberConfig);") < branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
+    load_index = branch.index("await window.loadPNGTuberAvatar(")
+    cancel_guard_index = branch.index("if (isReturnCancelled()) return false;", load_index)
+    enter_rect_index = branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
+    assert load_index < cancel_guard_index < enter_rect_index
     assert "prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });" in branch
     assert "if (modelReturnEnterRect) {" in branch
     assert "playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);" in branch

--- a/tests/unit/test_cat_idle_state_machine_static.py
+++ b/tests/unit/test_cat_idle_state_machine_static.py
@@ -180,7 +180,9 @@ def test_cat_mind_return_lifecycle_uses_committed_and_completed_boundaries():
 
     viewport_guard = handler.index("if (!preReturnViewportReady.ready) {")
     commit = handler.index("I.publishCatLocalActive(false")
-    show_model = handler.index("modelDisplayReady = await I.showCurrentModel()")
+    show_model = handler.index(
+        "modelDisplayReady = await I.showCurrentModel({ signal: returnLifecycle.signal })"
+    )
     show_model_guard = handler.index("if (modelDisplayReady === false) {")
     composer_restore = handler.index(
         "postGoodbyeChatComposerHiddenState(false, 'return-complete')"

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import importlib
 import json
@@ -42,6 +43,26 @@ class DummyConfigManager:
 
     async def asave_characters(self, characters, character_json_path=None):
         self.save_characters(characters, character_json_path)
+
+
+class CoordinatedConfigManager(DummyConfigManager):
+    def __init__(self, characters):
+        super().__init__(characters)
+        self.load_count = 0
+        self.save_count = 0
+        self.first_save_started = asyncio.Event()
+        self.allow_first_save = asyncio.Event()
+
+    async def aload_characters(self, character_json_path=None):
+        self.load_count += 1
+        return await super().aload_characters(character_json_path)
+
+    async def asave_characters(self, characters, character_json_path=None):
+        self.save_count += 1
+        if self.save_count == 1:
+            self.first_save_started.set()
+            await self.allow_first_save.wait()
+        await super().asave_characters(characters, character_json_path)
 
 
 def test_live2d_idle_animation_is_reserved_and_hidden_from_editable_fields():
@@ -425,6 +446,56 @@ async def test_pngtuber_placement_only_save_skips_a_replaced_binding(monkeypatch
         'applied_runtime': False,
     }
     assert saved is None
+
+
+@pytest.mark.asyncio
+async def test_pngtuber_placement_save_is_atomic_with_a_later_model_selection(monkeypatch):
+    characters = _build_characters_fixture()
+    catgirl = characters['猫娘']['测试角色']
+    set_reserved(catgirl, 'avatar', 'model_type', 'pngtuber')
+    set_reserved(catgirl, 'avatar', 'pngtuber', {
+        'idle_image': '/static/pngtuber/old/idle.png',
+        'scale': 1,
+        'offset_x': 0,
+        'offset_y': 0,
+    })
+    config_manager = CoordinatedConfigManager(characters)
+
+    async def _noop_init_one(_name, *, is_new=False):
+        return None
+
+    monkeypatch.setattr(characters_router_module, 'get_config_manager', lambda: config_manager)
+    monkeypatch.setattr(characters_router_module, 'get_init_one_catgirl', lambda: _noop_init_one)
+
+    placement_task = asyncio.create_task(characters_router_module.update_catgirl_l2d(
+        '测试角色',
+        DummyRequest({
+            'pngtuber_placement': {'offset_x': 25, 'offset_y': -40},
+            'expected_pngtuber_binding': '/static/pngtuber/old/idle.png',
+            'apply_runtime': False,
+        }),
+    ))
+    await asyncio.wait_for(config_manager.first_save_started.wait(), timeout=1)
+    model_selection_task = asyncio.create_task(characters_router_module.update_catgirl_l2d(
+        '测试角色',
+        DummyRequest({
+            'model_type': 'pngtuber',
+            'pngtuber': {'idle_image': '/static/pngtuber/new/idle.png'},
+            'apply_runtime': False,
+        }),
+    ))
+    await asyncio.sleep(0)
+
+    assert config_manager.load_count == 1
+    config_manager.allow_first_save.set()
+    responses = await asyncio.gather(placement_task, model_selection_task)
+
+    assert all(response.status_code == 200 for response in responses)
+    saved_catgirl = config_manager.characters['猫娘']['测试角色']
+    assert get_reserved(saved_catgirl, 'avatar', 'model_type') == 'pngtuber'
+    assert get_reserved(saved_catgirl, 'avatar', 'pngtuber', 'idle_image') == (
+        '/static/pngtuber/new/idle.png'
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -340,6 +340,94 @@ async def test_pngtuber_position_save_can_skip_runtime_refresh(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pngtuber_placement_only_save_preserves_active_model_binding(monkeypatch):
+    characters = _build_characters_fixture()
+    catgirl = characters['猫娘']['测试角色']
+    set_reserved(catgirl, 'avatar', 'pngtuber', {
+        'idle_image': '/static/pngtuber/default/idle.png',
+        'talking_image': '/static/pngtuber/default/talking.png',
+        'scale': 1,
+        'offset_x': 0,
+        'offset_y': 0,
+    })
+
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {
+            'pngtuber_placement': {
+                'scale': 1.5,
+                'offset_x': 24,
+                'offset_y': -36,
+                'mobile_scale': 9,
+                'mobile_offset_x': -7000,
+                'mobile_offset_y': 7000,
+                'position_anchor': 'center',
+                'mirror': True,
+            },
+            'expected_pngtuber_binding': '/static/pngtuber/default/idle.png',
+            'apply_runtime': False,
+        },
+        characters=characters,
+    )
+
+    assert response.status_code == 200
+    assert body == {
+        'success': True,
+        'pngtuber_placement_updated': True,
+        'applied_runtime': False,
+    }
+    saved_catgirl = saved['猫娘']['测试角色']
+    assert get_reserved(saved_catgirl, 'avatar', 'model_type') == 'live3d'
+    assert get_reserved(saved_catgirl, 'avatar', 'live3d_sub_type') == 'vrm'
+    pngtuber = get_reserved(saved_catgirl, 'avatar', 'pngtuber')
+    assert pngtuber['idle_image'] == '/static/pngtuber/default/idle.png'
+    assert pngtuber['talking_image'] == '/static/pngtuber/default/talking.png'
+    assert pngtuber['scale'] == 1.5
+    assert pngtuber['offset_x'] == 24
+    assert pngtuber['offset_y'] == -36
+    assert pngtuber['mobile_scale'] == 5
+    assert pngtuber['mobile_offset_x'] == -5000
+    assert pngtuber['mobile_offset_y'] == 5000
+    assert pngtuber['position_anchor'] == 'center'
+    assert pngtuber['mirror'] is True
+
+
+@pytest.mark.asyncio
+async def test_pngtuber_placement_only_save_skips_a_replaced_binding(monkeypatch):
+    characters = _build_characters_fixture()
+    catgirl = characters['猫娘']['测试角色']
+    set_reserved(catgirl, 'avatar', 'pngtuber', {
+        'idle_image': '/static/pngtuber/new/idle.png',
+        'scale': 2,
+        'offset_x': 10,
+        'offset_y': 20,
+    })
+
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {
+            'pngtuber_placement': {
+                'scale': 1,
+                'offset_x': 99,
+                'offset_y': 99,
+            },
+            'expected_pngtuber_binding': '/static/pngtuber/old/idle.png',
+            'apply_runtime': False,
+        },
+        characters=characters,
+    )
+
+    assert response.status_code == 200
+    assert body == {
+        'success': True,
+        'pngtuber_placement_updated': False,
+        'skipped': 'pngtuber_binding_changed',
+        'applied_runtime': False,
+    }
+    assert saved is None
+
+
+@pytest.mark.asyncio
 async def test_model_update_refreshes_runtime_by_default(monkeypatch):
     init_calls = []
     response, body, _saved = await _call_update(

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import importlib
 import json
+from pathlib import Path
 
 import pytest
 
@@ -21,6 +22,7 @@ def _single_saved_catgirl(saved):
 class DummyRequest:
     def __init__(self, payload):
         self._payload = payload
+        self.query_params = {}
 
     async def json(self):
         return self._payload
@@ -496,6 +498,143 @@ async def test_pngtuber_placement_save_is_atomic_with_a_later_model_selection(mo
     assert get_reserved(saved_catgirl, 'avatar', 'pngtuber', 'idle_image') == (
         '/static/pngtuber/new/idle.png'
     )
+
+
+@pytest.mark.asyncio
+async def test_model_persistence_operation_reports_authoritative_success(monkeypatch):
+    operation_id = 'default-model-test-success'
+    characters_router_module._model_persistence_operations.clear()
+
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {
+            'model_type': 'live2d',
+            'live2d': 'yui-lolita',
+            'live2d_idle_animation': None,
+            'persistence_operation_id': operation_id,
+            'apply_runtime': False,
+        },
+    )
+    status_response = await characters_router_module.get_model_persistence_operation(
+        operation_id
+    )
+    status_body = json.loads(status_response.body)
+
+    assert response.status_code == 200
+    assert body['success'] is True
+    assert saved is not None
+    assert status_body == {
+        'success': True,
+        'operation_id': operation_id,
+        'state': 'succeeded',
+        'error': '',
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancelled_model_persistence_waits_for_save_before_reporting_success(monkeypatch):
+    operation_id = 'default-model-test-cancelled-client'
+    characters_router_module._model_persistence_operations.clear()
+    config_manager = CoordinatedConfigManager(_build_characters_fixture())
+
+    async def _noop_init_one(_name, *, is_new=False):
+        return None
+
+    monkeypatch.setattr(characters_router_module, 'get_config_manager', lambda: config_manager)
+    monkeypatch.setattr(characters_router_module, 'get_init_one_catgirl', lambda: _noop_init_one)
+
+    update_task = asyncio.create_task(characters_router_module.update_catgirl_l2d(
+        '测试角色',
+        DummyRequest({
+            'model_type': 'live2d',
+            'live2d': 'yui-lolita',
+            'live2d_idle_animation': None,
+            'persistence_operation_id': operation_id,
+            'apply_runtime': False,
+        }),
+    ))
+    await asyncio.wait_for(config_manager.first_save_started.wait(), timeout=1)
+    update_task.cancel()
+    await asyncio.sleep(0)
+
+    running_response = await characters_router_module.get_model_persistence_operation(
+        operation_id
+    )
+    assert json.loads(running_response.body)['state'] == 'running'
+
+    config_manager.allow_first_save.set()
+    with pytest.raises(asyncio.CancelledError):
+        await update_task
+
+    status_response = await characters_router_module.get_model_persistence_operation(
+        operation_id
+    )
+    status_body = json.loads(status_response.body)
+    assert status_body['state'] == 'succeeded'
+    saved_catgirl = config_manager.characters['猫娘']['测试角色']
+    assert get_reserved(saved_catgirl, 'avatar', 'model_type') == 'live2d'
+
+
+@pytest.mark.asyncio
+async def test_pngtuber_placement_save_is_atomic_with_later_mmd_settings(monkeypatch):
+    characters = _build_characters_fixture()
+    catgirl = characters['猫娘']['测试角色']
+    set_reserved(catgirl, 'avatar', 'model_type', 'pngtuber')
+    set_reserved(catgirl, 'avatar', 'pngtuber', {
+        'idle_image': '/static/pngtuber/old/idle.png',
+        'offset_x': 0,
+        'offset_y': 0,
+    })
+    config_manager = CoordinatedConfigManager(characters)
+
+    monkeypatch.setattr(
+        characters_router_module,
+        'character_config_mutation_lock',
+        asyncio.Lock(),
+    )
+    monkeypatch.setattr(characters_router_module, 'get_config_manager', lambda: config_manager)
+
+    placement_task = asyncio.create_task(characters_router_module.update_catgirl_l2d(
+        '测试角色',
+        DummyRequest({
+            'pngtuber_placement': {'offset_x': 25, 'offset_y': -40},
+            'expected_pngtuber_binding': '/static/pngtuber/old/idle.png',
+            'apply_runtime': False,
+        }),
+    ))
+    await asyncio.wait_for(config_manager.first_save_started.wait(), timeout=1)
+    mmd_settings_task = asyncio.create_task(
+        characters_router_module.update_catgirl_mmd_settings(
+            '测试角色',
+            DummyRequest({'physics': {'enabled': False, 'strength': 1.5}}),
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert config_manager.load_count == 1
+    config_manager.allow_first_save.set()
+    responses = await asyncio.gather(placement_task, mmd_settings_task)
+
+    assert all(response.status_code == 200 for response in responses)
+    saved_catgirl = config_manager.characters['猫娘']['测试角色']
+    assert get_reserved(saved_catgirl, 'avatar', 'pngtuber', 'offset_x') == 25
+    assert get_reserved(saved_catgirl, 'avatar', 'mmd', 'physics', 'strength') == 1.5
+
+
+def test_all_live2d_model_config_writers_share_the_character_transaction_lock():
+    source = Path(characters_router_module.__file__).read_text(encoding='utf-8')
+
+    for function_name in (
+        'update_catgirl_l2d',
+        'update_catgirl_touch_set',
+        'update_catgirl_lighting',
+        'update_catgirl_mmd_settings',
+    ):
+        function_start = source.index(f'async def {function_name}')
+        next_route = source.find('\n@router.', function_start)
+        function_source = source[function_start:next_route if next_route != -1 else None]
+        assert 'character_config_mutation_lock.acquire()' in function_source
+        assert 'character_config_mutation_lock.release()' in function_source
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -445,6 +445,7 @@ def test_a_script_that_merely_runs_long_still_fails_its_deadline(runner):
 
 
 def test_a_heavy_synchronous_top_level_does_not_push_the_watchdog_past_the_ceiling(
+    monkeypatch,
 ):
     """The deadline is measured from node start, not from when the watchdog arms.
 
@@ -454,31 +455,20 @@ def test_a_heavy_synchronous_top_level_does_not_push_the_watchdog_past_the_ceili
     level; any top level heavier than the slack and the ceiling fires first,
     taking the diagnosis with it.
 
-    Use the production spawn slack here.  A deliberately shrunken one-second
-    gap raced the watchdog's synchronous Windows stderr flush under the four
-    xdist workers used by CI, so the outer ceiling occasionally killed a
-    correctly diagnosed process before ``process.exit`` completed.
+    Driven with a shrunken slack so the case costs ~2s instead of ~9s.
     """
     node_path = _node_or_skip()
-    script_budget = node_harness._SPAWN_SLACK_SECONDS + 1.0
-    top_level_ms = int(script_budget * 1_000)
+    monkeypatch.setattr(node_harness, "_SPAWN_SLACK_SECONDS", 1.0)
 
-    # Keep the synchronous top level longer than the slack: if the watchdog is
-    # armed after it instead of before it, the outer ceiling still wins and
-    # this regression test fails.  The real five-second gap leaves enough room
-    # for the diagnosed exit even when the Windows runner is saturated.
+    # 2s of synchronous top level - twice the slack - and then a leaked timer.
     script = (
-        f"var until = Date.now() + {top_level_ms};\n"
+        "var until = Date.now() + 2000;\n"
         "while (Date.now() < until) {}\n"
         "setInterval(function () {}, 1000);\n"
         "process.stdout.write('started');\n"
     )
     result = run_node_script(
-        node_path,
-        script,
-        capture_output=True,
-        check=False,
-        timeout=script_budget,
+        node_path, script, capture_output=True, check=False, timeout=2
     )
 
     assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -445,7 +445,6 @@ def test_a_script_that_merely_runs_long_still_fails_its_deadline(runner):
 
 
 def test_a_heavy_synchronous_top_level_does_not_push_the_watchdog_past_the_ceiling(
-    monkeypatch,
 ):
     """The deadline is measured from node start, not from when the watchdog arms.
 
@@ -455,20 +454,31 @@ def test_a_heavy_synchronous_top_level_does_not_push_the_watchdog_past_the_ceili
     level; any top level heavier than the slack and the ceiling fires first,
     taking the diagnosis with it.
 
-    Driven with a shrunken slack so the case costs ~2s instead of ~9s.
+    Use the production spawn slack here.  A deliberately shrunken one-second
+    gap raced the watchdog's synchronous Windows stderr flush under the four
+    xdist workers used by CI, so the outer ceiling occasionally killed a
+    correctly diagnosed process before ``process.exit`` completed.
     """
     node_path = _node_or_skip()
-    monkeypatch.setattr(node_harness, "_SPAWN_SLACK_SECONDS", 1.0)
+    script_budget = node_harness._SPAWN_SLACK_SECONDS + 1.0
+    top_level_ms = int(script_budget * 1_000)
 
-    # 2s of synchronous top level - twice the slack - and then a leaked timer.
+    # Keep the synchronous top level longer than the slack: if the watchdog is
+    # armed after it instead of before it, the outer ceiling still wins and
+    # this regression test fails.  The real five-second gap leaves enough room
+    # for the diagnosed exit even when the Windows runner is saturated.
     script = (
-        "var until = Date.now() + 2000;\n"
+        f"var until = Date.now() + {top_level_ms};\n"
         "while (Date.now() < until) {}\n"
         "setInterval(function () {}, 1000);\n"
         "process.stdout.write('started');\n"
     )
     result = run_node_script(
-        node_path, script, capture_output=True, check=False, timeout=2
+        node_path,
+        script,
+        capture_output=True,
+        check=False,
+        timeout=script_budget,
     )
 
     assert result.returncode == node_harness._WATCHDOG_EXIT_CODE, (

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1083,7 +1083,7 @@ def test_pngtuber_load_announces_identity_change_before_async_setup():
 
     config_assignment = "this.config = normalizedConfig;"
     loading_event = "window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {"
-    async_setup = "await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad });"
+    async_setup = "await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad, signal });"
     assert load_block.index(config_assignment) < load_block.index(loading_event)
     assert load_block.index(loading_event) < load_block.index(async_setup)
 
@@ -1091,7 +1091,7 @@ def test_pngtuber_load_announces_identity_change_before_async_setup():
 def test_pngtuber_loader_finishes_loading_state_on_every_exit():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     loader_block = source[
-        source.index("    async function loadPNGTuberAvatar(config) {"):
+        source.index("    async function loadPNGTuberAvatar(config, options = {}) {"):
         source.index("    function playPNGTuberAnimation")
     ]
 
@@ -1107,14 +1107,15 @@ def test_pngtuber_loader_binds_lifecycle_events_to_one_load_token():
         source.index("        stateToSrc(state)")
     ]
     loader_block = source[
-        source.index("    async function loadPNGTuberAvatar(config) {"):
+        source.index("    async function loadPNGTuberAvatar(config, options = {}) {"):
         source.index("    function playPNGTuberAnimation")
     ]
 
     assert "let pngtuberLoadSequence = 0;" in source
     assert "const loadToken = ++pngtuberLoadSequence;" in loader_block
-    assert "await window.pngtuberManager.load(config || {}, { loadToken });" in loader_block
+    assert "signal: returnSignal" in loader_block
     assert "const loadToken = Number(options.loadToken) || 0;" in load_block
+    assert "&& !(signal && signal.aborted)" in load_block
     assert "if (!isCurrentLoad()) return false;" in load_block
     assert loader_block.count("if (loadToken !== pngtuberLoadSequence)") == 3
     assert "if (!loaded || loadToken !== pngtuberLoadSequence)" in loader_block
@@ -1194,6 +1195,66 @@ manager.setupHTMLLockIcon = () => {{}};
   assert.equal(await older, false);
   assert.equal(manager.config.idle_image, 'newer.png');
   assert.equal(events.filter((event) => event.type === 'pngtuber-model-loading').length, 2);
+}})().catch((error) => {{ console.error(error); process.exit(1); }});
+"""
+
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
+
+
+def test_pngtuber_cancelled_load_cannot_resume_after_async_setup():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for PNGTuber cancellation tests")
+
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const window = {{
+  location: {{ pathname: '/' }},
+  innerWidth: 1280,
+  innerHeight: 720,
+  lanlan_config: {{ model_type: 'pngtuber' }},
+  dispatchEvent() {{}},
+}};
+const document = {{
+  body: {{ classList: {{ contains() {{ return false; }} }} }},
+  getElementById() {{ return null; }},
+  querySelectorAll() {{ return []; }},
+}};
+class CustomEvent {{
+  constructor(type, options = {{}}) {{ this.type = type; this.detail = options.detail; }}
+}}
+const context = {{ console, CustomEvent, document, fetch, window }};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
+
+const manager = new window.PNGTuberManager();
+let resolveSetup;
+let resumedMutations = 0;
+manager.detachDragListeners = () => {{}};
+manager.clearEmotion = () => {{}};
+manager.setupLayeredAdapter = () => new Promise((resolve) => {{ resolveSetup = resolve; }});
+manager.ensureContainer = () => {{ resumedMutations += 1; }};
+manager.preloadImages = () => {{ resumedMutations += 1; }};
+manager.attachSpeechListeners = () => {{ resumedMutations += 1; }};
+manager.attachDragListeners = () => {{ resumedMutations += 1; }};
+manager.setState = () => {{ resumedMutations += 1; }};
+manager.applyTransform = () => {{ resumedMutations += 1; }};
+manager.syncGlobalConfig = () => {{ resumedMutations += 1; }};
+manager.setupHTMLLockIcon = () => {{ resumedMutations += 1; }};
+
+(async () => {{
+  const controller = new AbortController();
+  const pending = manager.load({{ idle_image: 'slow.png' }}, {{
+    loadToken: 1,
+    signal: controller.signal,
+  }});
+  controller.abort();
+  resolveSetup(false);
+
+  assert.equal(await pending, false);
+  assert.equal(resumedMutations, 0);
 }})().catch((error) => {{ console.error(error); process.exit(1); }});
 """
 

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1264,6 +1264,64 @@ manager.setupHTMLLockIcon = () => {{ resumedMutations += 1; }};
     run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
 
 
+def test_layered_pngtuber_image_loading_aborts_without_waiting_for_image_events():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for PNGTuber cancellation tests")
+
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const pendingImages = [];
+class PendingImage {{
+  constructor() {{ pendingImages.push(this); }}
+  removeAttribute(name) {{ if (name === 'src') this.srcRemoved = true; }}
+}}
+const window = {{
+  location: {{ pathname: '/' }},
+  innerWidth: 1280,
+  innerHeight: 720,
+  addEventListener() {{}},
+  removeEventListener() {{}},
+  dispatchEvent() {{}},
+}};
+const document = {{
+  body: {{ classList: {{ contains() {{ return false; }} }} }},
+  getElementById() {{ return null; }},
+  querySelectorAll() {{ return []; }},
+}};
+const fetch = async () => ({{
+  ok: true,
+  async json() {{
+    return {{ runtime: 'layered_canvas', layers: [{{ image: 'slow.png' }}] }};
+  }},
+}});
+const context = {{ AbortController, console, document, fetch, Image: PendingImage, window }};
+vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
+
+(async () => {{
+  const manager = new window.PNGTuberManager();
+  const controller = new AbortController();
+  const pending = manager.setupLayeredAdapter({{
+    config: {{ adapter: 'layered_canvas_v1', layered_metadata: '/model/metadata.json' }},
+    isCurrentLoad: () => !controller.signal.aborted,
+    signal: controller.signal,
+  }});
+  while (pendingImages.length === 0) await Promise.resolve();
+  controller.abort();
+
+  assert.equal(await pending, false);
+  assert.equal(pendingImages[0].onload, null);
+  assert.equal(pendingImages[0].onerror, null);
+  assert.equal(pendingImages[0].srcRemoved, true);
+}})().catch((error) => {{ console.error(error); process.exit(1); }});
+"""
+
+    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
+
+
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     attach_block = source[

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -1083,7 +1083,7 @@ def test_pngtuber_load_announces_identity_change_before_async_setup():
 
     config_assignment = "this.config = normalizedConfig;"
     loading_event = "window.dispatchEvent(new CustomEvent('pngtuber-model-loading', {"
-    async_setup = "await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad, signal });"
+    async_setup = "await this.setupLayeredAdapter({ config: normalizedConfig, isCurrentLoad });"
     assert load_block.index(config_assignment) < load_block.index(loading_event)
     assert load_block.index(loading_event) < load_block.index(async_setup)
 
@@ -1091,7 +1091,7 @@ def test_pngtuber_load_announces_identity_change_before_async_setup():
 def test_pngtuber_loader_finishes_loading_state_on_every_exit():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     loader_block = source[
-        source.index("    async function loadPNGTuberAvatar(config, options = {}) {"):
+        source.index("    async function loadPNGTuberAvatar(config) {"):
         source.index("    function playPNGTuberAnimation")
     ]
 
@@ -1107,15 +1107,14 @@ def test_pngtuber_loader_binds_lifecycle_events_to_one_load_token():
         source.index("        stateToSrc(state)")
     ]
     loader_block = source[
-        source.index("    async function loadPNGTuberAvatar(config, options = {}) {"):
+        source.index("    async function loadPNGTuberAvatar(config) {"):
         source.index("    function playPNGTuberAnimation")
     ]
 
     assert "let pngtuberLoadSequence = 0;" in source
     assert "const loadToken = ++pngtuberLoadSequence;" in loader_block
-    assert "signal: returnSignal" in loader_block
+    assert "await window.pngtuberManager.load(config || {}, { loadToken });" in loader_block
     assert "const loadToken = Number(options.loadToken) || 0;" in load_block
-    assert "&& !(signal && signal.aborted)" in load_block
     assert "if (!isCurrentLoad()) return false;" in load_block
     assert loader_block.count("if (loadToken !== pngtuberLoadSequence)") == 3
     assert "if (!loaded || loadToken !== pngtuberLoadSequence)" in loader_block
@@ -1195,66 +1194,6 @@ manager.setupHTMLLockIcon = () => {{}};
   assert.equal(await older, false);
   assert.equal(manager.config.idle_image, 'newer.png');
   assert.equal(events.filter((event) => event.type === 'pngtuber-model-loading').length, 2);
-}})().catch((error) => {{ console.error(error); process.exit(1); }});
-"""
-
-    run_node_script(node, script, check=True, cwd=PROJECT_ROOT)
-
-
-def test_pngtuber_cancelled_load_cannot_resume_after_async_setup():
-    node = shutil.which("node")
-    if not node:
-        pytest.skip("Node.js is required for PNGTuber cancellation tests")
-
-    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
-    script = f"""
-const assert = require('node:assert/strict');
-const vm = require('node:vm');
-
-const window = {{
-  location: {{ pathname: '/' }},
-  innerWidth: 1280,
-  innerHeight: 720,
-  lanlan_config: {{ model_type: 'pngtuber' }},
-  dispatchEvent() {{}},
-}};
-const document = {{
-  body: {{ classList: {{ contains() {{ return false; }} }} }},
-  getElementById() {{ return null; }},
-  querySelectorAll() {{ return []; }},
-}};
-class CustomEvent {{
-  constructor(type, options = {{}}) {{ this.type = type; this.detail = options.detail; }}
-}}
-const context = {{ console, CustomEvent, document, fetch, window }};
-vm.runInNewContext({json.dumps(source)}, context, {{ filename: 'pngtuber-core.js' }});
-
-const manager = new window.PNGTuberManager();
-let resolveSetup;
-let resumedMutations = 0;
-manager.detachDragListeners = () => {{}};
-manager.clearEmotion = () => {{}};
-manager.setupLayeredAdapter = () => new Promise((resolve) => {{ resolveSetup = resolve; }});
-manager.ensureContainer = () => {{ resumedMutations += 1; }};
-manager.preloadImages = () => {{ resumedMutations += 1; }};
-manager.attachSpeechListeners = () => {{ resumedMutations += 1; }};
-manager.attachDragListeners = () => {{ resumedMutations += 1; }};
-manager.setState = () => {{ resumedMutations += 1; }};
-manager.applyTransform = () => {{ resumedMutations += 1; }};
-manager.syncGlobalConfig = () => {{ resumedMutations += 1; }};
-manager.setupHTMLLockIcon = () => {{ resumedMutations += 1; }};
-
-(async () => {{
-  const controller = new AbortController();
-  const pending = manager.load({{ idle_image: 'slow.png' }}, {{
-    loadToken: 1,
-    signal: controller.signal,
-  }});
-  controller.abort();
-  resolveSetup(false);
-
-  assert.equal(await pending, false);
-  assert.equal(resumedMutations, 0);
 }})().catch((error) => {{ console.error(error); process.exit(1); }});
 """
 

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -107,6 +107,9 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
     assert "this.config.mobile_scale" in runtime_save_block
     assert "this.config.position_anchor" in runtime_save_block
     assert "apply_runtime: false" in runtime_save_block
+    assert "pngtuber_placement:" in runtime_save_block
+    assert "expected_pngtuber_binding:" in runtime_save_block
+    assert "model_type: 'pngtuber'" not in runtime_save_block
 
 
 def test_pngtuber_drag_uses_the_shared_multiscreen_transfer_contract():

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -1090,7 +1090,10 @@ def test_cat_return_commit_always_publishes_complete_or_abort_terminal_event():
     commit_index = handler.index("new CustomEvent('neko:cat-return-commit'", try_index)
     failed_model_return = handler.index("if (modelDisplayReady === false) {", try_index)
     finally_index = handler.index("} finally {", failed_model_return)
-    abort_index = handler.index("new CustomEvent('neko:cat-return-abort'", finally_index)
+    abort_index = handler.index(
+        "abortNekoCatReturnLifecycle(returnLifecycle, returnAbortReason)",
+        finally_index,
+    )
     complete_index = handler.index(
         "new CustomEvent('neko:cat-return-complete'",
         try_index,

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -1085,9 +1085,9 @@ def test_cat_return_commit_always_publishes_complete_or_abort_terminal_event():
     brace = source.index("{", start)
     handler = source[start : _balanced_js_block_end(source, brace) + 1]
 
-    commit_index = handler.index("new CustomEvent('neko:cat-return-commit'")
-    guard_index = handler.index("let returnTerminalPublished = false;", commit_index)
+    guard_index = handler.index("let returnTerminalPublished = false;")
     try_index = handler.index("try {", guard_index)
+    commit_index = handler.index("new CustomEvent('neko:cat-return-commit'", try_index)
     failed_model_return = handler.index("if (modelDisplayReady === false) {", try_index)
     finally_index = handler.index("} finally {", failed_model_return)
     abort_index = handler.index("new CustomEvent('neko:cat-return-abort'", finally_index)
@@ -1102,7 +1102,7 @@ def test_cat_return_commit_always_publishes_complete_or_abort_terminal_event():
     finally_brace = handler.index("{", finally_index)
     finally_end = _balanced_js_block_end(handler, finally_brace)
 
-    assert commit_index < guard_index < try_index < failed_model_return < finally_index < abort_index
+    assert guard_index < try_index < commit_index < failed_model_return < finally_index < abort_index
     assert try_index < complete_index < published_index < finally_index
     assert finally_brace < abort_index <= finally_end
 

--- a/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
+++ b/tests/unit/test_widget_mode_return_ball_edge_anchor_static.py
@@ -29,7 +29,7 @@ def test_live2d_peek_restore_anchor_is_consumed_on_return():
     return_block = app_ui_source.split("const handleReturnClick", 1)[1]
 
     restore_call = "window.nekoLive2DPeek.restoreAnchor(live2DPeekRestoreAnchor)"
-    settle_call = "settleReturnedModelBounds(returnModelWasMoved)"
+    settle_call = "settleReturnedModelBounds(returnModelWasMoved, {"
     complete_dispatch = "new CustomEvent('neko:cat-return-complete'"
 
     assert "let live2DPeekRestoreAnchor = null;" in return_block


### PR DESCRIPTION
## 改动概述 / Summary

- 修复“请她离开”状态下从系统托盘恢复默认模型后模型消失的问题，默认目标固定为内置 `yui-lolita` Live2D。
- 先恢复完整 Pet viewport、退出离开态并临时加载验证默认 Live2D，成功后才持久化；临时加载或明确的持久化失败会恢复服务端现有模型。
- 热重载不可用时在退出离开态前失败；接口返回 HTTP 200 但 `success: false` 时也按失败处理，避免误报成功。
- 为普通和程序化返回提供有限生命周期；取消覆盖 viewport、角色配置请求与 PNGTuber 元数据/图片加载，超时后恢复可重试的 return 控件，位置持久化不再阻塞返回结算。

## 回归报告 / Regression Report

- 改动：默认模型 PUT 带唯一操作 ID，后端记录实际保存状态，并在客户端取消后等待底层 `to_thread` 写入结束；超时或响应丢失时前端释放模型重载队列，再查询服务端确定结果后决定成功或回滚。恢复原模型时强制绕过一秒重载去重。
- 改动：角色模型、PNGTuber 位置、触摸配置、VRM 灯光和 MMD 设置的完整读取-修改-写入统一参与 `character_config_mutation_lock`，避免任一旧快照覆盖另一项较新的设置。
- 改动：PNGTuber 分层图片加载响应 return lifecycle 的取消并清理图片事件；拖拽后的待返回位置只在完整返回结算成功后消费。角色切换会同步清除 PNGTuber 的 goodbye/return 状态和返回控件。
- 理由：浏览器 `AbortController` 不能撤销后端已进入线程的文件写入，不能把超时直接等同于“未持久化”；同理，分离的配置写入和可取消加载必须有明确的事务及生命周期边界。
- 前后表现：此前 10 秒边界附近可能出现“客户端报告失败、服务端随后写入默认模型”，回滚又读取到新配置；PNGTuber 重试可能丢失拖拽位置，角色切换也可能残留离开态。现在保存结果由服务端可观测状态确认，只有明确失败才恢复旧模型；队列因超时提前释放时，服务端终态确认后会再执行一次 authoritative reload，确保中途读取旧配置的排队重载不会成为最终显示状态；PNGTuber 取消和切换均保持可重试且不会残留旧状态。
- 潜在回归点与验证：重点检查 Live2D、VRM、MMD、PNGTuber 的完整模型更新、触摸/灯光/MMD 设置写入、超时及丢响应、快速回滚去重、分层 PNGTuber 取消、角色切换清理和返回位置重试。新增动态测试覆盖客户端取消但服务端保存成功、响应丢失后对账、明确失败回滚、配置写入并发以及图片永不完成时的取消。

## 测试 / Testing

- `node --test tests/frontend/default_model_goodbye_return.test.cjs`（35 passed）
- `uv run pytest -q tests/unit/test_avatar_return_button_idle_tiers_static.py tests/unit/test_pngtuber_static_contracts.py tests/unit/test_voice_start_failure_static.py tests/unit/test_cat_idle_state_machine_static.py tests/unit/test_characters_router_model_settings.py tests/frontend/test_mmd_hot_reload_visibility_race.py`（194 passed）
- 9 个相关 JavaScript 文件均通过 `node --check`
- `uv run ruff check main_routers/characters_router/live2d_models.py tests/unit/test_characters_router_model_settings.py tests/unit/test_pngtuber_static_contracts.py tests/unit/test_app_character_static.py` 通过
- `git diff --check` 通过
- `node --test test/window-control-return-ball-restore.test.js`（N.E.K.O.-PC，1 passed）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进
- 优化模型返回流程，支持超时、取消和重试，避免界面长时间阻塞。
- 返回中断或加载失败时，自动恢复界面状态并回滚已显示的模型。
- 改善视口恢复、模型显示及位置保存，减少异常状态。
- PNGTuber 加载支持取消和过期请求保护，避免旧请求覆盖当前模型。
- 支持仅保存 PNGTuber 位置调整，减少不必要的模型刷新。
- 重置默认 Live2D 模型时增加保存结果确认与超时处理，失败时恢复原模型。
- 改善 Goodbye 返回中断后的状态恢复，确保界面保持一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->