### PR TITLE
允许点击复制状态 Toast 文本

### DIFF
--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -434,14 +434,18 @@ I.mod = window.appUi;
         }
 
         function showStatusToastCopyFeedback(textEl, copyRevision) {
+            if (textEl._copyFeedbackTimer) clearTimeout(textEl._copyFeedbackTimer);
             textEl.classList.remove('status-toast-copy-success');
             void textEl.offsetWidth;
             textEl.classList.add('status-toast-copy-success');
-            setTimeout(() => {
+            const feedbackTimer = setTimeout(() => {
+                if (textEl._copyFeedbackTimer !== feedbackTimer) return;
                 if (statusToast._copyRevision === copyRevision) {
                     textEl.classList.remove('status-toast-copy-success');
                 }
+                textEl._copyFeedbackTimer = null;
             }, 450);
+            textEl._copyFeedbackTimer = feedbackTimer;
         }
 
         function hideNow() {
@@ -526,9 +530,7 @@ I.mod = window.appUi;
         textEl.onclick = (e) => {
             copyCurrentMessage(e);
             if (document.activeElement === textEl) textEl.blur();
-            if (!I.S.statusToastTimeout && !statusToast.classList.contains('hide')) {
-                scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
-            }
+            if (statusToast._toastFocusOut) statusToast._toastFocusOut();
         };
         textEl.onkeydown = (e) => {
             if (e.key !== 'Enter' && e.key !== ' ') return;

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -523,7 +523,13 @@ I.mod = window.appUi;
                 }
             });
         };
-        textEl.onclick = copyCurrentMessage;
+        textEl.onclick = (e) => {
+            copyCurrentMessage(e);
+            if (document.activeElement === textEl) textEl.blur();
+            if (!I.S.statusToastTimeout && !statusToast.classList.contains('hide')) {
+                scheduleHide(I.S._statusToastRemaining != null ? I.S._statusToastRemaining : duration);
+            }
+        };
         textEl.onkeydown = (e) => {
             if (e.key !== 'Enter' && e.key !== ' ') return;
             e.preventDefault();

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -433,14 +433,19 @@ I.mod = window.appUi;
             return copyWithWebClipboard();
         }
 
-        function showStatusToastCopyFeedback(textEl) {
+        function showStatusToastCopyFeedback(textEl, copyRevision) {
             textEl.classList.remove('status-toast-copy-success');
             void textEl.offsetWidth;
             textEl.classList.add('status-toast-copy-success');
-            setTimeout(() => textEl.classList.remove('status-toast-copy-success'), 450);
+            setTimeout(() => {
+                if (statusToast._copyRevision === copyRevision) {
+                    textEl.classList.remove('status-toast-copy-success');
+                }
+            }, 450);
         }
 
         function hideNow() {
+            statusToast._copyRevision = (Number(statusToast._copyRevision) || 0) + 1;
             if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
             if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
             if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
@@ -450,12 +455,15 @@ I.mod = window.appUi;
             if (statusToast._toastFocusOut) { statusToast.removeEventListener('focusout', statusToast._toastFocusOut); statusToast._toastFocusOut = null; }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
+            const _copyText = statusToast.querySelector('#status-toast-text');
+            if (_copyText) { _copyText.classList.remove('status-toast-copy-success'); _copyText.tabIndex = -1; _copyText.setAttribute('aria-hidden', 'true'); if (document.activeElement === _copyText) _copyText.blur(); }
             const _cb3 = statusToast.querySelector('#status-toast-close');
             if (_cb3) { _cb3.disabled = true; _cb3.tabIndex = -1; _cb3.setAttribute('aria-hidden','true'); }
             I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastPriority = 0; I.S._statusToastCleanupTimer = null; if (I.mod.api && I.mod.api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) I.mod.api.setMouseThrough(true); }, 400);
         }
 
         if (!message || message.trim() === '') {
+            statusToast._copyRevision = (Number(statusToast._copyRevision) || 0) + 1;
             if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
             if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
             if (I.S._statusToastCleanupTimer) { clearTimeout(I.S._statusToastCleanupTimer); I.S._statusToastCleanupTimer = null; }
@@ -465,6 +473,8 @@ I.mod = window.appUi;
             if (statusToast._toastFocusOut) { statusToast.removeEventListener('focusout', statusToast._toastFocusOut); statusToast._toastFocusOut = null; }
             const _cb2 = statusToast.querySelector('#status-toast-close');
             if (_cb2) { _cb2.disabled = true; _cb2.tabIndex = -1; _cb2.setAttribute('aria-hidden','true'); if (document.activeElement === _cb2) _cb2.blur(); }
+            const _copyText2 = statusToast.querySelector('#status-toast-text');
+            if (_copyText2) { _copyText2.classList.remove('status-toast-copy-success'); _copyText2.tabIndex = -1; _copyText2.setAttribute('aria-hidden', 'true'); if (document.activeElement === _copyText2) _copyText2.blur(); }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
             I.S._statusToastCleanupTimer = setTimeout(() => { const t = statusToast.querySelector('#status-toast-text'); if (t) t.textContent = ''; Array.from(statusToast.childNodes).forEach(n => { if (n.nodeType === 3) n.textContent = ''; }); I.S._statusToastCleanupTimer = null; if (I.mod.api && I.mod.api.setMouseThrough && !document.getElementById('prominent-notice-overlay')) I.mod.api.setMouseThrough(true); }, 400);
@@ -495,15 +505,29 @@ I.mod = window.appUi;
             I.S._statusToastCleanupTimer = null;
         }
         Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
+        const copyRevision = (Number(statusToast._copyRevision) || 0) + 1;
+        statusToast._copyRevision = copyRevision;
+        textEl.classList.remove('status-toast-copy-success');
         textEl.textContent = message;
         textEl.title = typeof window.t === 'function'
             ? window.t('chat.copyToClipboard', { defaultValue: 'Copy to clipboard' })
             : 'Copy to clipboard';
-        textEl.onclick = (e) => {
+        textEl.setAttribute('role', 'button');
+        textEl.setAttribute('aria-hidden', 'false');
+        textEl.tabIndex = 0;
+        const copyCurrentMessage = (e) => {
             e.stopPropagation();
             copyStatusToastText(message).then((copied) => {
-                if (copied) showStatusToastCopyFeedback(textEl);
+                if (copied && statusToast._copyRevision === copyRevision) {
+                    showStatusToastCopyFeedback(textEl, copyRevision);
+                }
             });
+        };
+        textEl.onclick = copyCurrentMessage;
+        textEl.onkeydown = (e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            e.preventDefault();
+            copyCurrentMessage(e);
         };
         closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -371,6 +371,75 @@ I.mod = window.appUi;
             I.S.statusToastTimeout = setTimeout(hideNow, ms);
         }
 
