### PR TITLE
修复破冰结束后 Gal 模式未衔接，并确保收尾消息完成后触发选项生成

### DIFF
--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -463,7 +463,10 @@
     var _pendingIcebreakerBridgeActions = [];
     var _icebreakerBridgeFlushTimer = null;
     var _icebreakerBridgeFlushAttempts = 0;
-    var _icebreakerBridgeAppendBarrier = Promise.resolve();
+    var _icebreakerBridgeAppendBarrier = Promise.resolve({
+        messageId: '',
+        succeeded: false
+    });
     var ICEBREAKER_BRIDGE_FLUSH_MAX_ATTEMPTS = 50;
 
     function scheduleIcebreakerBridgeFlush(delay) {
@@ -513,15 +516,22 @@
             try {
                 if (action.type === 'append' && action.message) {
                     shouldOpenHost = true;
-                    var appendPromise = Promise.resolve(host.appendMessage(action.message)).then(function (result) {
-                        if (!result) return result;
+                    var appendResult;
+                    try {
+                        appendResult = host.appendMessage(action.message);
+                    } catch (error) {
+                        appendResult = Promise.reject(error);
+                    }
+                    var appendPromise = Promise.resolve(appendResult).then(function (result) {
+                        if (!result) return false;
                         return waitForIcebreakerChatHostMounted(host).then(function () {
                             syncIcebreakerAssistantCompactCaption(action.message);
                             finalizeIcebreakerAssistantSubtitleTranslation(action.message);
-                            return result;
+                            return true;
                         });
                     }).catch(function (error) {
                         console.warn('[NewUserIcebreaker] Failed to append bridge message:', error);
+                        return false;
                     });
                     // Full Chat lives in an isolated Electron partition. Its final
                     // handoff signal can arrive while appendMessage is still
@@ -530,7 +540,12 @@
                     _icebreakerBridgeAppendBarrier = Promise.all([
                         _icebreakerBridgeAppendBarrier,
                         appendPromise
-                    ]).then(function () {});
+                    ]).then(function (results) {
+                        return {
+                            messageId: String(action.message.id || ''),
+                            succeeded: results[1] === true
+                        };
+                    });
                 } else if (action.type === 'set_prompt' && action.prompt && typeof host.setIcebreakerChoicePrompt === 'function') {
                     host.setIcebreakerChoicePrompt(action.prompt);
                     shouldOpenHost = true;
@@ -542,7 +557,9 @@
                     host.clearChoicePromptBySource(action.source, action.reason || 'icebreaker-bridge');
                 } else if (action.type === 'galgame_handoff' && action.detail) {
                     (function (handoffDetail) {
-                        Promise.resolve(_icebreakerBridgeAppendBarrier).then(function () {
+                        Promise.resolve(_icebreakerBridgeAppendBarrier).then(function (appendStatus) {
+                            if (!appendStatus || appendStatus.succeeded !== true) return;
+                            if (appendStatus.messageId !== String(handoffDetail.messageId || '')) return;
                             window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
                                 detail: handoffDetail
                             }));

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -698,6 +698,7 @@
             || action === 'icebreaker_set_choice_prompt'
             || action === 'icebreaker_clear_choice_prompt'
             || action === 'icebreaker_clear_choice_prompt_source'
+            || action === 'icebreaker_reset_session_state'
             || action === 'icebreaker_galgame_handoff'
             || action === 'icebreaker_choice_selected'
             || action === 'icebreaker_free_text_submitted';
@@ -740,6 +741,17 @@
     I.handleIcebreakerBridgeData = function handleIcebreakerBridgeData(data) {
         if (!data || !data.action) return false;
         if (!I.isIcebreakerBridgeAction(data.action)) return false;
+        // Main-process document reloads invalidate Pet's in-memory activeSession.
+        // This reset is intentionally character-agnostic so retained compact/full
+        // chat renderers cannot keep a terminal handoff that the new Pet cannot serve.
+        if (data.action === 'icebreaker_reset_session_state') {
+            if (I.isDuplicateMessage(data.action, data.timestamp)) return true;
+            clearIcebreakerChoicePromptSourceFromBroadcast(
+                'new_user_icebreaker',
+                data.reason || 'icebreaker-session-reset'
+            );
+            return true;
+        }
         if (!data.lanlan_name) return false;
         if (!I.getCurrentLanlanName()) {
             // Full Chat 的 preload 队列会早于异步配置注入排空。身份未知时不能把

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -1276,6 +1276,10 @@
     pendingIcebreakerBridgeMessages.forEach(function (message) {
         I.handleIcebreakerBridgeData(message);
     });
+    var desktopIcebreakerBridge = window.nekoElectronIcebreakerBridge;
+    if (desktopIcebreakerBridge && typeof desktopIcebreakerBridge.send === 'function') {
+        desktopIcebreakerBridge.send({ action: 'icebreaker_page_ready' });
+    }
     I.yuiGuideInterpageResources.addEventListener(
         window,
         'neko:config-injected',

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -463,6 +463,7 @@
     var _pendingIcebreakerBridgeActions = [];
     var _icebreakerBridgeFlushTimer = null;
     var _icebreakerBridgeFlushAttempts = 0;
+    var _icebreakerBridgeAppendBarrier = Promise.resolve();
     var ICEBREAKER_BRIDGE_FLUSH_MAX_ATTEMPTS = 50;
 
     function scheduleIcebreakerBridgeFlush(delay) {
@@ -512,7 +513,7 @@
             try {
                 if (action.type === 'append' && action.message) {
                     shouldOpenHost = true;
-                    return Promise.resolve(host.appendMessage(action.message)).then(function (result) {
+                    var appendPromise = Promise.resolve(host.appendMessage(action.message)).then(function (result) {
                         if (!result) return result;
                         return waitForIcebreakerChatHostMounted(host).then(function () {
                             syncIcebreakerAssistantCompactCaption(action.message);
@@ -522,6 +523,14 @@
                     }).catch(function (error) {
                         console.warn('[NewUserIcebreaker] Failed to append bridge message:', error);
                     });
+                    // Full Chat lives in an isolated Electron partition. Its final
+                    // handoff signal can arrive while appendMessage is still
+                    // committing the preceding assistant bubble, so retain a
+                    // cross-batch barrier for the semantic handoff below.
+                    _icebreakerBridgeAppendBarrier = Promise.all([
+                        _icebreakerBridgeAppendBarrier,
+                        appendPromise
+                    ]).then(function () {});
                 } else if (action.type === 'set_prompt' && action.prompt && typeof host.setIcebreakerChoicePrompt === 'function') {
                     host.setIcebreakerChoicePrompt(action.prompt);
                     shouldOpenHost = true;
@@ -531,6 +540,16 @@
                         && action.source === 'new_user_icebreaker'
                         && typeof host.clearChoicePromptBySource === 'function') {
                     host.clearChoicePromptBySource(action.source, action.reason || 'icebreaker-bridge');
+                } else if (action.type === 'galgame_handoff' && action.detail) {
+                    (function (handoffDetail) {
+                        Promise.resolve(_icebreakerBridgeAppendBarrier).then(function () {
+                            window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
+                                detail: handoffDetail
+                            }));
+                        }).catch(function (error) {
+                            console.warn('[NewUserIcebreaker] Failed to dispatch GalGame handoff:', error);
+                        });
+                    })(action.detail);
                 }
             } catch (error) {
                 console.warn('[NewUserIcebreaker] Failed to apply bridge action:', action.type, error);
@@ -567,6 +586,14 @@
             type: 'clear_prompt_source',
             source: String(source || ''),
             reason: String(reason || '')
+        });
+    }
+
+    function dispatchIcebreakerGalgameHandoffFromBroadcast(detail) {
+        if (!I.isStandaloneChatPage()) return;
+        queueIcebreakerBridgeAction({
+            type: 'galgame_handoff',
+            detail: detail && typeof detail === 'object' ? detail : {}
         });
     }
 
@@ -654,6 +681,7 @@
             || action === 'icebreaker_set_choice_prompt'
             || action === 'icebreaker_clear_choice_prompt'
             || action === 'icebreaker_clear_choice_prompt_source'
+            || action === 'icebreaker_galgame_handoff'
             || action === 'icebreaker_choice_selected'
             || action === 'icebreaker_free_text_submitted';
     }
@@ -719,6 +747,10 @@
             case 'icebreaker_clear_choice_prompt_source':
                 if (I.isDuplicateMessage(data.action, data.timestamp)) return true;
                 clearIcebreakerChoicePromptSourceFromBroadcast(data.source, data.reason);
+                return true;
+            case 'icebreaker_galgame_handoff':
+                if (I.isDuplicateMessage(data.action, data.timestamp)) return true;
+                dispatchIcebreakerGalgameHandoffFromBroadcast(data.detail || data);
                 return true;
             case 'icebreaker_choice_selected':
                 if (I.isDuplicateMessage(data.action, data.timestamp)) return true;

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -195,6 +195,7 @@
                     case 'icebreaker_append_chat_message':
                     case 'icebreaker_set_choice_prompt':
                     case 'icebreaker_clear_choice_prompt':
+                    case 'icebreaker_clear_choice_prompt_source':
                     case 'icebreaker_reset_session_state':
                     case 'icebreaker_galgame_handoff':
                     case 'icebreaker_choice_selected':

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -195,6 +195,7 @@
                     case 'icebreaker_append_chat_message':
                     case 'icebreaker_set_choice_prompt':
                     case 'icebreaker_clear_choice_prompt':
+                    case 'icebreaker_reset_session_state':
                     case 'icebreaker_galgame_handoff':
                     case 'icebreaker_choice_selected':
                     case 'icebreaker_free_text_submitted': {

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -195,6 +195,7 @@
                     case 'icebreaker_append_chat_message':
                     case 'icebreaker_set_choice_prompt':
                     case 'icebreaker_clear_choice_prompt':
+                    case 'icebreaker_galgame_handoff':
                     case 'icebreaker_choice_selected':
                     case 'icebreaker_free_text_submitted': {
                         I.handleIcebreakerBridgeData(event.data);

--- a/static/app/app-react-chat-window/bootstrap-state-and-geometry.js
+++ b/static/app/app-react-chat-window/bootstrap-state-and-geometry.js
@@ -170,6 +170,7 @@ I.BUNDLE_SRC = '/static/react/neko-chat/neko-chat-window.iife.js';
         _compactToolWheelRotateRequestSeq: 0,
         _compactToolWheelIndexRequestSeq: 0,
         _galgameRequestSeq: 0,
+        pendingIcebreakerGalgameHandoffMessageId: '',
         // 通用 ChoicePrompt 框架。当前承载 mini_game_invite 与新手破冰；
         // galgame mode 仍走 galgameOptions 路径（BC，渐进迁移）。
         // shape: { source, sessionId, gameType, options: [{choice,label}] } | null

--- a/static/app/app-react-chat-window/geometry-and-messages.js
+++ b/static/app/app-react-chat-window/geometry-and-messages.js
@@ -1033,6 +1033,16 @@
         I.syncCompactSurfaceAnchor();
         I.scheduleCompactMinimizeBallTracking();
         I.scheduleMobileContentLayout();
+        if (I.state.galgameModeEnabled) {
+            var seqAtReveal = I.state._galgameRequestSeq;
+            I.waitForAssistantBubblesFlushed(2000).then(function () {
+                if (!I.state.galgameModeEnabled) return;
+                if (I.state._galgameRequestSeq !== seqAtReveal) return;
+                var overlayNow = I.getOverlay();
+                if (!overlayNow || overlayNow.hidden) return;
+                I.fetchPendingIcebreakerGalgameHandoffOrLatest();
+            });
+        }
         return true;
     }
 

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1662,11 +1662,19 @@
         var normalizedSource = String(source || '');
         if (!normalizedSource) return false;
         if (normalizedSource !== 'new_user_icebreaker') return false;
-        if (!I.state.choicePrompt || I.state.choicePrompt.source !== normalizedSource) return false;
+        var hasMatchingPrompt = !!(
+            I.state.choicePrompt
+            && I.state.choicePrompt.source === normalizedSource
+        );
+        var hasPendingHandoff = !!I.state.pendingIcebreakerGalgameHandoffMessageId;
+        if (!hasMatchingPrompt && !hasPendingHandoff) return false;
         if (window.console && typeof window.console.debug === 'function') {
             window.console.debug('[NewUserIcebreaker] clearChoicePromptBySource:', normalizedSource, reason || '');
         }
-        I.state.choicePrompt = null;
+        if (hasMatchingPrompt) {
+            I.state.choicePrompt = null;
+        }
+        I.state.pendingIcebreakerGalgameHandoffMessageId = '';
         if (choicePromptRevealTimer) {
             window.clearTimeout(choicePromptRevealTimer);
             choicePromptRevealTimer = null;

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1216,7 +1216,7 @@
             icebreakerHandoffMessageId: messageId
         } : null;
         // A hidden window may remain closed while the conversation advances.
-        // In that case consume the stale one-shot approval, then use the normal
+        // In that case discard the stale scoped approval, then use the normal
         // latest-turn path instead of suppressing valid newer GalGame options.
         if (handoffOptions && !getRecentGalgameMessageHistory(handoffOptions).length) {
             I.state.pendingIcebreakerGalgameHandoffMessageId = '';
@@ -2077,17 +2077,20 @@
         if (I.state.messages.length > MAX_MESSAGES) {
             I.state.messages = I.state.messages.slice(-MAX_MESSAGES);
         }
+        var clearedIcebreakerHandoff = false;
         if ((normalized.role === 'assistant' || normalized.role === 'user')
                 && !isYuiGuideChatMessage(normalized)
                 && I.state.pendingIcebreakerGalgameHandoffMessageId
                 && String(normalized.id || '') !== I.state.pendingIcebreakerGalgameHandoffMessageId) {
             I.state.pendingIcebreakerGalgameHandoffMessageId = '';
+            clearedIcebreakerHandoff = true;
         }
         // A new user-role message means the conversation has advanced — even
         // when the message came in via voice / proactive / sendTextPayload
         // rather than the React composer. Invalidate any pending GalGame fetch
         // so its response can't render against the old turn context.
-        if (normalized.role === 'user' || isNewUserIcebreakerChatMessage(normalized)) {
+        if (normalized.role === 'user' || isNewUserIcebreakerChatMessage(normalized)
+                || clearedIcebreakerHandoff) {
             I.invalidatePendingGalgameRequest();
         }
         I.renderWindow();

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -973,7 +973,7 @@
             if (next && !requestOptions.suppressRefetch) {
                 var overlay = I.getOverlay();
                 if (overlay && !overlay.hidden) {
-                    I.fetchGalgameOptionsForLatestTurn();
+                    I.fetchPendingIcebreakerGalgameHandoffOrLatest();
                 }
             }
         }
@@ -1029,8 +1029,9 @@
             if (!m) continue;
             if (isYuiGuideChatMessage(m)) continue;
             if (m.role !== 'assistant' && m.role !== 'user') continue;
+            var isApprovedCompletedHandoff = false;
             if (isNewUserIcebreakerChatMessage(m)) {
-                var isApprovedCompletedHandoff = !!(
+                isApprovedCompletedHandoff = !!(
                     icebreakerHandoffMessageId
                     && String(m.id || '') === icebreakerHandoffMessageId
                     && m.role === 'assistant'
@@ -1045,6 +1046,12 @@
                     continue;
                 }
             }
+            // A delayed handoff is valid only while its final bubble is still
+            // the latest conversation turn. Never let its one-shot approval
+            // reach past newer ordinary user/assistant activity.
+            if (icebreakerHandoffMessageId && !collected.length && !isApprovedCompletedHandoff) {
+                return [];
+            }
             var text = '';
             if (Array.isArray(m.blocks)) {
                 for (var j = 0; j < m.blocks.length; j++) {
@@ -1057,6 +1064,10 @@
             text = text.replace(/\[play_music:[^\]]*(\]|$)/g, '').trim();
             if (!text) continue;
             collected.push({ role: m.role, text: text });
+            // The completed icebreaker handoff intentionally seeds GalGame
+            // from its final assistant line alone. Older scripted or ordinary
+            // history belongs to the conversation before this boundary.
+            if (isApprovedCompletedHandoff) break;
         }
         return collected.reverse();
     }
@@ -1191,6 +1202,28 @@
             I.renderWindow();
         });
     }
+
+    I.rememberIcebreakerGalgameHandoff = function rememberIcebreakerGalgameHandoff(messageId) {
+        var normalizedMessageId = String(messageId || '');
+        if (!normalizedMessageId) return false;
+        I.state.pendingIcebreakerGalgameHandoffMessageId = normalizedMessageId;
+        return true;
+    };
+
+    I.fetchPendingIcebreakerGalgameHandoffOrLatest = function fetchPendingIcebreakerGalgameHandoffOrLatest() {
+        var messageId = String(I.state.pendingIcebreakerGalgameHandoffMessageId || '');
+        I.state.pendingIcebreakerGalgameHandoffMessageId = '';
+        var handoffOptions = messageId ? {
+            icebreakerHandoffMessageId: messageId
+        } : null;
+        // A hidden window may remain closed while the conversation advances.
+        // In that case consume the stale one-shot approval, then use the normal
+        // latest-turn path instead of suppressing valid newer GalGame options.
+        if (handoffOptions && !getRecentGalgameMessageHistory(handoffOptions).length) {
+            handoffOptions = null;
+        }
+        I.fetchGalgameOptionsForLatestTurn(handoffOptions || undefined);
+    };
 
     I.handleGalgameModeToggle = function handleGalgameModeToggle() {
         if (I.isHomeTutorialInteractionLocked()) {
@@ -1808,6 +1841,12 @@
             }).filter(Boolean)
             : [];
         I.state.messages = I.sortMessages(normalized);
+        if (I.state.pendingIcebreakerGalgameHandoffMessageId
+                && !I.state.messages.some(function (message) {
+                    return String(message.id || '') === I.state.pendingIcebreakerGalgameHandoffMessageId;
+                })) {
+            I.state.pendingIcebreakerGalgameHandoffMessageId = '';
+        }
         I._sortKeySeq = nextSortKey;
         if (I.state.messages.length > MAX_MESSAGES) {
             I.state.messages = I.state.messages.slice(-MAX_MESSAGES);
@@ -2030,6 +2069,10 @@
         if (I.state.messages.length > MAX_MESSAGES) {
             I.state.messages = I.state.messages.slice(-MAX_MESSAGES);
         }
+        if (I.state.pendingIcebreakerGalgameHandoffMessageId
+                && String(normalized.id || '') !== I.state.pendingIcebreakerGalgameHandoffMessageId) {
+            I.state.pendingIcebreakerGalgameHandoffMessageId = '';
+        }
         // A new user-role message means the conversation has advanced — even
         // when the message came in via voice / proactive / sendTextPayload
         // rather than the React composer. Invalidate any pending GalGame fetch
@@ -2088,6 +2131,7 @@
 
     I.clearMessages = function clearMessages() {
         I.state.messages = [];
+        I.state.pendingIcebreakerGalgameHandoffMessageId = '';
         I._sortKeySeq = 0;
         I.invalidatePendingGalgameRequest();
         // 角色切换 / cloud reload 等触发 clearMessages 的路径也必须清掉 mini-game

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1020,6 +1020,8 @@
     }
 
     function getRecentGalgameMessageHistory() {
+        var requestOptions = arguments[0] && typeof arguments[0] === 'object' ? arguments[0] : {};
+        var icebreakerHandoffMessageId = String(requestOptions.icebreakerHandoffMessageId || '');
         var msgs = Array.isArray(I.state.messages) ? I.state.messages : [];
         var collected = [];
         for (var i = msgs.length - 1; i >= 0 && collected.length < I.GALGAME_HISTORY_LIMIT; i--) {
@@ -1028,11 +1030,20 @@
             if (isYuiGuideChatMessage(m)) continue;
             if (m.role !== 'assistant' && m.role !== 'user') continue;
             if (isNewUserIcebreakerChatMessage(m)) {
+                var isApprovedCompletedHandoff = !!(
+                    icebreakerHandoffMessageId
+                    && String(m.id || '') === icebreakerHandoffMessageId
+                    && m.role === 'assistant'
+                );
                 // While the latest conversation turn belongs to the scripted
                 // icebreaker, do not fall back to an older ordinary assistant
-                // turn and generate unrelated GalGame choices for it.
-                if (!collected.length) return [];
-                continue;
+                // turn and generate unrelated GalGame choices for it. The sole
+                // exception is the final handoff line explicitly released by the
+                // completed icebreaker session; that one line seeds GalGame once.
+                if (!isApprovedCompletedHandoff) {
+                    if (!collected.length) return [];
+                    continue;
+                }
             }
             var text = '';
             if (Array.isArray(m.blocks)) {
@@ -1076,6 +1087,7 @@
     }
 
     I.fetchGalgameOptionsForLatestTurn = function fetchGalgameOptionsForLatestTurn() {
+        var requestOptions = arguments[0] && typeof arguments[0] === 'object' ? arguments[0] : {};
         if (isGalgameModeTemporarilyDisabled()) return;
         if (!I.state.galgameModeEnabled) return;
         // icebreaker 脚本选项激活期间不抢选项槽——含揭示延迟内 prompt 已就位、按钮尚未
@@ -1084,7 +1096,7 @@
         // （Codex P2）。icebreaker 运行在 home tutorial 之外，galgameTemporarilyDisabled
         // 此时并不覆盖它，故须单独按 choicePrompt 拦。
         if (I.state.choicePrompt && I.state.choicePrompt.source === 'new_user_icebreaker') return;
-        var history = getRecentGalgameMessageHistory();
+        var history = getRecentGalgameMessageHistory(requestOptions);
         if (!history.length) return;
         if (history[history.length - 1].role !== 'assistant') return;
 

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1212,7 +1212,6 @@
 
     I.fetchPendingIcebreakerGalgameHandoffOrLatest = function fetchPendingIcebreakerGalgameHandoffOrLatest() {
         var messageId = String(I.state.pendingIcebreakerGalgameHandoffMessageId || '');
-        I.state.pendingIcebreakerGalgameHandoffMessageId = '';
         var handoffOptions = messageId ? {
             icebreakerHandoffMessageId: messageId
         } : null;
@@ -1220,6 +1219,7 @@
         // In that case consume the stale one-shot approval, then use the normal
         // latest-turn path instead of suppressing valid newer GalGame options.
         if (handoffOptions && !getRecentGalgameMessageHistory(handoffOptions).length) {
+            I.state.pendingIcebreakerGalgameHandoffMessageId = '';
             handoffOptions = null;
         }
         I.fetchGalgameOptionsForLatestTurn(handoffOptions || undefined);
@@ -2069,7 +2069,9 @@
         if (I.state.messages.length > MAX_MESSAGES) {
             I.state.messages = I.state.messages.slice(-MAX_MESSAGES);
         }
-        if (I.state.pendingIcebreakerGalgameHandoffMessageId
+        if ((normalized.role === 'assistant' || normalized.role === 'user')
+                && !isYuiGuideChatMessage(normalized)
+                && I.state.pendingIcebreakerGalgameHandoffMessageId
                 && String(normalized.id || '') !== I.state.pendingIcebreakerGalgameHandoffMessageId) {
             I.state.pendingIcebreakerGalgameHandoffMessageId = '';
         }

--- a/static/app/app-react-chat-window/minimize-and-idle-dock.js
+++ b/static/app/app-react-chat-window/minimize-and-idle-dock.js
@@ -2032,7 +2032,7 @@
                         if (I.state._galgameRequestSeq !== seqAtOpen) return;
                         var overlayNow = I.getOverlay();
                         if (!overlayNow || overlayNow.hidden) return;
-                        I.fetchGalgameOptionsForLatestTurn();
+                        I.fetchPendingIcebreakerGalgameHandoffOrLatest();
                     });
                 }
             })

--- a/static/app/app-react-chat-window/resize-drag-and-api.js
+++ b/static/app/app-react-chat-window/resize-drag-and-api.js
@@ -523,10 +523,12 @@
                 ? event.detail
                 : {};
             var messageId = String(detail.messageId || '');
-            if (!messageId || !I.state.galgameModeEnabled) return;
+            if (!messageId) return;
             if (detail.sessionId) {
                 I.clearIcebreakerChoicePrompt(String(detail.sessionId));
             }
+            I.rememberIcebreakerGalgameHandoff(messageId);
+            if (!I.state.galgameModeEnabled) return;
             var overlay = I.getOverlay();
             if (!overlay || overlay.hidden) return;
             var seqAtSchedule = I.state._galgameRequestSeq;
@@ -535,9 +537,8 @@
                 if (I.state._galgameRequestSeq !== seqAtSchedule) return;
                 var overlayNow = I.getOverlay();
                 if (!overlayNow || overlayNow.hidden) return;
-                I.fetchGalgameOptionsForLatestTurn({
-                    icebreakerHandoffMessageId: messageId
-                });
+                if (I.state.pendingIcebreakerGalgameHandoffMessageId !== messageId) return;
+                I.fetchPendingIcebreakerGalgameHandoffOrLatest();
             });
         });
 

--- a/static/app/app-react-chat-window/resize-drag-and-api.js
+++ b/static/app/app-react-chat-window/resize-drag-and-api.js
@@ -518,6 +518,29 @@
             I.clearChoicePromptBySource('new_user_icebreaker', 'new-user-icebreaker-reset');
         });
 
+        window.addEventListener('neko:icebreaker-galgame-handoff', function (event) {
+            var detail = event && event.detail && typeof event.detail === 'object'
+                ? event.detail
+                : {};
+            var messageId = String(detail.messageId || '');
+            if (!messageId || !I.state.galgameModeEnabled) return;
+            if (detail.sessionId) {
+                I.clearIcebreakerChoicePrompt(String(detail.sessionId));
+            }
+            var overlay = I.getOverlay();
+            if (!overlay || overlay.hidden) return;
+            var seqAtSchedule = I.state._galgameRequestSeq;
+            I.waitForAssistantBubblesFlushed(4000).then(function () {
+                if (!I.state.galgameModeEnabled) return;
+                if (I.state._galgameRequestSeq !== seqAtSchedule) return;
+                var overlayNow = I.getOverlay();
+                if (!overlayNow || overlayNow.hidden) return;
+                I.fetchGalgameOptionsForLatestTurn({
+                    icebreakerHandoffMessageId: messageId
+                });
+            });
+        });
+
         function isNewUserIcebreakerTurnEndEvent(event) {
             var detail = event && event.detail && typeof event.detail === 'object'
                 ? event.detail

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -1687,6 +1687,7 @@
         if (decision.action === 'release') {
             var releaseText = decision.reply || getText(localeData, fallback.releaseKey);
             var releaseVoiceKey = fallback.releaseVoiceKey || '';
+            var releaseMessage = null;
             recordFreeTextTurn(session, {
                 userText: info.userText,
                 action: 'release',
@@ -1702,6 +1703,7 @@
                 requestId: info.requestId || ''
             }, session).then(function (message) {
                 if (!didAppendChatMessage(message)) return false;
+                releaseMessage = message;
                 return true;
             }) : Promise.resolve(activeSession === session);
             return releaseAppend.then(function (didAppendRelease) {
@@ -1729,6 +1731,9 @@
                 });
                 if (activeSession === session) {
                     activeSession = null;
+                }
+                if (releaseMessage) {
+                    dispatchIcebreakerGalgameHandoff(session, releaseMessage);
                 }
                 dispatchIcebreakerEnded('free_text_release');
                 return true;

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -219,6 +219,25 @@
         } catch (_) {}
     }
 
+    function dispatchIcebreakerGalgameHandoff(session, message) {
+        if (!session || !message || !message.id) return;
+        var detail = {
+            sessionId: String(session.sessionId || ''),
+            messageId: String(message.id),
+            lanlanName: resolveSessionLanlanName(session)
+        };
+        try {
+            window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
+                detail: detail
+            }));
+        } catch (_) {}
+        broadcastIcebreaker(null, {
+            action: 'icebreaker_galgame_handoff',
+            detail: detail,
+            lanlan_name: detail.lanlanName
+        });
+    }
+
     function endIcebreakerRoute(session, reason) {
         if (!session || session.routeEnded) return Promise.resolve(false);
         session.routeEnded = true;
@@ -1482,6 +1501,7 @@
         var sessionId = session.sessionId;
         var handoffSpeechPromise = Promise.resolve(false);
         var handoffDelivered = false;
+        var handoffMessage = null;
         return appendAssistantChatMessage(text, {
             day: day,
             nodeId: nodeId,
@@ -1490,6 +1510,7 @@
         }, session).then(function (message) {
             if (!didAppendChatMessage(message)) return false;
             handoffDelivered = true;
+            handoffMessage = message;
             clearChoicePrompt();
             applyAssistantTextEmotion(text);
             handoffSpeechPromise = speakLine(text, option.handoffVoiceKey || '');
@@ -1513,6 +1534,7 @@
             if (activeSession === session) {
                 activeSession = null;
             }
+            dispatchIcebreakerGalgameHandoff(session, handoffMessage);
             dispatchIcebreakerEnded('handoff');
             return true;
         });

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -866,6 +866,15 @@ test('app interpage recognizes explicit Yui guide dedup bypass messages', () => 
     assert.match(source, /shouldBypassYuiGuideMessageDedup\(event\.data\.action,\s*event\.data\)/);
 });
 
