### PR TITLE
fix(browser): 修复源码版本的页面两次刷新导致后端退出

### DIFF
--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -43,6 +43,112 @@ logger = runtime.logger
 _AVATAR_TOOL_ASSET_DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
+# ``--open-browser`` owns the backend for as long as at least one of its UI
+# documents is alive. A page unload alone cannot tell a real tab close from a
+# reload, so shutdown is debounced and cancelled when the replacement document
+# registers. Electron/Steam never enables browser_mode_enabled and continues
+# to use the separate authenticated /api/runtime/shutdown path.
+_BROWSER_LIFECYCLE_CLOSE_GRACE_SECONDS = 2.0
+_BROWSER_LIFECYCLE_HEARTBEAT_TIMEOUT_SECONDS = 120.0
+_BROWSER_LIFECYCLE_MAX_CLIENTS = 64
+_browser_lifecycle_clients: dict[str, float] = {}
+_browser_lifecycle_expiry_tasks: dict[str, asyncio.Task] = {}
+_browser_lifecycle_shutdown_task: asyncio.Task | None = None
+
+
+def _cancel_browser_lifecycle_task(task: asyncio.Task | None) -> None:
+    if task is not None and not task.done():
+        task.cancel()
+
+
+def _cancel_pending_browser_lifecycle_shutdown() -> None:
+    global _browser_lifecycle_shutdown_task
+    _cancel_browser_lifecycle_task(_browser_lifecycle_shutdown_task)
+    _browser_lifecycle_shutdown_task = None
+
+
+async def _expire_browser_lifecycle_client(client_id: str, touched_at: float) -> None:
+    try:
+        await asyncio.sleep(_BROWSER_LIFECYCLE_HEARTBEAT_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        return
+
+    if _browser_lifecycle_clients.get(client_id) != touched_at:
+        return
+    _browser_lifecycle_clients.pop(client_id, None)
+    if _browser_lifecycle_expiry_tasks.get(client_id) is asyncio.current_task():
+        _browser_lifecycle_expiry_tasks.pop(client_id, None)
+    _schedule_browser_lifecycle_shutdown()
+
+
+async def _shutdown_browser_lifecycle_after_grace() -> None:
+    global _browser_lifecycle_shutdown_task
+    try:
+        await asyncio.sleep(_BROWSER_LIFECYCLE_CLOSE_GRACE_SECONDS)
+        if _browser_lifecycle_clients:
+            return
+        logger.info("浏览器页面已关闭，准备关闭源码模式服务器...")
+        await runtime.shutdown_server_async()
+    except asyncio.CancelledError:
+        return
+    finally:
+        if _browser_lifecycle_shutdown_task is asyncio.current_task():
+            _browser_lifecycle_shutdown_task = None
+
+
+def _schedule_browser_lifecycle_shutdown() -> None:
+    global _browser_lifecycle_shutdown_task
+    if _browser_lifecycle_clients:
+        return
+    if _browser_lifecycle_shutdown_task is not None:
+        if not _browser_lifecycle_shutdown_task.done():
+            return
+        _browser_lifecycle_shutdown_task = None
+    _browser_lifecycle_shutdown_task = asyncio.create_task(
+        _shutdown_browser_lifecycle_after_grace()
+    )
+
+
+def _touch_browser_lifecycle_client(client_id: str) -> bool:
+    if not client_id or len(client_id) > 128:
+        return False
+    if (
+        client_id not in _browser_lifecycle_clients
+        and len(_browser_lifecycle_clients) >= _BROWSER_LIFECYCLE_MAX_CLIENTS
+    ):
+        return False
+
+    _cancel_pending_browser_lifecycle_shutdown()
+    touched_at = asyncio.get_running_loop().time()
+    _browser_lifecycle_clients[client_id] = touched_at
+    _cancel_browser_lifecycle_task(_browser_lifecycle_expiry_tasks.get(client_id))
+    _browser_lifecycle_expiry_tasks[client_id] = asyncio.create_task(
+        _expire_browser_lifecycle_client(client_id, touched_at)
+    )
+    return True
+
+
+def _release_browser_lifecycle_client(client_id: str) -> None:
+    _browser_lifecycle_clients.pop(client_id, None)
+    _cancel_browser_lifecycle_task(_browser_lifecycle_expiry_tasks.pop(client_id, None))
+    _schedule_browser_lifecycle_shutdown()
+
+
+def _reset_browser_lifecycle_state() -> None:
+    """Cancel browser lifecycle tasks; primarily useful for isolated tests."""
+    _cancel_pending_browser_lifecycle_shutdown()
+    for task in _browser_lifecycle_expiry_tasks.values():
+        _cancel_browser_lifecycle_task(task)
+    _browser_lifecycle_expiry_tasks.clear()
+    _browser_lifecycle_clients.clear()
+
+
+def _browser_lifecycle_origin_allowed(request: Request) -> bool:
+    origin = (request.headers.get("origin") or "").strip().rstrip("/")
+    expected_origin = str(request.base_url).strip().rstrip("/")
+    return bool(origin and secrets.compare_digest(origin, expected_origin))
+
+
 def _has_generated_asset_version(query_string: bytes) -> bool:
     """Return whether ``v`` is a content-derived version safe to cache immutably."""
     try:
@@ -538,20 +644,63 @@ async def get_card_drop_active_character(
 
 
 @app.post("/api/beacon/shutdown")
-async def beacon_shutdown():
-    """Beacon endpoint: used for graceful server shutdown"""
+async def beacon_shutdown(request: Request):
+    """Track standalone-browser pages and stop their backend after the last closes."""
     try:
-        # 从 app.state 获取配置
         current_config = runtime.get_start_config()
-        # 仅当服务由 --open-browser 模式启动时才响应 beacon
-        if current_config["browser_mode_enabled"]:
-            logger.info("收到beacon信号，准备关闭服务器...")
-            # 调度服务器关闭任务
-            asyncio.create_task(runtime.shutdown_server_async())
-            return {"success": True, "message": "服务器关闭信号已接收"}
+        # Steam/Electron uses /api/runtime/shutdown. Keep this browser-page
+        # lease completely inert in packaged and ordinary server modes.
+        if not current_config.get("browser_mode_enabled"):
+            return {"success": True, "ignored": True, "reason": "browser_mode_disabled"}
+        if not _browser_lifecycle_origin_allowed(request):
+            return JSONResponse(
+                {"success": False, "error": "origin_not_allowed"},
+                status_code=403,
+            )
+
+        try:
+            payload = await request.json()
+        except Exception:
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+
+        action = str(payload.get("action") or "shutdown").strip().lower()
+        client_id = str(payload.get("client_id") or "").strip()
+        if action in {"register", "heartbeat"}:
+            if not _touch_browser_lifecycle_client(client_id):
+                return JSONResponse(
+                    {"success": False, "error": "invalid_browser_client"},
+                    status_code=400,
+                )
+            return {"success": True, "message": "浏览器页面租约已更新"}
+
+        if action == "release":
+            if not client_id:
+                return JSONResponse(
+                    {"success": False, "error": "invalid_browser_client"},
+                    status_code=400,
+                )
+            _release_browser_lifecycle_client(client_id)
+            return {"success": True, "message": "浏览器页面租约已释放"}
+
+        if action == "shutdown":
+            # Compatibility for a cached pre-fix page. New pages release an
+            # explicit client lease; a legacy signal may only close the backend
+            # when no live replacement page is registered.
+            _schedule_browser_lifecycle_shutdown()
+            return {"success": True, "message": "服务器关闭待确认"}
+
+        return JSONResponse(
+            {"success": False, "error": "unsupported_browser_lifecycle_action"},
+            status_code=400,
+        )
     except Exception as e:
         logger.error(f"Beacon处理错误: {e}")
-        return {"success": False, "error": str(e)}
+        return JSONResponse(
+            {"success": False, "error": "browser_lifecycle_failed"},
+            status_code=500,
+        )
 
 
 def _runtime_shutdown_has_target() -> bool:

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -3308,46 +3308,6 @@ function autoFillAssistApiKey(force) {
     }
 }
 
-// Beacon功能 - 页面关闭时发送信号给服务器
-let beaconSent = false;
-
-function sendBeacon() {
-    if (window.parent !== window) {
-        return;
-    }
-
-    if (beaconSent) return;
-    beaconSent = true;
-
-    try {
-        const payload = JSON.stringify({
-            timestamp: Date.now(),
-            action: 'shutdown'
-        });
-
-        const blob = new Blob([payload], { type: 'application/json' });
-        const success = navigator.sendBeacon('/api/beacon/shutdown', blob);
-
-        if (!success) {
-            console.warn('Beacon发送失败，尝试使用fetch');
-            fetch('/api/beacon/shutdown', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: payload,
-                keepalive: true
-            }).catch(() => { });
-        }
-    } catch (e) {
-        // 忽略异常
-    }
-}
-
-// 监听页面关闭事件（仅在直接打开时）
-if (window.parent === window) {
-    window.addEventListener('beforeunload', sendBeacon);
-    window.addEventListener('unload', sendBeacon);
-}
-
 // Tooltip 动态定位功能
 function positionTooltip(iconElement, tooltipElement) {
     const iconRect = iconElement.getBoundingClientRect();

--- a/static/js/browser-mode-lifecycle.js
+++ b/static/js/browser-mode-lifecycle.js
@@ -1,0 +1,81 @@
+/**
+ * Keep a standalone ``--open-browser`` backend tied to its real browser pages.
+ *
+ * Reload and close both emit pagehide/beforeunload. Each document therefore
+ * owns a short-lived lease: a replacement document registers before the
+ * server's close grace period expires, while a genuinely closed page does not.
+ * The endpoint is inert in Electron/Steam mode.
+ */
+(function registerBrowserModeLifecycle() {
+    'use strict';
+
+    if (window.parent !== window || window.__nekoBrowserModeLifecycleInstalled) {
+        return;
+    }
+    window.__nekoBrowserModeLifecycleInstalled = true;
+
+    const endpoint = '/api/beacon/shutdown';
+    const clientId = (window.crypto && typeof window.crypto.randomUUID === 'function')
+        ? window.crypto.randomUUID()
+        : 'page-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+    let active = false;
+    let browserModeDisabled = false;
+    let heartbeatTimer = null;
+
+    function sendSignal(action, useBeacon) {
+        const body = JSON.stringify({ action: action, client_id: clientId });
+        if (useBeacon && navigator.sendBeacon) {
+            const blob = new Blob([body], { type: 'application/json' });
+            if (navigator.sendBeacon(endpoint, blob)) return null;
+        }
+        return fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: body,
+            keepalive: useBeacon === true
+        });
+    }
+
+    function stopHeartbeat() {
+        if (heartbeatTimer !== null) {
+            window.clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+        }
+    }
+
+    function registerPage() {
+        if (active || browserModeDisabled) return;
+        active = true;
+        sendSignal('register', false).then(function (response) {
+            return response.json().catch(function () { return {}; });
+        }).then(function (payload) {
+            // Electron/Steam deliberately returns ignored=true. Stop here so
+            // packaged clients do not keep sending browser-mode heartbeats.
+            if (payload && payload.ignored === true) {
+                browserModeDisabled = true;
+                active = false;
+                stopHeartbeat();
+            }
+        }).catch(function () {
+            // A later pageshow or full reload can retry registration. Failure
+            // to reach the already-local backend should not disturb the UI.
+        });
+        heartbeatTimer = window.setInterval(function () {
+            if (active) {
+                sendSignal('heartbeat', false).catch(function () { });
+            }
+        }, 15000);
+    }
+
+    function releasePage() {
+        if (!active) return;
+        active = false;
+        stopHeartbeat();
+        sendSignal('release', true);
+    }
+
+    registerPage();
+    window.addEventListener('pageshow', registerPage);
+    window.addEventListener('pagehide', releasePage);
+    window.addEventListener('beforeunload', releasePage);
+})();

