### PR TITLE
修复“请她离开”状态下从系统托盘恢复默认模型后模型消失的问题

### DIFF
--- a/scripts/check_static_app_part_keys.cjs
+++ b/scripts/check_static_app_part_keys.cjs
@@ -33,7 +33,7 @@ const expectedPublicKeys = {
     appUi: [
         'completeGoodbyeResourceSuspend', 'ensureHiddenElements', 'hideLive2d',
         'hideVoicePreparingToast', 'initFinalUiGuards', 'initFloatingButtonListeners',
-        'restoreGoodbyeResourceSuspend', 'showCurrentModel', 'showLive2d',
+        'restoreGoodbyeResourceSuspend', 'returnFromGoodbye', 'showCurrentModel', 'showLive2d',
         'showProminentNotice', 'showReadyToSpeakToast', 'showStatusToast', 'showSurveyModal',
         'showVoicePreparingToast', 'syncFloatingMicButtonState', 'syncFloatingScreenButtonState',
     ],

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -367,6 +367,42 @@
                 throw new Error('missing_lanlan_name');
             }
 
+            async function ensureReturnedFromGoodbye() {
+                // 标准回来链会恢复 Electron Pet 的完整 viewport、解除资源暂停并
+                // 清掉 goodbye 标志。无条件调用还能加入一条已经开始、但 manager
+                // 标志恰好已清除的 return lifecycle。
+                if (window.appUi && typeof window.appUi.returnFromGoodbye === 'function') {
+                    var returnedFromGoodbye = await window.appUi.returnFromGoodbye({
+                        source: 'reset-to-default-model',
+                        retryViewportRestore: true
+                    });
+                    if (!returnedFromGoodbye) {
+                        throw new Error('goodbye_return_failed');
+                    }
+                    return;
+                }
+
+                var visibleReturnContainer = document.querySelector(
+                    '[id$="-return-button-container"][data-neko-return-visible="true"]'
+                );
+                var goodbyeActive = typeof window.isNekoGoodbyeModeActive === 'function'
+                    ? window.isNekoGoodbyeModeActive()
+                    : !!(
+                        (window.live2dManager && window.live2dManager._goodbyeClicked)
+                        || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                        || (window.mmdManager && window.mmdManager._goodbyeClicked)
+                    );
+                var returnTransitionActive = typeof window.isNekoModelCatTransitionActive === 'function'
+                    && window.isNekoModelCatTransitionActive();
+                if (goodbyeActive || visibleReturnContainer || returnTransitionActive) {
+                    throw new Error('goodbye_return_unavailable');
+                }
+            }
+
+            // 直接热重载会移除唯一可见的回来控件，却把新的 Live2D 留在
+            // 160x160 carrier 外。持久化前先完整回来。
+            await ensureReturnedFromGoodbye();
+
             // Persist the change so that future reloads keep the default avatar.
             var putUrl = '/api/characters/catgirl/l2d/' + encodeURIComponent(lanlanName);
             var putResp = await fetch(putUrl, {

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -16,6 +16,209 @@
 
     window.appUi = window.appUi || {};
     const I = window.__appUiParts || (window.__appUiParts = {});
+    const PROGRAMMATIC_GOODBYE_RETURN_TIMEOUT_MS = 15000;
+    let programmaticGoodbyeReturnPromise = null;
+
+    function getVisibleGoodbyeReturnContainer() {
+        if (typeof I.getVisibleIdleReturnBallContainer === 'function') {
+            const container = I.getVisibleIdleReturnBallContainer();
+            if (container) return container;
+        }
+        return document.querySelector(
+            '[id$="-return-button-container"][data-neko-return-visible="true"]'
+        );
+    }
+
+    function isGoodbyeRuntimeActive() {
+        if (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive()) {
+            return true;
+        }
+        return !!(
+            (window.live2dManager && window.live2dManager._goodbyeClicked)
+            || (window.vrmManager && window.vrmManager._goodbyeClicked)
+            || (window.mmdManager && window.mmdManager._goodbyeClicked)
+        );
+    }
+
+    function isModelCatTransitionActive(direction) {
+        return typeof I.isNekoModelCatTransitionActive === 'function'
+            && I.isNekoModelCatTransitionActive(direction);
+    }
+
+    function isReturnBallViewportActive() {
+        const pendingRestoreBounds = typeof I.getPendingModelViewportRestoreBounds === 'function'
+            ? I.getPendingModelViewportRestoreBounds()
+            : null;
+        if (pendingRestoreBounds) return true;
+        return !!(
+            window.nekoPetDrag
+            && typeof I.isNativeReturnBallViewportSize === 'function'
+            && I.isNativeReturnBallViewportSize(window.innerWidth, window.innerHeight)
+        );
+    }
+
+    function resolveGoodbyeReturnModelType(container) {
+        const visibleTypeMatch = container && String(container.id || '')
+            .match(/^(live2d|vrm|mmd|pngtuber)-return-button-container$/);
+        if (visibleTypeMatch) return visibleTypeMatch[1];
+
+        const configuredType = String(window.lanlan_config?.model_type || 'live2d').toLowerCase();
+        const live3dSubType = String(window.lanlan_config?.live3d_sub_type || '').toLowerCase();
+        if (configuredType === 'live3d') {
+            return live3dSubType === 'mmd' ? 'mmd' : 'vrm';
+        }
+        return ['live2d', 'vrm', 'mmd', 'pngtuber'].includes(configuredType)
+            ? configuredType
+            : 'live2d';
+    }
+
+    function waitForGoodbyeReturnTerminal(options) {
+        const timeoutMs = Number.isFinite(Number(options.timeoutMs))
+            ? Math.max(1000, Number(options.timeoutMs))
+            : PROGRAMMATIC_GOODBYE_RETURN_TIMEOUT_MS;
+
+        return new Promise((resolve) => {
+            let settled = false;
+            let timeoutId = null;
+            const waitForTransitionToSettle = async (direction) => {
+                while (!settled && isModelCatTransitionActive(direction)) {
+                    const transition = I.nekoModelCatTransitionActive;
+                    if (transition && transition.promise && typeof transition.promise.then === 'function') {
+                        try {
+                            await transition.promise;
+                        } catch (_) {
+                            // A rejected transition may remain registered until
+                            // its owner's cleanup runs. Yield before rechecking
+                            // so the loop cannot starve that cleanup or timeout.
+                            await new Promise((resume) => window.setTimeout(resume, 16));
+                        }
+                    } else {
+                        await new Promise((resume) => window.setTimeout(resume, 16));
+                    }
+                }
+            };
+            const finish = (restored) => {
+                if (settled) return;
+                settled = true;
+                if (timeoutId !== null) window.clearTimeout(timeoutId);
+                window.removeEventListener('neko:cat-return-complete', handleComplete);
+                window.removeEventListener('neko:cat-return-abort', handleAbort);
+                resolve(restored === true);
+            };
+            const handleComplete = () => {
+                // The canonical handler publishes complete from inside its
+                // finally-protected lifecycle. Let that stack unwind and wait
+                // for the concurrently running cat-to-model smoke transition
+                // before allowing a model reload to replace its container.
+                Promise.resolve().then(async () => {
+                    await waitForTransitionToSettle('cat-to-model');
+                    const fullyRestored = !isGoodbyeRuntimeActive()
+                        && !getVisibleGoodbyeReturnContainer()
+                        && !isReturnBallViewportActive()
+                        && !I.nekoCatReturnInProgress
+                        && !isModelCatTransitionActive('model-to-cat')
+                        && !isModelCatTransitionActive('cat-to-model');
+                    finish(fullyRestored);
+                }).catch((error) => {
+                    console.error('[App] 等待猫咪返回过渡结束失败:', error);
+                    finish(false);
+                });
+            };
+            const handleAbort = () => finish(false);
+
+            window.addEventListener('neko:cat-return-complete', handleComplete);
+            window.addEventListener('neko:cat-return-abort', handleAbort);
+            timeoutId = window.setTimeout(() => {
+                console.warn('[App] 程序化恢复模型超时:', options.source || 'unknown');
+                finish(false);
+            }, timeoutMs);
+
+            const dispatchReturnWhenReady = async () => {
+                // “请她离开”会先置 goodbye 标志，再播放 model-to-cat 动画；
+                // 统一 return handler 在动画结束前会忽略事件，因此这里先加入动画。
+                await waitForTransitionToSettle('model-to-cat');
+                if (settled) return;
+
+                // 用户可能已先点了“请她回来”。此时只等待同一条标准返回链的
+                // terminal event，不能再派发一次并发恢复。
+                if (I.nekoCatReturnInProgress) {
+                    return;
+                }
+                if (isModelCatTransitionActive('cat-to-model')) {
+                    // A manual return may have already published its terminal
+                    // event just before this helper installed listeners. Join
+                    // the remaining visual transition, then adjudicate state.
+                    await waitForTransitionToSettle('cat-to-model');
+                    if (settled) return;
+                    if (!isGoodbyeRuntimeActive()
+                        && !getVisibleGoodbyeReturnContainer()
+                        && !isReturnBallViewportActive()) {
+                        finish(true);
+                        return;
+                    }
+                }
+
+                const visibleReturnContainer = getVisibleGoodbyeReturnContainer();
+                if (!isGoodbyeRuntimeActive()
+                    && !visibleReturnContainer
+                    && !isReturnBallViewportActive()) {
+                    finish(true);
+                    return;
+                }
+
+                const activeType = resolveGoodbyeReturnModelType(visibleReturnContainer);
+                let returnButtonRect = null;
+                if (visibleReturnContainer && typeof visibleReturnContainer.getBoundingClientRect === 'function') {
+                    const clientRect = visibleReturnContainer.getBoundingClientRect();
+                    const transitionRect = typeof I.toNekoVirtualTransitionRect === 'function'
+                        ? (I.toNekoVirtualTransitionRect(clientRect) || clientRect)
+                        : clientRect;
+                    returnButtonRect = {
+                        left: transitionRect.left,
+                        top: transitionRect.top,
+                        width: transitionRect.width,
+                        height: transitionRect.height
+                    };
+                }
+                window.dispatchEvent(new CustomEvent(`${activeType}-return-click`, {
+                    detail: {
+                        source: options.source || 'programmatic-return',
+                        retryViewportRestore: options.retryViewportRestore === true,
+                        returnButtonRect
+                    }
+                }));
+            };
+
+            dispatchReturnWhenReady().catch((error) => {
+                console.error('[App] 程序化恢复模型失败:', error);
+                finish(false);
+            });
+        });
+    }
+
+    I.returnFromGoodbye = function returnFromGoodbye(options = {}) {
+        options = options && typeof options === 'object' ? options : {};
+        if (programmaticGoodbyeReturnPromise) return programmaticGoodbyeReturnPromise;
+
+        const hasReturnState = isGoodbyeRuntimeActive()
+            || !!getVisibleGoodbyeReturnContainer()
+            || !!I.nekoCatReturnInProgress
+            || isModelCatTransitionActive('model-to-cat')
+            || isModelCatTransitionActive('cat-to-model')
+            || isReturnBallViewportActive();
+        if (!hasReturnState) return Promise.resolve(true);
+
+        const returnPromise = waitForGoodbyeReturnTerminal(options);
+        programmaticGoodbyeReturnPromise = returnPromise;
+        const clearProgrammaticReturn = () => {
+            if (programmaticGoodbyeReturnPromise === returnPromise) {
+                programmaticGoodbyeReturnPromise = null;
+            }
+        };
+        returnPromise.then(clearProgrammaticReturn, clearProgrammaticReturn);
+        return returnPromise;
+    };
+
     function initFloatingButtonListeners() {
         // DOM refs from orchestrator
         const micButton = I.S.dom.micButton;
@@ -1424,6 +1627,29 @@
                 console.log('[App] 模型正在切换为猫形态，忽略本次请她回来事件');
                 return;
             }
+            if (I.nekoCatReturnInProgress) {
+                console.log('[App] 请她回来流程已在执行，忽略重复事件');
+                return;
+            }
+            I.nekoCatReturnInProgress = true;
+            const publishReturnAbort = () => {
+                window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
+                    detail: {
+                        source: event && event.type ? event.type : 'return-click',
+                        reason: 'return-incomplete',
+                        timestamp: Date.now()
+                    }
+                }));
+            };
+            const abortReturnBeforeTerminalGuard = () => {
+                I.nekoCatReturnInProgress = false;
+                publishReturnAbort();
+            };
+            let live2DPeekRestoreAnchor = null;
+            try {
+            const returnDetail = event && event.detail && typeof event.detail === 'object'
+                ? event.detail
+                : {};
             const hadPendingGoodbyeReset = !!window._goodbyeResetClickTimerId;
             if (hadPendingGoodbyeReset) {
                 clearTimeout(window._goodbyeResetClickTimerId);
@@ -1436,15 +1662,28 @@
             }
             const preReturnViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
             if (!preReturnViewportReady.ready) {
-                console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
-                restoreReturnBallAfterBlockedModelViewport(event);
-                if (hadPendingGoodbyeReset) {
-                    runGoodbyeResetClickIfActive('return-viewport-blocked');
+                let retryViewportReady = preReturnViewportReady;
+                if (returnDetail.retryViewportRestore === true) {
+                    // Electron 的 Pet carrier 从 160x160 恢复到完整 viewport 是异步的。
+                    // 托盘触发时额外给有限次数重试，避免 resize 通知略晚于首轮等待。
+                    for (let attempt = 0; attempt < 2 && !retryViewportReady.ready; attempt += 1) {
+                        await new Promise((resolve) => window.setTimeout(resolve, 50));
+                        retryViewportReady = await I.ensureModelViewportReadyBeforeShowCurrentModel();
+                    }
                 }
-                return;
+                if (retryViewportReady.ready) {
+                    console.log('[App] Pet viewport 重试后已恢复，继续请她回来流程');
+                } else {
+                    console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
+                    restoreReturnBallAfterBlockedModelViewport(event);
+                    if (hadPendingGoodbyeReset) {
+                        runGoodbyeResetClickIfActive('return-viewport-blocked');
+                    }
+                    abortReturnBeforeTerminalGuard();
+                    return;
+                }
             }
             let hadCatCycle = false;
-            let live2DPeekRestoreAnchor = null;
             try {
                 const returnContainer = I.getVisibleIdleReturnBallContainer();
                 hadCatCycle = !!(returnContainer &&
@@ -1472,6 +1711,10 @@
                     timestamp: Date.now()
                 }
             }));
