### PR TITLE
feat(tts): switch ElevenLabs cloning to V3 dialogue

### DIFF
--- a/main_logic/tts_client/_registry_meta.py
+++ b/main_logic/tts_client/_registry_meta.py
@@ -165,12 +165,12 @@ TTS_PROVIDER_REGISTRY: dict[str, TTSProviderMeta] = {
     "elevenlabs": TTSProviderMeta(
         name="elevenlabs",
         category="ws_bistream",
-        protocol="WebSocket (wss://api.elevenlabs.io/v1/text-to-speech/{voice_id}/stream-input)",
+        protocol="WebSocket (wss://api.elevenlabs.io/v1/text-to-dialogue/stream-input)",
         input_streaming=True,
         output_streaming=True,
         client_sentence_split=False,
         audio_format="PCM 24kHz -> resample 48kHz",
-        notes="ElevenLabs text-to-speech stream with Flash v2.5 by default",
+        notes="ElevenLabs Text-to-Dialogue stream with eleven_v3_conversational",
     ),
     "minimax": TTSProviderMeta(
         name="minimax",

--- a/main_logic/tts_client/workers/elevenlabs.py
+++ b/main_logic/tts_client/workers/elevenlabs.py
@@ -116,6 +116,18 @@ def _elevenlabs_dialogue_event_flags(payload: dict) -> tuple[bool, bool, bool]:
         ),
     )
 
+def _drain_elevenlabs_resampler(resampler, pcm_sample_rate: int) -> bytes:
+    """Return any PCM still buffered by the streaming sample-rate converter."""
+    if resampler is None:
+        return b""
+    return _resample_audio(
+        np.empty(0, dtype=np.int16),
+        pcm_sample_rate,
+        48000,
+        resampler,
+        last=True,
+    )
+
 def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base_url=None):
     """ElevenLabs V3 worker using Text-to-Dialogue WebSocket PCM output."""
     normalized_voice_id = _normalize_elevenlabs_voice_id(voice_id)
@@ -167,6 +179,18 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
             audio_jitter.reset()
             audio_done.reset()  # 新会话重置 audio_done 去重标记
 
+        def _flush_resampler_tail() -> None:
+            nonlocal resampler
+            active_resampler = resampler
+            if active_resampler is None:
+                return
+            # Mark it consumed before appending so every normal/error cleanup path is
+            # idempotent and cannot finalize the same streaming resampler twice.
+            resampler = None
+            audio_jitter.append(
+                _drain_elevenlabs_resampler(active_resampler, pcm_sample_rate)
+            )
+
         async def _close_ws(
             send_final_empty: bool = False,
             wait_for_final: bool = False,
@@ -202,6 +226,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
             ws = None
             if receive_task and not receive_task.done():
                 if not interrupt:
+                    _flush_resampler_tail()
                     audio_jitter.flush()
                 receive_task.cancel()
                 try:
@@ -297,6 +322,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                         # now, but keep receiving until is_final before publishing audio_done.
                         audio_jitter.flush()
                     if is_final:
+                        _flush_resampler_tail()
                         audio_jitter.flush()  # 本轮音频结束，放掉缓冲区里不足 steady 阈值的尾音
                         # flush 已经把尾音投进队列，此刻本轮音频流才真正关闭
                         audio_done.emit(speech_id)
@@ -317,6 +343,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                 logger.error("ElevenLabs WS receive failed: %s", exc)
             finally:
                 if not cancelled:
+                    _flush_resampler_tail()
                     audio_jitter.flush()
                 response_finished.set()
 

--- a/main_logic/tts_client/workers/elevenlabs.py
+++ b/main_logic/tts_client/workers/elevenlabs.py
@@ -102,6 +102,20 @@ def _elevenlabs_dialogue_input_payload(voice_id: str, text: str) -> dict:
         }],
     }
 
