### PR TITLE
修复聊天记录 Markdown 导出预览在切换格式或消息选择状态时偶发空白的问题

### DIFF
--- a/static/app/app-chat-export.js
+++ b/static/app/app-chat-export.js
@@ -2942,7 +2942,7 @@
             setWindowControlButtonLabel(minimizeButton, 'common.minimize', 'Minimize');
             title.textContent = translateLabel('chat.exportPreviewTitle', 'Export Preview');
             title.setAttribute('data-text', title.textContent);
-            frame.setAttribute('title', translateLabel('chat.exportPreviewTitle', 'Export Preview'));
+            modal.frame.setAttribute('title', translateLabel('chat.exportPreviewTitle', 'Export Preview'));
             previewImage.alt = translateLabel('chat.exportPreviewTitle', 'Export Preview');
             closeIcon.alt = translateLabel('common.close', 'Close');
             selectAllButton.textContent = translateLabel('chat.exportSelectAll', 'Select All');

--- a/static/app/app-chat-export.js
+++ b/static/app/app-chat-export.js
@@ -2677,9 +2677,9 @@
         // srcdoc browsing context blank. Replace it with a visible frame for
         // every Markdown navigation and keep the loading cover until the new
         // document has actually loaded.
+        nextFrame.srcdoc = String(previewDocument || '');
         modal.frame = nextFrame;
         modal.previewBody.replaceChild(nextFrame, currentFrame);
-        nextFrame.srcdoc = String(previewDocument || '');
     }
 
     function createPreviewModal(targetDocument) {

--- a/static/app/app-chat-export.js
+++ b/static/app/app-chat-export.js
@@ -48,7 +48,8 @@
         previewCache: new Map(),    // cacheKey -> { payload }
         previewCurrentCacheKey: '',
         isPreviewRendering: false,
-        previewRenderToken: 0
+        previewRenderToken: 0,
+        previewRenderPending: false
     };
 
     // ======================== Utilities ========================
@@ -2650,6 +2651,37 @@
 
     // ======================== Preview modal ========================
 