--- a/static/js/character_card_manager/sync-and-legacy-memory.js
+++ b/static/js/character_card_manager/sync-and-legacy-memory.js
@@ -37,19 +37,6 @@ function handleCloudsaveCharacterSync(data) {
     });
 })();
 
-// sendBeacon 生命周期
-window.addEventListener('beforeunload', function () {
-    try {
-        navigator.sendBeacon('/api/beacon/shutdown');
-    } catch (e) { /* ignore */ }
-});
-
-window.addEventListener('unload', function () {
-    try {
-        navigator.sendBeacon('/api/beacon/shutdown');
-    } catch (e) { /* ignore */ }
-});
-
 // =========================================================================
 // 清理遗留记忆（Legacy Memory Cleanup）
 // -----------------------------------------------------------------------

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="api.settingsTitle">API Key 设置 - Project N.E.K.O.</title>
+    <script src="/static/js/browser-mode-lifecycle.js?v={{ static_asset_version }}"></script>
     <!-- i18next 加载器（统一处理 CDN 加载和初始化） -->
     <script src="/static/i18n-i18next.js?v={{ static_asset_version }}"></script>
     <link rel="stylesheet" href="/static/css/api_key_settings.css?v={{ static_asset_version }}">

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -10,6 +10,7 @@
     <!-- 模型预览/编辑页豁免 avatar 空闲节流：用户在此手动播放任意动画（含无参
          playAnimation 的舞蹈 VMD），期望满帧预览，不应被空闲地板压到 30fps -->
     <script>window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;</script>
