### PR TITLE
fix(grok): core_model 改为 grok-voice-latest

### DIFF
--- a/config/api_profiles.py
+++ b/config/api_profiles.py
@@ -87,7 +87,7 @@ DEFAULT_CORE_API_PROFILES = {
     },
     'grok': {
         'CORE_URL': "wss://api.x.ai/v1/realtime",
-        'CORE_MODEL': "grok-voice-fast-1.0",
+        'CORE_MODEL': "grok-voice-latest",
     },
 }
 

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -55,7 +55,7 @@
       "name": "Grok Voice（xAI）",
       "description": "xAI 实时语音，国内无法直连，价格较高",
       "core_url": "wss://api.x.ai/v1/realtime",
-      "core_model": "grok-voice-fast-1.0"
+      "core_model": "grok-voice-latest"
     }
   },
   "assist_api_providers": {


### PR DESCRIPTION
## 改动

xAI 实时语音（`core_api_providers.grok`）的 `core_model` 由固定版本号 `grok-voice-fast-1.0` 改为 `grok-voice-latest`。

两处同步改：

- `config/api_providers.json` —— 权威源，后端按它分流
- `config/api_profiles.py` —— JSON 加载失败时的 Python 侧兜底

## 影响面

只影响核心 realtime 路径的默认模型名。Grok 的独立 TTS worker（`main_logic/tts_client/workers/grok.py`）不受影响——那条路连的是 `wss://api.x.ai/v1/tts`，全部配置走 query param（voice / language / codec / sample_rate），协议里没有 model 字段。

`grep -rn "grok-voice"` 全仓只有这两处引用，无测试断言该字面量。

## 验证

`uv run pytest tests/unit/test_api_config_manager.py` —— 118 passed。

未做上游连通性验证：`grok-voice-latest` 这个 id 是否被 xAI 接受，需要有 xAI key 的环境实测确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **变更**
  - 更新 Grok 语音服务使用的默认模型为 `grok-voice-latest`。
  - 语音请求将使用最新版本模型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->