### PR TITLE
fix(mc-agent): duplicate 不再当完成处理；拒收标识符形态的 task

### DIFF
--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -40,7 +40,11 @@ from plugin.sdk.plugin import (
 )
 
 from . import prompts
-from .service import GameAgentService, text_signals_blocked
+from .service import (
+    GameAgentService,
+    task_looks_like_identifier,
+    text_signals_blocked,
+)
 
 # JSON Schema reused by the @llm_tool decorator below. Pulled into a
 # module-level constant so the plugin's introspection (status entry,
@@ -121,8 +125,9 @@ MINECRAFT_TASK_DESCRIPTION = (
     "something new and that request has not already been dispatched, or when a "
     "keep-going turn identifies a genuinely obvious new action from current game "
     "state. Do NOT dispatch merely because a task finished or new awareness "
-    "context arrived. Do NOT use it for chat, status "
-    "questions, or abstract intent — see ``query_inventory`` for inventory lookups.\n\n"
+    "context arrived. Do NOT use it for chat, status questions, abstract intent, "
+    "or inventory checks — the inventory is reported to you separately, never "
+    "dispatch a lookup as a task.\n\n"
     "Parameters:\n"
     "  task (string, required): master's exact original new instruction when "
     "master-directed; otherwise one genuinely new autonomous action based on "
@@ -361,6 +366,15 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
                 "summary": prompts.t("TASK_SCHEMA_ERROR", lang=self._lang),
             }
         task_text = task.strip()
+        # Bare identifier (``mine_block``, ``query_inventory``,
+        # ``goToCoordinates(...)``) instead of a sentence — refuse with a
+        # structured hint so the token never reaches mc-agent nor the
+        # in-progress cue that would echo it back (see
+        # ``service.task_looks_like_identifier``).
+        if task_looks_like_identifier(task_text):
+            return {
+                "summary": prompts.t("TASK_IDENTIFIER_ERROR", lang=self._lang),
+            }
         # Some LLMs pass ``"true"`` / ``"1"`` / ``1`` as overwrite. Strict
         # ``is True`` keeps the destructive interrupt path off-by-default;
         # anything other than the canonical Python bool ``True`` is treated

--- a/plugin/plugins/game_agent_minecraft/prompts.py
+++ b/plugin/plugins/game_agent_minecraft/prompts.py
@@ -239,6 +239,16 @@ PROMPTS: Dict[str, Dict[str, str]] = {
         "es": "Llamada fallida — falta una descripción concreta de la acción. Define qué quieres hacer exactamente (p. ej. 'mine 4 oak logs nearby', 'walk to 120 64 -50') y vuelve a llamar.",
         "pt": "Chamada falhou — falta uma descrição concreta da ação. Pense no que você quer fazer (ex.: 'mine 4 oak logs nearby', 'walk to 120 64 -50') e chame de novo.",
     },