+def _elevenlabs_dialogue_event_flags(payload: dict) -> tuple[bool, bool, bool]:
+    """Return (has_error, turn_audio_finished, session_finished)."""
+    event_type = payload.get("type")
+    return (
+        bool(payload.get("error") or event_type == "error"),
+        bool(payload.get("is_final_audio_for_turn")),
+        bool(
+            payload.get("isFinal")
+            or payload.get("is_final")
+            or payload.get("final")
+            or event_type in {"final", "audio.done"}
+        ),
+    )
+
 def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base_url=None):
     """ElevenLabs V3 worker using Text-to-Dialogue WebSocket PCM output."""
     normalized_voice_id = _normalize_elevenlabs_voice_id(voice_id)
@@ -224,6 +238,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                 async for message in ws:
                     audio_bytes = None
                     is_final = False
+                    is_turn_final = False
                     payload = None
 
                     if isinstance(message, bytes):
@@ -244,6 +259,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
 
                     if payload is not None:
                         event_type = payload.get("type")
+                        has_error, is_turn_final, is_final = _elevenlabs_dialogue_event_flags(payload)
                         audio_b64 = payload.get("audio") or payload.get("data") or payload.get("delta") or ""
                         if audio_b64:
                             try:
@@ -251,20 +267,14 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                             except Exception as exc:
                                 logger.warning("ElevenLabs WS audio decode failed: %s", exc)
                                 audio_bytes = None
-                        is_final = bool(
-                            payload.get("isFinal")
-                            or payload.get("is_final")
-                            or payload.get("final")
-                            or event_type in {"final", "audio.done"}
-                        )
-                        if payload.get("error") or event_type == "error":
+                        if has_error:
                             _enqueue_error(response_queue, {
                                 "code": "API_REQUEST_FAILED",
                                 "provider": "elevenlabs",
                                 "message": f"ElevenLabs V3 dialogue API error: {payload}",
                             })
                             continue