+    <script src="/static/js/browser-mode-lifecycle.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/i18n-i18next.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/common_dialogs.js"></script>
     <link rel="stylesheet" href="/static/css/character_card_manager.css?v={{ static_asset_version | default('0') }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,7 @@
          配置帧率低于刷新率时改用定时器驱动而非 rAF 跳帧。只在本页加载；其它页面不加载
          即保持原行为。详见 static/frame-pacing.js。 -->
     <script src="/static/frame-pacing.js?v={{ static_asset_version }}"></script>
+    <script src="/static/js/browser-mode-lifecycle.js?v={{ static_asset_version }}"></script>
     <!-- i18next 加载器（统一处理 CDN 加载和初始化） -->
     <script src="/static/i18n-i18next.js?v={{ static_asset_version }}"></script>
     <script src="/static/common_dialogs.js?v={{ static_asset_version }}"></script>

--- a/tests/unit/test_browser_mode_lifecycle.py
+++ b/tests/unit/test_browser_mode_lifecycle.py
@@ -1,0 +1,217 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _RequestStub:
+    def __init__(self, payload, *, origin="http://testserver"):
+        self._payload = payload
+        self.headers = {"origin": origin}
+        self.base_url = "http://testserver/"
+
+    async def json(self):
+        return self._payload
+
+
+async def _reset_lifecycle(web_app) -> None:
+    web_app._reset_browser_lifecycle_state()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_browser_refresh_replaces_page_lease_without_stopping_backend():
+    from app.main_server import web_app
+
+    await _reset_lifecycle(web_app)
+    shutdown = AsyncMock()
+    try:
+        with (
+            patch.object(web_app, "_BROWSER_LIFECYCLE_CLOSE_GRACE_SECONDS", 0.02),
+            patch.object(web_app.runtime, "shutdown_server_async", shutdown),
+        ):
+            assert web_app._touch_browser_lifecycle_client("old-document") is True
+            web_app._release_browser_lifecycle_client("old-document")
+            await asyncio.sleep(0)
+            assert web_app._touch_browser_lifecycle_client("replacement-document") is True
+            await asyncio.sleep(0.04)
+
+        shutdown.assert_not_awaited()
+    finally:
+        await _reset_lifecycle(web_app)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_browser_close_stops_backend_after_last_page_releases():
+    from app.main_server import web_app
+
+    await _reset_lifecycle(web_app)
+    shutdown = AsyncMock()
+    try:
+        with (
+            patch.object(web_app, "_BROWSER_LIFECYCLE_CLOSE_GRACE_SECONDS", 0.01),
+            patch.object(web_app.runtime, "shutdown_server_async", shutdown),
+        ):
+            assert web_app._touch_browser_lifecycle_client("page-a") is True
+            assert web_app._touch_browser_lifecycle_client("page-b") is True
+            web_app._release_browser_lifecycle_client("page-a")
+            await asyncio.sleep(0.02)
+            shutdown.assert_not_awaited()
+
+            web_app._release_browser_lifecycle_client("page-b")
+            await asyncio.sleep(0.03)
+
+        shutdown.assert_awaited_once_with()
+    finally:
+        await _reset_lifecycle(web_app)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_browser_heartbeat_timeout_cleans_up_after_page_crash():
+    from app.main_server import web_app
+
+    await _reset_lifecycle(web_app)
+    shutdown = AsyncMock()
+    try:
+        with (
+            patch.object(web_app, "_BROWSER_LIFECYCLE_HEARTBEAT_TIMEOUT_SECONDS", 0.01),
+            patch.object(web_app, "_BROWSER_LIFECYCLE_CLOSE_GRACE_SECONDS", 0.01),
+            patch.object(web_app.runtime, "shutdown_server_async", shutdown),
+        ):
+            assert web_app._touch_browser_lifecycle_client("crashed-page") is True
+            await asyncio.sleep(0.04)
+
+        shutdown.assert_awaited_once_with()
+    finally:
+        await _reset_lifecycle(web_app)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_packaged_mode_ignores_browser_lifecycle_signal():
+    from app.main_server import web_app
+
+    await _reset_lifecycle(web_app)
+    shutdown = AsyncMock()
+    try:
+        with (
+            patch.object(
+                web_app.runtime,
+                "get_start_config",
+                return_value={"browser_mode_enabled": False},
+            ),
+            patch.object(web_app.runtime, "shutdown_server_async", shutdown),
+        ):
+            response = await web_app.beacon_shutdown(
+                _RequestStub({"action": "release", "client_id": "steam-page"})
+            )
+            await asyncio.sleep(0)
+
+        assert response == {
+            "success": True,
+            "ignored": True,
+            "reason": "browser_mode_disabled",
+        }
+        assert web_app._browser_lifecycle_clients == {}
+        shutdown.assert_not_awaited()
+    finally:
+        await _reset_lifecycle(web_app)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_browser_mode_endpoint_closes_after_registered_page_releases():
+    from app.main_server import web_app
+
+    await _reset_lifecycle(web_app)
+    shutdown = AsyncMock()
+    try:
+        with (
+            patch.object(
+                web_app.runtime,
+                "get_start_config",
+                return_value={"browser_mode_enabled": True},
+            ),
+            patch.object(web_app, "_BROWSER_LIFECYCLE_CLOSE_GRACE_SECONDS", 0.01),
+            patch.object(web_app.runtime, "shutdown_server_async", shutdown),
+        ):
+            register_response = await web_app.beacon_shutdown(
+                _RequestStub({"action": "register", "client_id": "source-page"})
+            )
+            release_response = await web_app.beacon_shutdown(
+                _RequestStub({"action": "release", "client_id": "source-page"})
+            )
+            await asyncio.sleep(0.03)
+
+        assert register_response["success"] is True
+        assert release_response["success"] is True
+        shutdown.assert_awaited_once_with()
+    finally:
+        await _reset_lifecycle(web_app)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_browser_mode_rejects_cross_origin_lifecycle_signal():
+    from app.main_server import web_app
+
+    await _reset_lifecycle(web_app)
+    shutdown = AsyncMock()
+    try:
+        with (
+            patch.object(
+                web_app.runtime,
+                "get_start_config",
+                return_value={"browser_mode_enabled": True},
+            ),
+            patch.object(web_app.runtime, "shutdown_server_async", shutdown),
+        ):
+            response = await web_app.beacon_shutdown(
+                _RequestStub(
+                    {"action": "register", "client_id": "foreign-page"},
+                    origin="https://example.invalid",
+                )
+            )
+
+        assert response.status_code == 403
+        assert web_app._browser_lifecycle_clients == {}
+        shutdown.assert_not_awaited()
+    finally:
+        await _reset_lifecycle(web_app)
+
+
+@pytest.mark.unit
+def test_browser_lifecycle_script_is_shared_by_all_standalone_pages():
+    lifecycle = (
+        PROJECT_ROOT / "static/js/browser-mode-lifecycle.js"
+    ).read_text(encoding="utf-8")
+    assert "sendSignal('register', false)" in lifecycle
+    assert "sendSignal('heartbeat', false)" in lifecycle
+    assert "sendSignal('release', true)" in lifecycle
+    assert "payload.ignored === true" in lifecycle
+
+    for template_name in (
+        "index.html",
+        "character_card_manager.html",
+        "api_key_settings.html",
+    ):
+        template = (PROJECT_ROOT / "templates" / template_name).read_text(
+            encoding="utf-8"
+        )
+        assert "/static/js/browser-mode-lifecycle.js" in template
+
+    character_lifecycle = (
+        PROJECT_ROOT / "static/js/character_card_manager/sync-and-legacy-memory.js"
+    ).read_text(encoding="utf-8")
+    api_key_settings = (PROJECT_ROOT / "static/js/api_key_settings.js").read_text(
+        encoding="utf-8"
+    )
+    assert "/api/beacon/shutdown" not in character_lifecycle
+    assert "/api/beacon/shutdown" not in api_key_settings


