### PR TITLE
优化 API 设置页帮助浮层的 N.E.K.O 主题样式

### DIFF
--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -795,30 +795,47 @@ margin-top: 20px;
 margin-left: 10px;
 }
 
-/* 悬浮提示窗样式 */
+/* API 说明悬浮窗：沿用 N.E.K.O 的蓝白圆角卡片语言。 */
 .tooltip-container {
 position: relative;
 display: inline-block;
 }
 
 .tooltip-icon {
-display: inline-block;
-width: 16px;
-height: 16px;
-background: #4f8cff;
-color: white;
+display: inline-flex;
+align-items: center;
+justify-content: center;
+width: 20px;
+height: 20px;
+box-sizing: border-box;
+background: linear-gradient(180deg, #ffffff 0%, #dff6ff 100%);
+color: #159dce;
+border: 1.5px solid rgba(64, 197, 241, 0.78);
 border-radius: 50%;
-text-align: center;
-line-height: 16px;
-font-size: 12px;
+line-height: 1;
+font-size: 13px;
 cursor: help;
 margin-left: 8px;
-font-weight: bold;
+font-weight: 800;
+box-shadow: 0 3px 10px rgba(23, 167, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+vertical-align: 1px;
+}
+
+.tooltip-icon:hover {
+transform: translateY(-1px) scale(1.06);
+border-color: #17a7ff;
+box-shadow: 0 5px 14px rgba(23, 167, 255, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.95);
 }
 
 .tooltip-content {
 position: fixed;
-background: #333;
+background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(231, 248, 255, 0.98));
+border: 1px solid rgba(64, 197, 241, 0.58);
+border-left: 4px solid #40c5f1;
+box-shadow: 0 14px 34px rgba(31, 137, 187, 0.2), 0 3px 10px rgba(23, 167, 255, 0.12);
+backdrop-filter: blur(14px);
+-webkit-backdrop-filter: blur(14px);
 }
 
 /* 自定义API配置区域 - 无外框样式 */
@@ -1382,18 +1399,37 @@ border-bottom: none;
 }
 
 .tooltip-content {
-color: white;
-padding: 12px;
-border-radius: 6px;
-font-size: 0.85em;
-line-height: 1.4;
+color: #365c70;
+padding: 15px 48px 15px 17px;
+border-radius: 16px;
+font-size: 0.88em;
+line-height: 1.62;
 z-index: 1001;
 opacity: 0;
 visibility: hidden;
 transition: opacity 0.3s, visibility 0.3s;
-max-width: min(500px, calc(100vw - 40px));
+width: min(600px, calc(100vw - 40px));
+max-width: calc(100vw - 40px);
+box-sizing: border-box;
 white-space: normal;
 pointer-events: none;
+letter-spacing: 0.01em;
+}
+
+.tooltip-content strong {
+color: #159dce;
+font-weight: 700;
+}
+
+.tooltip-content::before {
+content: '';
+position: absolute;
+top: 11px;
+right: 12px;
+width: 31px;
+height: 24px;
+background: url('/static/icons/paw_ui.png') center / contain no-repeat;
+opacity: 0.22;
 }
 
 .tooltip-content::after {
@@ -1404,13 +1440,14 @@ left: var(--arrow-left, 50%);
 margin-left: -5px;
 border-width: 5px;
 border-style: solid;
-border-color: #333 transparent transparent transparent;
+border-color: #dff5ff transparent transparent transparent;
+filter: drop-shadow(0 2px 1px rgba(31, 137, 187, 0.12));
 }
 
 .tooltip-content[data-position="bottom"]::after {
 top: auto;
 bottom: 100%;
-border-color: transparent transparent #333 transparent;
+border-color: transparent transparent #f7fcff transparent;
 }
 
 /* Toggle Switch 样式 */

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1400,7 +1400,7 @@ border-bottom: none;
 
 .tooltip-content {
 color: #365c70;
-padding: 15px 48px 15px 17px;
+padding: 0;
 border-radius: 16px;
 font-size: 0.88em;
 line-height: 1.62;
@@ -1412,8 +1412,27 @@ width: min(600px, calc(100vw - 40px));
 max-width: calc(100vw - 40px);
 box-sizing: border-box;
 white-space: normal;
-pointer-events: none;
+pointer-events: auto;
 letter-spacing: 0.01em;
+}
+
+.tooltip-scroll-content {
+max-height: var(--tooltip-max-height, calc(100vh - 42px));
+padding: 15px 48px 15px 17px;
+box-sizing: border-box;
+overflow-y: auto;
+overscroll-behavior: contain;
+scrollbar-width: thin;
+scrollbar-color: rgba(64, 197, 241, 0.68) transparent;
+}
+
+.tooltip-scroll-content::-webkit-scrollbar {
+width: 7px;
+}
+
+.tooltip-scroll-content::-webkit-scrollbar-thumb {
+background: rgba(64, 197, 241, 0.68);
+border-radius: 999px;
 }
 
 .tooltip-content strong {

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1312,6 +1312,37 @@ html[data-theme="dark"].subtitle-window-host body.subtitle-window-host {
   color: #4aa3df;
 }
 
+[data-theme="dark"] .api-key-settings-page .tooltip-content {
+  background: linear-gradient(145deg, rgba(30, 52, 68, 0.98), rgba(21, 37, 51, 0.98));
+  color: #d9eff8;
+  border-color: rgba(80, 202, 244, 0.42);
+  border-left-color: #50caf4;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.38), 0 3px 12px rgba(39, 171, 224, 0.16);
+}
+
+[data-theme="dark"] .api-key-settings-page .tooltip-icon {
+  color: #a7e9ff;
+  background: linear-gradient(180deg, #315f77 0%, #203f53 100%);
+  border-color: rgba(105, 220, 255, 0.72);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+[data-theme="dark"] .api-key-settings-page .tooltip-content strong {
+  color: #75dcff;
+}
+
+[data-theme="dark"] .api-key-settings-page .tooltip-content::before {
+  opacity: 0.16;
+}
+
+[data-theme="dark"] .api-key-settings-page .tooltip-content::after {
+  border-color: #172c3a transparent transparent transparent;
+}
+
+[data-theme="dark"] .api-key-settings-page .tooltip-content[data-position="bottom"]::after {
+  border-color: transparent transparent #1d3545 transparent;
+}
+
 /* ===== 子页面：模态框 / 警告 ===== */
 [data-theme="dark"] .modal-warning {
   background: #2d2d2d;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -3350,31 +3350,57 @@ if (window.parent === window) {
 
 // Tooltip 动态定位功能
 function positionTooltip(iconElement, tooltipElement) {
+    const viewportMargin = 20;
+    const tooltipGap = 10;
     const iconRect = iconElement.getBoundingClientRect();
-    const tooltipRect = tooltipElement.getBoundingClientRect();
+    tooltipElement.style.removeProperty('--tooltip-max-height');
+    let tooltipRect = tooltipElement.getBoundingClientRect();
+
+    const spaceAbove = Math.max(0, iconRect.top - viewportMargin - tooltipGap);
+    const spaceBelow = Math.max(0, window.innerHeight - iconRect.bottom - viewportMargin - tooltipGap);
+    let opensBelow = false;
+
+    if (tooltipRect.height > spaceAbove) {
+        opensBelow = tooltipRect.height <= spaceBelow || spaceBelow > spaceAbove;
+    }
+
+    const availableHeight = opensBelow ? spaceBelow : spaceAbove;
+    // The outer card keeps overflow visible so its arrow is not clipped; only
+    // the inner content scrolls when neither side can fit the full explanation.
+    tooltipElement.style.setProperty(
+        '--tooltip-max-height',
+        Math.max(0, Math.floor(availableHeight - 2)) + 'px'
+    );
+    tooltipRect = tooltipElement.getBoundingClientRect();
 
     let left = iconRect.left + iconRect.width / 2 - tooltipRect.width / 2;
-    let top = iconRect.top - tooltipRect.height - 10;
+    let top = opensBelow
+        ? iconRect.bottom + tooltipGap
+        : iconRect.top - tooltipRect.height - tooltipGap;
 
     let iconCenter = iconRect.left + iconRect.width / 2;
 
-    if (left < 20) {
-        left = 20;
+    if (left < viewportMargin) {
+        left = viewportMargin;
     }
 
-    if (left + tooltipRect.width > window.innerWidth - 20) {
-        left = window.innerWidth - tooltipRect.width - 20;
+    if (left + tooltipRect.width > window.innerWidth - viewportMargin) {
+        left = window.innerWidth - tooltipRect.width - viewportMargin;
     }
 
     let arrowLeft = iconCenter - left;
     arrowLeft = Math.max(15, Math.min(arrowLeft, tooltipRect.width - 15));
 
-    if (top < 20) {
-        top = iconRect.bottom + 10;
+    if (opensBelow) {
         tooltipElement.setAttribute('data-position', 'bottom');
     } else {
         tooltipElement.setAttribute('data-position', 'top');
     }
+
+    top = Math.max(
+        viewportMargin,
+        Math.min(top, window.innerHeight - tooltipRect.height - viewportMargin)
+    );
 
     tooltipElement.style.left = left + 'px';
     tooltipElement.style.top = top + 'px';
@@ -3547,7 +3573,26 @@ function initTooltips() {
 
         if (!icon || !tooltip) return;
 
+        let hideTimeout = null;
+
+        function cancelHide() {
+            if (hideTimeout !== null) {
+                clearTimeout(hideTimeout);
+                hideTimeout = null;
+            }
+        }
+
+        function scheduleHide() {
+            cancelHide();
+            hideTimeout = setTimeout(() => {
+                hideTimeout = null;
+                tooltip.style.opacity = '0';
+                tooltip.style.visibility = 'hidden';
+            }, 180);
+        }
+
         icon.addEventListener('mouseenter', function () {
+            cancelHide();
             tooltip.style.visibility = 'visible';
             tooltip.style.opacity = '0';
 
@@ -3557,14 +3602,13 @@ function initTooltips() {
             });
         });
 
-        icon.addEventListener('mouseleave', function () {
-            tooltip.style.opacity = '0';
-            setTimeout(() => {
-                if (tooltip.style.opacity === '0') {
-                    tooltip.style.visibility = 'hidden';
-                }
-            }, 300);
+        icon.addEventListener('mouseleave', scheduleHide);
+        tooltip.addEventListener('mouseenter', function () {
+            cancelHide();
+            tooltip.style.visibility = 'visible';
+            tooltip.style.opacity = '1';
         });
+        tooltip.addEventListener('mouseleave', scheduleHide);
     });
 
     let resizeTimeout;

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -136,13 +136,15 @@
                                     <div class="tooltip-container">
                                         <span class="tooltip-icon">?</span>
                                         <div class="tooltip-content">
-                                            <strong data-i18n="api.coreApiTitle">核心API负责对话功能：</strong><br>
-                                            • <span data-i18n="api.freeVersionCore">免费版：完全免费，无需API
-                                                Key，但不支持视频对话</span><br>
-                                            • <span data-i18n="api.aliCore">阿里：有免费额度，功能全面</span><br>
-                                            • <span data-i18n="api.glmCore">智谱：有免费额度，但需充值1元，内置联网搜索功能</span><br>
-                                            • <span data-i18n="api.stepCore">阶跃星辰：完全免费，但不支持视频</span><br>
-                                            • <span data-i18n="api.openaiCore">OpenAI：智能水平最高，但需要翻墙且价格昂贵</span>
+                                            <div class="tooltip-scroll-content">
+                                                <strong data-i18n="api.coreApiTitle">核心API负责对话功能：</strong><br>
+                                                • <span data-i18n="api.freeVersionCore">免费版：完全免费，无需API
+                                                    Key，但不支持视频对话</span><br>
+                                                • <span data-i18n="api.aliCore">阿里：有免费额度，功能全面</span><br>
+                                                • <span data-i18n="api.glmCore">智谱：有免费额度，但需充值1元，内置联网搜索功能</span><br>
+                                                • <span data-i18n="api.stepCore">阶跃星辰：完全免费，但不支持视频</span><br>
+                                                • <span data-i18n="api.openaiCore">OpenAI：智能水平最高，但需要翻墙且价格昂贵</span>
+                                            </div>
                                         </div>
                                     </div>
                                 </label>
@@ -174,17 +176,19 @@
                             <div class="tooltip-container">
                                 <span class="tooltip-icon">?</span>
                                 <div class="tooltip-content">
-                                    <strong data-i18n="api.assistApiTitle">辅助API负责记忆管理、文本对话和Agent模式：</strong><br>
-                                    • <span data-i18n="api.freeVersionAssist">免费版：完全免费，无需API Key，Agent 有免费配额</span><br>
-                                    • <span data-i18n="api.aliAssist">阿里：推荐选择，功能最全面，支持Agent模式</span><br>
-                                    • <span data-i18n="api.glmAssist">智谱：支持Agent模式</span><br>
-                                    • <span data-i18n="api.stepAssist">阶跃星辰：价格相对便宜</span><br>
-                                    • <span data-i18n="api.siliconAssist">硅基流动：性价比高</span><br>
-                                    • <span data-i18n="api.openaiAssist">OpenAI：记忆管理能力强</span><br>
-                                    • <span data-i18n="api.geminiAssist">Gemini：智能和性价比极高，但国内版不支持</span><br>
-                                    • <span data-i18n="api.kimiAssist">Kimi：国内可用，支持长上下文和视觉</span><br>
-                                    • <span data-i18n="api.kimiCodeAssist">Kimi Code：Anthropic Messages 兼容格式，适合代码与长文本任务</span><br>
-                                    <strong data-i18n="api.assistApiNote">注意：不建议使用智谱和阶跃星辰。</strong>
+                                    <div class="tooltip-scroll-content">
+                                        <strong data-i18n="api.assistApiTitle">辅助API负责记忆管理、文本对话和Agent模式：</strong><br>
+                                        • <span data-i18n="api.freeVersionAssist">免费版：完全免费，无需API Key，Agent 有免费配额</span><br>
+                                        • <span data-i18n="api.aliAssist">阿里：推荐选择，功能最全面，支持Agent模式</span><br>
+                                        • <span data-i18n="api.glmAssist">智谱：支持Agent模式</span><br>
+                                        • <span data-i18n="api.stepAssist">阶跃星辰：价格相对便宜</span><br>
+                                        • <span data-i18n="api.siliconAssist">硅基流动：性价比高</span><br>
+                                        • <span data-i18n="api.openaiAssist">OpenAI：记忆管理能力强</span><br>
+                                        • <span data-i18n="api.geminiAssist">Gemini：智能和性价比极高，但国内版不支持</span><br>
+                                        • <span data-i18n="api.kimiAssist">Kimi：国内可用，支持长上下文和视觉</span><br>
+                                        • <span data-i18n="api.kimiCodeAssist">Kimi Code：Anthropic Messages 兼容格式，适合代码与长文本任务</span><br>
+                                        <strong data-i18n="api.assistApiNote">注意：不建议使用智谱和阶跃星辰。</strong>
+                                    </div>
                                 </div>
                             </div>
                         </h3>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -18,7 +18,7 @@
     <script src="/static/js/window_controls.js?v={{ static_asset_version }}" defer></script>
 </head>
 
-<body>
+<body class="api-key-settings-page">
 
     <div id="loading-overlay"
         style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255, 255, 255, 0.9); display: flex; justify-content: center; align-items: center; z-index: 9999;">

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -111,6 +111,10 @@ def test_api_help_tooltips_follow_neko_theme_and_fit_viewport(
     assert light["color"] == "rgb(54, 92, 112)"
     assert light["radius"] == "16px"
     assert "paw_ui.png" in light["paw"]
+    paw_response = mock_page.request.get(f"{running_server}/static/icons/paw_ui.png")
+    assert paw_response.ok
+    assert paw_response.headers["content-type"].startswith("image/png")
+    assert paw_response.body().startswith(b"\x89PNG\r\n\x1a\n")
     assert light["left"] >= 20
     assert light["right"] <= 1260
     assert light["width"] <= 1240

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -75,6 +75,76 @@ def test_api_key_settings(mock_page: Page, running_server: str):
 
 
 @pytest.mark.frontend
+def test_api_help_tooltips_follow_neko_theme_and_fit_viewport(
+    mock_page: Page, running_server: str
+):
+    """API explanations use the N.E.K.O card language in both themes."""
+    mock_page.set_viewport_size({"width": 1280, "height": 720})
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    icon = mock_page.locator(".tooltip-icon").first
+    tooltip = mock_page.locator(".tooltip-content").first
+    icon.hover()
+    expect(tooltip).to_be_visible()
+
+    light = tooltip.evaluate("""
+        element => {
+            const style = getComputedStyle(element);
+            const decoration = getComputedStyle(element, '::before');
+            const rect = element.getBoundingClientRect();
+            return {
+                background: style.backgroundImage,
+                borderLeftColor: style.borderLeftColor,
+                color: style.color,
+                radius: style.borderRadius,
+                paw: decoration.backgroundImage,
+                left: rect.left,
+                right: rect.right,
+                width: rect.width,
+            };
+        }
+    """)
+    assert "linear-gradient" in light["background"]
+    assert light["borderLeftColor"] == "rgb(64, 197, 241)"
+    assert light["color"] == "rgb(54, 92, 112)"
+    assert light["radius"] == "16px"
+    assert "paw_ui.png" in light["paw"]
+    assert light["left"] >= 20
+    assert light["right"] <= 1260
+    assert light["width"] <= 1240
+
+    mock_page.evaluate("document.documentElement.setAttribute('data-theme', 'dark')")
+    dark = tooltip.evaluate("""
+        element => {
+            const style = getComputedStyle(element);
+            const title = getComputedStyle(element.querySelector('strong'));
+            return {
+                background: style.backgroundImage,
+                color: style.color,
+                titleColor: title.color,
+            };
+        }
+    """)
+    assert "linear-gradient" in dark["background"]
+    assert dark["color"] == "rgb(217, 239, 248)"
+    assert dark["titleColor"] == "rgb(117, 220, 255)"
+
+    mock_page.set_viewport_size({"width": 390, "height": 720})
+    icon.hover()
+    narrow = tooltip.evaluate("""
+        element => {
+            const rect = element.getBoundingClientRect();
+            return { left: rect.left, right: rect.right, width: rect.width };
+        }
+    """)
+    assert narrow["left"] >= 20
+    assert narrow["right"] <= 370
+    assert narrow["width"] <= 350
+
+
+@pytest.mark.frontend
 def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_server: str):
     """Collapsed custom-model headers must not borrow rounded corners from a wrapper."""
     mock_page.set_viewport_size({"width": 1280, "height": 1200})

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -147,6 +147,48 @@ def test_api_help_tooltips_follow_neko_theme_and_fit_viewport(
     assert narrow["right"] <= 370
     assert narrow["width"] <= 350
 
+    mock_page.evaluate("window.changeLanguage('es')")
+    assist_icon = mock_page.locator(".tooltip-icon").nth(1)
+    assist_tooltip = mock_page.locator(".tooltip-content").nth(1)
+    assist_icon.scroll_into_view_if_needed()
+    assist_icon.hover()
+    expect(assist_tooltip).to_be_visible()
+    vertical = assist_tooltip.evaluate("""
+        element => {
+            const rect = element.getBoundingClientRect();
+            const scrollRegion = element.querySelector('.tooltip-scroll-content') || element;
+            return {
+                top: rect.top,
+                bottom: rect.bottom,
+                overflowY: getComputedStyle(scrollRegion).overflowY,
+                clientHeight: scrollRegion.clientHeight,
+                scrollHeight: scrollRegion.scrollHeight,
+            };
+        }
+    """)
+    assert vertical["top"] >= 20
+    assert vertical["bottom"] <= 700
+    assert vertical["overflowY"] == "auto"
+    assert vertical["scrollHeight"] > vertical["clientHeight"]
+
+    assist_tooltip.hover()
+    mock_page.wait_for_timeout(250)
+    expect(assist_tooltip).to_be_visible()
+    scroll_state = assist_tooltip.evaluate("""
+        element => {
+            const scrollRegion = element.querySelector('.tooltip-scroll-content');
+            scrollRegion.scrollTop = scrollRegion.scrollHeight;
+            return {
+                opacity: getComputedStyle(element).opacity,
+                pointerEvents: getComputedStyle(element).pointerEvents,
+                scrollTop: scrollRegion.scrollTop,
+            };
+        }
+    """)
+    assert scroll_state["opacity"] == "1"
+    assert scroll_state["pointerEvents"] == "auto"
+    assert scroll_state["scrollTop"] > 0
+
 
 @pytest.mark.frontend
 def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_server: str):


### PR DESCRIPTION
## 修改目的

API Key 设置页中 `?` 帮助浮层仍使用通用深色样式，与页面现有的蓝白色 N.E.K.O 视觉语言不一致。

本次修改统一帮助图标与说明浮层的主题表现，并补充亮色、暗色和窄窗口下的回归测试。

## 用户可感知变化

- 帮助图标调整为蓝白渐变、青色描边的圆形样式。
- 帮助浮层调整为 N.E.K.O 蓝白圆角卡片风格。
- 浮层增加淡化猫爪装饰、主题色标题和方向箭头。
- 暗色模式下自动切换为深蓝背景和高对比度文字。
- 窄窗口下限制浮层宽度，避免超出可视区域。

## 修改内容

- 更新 API Key 设置页帮助图标与浮层样式。
- 为 API Key 设置页增加独立页面作用域，避免暗色规则影响其他页面。
- 增加暗色模式专属样式。
- 增加前端回归测试，验证：
  - 实际悬停可以显示浮层；
  - 亮色与暗色主题样式正确；
  - 猫爪装饰资源正常应用；
  - 390px 窄窗口下浮层不会横向溢出。

## 影响范围

涉及文件：

- `static/css/api_key_settings.css`
- `static/css/dark-mode.css`
- `templates/api_key_settings.html`
- `tests/frontend/test_api_settings.py`

不影响：

- API Key 的读取、保存和测试逻辑；
- API 服务商及模型配置；
- 密钥存储方式；
- 后端接口和网络请求；
- N.E.K.O.-PC 的 Electron 主进程逻辑。

## 测试结果

```bash
uv run pytest \
  'tests/frontend/test_api_settings.py::test_api_key_settings[chromium]' \
  'tests/frontend/test_api_settings.py::test_api_help_tooltips_follow_neko_theme_and_fit_viewport[chromium]' \
  -q --tb=short

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式优化**
  * 优化 API Key 设置页帮助提示框的渐变背景、边框、阴影、模糊效果及悬停动效。
  * 完善浅色与深色主题下的提示框、图标、强调文本和箭头配色。
  * 支持不同屏幕宽度，并增加可滚动内容区域，改善移动端显示效果。

* **交互改进**
  * 根据可用空间自动调整提示框位置与高度，避免超出视口。
  * 支持在提示框内移动或滚动时保持显示。

* **测试**
  * 增加浅色、深色主题及不同视口尺寸下的提示框显示验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->