### PR TITLE
为聊天框和悬浮菜单接入统一透明度适配，默认值为 50%

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -7267,7 +7267,9 @@ describe('App', () => {
 
   it('gives the compact surface the full chat liquid-glass edge hierarchy', () => {
     const steadyFrameRule = compactChatStyles.match(/\.compact-chat-surface-frame\s*\{[\s\S]*?\n\}/)?.[0] ?? '';
-    expect(compactChatStyles).toContain('--compact-chat-surface-edge-top: rgba(255, 255, 255, 0.7);');
+    expect(compactChatStyles).toContain(
+      '--compact-chat-surface-edge-top: rgba(255, 255, 255, calc(0.7 * var(--neko-chat-opacity-factor, 1)));',
+    );
     expect(compactChatStyles).toContain('border-width: 2px 1px 1px 1px;');
     expect(compactChatStyles).toContain('box-shadow: var(--compact-chat-surface-shadow);');
     expect(steadyFrameRule).not.toContain('clip-path: inset(0 round 999px);');
@@ -7278,7 +7280,9 @@ describe('App', () => {
     expect(compactChatStyles).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{\s*\.compact-chat-surface-frame::after\s*\{\s*animation: none;/,
     );
-    expect(compactChatStyles).toContain('--compact-chat-surface-edge-top: rgba(196, 228, 255, 0.44);');
+    expect(compactChatStyles).toContain(
+      '--compact-chat-surface-edge-top: rgba(196, 228, 255, calc(0.44 * var(--neko-chat-opacity-factor, 1)));',
+    );
   });
 
   it('keeps the backdrop layer pill-clipped while compact reveal masks are active', () => {
@@ -7289,19 +7293,19 @@ describe('App', () => {
 
   it('frosts the backdrop while strengthening compact surface opacity', () => {
     expect(compactChatStyles).toMatch(
-      /\.compact-chat-surface-frame\s*\{[\s\S]*?background-clip: padding-box;[\s\S]*?background-color: rgba\(255, 255, 255, 0\.035\);[\s\S]*?backdrop-filter: blur\(36px\) saturate\(0\.9\) contrast\(0\.78\) brightness\(1\.08\);/,
+      /\.compact-chat-surface-frame\s*\{[\s\S]*?background-clip: padding-box;[\s\S]*?background-color: rgba\(255, 255, 255, calc\(0\.035 \* var\(--neko-chat-opacity-factor, 1\)\)\);[\s\S]*?backdrop-filter: blur\(36px\) saturate\(0\.9\) contrast\(0\.78\) brightness\(1\.08\);/,
     );
     expect(compactChatStyles).toContain(
-      'linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(242, 249, 255, 0.42) 46%, rgba(219, 238, 253, 0.48))',
+      'linear-gradient(180deg,\n      rgba(255, 255, 255, calc(0.58 * var(--neko-chat-opacity-factor, 1))),\n      rgba(242, 249, 255, calc(0.42 * var(--neko-chat-opacity-factor, 1))) 46%,\n      rgba(219, 238, 253, calc(0.48 * var(--neko-chat-opacity-factor, 1))))',
     );
     expect(compactChatStyles).toContain(
-      'linear-gradient(180deg, rgba(31, 48, 66, 0.80), rgba(15, 29, 46, 0.76) 58%, rgba(8, 17, 30, 0.72))',
+      'linear-gradient(180deg,\n      rgba(31, 48, 66, calc(0.80 * var(--neko-chat-opacity-factor, 1))),\n      rgba(15, 29, 46, calc(0.76 * var(--neko-chat-opacity-factor, 1))) 58%,\n      rgba(8, 17, 30, calc(0.72 * var(--neko-chat-opacity-factor, 1))))',
     );
     expect(compactChatStyles).toContain(
-      '--compact-chat-capsule-surface-bg:\n    linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(242, 249, 255, 0.68) 46%, rgba(219, 238, 253, 0.72));',
+      '--compact-chat-capsule-surface-bg:\n    linear-gradient(180deg,\n      rgba(255, 255, 255, calc(0.78 * var(--neko-chat-opacity-factor, 1))),\n      rgba(242, 249, 255, calc(0.68 * var(--neko-chat-opacity-factor, 1))) 46%,\n      rgba(219, 238, 253, calc(0.72 * var(--neko-chat-opacity-factor, 1))));',
     );
     expect(compactChatStyles).toContain(
-      '--compact-chat-capsule-surface-bg:\n    linear-gradient(180deg, rgba(31, 48, 66, 0.86), rgba(15, 29, 46, 0.82) 58%, rgba(8, 17, 30, 0.78));',
+      '--compact-chat-capsule-surface-bg:\n    linear-gradient(180deg,\n      rgba(31, 48, 66, calc(0.86 * var(--neko-chat-opacity-factor, 1))),\n      rgba(15, 29, 46, calc(0.82 * var(--neko-chat-opacity-factor, 1))) 58%,\n      rgba(8, 17, 30, calc(0.78 * var(--neko-chat-opacity-factor, 1))));',
     );
     expect(compactChatStyles).toMatch(
       /\.compact-chat-surface-frame\[data-compact-chat-state="default"\]::before,[\s\S]*?\.compact-chat-surface-frame\[data-compact-chat-state="options"\]::before,[\s\S]*?\.compact-chat-surface-frame\[data-compact-chat-state="input"\]::before\s*\{[\s\S]*?background: var\(--compact-chat-capsule-surface-bg\);/,

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -831,7 +831,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   padding: 10px 14px 8px;
   position: relative;
   border-bottom: 1px solid rgba(255, 255, 255, 0.5);
-  background: rgba(255, 255, 255, 0.75);
+  background: rgba(255, 255, 255, calc(0.75 * var(--neko-chat-opacity-factor, 1)));
   backdrop-filter: blur(48px) saturate(180%);
   -webkit-backdrop-filter: blur(48px) saturate(180%);
   box-shadow:
@@ -968,7 +968,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 .chat-body {
   min-height: 0;
   padding: 0;
-  background: rgba(255, 255, 255, 0.91);
+  background: rgba(255, 255, 255, calc(0.91 * var(--neko-chat-opacity-factor, 1)));
   position: relative;
 }
 
@@ -1601,7 +1601,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   padding: 6px;
   position: relative;
   z-index: 15;
-  background: rgba(255, 255, 255, 0.91);
+  background: rgba(255, 255, 255, calc(0.91 * var(--neko-chat-opacity-factor, 1)));
   min-width: 0;
 }
 
@@ -1750,7 +1750,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   min-width: 0;
   padding: 0 16px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.91);
+  background: rgba(255, 255, 255, calc(0.91 * var(--neko-chat-opacity-factor, 1)));
   border: 1.5px solid rgba(127, 144, 170, 0.25);
   transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
   box-shadow:
@@ -1760,7 +1760,7 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 
 .composer-input-shell:focus-within {
   border-color: rgba(64, 197, 241, 0.55);
-  background: rgba(255, 255, 255, 0.91);
+  background: rgba(255, 255, 255, calc(0.91 * var(--neko-chat-opacity-factor, 1)));
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.92),
     0 0 0 3px rgba(64, 197, 241, 0.14),
@@ -2645,26 +2645,32 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     + var(--compact-chat-minimize-ball-gap)
   );
   --compact-chat-surface-bg:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(242, 249, 255, 0.42) 46%, rgba(219, 238, 253, 0.48));
+    linear-gradient(180deg,
+      rgba(255, 255, 255, calc(0.58 * var(--neko-chat-opacity-factor, 1))),
+      rgba(242, 249, 255, calc(0.42 * var(--neko-chat-opacity-factor, 1))) 46%,
+      rgba(219, 238, 253, calc(0.48 * var(--neko-chat-opacity-factor, 1))));
   --compact-chat-capsule-surface-bg:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(242, 249, 255, 0.68) 46%, rgba(219, 238, 253, 0.72));
-  --compact-chat-surface-edge-top: rgba(255, 255, 255, 0.7);
-  --compact-chat-surface-edge-right: rgba(255, 255, 255, 0.15);
-  --compact-chat-surface-edge-bottom: rgba(255, 255, 255, 0.06);
-  --compact-chat-surface-edge-left: rgba(255, 255, 255, 0.35);
-  --compact-chat-surface-glow: rgba(255, 255, 255, 0.2);
+    linear-gradient(180deg,
+      rgba(255, 255, 255, calc(0.78 * var(--neko-chat-opacity-factor, 1))),
+      rgba(242, 249, 255, calc(0.68 * var(--neko-chat-opacity-factor, 1))) 46%,
+      rgba(219, 238, 253, calc(0.72 * var(--neko-chat-opacity-factor, 1))));
+  --compact-chat-surface-edge-top: rgba(255, 255, 255, calc(0.7 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-edge-right: rgba(255, 255, 255, calc(0.15 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-edge-bottom: rgba(255, 255, 255, calc(0.06 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-edge-left: rgba(255, 255, 255, calc(0.35 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-glow: rgba(255, 255, 255, calc(0.2 * var(--neko-chat-opacity-factor, 1)));
   --compact-chat-surface-shadow:
     0 8px 20px rgba(12, 20, 34, 0.16),
     0 2px 7px rgba(49, 104, 154, 0.08),
     inset 0 2px 4px rgba(255, 255, 255, 0.34),
     inset 0 -1px 2px rgba(68, 126, 176, 0.08);
-  --compact-chat-highlight-top: rgba(255, 255, 255, 0.46);
-  --compact-chat-highlight-bottom: rgba(255, 255, 255, 0.08);
-  --compact-chat-highlight-left: rgba(255, 255, 255, 0.14);
-  --compact-chat-highlight-right: rgba(255, 255, 255, 0.06);
-  --compact-chat-refraction-blue: rgba(100, 180, 255, 0.18);
-  --compact-chat-refraction-violet: rgba(180, 140, 255, 0.12);
-  --compact-chat-refraction-rose: rgba(240, 150, 200, 0.09);
+  --compact-chat-highlight-top: rgba(255, 255, 255, calc(0.46 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-highlight-bottom: rgba(255, 255, 255, calc(0.08 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-highlight-left: rgba(255, 255, 255, calc(0.14 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-highlight-right: rgba(255, 255, 255, calc(0.06 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-refraction-blue: rgba(100, 180, 255, calc(0.18 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-refraction-violet: rgba(180, 140, 255, calc(0.12 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-refraction-rose: rgba(240, 150, 200, calc(0.09 * var(--neko-chat-opacity-factor, 1)));
   position: relative;
   overflow: hidden;
   isolation: isolate;
@@ -2688,7 +2694,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     var(--compact-chat-surface-edge-bottom)
     var(--compact-chat-surface-edge-left);
   border-radius: 999px;
-  background-color: rgba(255, 255, 255, 0.035);
+  background-color: rgba(255, 255, 255, calc(0.035 * var(--neko-chat-opacity-factor, 1)));
   box-shadow: var(--compact-chat-surface-shadow);
   backdrop-filter: blur(36px) saturate(0.9) contrast(0.78) brightness(1.08);
   -webkit-backdrop-filter: blur(36px) saturate(0.9) contrast(0.78) brightness(1.08);
@@ -2796,7 +2802,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   z-index: 1;
   border-radius: inherit;
   background-image:
-    linear-gradient(180deg, var(--compact-chat-surface-glow) 0%, rgba(255, 255, 255, 0.05) 16%, transparent 40%, transparent 82%, rgba(115, 181, 229, 0.05) 100%),
+    linear-gradient(180deg, var(--compact-chat-surface-glow) 0%, rgba(255, 255, 255, calc(0.05 * var(--neko-chat-opacity-factor, 1))) 16%, transparent 40%, transparent 82%, rgba(115, 181, 229, calc(0.05 * var(--neko-chat-opacity-factor, 1))) 100%),
     radial-gradient(ellipse at 14% 4%, var(--compact-chat-refraction-blue) 0%, transparent 34%),
     radial-gradient(ellipse at 62% 100%, var(--compact-chat-refraction-violet) 0%, transparent 36%),
     radial-gradient(ellipse at 92% 12%, var(--compact-chat-refraction-rose) 0%, transparent 30%);
@@ -6507,8 +6513,8 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 [data-theme="dark"] .window-topbar {
   background:
     linear-gradient(180deg,
-      rgba(50, 50, 72, 0.6) 0%,
-      rgba(38, 38, 58, 0.5) 100%);
+      rgba(50, 50, 72, calc(0.6 * var(--neko-chat-opacity-factor, 1))) 0%,
+      rgba(38, 38, 58, calc(0.5 * var(--neko-chat-opacity-factor, 1))) 100%);
   border-bottom-color: rgba(255, 255, 255, 0.12);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.1),
@@ -6520,9 +6526,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background:
     linear-gradient(105deg,
       rgba(255, 255, 255, 0) 0%,
-      rgba(255, 255, 255, 0.06) 35%,
+      rgba(255, 255, 255, calc(0.06 * var(--neko-chat-opacity-factor, 1))) 35%,
       rgba(255, 255, 255, 0) 50%,
-      rgba(140, 180, 255, 0.04) 70%,
+      rgba(140, 180, 255, calc(0.04 * var(--neko-chat-opacity-factor, 1))) 70%,
       rgba(255, 255, 255, 0) 100%);
 }
 
@@ -6558,7 +6564,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 [data-theme="dark"] .chat-body {
-  background: rgba(28, 28, 46, 0.91);
+  background: rgba(28, 28, 46, calc(0.91 * var(--neko-chat-opacity-factor, 1)));
 }
 
 /* --- 消息列表滚动条 --- */
@@ -6755,7 +6761,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 /* --- 输入区域 --- */
 [data-theme="dark"] .composer-panel {
-  background: rgba(28, 28, 46, 0.91);
+  background: rgba(28, 28, 46, calc(0.91 * var(--neko-chat-opacity-factor, 1)));
 }
 
 [data-theme="dark"] .composer-attachment-viewport {
@@ -6949,7 +6955,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 [data-theme="dark"] .composer-input-shell {
-  background: rgba(42, 42, 60, 0.85);
+  background: rgba(42, 42, 60, calc(0.85 * var(--neko-chat-opacity-factor, 1)));
   border-color: rgba(255, 255, 255, 0.08);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.04),
@@ -6958,7 +6964,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 [data-theme="dark"] .composer-input-shell:focus-within {
   border-color: rgba(64, 197, 241, 0.4);
-  background: rgba(48, 48, 74, 0.85);
+  background: rgba(48, 48, 74, calc(0.85 * var(--neko-chat-opacity-factor, 1)));
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.06),
     0 0 0 3px rgba(64, 197, 241, 0.1),
@@ -6979,27 +6985,33 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 [data-theme="dark"] .compact-chat-surface-frame {
   --compact-chat-surface-bg:
-    linear-gradient(180deg, rgba(31, 48, 66, 0.80), rgba(15, 29, 46, 0.76) 58%, rgba(8, 17, 30, 0.72));
+    linear-gradient(180deg,
+      rgba(31, 48, 66, calc(0.80 * var(--neko-chat-opacity-factor, 1))),
+      rgba(15, 29, 46, calc(0.76 * var(--neko-chat-opacity-factor, 1))) 58%,
+      rgba(8, 17, 30, calc(0.72 * var(--neko-chat-opacity-factor, 1))));
   --compact-chat-capsule-surface-bg:
-    linear-gradient(180deg, rgba(31, 48, 66, 0.86), rgba(15, 29, 46, 0.82) 58%, rgba(8, 17, 30, 0.78));
-  --compact-chat-surface-edge-top: rgba(196, 228, 255, 0.44);
-  --compact-chat-surface-edge-right: rgba(156, 207, 249, 0.13);
-  --compact-chat-surface-edge-bottom: rgba(132, 189, 232, 0.07);
-  --compact-chat-surface-edge-left: rgba(177, 216, 255, 0.24);
-  --compact-chat-surface-glow: rgba(176, 219, 255, 0.1);
+    linear-gradient(180deg,
+      rgba(31, 48, 66, calc(0.86 * var(--neko-chat-opacity-factor, 1))),
+      rgba(15, 29, 46, calc(0.82 * var(--neko-chat-opacity-factor, 1))) 58%,
+      rgba(8, 17, 30, calc(0.78 * var(--neko-chat-opacity-factor, 1))));
+  --compact-chat-surface-edge-top: rgba(196, 228, 255, calc(0.44 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-edge-right: rgba(156, 207, 249, calc(0.13 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-edge-bottom: rgba(132, 189, 232, calc(0.07 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-edge-left: rgba(177, 216, 255, calc(0.24 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-surface-glow: rgba(176, 219, 255, calc(0.1 * var(--neko-chat-opacity-factor, 1)));
   --compact-chat-surface-shadow:
     0 8px 20px rgba(0, 0, 0, 0.28),
     0 2px 7px rgba(0, 0, 0, 0.16),
     inset 0 2px 4px rgba(225, 242, 255, 0.12),
     inset 0 -1px 2px rgba(0, 0, 0, 0.18);
-  --compact-chat-highlight-top: rgba(225, 242, 255, 0.18);
-  --compact-chat-highlight-bottom: rgba(177, 216, 255, 0.05);
-  --compact-chat-highlight-left: rgba(177, 216, 255, 0.09);
-  --compact-chat-highlight-right: rgba(177, 216, 255, 0.04);
-  --compact-chat-refraction-blue: rgba(90, 174, 255, 0.16);
-  --compact-chat-refraction-violet: rgba(170, 125, 255, 0.11);
-  --compact-chat-refraction-rose: rgba(235, 120, 190, 0.07);
-  background: rgba(12, 22, 35, 0.1);
+  --compact-chat-highlight-top: rgba(225, 242, 255, calc(0.18 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-highlight-bottom: rgba(177, 216, 255, calc(0.05 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-highlight-left: rgba(177, 216, 255, calc(0.09 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-highlight-right: rgba(177, 216, 255, calc(0.04 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-refraction-blue: rgba(90, 174, 255, calc(0.16 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-refraction-violet: rgba(170, 125, 255, calc(0.11 * var(--neko-chat-opacity-factor, 1)));
+  --compact-chat-refraction-rose: rgba(235, 120, 190, calc(0.07 * var(--neko-chat-opacity-factor, 1)));
+  background: rgba(12, 22, 35, calc(0.1 * var(--neko-chat-opacity-factor, 1)));
 }
 
 [data-theme="dark"] .compact-chat-surface-shell[data-compact-chat-state="input"],

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -507,7 +507,7 @@ function createSettingsPopupContent(manager, prefix, popup) {
         }
     });
 
-    // 5. 桌面端添加导航菜单
+    // 6. 桌面端添加导航菜单
     if (!window.isMobileWidth || !window.isMobileWidth()) {
         const separator = document.createElement('div');
         separator.className = `${prefix}-settings-separator`;

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -49,7 +49,10 @@ html #chat-container {
 
 /* ===== 弹出框 & 按钮主题变量（供 JS 内联样式引用） ===== */
 :root {
-  --neko-popup-bg: rgba(255, 255, 255, 0.65);
+  /* 50% 映射到原有观感；设置模块将 0–100% 转成 0–2 系数。 */
+  --neko-chat-opacity-factor: 1;
+  --neko-floating-menu-opacity-factor: 1;
+  --neko-popup-bg: rgba(255, 255, 255, calc(0.65 * var(--neko-floating-menu-opacity-factor, 1)));
   --neko-popup-border: 1px solid rgba(255, 255, 255, 0.18);
   --neko-popup-border-color: rgba(0, 0, 0, 0.06);
   --neko-popup-shadow: 0 2px 4px rgba(0, 0, 0, 0.04), 0 8px 16px rgba(0, 0, 0, 0.08), 0 16px 32px rgba(0, 0, 0, 0.04);
@@ -75,16 +78,16 @@ html #chat-container {
   --neko-popup-error-border: rgba(220, 38, 38, 0.2);
   --neko-hud-subtle-bg: rgba(0, 0, 0, 0.06);
   /* 浮动按钮变量 */
-  --neko-btn-bg: rgba(255, 255, 255, 0.65);
-  --neko-btn-bg-hover: rgba(255, 255, 255, 0.8);
-  --neko-btn-bg-active: rgba(255, 255, 255, 0.75);
+  --neko-btn-bg: rgba(255, 255, 255, calc(0.65 * var(--neko-floating-menu-opacity-factor, 1)));
+  --neko-btn-bg-hover: rgba(255, 255, 255, calc(0.8 * var(--neko-floating-menu-opacity-factor, 1)));
+  --neko-btn-bg-active: rgba(255, 255, 255, calc(0.75 * var(--neko-floating-menu-opacity-factor, 1)));
   --neko-btn-border: 1px solid rgba(255, 255, 255, 0.18);
   --neko-btn-shadow: 0 2px 4px rgba(0, 0, 0, 0.04), 0 4px 8px rgba(0, 0, 0, 0.08);
   --neko-btn-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.08), 0 8px 16px rgba(0, 0, 0, 0.08);
 }
 
 [data-theme="dark"] {
-  --neko-popup-bg: rgba(30, 30, 30, 0.82);
+  --neko-popup-bg: rgba(30, 30, 30, calc(0.82 * var(--neko-floating-menu-opacity-factor, 1)));
   --neko-popup-border: 1px solid rgba(255, 255, 255, 0.1);
   --neko-popup-border-color: rgba(255, 255, 255, 0.06);
   --neko-popup-shadow: 0 2px 4px rgba(0, 0, 0, 0.15), 0 8px 16px rgba(0, 0, 0, 0.25), 0 16px 32px rgba(0, 0, 0, 0.15);
@@ -110,9 +113,9 @@ html #chat-container {
   --neko-popup-error-border: rgba(255, 107, 107, 0.2);
   --neko-hud-subtle-bg: rgba(255, 255, 255, 0.08);
   /* 浮动按钮变量 - 暗色 */
-  --neko-btn-bg: rgba(35, 35, 35, 0.75);
-  --neko-btn-bg-hover: rgba(50, 50, 50, 0.85);
-  --neko-btn-bg-active: rgba(45, 45, 45, 0.8);
+  --neko-btn-bg: rgba(35, 35, 35, calc(0.75 * var(--neko-floating-menu-opacity-factor, 1)));
+  --neko-btn-bg-hover: rgba(50, 50, 50, calc(0.85 * var(--neko-floating-menu-opacity-factor, 1)));
+  --neko-btn-bg-active: rgba(45, 45, 45, calc(0.8 * var(--neko-floating-menu-opacity-factor, 1)));
   --neko-btn-border: 1px solid rgba(255, 255, 255, 0.1);
   --neko-btn-shadow: 0 2px 4px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.16);
   --neko-btn-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.16), 0 8px 16px rgba(0, 0, 0, 0.2);

--- a/static/theme-manager.js
+++ b/static/theme-manager.js
@@ -23,6 +23,9 @@
   });
 
   function normalizeUiOpacity(value) {
+    if (value === null || (typeof value === 'string' && value.trim() === '')) {
+      return DEFAULT_UI_OPACITY;
+    }
     const numericValue = Number(value);
     if (!Number.isFinite(numericValue)) return DEFAULT_UI_OPACITY;
     return Math.min(100, Math.max(0, Math.round(numericValue)));

--- a/static/theme-manager.js
+++ b/static/theme-manager.js
@@ -7,6 +7,104 @@
   let themeTransitionTimeout = null;
   let initialized = false;
 
+  // 聊天框与悬浮菜单共用同一套 0–100 透明度语义：50 保持原视觉，
+  // 100 将主表面推至不透明。放在主题管理器中同步恢复，避免首帧闪烁。
+  const DEFAULT_UI_OPACITY = 50;
+  const UI_OPACITY_BASELINE = 50;
+  const UI_OPACITY_SETTINGS = Object.freeze({
+    chat: Object.freeze({
+      storageKey: 'nekoChatOpacity',
+      cssVariable: '--neko-chat-opacity-factor'
+    }),
+    floatingMenu: Object.freeze({
+      storageKey: 'nekoFloatingMenuOpacity',
+      cssVariable: '--neko-floating-menu-opacity-factor'
+    })
+  });
+
+  function normalizeUiOpacity(value) {
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) return DEFAULT_UI_OPACITY;
+    return Math.min(100, Math.max(0, Math.round(numericValue)));
+  }
+
+  function readStoredUiOpacity(setting) {
+    try {
+      const storedValue = localStorage.getItem(setting.storageKey);
+      return storedValue === null ? DEFAULT_UI_OPACITY : normalizeUiOpacity(storedValue);
+    } catch (_) {
+      return DEFAULT_UI_OPACITY;
+    }
+  }
+
+  function applyUiOpacity(name, value) {
+    const setting = UI_OPACITY_SETTINGS[name];
+    if (!setting || !document || !document.documentElement) return;
+    const normalizedValue = normalizeUiOpacity(value);
+    document.documentElement.style.setProperty(
+      setting.cssVariable,
+      String(normalizedValue / UI_OPACITY_BASELINE)
+    );
+  }
+
+  function getUiOpacity(name) {
+    const setting = UI_OPACITY_SETTINGS[name];
+    return setting ? readStoredUiOpacity(setting) : DEFAULT_UI_OPACITY;
+  }
+
+  function applyRuntimeUiOpacity(name, value) {
+    if (!UI_OPACITY_SETTINGS[name]) return DEFAULT_UI_OPACITY;
+    const normalizedValue = normalizeUiOpacity(value);
+    applyUiOpacity(name, normalizedValue);
+    return normalizedValue;
+  }
+
+  function syncUiOpacity(name, value) {
+    const setting = UI_OPACITY_SETTINGS[name];
+    if (!setting) return DEFAULT_UI_OPACITY;
+    const normalizedValue = normalizeUiOpacity(value);
+    try {
+      localStorage.setItem(setting.storageKey, String(normalizedValue));
+    } catch (_) {}
+    applyUiOpacity(name, normalizedValue);
+    return normalizedValue;
+  }
+
+  function setUiOpacity(name, value) {
+    const normalizedValue = syncUiOpacity(name, value);
+    if (!UI_OPACITY_SETTINGS[name]) return normalizedValue;
+    window.dispatchEvent(new CustomEvent('neko-ui-opacity-changed', {
+      detail: { name, value: normalizedValue }
+    }));
+    return normalizedValue;
+  }
+
+  function refreshUiOpacity() {
+    Object.keys(UI_OPACITY_SETTINGS).forEach((name) => applyUiOpacity(name, getUiOpacity(name)));
+  }
+
+  window.addEventListener('storage', (event) => {
+    if (!event || event.storageArea !== localStorage) return;
+    const matchedName = Object.keys(UI_OPACITY_SETTINGS).find(
+      (name) => UI_OPACITY_SETTINGS[name].storageKey === event.key
+    );
+    if (matchedName) {
+      applyUiOpacity(matchedName, event.newValue === null ? DEFAULT_UI_OPACITY : event.newValue);
+    } else if (event.key === null) {
+      refreshUiOpacity();
+    }
+  });
+
+  window.NekoUiOpacityPreferences = Object.freeze({
+    get: getUiOpacity,
+    set: setUiOpacity,
+    apply: applyRuntimeUiOpacity,
+    sync: syncUiOpacity,
+    refresh: refreshUiOpacity,
+    normalize: normalizeUiOpacity
+  });
+  refreshUiOpacity();
+
   try {
     const savedTheme = localStorage.getItem(STORAGE_KEY);
     if (savedTheme === 'true') {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -83,15 +83,15 @@
             transform: none;
             border-radius: 22px;
             /* 液态边缘反光 — 顶部最亮、左次之，模拟顶光 */
-            border-top: 2px solid rgba(255, 255, 255, 0.7);
-            border-left: 1px solid rgba(255, 255, 255, 0.35);
-            border-right: 1px solid rgba(255, 255, 255, 0.15);
-            border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+            border-top: 2px solid rgba(255, 255, 255, calc(0.7 * var(--neko-chat-opacity-factor, 1)));
+            border-left: 1px solid rgba(255, 255, 255, calc(0.35 * var(--neko-chat-opacity-factor, 1)));
+            border-right: 1px solid rgba(255, 255, 255, calc(0.15 * var(--neko-chat-opacity-factor, 1)));
+            border-bottom: 1px solid rgba(255, 255, 255, calc(0.06 * var(--neko-chat-opacity-factor, 1)));
             /* 收敛外阴影（落在 30px inset 留白内，不被窗口边缘裁掉）+ 玻璃内高光带 */
             box-shadow:
                 0 8px 20px rgba(12, 20, 34, 0.28),
-                inset 0 2px 4px rgba(255, 255, 255, 0.5),
-                inset 0 -1px 2px rgba(255, 255, 255, 0.08);
+                inset 0 2px 4px rgba(255, 255, 255, calc(0.5 * var(--neko-chat-opacity-factor, 1))),
+                inset 0 -1px 2px rgba(255, 255, 255, calc(0.08 * var(--neko-chat-opacity-factor, 1)));
         }
         /* 三色流光关键帧：7 个径向光斑各自缓慢漂移，模拟玻璃折射 */
         @keyframes liquidFlow {
@@ -114,17 +114,17 @@
             pointer-events: none;
             z-index: 0;
             box-shadow:
-                inset 0 2px 6px rgba(255, 255, 255, 0.5),
-                inset 0 -1px 3px rgba(255, 255, 255, 0.1),
-                inset 2px 0 4px rgba(255, 255, 255, 0.15),
-                inset -2px 0 4px rgba(255, 255, 255, 0.08);
+                inset 0 2px 6px rgba(255, 255, 255, calc(0.5 * var(--neko-chat-opacity-factor, 1))),
+                inset 0 -1px 3px rgba(255, 255, 255, calc(0.1 * var(--neko-chat-opacity-factor, 1))),
+                inset 2px 0 4px rgba(255, 255, 255, calc(0.15 * var(--neko-chat-opacity-factor, 1))),
+                inset -2px 0 4px rgba(255, 255, 255, calc(0.08 * var(--neko-chat-opacity-factor, 1)));
             background: linear-gradient(
                 180deg,
-                rgba(255, 255, 255, 0.25) 0%,
-                rgba(255, 255, 255, 0.08) 8%,
+                rgba(255, 255, 255, calc(0.25 * var(--neko-chat-opacity-factor, 1))) 0%,
+                rgba(255, 255, 255, calc(0.08 * var(--neko-chat-opacity-factor, 1))) 8%,
                 transparent 20%,
                 transparent 85%,
-                rgba(255, 255, 255, 0.04) 100%
+                rgba(255, 255, 255, calc(0.04 * var(--neko-chat-opacity-factor, 1))) 100%
             );
         }
         /* 三色流光层 — 三色径向渐变缓慢漂移，模拟玻璃折射（z-index:10，输入区 z-index:15
@@ -138,13 +138,13 @@
             pointer-events: none;
             z-index: 10;
             background-image:
-                radial-gradient(circle at 15% 10%, rgba(100,180,255,0.14) 0%, transparent 22%),
-                radial-gradient(circle at 75% 15%, rgba(180,140,255,0.11) 0%, transparent 20%),
-                radial-gradient(circle at 40% 35%, rgba(220,140,240,0.12) 0%, transparent 18%),
-                radial-gradient(circle at 85% 50%, rgba(120,200,255,0.13) 0%, transparent 20%),
-                radial-gradient(circle at 25% 65%, rgba(200,160,255,0.10) 0%, transparent 19%),
-                radial-gradient(circle at 60% 80%, rgba(100,190,255,0.12) 0%, transparent 21%),
-                radial-gradient(circle at 90% 85%, rgba(240,150,200,0.10) 0%, transparent 17%);
+                radial-gradient(circle at 15% 10%, rgba(100,180,255,calc(0.14 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 22%),
+                radial-gradient(circle at 75% 15%, rgba(180,140,255,calc(0.11 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 20%),
+                radial-gradient(circle at 40% 35%, rgba(220,140,240,calc(0.12 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 18%),
+                radial-gradient(circle at 85% 50%, rgba(120,200,255,calc(0.13 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 20%),
+                radial-gradient(circle at 25% 65%, rgba(200,160,255,calc(0.10 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 19%),
+                radial-gradient(circle at 60% 80%, rgba(100,190,255,calc(0.12 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 21%),
+                radial-gradient(circle at 90% 85%, rgba(240,150,200,calc(0.10 * var(--neko-chat-opacity-factor, 1))) 0%, transparent 17%);
             background-size: 200% 200%, 200% 200%, 200% 200%, 200% 200%, 200% 200%, 200% 200%, 200% 200%;
             background-repeat: no-repeat;
             animation: liquidFlow 20s ease-in-out infinite;
@@ -182,10 +182,10 @@
            注：full 窗口 transparent:true 且同期 lanlan_frd 无 vibrancy/acrylic（已核 git 全史），
            桌面是锐透出来的、非 OS 磨砂 —— 与当年一致，纯 CSS 半透明，无需 lanlan_frd 配合。 */
         body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) .window-topbar {
-            background: rgba(255, 255, 255, 0.35);
+            background: rgba(255, 255, 255, calc(0.35 * var(--neko-chat-opacity-factor, 1)));
         }
         [data-theme="dark"] body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) .window-topbar {
-            background: rgba(50, 50, 72, 0.35);
+            background: rgba(50, 50, 72, calc(0.35 * var(--neko-chat-opacity-factor, 1)));
         }
         /* ──────────────────────────────────────────────────────────────────────
            full 形态在**共享 /chat（compact）**上不注入，仅在此留档：

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -182,10 +182,10 @@
            注：full 窗口 transparent:true 且同期 lanlan_frd 无 vibrancy/acrylic（已核 git 全史），
            桌面是锐透出来的、非 OS 磨砂 —— 与当年一致，纯 CSS 半透明，无需 lanlan_frd 配合。 */
         body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) .window-topbar {
-            background: rgba(255, 255, 255, calc(0.35 * var(--neko-chat-opacity-factor, 1)));
+            background: rgba(255, 255, 255, calc(0.35 * var(--neko-chat-opacity-factor, 1) + 0.3 * max(0, var(--neko-chat-opacity-factor, 1) - 1)));
         }
         [data-theme="dark"] body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) .window-topbar {
-            background: rgba(50, 50, 72, calc(0.35 * var(--neko-chat-opacity-factor, 1)));
+            background: rgba(50, 50, 72, calc(0.35 * var(--neko-chat-opacity-factor, 1) + 0.3 * max(0, var(--neko-chat-opacity-factor, 1) - 1)));
         }
         /* ──────────────────────────────────────────────────────────────────────
            full 形态在**共享 /chat（compact）**上不注入，仅在此留档：

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,7 +54,7 @@
     <link rel="stylesheet" href="/static/css/avatar-reaction-bubble.css?v={{ static_asset_version }}">
     <!-- 暗色模式样式 -->
     <link rel="stylesheet" href="/static/css/dark-mode.css?v={{ static_asset_version }}">
-    <!-- 主题管理器（尽早加载以避免闪烁） -->
+    <!-- 主题与界面透明度管理器（在 body 前同步恢复，避免首帧闪烁） -->
     <script src="/static/theme-manager.js?v={{ static_asset_version }}"></script>
 
     <!-- 教程样式定制 -->

--- a/tests/unit/test_ui_opacity_preferences.py
+++ b/tests/unit/test_ui_opacity_preferences.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 import textwrap
 from pathlib import Path
@@ -17,6 +18,37 @@ INDEX_TEMPLATE_PATH = PROJECT_ROOT / "templates" / "index.html"
 CHAT_TEMPLATE_PATH = PROJECT_ROOT / "templates" / "chat.html"
 LOCALES_PATH = PROJECT_ROOT / "static" / "locales"
 LOCALES = ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "pt", "es")
+CHAT_OPACITY_FACTOR = "var(--neko-chat-opacity-factor, 1)"
+FLOATING_MENU_OPACITY_FACTOR = "var(--neko-floating-menu-opacity-factor, 1)"
+
+
+def _css_rule_body(source: str, selector: str) -> str:
+    match = re.search(
+        rf"^\s*{re.escape(selector)}\s*\{{(?P<body>.*?)^\s*\}}",
+        source,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None, f"missing CSS rule for {selector}"
+    return match.group("body")
+
+
+def _assert_css_properties_use_opacity(
+    source: str,
+    selector: str,
+    properties: tuple[str, ...],
+    opacity_factor: str,
+) -> None:
+    rule_body = _css_rule_body(source, selector)
+    for property_name in properties:
+        declaration = re.search(
+            rf"^\s*{re.escape(property_name)}\s*:[^;]*;",
+            rule_body,
+            flags=re.DOTALL | re.MULTILINE,
+        )
+        assert declaration is not None, f"missing {property_name} in {selector}"
+        assert opacity_factor in declaration.group(0), (
+            f"{selector} {property_name} must use {opacity_factor}"
+        )
 
 
 def test_ui_opacity_preferences_restore_clamp_apply_and_sync() -> None:
@@ -32,7 +64,7 @@ def test_ui_opacity_preferences_restore_clamp_apply_and_sync() -> None:
 
         const stored = new Map([
             ['nekoChatOpacity', '64'],
-            ['nekoFloatingMenuOpacity', 'not-a-number'],
+            ['nekoFloatingMenuOpacity', '   '],
         ]);
         const applied = new Map();
         const listeners = new Map();
@@ -75,6 +107,11 @@ def test_ui_opacity_preferences_restore_clamp_apply_and_sync() -> None:
         assert.equal(dispatched.at(-1).detail.value, 38);
         assert.equal(preferences.normalize(-10), 0);
         assert.equal(preferences.normalize(120), 100);
+        assert.equal(preferences.normalize(''), 50);
+        assert.equal(preferences.normalize('   '), 50);
+        assert.equal(preferences.normalize(null), 50);
+        assert.equal(preferences.normalize('not-a-number'), 50);
+        assert.equal(preferences.normalize('0'), 0);
 
         preferences.set('chat', 100);
         assert.equal(applied.get('--neko-chat-opacity-factor'), '2');
@@ -127,8 +164,110 @@ def test_ui_opacity_has_all_surface_adapters_and_no_model_popup_controls() -> No
 
     chat_styles = CHAT_STYLES_PATH.read_text(encoding="utf-8")
     dark_mode_css = DARK_MODE_CSS_PATH.read_text(encoding="utf-8")
-    assert chat_styles.count("var(--neko-chat-opacity-factor, 1)") >= 25
-    assert dark_mode_css.count("var(--neko-floating-menu-opacity-factor, 1)") == 8
+    chat_template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    chat_surface_properties = {
+        ".window-topbar": ("background",),
+        ".chat-body": ("background",),
+        ".composer-panel": ("background",),
+        ".composer-input-shell": ("background",),
+        ".composer-input-shell:focus-within": ("background",),
+        ".compact-chat-surface-frame": (
+            "--compact-chat-surface-bg",
+            "--compact-chat-capsule-surface-bg",
+            "--compact-chat-surface-edge-top",
+            "--compact-chat-surface-edge-right",
+            "--compact-chat-surface-edge-bottom",
+            "--compact-chat-surface-edge-left",
+            "--compact-chat-surface-glow",
+            "--compact-chat-highlight-top",
+            "--compact-chat-highlight-bottom",
+            "--compact-chat-highlight-left",
+            "--compact-chat-highlight-right",
+            "--compact-chat-refraction-blue",
+            "--compact-chat-refraction-violet",
+            "--compact-chat-refraction-rose",
+            "background-color",
+        ),
+        ".compact-chat-surface-frame::after": ("background-image",),
+        '[data-theme="dark"] .window-topbar': ("background",),
+        '[data-theme="dark"] .window-topbar::before': ("background",),
+        '[data-theme="dark"] .chat-body': ("background",),
+        '[data-theme="dark"] .composer-panel': ("background",),
+        '[data-theme="dark"] .composer-input-shell': ("background",),
+        '[data-theme="dark"] .composer-input-shell:focus-within': ("background",),
+        '[data-theme="dark"] .compact-chat-surface-frame': (
+            "--compact-chat-surface-bg",
+            "--compact-chat-capsule-surface-bg",
+            "--compact-chat-surface-edge-top",
+            "--compact-chat-surface-edge-right",
+            "--compact-chat-surface-edge-bottom",
+            "--compact-chat-surface-edge-left",
+            "--compact-chat-surface-glow",
+            "--compact-chat-highlight-top",
+            "--compact-chat-highlight-bottom",
+            "--compact-chat-highlight-left",
+            "--compact-chat-highlight-right",
+            "--compact-chat-refraction-blue",
+            "--compact-chat-refraction-violet",
+            "--compact-chat-refraction-rose",
+            "background",
+        ),
+    }
+    for selector, properties in chat_surface_properties.items():
+        _assert_css_properties_use_opacity(
+            chat_styles,
+            selector,
+            properties,
+            CHAT_OPACITY_FACTOR,
+        )
+
+    floating_menu_properties = (
+        "--neko-popup-bg",
+        "--neko-btn-bg",
+        "--neko-btn-bg-hover",
+        "--neko-btn-bg-active",
+    )
+    for selector in (":root", '[data-theme="dark"]'):
+        _assert_css_properties_use_opacity(
+            dark_mode_css,
+            selector,
+            floating_menu_properties,
+            FLOATING_MENU_OPACITY_FACTOR,
+        )
+
+    electron_full_selector = (
+        'body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]'
+        ":not(.is-minimized):not(.neko-e-collapsed)"
+    )
+    _assert_css_properties_use_opacity(
+        chat_template,
+        electron_full_selector,
+        ("border-top", "border-left", "border-right", "border-bottom", "box-shadow"),
+        CHAT_OPACITY_FACTOR,
+    )
+    _assert_css_properties_use_opacity(
+        chat_template,
+        f"{electron_full_selector}::before",
+        ("box-shadow", "background"),
+        CHAT_OPACITY_FACTOR,
+    )
+    _assert_css_properties_use_opacity(
+        chat_template,
+        f"{electron_full_selector}::after",
+        ("background-image",),
+        CHAT_OPACITY_FACTOR,
+    )
+    full_topbar_selector = f"{electron_full_selector} .window-topbar"
+    for selector in (full_topbar_selector, f'[data-theme="dark"] {full_topbar_selector}'):
+        _assert_css_properties_use_opacity(
+            chat_template,
+            selector,
+            ("background",),
+            CHAT_OPACITY_FACTOR,
+        )
+        topbar_rule = _css_rule_body(chat_template, selector)
+        assert "0.3 * max(0, var(--neko-chat-opacity-factor, 1) - 1)" in topbar_rule
 
     for locale in LOCALES:
         messages = json.loads((LOCALES_PATH / f"{locale}.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_ui_opacity_preferences.py
+++ b/tests/unit/test_ui_opacity_preferences.py
@@ -1,0 +1,138 @@
+import json
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PREFERENCES_PATH = PROJECT_ROOT / "static" / "theme-manager.js"
+POPUP_PATH = PROJECT_ROOT / "static" / "avatar" / "avatar-ui-popup.js"
+DARK_MODE_CSS_PATH = PROJECT_ROOT / "static" / "css" / "dark-mode.css"
+CHAT_STYLES_PATH = PROJECT_ROOT / "frontend" / "react-neko-chat" / "src" / "styles.css"
+INDEX_TEMPLATE_PATH = PROJECT_ROOT / "templates" / "index.html"
+CHAT_TEMPLATE_PATH = PROJECT_ROOT / "templates" / "chat.html"
+LOCALES_PATH = PROJECT_ROOT / "static" / "locales"
+LOCALES = ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "pt", "es")
+
+
+def test_ui_opacity_preferences_restore_clamp_apply_and_sync() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the UI opacity browser contract test")
+
+    script = textwrap.dedent(
+        f"""
+        const assert = require('node:assert/strict');
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+
+        const stored = new Map([
+            ['nekoChatOpacity', '64'],
+            ['nekoFloatingMenuOpacity', 'not-a-number'],
+        ]);
+        const applied = new Map();
+        const listeners = new Map();
+        const dispatched = [];
+        const localStorage = {{
+            getItem(key) {{ return stored.has(key) ? stored.get(key) : null; }},
+            setItem(key, value) {{ stored.set(key, String(value)); }},
+        }};
+        class CustomEvent {{
+            constructor(type, init) {{ this.type = type; this.detail = init.detail; }}
+        }}
+        const document = {{
+            readyState: 'loading',
+            addEventListener() {{}},
+            documentElement: {{
+                style: {{ setProperty(name, value) {{ applied.set(name, value); }} }},
+            }},
+        }};
+        const window = {{
+            localStorage,
+            document,
+            CustomEvent,
+            addEventListener(type, listener) {{ listeners.set(type, listener); }},
+            dispatchEvent(event) {{ dispatched.push(event); }},
+        }};
+
+        const source = fs.readFileSync({json.dumps(str(PREFERENCES_PATH))}, 'utf8');
+        vm.runInNewContext(source, {{ window, document, localStorage, CustomEvent, console, setTimeout, clearTimeout }}, {{ filename: 'theme-manager.js' }});
+
+        const preferences = window.NekoUiOpacityPreferences;
+        assert.equal(preferences.get('chat'), 64);
+        assert.equal(preferences.get('floatingMenu'), 50);
+        assert.equal(applied.get('--neko-chat-opacity-factor'), '1.28');
+        assert.equal(applied.get('--neko-floating-menu-opacity-factor'), '1');
+
+        assert.equal(preferences.set('floatingMenu', 37.6), 38);
+        assert.equal(stored.get('nekoFloatingMenuOpacity'), '38');
+        assert.equal(applied.get('--neko-floating-menu-opacity-factor'), '0.76');
+        assert.equal(dispatched.at(-1).detail.name, 'floatingMenu');
+        assert.equal(dispatched.at(-1).detail.value, 38);
+        assert.equal(preferences.normalize(-10), 0);
+        assert.equal(preferences.normalize(120), 100);
+
+        preferences.set('chat', 100);
+        assert.equal(applied.get('--neko-chat-opacity-factor'), '2');
+
+        const storedChatOpacity = stored.get('nekoChatOpacity');
+        const dispatchedCount = dispatched.length;
+        assert.equal(preferences.apply('chat', 25), 25);
+        assert.equal(applied.get('--neko-chat-opacity-factor'), '0.5');
+        assert.equal(stored.get('nekoChatOpacity'), storedChatOpacity);
+        assert.equal(dispatched.length, dispatchedCount);
+
+        assert.equal(preferences.sync('chat', 75), 75);
+        assert.equal(applied.get('--neko-chat-opacity-factor'), '1.5');
+        assert.equal(stored.get('nekoChatOpacity'), '75');
+        assert.equal(dispatched.length, dispatchedCount);
+
+        listeners.get('storage')({{
+            key: 'nekoChatOpacity',
+            newValue: '25',
+            storageArea: localStorage,
+        }});
+        assert.equal(applied.get('--neko-chat-opacity-factor'), '0.5');
+        """
+    )
+    result = run_node_script(
+        node,
+        script,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_ui_opacity_has_all_surface_adapters_and_no_model_popup_controls() -> None:
+    popup_source = POPUP_PATH.read_text(encoding="utf-8")
+    assert "createSurfaceOpacitySettingsSidePanel" not in popup_source
+    assert "settings.toggles.opacitySettings" not in popup_source
+
+    theme_source = PREFERENCES_PATH.read_text(encoding="utf-8")
+    assert "nekoChatOpacity" in theme_source
+    assert "nekoFloatingMenuOpacity" in theme_source
+
+    for template_path in (INDEX_TEMPLATE_PATH, CHAT_TEMPLATE_PATH):
+        template_source = template_path.read_text(encoding="utf-8")
+        assert "/static/theme-manager.js" in template_source
+        assert "/static/ui-opacity-preferences.js" not in template_source
+
+    chat_styles = CHAT_STYLES_PATH.read_text(encoding="utf-8")
+    dark_mode_css = DARK_MODE_CSS_PATH.read_text(encoding="utf-8")
+    assert chat_styles.count("var(--neko-chat-opacity-factor, 1)") >= 25
+    assert dark_mode_css.count("var(--neko-floating-menu-opacity-factor, 1)") == 8
+
+    for locale in LOCALES:
+        messages = json.loads((LOCALES_PATH / f"{locale}.json").read_text(encoding="utf-8"))
+        toggles = messages["settings"]["toggles"]
+        assert "opacitySettings" not in toggles
+        assert "chatOpacity" not in toggles
+        assert "floatingMenuOpacity" not in toggles


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

为聊天框和悬浮菜单接入统一透明度适配，默认值为 50%
[在系统托盘显示设置中新增聊天框与悬浮菜单透明度滑条，并实时同步到各窗口](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/481)

## 测试 / Testing

测试确认功能正常使用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增界面透明度管理，可分别调整聊天界面与浮动菜单的透明度。
  * 透明度设置支持持久化，并可在页面加载、主题切换及跨页面变化时保持同步。
  * 聊天窗口、弹出菜单、按钮及玻璃效果支持统一透明度调节，并兼容浅色和深色主题。

* **测试**
  * 新增透明度读取、设置、同步及边界值处理的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->