+            } catch (error) {
+                abortReturnBeforeTerminalGuard();
+                throw error;
+            }
             let returnTerminalPublished = false;
             try {
             const isReturningToPngtuber = (window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber';
@@ -1958,6 +2201,7 @@
 
             console.log('[App] 请她回来完成，未自动开始会话，等待用户主动发起对话');
             } finally {
+                I.nekoCatReturnInProgress = false;
                 if (!returnTerminalPublished) {
                     window.dispatchEvent(new CustomEvent('neko:cat-return-abort', {
                         detail: {
@@ -1978,6 +2222,7 @@
     }
 
     I.mod.initFloatingButtonListeners = initFloatingButtonListeners;
+    I.mod.returnFromGoodbye = I.returnFromGoodbye;
 
     // ================================================================
     //  5. ensureHiddenElements & final UI init  (app.js lines 11354-11420)

--- a/tests/frontend/default_model_goodbye_return.test.cjs
+++ b/tests/frontend/default_model_goodbye_return.test.cjs
@@ -1,0 +1,410 @@
+// Copyright 2025-2026 Project N.E.K.O. Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// pytest's shared Node launcher copies this source to a temporary directory.
+// Fall back to its cwd so direct Node runs and CI resolve the same real files.
+const fileRoot = path.resolve(__dirname, '..', '..');
+const projectRoot = fs.existsSync(path.join(fileRoot, 'static')) ? fileRoot : process.cwd();
+const surfaceSource = fs.readFileSync(
+  path.join(projectRoot, 'static/app/app-ui/surface-floating-controls.js'),
+  'utf8',
+);
+const resetSource = fs.readFileSync(
+  path.join(projectRoot, 'static/app/app-interpage/listeners-and-api.js'),
+  'utf8',
+);
+
+function extractResetBlock() {
+  const start = resetSource.indexOf("var DEFAULT_LIVE2D_MODEL_NAME = 'yui-lolita';");
+  const end = resetSource.indexOf('// Public API', start);
+  assert.notEqual(start, -1, 'default-model reset declaration must exist');
+  assert.notEqual(end, -1, 'default-model reset block must have a stable end marker');
+  return `${resetSource.slice(start, end)}\nwindow.__testResetToDefaultModel = resetToDefaultModel;`;
+}
+
+function extractCanonicalReturnBlock() {
+  const start = surfaceSource.indexOf('function restoreReturnBallAfterBlockedModelViewport(event)');
+  const end = surfaceSource.indexOf('// 统一监听各模型类型的回来事件', start);
+  assert.notEqual(start, -1, 'return viewport recovery helper must exist');
+  assert.notEqual(end, -1, 'canonical return handler must have a stable end marker');
+  return `${surfaceSource.slice(start, end)}
+    window.addEventListener('live2d-return-click', handleReturnClick);
+    window.addEventListener('vrm-return-click', handleReturnClick);
+    window.addEventListener('mmd-return-click', handleReturnClick);
+    window.addEventListener('pngtuber-return-click', handleReturnClick);`;
+}
+
+function createHarness({
+  modelType = 'live2d',
+  subType = '',
+  goodbyeActive = true,
+  visibleReturnType = '',
+} = {}) {
+  const listeners = new Map();
+  const dispatched = [];
+  const timeline = [];
+  let active = goodbyeActive;
+  let visibleContainer = null;
+  let transitionDirection = '';
+  let transitionPromise = null;
+  let viewportCheckCount = 0;
+  let returnBallShowCount = 0;
+  let returnBallRevealCount = 0;
+  const testConsole = { log() {}, warn() {}, error() {} };
+
+  const makeReturnContainer = (type) => ({
+    id: `${type}-return-button-container`,
+    style: { display: 'block' },
+    getBoundingClientRect() {
+      return { left: 12, top: 24, width: 80, height: 80 };
+    },
+  });
+  const setVisibleReturnType = (type) => {
+    visibleContainer = type ? makeReturnContainer(type) : null;
+  };
+  setVisibleReturnType(visibleReturnType);
+
+  const parts = {
+    mod: {},
+    getVisibleIdleReturnBallContainer() {
+      return visibleContainer;
+    },
+    isNekoModelCatTransitionActive(direction) {
+      return direction ? transitionDirection === direction : !!transitionDirection;
+    },
+    toNekoVirtualTransitionRect(rect) {
+      return rect;
+    },
+  };
+
+  const document = {
+    querySelector(selector) {
+      if (!selector.includes('-return-button-container')) return null;
+      return visibleContainer;
+    },
+    getElementById(id) {
+      return visibleContainer && visibleContainer.id === id ? visibleContainer : null;
+    },
+  };
+
+  const window = {
+    appUi: {},
+    __appUiParts: parts,
+    innerWidth: 1280,
+    innerHeight: 720,
+    lanlan_config: {
+      lanlan_name: '测试角色',
+      model_type: modelType,
+      live3d_sub_type: subType,
+    },
+    isNekoGoodbyeModeActive: () => active,
+    addEventListener(type, listener) {
+      const bucket = listeners.get(type) || [];
+      bucket.push(listener);
+      listeners.set(type, bucket);
+    },
+    removeEventListener(type, listener) {
+      const bucket = listeners.get(type) || [];
+      listeners.set(type, bucket.filter((entry) => entry !== listener));
+    },
+    dispatchEvent(event) {
+      dispatched.push(event);
+      if (event.type.endsWith('-return-click')) timeline.push(event.type);
+      for (const listener of [...(listeners.get(event.type) || [])]) listener(event);
+      return true;
+    },
+    setTimeout,
+    clearTimeout,
+    showStatusToast() {},
+    t: (key) => key,
+  };
+
+  class CustomEvent {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.detail = init.detail;
+    }
+  }
+
+  const context = {
+    window,
+    document,
+    CustomEvent,
+    console: testConsole,
+    setTimeout,
+    clearTimeout,
+  };
+  vm.runInNewContext(surfaceSource, context, { filename: 'surface-floating-controls.js' });
+
+  const interpage = {
+    async handleModelReload() {
+      timeline.push('reload');
+      return true;
+    },
+  };
+  vm.runInNewContext(extractResetBlock(), {
+    window,
+    document,
+    I: interpage,
+    console: testConsole,
+    fetch: async (_url, options = {}) => {
+      assert.equal(options.method, 'PUT');
+      timeline.push('put');
+      return {
+        ok: true,
+        status: 200,
+        async text() { return ''; },
+      };
+    },
+    setTimeout,
+    clearTimeout,
+  }, { filename: 'listeners-and-api-reset.js' });
+
+  return {
+    window,
+    parts,
+    dispatched,
+    timeline,
+    runReset: () => window.__testResetToDefaultModel(),
+    waitForEvent(type) {
+      return new Promise((resolve) => {
+        const listener = (event) => {
+          window.removeEventListener(type, listener);
+          resolve(event);
+        };
+        window.addEventListener(type, listener);
+      });
+    },
+    installCanonicalReturnHandler({ viewportReady = false } = {}) {
+      parts.ensureModelViewportReadyBeforeShowCurrentModel = async () => {
+        viewportCheckCount += 1;
+        return { ready: viewportReady };
+      };
+      parts.showReturnBallContainer = (container) => {
+        returnBallShowCount += 1;
+        container.style.display = 'block';
+        return container;
+      };
+      parts.revealReturnBallContainer = () => {
+        returnBallRevealCount += 1;
+      };
+      vm.runInNewContext(extractCanonicalReturnBlock(), {
+        window,
+        document,
+        CustomEvent,
+        I: parts,
+        console: testConsole,
+        setTimeout,
+        clearTimeout,
+      }, { filename: 'canonical-goodbye-return.js' });
+    },
+    setReturnInProgress(value) {
+      parts.nekoCatReturnInProgress = value === true;
+    },
+    hideVisibleReturnContainer() {
+      if (visibleContainer) visibleContainer.style.display = 'none';
+    },
+    get viewportCheckCount() { return viewportCheckCount; },
+    get returnBallShowCount() { return returnBallShowCount; },
+    get returnBallRevealCount() { return returnBallRevealCount; },
+    setTransition(direction, promise = null) {
+      transitionDirection = direction;
+      transitionPromise = promise;
+      parts.nekoModelCatTransitionActive = direction ? { direction, promise: transitionPromise } : null;
+    },
+    clearTransition() {
+      transitionDirection = '';
+      transitionPromise = null;
+      parts.nekoModelCatTransitionActive = null;
+    },
+    completeReturn() {
+      active = false;
+      setVisibleReturnType('');
+      timeline.push('complete');
+      window.dispatchEvent(new CustomEvent('neko:cat-return-complete'));
+      parts.nekoCatReturnInProgress = false;
+    },
+    abortReturn() {
+      timeline.push('abort');
+      parts.nekoCatReturnInProgress = false;
+      window.dispatchEvent(new CustomEvent('neko:cat-return-abort'));
+    },
+  };
+}
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+test('default reset waits for the canonical goodbye return before PUT and reload', async () => {
+  const harness = createHarness({ visibleReturnType: 'live2d' });
+  const reset = harness.runReset();
+  await flushMicrotasks();
+
+  assert.deepEqual(harness.timeline, ['live2d-return-click']);
+  const returnEvent = harness.dispatched.find((event) => event.type === 'live2d-return-click');
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(returnEvent.detail.returnButtonRect)),
+    { left: 12, top: 24, width: 80, height: 80 },
+  );
+  harness.completeReturn();
+
+  assert.equal((await reset).success, true);
+  assert.deepEqual(harness.timeline, ['live2d-return-click', 'complete', 'put', 'reload']);
+});
+
+test('an aborted goodbye return does not persist or reload the default model', async () => {
+  const harness = createHarness({ visibleReturnType: 'live2d' });
+  const reset = harness.runReset();
+  await flushMicrotasks();
+  harness.abortReturn();
+
+  const result = await reset;
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'goodbye_return_failed');
+  assert.deepEqual(harness.timeline, ['live2d-return-click', 'abort']);
+});
+
+test('default reset keeps its existing direct path outside goodbye mode', async () => {
+  const harness = createHarness({ goodbyeActive: false });
+  assert.equal((await harness.runReset()).success, true);
+  assert.deepEqual(harness.timeline, ['put', 'reload']);
+  assert.equal(harness.dispatched.some((event) => event.type.endsWith('-return-click')), false);
+});
+
+for (const [modelType, subType, expectedEvent] of [
+  ['live2d', '', 'live2d-return-click'],
+  ['vrm', '', 'vrm-return-click'],
+  ['live3d', 'vrm', 'vrm-return-click'],
+  ['live3d', 'mmd', 'mmd-return-click'],
+  ['mmd', '', 'mmd-return-click'],
+  ['pngtuber', '', 'pngtuber-return-click'],
+]) {
+  test(`programmatic return follows the ${modelType}/${subType || '-'} route`, async () => {
+    const harness = createHarness({ modelType, subType });
+    const returned = harness.window.appUi.returnFromGoodbye({ source: 'reset-to-default-model' });
+    await flushMicrotasks();
+    assert.deepEqual(harness.timeline, [expectedEvent]);
+    harness.completeReturn();
+    assert.equal(await returned, true);
+  });
+}
+
+test('the visible return control wins over stale model configuration', async () => {
+  const harness = createHarness({ modelType: 'vrm', visibleReturnType: 'mmd' });
+  const returned = harness.window.appUi.returnFromGoodbye();
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, ['mmd-return-click']);
+  harness.completeReturn();
+  assert.equal(await returned, true);
+});
+
+test('programmatic return waits for the model-to-cat transition', async () => {
+  const harness = createHarness({ visibleReturnType: 'live2d' });
+  let finishTransition;
+  const transition = new Promise((resolve) => { finishTransition = resolve; });
+  harness.setTransition('model-to-cat', transition);
+
+  const returned = harness.window.appUi.returnFromGoodbye();
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, []);
+
+  harness.clearTransition();
+  finishTransition();
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, ['live2d-return-click']);
+  harness.completeReturn();
+  assert.equal(await returned, true);
+});
+
+test('concurrent programmatic returns share one canonical return request', async () => {
+  const harness = createHarness({ visibleReturnType: 'pngtuber' });
+  const first = harness.window.appUi.returnFromGoodbye();
+  const second = harness.window.appUi.returnFromGoodbye();
+
+  assert.strictEqual(first, second);
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, ['pngtuber-return-click']);
+  harness.completeReturn();
+  assert.equal(await first, true);
+});
+
+test('default reset joins a manual return already in progress without redispatching', async () => {
+  const harness = createHarness({ visibleReturnType: 'vrm' });
+  const reset = harness.runReset();
+  // Race a user-initiated return into the helper's first async boundary.
+  harness.setReturnInProgress(true);
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, []);
+
+  harness.completeReturn();
+  assert.equal((await reset).success, true);
+  assert.deepEqual(harness.timeline, ['complete', 'put', 'reload']);
+});
+
+test('default reset joins a cat-to-model transition after its terminal event', async () => {
+  const harness = createHarness({ goodbyeActive: false });
+  let finishTransition;
+  const transition = new Promise((resolve) => { finishTransition = resolve; });
+  harness.setTransition('cat-to-model', transition);
+
+  const reset = harness.runReset();
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, []);
+
+  harness.clearTransition();
+  finishTransition();
+  assert.equal((await reset).success, true);
+  assert.deepEqual(harness.timeline, ['put', 'reload']);
+  assert.equal(harness.dispatched.some((event) => event.type.endsWith('-return-click')), false);
+});
+
+test('programmatic return waits for a reserved model-to-cat transition without a promise', async () => {
+  const harness = createHarness({ visibleReturnType: 'live2d' });
+  harness.setTransition('model-to-cat');
+
+  const returned = harness.window.appUi.returnFromGoodbye();
+  await flushMicrotasks();
+  assert.deepEqual(harness.timeline, []);
+
+  const returnEvent = harness.waitForEvent('live2d-return-click');
+  harness.clearTransition();
+  await returnEvent;
+  assert.deepEqual(harness.timeline, ['live2d-return-click']);
+  harness.completeReturn();
+  assert.equal(await returned, true);
+});
+
+test('a real viewport restore abort prevents persistence and leaves return retryable', async () => {
+  const harness = createHarness({ visibleReturnType: 'live2d' });
+  harness.installCanonicalReturnHandler({ viewportReady: false });
+  harness.hideVisibleReturnContainer();
+
+  const result = await harness.runReset();
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'goodbye_return_failed');
+  assert.equal(harness.viewportCheckCount, 3);
+  assert.equal(harness.returnBallShowCount, 1);
+  assert.equal(harness.returnBallRevealCount, 1);
+  assert.equal(harness.parts.nekoCatReturnInProgress, false);
+  assert.deepEqual(harness.timeline, ['live2d-return-click']);
+  const abortEvents = harness.dispatched.filter((event) => event.type === 'neko:cat-return-abort');
+  assert.equal(abortEvents.length, 1);
+  assert.equal(abortEvents[0].detail.reason, 'return-incomplete');
+});

--- a/tests/unit/test_default_model_goodbye_return.py
+++ b/tests/unit/test_default_model_goodbye_return.py
@@ -1,0 +1,32 @@
+"""Pytest entry point for the default-model/goodbye return behavior suite."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_default_model_goodbye_return_node_suite() -> None:
+    node_path = shutil.which("node")
+    if not node_path:
+        pytest.skip("node not found")
+
+    suite_path = PROJECT_ROOT / "tests" / "frontend" / "default_model_goodbye_return.test.cjs"
+    result = run_node_script(
+        node_path,
+        f"require({json.dumps(str(suite_path))});",
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复“请她离开”状态下从系统托盘恢复默认模型后模型消失的问题

## 测试 / Testing

手动确认问题已经解决


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持以编程方式退出 Goodbye 模式并恢复模型。
  * 重置默认模型前会自动完成返回流程，确保模型状态正确恢复。
  * 支持等待返回动画完成，并在视口尚未就绪时自动重试。

* **错误修复**
  * 防止重复触发返回操作造成流程冲突。
  * 返回失败或中止时不会保存未完成的默认模型状态，并支持后续重试。

* **测试**
  * 增加 Goodbye 返回、默认模型重置及异常场景的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->