+        function copyStatusToastTextLegacy(value) {
+            if (!document.body || typeof document.execCommand !== 'function') return false;
+            const activeElement = document.activeElement;
+            const selectionStart = activeElement && typeof activeElement.selectionStart === 'number'
+                ? activeElement.selectionStart
+                : null;
+            const selectionEnd = activeElement && typeof activeElement.selectionEnd === 'number'
+                ? activeElement.selectionEnd
+                : null;
+            const textArea = document.createElement('textarea');
+            textArea.value = value;
+            textArea.setAttribute('readonly', '');
+            textArea.style.cssText = 'position:fixed;left:-9999px;top:0;opacity:0;pointer-events:none;';
+            document.body.appendChild(textArea);
+            let copied = false;
+            try {
+                textArea.focus({ preventScroll: true });
+                textArea.select();
+                copied = document.execCommand('copy') === true;
+            } catch (_) {
+                copied = false;
+            }
+            textArea.remove();
+            try {
+                if (activeElement && typeof activeElement.focus === 'function') {
+                    activeElement.focus({ preventScroll: true });
+                    if (selectionStart !== null
+                        && selectionEnd !== null
+                        && typeof activeElement.setSelectionRange === 'function') {
+                        activeElement.setSelectionRange(selectionStart, selectionEnd);
+                    }
+                }
+            } catch (_) {}
+            return copied;
+        }
+
+        function copyStatusToastText(value) {
+            if (!value) return Promise.resolve(false);
+            const copyWithWebClipboard = () => {
+                try {
+                    if (typeof navigator !== 'undefined'
+                        && navigator.clipboard
+                        && typeof navigator.clipboard.writeText === 'function') {
+                        return navigator.clipboard.writeText(value)
+                            .then(() => true)
+                            .catch(() => copyStatusToastTextLegacy(value));
+                    }
+                } catch (_) {}
+                return Promise.resolve(copyStatusToastTextLegacy(value));
+            };
+            try {
+                if (I.mod.api && typeof I.mod.api.copyText === 'function') {
+                    return Promise.resolve(I.mod.api.copyText(value))
+                        .then(result => result !== false ? true : copyWithWebClipboard())
+                        .catch(copyWithWebClipboard);
+                }
+            } catch (_) {
+                return copyWithWebClipboard();
+            }
+            return copyWithWebClipboard();
+        }
+
+        function showStatusToastCopyFeedback(textEl) {
+            textEl.classList.remove('status-toast-copy-success');
+            void textEl.offsetWidth;
+            textEl.classList.add('status-toast-copy-success');
+            setTimeout(() => textEl.classList.remove('status-toast-copy-success'), 450);
+        }
+
         function hideNow() {
             if (I.S._statusToastShowTimer) { clearTimeout(I.S._statusToastShowTimer); I.S._statusToastShowTimer = null; }
             if (I.S.statusToastTimeout) { clearTimeout(I.S.statusToastTimeout); I.S.statusToastTimeout = null; }
@@ -427,6 +496,15 @@ I.mod = window.appUi;
         }
         Array.from(statusToast.childNodes).forEach(n => { if (n !== textEl && n !== closeBtn && n.nodeType === 3) n.textContent = ''; });
         textEl.textContent = message;
+        textEl.title = typeof window.t === 'function'
+            ? window.t('chat.copyToClipboard', { defaultValue: 'Copy to clipboard' })
+            : 'Copy to clipboard';
+        textEl.onclick = (e) => {
+            e.stopPropagation();
+            copyStatusToastText(message).then((copied) => {
+                if (copied) showStatusToastCopyFeedback(textEl);
+            });
+        };
         closeBtn.disabled = false; closeBtn.tabIndex = 0; closeBtn.removeAttribute('aria-hidden');
         closeBtn.onclick = (e) => { e.stopPropagation(); hideNow(); };
         if (I.mod.api && I.mod.api.setMouseThrough) I.mod.api.setMouseThrough(false);

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -147,7 +147,9 @@ body {
     }
 }
 