+test('app interpage acknowledges Electron icebreaker hydration after draining startup messages', () => {
+    const source = readJsParts(path.join(repoRoot, 'static', 'app/app-interpage'));
+
+    assert.match(
+        source,
+        /window\.__nekoIcebreakerBridgeReady = true;[\s\S]*?pendingIcebreakerBridgeMessages\.forEach\([\s\S]*?nekoElectronIcebreakerBridge[\s\S]*?send\(\{ action: 'icebreaker_page_ready' \}\)/
+    );
+});
+
 test('app interpage sends external chat pet reports through the command bus', () => {
     const source = readJsParts(path.join(repoRoot, 'static', 'app/app-interpage'));
     const bridgeDataBlock = source.split('    function handleYuiGuideChatBridgeData(data) {')[1].split(

--- a/tests/frontend/test_galgame_voice_idle.py
+++ b/tests/frontend/test_galgame_voice_idle.py
@@ -304,6 +304,42 @@ def test_full_chat_electron_bridge_waits_for_handoff_bubble_before_galgame(
         {"role": "assistant", "text": "完整聊天框破冰收尾台词"}
     ]
 
+    mock_page.evaluate(
+        """
+        () => {
+            const timestamp = Date.now();
+            const channel = new BroadcastChannel('neko_page_channel');
+            window.__icebreakerTestBroadcastChannel = channel;
+            channel.postMessage({
+                action: 'icebreaker_append_chat_message',
+                lanlan_name: 'yui',
+                message: {
+                    id: 'icebreaker-assistant-broadcast-final',
+                    role: 'assistant',
+                    blocks: [{ type: 'text', text: 'BroadcastChannel 收尾台词' }],
+                    icebreaker: { source: 'new_user_icebreaker', handoff: true }
+                },
+                timestamp
+            });
+            channel.postMessage({
+                action: 'icebreaker_galgame_handoff',
+                lanlan_name: 'yui',
+                detail: {
+                    sessionId: 'broadcast-session-1',
+                    messageId: 'icebreaker-assistant-broadcast-final'
+                },
+                timestamp: timestamp + 1
+            });
+        }
+        """
+    )
+    mock_page.wait_for_timeout(1200)
+
+    assert len(galgame_payloads) == 2
+    assert galgame_payloads[1]["messages"] == [
+        {"role": "assistant", "text": "BroadcastChannel 收尾台词"}
+    ]
+
 
 @pytest.mark.frontend
 def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
@@ -320,7 +356,7 @@ def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
         )
 
     mock_page.route("**/api/galgame/options", _handle)
-    mock_page.goto(f"{running_server}/", wait_until="domcontentloaded")
+    mock_page.goto(f"{running_server}/chat_full", wait_until="domcontentloaded")
     mock_page.wait_for_function(
         """() => !!(
             window.reactChatWindowHost
@@ -333,6 +369,7 @@ def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
     mock_page.evaluate(
         """
         () => {
+            window.appState.lanlan_name = 'yui';
             window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
                 detail: { page: 'home' }
             }));
@@ -352,6 +389,12 @@ def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
                     messageId: 'icebreaker-assistant-hidden-final'
                 }
             }));
