### PR TITLE
fix(tts): 文本空闲软 flush，CosyVoice 尾句不再等 provider 的 response.done

### DIFF
--- a/main_logic/core/manager.py
+++ b/main_logic/core/manager.py
@@ -328,6 +328,11 @@ class LLMSessionManager(
         self._tts_notified_error_keys: set[tuple[str, str]] = set()
         self._tts_done_queued_for_turn: bool = False  # 防止同一轮次多次排入 TTS 结束信号
         self._tts_done_pending_until_ready: bool = False  # TTS未就绪时延迟到 flush 后再排入结束信号
+        # 文本空闲软 flush：realtime 语音 + 自定义 TTS 时，本轮转录停下 ~1s 而
+        # provider 的 response.done 还没来，就让 worker 先把攒着的尾句合成出来。
+        # 定时器由每个入队的文本 chunk 重置，done 入队 / 打断 / 拆除时取消。
+        self._tts_soft_flush_task: Optional[asyncio.Task] = None
+        self._tts_soft_flush_supported: bool = False  # 由 _start_tts_thread 按 provider 能力位设置
         # Keep one utterance ledger so a replacement worker can replay consumed text.
         # 已送入当前 worker 的原始文本账本。配置型 provider 运行时失败时，
         # 用它把本轮文本与 done 信号交给替代 worker，避免整段回复静音。

--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -41,6 +41,7 @@ from main_logic.tts_client import (
     dummy_tts_worker,
     TTS_SHUTDOWN_SENTINEL,
     TTS_AUDIO_DONE_SENTINEL,
+    TTS_SOFT_FLUSH_SENTINEL,
     TTS_PROVIDER_REGISTRY,
     VLLM_OMNI_DEFAULT_BASE_URL,
     VLLM_OMNI_DEFAULT_MODEL,
@@ -320,6 +321,79 @@ class TtsRuntimeMixin:
         self.tts_request_queue.put((speech_id, text))
         self._remember_tts_sent_chunk(speech_id, text)
         self._remember_pending_ai_voice_echo(speech_id, text)
+        # 每个入队的 chunk 都把空闲定时器重新拨到 idle 秒之后：文本停了、done
+        # 又迟迟不来，就让 worker 先把攒着的尾句合成出来。
+        self._arm_tts_soft_flush(speech_id)
+
+    @staticmethod
+    def _tts_soft_flush_idle_seconds() -> float:
+        """How long the turn's text may go quiet before the worker is told to flush.
+
+        Measured on lanlan.app: gaps between transcript deltas inside one reply
+        stay under ~0.6s, while ``response.done`` trails the last delta by 1.2s
+        in the good case and 9.5s in the bad one. 1s sits between the two.
+        Overridable via ``NEKO_TTS_SOFT_FLUSH_IDLE_SECONDS`` (floored at 0.3s so
+        a typo cannot turn every inter-word pause into a synthesizer rebuild).
+        """
+        import os
+        raw = os.environ.get("NEKO_TTS_SOFT_FLUSH_IDLE_SECONDS", "").strip()
+        if not raw:
+            return 1.0
+        try:
+            return max(0.3, float(raw))
+        except ValueError:
+            return 1.0
+
+    def _arm_tts_soft_flush(self, speech_id) -> None:
+        """(Re)start the idle timer that asks the worker to flush the held tail.
+
+        Only for realtime voice sessions on a provider whose worker understands
+        ``TTS_SOFT_FLUSH_SENTINEL``. In text mode the completion callback lands
+        right behind the last chunk, so there is nothing to bridge; a worker
+        that does not know the sentinel would read it as a new speech id.
+        """
+        if not getattr(self, "_tts_soft_flush_supported", False):
+            return
+        if getattr(self, "input_mode", None) != "audio":
+            return
+        self._cancel_tts_soft_flush()
+        try:
+            self._tts_soft_flush_task = self._fire_task(
+                self._tts_soft_flush_after_idle(speech_id)
+            )
+        except RuntimeError:
+            # 没有运行中的事件循环（同步测试夹具直接调用入队）：不兜底，就是不发
+            self._tts_soft_flush_task = None
+
+    def _cancel_tts_soft_flush(self) -> None:
+        task = getattr(self, "_tts_soft_flush_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+        self._tts_soft_flush_task = None
+
+    async def _tts_soft_flush_after_idle(self, speech_id) -> None:
+        """Fire the soft flush if the turn is still open and still this speech.
+
+        Everything that would make the flush wrong is re-checked under the
+        cache lock after the sleep: the round already has its done sentinel
+        queued (or deferred until the worker is ready — the pending chunks will
+        re-arm this timer when they flush), the speech id moved on (barge-in /
+        rotation), the worker went away, or chunks are still waiting to be
+        replayed to it.
+        """
+        await asyncio.sleep(self._tts_soft_flush_idle_seconds())
+        async with self.tts_cache_lock:
+            if self._tts_done_queued_for_turn or self._tts_done_pending_until_ready:
+                return
+            if speech_id is None or speech_id != self.current_speech_id:
+                return
+            if not (self.tts_ready and self.tts_thread and self.tts_thread.is_alive()):
+                return
+            if self.tts_pending_chunks:
+                return
+            self.tts_request_queue.put((TTS_SOFT_FLUSH_SENTINEL, speech_id))
+        logger.debug("TTS 文本空闲 %.1fs 且 done 未到，发软 flush speech_id=%s",
+                     self._tts_soft_flush_idle_seconds(), speech_id)
 
     def _reset_tts_stream_normalizer(self) -> None:
         """Clear all TTS text stripper state. Called on interrupt / turn end / session rebuild."""
@@ -342,6 +416,9 @@ class TtsRuntimeMixin:
         worker_alive = bool(self.tts_thread and self.tts_thread.is_alive())
         if not worker_alive:
             return "no_worker"
+
+        # 本轮要收尾了（立即排入或等 ready 后补发都算）：空闲软 flush 没有意义了
+        self._cancel_tts_soft_flush()
 
         if not self.tts_ready or self.tts_pending_chunks:
             self._tts_replay_done = True
@@ -951,6 +1028,9 @@ class TtsRuntimeMixin:
         # 调用方在本函数返回后的重复清零保留不动：那是给 sleep 窗口内被并发
         # 置回 True 的情况兜底，与这里要修的取消残留是两件事。
         self._tts_done_queued_for_turn = False
+        # 打断作废的是这一轮的一切，包括还没到点的空闲软 flush；同样在第一个
+        # await 之前同步取消，让它和 __interrupt__ 入队一起落地。
+        self._cancel_tts_soft_flush()
         self._cancel_game_speech_completion_wait()
         self._clear_game_speech_correlation()
         GAME_SPEECH_AUDIO_CACHE.discard_owner(self)
@@ -1139,6 +1219,9 @@ class TtsRuntimeMixin:
         # 因为 free 国外模式走 Gemini 后端，需要 CJK 空格清理。
         meta = TTS_PROVIDER_REGISTRY.get(provider_key) if provider_key else None
         self._tts_normalize_enabled = not meta or meta.category != "ws_bistream"
+        # 文本空闲软 flush 只发给认这个哨兵的 worker（能力位在注册表）。
+        self._tts_soft_flush_supported = bool(meta and meta.soft_flush)
+        self._cancel_tts_soft_flush()
         self._tts_replay_progress_supported = bool(
             meta and meta.category == "http_sentence"
         )
@@ -1266,6 +1349,7 @@ class TtsRuntimeMixin:
         if notified_error_keys is not None:
             notified_error_keys.clear()
         self._tts_done_queued_for_turn = False
+        self._cancel_tts_soft_flush()
         self._tts_fallback_uses_default_voice = False
         self._reset_tts_replay_state()
         self._tts_done_pending_until_ready = False
@@ -1325,6 +1409,7 @@ class TtsRuntimeMixin:
         # 只在被拆除的 runtime 仍是当前 runtime 时才清全局 TTS 状态，
         # 避免新 session 已创建新队列/worker 后被旧 teardown 误重置
         if resp_queue_ref is self.tts_response_queue:
+            self._cancel_tts_soft_flush()
             self._cancel_game_speech_completion_wait()
             self._clear_game_speech_correlation()
             self.cancel_game_speech_preloads()

--- a/main_logic/tts_client/__init__.py
+++ b/main_logic/tts_client/__init__.py
@@ -39,6 +39,7 @@ from utils.logger_config import get_module_logger
 from ._infra import (
     TTS_SHUTDOWN_SENTINEL,
     TTS_AUDIO_DONE_SENTINEL,
+    TTS_SOFT_FLUSH_SENTINEL,
     AudioDoneEmitter,
     _resample_audio,
     _parse_env_float,
@@ -151,7 +152,7 @@ __all__ = [
     "get_tts_worker", "_get_voice_meta", "_grok_voice_id_is_xai_custom",
     "_XAI_CUSTOM_VOICE_PATTERN", "logger",
     # shared infrastructure
-    "TTS_SHUTDOWN_SENTINEL", "TTS_AUDIO_DONE_SENTINEL", "AudioDoneEmitter",
+    "TTS_SHUTDOWN_SENTINEL", "TTS_AUDIO_DONE_SENTINEL", "TTS_SOFT_FLUSH_SENTINEL", "AudioDoneEmitter",
     "_resample_audio", "_parse_env_float", "_enqueue_error",
     "_ws_is_open", "SentenceBuffer", "_AudioQueueProxy", "_non_bistream_tts_main_loop",
     "_run_sentence_tts_worker", "_record_tts_telemetry",

--- a/main_logic/tts_client/_infra.py
+++ b/main_logic/tts_client/_infra.py
@@ -38,6 +38,16 @@ TTS_SHUTDOWN_SENTINEL = "__shutdown__"
 # 的 tts_response_handler 消费。
 TTS_AUDIO_DONE_SENTINEL = "__audio_done__"
 
+# 软 flush 哨兵：core 通过 request_queue.put((TTS_SOFT_FLUSH_SENTINEL, speech_id))
+# 告诉 worker「这一轮的文本停了一会儿，先把手上攒着的合成出来」。它不是收尾：
+# 不发 audio_done、不动 core 的 done 记账，之后同一 speech_id 还可能继续来文本，
+# worker 要能接着说。只发给 TTS_PROVIDER_REGISTRY 里 soft_flush=True 的 provider——
+# 不认识它的 worker 会把陌生 sid 当成新一轮，所以 core 侧按能力位过滤，不广播。
+# 背景：realtime 语音 + 自定义 TTS 时，core 只在 provider 的 response.done 才发
+# (None, None)，而某些 provider（lanlan.app 的 Gemini 代理）要把自己那份没人用的
+# 音频推完才发 done，尾句因此被 CosyVoice 一直扣着，落到用户下一轮才出声。
+TTS_SOFT_FLUSH_SENTINEL = "__soft_flush__"
+
 
 class AudioDoneEmitter:
     """One-shot per-speech "audio stream closed" signal for the frontend.

--- a/main_logic/tts_client/_registry_meta.py
+++ b/main_logic/tts_client/_registry_meta.py
@@ -54,6 +54,9 @@ class TTSProviderMeta:
     client_sentence_split: bool     # 客户端是否做句子分割
     audio_format: str               # 原始音频格式，如 "PCM 24kHz", "OGG OPUS 48kHz"
     notes: str = ""                 # 特殊说明
+    # worker 认 TTS_SOFT_FLUSH_SENTINEL：文本空闲时先把攒着的尾句合成出来，
+    # 之后同一 speech_id 还能继续说。core 只对 True 的 provider 发这个哨兵。
+    soft_flush: bool = False
 
 TTS_PROVIDER_REGISTRY: dict[str, TTSProviderMeta] = {
     "step": TTSProviderMeta(
@@ -95,7 +98,9 @@ TTS_PROVIDER_REGISTRY: dict[str, TTSProviderMeta] = {
         client_sentence_split=False,
         audio_format="OGG OPUS 48kHz (直接透传)",
         notes="streaming_call() 逐片发送；最小 6 字符缓冲 + 日文检测；"
-              "首包聚合 1KB + 后续聚合 4KB；空闲 15s 主动 complete",
+              "首包聚合 1KB + 后续聚合 4KB；空闲 15s 主动 complete；"
+              "服务端把尾句扣到 FINISH 才合成，故认 core 的软 flush 哨兵",
+        soft_flush=True,
     ),
     "cogtts": TTSProviderMeta(
         name="cogtts",

--- a/main_logic/tts_client/workers/cosyvoice.py
+++ b/main_logic/tts_client/workers/cosyvoice.py
@@ -299,6 +299,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
     # 软 flush 期间收到 (None, None)：等旧流放干净再决定是补发 audio_done 还是
     # 起新流把攒着的文本说完再收尾。
     round_end_pending = False
+    # 排空期间又来了 core 的软 flush 哨兵（针对排空期间攒下的续接文本）：不能
+    # 丢——续接流起来之后没人再给它 FINISH，尾句又会回到等 done。记下来，续接
+    # 流一起来就补做；期间再来文本就作废（core 会为新文本重新武装定时器）。
+    soft_flush_pending = False
 
     def _create_synthesizer(lang_hint=None):
         """Create a new SpeechSynthesizer, with an optional language hint.
@@ -439,6 +443,9 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         # on_close，没有当代可比对时它们一律按过期丢弃，不会混进接下来同一
         # speech_id 的新流。新 synthesizer 建出来会盖上自己的代号。
         callback.current_generation = None
+        # 「断开」是这条连接的状态，随它一起退役；不然新流建起来之前它一直是
+        # True，谁在这个窗口里问 connection_lost 都会跳过 FINISH。
+        callback.connection_lost = False
         if synthesizer is not None:
             try:
                 synthesizer.close()
@@ -465,7 +472,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         pending round end either finishes that new stream or, with nothing
         left to say, closes the audio stream directly.
         """
-        nonlocal char_buffer, round_end_pending, soft_finished, soft_finish_deadline
+        nonlocal char_buffer, round_end_pending, soft_finished, soft_finish_deadline, soft_flush_pending
         if not soft_finished:
             return
         drained = callback.completed_generation == synth_generation
@@ -481,6 +488,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 char_buffer = ""
             if round_end_pending:
                 _do_streaming_complete(round_end=True)
+            elif soft_flush_pending:
+                # 排空期间 core 已经判定这段续接文本停了：续接流一起来就把它
+                # 也软 flush 掉，否则它的尾句要等 done
+                _soft_finish()
         elif round_end_pending:
             if drained:
                 # 旧流的尾包早已投进队列，这里补的收尾排在它们后面
@@ -495,6 +506,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             # 放干净了但本轮没结束、也没新文本：保持软完成态，等下一个信号
             return
         round_end_pending = False
+        soft_flush_pending = False
 
     while True:
         # 非阻塞检查队列，优先处理打断
@@ -545,6 +557,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 soft_finished = False
                 soft_finish_deadline = None
                 round_end_pending = False
+                soft_flush_pending = False
             finally:
                 audio_done.end_interrupt()
             continue
@@ -553,7 +566,12 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             # core 的文本空闲哨兵：只对仍在说的这一轮有效。迟到的（sid 已经换了、
             # 或本轮已经正常收尾）直接忽略，不然会把别的轮次的流截断。
             if tts_text is not None and tts_text == current_speech_id:
-                _soft_finish()
+                if soft_finished:
+                    # 旧流还在排空：这条是给排空期间攒下的续接文本的，续接流
+                    # 起来后再补做，不能就地丢掉
+                    soft_flush_pending = bool(char_buffer.strip())
+                else:
+                    _soft_finish()
             continue
 
         if sid is None:
@@ -602,6 +620,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             soft_finished = False
             soft_finish_deadline = None
             round_end_pending = False
+            soft_flush_pending = False
 
         if tts_text is None or not tts_text.strip():
             time.sleep(0.01)
@@ -615,6 +634,8 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             hint = detect_tts_language_hint(tts_text)
             if hint and detected_lang != hint:
                 detected_lang = hint
+            # 之前记下的软 flush 是针对更早的文本的；core 会为这一片重新武装定时器
+            soft_flush_pending = False
             _service_soft_finished()
             continue
 

--- a/main_logic/tts_client/workers/cosyvoice.py
+++ b/main_logic/tts_client/workers/cosyvoice.py
@@ -14,6 +14,7 @@
 
 """Aliyun CosyVoice (hosted) TTS worker."""
 
+import threading
 import time
 
 from utils.config_manager import get_config_manager
@@ -140,13 +141,21 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             # 减少前端处理次数、增大每段解码出的音频长度。
             self._agg_buffer = bytearray()
             self._agg_min_bytes = 4096
+            # 这个对象被 SDK 的接收线程（on_data / on_complete）和 worker 主循环
+            # （退役旧流、回合边界 reset）同时改。generation 戳只能挡住「退役之后
+            # 才进来」的回调；一条已经过了戳、被调度出去的回调醒来后照样会
+            # 冲刷、清掉此刻已属于新流的缓冲和 FINISH 标记。所以改共享状态的路径
+            # 都持这把锁：退役要等在飞的回调跑完，回调进来时再看一眼当代。
+            # 可重入：on_complete 的 finally 里要调 reset_bootstrap_state。
+            self._lock = threading.RLock()
 
         def reset_bootstrap_state(self):
-            self._active_sid = None
-            self._bootstrap_buffer.clear()
-            self._bootstrap_sent = False
-            self._agg_buffer.clear()
-            self.finish_requested_speech_id = None
+            with self._lock:
+                self._active_sid = None
+                self._bootstrap_buffer.clear()
+                self._bootstrap_sent = False
+                self._agg_buffer.clear()
+                self.finish_requested_speech_id = None
 
         def on_open(self): 
             self.connection_lost = False
@@ -155,6 +164,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             logger.debug(f"TTS 连接已建立 (构造到open耗时: {elapsed:.2f}s)")
             
         def on_complete(self, generation=None):
+            with self._lock:
+                self._on_complete_locked(generation)
+
+        def _on_complete_locked(self, generation):
             # 过期的 synthesizer（连切两轮 / 轮内重连时被 close 掉的那个）迟到的完成
             # 通知：它描述的是上一代的流，而这个 callback 的状态早已换成当前轮的。
             # 整个早退——不冲刷（缓冲里是别人的数据）、不发信号（会把还在说话的这轮
@@ -178,11 +191,14 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                     if sid == self.finish_requested_speech_id:
                         # 尾包已经投进队列，本轮音频流到此关闭
                         self.audio_done.emit(sid)
-                # 尾包都投完了才记「这一代放干净」：主循环读到它之后再往队列里
-                # 放的任何东西（补发的 audio_done、下一段的音频）都排在尾包后面。
-                self.completed_generation = generation
             finally:
                 self.reset_bootstrap_state()
+                # 「这一代放干净」必须在共享状态归零之后才发布：主循环一读到它就会
+                # 退役旧流、起续接流，若发布得早，上面这个 reset 就会落在新流身上，
+                # 把它刚攒的缓冲和 round-end 的 FINISH 标记一起抹掉。尾包都已投进
+                # 队列，主循环之后放的任何东西（补发的 audio_done、下一段的音频）
+                # 仍然排在尾包后面。
+                self.completed_generation = generation
 
         def on_error(self, message: str, generation=None):
             # 旧 synthesizer（软 flush 后已放干净、或重建时被换掉的那个）的报错
@@ -213,6 +229,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             pass
             
         def on_data(self, data: bytes, generation=None) -> None:
+            with self._lock:
+                self._on_data_locked(data, generation)
+
+        def _on_data_locked(self, data: bytes, generation) -> None:
             # 过期 synthesizer（软 flush 排空超时后被退役、或重建时被换掉的那个）
             # 迟到的页：同一 speech_id 的新流正在用同一份聚合缓冲，混进去就是
             # 两条 OGG 流交错成坏音频。
@@ -438,14 +458,21 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
     def _retire_soft_finished_synthesizer(*, drained: bool):
         """Drop a soft-finished synthesizer so the next text starts a fresh stream."""
         nonlocal synthesizer, soft_finished, soft_finish_deadline, last_streaming_call_time
-        callback.finish_requested_speech_id = None
-        # 先把这一代退役：close() 之后 SDK 线程仍可能迟到地打回 on_data /
-        # on_close，没有当代可比对时它们一律按过期丢弃，不会混进接下来同一
-        # speech_id 的新流。新 synthesizer 建出来会盖上自己的代号。
-        callback.current_generation = None
-        # 「断开」是这条连接的状态，随它一起退役；不然新流建起来之前它一直是
-        # True，谁在这个窗口里问 connection_lost 都会跳过 FINISH。
-        callback.connection_lost = False
+        # 持锁退役：一条已经过了 generation 检查、正在冲刷/reset 的回调跑完之前
+        # 不能换代，否则它醒来后清掉的是新流的缓冲和 FINISH 标记。
+        with callback._lock:
+            callback.finish_requested_speech_id = None
+            # 先把这一代退役：close() 之后 SDK 线程仍可能迟到地打回 on_data /
+            # on_close，没有当代可比对时它们一律按过期丢弃，不会混进接下来同一
+            # speech_id 的新流。新 synthesizer 建出来会盖上自己的代号。
+            callback.current_generation = None
+            # 「断开」是这条连接的状态，随它一起退役；不然新流建起来之前它一直是
+            # True，谁在这个窗口里问 connection_lost 都会跳过 FINISH。
+            callback.connection_lost = False
+            if not drained:
+                # 没等到完成通知就放弃了：共享缓冲里可能留着旧流的半页，
+                # 不能拼进新流（与重连路径同一条理由）。锁内做，和换代同一步。
+                callback.reset_bootstrap_state()
         if synthesizer is not None:
             try:
                 synthesizer.close()
@@ -457,10 +484,6 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         soft_finished = False
         soft_finish_deadline = None
         last_streaming_call_time = None
-        if not drained:
-            # 没等到完成通知就放弃了：共享缓冲里可能留着旧流的半页，
-            # 不能拼进新流（与重连路径同一条理由）。
-            callback.reset_bootstrap_state()
 
     def _service_soft_finished():
         """Advance the soft-finished state once the old stream has drained.

--- a/main_logic/tts_client/workers/cosyvoice.py
+++ b/main_logic/tts_client/workers/cosyvoice.py
@@ -212,7 +212,12 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         def on_event(self, message):
             pass
             
-        def on_data(self, data: bytes) -> None:
+        def on_data(self, data: bytes, generation=None) -> None:
+            # 过期 synthesizer（软 flush 排空超时后被退役、或重建时被换掉的那个）
+            # 迟到的页：同一 speech_id 的新流正在用同一份聚合缓冲，混进去就是
+            # 两条 OGG 流交错成坏音频。
+            if generation is not None and generation != self.current_generation:
+                return
             sid = self.accepted_speech_id
             if not sid or self._muted:
                 # 回合切换窗口或未就绪时直接丢弃，避免错序串包
@@ -273,7 +278,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             self._inner.on_event(message)
 
         def on_data(self, data: bytes) -> None:
-            self._inner.on_data(data)
+            self._inner.on_data(data, generation=self._generation)
 
     audio_done = AudioDoneEmitter(response_queue)
     callback = Callback(response_queue, audio_done)
@@ -362,7 +367,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         if synthesizer is None:
             callback.accepted_speech_id = None
             callback.reset_bootstrap_state()
-            return
+            return False
         if callback.connection_lost:
             logger.info("CosyVoice WebSocket 已断开，跳过 streaming_complete")
             try:
@@ -371,7 +376,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 pass
             synthesizer = None
             last_streaming_call_time = None
-            return
+            return False
 
         # 标记必须在 send 之前武装：SDK 的接收线程可能在 send 返回前就把
         # on_complete 打回来（短句尤其快），标记晚一步就等于本轮白白漏发一次
@@ -380,6 +385,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         # 空闲保活的 FINISH 不算：本轮还可能继续来文本（届时会新建 synthesizer），
         # 那次 on_complete 发 audio_done 就是早发，前端会提前收尾。
         callback.finish_requested_speech_id = current_speech_id if round_end else None
+        sent = True
         try:
             synthesizer.ws.send(synthesizer.request.getFinishRequest())
         except Exception as e:
@@ -387,9 +393,12 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             # FINISH 没发出去，服务端不会给这一轮的完成通知；撤回标记，
             # 免得后面某个别的完成通知被当成本轮收尾（早发）。
             callback.finish_requested_speech_id = None
+            sent = False
         last_streaming_call_time = None
         # 这里不能立刻清 accepted_speech_id/bootstrap。
         # FINISH 发出后，服务端仍可能继续回传尾包；应由 on_complete 或后续中断/切换来收口状态。
+        # 回报 FINISH 有没有真的发出去：软 flush 据此决定是等排空还是直接换流。
+        return sent
 
     def _soft_finish():
         """Send FINISH for everything said so far without ending the round.
@@ -410,9 +419,14 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             logger.warning(f"TTS soft flush buffer 失败: {e}")
         if synthesizer is None:
             return
-        _do_streaming_complete(round_end=False)
+        sent = _do_streaming_complete(round_end=False)
         if synthesizer is None:
             # 连接已断，_do_streaming_complete 直接丢掉了 synthesizer，没什么可等的
+            return
+        if not sent:
+            # FINISH 没发出去：服务端永远不会给完成通知，进软完成态就是白等
+            # 2.5s；这条连接已经不可信，直接丢掉，后续文本走新 synthesizer。
+            _retire_soft_finished_synthesizer(drained=False)
             return
         soft_finished = True
         soft_finish_deadline = time.time() + SOFT_FLUSH_DRAIN_TIMEOUT_SECONDS
@@ -421,10 +435,16 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         """Drop a soft-finished synthesizer so the next text starts a fresh stream."""
         nonlocal synthesizer, soft_finished, soft_finish_deadline, last_streaming_call_time
         callback.finish_requested_speech_id = None
+        # 先把这一代退役：close() 之后 SDK 线程仍可能迟到地打回 on_data /
+        # on_close，没有当代可比对时它们一律按过期丢弃，不会混进接下来同一
+        # speech_id 的新流。新 synthesizer 建出来会盖上自己的代号。
+        callback.current_generation = None
         if synthesizer is not None:
             try:
                 synthesizer.close()
             except Exception:
+                # 这条连接反正要丢，close 失败也得继续换流；SDK 关一条多半已被
+                # 服务端收掉的 ws 本来就常抛，与打断路径同款处理。
                 pass
         synthesizer = None
         soft_finished = False

--- a/main_logic/tts_client/workers/cosyvoice.py
+++ b/main_logic/tts_client/workers/cosyvoice.py
@@ -23,7 +23,12 @@ from utils.dashscope_region import (
     prefer_dashscope_websocket_ipv4,
 )
 
-from .._infra import AudioDoneEmitter, TTS_SHUTDOWN_SENTINEL, _enqueue_error
+from .._infra import (
+    AudioDoneEmitter,
+    TTS_SHUTDOWN_SENTINEL,
+    TTS_SOFT_FLUSH_SENTINEL,
+    _enqueue_error,
+)
 from .._telemetry import _record_tts_telemetry
 from .dummy import dummy_tts_worker
 from utils.logger_config import get_module_logger
@@ -117,6 +122,9 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             # _active_sid 和 FINISH 标记，把还在说话的那一轮判成放完（早发），
             # 顺带还把它的聚合缓冲清掉。迟到的旧回调据此认出自己已经过期。
             self.current_generation = None
+            # 已经收到完成通知的那一代。软 flush 之后主循环靠它判断旧流是否已经
+            # 放干净：干净了才敢关掉旧 synthesizer 接着说 / 直接补发 audio_done。
+            self.completed_generation = None
             # 当前允许投递的 speech_id（由 worker 在回合边界显式设置）
             # 不能在 on_data 时动态读取 current_speech_id，否则旧流尾包可能被错标到新流。
             self.accepted_speech_id = None
@@ -170,10 +178,19 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                     if sid == self.finish_requested_speech_id:
                         # 尾包已经投进队列，本轮音频流到此关闭
                         self.audio_done.emit(sid)
+                # 尾包都投完了才记「这一代放干净」：主循环读到它之后再往队列里
+                # 放的任何东西（补发的 audio_done、下一段的音频）都排在尾包后面。
+                self.completed_generation = generation
             finally:
                 self.reset_bootstrap_state()
-                
-        def on_error(self, message: str):
+
+        def on_error(self, message: str, generation=None):
+            # 旧 synthesizer（软 flush 后已放干净、或重建时被换掉的那个）的报错
+            # 描述的是别人的连接：既不能把当代标成断开，也不该当成本轮出错上报。
+            if generation is not None and generation != self.current_generation:
+                logger.debug("CosyVoice 忽略过期 synthesizer 的 on_error (gen=%s, 当前 gen=%s)",
+                             generation, self.current_generation)
+                return
             if "request timeout after 23 seconds" in message:
                 self.connection_lost = True
                 logger.debug("CosyVoice SDK 内部 WebSocket 空闲超时，标记连接已断开")
@@ -184,10 +201,15 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             else:
                 _enqueue_error(self.response_queue, message)
             
-        def on_close(self): 
+        def on_close(self, generation=None):
+            # 只有当代连接的关闭才算「断开」。软 flush 之后服务端会在放完尾包后
+            # 关掉旧连接，那时新 synthesizer 可能已经在说下一段——把它标成断开，
+            # 下一次收尾就会跳过 FINISH 并丢掉 synthesizer，新一段的尾句直接消失。
+            if generation is not None and generation != self.current_generation:
+                return
             self.connection_lost = True
-            
-        def on_event(self, message): 
+
+        def on_event(self, message):
             pass
             
         def on_data(self, data: bytes) -> None:
@@ -242,10 +264,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             self._inner.on_complete(generation=self._generation)
 
         def on_error(self, message: str):
-            self._inner.on_error(message)
+            self._inner.on_error(message, generation=self._generation)
 
         def on_close(self):
-            self._inner.on_close()
+            self._inner.on_close(generation=self._generation)
 
         def on_event(self, message):
             self._inner.on_event(message)
@@ -261,6 +283,17 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
     detected_lang = None
     last_streaming_call_time = None  # 追踪最后一次 streaming_call 的时间
     IDLE_AUTO_COMPLETE_SECONDS = 15  # 空闲超过此秒数则主动 complete（须 < 服务端 23s 超时）
+    # 软 flush（core 的空闲哨兵 / 上面的空闲保活）发过 FINISH 之后，旧 synthesizer
+    # 还在往回吐尾包。同一轮再来文本时不能立刻在旁边开新流：两条 OGG 流的页会在
+    # 共享缓冲里交错成坏音频，所以先攒在 char_buffer 里等旧流的完成通知，最多等
+    # 这么久（DashScope FINISH→complete 通常 <1s）。
+    SOFT_FLUSH_DRAIN_TIMEOUT_SECONDS = 2.5
+    # 当前 synthesizer 已经因软 flush 发过 FINISH（本轮没结束、还可能来文本）。
+    soft_finished = False
+    soft_finish_deadline = None
+    # 软 flush 期间收到 (None, None)：等旧流放干净再决定是补发 audio_done 还是
+    # 起新流把攒着的文本说完再收尾。
+    round_end_pending = False
 
     def _create_synthesizer(lang_hint=None):
         """Create a new SpeechSynthesizer, with an optional language hint.
@@ -358,16 +391,104 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         # 这里不能立刻清 accepted_speech_id/bootstrap。
         # FINISH 发出后，服务端仍可能继续回传尾包；应由 on_complete 或后续中断/切换来收口状态。
 
+    def _soft_finish():
+        """Send FINISH for everything said so far without ending the round.
+
+        The server only synthesizes the trailing sentence once it sees FINISH,
+        and on some realtime routes the round's real FINISH (core's ``(None,
+        None)``, tied to the provider's ``response.done``) trails the last text
+        by seconds. Finishing early releases that tail; the synthesizer is then
+        left to drain and more text of the same speech is handled by
+        ``_service_soft_finished``.
+        """
+        nonlocal soft_finished, soft_finish_deadline
+        if soft_finished:
+            return
+        try:
+            _flush_buffer()  # 短尾巴可能还卡在 6 字缓冲里没建 synthesizer
+        except Exception as e:
+            logger.warning(f"TTS soft flush buffer 失败: {e}")
+        if synthesizer is None:
+            return
+        _do_streaming_complete(round_end=False)
+        if synthesizer is None:
+            # 连接已断，_do_streaming_complete 直接丢掉了 synthesizer，没什么可等的
+            return
+        soft_finished = True
+        soft_finish_deadline = time.time() + SOFT_FLUSH_DRAIN_TIMEOUT_SECONDS
+
+    def _retire_soft_finished_synthesizer(*, drained: bool):
+        """Drop a soft-finished synthesizer so the next text starts a fresh stream."""
+        nonlocal synthesizer, soft_finished, soft_finish_deadline, last_streaming_call_time
+        callback.finish_requested_speech_id = None
+        if synthesizer is not None:
+            try:
+                synthesizer.close()
+            except Exception:
+                pass
+        synthesizer = None
+        soft_finished = False
+        soft_finish_deadline = None
+        last_streaming_call_time = None
+        if not drained:
+            # 没等到完成通知就放弃了：共享缓冲里可能留着旧流的半页，
+            # 不能拼进新流（与重连路径同一条理由）。
+            callback.reset_bootstrap_state()
+
+    def _service_soft_finished():
+        """Advance the soft-finished state once the old stream has drained.
+
+        Called from the idle loop and after every queue item while
+        ``soft_finished`` is set. Nothing happens until the current
+        generation's completion arrives (or the drain timeout passes); then
+        buffered text of the same speech starts a new synthesizer, and a
+        pending round end either finishes that new stream or, with nothing
+        left to say, closes the audio stream directly.
+        """
+        nonlocal char_buffer, round_end_pending, soft_finished, soft_finish_deadline
+        if not soft_finished:
+            return
+        drained = callback.completed_generation == synth_generation
+        if not drained and time.time() < soft_finish_deadline:
+            return
+        if char_buffer.strip():
+            _retire_soft_finished_synthesizer(drained=drained)
+            try:
+                _flush_buffer()  # 同一轮接着说：新 synthesizer + 攒下的文本
+            except Exception as e:
+                # 与 TTS Init Error 路径同款：这段文本丢弃，别让它每 10ms 重试一次
+                logger.error(f"TTS soft flush 续接失败: {e}")
+                char_buffer = ""
+            if round_end_pending:
+                _do_streaming_complete(round_end=True)
+        elif round_end_pending:
+            if drained:
+                # 旧流的尾包早已投进队列，这里补的收尾排在它们后面
+                audio_done.emit(current_speech_id)
+            else:
+                # 放弃等待：完成通知若迟到，还能借它把收尾补上；不来就漏发，
+                # 前端 give-up 兜底（宁可漏发不可早发）。
+                callback.finish_requested_speech_id = current_speech_id
+            soft_finished = False
+            soft_finish_deadline = None
+        else:
+            # 放干净了但本轮没结束、也没新文本：保持软完成态，等下一个信号
+            return
+        round_end_pending = False
+
     while True:
         # 非阻塞检查队列，优先处理打断
         if request_queue.empty():
+            _service_soft_finished()
             # 主动完成：合成器空闲超过阈值，趁 WebSocket 还活着主动 complete
-            # 避免等到 (None,None) 到达时 WebSocket 已被服务端回收（23s 超时）
-            if (synthesizer is not None
+            # 避免等到 (None,None) 到达时 WebSocket 已被服务端回收（23s 超时）。
+            # 走软 flush 同一条状态机：之后同一轮再来文本会等旧流放干净再续。
+            if (not soft_finished
+                    and synthesizer is not None
                     and last_streaming_call_time is not None
                     and time.time() - last_streaming_call_time > IDLE_AUTO_COMPLETE_SECONDS):
                 logger.debug(f"CosyVoice 空闲 >{IDLE_AUTO_COMPLETE_SECONDS}s，主动 streaming_complete")
-                _do_streaming_complete(round_end=False)
+                _soft_finish()
             time.sleep(0.01)
             continue
 
@@ -401,11 +522,28 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 callback.accepted_speech_id = None
                 callback.reset_bootstrap_state()
                 audio_done.reset()
+                soft_finished = False
+                soft_finish_deadline = None
+                round_end_pending = False
             finally:
                 audio_done.end_interrupt()
             continue
 
+        if sid == TTS_SOFT_FLUSH_SENTINEL:
+            # core 的文本空闲哨兵：只对仍在说的这一轮有效。迟到的（sid 已经换了、
+            # 或本轮已经正常收尾）直接忽略，不然会把别的轮次的流截断。
+            if tts_text is not None and tts_text == current_speech_id:
+                _soft_finish()
+            continue
+
         if sid is None:
+            if soft_finished:
+                # 软 flush 已经把 FINISH 发出去了，同一条连接不能再发一次。
+                # 等旧流放干净：有攒着的文本就起新流说完再收尾，没有就直接补收尾。
+                round_end_pending = True
+                _service_soft_finished()
+                detected_lang = None
+                continue
             # 正常结束 - 告诉TTS没有更多文本了（非阻塞）
             try:
                 _flush_buffer()
@@ -441,9 +579,23 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             callback.reset_bootstrap_state()
             callback.accepted_speech_id = sid
             audio_done.reset()  # 新轮次重置 audio_done 去重标记
+            soft_finished = False
+            soft_finish_deadline = None
+            round_end_pending = False
 
         if tts_text is None or not tts_text.strip():
             time.sleep(0.01)
+            continue
+
+        if soft_finished:
+            # 软 flush 之后同一轮又来文本：旧 synthesizer 已经发过 FINISH，不能再往
+            # 里 streaming_call（服务端会报 task 已结束）；也不能立刻开新流（两条
+            # OGG 流的页会在共享缓冲里交错）。先攒着，等旧流放干净再续。
+            char_buffer += tts_text
+            hint = detect_tts_language_hint(tts_text)
+            if hint and detected_lang != hint:
+                detected_lang = hint
+            _service_soft_finished()
             continue
 
         # 尚未创建 synthesizer 时先缓冲，等够 TTS_LANG_DETECT_MIN_CHARS 个字符再一起发送

--- a/main_logic/tts_client/workers/cosyvoice.py
+++ b/main_logic/tts_client/workers/cosyvoice.py
@@ -157,9 +157,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 self._agg_buffer.clear()
                 self.finish_requested_speech_id = None
 
-        def on_open(self): 
-            self.connection_lost = False
-            self._muted = False
+        def on_open(self):
+            with self._lock:
+                self.connection_lost = False
+                self._muted = False
             elapsed = time.time() - self.construct_start_time if hasattr(self, 'construct_start_time') else -1
             logger.debug(f"TTS 连接已建立 (构造到open耗时: {elapsed:.2f}s)")
             
@@ -201,6 +202,12 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 self.completed_generation = generation
 
         def on_error(self, message: str, generation=None):
+            # 代际检查和它的副作用（标断开）必须在同一临界区：过了检查再被调度
+            # 出去、退役后醒来写 connection_lost，写的就是新流的状态。
+            with self._lock:
+                self._on_error_locked(message, generation)
+
+        def _on_error_locked(self, message: str, generation):
             # 旧 synthesizer（软 flush 后已放干净、或重建时被换掉的那个）的报错
             # 描述的是别人的连接：既不能把当代标成断开，也不该当成本轮出错上报。
             if generation is not None and generation != self.current_generation:
@@ -221,9 +228,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             # 只有当代连接的关闭才算「断开」。软 flush 之后服务端会在放完尾包后
             # 关掉旧连接，那时新 synthesizer 可能已经在说下一段——把它标成断开，
             # 下一次收尾就会跳过 FINISH 并丢掉 synthesizer，新一段的尾句直接消失。
-            if generation is not None and generation != self.current_generation:
-                return
-            self.connection_lost = True
+            with self._lock:
+                if generation is not None and generation != self.current_generation:
+                    return
+                self.connection_lost = True
 
         def on_event(self, message):
             pass

--- a/tests/unit/test_tts_soft_flush.py
+++ b/tests/unit/test_tts_soft_flush.py
@@ -28,8 +28,6 @@ drained stream instead of the closed socket.
 """
 
 import asyncio
-import queue
-import threading
 import time
 from queue import Queue
 from unittest.mock import MagicMock
@@ -37,10 +35,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from main_logic.core import LLMSessionManager, tts_runtime as tts_runtime_mod
-from main_logic.tts_client._infra import (
-    TTS_AUDIO_DONE_SENTINEL,
-    TTS_SOFT_FLUSH_SENTINEL,
-)
+from main_logic.tts_client._infra import TTS_SOFT_FLUSH_SENTINEL
 from tests.unit.test_cosyvoice_audio_done_generation import (  # noqa: F401 - fixtures
     _LONG_ENOUGH,
     _FakeSynthesizer,
@@ -159,6 +154,48 @@ def test_stale_close_from_the_drained_stream_does_not_mark_the_new_one_lost(work
     request_queue.put((None, None))
     _wait_for(lambda: second.finish_payloads,
               "round-end FINISH still sent: the new stream was never lost")
+
+
+def test_late_pages_from_the_retired_stream_do_not_reach_the_continuation(worker):
+    """close() does not stop the SDK thread; whatever it still delivers is stale."""
+    request_queue, response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+    first.callback.on_complete()
+    request_queue.put(("speech-a", "同一轮后面还有话。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation synthesizer")
+    _drain(response_queue)
+
+    first.callback.on_data(b"X" * 4096)  # 旧连接迟到的页
+    _settle()
+    leaked = [item for item in _drain(response_queue)
+              if isinstance(item, tuple) and len(item) == 3 and item[0] == "__audio__" and b"X" in item[2]]
+    assert leaked == [], "a retired stream's pages must not be spliced into the new stream"
+
+
+def test_soft_flush_whose_finish_fails_to_send_drops_the_dead_stream(worker):
+    """No FINISH on the wire means no completion will ever come; do not wait for it."""
+    request_queue, _response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+
+    def _broken_send(_payload):
+        raise ConnectionError("socket gone")
+
+    first.ws.send = _broken_send
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.closed, "the dead stream is released")
+
+    # 后续文本不该被扣到 2.5s 排空期限，立刻走新 synthesizer
+    request_queue.put(("speech-a", _LONG_ENOUGH + "接着说。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "new synthesizer right away", timeout=1.0)
+    assert _FakeSynthesizer.instances[1].spoken == [_LONG_ENOUGH + "接着说。"]
 
 
 def test_soft_flush_for_another_speech_is_ignored(worker):

--- a/tests/unit/test_tts_soft_flush.py
+++ b/tests/unit/test_tts_soft_flush.py
@@ -302,7 +302,7 @@ def test_timeout_retirement_waits_for_an_in_flight_completion(fake_dashscope, mo
     monkeypatch.setattr(mod, "get_config_manager", lambda: types.SimpleNamespace(
         get_model_api_config=lambda _name: {"base_url": ""}
     ))
-    monkeypatch.setattr("main_logic.tts_client._get_voice_meta", lambda _vid: {}, raising=False)
+    monkeypatch.setattr("main_logic.tts_client._get_voice_meta", lambda _vid: {})
     real_time = time.time
     offset = {"seconds": 0.0}
     monkeypatch.setattr(mod, "time", types.SimpleNamespace(

--- a/tests/unit/test_tts_soft_flush.py
+++ b/tests/unit/test_tts_soft_flush.py
@@ -177,6 +177,52 @@ def test_late_pages_from_the_retired_stream_do_not_reach_the_continuation(worker
     assert leaked == [], "a retired stream's pages must not be spliced into the new stream"
 
 
+def test_soft_flush_arriving_during_the_drain_is_applied_to_the_continuation(worker):
+    """core re-arms its timer for text buffered during the drain; that flush must not be lost."""
+    request_queue, _response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+
+    # 排空期间：续接文本到达，随后 core 为它武装的定时器也到了
+    request_queue.put(("speech-a", "同一轮后面还有话。"))
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _settle()
+    assert len(_FakeSynthesizer.instances) == 1
+
+    first.callback.on_complete()
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation synthesizer")
+    second = _FakeSynthesizer.instances[1]
+    assert second.spoken == ["同一轮后面还有话。"]
+    # 没有 (None, None)：续接流的尾句靠排空期间记下的软 flush 释放
+    _wait_for(lambda: second.finish_payloads, "FINISH carried over to the continuation stream")
+
+
+def test_text_after_a_pending_soft_flush_supersedes_it(worker):
+    """Newer text during the drain voids the earlier flush; core will re-arm for it."""
+    request_queue, _response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+
+    request_queue.put(("speech-a", "第二段"))
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    request_queue.put(("speech-a", "，还没说完"))
+    _settle()  # 三条都要在旧流放干净之前被 worker 消化掉，顺序才是这条用例要钉的
+    first.callback.on_complete()
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation synthesizer")
+    second = _FakeSynthesizer.instances[1]
+    _settle()
+    assert second.spoken == ["第二段，还没说完"]
+    assert second.finish_payloads == [], "the flush predates the newest text; wait for core's next one"
+
+
 def test_soft_flush_whose_finish_fails_to_send_drops_the_dead_stream(worker):
     """No FINISH on the wire means no completion will ever come; do not wait for it."""
     request_queue, _response_queue, _thread = worker

--- a/tests/unit/test_tts_soft_flush.py
+++ b/tests/unit/test_tts_soft_flush.py
@@ -244,6 +244,103 @@ def test_soft_flush_whose_finish_fails_to_send_drops_the_dead_stream(worker):
     assert _FakeSynthesizer.instances[1].spoken == [_LONG_ENOUGH + "接着说。"]
 
 
+def _block_next_reset(shared_callback):
+    """Make the next reset_bootstrap_state() (from the SDK thread) wait on an event.
+
+    Simulates the SDK callback being descheduled between flushing its buffers
+    and finishing its cleanup — the window both races below live in.
+    """
+    import threading
+
+    entered, release = threading.Event(), threading.Event()
+    real_reset = shared_callback.reset_bootstrap_state
+    armed = {"on": True}
+
+    def _reset():
+        if armed["on"]:
+            armed["on"] = False
+            entered.set()
+            release.wait(5)
+        real_reset()
+
+    shared_callback.reset_bootstrap_state = _reset
+    return entered, release
+
+
+def test_drain_completion_is_published_only_after_the_old_stream_reset(worker):
+    """The worker must not start the continuation while the old callback still owns the buffers."""
+    import threading
+
+    request_queue, _response_queue, _thread = worker
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+    request_queue.put(("speech-a", "同一轮后面还有话。"))
+    _settle()
+
+    entered, release = _block_next_reset(first.callback._inner)
+    threading.Thread(target=first.callback.on_complete, daemon=True).start()
+    assert entered.wait(2), "completion callback did not reach its cleanup"
+    _settle()
+    assert len(_FakeSynthesizer.instances) == 1, (
+        "continuation started while the old completion was still resetting shared state"
+    )
+    release.set()
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation after the reset finished")
+
+
+def test_timeout_retirement_waits_for_an_in_flight_completion(fake_dashscope, monkeypatch):
+    """A callback past its generation check must finish before the generation is retired."""
+    import threading
+    import types
+
+    from main_logic.tts_client.workers import cosyvoice as mod
+
+    monkeypatch.setattr(mod, "configure_dashscope_sdk_urls", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "get_config_manager", lambda: types.SimpleNamespace(
+        get_model_api_config=lambda _name: {"base_url": ""}
+    ))
+    import main_logic.tts_client as pkg
+    monkeypatch.setattr(pkg, "_get_voice_meta", lambda _vid: {}, raising=False)
+    real_time = time.time
+    offset = {"seconds": 0.0}
+    monkeypatch.setattr(mod, "time", types.SimpleNamespace(
+        time=lambda: real_time() + offset["seconds"], sleep=time.sleep,
+    ))
+
+    request_queue, response_queue = Queue(), Queue()
+    thread = threading.Thread(target=mod.cosyvoice_vc_tts_worker,
+                              args=(request_queue, response_queue, "test-key", "voice-x"), daemon=True)
+    thread.start()
+    try:
+        _wait_for(lambda: response_queue.get(timeout=0.2) == ("__ready__", True), "ready signal")
+        request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+        _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+        first = _FakeSynthesizer.instances[0]
+        request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+        _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+        request_queue.put(("speech-a", "同一轮后面还有话。"))
+        _settle()
+
+        # 完成通知已过 generation 检查、卡在清理里；此时排空期限到期
+        entered, release = _block_next_reset(first.callback._inner)
+        threading.Thread(target=first.callback.on_complete, daemon=True).start()
+        assert entered.wait(2)
+        offset["seconds"] = 10.0
+        _settle(0.3)
+        assert len(_FakeSynthesizer.instances) == 1, (
+            "retired the generation under a callback that was still mutating shared state"
+        )
+        release.set()
+        _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation once the callback finished")
+        assert _FakeSynthesizer.instances[1].spoken == ["同一轮后面还有话。"]
+    finally:
+        request_queue.put(("__shutdown__", None))
+        thread.join(timeout=5)
+
+
 def test_soft_flush_for_another_speech_is_ignored(worker):
     request_queue, _response_queue, _thread = worker
 

--- a/tests/unit/test_tts_soft_flush.py
+++ b/tests/unit/test_tts_soft_flush.py
@@ -302,8 +302,7 @@ def test_timeout_retirement_waits_for_an_in_flight_completion(fake_dashscope, mo
     monkeypatch.setattr(mod, "get_config_manager", lambda: types.SimpleNamespace(
         get_model_api_config=lambda _name: {"base_url": ""}
     ))
-    import main_logic.tts_client as pkg
-    monkeypatch.setattr(pkg, "_get_voice_meta", lambda _vid: {}, raising=False)
+    monkeypatch.setattr("main_logic.tts_client._get_voice_meta", lambda _vid: {}, raising=False)
     real_time = time.time
     offset = {"seconds": 0.0}
     monkeypatch.setattr(mod, "time", types.SimpleNamespace(

--- a/tests/unit/test_tts_soft_flush.py
+++ b/tests/unit/test_tts_soft_flush.py
@@ -1,0 +1,310 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Text-idle soft flush: the held tail is spoken before the provider's done.
+
+On a realtime voice route with a custom TTS voice, core only sends the round's
+FINISH at the provider's ``response.done``. CosyVoice keeps the trailing
+sentence unsynthesized until FINISH, and the lanlan.app proxy delivers
+``response.done`` only after streaming Gemini's own (discarded) audio — 1.2s
+after the last transcript delta when things go well, 9.5s when they do not. The
+tail then surfaces after the user has already started the next turn.
+
+The fix is a flush that is not a round end: core asks the worker to finish what
+it has when the turn's text goes quiet, the worker drains that stream, and
+anything that follows (more text, the real round end) is reconciled against the
+drained stream instead of the closed socket.
+"""
+
+import asyncio
+import queue
+import threading
+import time
+from queue import Queue
+from unittest.mock import MagicMock
+
+import pytest
+
+from main_logic.core import LLMSessionManager, tts_runtime as tts_runtime_mod
+from main_logic.tts_client._infra import (
+    TTS_AUDIO_DONE_SENTINEL,
+    TTS_SOFT_FLUSH_SENTINEL,
+)
+from tests.unit.test_cosyvoice_audio_done_generation import (  # noqa: F401 - fixtures
+    _LONG_ENOUGH,
+    _FakeSynthesizer,
+    _audio_done_ids,
+    _drain,
+    _wait_for,
+    fake_dashscope,
+    worker,
+)
+
+
+def _settle(seconds=0.15):
+    """Give the worker thread a few polling ticks to act (or to not act)."""
+    time.sleep(seconds)
+
+
+# ───────────────────────── worker: cosyvoice ─────────────────────────
+
+
+def test_soft_flush_finishes_the_held_tail_without_closing_the_round(worker):
+    request_queue, response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "尾句还没说完"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "synthesizer")
+    synth = _FakeSynthesizer.instances[0]
+
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: synth.finish_payloads, "FINISH from the soft flush")
+
+    # 服务端放完尾包：这只是一次软 flush，本轮没结束，不能宣告音频流关闭
+    synth.callback.on_complete()
+    _settle()
+    assert _audio_done_ids(_drain(response_queue)) == []
+
+    # 真正的收尾到了：旧流已经放干净，直接补收尾，同一条连接不再发第二个 FINISH
+    request_queue.put((None, None))
+    seen = []
+    _wait_for(lambda: (seen.extend(_drain(response_queue)) or _audio_done_ids(seen) == ["speech-a"]),
+              "audio_done after the round end")
+    assert len(synth.finish_payloads) == 1, "a finished synthesizer must not be finished twice"
+
+
+def test_round_end_while_the_soft_finished_stream_drains_waits_for_its_completion(worker):
+    request_queue, response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "尾句"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "synthesizer")
+    synth = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: synth.finish_payloads, "FINISH from the soft flush")
+
+    # 收尾先于完成通知到达：尾包还在路上，此刻宣告关闭就是早发
+    request_queue.put((None, None))
+    _settle()
+    assert _audio_done_ids(_drain(response_queue)) == []
+    assert len(synth.finish_payloads) == 1
+
+    synth.callback.on_complete()
+    seen = []
+    _wait_for(lambda: (seen.extend(_drain(response_queue)) or _audio_done_ids(seen) == ["speech-a"]),
+              "audio_done once the drained stream completed")
+
+
+def test_text_after_soft_flush_waits_for_the_drain_then_continues_on_a_new_stream(worker):
+    request_queue, response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+
+    # 同一轮又来文本：旧流还没放干净，不能往已 FINISH 的连接里塞，也不能开新流
+    request_queue.put(("speech-a", "同一轮后面还有话。"))
+    _settle()
+    assert len(_FakeSynthesizer.instances) == 1
+    assert first.spoken == [_LONG_ENOUGH + "第一段。"]
+
+    # 旧流放干净 → 新 synthesizer 接着说攒下的文本
+    first.callback.on_complete()
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation synthesizer")
+    second = _FakeSynthesizer.instances[1]
+    assert second.spoken == ["同一轮后面还有话。"]
+    assert first.closed, "the drained stream is released once the continuation starts"
+
+    request_queue.put((None, None))
+    _wait_for(lambda: second.finish_payloads, "round-end FINISH on the continuation stream")
+    second.callback.on_complete()
+    seen = []
+    _wait_for(lambda: (seen.extend(_drain(response_queue)) or _audio_done_ids(seen) == ["speech-a"]),
+              "exactly one audio_done for the whole speech")
+
+
+def test_stale_close_from_the_drained_stream_does_not_mark_the_new_one_lost(worker):
+    request_queue, response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "第一段。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "first synthesizer")
+    first = _FakeSynthesizer.instances[0]
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: first.finish_payloads, "FINISH from the soft flush")
+    first.callback.on_complete()
+
+    request_queue.put(("speech-a", "同一轮后面还有话。"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 2, "continuation synthesizer")
+    second = _FakeSynthesizer.instances[1]
+
+    # 服务端这时才关掉旧连接：这是上一代的事，当代连接没有断
+    first.callback.on_close()
+    first.callback.on_error("request timeout after 23 seconds")
+    _settle()
+    assert all(item[0] not in ("__reconnecting__", "__error__") for item in _drain(response_queue)), (
+        "a superseded stream's errors must not be reported as the current one's"
+    )
+
+    request_queue.put((None, None))
+    _wait_for(lambda: second.finish_payloads,
+              "round-end FINISH still sent: the new stream was never lost")
+
+
+def test_soft_flush_for_another_speech_is_ignored(worker):
+    request_queue, _response_queue, _thread = worker
+
+    request_queue.put(("speech-a", _LONG_ENOUGH + "尾句"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "synthesizer")
+    synth = _FakeSynthesizer.instances[0]
+
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-stale"))
+    _settle()
+    assert synth.finish_payloads == [], "a late soft flush for a dead speech must not cut the live one"
+
+
+def test_soft_flush_releases_a_short_tail_still_below_the_language_buffer(worker):
+    """A tail shorter than TTS_LANG_DETECT_MIN_CHARS has no synthesizer yet."""
+    request_queue, _response_queue, _thread = worker
+
+    request_queue.put(("speech-a", "嗯。"))
+    _settle()
+    assert _FakeSynthesizer.instances == [], "still buffering for language detection"
+
+    request_queue.put((TTS_SOFT_FLUSH_SENTINEL, "speech-a"))
+    _wait_for(lambda: len(_FakeSynthesizer.instances) == 1, "synthesizer built for the short tail")
+    synth = _FakeSynthesizer.instances[0]
+    assert synth.spoken == ["嗯。"]
+    _wait_for(lambda: synth.finish_payloads, "FINISH for the short tail")
+
+
+# ───────────────────────── core: idle timer ─────────────────────────
+
+
+def _make_mgr() -> LLMSessionManager:
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.tts_request_queue = Queue()
+    mgr.tts_pending_chunks = []
+    mgr.tts_thread = MagicMock()
+    mgr.tts_thread.is_alive.return_value = True
+    mgr.tts_ready = True
+    mgr.current_speech_id = "s1"
+    mgr.input_mode = "audio"
+    mgr._tts_done_queued_for_turn = False
+    mgr._tts_done_pending_until_ready = False
+    mgr._tts_soft_flush_supported = True
+    mgr._tts_soft_flush_task = None
+    mgr._bg_tasks = set()
+    # _request_tts_done_locked 的 stripper 依赖
+    mgr._tts_markdown_stripper = MagicMock()
+    mgr._tts_markdown_stripper.flush.return_value = ""
+    mgr._tts_bracket_stripper = MagicMock()
+    mgr._tts_bracket_stripper.flush.return_value = ""
+    mgr._tts_norm_speech_id = "s1"
+    mgr._tts_replay_done = False
+    return mgr
+
+
+@pytest.fixture
+def fast_idle(monkeypatch):
+    monkeypatch.setattr(
+        tts_runtime_mod.TtsRuntimeMixin,
+        "_tts_soft_flush_idle_seconds",
+        staticmethod(lambda: 0.05),
+    )
+
+
+def _queued(mgr):
+    return _drain(mgr.tts_request_queue)
+
+
+@pytest.mark.asyncio
+async def test_idle_text_fires_a_soft_flush_for_the_live_speech(fast_idle):
+    mgr = _make_mgr()
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == [(TTS_SOFT_FLUSH_SENTINEL, "s1")]
+
+
+@pytest.mark.asyncio
+async def test_each_chunk_rearms_the_timer_so_only_one_flush_fires(fast_idle):
+    mgr = _make_mgr()
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    await asyncio.sleep(0.02)
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    await asyncio.sleep(0.02)
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == [(TTS_SOFT_FLUSH_SENTINEL, "s1")]
+
+
+@pytest.mark.asyncio
+async def test_round_end_cancels_the_pending_soft_flush(fast_idle):
+    mgr = _make_mgr()
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    assert LLMSessionManager._request_tts_done_locked(mgr) == "queued"
+    # 定时器在 done 入队的同一步被撤掉，而不是留到点火时再靠 flag 自查
+    assert mgr._tts_soft_flush_task is None
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == [(None, None)], "the real FINISH makes the soft one pointless"
+
+
+@pytest.mark.asyncio
+async def test_soft_flush_stands_down_when_the_speech_moved_on(fast_idle):
+    mgr = _make_mgr()
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    mgr.current_speech_id = "s2"  # barge-in / rotation before the timer fired
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == []
+
+
+@pytest.mark.asyncio
+async def test_soft_flush_stands_down_once_done_is_queued_or_deferred(fast_idle):
+    mgr = _make_mgr()
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    mgr._tts_done_pending_until_ready = True
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field, value", [
+    ("_tts_soft_flush_supported", False),  # worker 不认这个哨兵（会当成新 sid）
+    ("input_mode", "text"),                # 文本模式的 completion 紧跟最后一个 chunk
+])
+async def test_soft_flush_is_not_armed_where_it_cannot_help(fast_idle, field, value):
+    mgr = _make_mgr()
+    setattr(mgr, field, value)
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    assert mgr._tts_soft_flush_task is None
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_an_armed_timer(fast_idle):
+    mgr = _make_mgr()
+    LLMSessionManager._arm_tts_soft_flush(mgr, "s1")
+    LLMSessionManager._cancel_tts_soft_flush(mgr)
+    await asyncio.sleep(0.2)
+    assert _queued(mgr) == []
+    assert mgr._tts_soft_flush_task is None
+
+
+def test_registry_declares_soft_flush_only_for_workers_that_handle_it():
+    from main_logic.tts_client import TTS_PROVIDER_REGISTRY
+
+    supporting = {name for name, meta in TTS_PROVIDER_REGISTRY.items() if meta.soft_flush}
+    # 加 provider 时同步扩这个集合，并给它的 worker 补 TTS_SOFT_FLUSH_SENTINEL 分支。
+    assert supporting == {"cosyvoice"}


### PR DESCRIPTION
## 现象

海外免费 realtime（lanlan.app）+ CosyVoice 自定义音色：每轮回答的最后半句总要等到用户开口说下一轮才冒出来。

## 根因（真后端实测）

- CosyVoice（DashScope streaming）把最后一句/半句一直扣到 FINISH 才合成，句尾带「？」也照扣。
- core 只在 provider 的 `response.done`（`handle_response_complete`）才发 `(None, None)` FINISH。
- lanlan.app 代理要把 Gemini 自己那份音频推完才发 `response.done`，而 `use_tts=True` 时这份音频在 `handle_audio_data` 被整段丢弃。实测 done 落后最后一片转录 1.2s（好）到 9.5s（坏）。
- 最新 Gemini Live 不允许 `modalities=['text']`，代理侧关不掉这份音频，只能客户端兜。

排除掉的假设（都实测过）：转录迟到 done 之后（done 后零文本）、前端 ogg 解码器扣尾包（只扣 60ms）、worker 没发 FINISH。

## 改法

**core**（`tts_runtime.py`）：每个入队的文本 chunk 重置一个空闲定时器（默认 1s，`NEKO_TTS_SOFT_FLUSH_IDLE_SECONDS` 可调，下限 0.3s）。到点时本轮 done 未排、sid 未换、worker 在线 → 发 `TTS_SOFT_FLUSH_SENTINEL`。只对注册表 `soft_flush=True` 的 provider（目前仅 cosyvoice）、只在 `input_mode=='audio'` 下武装；done 入队 / 打断 / 拆除 / 换 worker 时取消。

**cosyvoice worker**：软 flush = 发 FINISH 但不收尾（不发 audio_done）。之后同一轮再来文本先攒着，等这一代的完成通知（最多 2.5s）再起新流接着说——不能往已 FINISH 的连接 `streaming_call`（服务端报错→前端弹提示），也不能并行开新流（两条 OGG 流的页在共享缓冲交错）。收尾撞上软完成态不再发第二个 FINISH：放干净就直接补 `audio_done`，没放干净就武装标记让完成通知来发。15s 空闲保活并入同一状态机。

`on_close` / `on_error` 补 generation 戳（#2572 只给 `on_complete` 补了）：软 flush 后服务端关旧连接时新流可能已在说，把当代标成 `connection_lost` 会让下次收尾跳过 FINISH 丢掉 synthesizer。

契约不变：`(None, None)` 一轮一次（#731）、audio_done 宁可漏发不可早发（#2572）、`response.done` 处轮换 sid 且不清管线（#1369）都没动。

## 验证

- 真后端端到端（探针直连 `/ws/<name>` 发 NEKO 帧）：阈值 0.5s 时最后一片转录 10.55s、尾包 11.79s 开始流、`turn end` 12.15s 才到；`audio_done` 每轮恰一次，无错误提示。
- `tests/unit/test_tts_soft_flush.py`：worker 6 条 + core 7 条 + 注册表 1 条。变异验证 5 条守卫各自转红。
- 相关子集 1324 passed；`check_core_contracts.py` / docstring 禁 CJK 守卫绿。

## 回归报告

**改动**：core 给 realtime 语音 + 自定义 TTS 加「文本空闲 1s 软 flush」哨兵；cosyvoice worker 加软完成状态机并给 `on_close/on_error` 补 generation 戳；注册表加 `soft_flush` 能力位。

**必要性**：尾句被 CosyVoice 扣到 FINISH，而 FINISH 绑在代理的 `response.done` 上，实测落后 1.2–9.5s；代理不认 text-only modality（最新 Gemini Live 不允许），服务器侧无解。

**改动前**：最后半句要等 `response.done` 才出声，坏情况用户已开口说下一轮。
**改动后**：文本停 1s 后尾句就开始合成（真后端实测阈值 0.5s 时尾包比 `turn end` 早 0.35s 开始流）；`audio_done` 仍每轮恰一次、仍排在最后一块音频之后。

**可能的回归**：
- Gemini 转录内部空档 >1s 会触发一次软 flush，之后的文本要等旧流放干净再起新 synthesizer（多一次 DashScope 建连 ~0.25s + 句间韵律断一下）。实测轮内空档最大 ~0.6s；阈值可用 `NEKO_TTS_SOFT_FLUSH_IDLE_SECONDS` 调，下限 0.3s。
- 软 flush 后旧流 2.5s 内没等到完成通知会放弃等待、起新流，旧流剩余音频（若有）丢失；缓冲区按重连路径同样清空，不会拼进新流。
- 只影响 `input_mode=='audio'` 且 provider 为 cosyvoice 的路径；step/qwen/http_sentence 类 worker、文本模式、原生语音（`use_tts=False`）不武装定时器，行为不变。
- 契约不变：`(None, None)` 一轮一次（#731）、audio_done 宁可漏发不可早发（#2572）、`response.done` 处轮换 sid 且不清管线（#1369）。
- 覆盖：`tests/unit/test_tts_soft_flush.py` 14 条（5 条守卫做过变异验证），相关子集 1324 passed，`check_core_contracts.py` 绿。

## 遗留（本 PR 不碰）

- worker 4KB 聚合缓冲只在 `on_complete` 才冲，DashScope 的 task-finished 有时比最后一包晚 ~1s。
- 偶发空 `response.done` 让 `_reset_per_turn_output_state` 清掉 `_print_input_transcript`，整轮转录被缓冲到下一次 done。

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增语音文本空闲软刷新：短暂停顿时及时合成尾部文本，同时保持当前语音回合不中断。
  * 支持软刷新后的后续文本继续合成，改善短文本及停顿场景下的语音输出体验。
  * CosyVoice 支持软刷新，并隔离已结束音频流的迟到事件，减少对当前语音的影响。

* **Bug 修复**
  * 改善语音流切换、并发回调及异常恢复时的稳定性，避免旧音频流干扰新内容。

* **测试**
  * 新增软刷新、定时器、回合切换、并发处理、错误恢复及多种边界场景的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->