-#status-toast-text{position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere}
+#status-toast-text{position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere;cursor:copy;user-select:text;-webkit-user-select:text}
+#status-toast-text.status-toast-copy-success{animation:statusToastCopySuccess 0.45s ease}
+@keyframes statusToastCopySuccess{0%,100%{filter:none}45%{filter:drop-shadow(0 0 7px rgba(210,255,220,0.95));color:#e1ffe8}}
 #status-toast-close{position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;transition:background 0.15s,opacity 0.15s;text-shadow:none;font-size:0;line-height:0}
 #status-toast.show #status-toast-close{pointer-events:auto}
 #status-toast-close::before,#status-toast-close::after{content:"";position:absolute;left:50%;top:50%;width:10px;height:2px;border-radius:999px;background:#fff;pointer-events:none}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -149,6 +149,7 @@ body {
 
 #status-toast-text{position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere;cursor:copy;user-select:text;-webkit-user-select:text}
 #status-toast-text.status-toast-copy-success{animation:statusToastCopySuccess 0.45s ease}
+#status-toast-text:focus-visible{outline:2px solid rgba(255,255,255,0.9);outline-offset:2px;border-radius:4px}
 @keyframes statusToastCopySuccess{0%,100%{filter:none}45%{filter:drop-shadow(0 0 7px rgba(210,255,220,0.95));color:#e1ffe8}}
 #status-toast-close{position:absolute;top:6px;right:8px;z-index:2;width:22px;height:22px;border:none;border-radius:50%;background:rgba(255,255,255,0.22);cursor:pointer;padding:0;opacity:0.85;transition:background 0.15s,opacity 0.15s;text-shadow:none;font-size:0;line-height:0}
 #status-toast.show #status-toast-close{pointer-events:auto}

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -323,6 +323,41 @@
             toastRemaining = ms; toastStart = Date.now();
             statusTimeout = setTimeout(hideStatusNow, ms);
         }
+        function copyStatusToastTextLegacy(value) {
+            if (!document.body || typeof document.execCommand !== 'function') return false;
+            var activeElement = document.activeElement;
+            var selectionStart = activeElement && typeof activeElement.selectionStart === 'number'
+                ? activeElement.selectionStart
+                : null;
+            var selectionEnd = activeElement && typeof activeElement.selectionEnd === 'number'
+                ? activeElement.selectionEnd
+                : null;
+            var textArea = document.createElement('textarea');
+            textArea.value = value;
+            textArea.setAttribute('readonly', '');
+            textArea.style.cssText = 'position:fixed;left:-9999px;top:0;opacity:0;pointer-events:none;';
+            document.body.appendChild(textArea);
+            var copied = false;
+            try {
+                textArea.focus({ preventScroll: true });
+                textArea.select();
+                copied = document.execCommand('copy') === true;
+            } catch (_) {
+                copied = false;
+            }
+            textArea.remove();
+            try {
+                if (activeElement && typeof activeElement.focus === 'function') {
+                    activeElement.focus({ preventScroll: true });
+                    if (selectionStart !== null
+                        && selectionEnd !== null
+                        && typeof activeElement.setSelectionRange === 'function') {
+                        activeElement.setSelectionRange(selectionStart, selectionEnd);
+                    }
+                }
+            } catch (_) { }
+            return copied;
+        }
         function copyStatusToastText(value) {
             if (!value) return Promise.resolve(false);
             function copyWithWebClipboard() {
@@ -330,10 +365,12 @@
                     if (typeof navigator !== 'undefined'
                         && navigator.clipboard
                         && typeof navigator.clipboard.writeText === 'function') {
-                        return navigator.clipboard.writeText(value).then(function() { return true; }).catch(function() { return false; });
+                        return navigator.clipboard.writeText(value)
+                            .then(function() { return true; })
+                            .catch(function() { return copyStatusToastTextLegacy(value); });
                     }
                 } catch (_) { }
-                return Promise.resolve(false);
+                return Promise.resolve(copyStatusToastTextLegacy(value));
             }
             try {
                 if (api && typeof api.copyText === 'function') {
@@ -403,7 +440,11 @@
                     }
                 });
             }
-            textEl.onclick = copyCurrentMessage;
+            textEl.onclick = function(e) {
+                copyCurrentMessage(e);
+                if (document.activeElement === textEl) textEl.blur();
+                if (statusToast._resumeAutoHide) statusToast._resumeAutoHide();
+            };
             textEl.onkeydown = function(e) {
                 if (e.key !== 'Enter' && e.key !== ' ') return;
                 e.preventDefault();

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -384,14 +384,18 @@
             return copyWithWebClipboard();
         }
         function showStatusToastCopyFeedback(textEl, copyRevision) {
+            if (textEl._copyFeedbackTimer) clearTimeout(textEl._copyFeedbackTimer);
             textEl.classList.remove('status-toast-copy-success');
             void textEl.offsetWidth;
             textEl.classList.add('status-toast-copy-success');
-            setTimeout(function() {
+            var feedbackTimer = setTimeout(function() {
+                if (textEl._copyFeedbackTimer !== feedbackTimer) return;
                 if (statusCopyRevision === copyRevision) {
                     textEl.classList.remove('status-toast-copy-success');
                 }
+                textEl._copyFeedbackTimer = null;
             }, 450);
+            textEl._copyFeedbackTimer = feedbackTimer;
         }
         function showStatusToast(message, duration) {
             if (duration == null) duration = 3000;
@@ -443,7 +447,7 @@
             textEl.onclick = function(e) {
                 copyCurrentMessage(e);
                 if (document.activeElement === textEl) textEl.blur();
-                if (statusToast._resumeAutoHide) statusToast._resumeAutoHide();
+                if (statusToast._focusOut) statusToast._focusOut();
             };
             textEl.onkeydown = function(e) {
                 if (e.key !== 'Enter' && e.key !== ' ') return;

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -70,6 +70,9 @@
         var statusPointerPollTimer = null;
         var statusPointerPollGeneration = 0;
         var STATUS_POINTER_POLL_MS = 50;
+        var compactStatusInputRegionFrame = null;
+        var compactStatusInputRegionGeneration = 0;
+        var statusCopyRevision = 0;
         // 命中检测开着时，轮询结果是「光标在不在提示上」的唯一权威。
         // 窗口在穿透态收不到任何鼠标事件，所以「光标跨进矩形」这一刻必然发生在
         // 渲染进程失聪期间：若用户在窗口恢复命中前就停稳，mouseenter 永远不会补发，
@@ -257,16 +260,47 @@
                 api.setStatusInputRegion(null);
                 return;
             }
+            var rect = statusToast.getBoundingClientRect();
             api.setStatusInputRegion({
-                x: statusToast.offsetLeft,
-                y: statusToast.offsetTop,
-                width: statusToast.offsetWidth,
-                height: statusToast.offsetHeight,
+                x: rect.left,
+                y: rect.top,
+                width: rect.width,
+                height: rect.height,
             });
+        }
+
+        function stopCompactStatusInputRegionTracking() {
+            compactStatusInputRegionGeneration += 1;
+            if (compactStatusInputRegionFrame !== null
+                && typeof window.cancelAnimationFrame === 'function') {
+                window.cancelAnimationFrame(compactStatusInputRegionFrame);
+            }
+            compactStatusInputRegionFrame = null;
+        }
+
+        function trackCompactStatusInputRegionThroughTransition() {
+            stopCompactStatusInputRegionTracking();
+            var generation = compactStatusInputRegionGeneration;
+            var startedAt = Date.now();
+            function sync() {
+                if (generation !== compactStatusInputRegionGeneration
+                    || prominentNoticeInteractive
+                    || !isStatusToastVisible()) return;
+                updateCompactStatusInputRegion(true);
+                if (Date.now() - startedAt >= 450
+                    || typeof window.requestAnimationFrame !== 'function') {
+                    compactStatusInputRegionFrame = null;
+                    return;
+                }
+                compactStatusInputRegionFrame = window.requestAnimationFrame(sync);
+            }
+            sync();
         }
 
         var toastRemaining = 3000; var toastStart = 0; var showTimer = null;
         function hideStatusNow() {
+            statusCopyRevision += 1;
+            stopCompactStatusInputRegionTracking();
             updateCompactStatusInputRegion(false);
             stopStatusPointerTracking(false);
             if (showTimer) { clearTimeout(showTimer); showTimer = null; }
@@ -278,6 +312,8 @@
             if (statusToast._focusOut) { statusToast.removeEventListener('focusout', statusToast._focusOut); statusToast._focusOut = null; }
             var _cb = statusToast.querySelector('#status-toast-close');
             if (_cb) { _cb.disabled = true; _cb.tabIndex = -1; _cb.setAttribute('aria-hidden','true'); if (document.activeElement === _cb) _cb.blur(); }
+            var _copyText = statusToast.querySelector('#status-toast-text');
+            if (_copyText) { _copyText.classList.remove('status-toast-copy-success'); _copyText.tabIndex = -1; _copyText.setAttribute('aria-hidden','true'); if (document.activeElement === _copyText) _copyText.blur(); }
             statusToast.classList.remove('show');
             statusToast.classList.add('hide');
             cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 400);
@@ -289,31 +325,42 @@
         }
         function copyStatusToastText(value) {
             if (!value) return Promise.resolve(false);
+            function copyWithWebClipboard() {
+                try {
+                    if (typeof navigator !== 'undefined'
+                        && navigator.clipboard
+                        && typeof navigator.clipboard.writeText === 'function') {
+                        return navigator.clipboard.writeText(value).then(function() { return true; }).catch(function() { return false; });
+                    }
+                } catch (_) { }
+                return Promise.resolve(false);
+            }
             try {
                 if (api && typeof api.copyText === 'function') {
                     return Promise.resolve(api.copyText(value)).then(function(result) {
-                        return result !== false;
-                    }).catch(function() { return false; });
-                }
-                if (typeof navigator !== 'undefined'
-                    && navigator.clipboard
-                    && typeof navigator.clipboard.writeText === 'function') {
-                    return navigator.clipboard.writeText(value).then(function() { return true; }).catch(function() { return false; });
+                        return result !== false ? true : copyWithWebClipboard();
+                    }).catch(copyWithWebClipboard);
                 }
             } catch (_) {
-                return Promise.resolve(false);
+                return copyWithWebClipboard();
             }
-            return Promise.resolve(false);
+            return copyWithWebClipboard();
         }