+            host.appendMessage({
+                id: 'yui-guide-after-hidden-handoff',
+                role: 'assistant',
+                source: 'yui_guide',
+                blocks: [{ type: 'text', text: '不应使交接失效的引导消息' }]
+            });
         }
         """
     )
@@ -364,6 +407,16 @@ def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
     assert [payload["messages"] for payload in galgame_payloads] == [[
         {"role": "assistant", "text": "隐藏期间的破冰收尾"}
     ]]
+
+    mock_page.evaluate("() => window.reactChatWindowHost.closeWindow()")
+    mock_page.wait_for_timeout(350)
+    mock_page.evaluate("() => window.reactChatWindowHost.openWindow()")
+    mock_page.wait_for_timeout(1200)
+
+    assert [payload["messages"] for payload in galgame_payloads] == [
+        [{"role": "assistant", "text": "隐藏期间的破冰收尾"}],
+        [{"role": "assistant", "text": "隐藏期间的破冰收尾"}],
+    ]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_galgame_voice_idle.py
+++ b/tests/frontend/test_galgame_voice_idle.py
@@ -490,6 +490,76 @@ def test_delayed_icebreaker_handoff_does_not_cross_a_newer_turn(
 
 
 @pytest.mark.frontend
+def test_inflight_icebreaker_handoff_is_aborted_by_newer_assistant(
+    mock_page: Page, running_server: str
+):
+    mock_page.goto(f"{running_server}/chat_full", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        """() => !!(
+            window.reactChatWindowHost
+            && window.reactChatWindowHost.isMounted
+            && window.reactChatWindowHost.isMounted()
+        )""",
+        timeout=10000,
+    )
+
+    mock_page.evaluate(
+        """() => {
+            window.appState.lanlan_name = 'yui';
+            window.__resolveIcebreakerOptions = null;
+            const nativeFetch = window.fetch.bind(window);
+            window.fetch = (url, options) => {
+                if (!String(url).includes('/api/galgame/options')) {
+                    return nativeFetch(url, options);
+                }
+                return new Promise((resolve) => {
+                    window.__resolveIcebreakerOptions = resolve;
+                });
+            };
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
+            host.setMessages([{
+                id: 'icebreaker-assistant-inflight-final',
+                role: 'assistant',
+                blocks: [{ type: 'text', text: '即将过时的破冰收尾' }]
+            }]);
+            document.getElementById('react-chat-window-overlay').hidden = false;
+            window._realisticGeminiQueue = [];
+            window._isProcessingRealisticQueue = false;
+            window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
+                detail: {
+                    sessionId: 'icebreaker-inflight-session',
+                    messageId: 'icebreaker-assistant-inflight-final'
+                }
+            }));
+        }"""
+    )
+    mock_page.wait_for_function("() => typeof window.__resolveIcebreakerOptions === 'function'")
+    mock_page.evaluate(
+        """() => {
+            window.reactChatWindowHost.appendMessage({
+                id: 'ordinary-assistant-after-handoff',
+                role: 'assistant',
+                blocks: [{ type: 'text', text: '新的主动对话' }]
+            });
+            window.__resolveIcebreakerOptions({
+                ok: true,
+                json: () => Promise.resolve({
+                    options: [{ label: 'A', text: '不应出现的旧选项' }]
+                })
+            });
+        }"""
+    )
+    mock_page.wait_for_timeout(300)
+
+    assert mock_page.locator(".composer-galgame-option").count() == 0
+    assert "不应出现的旧选项" not in mock_page.locator("body").inner_text()
+
+
+@pytest.mark.frontend
 @pytest.mark.parametrize("append_failure", ["throw", "reject", "null"])
 def test_full_chat_bridge_drops_handoff_when_final_bubble_append_fails(
     mock_page: Page, running_server: str, append_failure: str

--- a/tests/frontend/test_galgame_voice_idle.py
+++ b/tests/frontend/test_galgame_voice_idle.py
@@ -418,6 +418,26 @@ def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
         [{"role": "assistant", "text": "隐藏期间的破冰收尾"}],
     ]
 
+    mock_page.evaluate(
+        """() => window.dispatchEvent(new CustomEvent(
+            'neko:electron-icebreaker-bridge',
+            { detail: {
+                action: 'icebreaker_reset_session_state',
+                timestamp: Date.now(),
+                reason: 'storage-maintenance-reload'
+            } }
+        ))"""
+    )
+    mock_page.evaluate("() => window.reactChatWindowHost.closeWindow()")
+    mock_page.wait_for_timeout(350)
+    mock_page.evaluate("() => window.reactChatWindowHost.openWindow()")
+    mock_page.wait_for_timeout(1200)
+
+    assert [payload["messages"] for payload in galgame_payloads] == [
+        [{"role": "assistant", "text": "隐藏期间的破冰收尾"}],
+        [{"role": "assistant", "text": "隐藏期间的破冰收尾"}],
+    ]
+
 
 @pytest.mark.frontend
 def test_delayed_icebreaker_handoff_does_not_cross_a_newer_turn(

--- a/tests/frontend/test_galgame_voice_idle.py
+++ b/tests/frontend/test_galgame_voice_idle.py
@@ -156,11 +156,23 @@ def test_completed_icebreaker_handoff_seeds_visible_galgame_options(
             }));
             const host = window.reactChatWindowHost;
             host.setGalgameModeEnabled(true, { persist: false, force: true });
-            host.setMessages([{
-                id: 'icebreaker-assistant-final',
-                role: 'assistant',
-                blocks: [{ type: 'text', text: '破冰收尾台词' }]
-            }]);
+            host.setMessages([
+                {
+                    id: 'ordinary-before-icebreaker',
+                    role: 'assistant',
+                    blocks: [{ type: 'text', text: '不应进入请求的旧对话' }]
+                },
+                {
+                    id: 'icebreaker-user-before-final',
+                    role: 'user',
+                    blocks: [{ type: 'text', text: '不应进入请求的破冰对话' }]
+                },
+                {
+                    id: 'icebreaker-assistant-final',
+                    role: 'assistant',
+                    blocks: [{ type: 'text', text: '破冰收尾台词' }]
+                }
+            ]);
             host.setIcebreakerChoicePrompt({
                 sessionId: 'icebreaker-session-1',
                 options: [{ choice: 'A', label: '最后一个选择' }]
@@ -291,3 +303,181 @@ def test_full_chat_electron_bridge_waits_for_handoff_bubble_before_galgame(
     assert galgame_payloads[0]["messages"] == [
         {"role": "assistant", "text": "完整聊天框破冰收尾台词"}
     ]
+
+
+@pytest.mark.frontend
+def test_hidden_icebreaker_handoff_is_consumed_when_chat_reopens(
+    mock_page: Page, running_server: str
+):
+    galgame_payloads = []
+
+    def _handle(route: Route):
+        galgame_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"success": true, "options": [{"label": "A", "text": "x"}]}',
+        )
+
+    mock_page.route("**/api/galgame/options", _handle)
+    mock_page.goto(f"{running_server}/", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        """() => !!(
+            window.reactChatWindowHost
+            && window.reactChatWindowHost.isMounted
+            && window.reactChatWindowHost.isMounted()
+        )""",
+        timeout=10000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
+            host.setMessages([{
+                id: 'icebreaker-assistant-hidden-final',
+                role: 'assistant',
+                blocks: [{ type: 'text', text: '隐藏期间的破冰收尾' }]
+            }]);
+            document.getElementById('react-chat-window-overlay').hidden = true;
+            window._realisticGeminiQueue = [];
+            window._isProcessingRealisticQueue = false;
+            window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
+                detail: {
+                    sessionId: 'icebreaker-hidden-session',
+                    messageId: 'icebreaker-assistant-hidden-final'
+                }
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_timeout(300)
+    assert galgame_payloads == []
+
+    mock_page.evaluate("() => window.reactChatWindowHost.openWindow()")
+    mock_page.wait_for_timeout(1200)
+
+    assert [payload["messages"] for payload in galgame_payloads] == [[
+        {"role": "assistant", "text": "隐藏期间的破冰收尾"}
+    ]]
+
+
+@pytest.mark.frontend
+def test_delayed_icebreaker_handoff_does_not_cross_a_newer_turn(
+    mock_page: Page, running_server: str
+):
+    galgame_payloads = []
+
+    def _handle(route: Route):
+        galgame_payloads.append(route.request.post_data_json)
+        route.fulfill(status=200, content_type="application/json", body='{"options": []}')
+
+    mock_page.route("**/api/galgame/options", _handle)
+    mock_page.goto(f"{running_server}/", wait_until="domcontentloaded")
+    mock_page.wait_for_function("() => !!window.reactChatWindowHost", timeout=10000)
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
+            host.setMessages([
+                {
+                    id: 'icebreaker-assistant-delayed-final',
+                    role: 'assistant',
+                    blocks: [{ type: 'text', text: '已经过时的收尾' }]
+                },
+                {
+                    id: 'ordinary-user-after-handoff',
+                    role: 'user',
+                    blocks: [{ type: 'text', text: '后续消息' }]
+                }
+            ]);
+            document.getElementById('react-chat-window-overlay').hidden = false;
+            window._realisticGeminiQueue = [];
+            window._isProcessingRealisticQueue = false;
+            window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
+                detail: {
+                    sessionId: 'icebreaker-delayed-session',
+                    messageId: 'icebreaker-assistant-delayed-final'
+                }
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_timeout(700)
+
+    assert galgame_payloads == []
+
+
+@pytest.mark.frontend
+@pytest.mark.parametrize("append_failure", ["throw", "reject", "null"])
+def test_full_chat_bridge_drops_handoff_when_final_bubble_append_fails(
+    mock_page: Page, running_server: str, append_failure: str
+):
+    galgame_payloads = []
+
+    def _handle(route: Route):
+        galgame_payloads.append(route.request.post_data_json)
+        route.fulfill(status=200, content_type="application/json", body='{"options": []}')
+
+    mock_page.route("**/api/galgame/options", _handle)
+    mock_page.goto(f"{running_server}/chat_full", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        """() => !!(
+            window.reactChatWindowHost
+            && window.reactChatWindowHost.isMounted
+            && window.reactChatWindowHost.isMounted()
+            && window.__nekoIcebreakerBridgeReady
+        )""",
+        timeout=10000,
+    )
+
+    mock_page.evaluate(
+        """(failure) => {
+            window.appState.lanlan_name = 'yui';
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
+            document.getElementById('react-chat-window-overlay').hidden = false;
+            host.appendMessage = () => {
+                if (failure === 'throw') throw new Error('sync append failure');
+                if (failure === 'reject') return Promise.reject(new Error('async append failure'));
+                return null;
+            };
+            const messageId = `icebreaker-assistant-failed-${failure}`;
+            const timestamp = Date.now();
+            window.dispatchEvent(new CustomEvent('neko:electron-icebreaker-bridge', {
+                detail: {
+                    action: 'icebreaker_append_chat_message',
+                    lanlan_name: 'yui',
+                    message: {
+                        id: messageId,
+                        role: 'assistant',
+                        blocks: [{ type: 'text', text: '不会成功追加' }]
+                    },
+                    timestamp
+                }
+            }));
+            window.dispatchEvent(new CustomEvent('neko:electron-icebreaker-bridge', {
+                detail: {
+                    action: 'icebreaker_galgame_handoff',
+                    lanlan_name: 'yui',
+                    detail: { sessionId: 'failed-session', messageId },
+                    timestamp: timestamp + 1
+                }
+            }));
+        }""",
+        append_failure,
+    )
+    mock_page.wait_for_timeout(700)
+
+    assert galgame_payloads == []

--- a/tests/frontend/test_galgame_voice_idle.py
+++ b/tests/frontend/test_galgame_voice_idle.py
@@ -36,7 +36,12 @@ def test_galgame_options_gated_by_chat_window_visibility(
 
     mock_page.goto(f"{running_server}/", wait_until="domcontentloaded")
     mock_page.wait_for_function(
-        "() => !!(window.appState && window.reactChatWindowHost)",
+        """() => !!(
+            window.appState
+            && window.reactChatWindowHost
+            && window.reactChatWindowHost.isMounted
+            && window.reactChatWindowHost.isMounted()
+        )""",
         timeout=10000,
     )
 
@@ -49,7 +54,7 @@ def test_galgame_options_gated_by_chat_window_visibility(
                 window.dispatchEvent(new CustomEvent(name, { detail: { page: 'home' } }));
             });
             const host = window.reactChatWindowHost;
-            host.setGalgameModeEnabled(true, { persist: false });
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
             // 注入一段以 assistant 结尾的历史 —— 这样「没发请求」不会被归因到
             // history 为空，而唯一归因到 overlay.hidden 这道关。
             host.setMessages([
@@ -57,6 +62,7 @@ def test_galgame_options_gated_by_chat_window_visibility(
                 { id: 'a1', role: 'assistant', blocks: [{ type: 'text', text: '在的呀' }] },
             ]);
             const overlay = document.getElementById('react-chat-window-overlay');
+            if (overlay) overlay.hidden = true;
             return {
                 galgameEnabled: host.isGalgameModeEnabled(),
                 overlayHidden: !overlay || overlay.hidden,
@@ -86,6 +92,13 @@ def test_galgame_options_gated_by_chat_window_visibility(
     mock_page.evaluate(
         """
         () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            window.reactChatWindowHost.setGalgameModeEnabled(true, {
+                persist: false,
+                force: true
+            });
             // 直接揭开 overlay（不走完整 openWindow，避免 React bundle 异步 mount
             // 的时序）—— turn-end handler 只读 overlay.hidden。
             document.getElementById('react-chat-window-overlay').hidden = false;