+    "TASK_IDENTIFIER_ERROR": {
+        "zh": "调用没成功——task 里填的是一个内部标识符，不是动作描述。用一句大白话说清要做什么（比如 'mine 4 oak logs nearby'、'walk to 120 64 -50'），再重新调用。",
+        "zh-TW": "呼叫沒成功——task 裡填的是一個內部識別字，不是動作描述。用一句白話說清楚要做什麼（例如 'mine 4 oak logs nearby'、'walk to 120 64 -50'），再重新呼叫一次。",
+        "en": "Call failed — task is an internal identifier, not an action description. Say what to do in a plain sentence (e.g. 'mine 4 oak logs nearby', 'walk to 120 64 -50') and call again.",
+        "ja": "呼び出し失敗——task に入っているのは内部の識別子で、動作の説明じゃない。何をするか普通の一文で書いて（例: 'mine 4 oak logs nearby'、'walk to 120 64 -50'）もう一度呼んで。",
+        "ko": "호출 실패——task에 들어간 건 내부 식별자지 동작 설명이 아니야. 뭘 할지 평범한 한 문장으로 적고 (예: 'mine 4 oak logs nearby', 'walk to 120 64 -50') 다시 호출해.",
+        "ru": "Вызов не удался — в task стоит внутренний идентификатор, а не описание действия. Опиши, что сделать, обычным предложением (например, 'mine 4 oak logs nearby', 'walk to 120 64 -50'), и вызови снова.",
+        "es": "Llamada fallida — task contiene un identificador interno, no una descripción de la acción. Di qué hacer en una frase normal (p. ej. 'mine 4 oak logs nearby', 'walk to 120 64 -50') y vuelve a llamar.",
+        "pt": "Chamada falhou — task contém um identificador interno, não uma descrição da ação. Diga o que fazer em uma frase normal (ex.: 'mine 4 oak logs nearby', 'walk to 120 64 -50') e chame de novo.",
+    },
     "TASK_NOT_CONNECTED": {
         "zh": "你刚连上游戏还没就位，没法立刻动。稍等再来一次。",
         "zh-TW": "你剛連上遊戲還沒就位，沒辦法立刻動。稍等再試一次。",

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -230,6 +230,12 @@ class GameAgentService:
         # overwrites.
         self._dispatched_history: "collections.OrderedDict[str, str]" = collections.OrderedDict()
         self._dispatched_history_max: int = 32
+        # task_id → root task_id for dispatches mc-agent answered with
+        # ``duplicate`` (they never ran; the root is the one executing).
+        # ``_find_prior_dispatch_id`` resolves through this so a chain of
+        # re-dispatches of one long task all alias the root, never a sibling
+        # duplicate whose id no completion frame will ever carry.
+        self._duplicate_root: Dict[str, str] = {}
         # One-way latch: flips True the first time mc-agent echoes a
         # task_id on task_finished. Used by ``_on_task_finished`` to
         # disable the FIFO fallback once we know the agent is modern —
@@ -791,15 +797,21 @@ class GameAgentService:
             return
         self._dispatched_history[task_id] = task_text
         while len(self._dispatched_history) > self._dispatched_history_max:
-            self._dispatched_history.popitem(last=False)
+            evicted, _ = self._dispatched_history.popitem(last=False)
+            self._duplicate_root.pop(evicted, None)
 
     def _find_prior_dispatch_id(self, task_text: str, *, exclude: str) -> str:
-        """Most recent dispatched id carrying exactly ``task_text``, other
-        than ``exclude`` (the current slot's own id). Used to alias a
-        ``duplicate`` answer back to the dispatch that is really running."""
+        """Id of the dispatch really running ``task_text``, other than
+        ``exclude`` (the current slot's own id). Walks history newest-first
+        and resolves any dispatch that itself got ``duplicate`` to its root,
+        so a chain of re-dispatches never aliases a sibling that never ran."""
         for task_id, text in reversed(self._dispatched_history.items()):
-            if task_id != exclude and text == task_text:
-                return task_id
+            if task_id == exclude or text != task_text:
+                continue
+            root = self._duplicate_root.get(task_id, task_id)
+            if root == exclude:
+                continue
+            return root
         return ""
 
     async def try_claim_pending(
@@ -1708,6 +1720,7 @@ class GameAgentService:
                 )
                 if prior_id:
                     pending.alias_task_id = prior_id
+                    self._duplicate_root[pending.task_id] = prior_id
                 if text:
                     self._log_cache.append(text)
                 self._log_info(

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -98,6 +98,32 @@ def text_signals_blocked(text: str) -> bool:
     return any(m in low for m in _BLOCKED_TEXT_MARKERS)
 
 
+# [ANTI-PARROT] A task that is a bare identifier rather than a sentence.
+# Observed 2026-09-07: the dialog LLM dispatched ``query_inventory`` (an entry
+# name it saw in the tool description) and ``mine_block`` (invented) as the
+# task text. mc-agent runs them literally, the in-progress cue echoes
+# ``You're doing: "mine_block"`` back, and the model re-sends the same token
+# forever. Three shapes cover every leak seen so far: snake_case, camelCase,
+# and single-token function-call syntax. A plain word ("stop", "mine") or any
+# text with a space / CJK stays allowed — those are real instructions.
+_IDENTIFIER_TASK_RE = re.compile(
+    r"^(?:"
+    r"[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+"          # mine_block, GET_DIAMOND
+    r"|[a-z]+(?:[A-Z][a-z0-9]*)+"                       # mineDiamonds, goToCoordinates
+    r"|[A-Za-z_][A-Za-z0-9_]*[(][^)]*[)]"               # goToCoordinates(1,2,3)
+    r")$"
+)
+
+
+def task_looks_like_identifier(text: str) -> bool:
+    """True when ``text`` is an internal identifier / command token rather
+    than a plain-language instruction. Shared by the facade handler and
+    ``execute_minecraft_task`` so both entry points refuse the same shapes."""
+    if not text:
+        return False
+    return bool(_IDENTIFIER_TASK_RE.match(text.strip()))
+
+
 @dataclass
 class PendingTask:
     """State for a single in-flight ``minecraft_task`` invocation.
@@ -116,6 +142,12 @@ class PendingTask:
     # pending slot (normal wake), a known previously-dispatched task
     # (emit retroactive completion cue), or unknown (FIFO fallback).
     task_id: str = ""
+    # Set when mc-agent answered this dispatch with ``status=duplicate``
+    # ("same instruction already running"): the id of the earlier dispatch
+    # of the same text that is actually running. The eventual
+    # ``task_finished`` arrives under THAT id, so ``_on_task_finished``
+    # treats a frame echoing ``alias_task_id`` as this slot's completion.
+    alias_task_id: str = ""
     # Filled in by the WebSocket callback (or by overwrite/timeout
     # paths) right before ``event`` is set.
     result: Dict[str, Any] = field(default_factory=dict)
@@ -761,6 +793,15 @@ class GameAgentService:
         while len(self._dispatched_history) > self._dispatched_history_max:
             self._dispatched_history.popitem(last=False)
 
+    def _find_prior_dispatch_id(self, task_text: str, *, exclude: str) -> str:
+        """Most recent dispatched id carrying exactly ``task_text``, other
+        than ``exclude`` (the current slot's own id). Used to alias a
+        ``duplicate`` answer back to the dispatch that is really running."""
+        for task_id, text in reversed(self._dispatched_history.items()):
+            if task_id != exclude and text == task_text:
+                return task_id
+        return ""
+
     async def try_claim_pending(
         self, task: str, *, overwrite: bool
     ) -> Optional[PendingTask]:
@@ -943,6 +984,12 @@ class GameAgentService:
         if not isinstance(task, str) or not task.strip():
             return {
                 "output": {"error": "task must be a non-empty string"},
+                "is_error": True,
+                "error": "INVALID_TASK",
+            }
+        if task_looks_like_identifier(task):
+            return {
+                "output": {"error": "task must be a plain-language instruction, not an identifier"},
                 "is_error": True,
                 "error": "INVALID_TASK",
             }
@@ -1602,7 +1649,9 @@ class GameAgentService:
             pending = self._pending
             historical_text: Optional[str] = None
             if echoed_task_id is not None:
-                if pending is not None and pending.task_id == echoed_task_id:
+                if pending is not None and echoed_task_id in (
+                    pending.task_id, pending.alias_task_id or None
+                ):
                     bucket = "current"
                     # Only flip the latch once the id has been proven to
                     # belong to OUR dispatch (current pending or recent
@@ -1644,6 +1693,28 @@ class GameAgentService:
             if parsed_inv is not None and bucket in ("current", "fifo", "retroactive"):
                 self._last_inventory = parsed_inv
                 self._last_inventory_at = time.time()
+
+            # ``duplicate`` is NOT a terminal frame. mc-agent sends it when the
+            # same instruction is already running ("继续当前任务、不重新开始…
+            # 请勿重发"). Treating it as a completion (observed 2026-09-07)
+            # cleared the slot AND told the dialog LLM the action "couldn't
+            # finish" → it re-sent the same text → duplicate again, forever.
+            # Keep the slot claimed and don't wake the handler; remember the
+            # id of the earlier dispatch that is really running so its
+            # eventual ``task_finished`` resolves this slot.
+            if status.strip().lower() == "duplicate" and bucket in ("current", "fifo"):
+                prior_id = self._find_prior_dispatch_id(
+                    pending.task_text, exclude=pending.task_id
+                )
+                if prior_id:
+                    pending.alias_task_id = prior_id
+                if text:
+                    self._log_cache.append(text)
+                self._log_info(
+                    "task_finished duplicate: keeping pending {!r} (alias={})",
+                    pending.task_text[:40], prior_id or "-",
+                )
+                return
 
             if bucket == "current":
                 self._pending = None

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -1933,6 +1933,45 @@ async def test_duplicate_frame_keeps_pending_and_resolves_via_original_id():
 
 
 @pytest.mark.asyncio
+async def test_duplicate_chain_aliases_root_not_sibling_duplicate():
+    """Three dispatches of one long task: the first really runs, the second
+    and third both get ``duplicate``. The third must alias the FIRST id (the
+    running one), not the second (which never ran and whose id no completion
+    frame will ever carry) — otherwise the root's completion routes to the
+    retroactive bucket and the third slot waits until timeout."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    async def _drop_slot_as_timeout(runner):
+        service._pending.result = {"status": "timeout", "query": "mine 10 logs"}
+        service._pending.event.set()
+        service._pending = None
+        await asyncio.wait_for(runner, timeout=2.0)
+
+    runner1, first_id = await _dispatch_and_get_id(service, "mine 10 logs")
+    await _drop_slot_as_timeout(runner1)
+
+    runner2, second_id = await _dispatch_and_get_id(service, "mine 10 logs")
+    await service._on_task_finished({"status": "duplicate", "task_id": second_id})
+    await asyncio.sleep(0.02)
+    assert service._pending.alias_task_id == first_id
+    await _drop_slot_as_timeout(runner2)
+
+    runner3, third_id = await _dispatch_and_get_id(service, "mine 10 logs")
+    await service._on_task_finished({"status": "duplicate", "task_id": third_id})
+    await asyncio.sleep(0.02)
+    assert service._pending.alias_task_id == first_id, (
+        "third slot aliased a sibling duplicate instead of the running root"
+    )
+
+    await service._on_task_finished({"status": "ok", "task_id": first_id})
+    out = await asyncio.wait_for(runner3, timeout=2.0)
+    assert out["status"] == "ok"
+    assert service._pending is None
+
+
+@pytest.mark.asyncio
 async def test_duplicate_frame_without_prior_dispatch_keeps_pending():
     """No earlier dispatch of the same text in history (mc-agent is running
     its own task, or the history rolled over): still hold the slot; the

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -1872,3 +1872,166 @@ async def test_autonomous_status_rearms_busy_without_pending():
     )
 
     assert service._agent_busy is True
+
+
+# ---------------------------------------------------------------------------
+# duplicate frames — "same instruction already running" is not a completion
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_and_get_id(service, task: str) -> tuple[asyncio.Task, str]:
+    runner = asyncio.create_task(service.execute_minecraft_task(task=task))
+    for _ in range(50):
+        if service._pending is not None and service._pending.task_text == task:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set")
+    return runner, service._pending.task_id
+
+
+@pytest.mark.asyncio
+async def test_duplicate_frame_keeps_pending_and_resolves_via_original_id():
+    """Regression for the 2026-09-07 resend loop: a re-dispatch of text that
+    mc-agent is still running gets ``status=duplicate``. That frame must NOT
+    clear the slot nor wake the handler as a failure; the eventual
+    ``task_finished`` for the ORIGINAL dispatch id resolves the new slot."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    runner1, first_id = await _dispatch_and_get_id(service, "mine 10 logs")
+    # First dispatch drops out of the slot (e.g. plugin-side timeout) while
+    # mc-agent keeps running it. Simulate by timing the wait out directly.
+    service._pending.result = {"status": "timeout", "query": "mine 10 logs"}
+    service._pending.event.set()
+    service._pending = None
+    await asyncio.wait_for(runner1, timeout=2.0)
+
+    runner2, second_id = await _dispatch_and_get_id(service, "mine 10 logs")
+    assert second_id != first_id
+
+    await service._on_task_finished({
+        "status": "duplicate",
+        "task_id": second_id,
+        "message": "收到。相同指令已在执行中（已运行20秒），请勿重发。",
+    })
+    await asyncio.sleep(0.05)
+
+    assert not runner2.done(), "duplicate frame must not resolve the handler"
+    assert service._pending is not None
+    assert service._pending.task_id == second_id
+    assert service._pending.alias_task_id == first_id
+    assert any("相同指令已在执行中" in line for line in service._log_cache)
+
+    await service._on_task_finished(
+        {"status": "ok", "task_id": first_id, "text": "done"}
+    )
+    out = await asyncio.wait_for(runner2, timeout=2.0)
+    assert out["status"] == "ok"
+    assert service._pending is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_frame_without_prior_dispatch_keeps_pending():
+    """No earlier dispatch of the same text in history (mc-agent is running
+    its own task, or the history rolled over): still hold the slot; the
+    slot's own id resolves it later."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    runner, task_id = await _dispatch_and_get_id(service, "go to the village")
+    await service._on_task_finished({"status": "duplicate", "task_id": task_id})
+    await asyncio.sleep(0.05)
+
+    assert not runner.done()
+    assert service._pending is not None
+    assert service._pending.alias_task_id == ""
+
+    await service._on_task_finished({"status": "ok", "task_id": task_id})
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_frame_for_historical_id_stays_retroactive():
+    """A duplicate echoing an id that is no longer pending is not our slot's
+    business — it must not disturb the current pending task."""
+    service, push_calls = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    runner, task_id = await _dispatch_and_get_id(service, "mine 10 logs")
+    await service._on_task_finished({"status": "duplicate", "task_id": "ghost-id"})
+    await asyncio.sleep(0.05)
+
+    assert not runner.done()
+    assert service._pending is not None and service._pending.task_id == task_id
+
+    await service._on_task_finished({"status": "ok", "task_id": task_id})
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# identifier-shaped task text is refused at the entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "mine_block",
+        "query_inventory",
+        "GET_DIAMOND",
+        "mineDiamonds",
+        "goToCoordinates(118,64,-115,1)",
+        "  mine_block  ",
+    ],
+)
+def test_task_looks_like_identifier_true(text):
+    from plugin.plugins.game_agent_minecraft.service import task_looks_like_identifier
+
+    assert task_looks_like_identifier(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "mine 4 oak logs nearby",
+        "挖钻石",
+        "stop",
+        "mine",
+        "Mine diamonds",
+        "walk to 120 64 -50",
+        "come here",
+        "",
+    ],
+)
+def test_task_looks_like_identifier_false(text):
+    from plugin.plugins.game_agent_minecraft.service import task_looks_like_identifier
+
+    assert task_looks_like_identifier(text) is False
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_identifier_task_before_claiming():
+    service, _ = _make_service()
+    service._client = _FakeClient()
+
+    out = await service.execute_minecraft_task(task="mine_block")
+
+    assert out["is_error"] is True
+    assert out["error"] == "INVALID_TASK"
+    assert service._pending is None
+    assert service._client.sent == []
+
+
+def test_task_tool_description_does_not_name_other_entries():
+    """The description must not contain identifier-shaped entry names the
+    model could copy into ``task`` (observed: ``query_inventory``)."""
+    from plugin.plugins.game_agent_minecraft import MINECRAFT_TASK_DESCRIPTION
+
+    assert "query_inventory" not in MINECRAFT_TASK_DESCRIPTION
+    assert "inventory" in MINECRAFT_TASK_DESCRIPTION


### PR DESCRIPTION
## 背景

2026-09-07 实测 game_agent_minecraft 插件，猫娘反复重发同一 task、游戏里一直敲同一块石头。追日志（`D:\Documents\N.E.K.O\logs\plugin\N.E.K.O_Plugin_game_agent_minecraft_20260907.log`）定位到三处：

1. mc-agent 回 `status=duplicate`（"相同指令已在执行中…请勿重发"）时，`_on_task_finished` 把它当终态处理：清空 pending 槽 + 推「没做成」cue。模型被告知失败且槽已空 → 立刻重发同文本 → 又是 duplicate。日志上 22:33:06 / 22:33:15 / 23:07:34 三次精确复现。
2. 模型把内部标识符当 task 发出去：`query_inventory`（三次）、`mine_block`（两次）。进行中 cue 又原样回显 `You're doing: "mine_block"`，令牌自锁。
3. `query_inventory` 这个词字面出现在 `minecraft_task` 的工具描述里（"see ``query_inventory`` for inventory lookups"），是模型抄进 task 的来源。

## 改动

**现状 → 改成什么**

- `service._on_task_finished`：`duplicate` 命中当前槽（`current` / `fifo`）时不清槽、不唤醒 handler，反馈文本只进 log cache；同时在 `_dispatched_history` 里找同文本的更早派发 id 记到 `PendingTask.alias_task_id`，其 `task_finished` 到达时视作本槽完成（mc-agent 真正在跑的是那一次）。
- 新增 `task_looks_like_identifier()`：snake_case / camelCase / 单 token 函数调用三种形态一律拒收。门面返回新文案 `TASK_IDENTIFIER_ERROR`（八语种齐），`execute_minecraft_task` 返回 `INVALID_TASK`。单词（`stop`）、含空格、CJK 都放行。
- 工具描述去掉 `query_inventory` 字样。

**回归风险**

- duplicate 之后若原任务的完成帧带的是未知 id（mc-agent 自己起的任务），新槽会等到 `task_timeout_seconds` 才超时——与改前"立刻误报失败"相比是更保守的方向。
- 标识符正则可能误拒某些英文单 token 指令；已把纯单词（无下划线、无内部大写）排除在外。

**收益**：重发循环断掉；标识符不再流到 mc-agent 和进行中 cue。

## 验证

- `tests/unit/test_game_agent_minecraft_plugin.py` + ingame_chat + zh_tw_locale：136 passed（新增 7 条：三种 duplicate 场景、标识符真/假表、入口拒收、描述守卫）。
- 变异验证：把 duplicate 分支关掉，两条依赖它的新测试变红，不受影响的 ghost-id 用例保持绿。
- `check_docstring_no_cjk --base origin/main`、`check_i18n_sync`、`check_no_loguru` 均 exit 0。

## 未包含（另议）

- `task_timeout_seconds` 仍为 120s，实测一条任务 149s 才完成。
- `try_claim_pending` 的 busy 静默拒绝没有日志。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - Minecraft 任务调用新增多语言提示，引导用户将内部标识符改写为自然语言动作描述。
  - 任务处理支持识别重复派发，并持续等待实际运行任务完成。

- **问题修复**
  - 拦截函数名、命令名、坐标调用等非动作描述，避免无效任务发送。
  - 修复重复任务响应导致任务提前结束或反复重试的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->