-        function showStatusToastCopyFeedback(textEl) {
+        function showStatusToastCopyFeedback(textEl, copyRevision) {
             textEl.classList.remove('status-toast-copy-success');
             void textEl.offsetWidth;
             textEl.classList.add('status-toast-copy-success');
-            setTimeout(function() { textEl.classList.remove('status-toast-copy-success'); }, 450);
+            setTimeout(function() {
+                if (statusCopyRevision === copyRevision) {
+                    textEl.classList.remove('status-toast-copy-success');
+                }
+            }, 450);
         }
         function showStatusToast(message, duration) {
             if (duration == null) duration = 3000;
             if (!message || !message.trim()) {
+                statusCopyRevision += 1;
+                stopCompactStatusInputRegionTracking();
                 updateCompactStatusInputRegion(false);
                 stopStatusPointerTracking(false);
                 if (showTimer) { clearTimeout(showTimer); showTimer=null; }
@@ -324,6 +371,7 @@
                 if (statusToast._focusIn) { statusToast.removeEventListener('focusin', statusToast._focusIn); statusToast._focusIn = null; }
                 if (statusToast._focusOut) { statusToast.removeEventListener('focusout', statusToast._focusOut); statusToast._focusOut = null; }
                 var _cb2=statusToast.querySelector('#status-toast-close'); if(_cb2){ _cb2.disabled=true; _cb2.tabIndex=-1; _cb2.setAttribute('aria-hidden','true'); if(document.activeElement===_cb2) _cb2.blur(); }
+                var _copyText2=statusToast.querySelector('#status-toast-text'); if(_copyText2){ _copyText2.classList.remove('status-toast-copy-success'); _copyText2.tabIndex=-1; _copyText2.setAttribute('aria-hidden','true'); if(document.activeElement===_copyText2) _copyText2.blur(); }
                 statusToast.classList.remove('show');
                 statusToast.classList.add('hide');
                 cleanupTimer = setTimeout(function() { var t=statusToast.querySelector('#status-toast-text'); if(t) t.textContent=''; Array.from(statusToast.childNodes).forEach(function(n){ if(n.nodeType===3) n.textContent=''; }); cleanupTimer=null; }, 400);
@@ -337,15 +385,29 @@
             if (!textEl) { textEl=document.createElement('span'); textEl.id='status-toast-text'; textEl.style.cssText='position:relative;z-index:1;flex:1;min-width:0;overflow-wrap:anywhere;'; statusToast.appendChild(textEl); }
             Array.from(statusToast.childNodes).forEach(function(n){ if(n!==textEl && n.nodeType===3) n.textContent=''; });
             if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
+            statusCopyRevision += 1;
+            var copyRevision = statusCopyRevision;
+            textEl.classList.remove('status-toast-copy-success');
             textEl.textContent = message;
             textEl.title = (typeof window.t === 'function')
                 ? window.t('chat.copyToClipboard', { defaultValue: 'Copy to clipboard' })
                 : 'Copy to clipboard';
-            textEl.onclick = function(e) {
+            textEl.setAttribute('role', 'button');
+            textEl.setAttribute('aria-hidden', 'false');
+            textEl.tabIndex = 0;
+            function copyCurrentMessage(e) {
                 e.stopPropagation();
                 copyStatusToastText(message).then(function(copied) {
-                    if (copied) showStatusToastCopyFeedback(textEl);
+                    if (copied && statusCopyRevision === copyRevision) {
+                        showStatusToastCopyFeedback(textEl, copyRevision);
+                    }
                 });
+            }
+            textEl.onclick = copyCurrentMessage;
+            textEl.onkeydown = function(e) {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                e.preventDefault();
+                copyCurrentMessage(e);
             };
             var closeBtn = statusToast.querySelector('#status-toast-close');
             if (!closeBtn) {
@@ -371,7 +433,7 @@
             showTimer = setTimeout(function() {
                 statusToast.classList.add('show');
                 showTimer=null;
-                updateCompactStatusInputRegion(true);
+                trackCompactStatusInputRegionThroughTransition();
                 startStatusPointerTracking();
             }, 10);
             if (statusToast._enter) statusToast.removeEventListener('mouseenter', statusToast._enter);
@@ -737,16 +799,18 @@
 
         document.addEventListener('visibilitychange', function() {
             if (document.hidden) {
+                stopCompactStatusInputRegionTracking();
                 updateCompactStatusInputRegion(false);
                 stopStatusPointerTracking(false);
             } else if (isStatusToastVisible() && !prominentNoticeInteractive) {
-                updateCompactStatusInputRegion(true);
+                trackCompactStatusInputRegionThroughTransition();
                 startStatusPointerTracking();
             }
         });
 
         window.addEventListener('beforeunload', function() {
             prominentNoticeInteractive = false;
+            stopCompactStatusInputRegionTracking();
             updateCompactStatusInputRegion(false);
             stopStatusPointerTracking(true);
             setToastMouseThrough(true, true);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -143,7 +143,11 @@
                 && !statusToast.matches(':focus-within')) {
                 statusToast._resumeAutoHide();
             }
-            if (!keepCurrentMouseState && !prominentNoticeInteractive) {
+            if (!keepCurrentMouseState
+                && !prominentNoticeInteractive
+                && !(api
+                    && api.supportsStatusPointerTracking === false
+                    && typeof api.setStatusInputRegion === 'function')) {
                 setToastMouseThrough(true);
             }
         }
@@ -226,10 +230,15 @@
             stopStatusPointerTracking(true);
             if (prominentNoticeInteractive) return;
 
-            // 旧版 Electron preload、普通网页环境和 Niri 小窗均安全降级为全程穿透。
-            if (!api
-                || api.supportsStatusPointerTracking === false
-                || typeof api.getCursorPoint !== 'function') {
+            // 旧版 Electron preload 和普通网页环境安全降级为全程穿透。Niri 小窗
+            // 不做全局光标轮询，而是由 setStatusInputRegion 精确开放气泡区域。
+            if (!api || api.supportsStatusPointerTracking === false) {
+                if (!api || typeof api.setStatusInputRegion !== 'function') {
+                    setToastMouseThrough(true);
+                }
+                return;
+            }
+            if (typeof api.getCursorPoint !== 'function') {
                 setToastMouseThrough(true);
                 return;
             }
@@ -240,8 +249,25 @@
             pollStatusPointer(generation);
         }
 
+        function updateCompactStatusInputRegion(visible) {
+            if (!api
+                || api.supportsStatusPointerTracking !== false
+                || typeof api.setStatusInputRegion !== 'function') return;
+            if (!visible) {
+                api.setStatusInputRegion(null);
+                return;
+            }
+            api.setStatusInputRegion({
+                x: statusToast.offsetLeft,
+                y: statusToast.offsetTop,
+                width: statusToast.offsetWidth,
+                height: statusToast.offsetHeight,
+            });
+        }
+
         var toastRemaining = 3000; var toastStart = 0; var showTimer = null;
         function hideStatusNow() {
+            updateCompactStatusInputRegion(false);
             stopStatusPointerTracking(false);
             if (showTimer) { clearTimeout(showTimer); showTimer = null; }
             if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
@@ -261,9 +287,34 @@
             toastRemaining = ms; toastStart = Date.now();
             statusTimeout = setTimeout(hideStatusNow, ms);
         }
+        function copyStatusToastText(value) {
+            if (!value) return Promise.resolve(false);
+            try {
+                if (api && typeof api.copyText === 'function') {
+                    return Promise.resolve(api.copyText(value)).then(function(result) {
+                        return result !== false;
+                    }).catch(function() { return false; });
+                }
+                if (typeof navigator !== 'undefined'
+                    && navigator.clipboard
+                    && typeof navigator.clipboard.writeText === 'function') {
+                    return navigator.clipboard.writeText(value).then(function() { return true; }).catch(function() { return false; });
+                }
+            } catch (_) {
+                return Promise.resolve(false);
+            }
+            return Promise.resolve(false);
+        }
+        function showStatusToastCopyFeedback(textEl) {
+            textEl.classList.remove('status-toast-copy-success');
+            void textEl.offsetWidth;
+            textEl.classList.add('status-toast-copy-success');
+            setTimeout(function() { textEl.classList.remove('status-toast-copy-success'); }, 450);
+        }
         function showStatusToast(message, duration) {
             if (duration == null) duration = 3000;
             if (!message || !message.trim()) {
+                updateCompactStatusInputRegion(false);
                 stopStatusPointerTracking(false);
                 if (showTimer) { clearTimeout(showTimer); showTimer=null; }
                 if (statusTimeout) { clearTimeout(statusTimeout); statusTimeout = null; }
@@ -287,6 +338,15 @@
             Array.from(statusToast.childNodes).forEach(function(n){ if(n!==textEl && n.nodeType===3) n.textContent=''; });
             if (cleanupTimer) { clearTimeout(cleanupTimer); cleanupTimer = null; }
             textEl.textContent = message;
+            textEl.title = (typeof window.t === 'function')
+                ? window.t('chat.copyToClipboard', { defaultValue: 'Copy to clipboard' })
+                : 'Copy to clipboard';
+            textEl.onclick = function(e) {
+                e.stopPropagation();
+                copyStatusToastText(message).then(function(copied) {
+                    if (copied) showStatusToastCopyFeedback(textEl);
+                });
+            };
             var closeBtn = statusToast.querySelector('#status-toast-close');
             if (!closeBtn) {
                 closeBtn = document.createElement('button');
@@ -311,6 +371,7 @@
             showTimer = setTimeout(function() {
                 statusToast.classList.add('show');
                 showTimer=null;
+                updateCompactStatusInputRegion(true);
                 startStatusPointerTracking();
             }, 10);
             if (statusToast._enter) statusToast.removeEventListener('mouseenter', statusToast._enter);
@@ -675,12 +736,18 @@
         }
 
         document.addEventListener('visibilitychange', function() {
-            if (document.hidden) stopStatusPointerTracking(false);
-            else if (isStatusToastVisible() && !prominentNoticeInteractive) startStatusPointerTracking();
+            if (document.hidden) {
+                updateCompactStatusInputRegion(false);
+                stopStatusPointerTracking(false);
+            } else if (isStatusToastVisible() && !prominentNoticeInteractive) {
+                updateCompactStatusInputRegion(true);
+                startStatusPointerTracking();
+            }
         });
 
         window.addEventListener('beforeunload', function() {
             prominentNoticeInteractive = false;
+            updateCompactStatusInputRegion(false);
             stopStatusPointerTracking(true);
             setToastMouseThrough(true, true);
         });

--- a/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
+++ b/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
@@ -47,7 +47,8 @@ function createElement(tagName) {
     removeAttribute() {},
     addEventListener() {},
     removeEventListener() {},
-    matches() { return false; },
+    _hover: false,
+    matches(selector) { return this._hover && String(selector).includes(':hover'); },
     focus() { document.activeElement = this; },
     blur() { if (document.activeElement === this) document.activeElement = null; },
     select() {},
@@ -69,6 +70,8 @@ function createHarness(navigatorClipboard) {
   const body = createElement('body');
   const head = createElement('head');
   const copied = [];
+  const timers = new Map();
+  let nextTimerId = 0;
   document = {
     body,
     head,
@@ -102,13 +105,30 @@ function createHarness(navigatorClipboard) {
     Number,
     String,
     Math,
-    setTimeout() { return 1; },
-    clearTimeout() {},
+    setTimeout(callback, delay) {
+      nextTimerId += 1;
+      timers.set(nextTimerId, { callback, delay });
+      return nextTimerId;
+    },
+    clearTimeout(id) { timers.delete(id); },
     CustomEvent: class CustomEvent {
       constructor(type, init) { this.type = type; this.detail = init && init.detail; }
     },
   }, { filename: sourcePath });
-  return { window, statusToast, copied };
+  return {
+    window,
+    statusToast,
+    copied,
+    countTimers(delay) {
+      return Array.from(timers.values()).filter((timer) => timer.delay === delay).length;
+    },
+    runTimer(delay) {
+      const match = Array.from(timers.entries()).find(([, timer]) => timer.delay === delay);
+      assert.ok(match, `expected a pending ${delay}ms timer`);
+      timers.delete(match[0]);
+      match[1].callback();
+    },
+  };
 }
 
 async function clickToastText(harness) {
@@ -147,6 +167,42 @@ test('ordinary pointer copy releases focus and resumes auto-hide', () => {
 
   assert.equal(document.activeElement, null);
   assert.notEqual(harness.window.appState.statusToastTimeout, null);
+});
+
+test('ordinary pointer copy keeps auto-hide paused while the toast remains hovered', () => {
+  const harness = createHarness(null);
+  harness.window.showStatusToast('keep reading');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.focus();
+  harness.window.appState.statusToastTimeout = null;
+  harness.statusToast._hover = true;
+
+  text.onclick({ stopPropagation() {} });
+
+  assert.equal(document.activeElement, null);
+  assert.equal(harness.window.appState.statusToastTimeout, null);
+
+  harness.statusToast._hover = false;
+  harness.statusToast._toastLeave();
+  assert.notEqual(harness.window.appState.statusToastTimeout, null);
+});
+
+test('ordinary repeated copies reset the success feedback timer', async () => {
+  const harness = createHarness(null);
+  harness.window.showStatusToast('copy twice');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+
+  text.onclick({ stopPropagation() {} });
+  await Promise.resolve();
+  await Promise.resolve();
+  text.onclick({ stopPropagation() {} });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(harness.countTimers(450), 1);
+  assert.equal(text.classList.contains('status-toast-copy-success'), true);
+  harness.runTimer(450);
+  assert.equal(text.classList.contains('status-toast-copy-success'), false);
 });
 
 test('a delayed web copy cannot flash success on a newer toast', async () => {

--- a/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
+++ b/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
@@ -136,6 +136,19 @@ test('ordinary web toast falls back when Clipboard API rejects', async () => {
   assert.deepEqual(harness.copied, ['copy']);
 });
 
+test('ordinary pointer copy releases focus and resumes auto-hide', () => {
+  const harness = createHarness(null);
+  harness.window.showStatusToast('copy and close later');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.focus();
+  harness.window.appState.statusToastTimeout = null;
+
+  text.onclick({ stopPropagation() {} });
+
+  assert.equal(document.activeElement, null);
+  assert.notEqual(harness.window.appState.statusToastTimeout, null);
+});
+
 test('a delayed web copy cannot flash success on a newer toast', async () => {
   const pendingCopy = createDeferred();
   const harness = createHarness({ writeText: () => pendingCopy.promise });

--- a/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
+++ b/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
@@ -57,6 +57,12 @@ function createElement(tagName) {
 
 let document;
 
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
 function createHarness(navigatorClipboard) {
   const statusToast = createElement('div');
   statusToast.id = 'status-toast';
@@ -128,4 +134,20 @@ test('ordinary web toast falls back when Clipboard API rejects', async () => {
   await clickToastText(harness);
 
   assert.deepEqual(harness.copied, ['copy']);
+});
+
+test('a delayed web copy cannot flash success on a newer toast', async () => {
+  const pendingCopy = createDeferred();
+  const harness = createHarness({ writeText: () => pendingCopy.promise });
+  harness.window.showStatusToast('first error');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.onclick({ stopPropagation() {} });
+
+  harness.window.showStatusToast('second error');
+  pendingCopy.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(text.textContent, 'second error');
+  assert.equal(text.classList.contains('status-toast-copy-success'), false);
 });

--- a/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
+++ b/tests/frontend/status_toast_web_clipboard_fallback.test.cjs
@@ -1,0 +1,131 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const sourcePath = path.resolve(__dirname, '../../static/app/app-ui/bootstrap-goodbye-and-toasts.js');
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+function classList() {
+  const values = new Set();
+  return {
+    add(value) { values.add(value); },
+    remove(value) { values.delete(value); },
+    contains(value) { return values.has(value); },
+  };
+}
+
+function createElement(tagName) {
+  const element = {
+    id: '',
+    tagName: String(tagName).toUpperCase(),
+    nodeType: 1,
+    childNodes: [],
+    parentNode: null,
+    classList: classList(),
+    style: { cssText: '' },
+    textContent: '',
+    value: '',
+    appendChild(child) {
+      child.parentNode = this;
+      this.childNodes.push(child);
+      return child;
+    },
+    remove() {
+      if (!this.parentNode) return;
+      this.parentNode.childNodes = this.parentNode.childNodes.filter((child) => child !== this);
+      this.parentNode = null;
+    },
+    querySelector(selector) {
+      if (!selector.startsWith('#')) return null;
+      return this.childNodes.find((child) => child.id === selector.slice(1)) || null;
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    addEventListener() {},
+    removeEventListener() {},
+    matches() { return false; },
+    focus() { document.activeElement = this; },
+    blur() { if (document.activeElement === this) document.activeElement = null; },
+    select() {},
+  };
+  return element;
+}
+
+let document;
+
+function createHarness(navigatorClipboard) {
+  const statusToast = createElement('div');
+  statusToast.id = 'status-toast';
+  const body = createElement('body');
+  const head = createElement('head');
+  const copied = [];
+  document = {
+    body,
+    head,
+    activeElement: null,
+    createElement,
+    getElementById(id) { return id === 'status-toast' ? statusToast : null; },
+    querySelector() { return null; },
+    execCommand(command) {
+      copied.push(command);
+      return command === 'copy';
+    },
+  };
+  const window = {
+    appUi: {},
+    __appUiParts: {},
+    appState: { dom: { statusToast }, _statusToastPriority: 0 },
+    appConst: {},
+    t(_key, options) { return options && options.defaultValue ? options.defaultValue : ''; },
+    addEventListener() {},
+    dispatchEvent() {},
+  };
+  vm.runInNewContext(source, {
+    window,
+    document,
+    navigator: navigatorClipboard ? { clipboard: navigatorClipboard } : {},
+    console: { log() {}, error() {} },
+    Promise,
+    Date,
+    Array,
+    Object,
+    Number,
+    String,
+    Math,
+    setTimeout() { return 1; },
+    clearTimeout() {},
+    CustomEvent: class CustomEvent {
+      constructor(type, init) { this.type = type; this.detail = init && init.detail; }
+    },
+  }, { filename: sourcePath });
+  return { window, statusToast, copied };
+}
+
+async function clickToastText(harness) {
+  harness.window.showStatusToast('API request failed: 401');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  assert.ok(text);
+  text.onclick({ stopPropagation() {} });
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test('ordinary web toast falls back to execCommand when Clipboard API is unavailable', async () => {
+  const harness = createHarness(null);
+
+  await clickToastText(harness);
+
+  assert.deepEqual(harness.copied, ['copy']);
+});
+
+test('ordinary web toast falls back when Clipboard API rejects', async () => {
+  const harness = createHarness({ writeText: () => Promise.reject(new Error('denied')) });
+
+  await clickToastText(harness);
+
+  assert.deepEqual(harness.copied, ['copy']);
+});

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -97,6 +97,8 @@ function createDeferred() {
 function createHarness(options = {}) {
   const callbacks = {};
   const mouseThrough = [];
+  const copied = [];
+  const statusInputRegions = [];
   const timers = new Map();
   const windowListeners = new Map();
   const documentListeners = new Map();
@@ -108,6 +110,10 @@ function createHarness(options = {}) {
   const head = createElement('head');
   const statusToast = createElement('div');
   statusToast.id = 'status-toast';
+  statusToast.offsetLeft = 100;
+  statusToast.offsetTop = 40;
+  statusToast.offsetWidth = 200;
+  statusToast.offsetHeight = 60;
   statusToast.getBoundingClientRect = () => ({
     left: 100,
     top: 40,
@@ -141,9 +147,11 @@ function createHarness(options = {}) {
   };
 
   const api = {
+    copyText(value) { copied.push(value); return true; },
     supportsStatusPointerTracking: options.supportsStatusPointerTracking !== false,
     getCursorPoint() { return cursorProvider(); },
     setMouseThrough(ignore) { mouseThrough.push(ignore); },
+    setStatusInputRegion(rect) { statusInputRegions.push(rect); return true; },
     onShowStatusToast(callback) { callbacks.status = callback; },
     onShowVoicePreparing(callback) { callbacks.voicePreparing = callback; },
     onHideVoicePreparing(callback) { callbacks.voiceHide = callback; },
@@ -180,6 +188,8 @@ function createHarness(options = {}) {
   return {
     statusToast,
     mouseThrough,
+    copied,
+    statusInputRegions,
     setCursor(point) { cursorPoint = point; },
     setCursorProvider(provider) { cursorProvider = provider; },
     emitStatus(message = 'saved') { callbacks.status({ message, duration: 3000 }); },
@@ -220,6 +230,19 @@ async function flushPromises() {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+test('clicking status text copies the complete toast without changing mouse-through state', async () => {
+  const harness = createHarness();
+  harness.emitStatus('API request failed: 401');
+
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.onclick({ stopPropagation() {} });
+  await flushPromises();
+
+  assert.deepEqual(harness.copied, ['API request failed: 401']);
+  assert.deepEqual(harness.mouseThrough, []);
+  assert.equal(text.classList.contains('status-toast-copy-success'), true);
+});
 
 test('ordinary status toast only captures input while the cursor is inside its rectangle', async () => {
   const harness = createHarness();
@@ -346,8 +369,8 @@ test('a real DOM mouseenter does not double-count the poll-driven pause', async 
   );
 });
 
-// Niri 小窗与非 Electron 环境走 supportsStatusPointerTracking === false，
-// 此时轮询不启动，hover 判定必须退回纯 DOM 语义。
+// Niri 小窗走 supportsStatusPointerTracking === false，不做不可靠的全局光标轮询；
+// 由 preload 把真实气泡矩形交给合成器，透明余量仍保持穿透。
 test('with pointer tracking unsupported the DOM hover path still governs', async () => {
   const harness = createHarness({ supportsStatusPointerTracking: false });
   harness.setCursor({ x: 150, y: 60 });
@@ -356,7 +379,10 @@ test('with pointer tracking unsupported the DOM hover path still governs', async
   harness.runTimer(10);
   await flushPromises();
 
-  assert.deepEqual(harness.mouseThrough, [true], '不支持时应全程穿透，不发起轮询');
+  assert.deepEqual(harness.mouseThrough, [], 'Niri 精确输入区域不应再切换整窗穿透状态');
+  assert.deepEqual(JSON.parse(JSON.stringify(harness.statusInputRegions)), [
+    { x: 100, y: 40, width: 200, height: 60 },
+  ]);
   assert.equal(harness.hasTimer(50), false);
   assert.equal(
     harness.hasAutoHideTimer(),
@@ -366,6 +392,19 @@ test('with pointer tracking unsupported the DOM hover path still governs', async
 
   harness.statusToast.dispatch('mouseenter', {});
   assert.equal(harness.hasAutoHideTimer(), false, 'DOM hover 仍应能暂停');
+});
+
+test('Niri compact status input region is cleared as soon as the toast closes', () => {
+  const harness = createHarness({ supportsStatusPointerTracking: false });
+
+  harness.emitStatus();
+  harness.runTimer(10);
+  harness.statusToast.querySelector('#status-toast-close').onclick({ stopPropagation() {} });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(harness.statusInputRegions)), [
+    { x: 100, y: 40, width: 200, height: 60 },
+    null,
+  ]);
 });
 
 // 连发场景：光标全程停在矩形上不动。第二条提示必须重新 pin —— 若 inside 标志位

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -65,6 +65,7 @@ function createElement(tagName = 'div') {
     },
     focus() { document.activeElement = this; },
     blur() { if (document.activeElement === this) document.activeElement = null; },
+    select() {},
     getBoundingClientRect() {
       return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
     },
@@ -99,6 +100,7 @@ function createHarness(options = {}) {
   const mouseThrough = [];
   const copied = [];
   const statusInputRegions = [];
+  const legacyCopies = [];
   const timers = new Map();
   const windowListeners = new Map();
   const documentListeners = new Map();
@@ -143,6 +145,10 @@ function createHarness(options = {}) {
         ));
       }
       return null;
+    },
+    execCommand(command) {
+      legacyCopies.push(command);
+      return command === 'copy';
     },
     addEventListener(type, listener) { documentListeners.set(type, listener); },
   };
@@ -200,6 +206,7 @@ function createHarness(options = {}) {
     statusToast,
     mouseThrough,
     copied,
+    legacyCopies,
     statusInputRegions,
     setStatusRect(rect) { statusRect = { ...rect }; },
     setCursor(point) { cursorPoint = point; },
@@ -306,6 +313,35 @@ test('dedicated toast falls back to the web clipboard when its bridge declines',
 
   assert.deepEqual(webCopies, ['bridge fallback']);
   assert.equal(text.classList.contains('status-toast-copy-success'), true);
+});
+
+test('dedicated toast falls back to legacy copy when bridge and web clipboard fail', async () => {
+  const harness = createHarness({
+    copyText: () => false,
+    navigatorClipboard: { writeText() { return Promise.reject(new Error('denied')); } },
+  });
+  harness.emitStatus('legacy fallback');
+
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.onclick({ stopPropagation() {} });
+  await flushPromises();
+
+  assert.deepEqual(harness.legacyCopies, ['copy']);
+  assert.equal(text.classList.contains('status-toast-copy-success'), true);
+});
+
+test('pointer copy releases focus and resumes auto-hide', () => {
+  const harness = createHarness();
+  harness.emitStatus('copy and close later');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.focus();
+  harness.statusToast.dispatch('focusin');
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  text.onclick({ stopPropagation() {} });
+
+  assert.equal(document.activeElement, null);
+  assert.equal(harness.hasAutoHideTimer(), true);
 });
 
 test('ordinary status toast only captures input while the cursor is inside its rectangle', async () => {

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -105,6 +105,14 @@ function createHarness(options = {}) {
   let nextTimerId = 0;
   let cursorPoint = { x: 20, y: 20 };
   let cursorProvider = () => Promise.resolve(cursorPoint);
+  let statusRect = {
+    left: 100,
+    top: 40,
+    right: 300,
+    bottom: 100,
+    width: 200,
+    height: 60,
+  };
 
   const body = createElement('body');
   const head = createElement('head');
@@ -114,14 +122,7 @@ function createHarness(options = {}) {
   statusToast.offsetTop = 40;
   statusToast.offsetWidth = 200;
   statusToast.offsetHeight = 60;
-  statusToast.getBoundingClientRect = () => ({
-    left: 100,
-    top: 40,
-    right: 300,
-    bottom: 100,
-    width: 200,
-    height: 60,
-  });
+  statusToast.getBoundingClientRect = () => ({ ...statusRect });
   body.appendChild(statusToast);
 
   document = {
@@ -147,7 +148,10 @@ function createHarness(options = {}) {
   };
 
   const api = {
-    copyText(value) { copied.push(value); return true; },
+    copyText(value) {
+      copied.push(value);
+      return typeof options.copyText === 'function' ? options.copyText(value) : true;
+    },
     supportsStatusPointerTracking: options.supportsStatusPointerTracking !== false,
     getCursorPoint() { return cursorProvider(); },
     setMouseThrough(ignore) { mouseThrough.push(ignore); },
@@ -163,11 +167,18 @@ function createHarness(options = {}) {
     t(_key, options) { return options.defaultValue; },
     addEventListener(type, listener) { windowListeners.set(type, listener); },
     removeEventListener() {},
+    requestAnimationFrame(callback) {
+      nextTimerId += 1;
+      timers.set(nextTimerId, { callback, delay: 16 });
+      return nextTimerId;
+    },
+    cancelAnimationFrame(id) { timers.delete(id); },
   };
 
   vm.runInNewContext(inlineScript, {
     window,
     document,
+    navigator: options.navigatorClipboard ? { clipboard: options.navigatorClipboard } : {},
     console: { log() {} },
     Promise,
     Date,
@@ -190,6 +201,7 @@ function createHarness(options = {}) {
     mouseThrough,
     copied,
     statusInputRegions,
+    setStatusRect(rect) { statusRect = { ...rect }; },
     setCursor(point) { cursorPoint = point; },
     setCursorProvider(provider) { cursorProvider = provider; },
     emitStatus(message = 'saved') { callbacks.status({ message, duration: 3000 }); },
@@ -229,6 +241,8 @@ async function flushPromises() {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 test('clicking status text copies the complete toast without changing mouse-through state', async () => {
@@ -241,6 +255,56 @@ test('clicking status text copies the complete toast without changing mouse-thro
 
   assert.deepEqual(harness.copied, ['API request failed: 401']);
   assert.deepEqual(harness.mouseThrough, []);
+  assert.equal(text.classList.contains('status-toast-copy-success'), true);
+});
+
+test('status text exposes the same copy action to the keyboard', async () => {
+  const harness = createHarness();
+  harness.emitStatus('API request failed: 403');
+
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  let prevented = false;
+  text.onkeydown({
+    key: 'Enter',
+    preventDefault() { prevented = true; },
+    stopPropagation() {},
+  });
+  await flushPromises();
+
+  assert.equal(text._attributes.get('role'), 'button');
+  assert.equal(text.tabIndex, 0);
+  assert.equal(prevented, true);
+  assert.deepEqual(harness.copied, ['API request failed: 403']);
+});
+
+test('a completed copy cannot show feedback on a replacement toast', async () => {
+  const pendingCopy = createDeferred();
+  const harness = createHarness({ copyText: () => pendingCopy.promise });
+  harness.emitStatus('first error');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.onclick({ stopPropagation() {} });
+
+  harness.emitStatus('second error');
+  pendingCopy.resolve(true);
+  await flushPromises();
+
+  assert.equal(text.textContent, 'second error');
+  assert.equal(text.classList.contains('status-toast-copy-success'), false);
+});
+
+test('dedicated toast falls back to the web clipboard when its bridge declines', async () => {
+  const webCopies = [];
+  const harness = createHarness({
+    copyText: () => false,
+    navigatorClipboard: { writeText(value) { webCopies.push(value); return Promise.resolve(); } },
+  });
+  harness.emitStatus('bridge fallback');
+
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.onclick({ stopPropagation() {} });
+  await flushPromises();
+
+  assert.deepEqual(webCopies, ['bridge fallback']);
   assert.equal(text.classList.contains('status-toast-copy-success'), true);
 });
 
@@ -405,6 +469,22 @@ test('Niri compact status input region is cleared as soon as the toast closes', 
     { x: 100, y: 40, width: 200, height: 60 },
     null,
   ]);
+});
+
+test('Niri compact status input region follows the visible transform during entry', () => {
+  const harness = createHarness({ supportsStatusPointerTracking: false });
+  harness.emitStatus();
+  harness.runTimer(10);
+
+  harness.setStatusRect({ left: 116, top: 24, right: 284, bottom: 74, width: 168, height: 50 });
+  harness.runTimer(16);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(harness.statusInputRegions.at(-1))), {
+    x: 116,
+    y: 24,
+    width: 168,
+    height: 50,
+  });
 });
 
 // 连发场景：光标全程停在矩形上不动。第二条提示必须重新 pin —— 若 inside 标志位

--- a/tests/frontend/toast_pointer_passthrough.test.cjs
+++ b/tests/frontend/toast_pointer_passthrough.test.cjs
@@ -222,6 +222,9 @@ function createHarness(options = {}) {
     hasTimer(delay) {
       return Array.from(timers.values()).some((timer) => timer.delay === delay);
     },
+    countTimers(delay) {
+      return Array.from(timers.values()).filter((timer) => timer.delay === delay).length;
+    },
     // 自动消失计时器是唯一延迟大于 1s 的：show=10ms、轮询=50ms、cleanup=400ms。
     // 按区间而不是精确值判定，因为暂停/恢复会把剩余时长按实际经过时间扣掉。
     hasAutoHideTimer() {
@@ -342,6 +345,40 @@ test('pointer copy releases focus and resumes auto-hide', () => {
 
   assert.equal(document.activeElement, null);
   assert.equal(harness.hasAutoHideTimer(), true);
+});
+
+test('pointer copy keeps auto-hide paused while the toast remains hovered', () => {
+  const harness = createHarness();
+  harness.emitStatus('keep reading');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+  text.focus();
+  harness.statusToast.dispatch('focusin');
+  harness.setHover(true);
+
+  text.onclick({ stopPropagation() {} });
+
+  assert.equal(document.activeElement, null);
+  assert.equal(harness.hasAutoHideTimer(), false);
+
+  harness.setHover(false);
+  harness.statusToast.dispatch('mouseleave');
+  assert.equal(harness.hasAutoHideTimer(), true);
+});
+
+test('dedicated repeated copies reset the success feedback timer', async () => {
+  const harness = createHarness();
+  harness.emitStatus('copy twice');
+  const text = harness.statusToast.querySelector('#status-toast-text');
+
+  text.onclick({ stopPropagation() {} });
+  await flushPromises();
+  text.onclick({ stopPropagation() {} });
+  await flushPromises();
+
+  assert.equal(harness.countTimers(450), 1);
+  assert.equal(text.classList.contains('status-toast-copy-success'), true);
+  harness.runTimer(450);
+  assert.equal(text.classList.contains('status-toast-copy-success'), false);
 });
 
 test('ordinary status toast only captures input while the cursor is inside its rectangle', async () => {


### PR DESCRIPTION
## 改动概述 / Summary

- 允许点击状态 Toast 文本，将完整提示复制到剪贴板，并支持 Tab、Enter 与 Space 操作。
- 普通网页优先使用 Clipboard API，并在不可用或被拒绝时回退到兼容复制路径；独立窗口桥接失败时也会继续降级。
- 隔离异步复制反馈，避免旧消息或旧计时器干扰当前 Toast。
- 点击复制后释放文字焦点，同时保留现有悬停暂停；指针离开后继续自动隐藏。
- Niri 紧凑 Toast 在入场动画期间按实际可见几何持续更新输入区域。
- 保持现有关闭按钮和鼠标穿透行为。

配套 Electron/Wayland/Niri 桥接改动：https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/477

## 回归报告 / Regression Report

不适用。本 PR 未修改 app、main_logic 或 memory 下的 Python 模块。

## 不拆分理由 / Why Not Split

不适用。改动规模未超过拆分阈值。

## 测试 / Testing

- Node Toast 测试：29/29 通过。
- Python Toast 静态契约测试：7/7 通过。
- 差异格式检查通过。
- Windows Electron 实测点击后可复制完整报错文本。