@@ -102,3 +115,179 @@ def test_galgame_options_gated_by_chat_window_visibility(
     assert any("/api/galgame/options" in url for url in galgame_requests), (
         f"对照失败：overlay 可见时 turn-end 应触发选项生成，实际: {galgame_requests}"
     )
+
+
+@pytest.mark.frontend
+def test_completed_icebreaker_handoff_seeds_visible_galgame_options(
+    mock_page: Page, running_server: str
+):
+    galgame_payloads = []
+
+    def _handle(route: Route):
+        galgame_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=(
+                '{"success": true, "options": ['
+                '{"label": "A", "text": "x"},'
+                '{"label": "B", "text": "y"},'
+                '{"label": "C", "text": "z"}]}'
+            ),
+        )
+
+    mock_page.route("**/api/galgame/options", _handle)
+    mock_page.goto(f"{running_server}/", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        """() => !!(
+            window.appState
+            && window.reactChatWindowHost
+            && window.reactChatWindowHost.isMounted
+            && window.reactChatWindowHost.isMounted()
+        )""",
+        timeout=10000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
+                detail: { page: 'home' }
+            }));
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
+            host.setMessages([{
+                id: 'icebreaker-assistant-final',
+                role: 'assistant',
+                blocks: [{ type: 'text', text: '破冰收尾台词' }]
+            }]);
+            host.setIcebreakerChoicePrompt({
+                sessionId: 'icebreaker-session-1',
+                options: [{ choice: 'A', label: '最后一个选择' }]
+            });
+            document.getElementById('react-chat-window-overlay').hidden = false;
+            window._realisticGeminiQueue = [];
+            window._isProcessingRealisticQueue = false;
+            window.dispatchEvent(new CustomEvent('neko-assistant-turn-end', {
+                detail: { source: 'new_user_icebreaker', timestamp: Date.now() }
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_timeout(500)
+    assert galgame_payloads == [], "普通破冰 turn-end 仍应被 GalGame 隔离"
+
+    mock_page.evaluate(
+        """
+        () => {
+            // 页面其余首启脚本可能在 domcontentloaded 后才真正拉起教程；在主张前
+            // 再释放一次，避免测试把异步教程锁误判成交接失败。
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            window.reactChatWindowHost.setGalgameModeEnabled(true, {
+                persist: false,
+                force: true
+            });
+            document.getElementById('react-chat-window-overlay').hidden = false;
+            window.dispatchEvent(new CustomEvent('neko:icebreaker-galgame-handoff', {
+                detail: {
+                    sessionId: 'icebreaker-session-1',
+                    messageId: 'icebreaker-assistant-final'
+                }
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_timeout(1200)
+
+    assert len(galgame_payloads) == 1
+    assert galgame_payloads[0]["messages"] == [
+        {"role": "assistant", "text": "破冰收尾台词"}
+    ]
+
+
+@pytest.mark.frontend
+def test_full_chat_electron_bridge_waits_for_handoff_bubble_before_galgame(
+    mock_page: Page, running_server: str
+):
+    galgame_payloads = []
+
+    def _handle(route: Route):
+        galgame_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=(
+                '{"success": true, "options": ['
+                '{"label": "A", "text": "x"},'
+                '{"label": "B", "text": "y"},'
+                '{"label": "C", "text": "z"}]}'
+            ),
+        )
+
+    mock_page.route("**/api/galgame/options", _handle)
+    mock_page.goto(f"{running_server}/chat_full", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        """() => !!(
+            window.appState
+            && window.reactChatWindowHost
+            && window.reactChatWindowHost.isMounted
+            && window.reactChatWindowHost.isMounted()
+            && window.__nekoIcebreakerBridgeReady
+        )""",
+        timeout=10000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.appState.lanlan_name = 'yui';
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' }
+            }));
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false, force: true });
+            document.getElementById('react-chat-window-overlay').hidden = false;
+
+            const timestamp = Date.now();
+            const finalMessage = {
+                id: 'icebreaker-assistant-full-final',
+                role: 'assistant',
+                blocks: [{ type: 'text', text: '完整聊天框破冰收尾台词' }],
+                icebreaker: {
+                    source: 'new_user_icebreaker',
+                    sessionId: 'full-chat-session-1',
+                    handoff: true
+                }
+            };
+            window.dispatchEvent(new CustomEvent('neko:electron-icebreaker-bridge', {
+                detail: {
+                    action: 'icebreaker_append_chat_message',
+                    lanlan_name: 'yui',
+                    message: finalMessage,
+                    timestamp
+                }
+            }));
+            // Electron IPC sends this immediately after the append message. The
+            // Full Chat bridge must delay it until appendMessage has committed.
+            window.dispatchEvent(new CustomEvent('neko:electron-icebreaker-bridge', {
+                detail: {
+                    action: 'icebreaker_galgame_handoff',
+                    lanlan_name: 'yui',
+                    detail: {
+                        sessionId: 'full-chat-session-1',
+                        messageId: 'icebreaker-assistant-full-final'
+                    },
+                    timestamp: timestamp + 1
+                }
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_timeout(1500)
+
+    assert len(galgame_payloads) == 1
+    assert galgame_payloads[0]["messages"] == [
+        {"role": "assistant", "text": "完整聊天框破冰收尾台词"}
+    ]

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -5862,6 +5862,130 @@ def test_interrupted_icebreaker_ignores_another_characters_snapshot(mock_page: P
 
 
 @pytest.mark.frontend
+def test_icebreaker_free_text_release_dispatches_galgame_handoff_for_release_message(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.appState = { lanlan_name: 'yui' };
+            window.__NEKO_MULTI_WINDOW__ = true;
+            window.__icebreakerBridgeEvents = [];
+            window.__routeEndCount = 0;
+            window.nekoElectronIcebreakerBridge = {
+                send: (message) => window.__icebreakerBridgeEvents.push(message),
+            };
+            window.nekoLocalMutationSecurity = {
+                getMutationHeaders: async () => ({ 'X-CSRF-Token': 'test-token' }),
+            };
+            localStorage.setItem('i18nextLng', 'en');
+        """,
+        fetch_js="""
+            if (requestUrl === '/static/tutorial/icebreaker/icebreaker_scripts.json') {
+                return jsonResponse({
+                    days: {
+                        '1': {
+                            root: 'root',
+                            fallback: {
+                                releaseKey: 'fallback.release',
+                                releaseVoiceKey: 'fallback.release.voice',
+                            },
+                            nodes: {
+                                root: {
+                                    lineKey: 'root.line',
+                                    options: [{ id: 'A', labelKey: 'root.A', next: 'root' }],
+                                },
+                            },
+                        },
+                    },
+                });
+            }
+            if (requestUrl === '/static/tutorial/icebreaker/locales/en.json') {
+                return jsonResponse({
+                    'root.line': 'Question',
+                    'root.A': 'Answer',
+                    'fallback.release': 'Let us continue normally.',
+                });
+            }
+            if (requestUrl === '/api/icebreaker/route/start' && method === 'POST') {
+                return jsonResponse({ ok: true });
+            }
+            if (requestUrl === '/api/icebreaker/context' && method === 'POST') {
+                return jsonResponse({ ok: true });
+            }
+            if (requestUrl === '/api/icebreaker/free-text/interpret' && method === 'POST') {
+                return jsonResponse({
+                    ok: true,
+                    action: 'release',
+                    choice: '',
+                    reply: 'Let us continue normally.',
+                    topic_state: 'soft_derail',
+                });
+            }
+            if (requestUrl === '/api/icebreaker/route/end' && method === 'POST') {
+                window.__routeEndCount += 1;
+                return jsonResponse({ ok: true });
+            }
+            if (requestUrl === '/api/icebreaker/speak' && method === 'POST') {
+                return jsonResponse({ ok: true });
+            }
+        """,
+        script_names=(
+            "tutorial/icebreaker/free-text-runtime.js",
+            "tutorial/icebreaker/new-user-icebreaker.js",
+        ),
+    )
+
+    mock_page.evaluate("() => window.newUserIcebreaker.start(1)")
+    mock_page.wait_for_function(
+        """() => window.__icebreakerBridgeEvents.some(
+            (event) => event.action === 'icebreaker_set_choice_prompt'
+        )"""
+    )
+    session_id = mock_page.evaluate("() => window.newUserIcebreaker.getActiveSession().sessionId")
+    mock_page.evaluate(
+        """(sessionId) => window.dispatchEvent(new CustomEvent(
+            'neko:icebreaker-free-text-submitted',
+            { detail: { sessionId, text: '聊点别的', requestId: 'free-release-1' } }
+        ))""",
+        session_id,
+    )
+    mock_page.wait_for_function(
+        """() => window.__icebreakerBridgeEvents.some(
+            (event) => event.action === 'icebreaker_galgame_handoff'
+        )"""
+    )
+
+    result = mock_page.evaluate(
+        """() => {
+            const messages = window.__icebreakerBridgeEvents
+                .filter((event) => event.action === 'icebreaker_append_chat_message')
+                .map((event) => event.message);
+            const handoff = window.__icebreakerBridgeEvents.find(
+                (event) => event.action === 'icebreaker_galgame_handoff'
+            );
+            return {
+                activeSession: window.newUserIcebreaker.getActiveSession(),
+                routeEndCount: window.__routeEndCount,
+                roles: messages.map((message) => message.role),
+                finalText: messages.at(-1).blocks[0].text,
+                handoffMatchesFinalMessage: handoff.detail.messageId === messages.at(-1).id,
+                handoffSessionId: handoff.detail.sessionId,
+            };
+        }"""
+    )
+
+    assert result == {
+        "activeSession": None,
+        "routeEndCount": 1,
+        "roles": ["assistant", "user", "assistant"],
+        "finalText": "Let us continue normally.",
+        "handoffMatchesFinalMessage": True,
+        "handoffSessionId": session_id,
+    }
+
+
+@pytest.mark.frontend
 def test_icebreaker_marks_terminal_complete_only_after_choice_and_route_end_succeed(mock_page: Page):
     _bootstrap_page(
         mock_page,

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -5979,19 +5979,34 @@ def test_icebreaker_marks_terminal_complete_only_after_choice_and_route_end_succ
             localStorage.getItem('neko.new_user_icebreaker.v1')
         ).days['1'].completed === true"""
     )
+    mock_page.wait_for_function(
+        """() => window.__icebreakerBridgeEvents.some(
+            (event) => event.action === 'icebreaker_galgame_handoff'
+        )"""
+    )
     completed = mock_page.evaluate(
-        """() => ({
-            routeEndCount: window.__routeEndCount,
-            routeStateCount: window.__routeStateCount,
-            messages: window.__icebreakerBridgeEvents
+        """() => {
+            const messageEvents = window.__icebreakerBridgeEvents
                 .filter((event) => event.action === 'icebreaker_append_chat_message')
-                .map((event) => event.message.role),
-        })"""
+            const handoff = window.__icebreakerBridgeEvents.find(
+                (event) => event.action === 'icebreaker_galgame_handoff'
+            );
+            return {
+                routeEndCount: window.__routeEndCount,
+                routeStateCount: window.__routeStateCount,
+                messages: messageEvents.map((event) => event.message.role),
+                handoffMatchesFinalMessage: handoff.detail.messageId
+                    === messageEvents[messageEvents.length - 1].message.id,
+                handoffSessionId: handoff.detail.sessionId,
+            };
+        }"""
     )
     assert completed == {
         "routeEndCount": 2,
         "routeStateCount": 2,
         "messages": ["assistant", "user", "assistant"],
+        "handoffMatchesFinalMessage": True,
+        "handoffSessionId": session_id,
     }
 
 

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -1268,8 +1268,11 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "clearIcebreakerChoicePromptFromBroadcast(data.sessionId)" in interpage
     assert "clearIcebreakerChoicePromptSourceFromBroadcast(data.source, data.reason)" in interpage
     assert "new CustomEvent('neko:icebreaker-galgame-handoff'" in interpage
+    assert "action === 'icebreaker_reset_session_state'" in interpage
+    assert "data.reason || 'icebreaker-session-reset'" in interpage
     relay_part = (APP_INTERPAGE_PATH / "guide-message-relay.js").read_text(encoding="utf-8")
     assert "case 'icebreaker_galgame_handoff':" in relay_part
+    assert "case 'icebreaker_reset_session_state':" in relay_part
     assert "I.handleIcebreakerBridgeData(event.data);" in relay_part
     icebreaker_flush_block = interpage.split("function flushPendingIcebreakerBridgeActions()", 1)[1].split(
         "function appendIcebreakerChatMessage",

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -1268,6 +1268,9 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "clearIcebreakerChoicePromptFromBroadcast(data.sessionId)" in interpage
     assert "clearIcebreakerChoicePromptSourceFromBroadcast(data.source, data.reason)" in interpage
     assert "new CustomEvent('neko:icebreaker-galgame-handoff'" in interpage
+    relay_part = (APP_INTERPAGE_PATH / "guide-message-relay.js").read_text(encoding="utf-8")
+    assert "case 'icebreaker_galgame_handoff':" in relay_part
+    assert "I.handleIcebreakerBridgeData(event.data);" in relay_part
     icebreaker_flush_block = interpage.split("function flushPendingIcebreakerBridgeActions()", 1)[1].split(
         "function appendIcebreakerChatMessage",
         1,

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -1272,6 +1272,7 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "data.reason || 'icebreaker-session-reset'" in interpage
     relay_part = (APP_INTERPAGE_PATH / "guide-message-relay.js").read_text(encoding="utf-8")
     assert "case 'icebreaker_galgame_handoff':" in relay_part
+    assert "case 'icebreaker_clear_choice_prompt_source':" in relay_part
     assert "case 'icebreaker_reset_session_state':" in relay_part
     assert "I.handleIcebreakerBridgeData(event.data);" in relay_part
     icebreaker_flush_block = interpage.split("function flushPendingIcebreakerBridgeActions()", 1)[1].split(

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -612,11 +612,11 @@ def test_icebreaker_assistant_messages_update_compact_caption_like_normal_chat()
     assert "bridge.finalizeTurnWithTranslation(line)" in interpage_subtitle_block
     assert "setSubtitleEnabled(true" not in interpage_subtitle_block
     assert "setTranslateEnabled(true" not in interpage_subtitle_block
-    assert "return Promise.resolve(host.appendMessage(action.message)).then(function (result) {" in interpage_runtime
+    assert "var appendPromise = Promise.resolve(host.appendMessage(action.message)).then(function (result) {" in interpage_runtime
     assert "return waitForIcebreakerChatHostMounted(host).then(function () {" in interpage_runtime
     assert "syncIcebreakerAssistantCompactCaption(action.message);" in interpage_runtime
     assert "finalizeIcebreakerAssistantSubtitleTranslation(action.message);" in interpage_runtime
-    assert interpage_runtime.index("return Promise.resolve(host.appendMessage(action.message)).then(function (result) {") < interpage_runtime.index(
+    assert interpage_runtime.index("var appendPromise = Promise.resolve(host.appendMessage(action.message)).then(function (result) {") < interpage_runtime.index(
         "return waitForIcebreakerChatHostMounted(host).then(function () {"
     ) < interpage_runtime.index(
         "syncIcebreakerAssistantCompactCaption(action.message);"
@@ -848,6 +848,8 @@ def test_icebreaker_handoff_waits_for_context_append_before_route_end():
     )
     assert "return endIcebreakerRouteForCompletion(session, 'icebreaker_handoff');" in handoff_block
     assert "return Promise.resolve(handoffSpeechPromise).catch(function () {}).then(function () {" in handoff_block
+    assert "var handoffMessage = null;" in handoff_block
+    assert "handoffMessage = message;" in handoff_block
     assert "}).then(function (completed) {" in handoff_block
     assert "if (!completed) return false;" in handoff_block
     assert handoff_block.index("return appendAssistantChatMessage(text") < handoff_block.index(
@@ -866,6 +868,10 @@ def test_icebreaker_handoff_waits_for_context_append_before_route_end():
         "return Promise.resolve(handoffSpeechPromise)"
     )
     assert handoff_block.index("completed: true") < handoff_block.index("dispatchIcebreakerEnded('handoff');")
+    assert "dispatchIcebreakerGalgameHandoff(session, handoffMessage);" in handoff_block
+    assert handoff_block.index("dispatchIcebreakerGalgameHandoff(session, handoffMessage);") < handoff_block.index(
+        "dispatchIcebreakerEnded('handoff');"
+    )
     assert "if (activeSession === session) {" in handoff_block
     assert handoff_block.index("return endIcebreakerRouteForCompletion(session, 'icebreaker_handoff');") < handoff_block.index(
         "activeSession = null;"
@@ -1242,6 +1248,7 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "action: 'icebreaker_append_chat_message'" in runtime
     assert "action: 'icebreaker_set_choice_prompt'" in runtime
     assert "action: 'icebreaker_clear_choice_prompt'" in runtime
+    assert "action: 'icebreaker_galgame_handoff'" in runtime
     assert "lanlan_name: resolveSessionLanlanName(activeSession)" in runtime
 
     assert "handleIcebreakerBridgeData" in interpage
@@ -1251,10 +1258,12 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "case 'icebreaker_set_choice_prompt'" in interpage
     assert "case 'icebreaker_clear_choice_prompt'" in interpage
     assert "case 'icebreaker_clear_choice_prompt_source'" in interpage
+    assert "case 'icebreaker_galgame_handoff'" in interpage
     assert "appendIcebreakerChatMessage(data.message)" in interpage
     assert "setIcebreakerChoicePromptFromBroadcast(data.prompt)" in interpage
     assert "clearIcebreakerChoicePromptFromBroadcast(data.sessionId)" in interpage
     assert "clearIcebreakerChoicePromptSourceFromBroadcast(data.source, data.reason)" in interpage
+    assert "new CustomEvent('neko:icebreaker-galgame-handoff'" in interpage
     icebreaker_flush_block = interpage.split("function flushPendingIcebreakerBridgeActions()", 1)[1].split(
         "function appendIcebreakerChatMessage",
         1,
@@ -1262,6 +1271,10 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "shouldOpenHost = true" in icebreaker_flush_block
     assert "host.openWindow()" in icebreaker_flush_block
     assert "action.source === 'new_user_icebreaker'" in icebreaker_flush_block
+    assert "_icebreakerBridgeAppendBarrier" in interpage
+    assert "action.type === 'galgame_handoff'" in icebreaker_flush_block
+    assert "Promise.resolve(_icebreakerBridgeAppendBarrier)" in icebreaker_flush_block
+    assert "dispatchIcebreakerGalgameHandoffFromBroadcast(data.detail || data)" in interpage
     assert "case 'icebreaker_choice_selected'" in interpage
     assert "postIcebreakerBridgeEvent('icebreaker_choice_selected'" in interpage
     assert "case 'icebreaker_free_text_submitted'" in interpage

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -612,11 +612,15 @@ def test_icebreaker_assistant_messages_update_compact_caption_like_normal_chat()
     assert "bridge.finalizeTurnWithTranslation(line)" in interpage_subtitle_block
     assert "setSubtitleEnabled(true" not in interpage_subtitle_block
     assert "setTranslateEnabled(true" not in interpage_subtitle_block
-    assert "var appendPromise = Promise.resolve(host.appendMessage(action.message)).then(function (result) {" in interpage_runtime
+    assert "appendResult = host.appendMessage(action.message);" in interpage_runtime
+    assert "appendResult = Promise.reject(error);" in interpage_runtime
+    assert "var appendPromise = Promise.resolve(appendResult).then(function (result) {" in interpage_runtime
+    assert "appendStatus.succeeded !== true" in interpage_runtime
+    assert "appendStatus.messageId !== String(handoffDetail.messageId || '')" in interpage_runtime
     assert "return waitForIcebreakerChatHostMounted(host).then(function () {" in interpage_runtime
     assert "syncIcebreakerAssistantCompactCaption(action.message);" in interpage_runtime
     assert "finalizeIcebreakerAssistantSubtitleTranslation(action.message);" in interpage_runtime
-    assert interpage_runtime.index("var appendPromise = Promise.resolve(host.appendMessage(action.message)).then(function (result) {") < interpage_runtime.index(
+    assert interpage_runtime.index("var appendPromise = Promise.resolve(appendResult).then(function (result) {") < interpage_runtime.index(
         "return waitForIcebreakerChatHostMounted(host).then(function () {"
     ) < interpage_runtime.index(
         "syncIcebreakerAssistantCompactCaption(action.message);"
@@ -1446,6 +1450,9 @@ def test_icebreaker_free_text_llm_flow_uses_session_snapshot_after_async_append(
     assert "return speakLine(releaseText, releaseVoiceKey);" in runtime
     assert "}).catch(function () {}).then(function () {" in runtime
     assert "didAppendRelease" in runtime
+    assert "var releaseMessage = null;" in runtime
+    assert "releaseMessage = message;" in runtime
+    assert "dispatchIcebreakerGalgameHandoff(session, releaseMessage);" in runtime
     assert "var releaseAppend = releaseText ? appendAssistantChatMessage(releaseText, {" in runtime
     assert "}) : Promise.resolve(activeSession === session);" in runtime
     assert "if (!didAppendRelease || activeSession !== session) return false;" in runtime

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1652,7 +1652,9 @@ def test_completed_icebreaker_handoff_seeds_galgame_once():
     )[1].split("function isNewUserIcebreakerTurnEndEvent", 1)[0]
     assert "clearIcebreakerChoicePrompt(String(detail.sessionId));" in handoff_listener
     assert "waitForAssistantBubblesFlushed(4000)" in handoff_listener
-    assert "icebreakerHandoffMessageId: messageId" in handoff_listener
+    assert "rememberIcebreakerGalgameHandoff(messageId)" in handoff_listener
+    assert "pendingIcebreakerGalgameHandoffMessageId !== messageId" in handoff_listener
+    assert "fetchPendingIcebreakerGalgameHandoffOrLatest()" in handoff_listener
 
     node_path = shutil.which("node")
     if not node_path:
@@ -1674,7 +1676,22 @@ const handoff = {{
     blocks: [{{ type: 'text', text: 'final handoff' }}],
     icebreaker: {{ source: 'new_user_icebreaker', handoff: true }}
 }};
-context.I.state.messages = [handoff];
+const ordinaryBefore = {{
+    id: 'ordinary-before',
+    role: 'assistant',
+    blocks: [{{ type: 'text', text: 'old ordinary history' }}]
+}};
+const icebreakerBefore = {{
+    id: 'icebreaker-user-before',
+    role: 'user',
+    blocks: [{{ type: 'text', text: 'old scripted history' }}]
+}};
+const ordinaryAfter = {{
+    id: 'ordinary-after',
+    role: 'user',
+    blocks: [{{ type: 'text', text: 'newer turn' }}]
+}};
+context.I.state.messages = [ordinaryBefore, icebreakerBefore, handoff];
 assert.equal(JSON.stringify(vm.runInContext('getRecentGalgameMessageHistory()', context)), '[]');
 assert.equal(
     JSON.stringify(vm.runInContext("getRecentGalgameMessageHistory({{ icebreakerHandoffMessageId: 'wrong' }})", context)),
@@ -1683,6 +1700,11 @@ assert.equal(
 assert.equal(
     JSON.stringify(vm.runInContext("getRecentGalgameMessageHistory({{ icebreakerHandoffMessageId: 'icebreaker-assistant-final' }})", context)),
     '[{{"role":"assistant","text":"final handoff"}}]'
+);
+context.I.state.messages.push(ordinaryAfter);
+assert.equal(
+    JSON.stringify(vm.runInContext("getRecentGalgameMessageHistory({{ icebreakerHandoffMessageId: 'icebreaker-assistant-final' }})", context)),
+    '[]'
 );
 """
     result = run_node_script(

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1655,6 +1655,11 @@ def test_completed_icebreaker_handoff_seeds_galgame_once():
     assert "rememberIcebreakerGalgameHandoff(messageId)" in handoff_listener
     assert "pendingIcebreakerGalgameHandoffMessageId !== messageId" in handoff_listener
     assert "fetchPendingIcebreakerGalgameHandoffOrLatest()" in handoff_listener
+    append_block = react_host.split("function appendMessage(message)", 1)[1].split(
+        "function updateMessage",
+        1,
+    )[0]
+    assert "!isYuiGuideChatMessage(normalized)" in append_block
 
     node_path = shutil.which("node")
     if not node_path:

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1660,6 +1660,8 @@ def test_completed_icebreaker_handoff_seeds_galgame_once():
         1,
     )[0]
     assert "!isYuiGuideChatMessage(normalized)" in append_block
+    assert "clearedIcebreakerHandoff" in append_block
+    assert "|| clearedIcebreakerHandoff" in append_block
     clear_source_block = react_host.split("function clearChoicePromptBySource(source, reason)", 1)[1].split(
         "function clearIcebreakerChoicePrompt",
         1,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1629,6 +1629,73 @@ def test_galgame_history_excludes_new_user_icebreaker_messages():
     assert "invalidatePendingGalgameRequest();" in append_block
 
 
+def test_completed_icebreaker_handoff_seeds_galgame_once():
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    react_host_runtime = read_js_parts(
+        APP_REACT_CHAT_WINDOW_PATH.directory,
+        encoding="utf-8",
+        contract_view=False,
+    )
+
+    history_source = "function isNewUserIcebreakerChatMessage(message)" + react_host_runtime.split(
+        "function isNewUserIcebreakerChatMessage(message)",
+        1,
+    )[1].split("function pickAcceptLanguage", 1)[0]
+    history_block = history_source.split("function getRecentGalgameMessageHistory()", 1)[1]
+    assert "icebreakerHandoffMessageId" in history_block
+    assert "String(m.id || '') === icebreakerHandoffMessageId" in history_block
+    assert "m.role === 'assistant'" in history_block
+
+    handoff_listener = react_host.split(
+        "window.addEventListener('neko:icebreaker-galgame-handoff'",
+        1,
+    )[1].split("function isNewUserIcebreakerTurnEndEvent", 1)[0]
+    assert "clearIcebreakerChoicePrompt(String(detail.sessionId));" in handoff_listener
+    assert "waitForAssistantBubblesFlushed(4000)" in handoff_listener
+    assert "icebreakerHandoffMessageId: messageId" in handoff_listener
+
+    node_path = shutil.which("node")
+    if not node_path:
+        pytest.skip("node is required to verify the completed icebreaker handoff history")
+    script = f"""
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const context = {{}};
+vm.createContext(context);
+vm.runInContext(`
+var I = {{ GALGAME_HISTORY_LIMIT: 6, state: {{ messages: [] }} }};
+function isYuiGuideChatMessage() {{ return false; }}
+${{{json.dumps(history_source)}}}
+`, context);
+
+const handoff = {{
+    id: 'icebreaker-assistant-final',
+    role: 'assistant',
+    blocks: [{{ type: 'text', text: 'final handoff' }}],
+    icebreaker: {{ source: 'new_user_icebreaker', handoff: true }}
+}};
+context.I.state.messages = [handoff];
+assert.equal(JSON.stringify(vm.runInContext('getRecentGalgameMessageHistory()', context)), '[]');
+assert.equal(
+    JSON.stringify(vm.runInContext("getRecentGalgameMessageHistory({{ icebreakerHandoffMessageId: 'wrong' }})", context)),
+    '[]'
+);
+assert.equal(
+    JSON.stringify(vm.runInContext("getRecentGalgameMessageHistory({{ icebreakerHandoffMessageId: 'icebreaker-assistant-final' }})", context)),
+    '[{{"role":"assistant","text":"final handoff"}}]'
+);
+"""
+    result = run_node_script(
+        node_path,
+        script,
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_galgame_turn_end_listener_ignores_new_user_icebreaker():
     react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1660,6 +1660,12 @@ def test_completed_icebreaker_handoff_seeds_galgame_once():
         1,
     )[0]
     assert "!isYuiGuideChatMessage(normalized)" in append_block
+    clear_source_block = react_host.split("function clearChoicePromptBySource(source, reason)", 1)[1].split(
+        "function clearIcebreakerChoicePrompt",
+        1,
+    )[0]
+    assert "hasPendingHandoff" in clear_source_block
+    assert "state.pendingIcebreakerGalgameHandoffMessageId = '';" in clear_source_block
 
     node_path = shutil.which("node")
     if not node_path:
@@ -1818,7 +1824,9 @@ def test_icebreaker_reset_clears_prompt_by_source_without_session_match():
         1,
     )[0]
     assert "if (normalizedSource !== 'new_user_icebreaker') return false;" in reset_block
-    assert "state.choicePrompt.source !== normalizedSource" in reset_block
+    assert "state.choicePrompt.source === normalizedSource" in reset_block
+    assert "hasPendingHandoff" in reset_block
+    assert "state.pendingIcebreakerGalgameHandoffMessageId = '';" in reset_block
     assert "clearChoicePromptBySource:', normalizedSource, reason || ''" in reset_block
     assert "state.choicePrompt = null;" in reset_block
     assert "invalidatePendingGalgameRequest();" in reset_block


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复破冰结束后 Gal 模式未衔接，并确保收尾消息完成后触发选项生成
[补齐完整聊天框的破冰交接 IPC 转发、消息时序及延迟窗口状态重放](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/480)

## 测试 / Testing

手动测试确认可以触发gal选项


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 破冰流程结束后，可将收尾消息交接至 GalGame 模式并生成后续选项。
  - 支持通过选项或自由文本完成交接，并同步至其他窗口或标签页。
  - 窗口重新打开、界面恢复或桌面端桥接就绪后，可继续处理待交接消息。

- **问题修复**
  - 避免无效、过期或进行中的旧请求显示错误的 GalGame 选项。
  - 防止同一条交接消息被重复消费。
  - 重置破冰会话后，不再恢复旧的交接消息或提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->