### PR DESCRIPTION
## 修改目的

修复 N.E.K.O 使用 `--open-browser` 源码模式运行时，刷新角色管理页或 API 设置页会错误关闭后端的问题。

## 问题原因

角色管理页和 API 设置页在 `beforeunload` / `unload` 阶段直接向 `/api/beacon/shutdown` 发送关闭请求。

浏览器刷新和真正关闭页面都会触发卸载事件，后端无法仅凭该事件区分两者。因此第一次刷新已经触发后端关闭；新页面可能短暂加载成功，但随后会失去连接。

## 修改内容

- 新增浏览器页面生命周期租约：
  - 页面加载时注册。
  - 页面存活期间定期发送心跳。
  - 页面卸载时释放。
- 最后一个页面释放后等待约 2 秒再关闭源码后端。
- 刷新后的新页面会在宽限期内重新注册并取消关闭。
- 多个页面同时打开时，关闭其中一个不会误关后端。
- 浏览器崩溃或卸载信号丢失时，最长约 120 秒后通过心跳超时清理后端。
- 移除角色管理页和 API 设置页原有的直接关闭 beacon。
- 首页、角色管理页和 API 设置页统一使用共享生命周期脚本。
- 生命周期接口增加同源检查和客户端数量上限。
- 保留旧页面 `shutdown` 请求的兼容处理。

