### PR TITLE
本地化并简化 PNGTuber 模型导入成功提示，同步更新 8 个语言包及缓存版本。

### DIFF
--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -29,9 +29,9 @@
     const SUPPORTED_LANGUAGES = ['zh-CN', 'zh-TW', 'en', 'ja', 'ko', 'ru', 'es', 'pt'];
 
     // locale 资源版本（用于 cache-busting，避免客户端长期缓存旧语言包导致新增 key 不生效）
-    // 合并 Day 1/Day 2 引导与 vLLM-Omni 克隆提示后新增了 key；递增版本让 Electron、
-    // Docker 等长期缓存重新拉取完整语言包，避免界面直接显示 voice.* key。
-    const LOCALE_VERSION = '2026-09-02-vllm-omni-clone-tts-state';
+    // PNGTuber 工程导入状态新增了 key；递增版本让 Electron、Docker 等长期缓存
+    // 重新拉取完整语言包，避免成功提示继续显示接口返回的未本地化文案。
+    const LOCALE_VERSION = '2026-09-09-pngtuber-import-status';
     function initDecorativeImageDragGuard() {
         const markImage = (img) => {
             if (!(img instanceof HTMLImageElement)) return;

--- a/static/js/model_manager/page-controller.js
+++ b/static/js/model_manager/page-controller.js
@@ -8049,7 +8049,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const result = await response.json();
 
             if (result.success) {
-                uploadStatus.textContent = `✓ ${result.message}`;
+                uploadStatus.textContent = `✓ ${t('live2d.pngtuberImportSuccess', 'PNGTuber model imported successfully.')}`;
                 uploadStatus.style.color = '#28a745';
                 await loadPNGTuberModels();
                 if (result.folder && modelSelect) {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "Test Talking",
         "pngtuberStatePreview": "State Preview",
         "pngtuberImportProjectFile": "Import Project File",
-        "pngtuberImportFolder": "Import Folder"
+        "pngtuberImportFolder": "Import Folder",
+        "pngtuberImportSuccess": "PNGTuber model imported successfully."
     },
     "voice": {
         "title": "Voice Registration",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "Probar habla",
         "pngtuberStatePreview": "Vista previa de estado",
         "pngtuberImportProjectFile": "Importar archivo de proyecto",
-        "pngtuberImportFolder": "Importar carpeta"
+        "pngtuberImportFolder": "Importar carpeta",
+        "pngtuberImportSuccess": "El modelo PNGTuber se importó correctamente."
     },
     "voice": {
         "title": "Registro de voz",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "発話をテスト",
         "pngtuberStatePreview": "状態プレビュー",
         "pngtuberImportProjectFile": "プロジェクトファイルをインポート",
-        "pngtuberImportFolder": "フォルダーをインポート"
+        "pngtuberImportFolder": "フォルダーをインポート",
+        "pngtuberImportSuccess": "PNGTuber モデルをインポートしました。"
     },
     "voice": {
         "title": "ボイス登録",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "말하기 테스트",
         "pngtuberStatePreview": "상태 미리보기",
         "pngtuberImportProjectFile": "프로젝트 파일 가져오기",
-        "pngtuberImportFolder": "폴더 가져오기"
+        "pngtuberImportFolder": "폴더 가져오기",
+        "pngtuberImportSuccess": "PNGTuber 모델을 가져왔습니다."
     },
     "voice": {
         "title": "음성 등록",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "Testar fala",
         "pngtuberStatePreview": "Prévia de estado",
         "pngtuberImportProjectFile": "Importar arquivo de projeto",
-        "pngtuberImportFolder": "Importar pasta"
+        "pngtuberImportFolder": "Importar pasta",
+        "pngtuberImportSuccess": "O modelo PNGTuber foi importado com sucesso."
     },
     "voice": {
         "title": "Registro de voz",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "Проверить речь",
         "pngtuberStatePreview": "Предпросмотр состояния",
         "pngtuberImportProjectFile": "Импорт файла проекта",
-        "pngtuberImportFolder": "Импорт папки"
+        "pngtuberImportFolder": "Импорт папки",
+        "pngtuberImportSuccess": "Модель PNGTuber успешно импортирована."
     },
     "voice": {
         "title": "Регистрация голоса",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "测试说话",
         "pngtuberStatePreview": "状态预览",
         "pngtuberImportProjectFile": "导入工程文件",
-        "pngtuberImportFolder": "导入文件夹"
+        "pngtuberImportFolder": "导入文件夹",
+        "pngtuberImportSuccess": "PNGTuber 模型导入成功。"
     },
     "voice": {
         "title": "音色注册",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1684,7 +1684,8 @@
         "pngtuberTalkPreview": "測試說話",
         "pngtuberStatePreview": "狀態預覽",
         "pngtuberImportProjectFile": "導入工程檔案",
-        "pngtuberImportFolder": "導入資料夾"
+        "pngtuberImportFolder": "導入資料夾",
+        "pngtuberImportSuccess": "PNGTuber 模型匯入成功。"
     },
     "voice": {
         "title": "音色注冊",

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -348,6 +348,8 @@ def test_model_manager_pngtuber_upload_supports_project_file_without_removing_fo
     assert "const pngtuberPackageUpload = document.getElementById('pngtuber-package-upload');" in script
     assert "showPNGTuberUploadChoice()" in script
     assert "async function uploadPNGTuberFiles(files, inputElement = null)" in script
+    assert "live2d.pngtuberImportSuccess" in script
+    assert "t('live2d.pngtuberImportSuccess', 'PNGTuber model imported successfully.')" in script
     assert "await uploadPNGTuberFiles(e.target.files, pngtuberModelUpload);" in script
     assert "await uploadPNGTuberFiles(e.target.files, pngtuberPackageUpload);" in script
     assert "inputElement.value = '';" in script

--- a/tests/unit/test_locale_cache_bust_contract.py
+++ b/tests/unit/test_locale_cache_bust_contract.py
@@ -133,6 +133,7 @@ RETIRED_LOCALE_VERSIONS = frozenset(
         "2026-09-01-add-guide-main-merge",
         "2026-09-01-vllm-omni-clone-preflight",
         "2026-09-02-vllm-omni-clone-preflight",
+        "2026-09-02-vllm-omni-clone-tts-state",
     }
 )
 
@@ -145,7 +146,7 @@ RETIRED_LOCALE_VERSIONS = frozenset(
 #
 # 数组也按下标展开，所以往 badminton.lines.* 这类台词数组里追加一条同样会打红：
 # 陈旧缓存下那一条会取到 undefined，症状和缺 key 是一类。
-LOCALE_KEY_SIGNATURE = "d9200cddce7c21d4fd1b6db19b4d5a56b9bc6116c1074a7c42d753e0e4f10fa2"
+LOCALE_KEY_SIGNATURE = "19567dba650746c4bee125bb94c882858dbf3ddbb575629f20bd4b8a2417b9e3"
 
 _BUMP_INSTRUCTIONS = (
     "static/locales 的 key 结构变了。请在 static/i18n-i18next.js 里把 LOCALE_VERSION "


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

本地化并简化 PNGTuber 模型导入成功提示，同步更新 8 个语言包及缓存版本。

## 测试 / Testing

手动确认已经本地化


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - PNGTuber 模型导入成功后，现显示本地化的成功提示，提升反馈一致性。
  - 新增简体中文、繁体中文、英语、西班牙语、日语、韩语、葡萄牙语和俄语等语言支持。

- **改进**
  - 更新语言包版本，确保用户能够获取最新的 PNGTuber 导入相关翻译内容。

- **测试**
  - 增加对 PNGTuber 导入成功提示及语言包内容的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->