### PR TITLE
fix(asr): 按实测协议修正 xAI STT 的发声收尾与空事件

### DIFF
--- a/main_logic/asr_client/workers/grok.py
+++ b/main_logic/asr_client/workers/grok.py
@@ -54,6 +54,24 @@ def _grok_is_auth_rejection(exc: BaseException) -> bool:
     return is_auth_rejection(exc)
 
 
+def _utterance_final_text(terminal_text: str, chunk_texts: list[str]) -> str:
+    """Transcript for one xAI utterance that ended with ``speech_final``.
+
+    xAI's utterance final restates the WHOLE utterance -- every chunk final
+    (``is_final=true, speech_final=false``) locked inside it is included
+    again. Measured against wss://api.x.ai/v1/stt: two locked chunks were
+    followed by a terminal event carrying both, so concatenating the locked
+    chunks onto it repeated the whole locked prefix in the transcript.
+    Interim events are the opposite -- they only cover the audio after the
+    last lock -- which is why the preview still concatenates and only the
+    final replaces.
+
+    An empty restatement falls back to the locked chunks so a blank terminal
+    event cannot swallow speech the provider already committed.
+    """
+    return terminal_text or "".join(chunk_texts)
+
+
 async def grok_asr_worker(
     request_queue: asyncio.Queue[_AsrWorkerRequest],
     response_queue: asyncio.Queue[_AsrWorkerEvent],
@@ -137,7 +155,12 @@ async def grok_asr_worker(
 
         latest_audio_key: _UtteranceKey | None = None
         pending_manual_commits: deque[_UtteranceKey] = deque()
+        # Completed utterances of a PTT hold (one entry per ``speech_final``
+        # natural endpointing fired mid-hold), kept apart from the chunk
+        # finals of the utterance still in flight: separate utterances
+        # concatenate, chunks of one utterance are superseded by its final.
         manual_locked_segments: dict[_UtteranceKey, list[str]] = {}
+        manual_chunk_segments: dict[_UtteranceKey, list[str]] = {}
         active_server_key: _UtteranceKey | None = None
         server_locked_segments: list[str] = []
         stalled_deadline: float | None = None
@@ -185,6 +208,19 @@ async def grok_asr_worker(
                     is_final = event.get("is_final") is True
                     speech_final = event.get("speech_final") is True
 
+                    if not text and not (is_final and speech_final):
+                        # xAI transcribes non-speech audio as EMPTY partials
+                        # rather than staying quiet: 25 s of room-noise-level
+                        # input produced 34 transcript.partial events (interim
+                        # AND is_final chunk finals), all with text="", and no
+                        # speech_final at all. Acting on one starts a phantom
+                        # utterance that no final can ever close, which stalls
+                        # every real utterance queued behind it. They carry no
+                        # transcript, so skipping loses nothing. A terminal
+                        # event is exempt: an empty utterance final is how a
+                        # real turn legitimately ends with nothing said.
+                        continue
+
                     if config.endpointing_mode == "manual":
                         key = (
                             pending_manual_commits[0]
@@ -194,10 +230,15 @@ async def grok_asr_worker(
                         if key is None:
                             continue
                         if is_final and speech_final:
+                            # The terminal event restates this utterance whole,
+                            # so its own chunk finals are dropped here instead
+                            # of being concatenated onto it.
+                            chunk_texts = manual_chunk_segments.pop(key, [])
+                            utterance_text = _utterance_final_text(text, chunk_texts)
                             if pending_manual_commits:
                                 final_key = pending_manual_commits.popleft()
                                 segments = manual_locked_segments.pop(final_key, [])
-                                segments.append(text)
+                                segments.append(utterance_text)
                                 await response_queue.put(
                                     _AsrWorkerEvent(
                                         kind="final",
@@ -213,7 +254,7 @@ async def grok_asr_worker(
                                 # the public commit still sends ``finalize`` so
                                 # later speech cannot be lost or overwritten.
                                 segments = manual_locked_segments.setdefault(key, [])
-                                segments.append(text)
+                                segments.append(utterance_text)
                                 await response_queue.put(
                                     _AsrWorkerEvent(
                                         kind="partial",
@@ -226,6 +267,16 @@ async def grok_asr_worker(
                             continue
                         # Both mutable interim results and locked chunks
                         # (is_final=true, speech_final=false) remain partial.
+                        # A locked chunk is retained because the interim
+                        # events that follow it only carry the audio after
+                        # the lock; without it the preview would lose the
+                        # already-spoken head mid-hold.
+                        chunk_texts = manual_chunk_segments.setdefault(key, [])
+                        if is_final:
+                            chunk_texts.append(text)
+                            tail = ""
+                        else:
+                            tail = text
                         await response_queue.put(
                             _AsrWorkerEvent(
                                 kind="partial",
@@ -233,7 +284,11 @@ async def grok_asr_worker(
                                 buffer_epoch=key[1],
                                 utterance_id=key[2],
                                 text="".join(
-                                    [*manual_locked_segments.get(key, []), text]
+                                    [
+                                        *manual_locked_segments.get(key, []),
+                                        *chunk_texts,
+                                        tail,
+                                    ]
                                 ),
                             )
                         )
@@ -249,6 +304,12 @@ async def grok_asr_worker(
                         continue
                     if active_server_key is None:
                         if latest_audio_key is None:
+                            continue
+                        if not text:
+                            # Empty terminal event with no utterance in
+                            # flight: nothing to close and nothing to say.
+                            # Opening one here would report speech for
+                            # silence.
                             continue
                         if next_server_utterance_id is None:
                             next_server_utterance_id = latest_audio_key[2] or 1
@@ -271,14 +332,13 @@ async def grok_asr_worker(
 
                     key = active_server_key
                     if is_final and speech_final:
-                        # xAI segments long utterances: every earlier
-                        # is_final=true / speech_final=false event locked one
-                        # segment and the terminal event carries only the
-                        # trailing segment's text, so concatenate the locked
-                        # segments (same joiner as the manual branch) into
-                        # the Core final.
-                        server_locked_segments.append(text)
-                        final_text = "".join(server_locked_segments)
+                        # The terminal event restates the whole utterance,
+                        # locked segments included, so it REPLACES them (same
+                        # rule as the manual branch). Appending here is what
+                        # made every locked chunk show up twice in one turn.
+                        final_text = _utterance_final_text(
+                            text, server_locked_segments
+                        )
                         server_locked_segments.clear()
                         active_server_key = None
                         stalled_deadline = None
@@ -517,8 +577,13 @@ async def grok_asr_worker(
             "interim_results": "true",
         }
         if config.endpointing_mode == "provider":
-            # Pin xAI's documented default so provider behavior cannot drift
-            # silently if the upstream default changes.
+            # Silence (ms) before xAI fires speech_final. Pinned so provider
+            # behaviour cannot drift silently -- this is NOT the upstream
+            # default (400 ms), it is deliberately far shorter: measured
+            # against wss://api.x.ai/v1/stt, 10 ms ends the utterance at the
+            # pause between two sentences and transcribes each cleanly, while
+            # 400 ms merged a 14 s take into one utterance whose final came
+            # back mangled.
             query["endpointing"] = 10
         if language is not None:
             query["language"] = language

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -2928,7 +2928,9 @@ async def test_grok_server_vad_three_states_and_clear_reconnect(monkeypatch) -> 
     for text, is_final, speech_final in (
         ("mutable", False, False),
         ("locked", True, False),
-        ("utterance", True, True),
+        # The terminal event restates the whole utterance, locked chunk
+        # included -- appending it would say "locked" twice.
+        ("lockedutterance", True, True),
     ):
         await first.server_send(
             {
@@ -2943,9 +2945,8 @@ async def test_grok_server_vad_three_states_and_clear_reconnect(monkeypatch) -> 
     locked = await _next_event(responses, "partial")
     final = await _next_event(responses, "final")
     assert started.utterance_id == 1
-    # The locked segment (is_final without speech_final) is retained and the
-    # terminal event only carries the trailing segment, so the Core final is
-    # the concatenation of both.
+    # The locked segment (is_final without speech_final) is retained for the
+    # preview, and the terminal event's restatement becomes the Core final.
     assert (mutable.text, locked.text, final.text) == (
         "mutable",
         "locked",
@@ -2975,7 +2976,7 @@ async def test_grok_server_vad_three_states_and_clear_reconnect(monkeypatch) -> 
     )
 
 
-async def test_grok_server_vad_concatenates_locked_segments_into_final(
+async def test_grok_server_vad_final_replaces_locked_segments(
     monkeypatch,
 ) -> None:
     async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
@@ -3022,8 +3023,10 @@ async def test_grok_server_vad_concatenates_locked_segments_into_final(
     # the preview always matches what the final will say.
     for expected in ("draft", "seg1", "seg1tail", "seg1seg2"):
         assert (await _next_event(responses, "partial")).text == expected
+    # The terminal event restates the whole utterance, so it replaces the
+    # locked segments instead of being appended to them.
     final = await _next_event(responses, "final")
-    assert (final.utterance_id, final.text) == (1, "seg1seg2seg3")
+    assert (final.utterance_id, final.text) == (1, "seg3")
 
     # A following utterance on the same connection starts from an empty
     # segment buffer: no text bleeds over, and a single-segment utterance's
@@ -3046,6 +3049,278 @@ async def test_grok_server_vad_concatenates_locked_segments_into_final(
     next_final = await _next_event(responses, "final")
     assert (next_final.utterance_id, next_final.text) == (2, "done")
     assert responses.empty()
+    await _stop_worker(task, requests, responses)
+
+
+async def test_grok_server_vad_final_does_not_repeat_locked_chunks(
+    monkeypatch,
+) -> None:
+    """Replay of a captured wss://api.x.ai/v1/stt utterance.
+
+    Two chunk finals are locked, each interim in between covers only the
+    audio after the last lock, and the terminal event restates both chunks.
+    The Core final must carry that restatement once, not the locked chunks
+    plus a second copy of them.
+    """
+
+    head = "那 那你 你觉得最骚的骚话是什么？"
+    tail = "我今天下午本来打算去图书馆看书。"
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}], on_send=on_send
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(
+            requests,
+            responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="provider"),
+        )
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: any(isinstance(item, bytes) for item in websocket.sent))
+    for text, is_final, speech_final in (
+        (head[:4], False, False),
+        (head, True, False),
+        (tail[:5], False, False),
+        (tail, True, False),
+        (head + tail, True, True),
+    ):
+        await websocket.server_send(
+            {
+                "type": "transcript.partial",
+                "text": text,
+                "is_final": is_final,
+                "speech_final": speech_final,
+            }
+        )
+    assert (await _next_event(responses, "utterance_started")).utterance_id == 1
+    for expected in (head[:4], head, head + tail[:5], head + tail):
+        assert (await _next_event(responses, "partial")).text == expected
+    final = await _next_event(responses, "final")
+    assert (final.utterance_id, final.text) == (1, head + tail)
+    assert responses.empty()
+    await _stop_worker(task, requests, responses)
+
+
+async def test_grok_server_vad_empty_final_keeps_locked_chunks(monkeypatch) -> None:
+    """A blank terminal event must not discard already locked speech."""
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}], on_send=on_send
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(
+            requests,
+            responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="provider"),
+        )
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: any(isinstance(item, bytes) for item in websocket.sent))
+    for text, is_final, speech_final in (
+        ("seg1", True, False),
+        ("", True, True),
+    ):
+        await websocket.server_send(
+            {
+                "type": "transcript.partial",
+                "text": text,
+                "is_final": is_final,
+                "speech_final": speech_final,
+            }
+        )
+    assert (await _next_event(responses, "utterance_started")).utterance_id == 1
+    assert (await _next_event(responses, "partial")).text == "seg1"
+    final = await _next_event(responses, "final")
+    assert (final.utterance_id, final.text) == (1, "seg1")
+    await _stop_worker(task, requests, responses)
+
+
+async def test_grok_manual_preview_keeps_locked_chunk_and_final_replaces_it(
+    monkeypatch,
+) -> None:
+    """Manual mode follows the same split: preview concatenates, final replaces."""
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if not isinstance(payload, str):
+            return
+        message = json.loads(payload)
+        if message["type"] == "finalize":
+            await ws.server_send(
+                {
+                    "type": "transcript.partial",
+                    "text": "seg1tail",
+                    "is_final": True,
+                    "speech_final": True,
+                }
+            )
+        elif message["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}], on_send=on_send
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: b"\0\0" in websocket.sent)
+    # Chunk final locks "seg1"; the interim after it carries only the tail,
+    # so the preview has to keep the locked head to stay readable.
+    await websocket.server_send(
+        {
+            "type": "transcript.partial",
+            "text": "seg1",
+            "is_final": True,
+            "speech_final": False,
+        }
+    )
+    assert (await _next_event(responses, "partial")).text == "seg1"
+    await websocket.server_send(
+        {
+            "type": "transcript.partial",
+            "text": "tail",
+            "is_final": False,
+            "speech_final": False,
+        }
+    )
+    assert (await _next_event(responses, "partial")).text == "seg1tail"
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    final = await _next_event(responses, "final")
+    assert final.text == "seg1tail"
+    await _stop_worker(task, requests, responses)
+
+
+async def test_grok_server_vad_empty_partials_start_no_utterance(monkeypatch) -> None:
+    """Non-speech audio must not open a phantom utterance.
+
+    xAI answers room noise with empty transcript.partial events -- interim
+    and is_final chunk finals alike -- and never sends speech_final for
+    them. An utterance opened on one of those can never be closed, and it
+    blocks every real utterance queued behind it.
+    """
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}], on_send=on_send
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(
+            requests,
+            responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="provider"),
+        )
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: any(isinstance(item, bytes) for item in websocket.sent))
+    for is_final, speech_final in ((False, False), (True, False), (True, True)):
+        await websocket.server_send(
+            {
+                "type": "transcript.partial",
+                "text": "",
+                "is_final": is_final,
+                "speech_final": speech_final,
+            }
+        )
+    # Real speech afterwards still opens the FIRST utterance id: nothing was
+    # consumed by the noise, and no event was emitted for it.
+    for text, is_final, speech_final in (("hi", False, False), ("hi there", True, True)):
+        await websocket.server_send(
+            {
+                "type": "transcript.partial",
+                "text": text,
+                "is_final": is_final,
+                "speech_final": speech_final,
+            }
+        )
+    assert (await _next_event(responses, "utterance_started")).utterance_id == 1
+    assert (await _next_event(responses, "partial")).text == "hi"
+    final = await _next_event(responses, "final")
+    assert (final.utterance_id, final.text) == (1, "hi there")
+    assert responses.empty()
+    await _stop_worker(task, requests, responses)
+
+
+async def test_grok_manual_empty_final_still_completes_commit(monkeypatch) -> None:
+    """A silent PTT hold must still deliver its (empty) final."""
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if not isinstance(payload, str):
+            return
+        message = json.loads(payload)
+        if message["type"] == "finalize":
+            await ws.server_send(
+                {
+                    "type": "transcript.partial",
+                    "text": "",
+                    "is_final": True,
+                    "speech_final": True,
+                }
+            )
+        elif message["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}], on_send=on_send
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: b"\0\0" in websocket.sent)
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    final = await _next_event(responses, "final")
+    assert (final.utterance_id, final.text) == (1, "")
     await _stop_worker(task, requests, responses)
 
 
@@ -3305,7 +3580,7 @@ async def test_grok_server_vad_partials_refresh_stalled_deadline(
     await websocket.server_send(
         {
             "type": "transcript.partial",
-            "text": "c",
+            "text": "abc",
             "is_final": True,
             "speech_final": True,
         }

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -3008,7 +3008,11 @@ async def test_grok_server_vad_final_replaces_locked_segments(
         ("seg1", True, False),
         ("tail", False, False),
         ("seg2", True, False),
-        ("seg3", True, True),
+        # A terminal event restates the whole utterance, locked chunks
+        # included -- a tail-only payload here would be a shape xAI never
+        # sends, and asserting on it would freeze "drop the locked prefix"
+        # into the guard.
+        ("seg1seg2seg3", True, True),
     ):
         await websocket.server_send(
             {
@@ -3024,9 +3028,10 @@ async def test_grok_server_vad_final_replaces_locked_segments(
     for expected in ("draft", "seg1", "seg1tail", "seg1seg2"):
         assert (await _next_event(responses, "partial")).text == expected
     # The terminal event restates the whole utterance, so it replaces the
-    # locked segments instead of being appended to them.
+    # locked segments instead of being appended to them (appending would
+    # say "seg1seg2" twice).
     final = await _next_event(responses, "final")
-    assert (final.utterance_id, final.text) == (1, "seg3")
+    assert (final.utterance_id, final.text) == (1, "seg1seg2seg3")
 
     # A following utterance on the same connection starts from an empty
     # segment buffer: no text bleeds over, and a single-segment utterance's


### PR DESCRIPTION
## 问题

切到 grok 之后语音链路两个症状：

1. **每次语音输入被识别成两句一样的话**，例如「那，那你，你觉得最骚的骚话是什么？那，那你你觉得最骚的骚话是什么？」
2. **说到一半语音戛然而止，输入框预览卡住刷一串字符**

## 抓到的协议真相

直接对 `wss://api.x.ai/v1/stt` 抓真实报文（合成一段 14 秒中文语音喂进去）：

| 事件 | start/dur | text |
|---|---|---|
| interim | 0.0 / 4.0 | 那 那你 你觉得最骚的骚话是什么？ |
| chunk final (`is_final`) | 0.0 / 4.14 | 那 那你 你觉得最骚的骚话是什么？ |
| interim | 0.0 / 5.14 | 我今天下午。 ← **只覆盖锁定点之后的音频** |
| chunk final | 0.0 / 14.14 | 我今天下午…半个小时。 |
| **utterance final** (`speech_final`) | 0.0 / 14.155 | **那，那你…是什么？我今天下午…半个小时。** ← **整段重述** |

再抓一次纯噪声：25 秒室噪级输入回了 **34 条 `text=""` 的 `transcript.partial`**（interim 与 `is_final` 都有），**且始终没有 `speech_final`**。

两条都与 worker 里写死的假设相反。

## 改动

**1. 收尾事件替换、不再追加**（症状 1）

原代码注释写的是「收尾事件只带尾部分段」，于是把它追加到已锁定分段后面。实测它重述整段发声，短句只有一个 chunk final 时 final 文本就是「整句 + 整句」——正好复读一遍。改为收尾事件替换本次发声的分段；跨发声（按住说话中途自然断句）仍然拼接；空重述回落到已锁定分段，不吞真话。

**2. 跳过非收尾的空事件**（症状 2）

worker 原来不看文本是否为空就开新发声（`utterance_started`）。这条幽灵发声永远等不到 final，卡在 `_utterance_order` 队首，后续每一条真实语音的预览与 final 全被压在它后面。改为非收尾的空事件直接跳过，且空事件不再开新发声；静默按住说话仍照常返回空 final（这是收尾事件豁免的原因）。

**3. manual 分支预览补齐**

chunk final 之后的 interim 只覆盖锁定点之后的音频，之前不留锁定块，按住说话中途预览会丢掉已说出的开头。

**4. 注释订正**

`endpointing=10` 的值不动，只改正「这是 xAI 文档默认值」这句错误注释（文档默认 400 ms）。实测 400 ms 会把 14 秒并成一条发声、final 还糊掉，10 ms 反而在两句之间干净断开，所以保留现值、把理由写对。

## 验证

- 新增 5 条回归测试，其中一条直接回放上面那段真实报文；**回滚源码后确认 6 条测试会红**（不是空转护栏）。
- `tests/unit/test_asr_workers.py`、`test_asr_client.py`、`test_core_independent_asr.py` 共 600 项全绿。
- `scripts/check_docstring_no_cjk.py --base origin/main` 通过。

## 回归报告

**改了什么**：`main_logic/asr_client/workers/grok.py` 三处行为改动 —— (a) 收尾事件（`is_final && speech_final`）的文本改为**替换**本次发声已锁定的 chunk 分段，不再追加；(b) 文本为空且非收尾的 `transcript.partial` 直接跳过，空事件也不再开新发声；(c) manual 分支把「已完成发声」与「进行中发声的 chunk」拆成两个缓冲，预览拼接两者。只动这一个 worker，其他 provider（openai / step / qwen / gemini / soniox）与 `_infra.py`、`runtime.py` 一行未碰。

**为什么必须改**：不是猜测，是对 `wss://api.x.ai/v1/stt` 抓的真实报文——收尾事件重述整段发声（正文表格），非语音音频回 34 条空 partial 且永不发 speech_final。原实现按相反的假设写死，导致每句话进对话历史时都是双份，以及噪声开出的幽灵发声卡死有序队列。

**改动前后行为**：

| 场景 | 改前 | 改后 |
|---|---|---|
| 单 chunk 短句 | final = 「整句整句」（复读） | final = 整句 |
| 多 chunk 长句 | final = chunk1+chunk2+整段重述 | final = 整段重述 |
| 收尾事件文本为空 | final = 已锁定分段 | 不变（回落到已锁定分段） |
| 纯噪声输入 | 开发声 → 永不 final → 后续真语音全被压住 | 无事件，不开发声 |
| 静默按住说话 | 返回空 final | 不变 |
| manual 中途 chunk final 后的预览 | 丢掉已说出的开头 | 保留开头 |

**潜在回归**：

1. *若 xAI 某天把收尾事件改成只带尾部分段*，则 final 会丢掉前面的 chunk。判据是本 PR 的实测报文，已写进 `_utterance_final_text` 的 docstring；若上游改协议，回归会以「长句只剩最后一段」的形态出现，测试 `test_grok_server_vad_final_does_not_repeat_locked_chunks` 会红。
2. *空事件跳过*可能掩盖一种真实场景：用户说话但 xAI 尚未出字。该场景下事件本就没有可显示文本，跳过只是不开发声；真正出字时照常开发声（`test_grok_server_vad_empty_partials_start_no_utterance` 锁定「噪声之后第一句真话仍拿 utterance_id=1」）。
3. *manual 双缓冲*：`manual_chunk_segments` 与 `manual_locked_segments` 都是连接作用域局部变量，`clear` 走重连会整体重建，不存在跨轮残留；`speech_final` 处按同一个 key 弹出，不会泄漏条目。
4. `endpointing` 的值未改，本 PR 不影响断句时机。

**验证**：新增 5 条回归测试（其中一条直接回放真实报文），回滚源码后确认 6 条会红；`test_asr_workers.py` / `test_asr_client.py` / `test_core_independent_asr.py` 共 600 项全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复转录终稿重复拼接已确认文本的问题，确保最终结果完整且不重复。
  - 空转录和静音输入不再创建虚假话语。
  - 终止文本为空时，保留已确认的转录内容。
  - 改善手动提交、预览刷新及停顿超时场景下的转录结果处理。
  - 修复多段转录过程中部分结果与最终结果衔接不一致的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->