-                        if not audio_bytes and not is_final:
+                        if not audio_bytes and not is_turn_final and not is_final:
                             preview = message if isinstance(message, str) else repr(message[:200])
                             logger.debug(
                                 "ElevenLabs WS recv unknown event type=%r raw=%s",
@@ -281,6 +291,11 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                             audio_bytes = audio_bytes[:usable_len]
                         audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
                         audio_jitter.append(_resample_audio(audio_array, pcm_sample_rate, 48000, resampler))
+                    if is_turn_final:
+                        # V3 emits a turn boundary before the session-level is_final that follows
+                        # close_socket. PCM has exact turn boundaries, so release the buffered tail
+                        # now, but keep receiving until is_final before publishing audio_done.
+                        audio_jitter.flush()
                     if is_final:
                         audio_jitter.flush()  # 本轮音频结束，放掉缓冲区里不足 steady 阈值的尾音
                         # flush 已经把尾音投进队列，此刻本轮音频流才真正关闭

--- a/main_logic/tts_client/workers/elevenlabs.py
+++ b/main_logic/tts_client/workers/elevenlabs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""ElevenLabs TTS worker."""
+"""ElevenLabs V3 Text-to-Dialogue worker."""
 
 import numpy as np
 import soxr
@@ -84,10 +84,26 @@ def _elevenlabs_ws_base_url(base_url: str | None) -> str:
         return raw
     return "wss://" + raw
 
-def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base_url=None):
-    """ElevenLabs TTS worker - WebSocket stream-input PCM output."""
+def _elevenlabs_dialogue_ws_url(base_url: str, model: str, output_format: str) -> str:
     from urllib.parse import urlencode
 
+    params = urlencode({"model_id": model, "output_format": output_format})
+    return f"{_elevenlabs_ws_base_url(base_url)}/v1/text-to-dialogue/stream-input?{params}"
+
+def _elevenlabs_dialogue_init_payload(voice_id: str) -> dict:
+    return {"voices": [voice_id]}
+
+def _elevenlabs_dialogue_input_payload(voice_id: str, text: str) -> dict:
+    return {
+        "inputs": [{
+            "text": text,
+            "voice_id": voice_id,
+            "new_turn": False,
+        }],
+    }
+
+def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base_url=None):
+    """ElevenLabs V3 worker using Text-to-Dialogue WebSocket PCM output."""
     normalized_voice_id = _normalize_elevenlabs_voice_id(voice_id)
     options = _get_elevenlabs_options(base_url)
     output_format = options['output_format']
@@ -100,24 +116,12 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
         response_queue.put(("__ready__", False))
         return
 
-    ws_base_url = _elevenlabs_ws_base_url(options['base_url'])
-    ws_url = f"{ws_base_url}/v1/text-to-speech/{normalized_voice_id}/stream-input"
-    ws_params = urlencode({
-        "model_id": options['model'],
-        "output_format": output_format,
-    })
-    ws_url = f"{ws_url}?{ws_params}"
-    chunk_schedule = list(_ELEVENLABS_WS_CHUNK_SCHEDULE)
+    ws_url = _elevenlabs_dialogue_ws_url(
+        options['base_url'],
+        options['model'],
+        output_format,
+    )
     pcm_sample_rate = _parse_elevenlabs_pcm_sample_rate(output_format)
-
-    def _build_voice_settings() -> dict:
-        return {
-            "stability": options['stability'],
-            "similarity_boost": options['similarity_boost'],
-            "style": options['style'],
-            "use_speaker_boost": options['use_speaker_boost'],
-            "speed": 1.0,
-        }
 
     async def async_worker():
         ws = None
@@ -168,10 +172,10 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
             if ws is not None:
                 if send_final_empty and not text_done_sent:
                     try:
-                        await ws.send(json.dumps({"text": ""}))
+                        await ws.send(json.dumps({"close_socket": True}))
                         text_done_sent = True
                     except Exception as exc:
-                        logger.debug("ElevenLabs WS final empty send failed: %s", exc)
+                        logger.debug("ElevenLabs V3 WS close_socket send failed: %s", exc)
                 if wait_for_final:
                     try:
                         await asyncio.wait_for(response_finished.wait(), timeout=30.0)
@@ -211,14 +215,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
             _reset_session_metrics()
             current_speech_id = speech_id
             receive_task = asyncio.create_task(_receive_ws_messages(speech_id))
-            init_payload = {
-                "text": " ",
-                "voice_settings": _build_voice_settings(),
-                "generation_config": {
-                    "chunk_length_schedule": chunk_schedule,
-                },
-                "xi_api_key": audio_api_key,
-            }
+            init_payload = _elevenlabs_dialogue_init_payload(normalized_voice_id)
             await ws.send(json.dumps(init_payload))
 
         async def _receive_ws_messages(speech_id: str) -> None:
@@ -260,11 +257,11 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                             or payload.get("final")
                             or event_type in {"final", "audio.done"}
                         )
-                        if event_type == "error":
+                        if payload.get("error") or event_type == "error":
                             _enqueue_error(response_queue, {
                                 "code": "API_REQUEST_FAILED",
                                 "provider": "elevenlabs",
-                                "message": f"ElevenLabs TTS API error: {payload}",
+                                "message": f"ElevenLabs V3 dialogue API error: {payload}",
                             })
                             continue
                         if not audio_bytes and not is_final:
@@ -311,12 +308,10 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
         async def _send_text(text: str, speech_id: str, *, final: bool = False) -> None:
             if ws is None:
                 raise RuntimeError("ElevenLabs WS is not connected")
-            payload = {"text": text}
-            if text and text.strip():
-                payload["try_trigger_generation"] = True
-            if final and text:
+            payload = _elevenlabs_dialogue_input_payload(normalized_voice_id, text)
+            if final:
                 payload["flush"] = True
-            await ws.send(json.dumps(payload))
+            await ws.send(json.dumps(payload, ensure_ascii=False))
 
         async def _ensure_session(speech_id: str) -> None:
             nonlocal current_speech_id, pending_text_sid
@@ -404,15 +399,15 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                             continue
                         pending_text.clear()
                         pending_text_sid = None
-                    # 只发 final empty，让 receive_task 在后台继续把剩余音频抽完；
+                    # close_socket 刷新 V3 服务端缓冲，让 receive_task 在后台抽完尾音；
                     # 真正的 close 由下一个 sid 切换 / __interrupt__ / shutdown 触发，
                     # 避免主循环在这里阻塞最长 30s 拖慢下一句 utterance 首音延迟喵。
                     if ws is not None and not text_done_sent:
                         try:
-                            await ws.send(json.dumps({"text": ""}))
+                            await ws.send(json.dumps({"close_socket": True}))
                             text_done_sent = True
                         except Exception as exc:
-                            logger.debug("ElevenLabs WS final empty send failed: %s", exc)
+                            logger.debug("ElevenLabs V3 WS close_socket send failed: %s", exc)
                     current_speech_id = None
                     pending_text.clear()
                     pending_text_sid = None

--- a/main_routers/characters_router/voice_providers.py
+++ b/main_routers/characters_router/voice_providers.py
@@ -142,16 +142,13 @@ async def _elevenlabs_synthesize_preview(
     base_url = (base_url or await _get_elevenlabs_base_url(config_manager)).rstrip('/')
 
     payload = {
-        "text": text,
+        "inputs": [{
+            "text": text,
+            "voice_id": raw_voice_id,
+        }],
         "model_id": ELEVENLABS_TTS_DEFAULT_MODEL,
-        "voice_settings": {
-            "stability": 0.5,
-            "similarity_boost": 0.75,
-            "style": 0.0,
-            "use_speaker_boost": True,
-        },
     }
-    url = f"{base_url}/v1/text-to-speech/{raw_voice_id}"
+    url = f"{base_url}/v1/text-to-dialogue"
     headers = {
         "xi-api-key": api_key,
         "Accept": "audio/mpeg",

--- a/tests/unit/test_audio_jitter_buffer.py
+++ b/tests/unit/test_audio_jitter_buffer.py
@@ -203,7 +203,8 @@ def test_realtime_workers_flush_jitter_on_non_cancelled_receiver_exit():
         "elevenlabs": 1,
     }
     pattern = re.compile(
-        r"finally:\s+if not cancelled:\s+(?:qwen_)?audio_jitter\.flush\(\)",
+        r"finally:\s+if not cancelled:\s+"
+        r"(?:_flush_resampler_tail\(\)\s+)?(?:qwen_)?audio_jitter\.flush\(\)",
         re.MULTILINE,
     )
 

--- a/tests/unit/test_audio_jitter_buffer.py
+++ b/tests/unit/test_audio_jitter_buffer.py
@@ -203,14 +203,19 @@ def test_realtime_workers_flush_jitter_on_non_cancelled_receiver_exit():
         "elevenlabs": 1,
     }
     pattern = re.compile(
+        r"finally:\s+if not cancelled:\s+(?:qwen_)?audio_jitter\.flush\(\)",
+        re.MULTILINE,
+    )
+    elevenlabs_pattern = re.compile(
         r"finally:\s+if not cancelled:\s+"
-        r"(?:_flush_resampler_tail\(\)\s+)?(?:qwen_)?audio_jitter\.flush\(\)",
+        r"_flush_resampler_tail\(\)\s+audio_jitter\.flush\(\)",
         re.MULTILINE,
     )
 
     for provider, expected_count in expected_flush_guards.items():
         source = REALTIME_WORKERS[provider].read_text(encoding="utf-8")
-        assert len(pattern.findall(source)) >= expected_count, provider
+        provider_pattern = elevenlabs_pattern if provider == "elevenlabs" else pattern
+        assert len(provider_pattern.findall(source)) >= expected_count, provider
 
 
 def test_realtime_workers_flush_tail_before_normal_receiver_cancel():

--- a/tests/unit/test_elevenlabs_v3_production.py
+++ b/tests/unit/test_elevenlabs_v3_production.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from main_logic.tts_client.workers import elevenlabs as elevenlabs_worker
@@ -92,3 +94,45 @@ def test_worker_classifies_v3_audio_turn_final_and_session_final_sequence():
     assert elevenlabs_worker._elevenlabs_dialogue_event_flags({
         "is_final": True,
     }) == (False, False, True)
+
+
+def test_worker_drains_streaming_resampler_before_finishing(monkeypatch):
+    captured = {}
+    sentinel_resampler = object()
+
+    def _fake_resample(audio, src_rate, dst_rate, resampler, *, last=False):
+        captured.update({
+            "audio": audio,
+            "src_rate": src_rate,
+            "dst_rate": dst_rate,
+            "resampler": resampler,
+            "last": last,
+        })
+        return b"tail-pcm"
+
+    monkeypatch.setattr(elevenlabs_worker, "_resample_audio", _fake_resample)
+
+    assert elevenlabs_worker._drain_elevenlabs_resampler(
+        sentinel_resampler,
+        24000,
+    ) == b"tail-pcm"
+    assert captured["audio"].dtype == np.int16
+    assert captured["audio"].size == 0
+    assert captured["src_rate"] == 24000
+    assert captured["dst_rate"] == 48000
+    assert captured["resampler"] is sentinel_resampler
+    assert captured["last"] is True
+
+
+def test_worker_enqueues_resampler_tail_before_final_jitter_flush_and_audio_done():
+    source = inspect.getsource(elevenlabs_worker.elevenlabs_tts_worker)
+    final_start = source.index("if is_final:")
+    final_end = source.index("break", final_start)
+    final_block = source[final_start:final_end]
+
+    assert final_block.index("_flush_resampler_tail()") < final_block.index(
+        "audio_jitter.flush()"
+    )
+    assert final_block.index("audio_jitter.flush()") < final_block.index(
+        "audio_done.emit(speech_id)"
+    )

--- a/tests/unit/test_elevenlabs_v3_production.py
+++ b/tests/unit/test_elevenlabs_v3_production.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+# Licensed under the Apache License, Version 2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from main_logic.tts_client.workers import elevenlabs as elevenlabs_worker
+from main_routers.characters_router import voice_providers
+from utils.tts.providers.elevenlabs import ELEVENLABS_TTS_DEFAULT_MODEL
+
+
+class _ConfigManager:
+    def get_tts_api_key(self, provider: str) -> str:
+        assert provider == "elevenlabs"
+        return "test-key"
+
+
+@pytest.mark.asyncio
+async def test_preview_uses_v3_text_to_dialogue(monkeypatch):
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["request_kwargs"] = kwargs
+            return SimpleNamespace(status_code=200, content=b"mp3", text="")
+
+    monkeypatch.setattr(voice_providers.httpx, "AsyncClient", _FakeClient)
+
+    audio, error = await voice_providers._elevenlabs_synthesize_preview(
+        _ConfigManager(),
+        "eleven:voice-123",
+        "正式预览文本",
+    )
+
+    assert audio == b"mp3"
+    assert error == ""
+    assert captured["url"] == "https://api.elevenlabs.io/v1/text-to-dialogue"
+    assert captured["request_kwargs"]["params"] == {"output_format": "mp3_44100_128"}
+    assert captured["request_kwargs"]["json"] == {
+        "inputs": [{"text": "正式预览文本", "voice_id": "voice-123"}],
+        "model_id": "eleven_v3_conversational",
+    }
+
+
+def test_worker_uses_v3_text_to_dialogue_protocol():
+    assert ELEVENLABS_TTS_DEFAULT_MODEL == "eleven_v3_conversational"
+    assert elevenlabs_worker._elevenlabs_dialogue_ws_url(
+        "https://api.elevenlabs.io",
+        ELEVENLABS_TTS_DEFAULT_MODEL,
+        "pcm_24000",
+    ) == (
+        "wss://api.elevenlabs.io/v1/text-to-dialogue/stream-input"
+        "?model_id=eleven_v3_conversational&output_format=pcm_24000"
+    )
+    assert elevenlabs_worker._elevenlabs_dialogue_init_payload("voice-123") == {
+        "voices": ["voice-123"],
+    }
+    assert elevenlabs_worker._elevenlabs_dialogue_input_payload(
+        "voice-123",
+        "正式对话文本",
+    ) == {
+        "inputs": [{
+            "text": "正式对话文本",
+            "voice_id": "voice-123",
+            "new_turn": False,
+        }],
+    }

--- a/tests/unit/test_elevenlabs_v3_production.py
+++ b/tests/unit/test_elevenlabs_v3_production.py
@@ -78,3 +78,17 @@ def test_worker_uses_v3_text_to_dialogue_protocol():
             "new_turn": False,
         }],
     }
+
+
+def test_worker_classifies_v3_audio_turn_final_and_session_final_sequence():
+    assert elevenlabs_worker._elevenlabs_dialogue_event_flags({"audio": "cGNt"}) == (
+        False,
+        False,
+        False,
+    )
+    assert elevenlabs_worker._elevenlabs_dialogue_event_flags({
+        "is_final_audio_for_turn": True,
+    }) == (False, True, False)
+    assert elevenlabs_worker._elevenlabs_dialogue_event_flags({
+        "is_final": True,
+    }) == (False, False, True)

--- a/utils/tts/providers/elevenlabs.py
+++ b/utils/tts/providers/elevenlabs.py
@@ -22,7 +22,7 @@ normalizer before sending the raw voice id to the upstream API.
 """
 
 ELEVENLABS_TTS_VOICE_PREFIX = "eleven:"
-ELEVENLABS_TTS_DEFAULT_MODEL = "eleven_flash_v2_5"
+ELEVENLABS_TTS_DEFAULT_MODEL = "eleven_v3_conversational"
 ELEVENLABS_TTS_DEFAULT_OUTPUT_FORMAT = "pcm_24000"
 
 # Backward-compatible names for older call sites.


### PR DESCRIPTION
## 改动概述 / Summary

- 将正式 ElevenLabs 克隆/设计音色默认模型从 Flash v2.5 更新为 `eleven_v3_conversational`。
- 将实时合成从旧 Text-to-Speech WebSocket 协议迁移到 V3 Text-to-Dialogue WebSocket 协议。
- 将既有音色预览 helper 迁移到 Text-to-Dialogue HTTP 接口。
- 保持原有 PCM 24 kHz → 48 kHz 重采样、jitter buffer、打断、重连和 `audio_done` 契约不变。

本 PR 不包含模型对比 UI、本地测试路由、克隆创建流程、持久化音色数据或 i18n 改动。

## 回归报告 / Regression Report

- 改动内容：仅更新 ElevenLabs provider 的默认模型、正式实时 worker 的 URL/消息协议、正式预览请求格式和 provider 元数据。
- 理由与必要性：Eleven V3 不支持旧的 Text-to-Speech WebSocket 消息协议；切换模型必须同时迁移到 Text-to-Dialogue，否则正式对话会请求失败。
- 改动前：克隆/设计音色默认使用 `eleven_flash_v2_5`，实时输入发送 `{text}`，结束以空文本帧触发；预览请求 `/v1/text-to-speech/{voice_id}`。
- 改动后：默认使用 `eleven_v3_conversational`，连接时注册 `voices`，文本通过 `inputs[]` 发送，结束使用 `close_socket`；预览请求 `/v1/text-to-dialogue`。
- 潜在回归点：ElevenLabs 克隆/设计音色的首包延迟、短文本服务端缓冲、PCM 解码与句尾完成事件。通过生产协议单测、现有 TTS soft-flush/兼容性/voice-design 回归测试，以及真实克隆音色的 V3 `pcm_24000` 冒烟测试验证。其他 TTS provider、克隆创建与前端路径未改动。

## 不拆分理由 / Why Not Split

本 PR 仅有 4 个生产文件，且它们共同完成同一个 ElevenLabs V3 协议迁移；无需拆分。

## 测试 / Testing

- `uv run pytest tests/unit/test_elevenlabs_v3_production.py tests/unit/test_tts_soft_flush.py tests/unit/test_tts_module_compatibility.py tests/unit/test_voice_design.py -q`（66 passed）
- `uv run ruff check utils/tts/providers/elevenlabs.py main_logic/tts_client/workers/elevenlabs.py main_logic/tts_client/_registry_meta.py main_routers/characters_router/voice_providers.py tests/unit/test_elevenlabs_v3_production.py`
- 使用已保存的克隆音色执行真实 ElevenLabs V3 `pcm_24000` 冒烟测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - ElevenLabs 语音合成已切换至 Text-to-Dialogue 流式协议。
  - 默认模型更新为 `eleven_v3_conversational`。
  - 语音预览支持新的 Text-to-Dialogue 请求格式。

- **Bug 修复**
  - 改进语音片段、回合结束和会话结束事件处理，减少音频尾部丢失。

- **测试**
  - 新增生产协议相关测试，覆盖预览请求、WebSocket 连接、事件处理及音频收尾。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->