+    function createPreviewFrame(doc) {
+        var frame = doc.createElement('iframe');
+        frame.className = 'chat-export-preview-frame';
+        frame.setAttribute('sandbox', 'allow-scripts');
+        frame.setAttribute('title', translateLabel('chat.exportPreviewTitle', 'Export Preview'));
+        return frame;
+    }
+
+    function mountMarkdownPreviewFrame(modal, previewDocument, renderToken) {
+        var currentFrame = modal.frame;
+        var doc = currentFrame.ownerDocument || document;
+        var nextFrame = createPreviewFrame(doc);
+
+        nextFrame.addEventListener('load', function () {
+            if (
+                renderToken !== state.previewRenderToken
+                || state.previewModal !== modal
+                || modal.frame !== nextFrame
+            ) return;
+            modal.placeholder.hidden = true;
+        }, { once: true });
+
+        // Reusing an iframe after it has been display:none can leave Chromium's
+        // srcdoc browsing context blank. Replace it with a visible frame for
+        // every Markdown navigation and keep the loading cover until the new
+        // document has actually loaded.
+        modal.frame = nextFrame;
+        modal.previewBody.replaceChild(nextFrame, currentFrame);
+        nextFrame.srcdoc = String(previewDocument || '');
+    }
+
     function createPreviewModal(targetDocument) {
         var doc = targetDocument || document;
         var backdrop = doc.createElement('div');
@@ -2774,11 +2806,8 @@
         var previewBody = doc.createElement('div');
         previewBody.className = 'chat-export-preview-body';
 
-        var frame = doc.createElement('iframe');
-        frame.className = 'chat-export-preview-frame';
+        var frame = createPreviewFrame(doc);
         frame.hidden = true;
-        frame.setAttribute('sandbox', 'allow-scripts');
-        frame.setAttribute('title', translateLabel('chat.exportPreviewTitle', 'Export Preview'));
 
         var previewImageWrap = doc.createElement('div');
         previewImageWrap.className = 'chat-export-preview-image-wrap';
@@ -2981,6 +3010,7 @@
         var previewWindow = state.previewWindow;
         var shouldDestroyWindow = !!(destroyWindow || closeWindow || (previewWindow && previewWindow.closed));
         state.previewRenderToken += 1;
+        state.previewRenderPending = false;
         if (modal) {
             var modalDocument = getPreviewModalDocument(modal);
             try {
@@ -3206,6 +3236,7 @@
         var formatId = state.exportFormat;
 
         if (entries.length === 0) {
+            state.previewRenderPending = false;
             modal.frame.hidden = true;
             modal.previewImageWrap.hidden = true;
             modal.placeholder.hidden = false;
@@ -3218,7 +3249,11 @@
         modal.downloadButton.disabled = false;
         modal.openWindowButton.disabled = false;
 
-        if (state.isPreviewRendering) return;
+        if (state.isPreviewRendering) {
+            state.previewRenderPending = true;
+            return;
+        }
+        state.previewRenderPending = false;
         state.isPreviewRendering = true;
         modal.placeholder.hidden = false;
         modal.placeholder.textContent = translateLabel('chat.exportPreviewLoading', 'Generating preview...');
@@ -3236,12 +3271,11 @@
                 modal.frame.hidden = true;
                 modal.placeholder.hidden = true;
             } else {
-                modal.frame.srcdoc = payload.previewDocument;
-                modal.frame.hidden = false;
                 modal.previewImageWrap.hidden = true;
-                modal.placeholder.hidden = true;
+                mountMarkdownPreviewFrame(modal, payload.previewDocument, myToken);
             }
         } catch (error) {
+            if (myToken !== state.previewRenderToken) return;
             logExportError('renderPreviewModal', error);
             modal.placeholder.hidden = false;
             modal.placeholder.textContent = translateLabel('chat.exportPreviewFailed', 'Failed to build the preview.')
@@ -3250,6 +3284,15 @@
             modal.previewImageWrap.hidden = true;
         } finally {
             state.isPreviewRendering = false;
+            if (
+                state.previewRenderPending
+                && state.previewModal
+                && state.previewModal.panel
+                && !state.previewModal.panel.hidden
+            ) {
+                state.previewRenderPending = false;
+                schedulePreviewRender();
+            }
         }
     }
 

--- a/tests/unit/test_chat_export_static_contracts.py
+++ b/tests/unit/test_chat_export_static_contracts.py
@@ -244,3 +244,15 @@ function getOrBuildPreviewPayload(_entries, formatId) {
     )
 
     run_node_script(node, harness, check=True, cwd=PROJECT_ROOT)
+
+
+def test_export_preview_locale_change_updates_the_current_replaced_frame():
+    source = CHAT_EXPORT_JS.read_text(encoding="utf-8")
+    modal_start = source.index("function createPreviewModal(targetDocument)")
+    modal_end = source.index("function getPreviewModalDocument(modal)", modal_start)
+    locale_handler = source[modal_start:modal_end].split(
+        "var localeHandler = function () {", 1
+    )[1].split("window.addEventListener('localechange', localeHandler);", 1)[0]
+
+    assert "modal.frame.setAttribute('title'" in locale_handler
+    assert "\n            frame.setAttribute('title'" not in locale_handler

--- a/tests/unit/test_chat_export_static_contracts.py
+++ b/tests/unit/test_chat_export_static_contracts.py
@@ -1,4 +1,9 @@
+import shutil
 from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -58,3 +63,184 @@ def test_export_preview_reuses_only_shell_window_handles():
     assert "returnedHref !== 'about:blank' && !isExportPreviewShellUrl(returnedHref)" in open_export
     assert "var openedShellWindow = isExportPreviewShellUrl(returnedHref);" in open_export
     assert "previewWindow.__nekoChatExportPreviewWindow = true;" in open_export
+
+
+def test_markdown_preview_replaces_hidden_frame_and_waits_for_latest_document_load():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the export preview lifecycle harness")
+
+    source = CHAT_EXPORT_JS.read_text(encoding="utf-8")
+    frame_start = source.index("function createPreviewFrame(doc)")
+    frame_end = source.index("function createPreviewModal(targetDocument)", frame_start)
+    frame_functions = source[frame_start:frame_end]
+    render_start = source.index("function schedulePreviewRender()")
+    render_end = source.index("function buildExportWindowFeatures()", render_start)
+    render_functions = source[render_start:render_end]
+
+    harness = (
+        """
+const assert = require('node:assert/strict');
+
+const animationFrames = [];
+function requestAnimationFrame(callback) {
+    animationFrames.push(callback);
+}
+function runAnimationFrame() {
+    const callback = animationFrames.shift();
+    assert.ok(callback, 'expected a queued animation frame');
+    callback();
+}
+
+let doc;
+function makeFrame() {
+    const listeners = new Map();
+    return {
+        ownerDocument: doc,
+        parentNode: null,
+        className: '',
+        hidden: false,
+        srcdoc: '',
+        attributes: {},
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        },
+        addEventListener(type, callback, options) {
+            listeners.set(type, { callback, once: !!(options && options.once) });
+        },
+        dispatch(type) {
+            const listener = listeners.get(type);
+            assert.ok(listener, `expected a ${type} listener`);
+            if (listener.once) listeners.delete(type);
+            listener.callback();
+        }
+    };
+}
+doc = {
+    createElement(tagName) {
+        assert.equal(tagName, 'iframe');
+        return makeFrame();
+    }
+};
+
+const previewBody = {
+    child: null,
+    replaceChild(nextFrame, currentFrame) {
+        assert.equal(this.child, currentFrame);
+        currentFrame.parentNode = null;
+        nextFrame.parentNode = this;
+        this.child = nextFrame;
+    }
+};
+const initialFrame = makeFrame();
+initialFrame.hidden = true;
+initialFrame.parentNode = previewBody;
+previewBody.child = initialFrame;
+
+const modal = {
+    panel: { hidden: false },
+    previewBody,
+    frame: initialFrame,
+    previewImage: { src: '' },
+    previewImageWrap: { hidden: true },
+    placeholder: { hidden: true, textContent: '' },
+    downloadButton: { disabled: false },
+    openWindowButton: { disabled: false }
+};
+const state = {
+    previewModal: modal,
+    previewRenderToken: 0,
+    previewRenderPending: false,
+    previewCurrentCacheKey: '',
+    isPreviewRendering: false,
+    exportFormat: 'image'
+};
+let selectedEntries = [{ id: 'message-1' }];
+const requestedFormats = [];
+let resolveFirstPreview;
+
+function ensurePreviewModal() { return modal; }
+function getSelectedEntries() { return selectedEntries; }
+function renderControls() {}
+function updateSummary() {}
+function translateLabel(_key, fallback) { return fallback; }
+function logExportError() {}
+function getErrorMessage(error) { return String(error); }
+function getOrBuildPreviewPayload(_entries, formatId) {
+    requestedFormats.push(formatId);
+    if (requestedFormats.length === 1) {
+        return new Promise(function (resolve) {
+            resolveFirstPreview = resolve;
+        });
+    }
+    return Promise.resolve({
+        cacheKey: `markdown-${requestedFormats.length}`,
+        previewKind: 'document',
+        previewDocument: `<p>Markdown preview ${requestedFormats.length}</p>`
+    });
+}
+"""
+        + frame_functions
+        + render_functions
+        + """
+(async function () {
+    // Start an image render, then request Markdown while it still owns the
+    // render lock. The latest request must be replayed after the image becomes
+    // stale instead of leaving the frame blank.
+    schedulePreviewRender();
+    runAnimationFrame();
+    assert.equal(state.isPreviewRendering, true);
+
+    state.exportFormat = 'markdown';
+    schedulePreviewRender();
+    runAnimationFrame();
+    assert.equal(state.previewRenderPending, true);
+
+    resolveFirstPreview({
+        cacheKey: 'stale-image',
+        previewKind: 'image',
+        previewUrl: 'blob:stale-image'
+    });
+    await Promise.resolve();
+
+    assert.equal(animationFrames.length, 1);
+    runAnimationFrame();
+    await Promise.resolve();
+
+    const firstMarkdownFrame = modal.frame;
+    assert.notEqual(firstMarkdownFrame, initialFrame);
+    assert.equal(firstMarkdownFrame.hidden, false);
+    assert.equal(firstMarkdownFrame.srcdoc, '<p>Markdown preview 2</p>');
+    assert.equal(modal.placeholder.hidden, false);
+    firstMarkdownFrame.dispatch('load');
+    assert.equal(modal.placeholder.hidden, true);
+
+    // Exercise the other reported path: selected -> empty -> selected. A new
+    // visible frame must be mounted and its own load event must reveal it.
+    selectedEntries = [];
+    schedulePreviewRender();
+    runAnimationFrame();
+    assert.equal(modal.frame.hidden, true);
+    assert.equal(modal.placeholder.hidden, false);
+
+    selectedEntries = [{ id: 'message-1' }];
+    schedulePreviewRender();
+    runAnimationFrame();
+    await Promise.resolve();
+
+    const secondMarkdownFrame = modal.frame;
+    assert.notEqual(secondMarkdownFrame, firstMarkdownFrame);
+    assert.equal(secondMarkdownFrame.hidden, false);
+    assert.equal(secondMarkdownFrame.srcdoc, '<p>Markdown preview 3</p>');
+    assert.equal(modal.placeholder.hidden, false);
+    secondMarkdownFrame.dispatch('load');
+    assert.equal(modal.placeholder.hidden, true);
+    assert.deepEqual(requestedFormats, ['image', 'markdown', 'markdown']);
+})().catch(function (error) {
+    console.error(error);
+    process.exitCode = 1;
+});
+"""
+    )
+
+    run_node_script(node, harness, check=True, cwd=PROJECT_ROOT)

--- a/tests/unit/test_chat_export_static_contracts.py
+++ b/tests/unit/test_chat_export_static_contracts.py
@@ -127,6 +127,11 @@ const previewBody = {
     child: null,
     replaceChild(nextFrame, currentFrame) {
         assert.equal(this.child, currentFrame);
+        assert.notEqual(
+            nextFrame.srcdoc,
+            '',
+            'srcdoc must be assigned before the replacement iframe is inserted'
+        );
         currentFrame.parentNode = null;
         nextFrame.parentNode = this;
         this.child = nextFrame;


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复聊天记录 Markdown 导出预览在切换格式或消息选择状态时偶发空白的问题

## 测试 / Testing

手动测试确认问题解决


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化 Markdown 预览切换体验：切换内容时会及时替换为最新预览，避免显示过期内容。
  - 在新预览加载完成前持续显示加载占位状态，加载完成后再展示内容。
  - 修复快速切换预览或清空后重新选择内容时，预览无法正确更新的问题。
  - 修复语言切换后预览框标题未同步更新的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->