## 用户可感知变化

- 源码模式下刷新角色管理页、API 设置页或首页后，页面能够继续连接后端。
- 真正关闭最后一个源码浏览器页面后，后端仍会自动退出。
- 不再出现“第一次刷新似乎成功，第二次刷新页面失去连接”的情况。

## 影响范围

- N.E.K.O 源码 `--open-browser` 模式。
- 首页、角色管理页和 API 设置页。
- `/api/beacon/shutdown` 浏览器生命周期接口。

## 不影响范围

- 不修改角色、记忆、配置或云存档数据。
- 不修改端口和进程所有权机制。
- 不修改 N.E.K.O-PC。
- Steam/Electron 模式的 `browser_mode_enabled` 为 `false`，会直接忽略浏览器生命周期请求。
- Steam 退出仍使用带令牌的 `/api/runtime/shutdown`，原有关闭链路不变。
- 无 UI、文案和多语言变化，因此不需要前后截图。

## 验证结果

基于官方 `main`：

- Base commit：`e7594e1333f918135df012694d2378896d13a25e`
- 修复 commit：`fc9911f2bb6694d0546b62059d58b6182f18f4d4`

执行：

```bash
uv run pytest \
  tests/unit/test_browser_mode_lifecycle.py \
  tests/unit/test_card_maker_static_contracts.py \
  tests/unit/test_cloudsave_lifecycle_flow.py \
  tests/frontend/test_character_card_manager_regressions.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增浏览器页面生命周期管理，支持页面注册、心跳续期和安全释放。
  * 浏览器模式下，所有页面关闭或心跳超时后，服务器会在宽限期后自动关闭。
  * 支持多页面使用，并校验客户端数量、标识及请求来源。

* **Bug 修复**
  * 避免单个页面刷新或关闭时误触发服务器关闭。
  * 非浏览器模式会忽略生命周期信号，跨来源请求将被拒绝。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->