### PR TITLE
为聊天发送事件区分 Enter 与按钮提交，发送被接受后立即请求收起，并修复紧凑聊天框按 Enter 时短暂换行的问题

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -9480,6 +9480,43 @@ describe('App', () => {
     expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test send', submitMethod: 'enter' });
   });
 
+  it('finishes a plain Enter submission when the compact input blurs before keyup', () => {
+    const onComposerSubmit = vi.fn();
+    renderInputApp({ onComposerSubmit });
+
+    const input = screen.getByPlaceholderText('Type a message...');
+    fireEvent.change(input, { target: { value: 'Send on blur' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    fireEvent.blur(input);
+    fireEvent.keyUp(input, { key: 'Enter', code: 'Enter' });
+
+    expect(onComposerSubmit).toHaveBeenCalledTimes(1);
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Send on blur', submitMethod: 'enter' });
+    expect(input).toHaveValue('');
+  });
+
+  it('does not turn Shift+Enter or IME confirmation into a submission on blur', () => {
+    const onComposerSubmit = vi.fn();
+    renderInputApp({ onComposerSubmit });
+
+    const input = screen.getByPlaceholderText('Type a message...');
+    fireEvent.change(input, { target: { value: 'Keep draft' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', shiftKey: true });
+    fireEvent.blur(input);
+
+    fireEvent.focus(input);
+    fireEvent.compositionStart(input);
+    fireEvent.keyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      isComposing: true,
+    });
+    fireEvent.blur(input);
+
+    expect(onComposerSubmit).not.toHaveBeenCalled();
+    expect(input).toHaveValue('Keep draft');
+  });
+
   it('submits plain Enter when WebKit inserts a line break before keyup', () => {
     const onComposerSubmit = vi.fn();
     renderInputApp({ onComposerSubmit });

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -328,7 +328,7 @@ describe('App', () => {
     fireEvent.change(input, { target: { value: '  你好  ' } });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好', submitMethod: 'button' });
     expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
     expect(container.querySelector('[data-compact-chat-state="input"]')).not.toBeNull();
 
@@ -353,7 +353,7 @@ describe('App', () => {
       target: { value: 'cat draft' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
-    expect(onComposerSubmit).toHaveBeenLastCalledWith({ text: 'cat draft' });
+    expect(onComposerSubmit).toHaveBeenLastCalledWith({ text: 'cat draft', submitMethod: 'button' });
 
     rerender(
       <App compactChatState="input" onComposerSubmit={onComposerSubmit} />,
@@ -383,7 +383,21 @@ describe('App', () => {
     fireEvent.change(input, { target: { value: '喵一下' } });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '喵一下' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '喵一下', submitMethod: 'button' });
+  });
+
+  it('marks a plain Enter submission from the full chat surface', () => {
+    const onComposerSubmit = vi.fn();
+    render(<App chatSurfaceMode="full" onComposerSubmit={onComposerSubmit} />);
+
+    const input = screen.getByPlaceholderText('Type a message...');
+    fireEvent.change(input, { target: { value: 'full Enter send' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(onComposerSubmit).toHaveBeenCalledWith({
+      text: 'full Enter send',
+      submitMethod: 'enter',
+    });
   });
 
   it('keeps the ordinary full-chat draft separate from the temporary cat draft', () => {
@@ -403,7 +417,7 @@ describe('App', () => {
       target: { value: 'full cat draft' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
-    expect(onComposerSubmit).toHaveBeenLastCalledWith({ text: 'full cat draft' });
+    expect(onComposerSubmit).toHaveBeenLastCalledWith({ text: 'full cat draft', submitMethod: 'button' });
 
     rerender(
       <App chatSurfaceMode="full" onComposerSubmit={onComposerSubmit} />,
@@ -9252,7 +9266,7 @@ describe('App', () => {
     expect(sendButton.querySelector('img')).toHaveAttribute('src', '/static/icons/send_new_icon.png');
     fireEvent.click(sendButton);
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test compact send' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test compact send', submitMethod: 'button' });
   });
 
   it('keeps controlled compact input focused after submitting text for continuous typing', async () => {
@@ -9279,7 +9293,7 @@ describe('App', () => {
     expect(document.activeElement).toBe(sendButton);
     fireEvent.click(sendButton);
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'First compact message' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'First compact message', submitMethod: 'button' });
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
     expect(screen.getByPlaceholderText('Type a message...')).toHaveValue('');
     await waitFor(() => {
@@ -9457,11 +9471,13 @@ describe('App', () => {
 
     const input = screen.getByPlaceholderText('Type a message...');
     fireEvent.change(input, { target: { value: 'Test send' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    const enterDispatchResult = fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(enterDispatchResult).toBe(false);
+    expect(input).toHaveValue('Test send');
     expect(onComposerSubmit).not.toHaveBeenCalled();
     fireEvent.keyUp(input, { key: 'Enter', code: 'Enter' });
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test send' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test send', submitMethod: 'enter' });
   });
 
   it('submits plain Enter when WebKit inserts a line break before keyup', () => {
@@ -9477,7 +9493,7 @@ describe('App', () => {
     });
     fireEvent.keyUp(input, { key: 'Enter', code: 'Enter' });
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Send without newline' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Send without newline', submitMethod: 'enter' });
     expect(input).toHaveValue('');
   });
 
@@ -9493,7 +9509,7 @@ describe('App', () => {
     });
     fireEvent.keyUp(input, { key: 'Enter', code: 'Enter' });
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Fallback send' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Fallback send', submitMethod: 'enter' });
   });
 
   it('treats an inputType-less text replacement as an IME candidate commit', () => {
@@ -9512,7 +9528,7 @@ describe('App', () => {
     expect(input).toHaveValue('candidate');
 
     pressEnter(input);
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'candidate' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'candidate', submitMethod: 'enter' });
   });
 
   it('keeps a Shift+Enter line break without submitting', () => {
@@ -9521,7 +9537,12 @@ describe('App', () => {
 
     const input = screen.getByPlaceholderText('Type a message...');
     fireEvent.change(input, { target: { value: 'First line' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', shiftKey: true });
+    const shiftEnterDispatchResult = fireEvent.keyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true,
+    });
+    expect(shiftEnterDispatchResult).toBe(true);
     fireEvent.input(input, {
       target: { value: 'First line\n' },
       inputType: 'insertLineBreak',
@@ -9552,7 +9573,7 @@ describe('App', () => {
     expect(input).toHaveValue('你好');
 
     pressEnter(input);
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好', submitMethod: 'enter' });
   });
 
   it('treats macOS WebKit keyCode 229 as IME confirmation until keyup', () => {
@@ -9580,7 +9601,7 @@ describe('App', () => {
     expect(input).toHaveValue('你好');
 
     pressEnter(input);
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好', submitMethod: 'enter' });
   });
 
   it('submits on the first Enter after an IME commit completed without Enter', () => {
@@ -9593,7 +9614,7 @@ describe('App', () => {
     fireEvent.compositionEnd(input);
 
     pressEnter(input);
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好', submitMethod: 'enter' });
   });
 
   it('does not submit an ASCII candidate committed without composition metadata', () => {
@@ -9614,7 +9635,7 @@ describe('App', () => {
     expect(input).toHaveValue('ok');
 
     pressEnter(input);
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'ok' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'ok', submitMethod: 'enter' });
   });
 
   it('allows an explicit pointer send while an IME composition is active', () => {
@@ -9626,7 +9647,7 @@ describe('App', () => {
     fireEvent.change(input, { target: { value: '你好' } });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }), { detail: 1 });
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: '你好', submitMethod: 'button' });
   });
 
   it('disables composer submission while the home tutorial owns interaction', () => {
@@ -9675,7 +9696,7 @@ describe('App', () => {
     fireEvent.change(input, { target: { value: 'No local optimistic bubble' } });
     pressEnter(input);
 
-    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'No local optimistic bubble' });
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'No local optimistic bubble', submitMethod: 'enter' });
     expect(screen.queryByText('No local optimistic bubble')).not.toBeInTheDocument();
     expect(screen.queryByText('You')).not.toBeInTheDocument();
   });

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4829,7 +4829,10 @@ function CompactChatApp({
     inputNode.setSelectionRange(selectionEnd, selectionEnd);
   }
 
-  function submitDraft(draftOverride?: string) {
+  function submitDraft(
+    draftOverride?: string,
+    submitMethod: ComposerSubmitPayload['submitMethod'] = 'button',
+  ) {
     if (compactTextEntryLocked) return;
     if (submittingRef.current) return;
     const text = (draftOverride ?? visibleDraft).trim();
@@ -4838,7 +4841,7 @@ function CompactChatApp({
     submittingRef.current = true;
     let shouldRefocusCompactInput = false;
     try {
-      onComposerSubmit?.({ text });
+      onComposerSubmit?.({ text, submitMethod });
       if (catLocalTextOnly) {
         setCatDraft('');
       } else {
@@ -5897,7 +5900,7 @@ function CompactChatApp({
                   || composerImeCommitPendingRef.current)) {
                 return;
               }
-              submitDraft();
+              submitDraft(undefined, 'button');
             }}>
               {isCompactSurface ? (
                 <div
@@ -6068,6 +6071,12 @@ function CompactChatApp({
                               composerEnterCycleImeRef.current = isImeEnter;
                               composerEnterCycleLineBreakRef.current = false;
                               composerEnterCycleDraftRef.current = event.currentTarget.value;
+
+                              // Plain Enter is submitted on keyup so the complete IME cycle can be
+                              // classified first, but its textarea newline must be canceled now.
+                              if (!event.shiftKey && !isImeEnter) {
+                                event.preventDefault();
+                              }
                             }
                           }}
                           onKeyUp={(event) => {
@@ -6104,7 +6113,10 @@ function CompactChatApp({
 
                             if (shouldSubmit) {
                               event.preventDefault();
-                              submitDraft(shouldRestoreDraft ? draftBeforeEnter : undefined);
+                              submitDraft(
+                                shouldRestoreDraft ? draftBeforeEnter : undefined,
+                                'enter',
+                              );
                             }
                           }}
                           onPointerUp={() => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4832,6 +4832,7 @@ function CompactChatApp({
   function submitDraft(
     draftOverride?: string,
     submitMethod: ComposerSubmitPayload['submitMethod'] = 'button',
+    { refocusCompactInput = true }: { refocusCompactInput?: boolean } = {},
   ) {
     if (compactTextEntryLocked) return;
     if (submittingRef.current) return;
@@ -4848,7 +4849,8 @@ function CompactChatApp({
         setDraft('');
       }
       restoreCompactExportHistoryToBottomForOutgoingMessage();
-      shouldRefocusCompactInput = isCompactSurface
+      shouldRefocusCompactInput = refocusCompactInput
+        && isCompactSurface
         && effectiveCompactChatState === 'input'
         && text.length > 0;
     } finally {
@@ -4859,6 +4861,26 @@ function CompactChatApp({
         }
       });
     }
+  }
+
+  function completeComposerEnterCycle() {
+    const shouldSubmit = composerEnterCycleActiveRef.current
+      && !composerEnterCycleShiftRef.current
+      && !composerEnterCycleImeRef.current
+      && !composerIsComposingRef.current
+      && !composerImeCommitPendingRef.current;
+    const draftBeforeEnter = composerEnterCycleDraftRef.current;
+    const shouldRestoreDraft = composerEnterCycleLineBreakRef.current
+      && !composerEnterCycleShiftRef.current;
+
+    composerEnterCycleActiveRef.current = false;
+    composerEnterCycleShiftRef.current = false;
+    composerEnterCycleImeRef.current = false;
+    composerEnterCycleLineBreakRef.current = false;
+    composerEnterCycleDraftRef.current = '';
+    composerImeCommitPendingRef.current = false;
+
+    return { draftBeforeEnter, shouldRestoreDraft, shouldSubmit };
   }
 
   const compactFanRunAction = (action: (() => void) | undefined) => (event: ReactMouseEvent) => {
@@ -6087,21 +6109,11 @@ function CompactChatApp({
                               return;
                             }
 
-                            const shouldSubmit = composerEnterCycleActiveRef.current
-                              && !composerEnterCycleShiftRef.current
-                              && !composerEnterCycleImeRef.current
-                              && !composerIsComposingRef.current
-                              && !composerImeCommitPendingRef.current;
-                            const draftBeforeEnter = composerEnterCycleDraftRef.current;
-                            const shouldRestoreDraft = composerEnterCycleLineBreakRef.current
-                              && !composerEnterCycleShiftRef.current;
-
-                            composerEnterCycleActiveRef.current = false;
-                            composerEnterCycleShiftRef.current = false;
-                            composerEnterCycleImeRef.current = false;
-                            composerEnterCycleLineBreakRef.current = false;
-                            composerEnterCycleDraftRef.current = '';
-                            composerImeCommitPendingRef.current = false;
+                            const {
+                              draftBeforeEnter,
+                              shouldRestoreDraft,
+                              shouldSubmit,
+                            } = completeComposerEnterCycle();
 
                             if (shouldRestoreDraft) {
                               if (catLocalTextOnly) {
@@ -6126,13 +6138,29 @@ function CompactChatApp({
                             }
                           }}
                           onBlur={() => {
+                            const {
+                              draftBeforeEnter,
+                              shouldRestoreDraft,
+                              shouldSubmit,
+                            } = completeComposerEnterCycle();
                             composerIsComposingRef.current = false;
                             composerImeCommitPendingRef.current = false;
-                            composerEnterCycleActiveRef.current = false;
-                            composerEnterCycleImeRef.current = false;
-                            composerEnterCycleShiftRef.current = false;
-                            composerEnterCycleLineBreakRef.current = false;
-                            composerEnterCycleDraftRef.current = '';
+
+                            if (shouldRestoreDraft) {
+                              if (catLocalTextOnly) {
+                                setCatDraft(draftBeforeEnter);
+                              } else {
+                                setDraft(draftBeforeEnter);
+                              }
+                            }
+
+                            if (shouldSubmit) {
+                              submitDraft(
+                                draftBeforeEnter,
+                                'enter',
+                                { refocusCompactInput: false },
+                              );
+                            }
                             scheduleCompactInputCollapse();
                           }}
                         />

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -2270,7 +2270,7 @@ export default function FullChatSurface({
     }
   }
 
-  function submitDraft() {
+  function submitDraft(submitMethod: ComposerSubmitPayload['submitMethod'] = 'button') {
     if (composerInteractionsDisabled) return;
     if (submittingRef.current) return;
     const text = visibleDraft.trim();
@@ -2278,7 +2278,7 @@ export default function FullChatSurface({
     closeCompactInputToolFan();
     submittingRef.current = true;
     try {
-      onComposerSubmit?.({ text });
+      onComposerSubmit?.({ text, submitMethod });
       if (catLocalTextOnly) {
         setCatDraft('');
       } else {
@@ -3238,7 +3238,7 @@ export default function FullChatSurface({
           ) : null}
           <form className="composer" onSubmit={(event) => {
             event.preventDefault();
-            submitDraft();
+            submitDraft('button');
           }}>
             {isCompactSurface ? (
               <div
@@ -3316,7 +3316,7 @@ export default function FullChatSurface({
                           if (event.nativeEvent.isComposing) return;
                           if (event.key === 'Enter' && !event.shiftKey) {
                             event.preventDefault();
-                            submitDraft();
+                            submitDraft('enter');
                           }
                         }}
                       />
@@ -3405,7 +3405,7 @@ export default function FullChatSurface({
                   if (event.nativeEvent.isComposing) return;
                   if (event.key === 'Enter' && !event.shiftKey) {
                     event.preventDefault();
-                    submitDraft();
+                    submitDraft('enter');
                   }
                 }}
               />

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -183,6 +183,7 @@ export const chatMessageSchema = z.object({
 export const composerSubmitSchema = z.object({
   text: z.string(),
   requestId: z.string().optional(),
+  submitMethod: z.enum(['enter', 'button']).optional(),
 });
 
 export const chatWindowPropsSchema = z.object({

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -3050,7 +3050,9 @@
 
             // Enter 已通过空内容、教程锁和附件预处理校验，即视为发送请求已被聊天逻辑接受。
             // 必须在首轮 start_session 的异步等待前收起，否则第一次聊天会等初始化完成才响应。
-            requestChatAutoCollapseAfterAcceptedEnter(options, requestId);
+            if (options.autoCollapseAfterEnterRequested !== true) {
+                requestChatAutoCollapseAfterAcceptedEnter(options, requestId);
+            }
 
             function shouldAppendLegacyUserMessage() {
                 return !isReactWindowSource && !(forceReactOptimisticMessage && reactOptimisticMessageAppended !== null);
@@ -3386,7 +3388,12 @@
                     && !hasScreenshots
                     && !hasExtraImages
                     && hasPendingAvatarInteractionContinuation()) {
-                queueDeferredTextSubmission(text, options);
+                var deferredOptions = Object.assign({}, options);
+                if (deferredOptions.autoCollapseAfterEnterRequested !== true
+                        && requestChatAutoCollapseAfterAcceptedEnter(deferredOptions, deferredOptions.requestId)) {
+                    deferredOptions.autoCollapseAfterEnterRequested = true;
+                }
+                queueDeferredTextSubmission(text, deferredOptions);
                 textInputBox.value = '';
                 textInputComposing = false;
                 lastTextCompositionEndAt = 0;

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -1878,7 +1878,8 @@
         host.setOnComposerSubmit(function (detail) {
             return mod.sendTextPayload(detail && detail.text, {
                 source: 'react-chat-window',
-                requestId: detail && detail.requestId
+                requestId: detail && detail.requestId,
+                submitMethod: detail && detail.submitMethod
             });
         });
         if (typeof host.setOnCompactHistoryDrop === 'function') {
@@ -2941,6 +2942,22 @@
             }
         }
 
+        function requestChatAutoCollapseAfterAcceptedEnter(options, requestId) {
+            if (
+                !options
+                || options.submitMethod !== 'enter'
+                || !window.nekoChatWindow
+                || typeof window.nekoChatWindow.requestAutoCollapseAfterEnter !== 'function'
+            ) return false;
+            try {
+                window.nekoChatWindow.requestAutoCollapseAfterEnter({ requestId: requestId });
+                return true;
+            } catch (error) {
+                console.warn('[Chat] 请求回车发送后自动收起失败:', error);
+                return false;
+            }
+        }
+
         async function sendTextPayloadInternal(rawText, options) {
             options = options || {};
             var text = String(typeof rawText === 'string' ? rawText : '').trim();
@@ -3030,6 +3047,10 @@
                     imageUrls: optimisticImageUrls
                 });
             }
+
+            // Enter 已通过空内容、教程锁和附件预处理校验，即视为发送请求已被聊天逻辑接受。
+            // 必须在首轮 start_session 的异步等待前收起，否则第一次聊天会等初始化完成才响应。
+            requestChatAutoCollapseAfterAcceptedEnter(options, requestId);
 
             function shouldAppendLegacyUserMessage() {
                 return !isReactWindowSource && !(forceReactOptimisticMessage && reactOptimisticMessageAppended !== null);
@@ -3309,7 +3330,8 @@
                             detail: {
                                 requestId: requestId,
                                 text: text,
-                                source: messageSource || 'text'
+                                source: messageSource || 'text',
+                                submitMethod: options.submitMethod === 'enter' ? 'enter' : 'button'
                             }
                         }));
                         // 标记"WS 已发、还没收到首 chunk"窗口，给 isAssistantTextResponseInFlight 用。

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -350,7 +350,10 @@
             : ('req-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
         var detail = {
             text: payload && typeof payload.text === 'string' ? payload.text : '',
-            requestId: requestId
+            requestId: requestId,
+            submitMethod: payload && (payload.submitMethod === 'enter' || payload.submitMethod === 'button')
+                ? payload.submitMethod
+                : 'button'
         };
 
         if (typeof I.isCatLocalChatActive === 'function' && I.isCatLocalChatActive()) {
@@ -421,7 +424,11 @@
                 console.error('[ReactChatWindow] onComposerSubmit failed:', error);
             }
         } else if (window.appButtons && typeof window.appButtons.sendTextPayload === 'function') {
-            window.appButtons.sendTextPayload(detail.text, { source: 'react-chat-window', requestId: detail.requestId });
+            window.appButtons.sendTextPayload(detail.text, {
+                source: 'react-chat-window',
+                requestId: detail.requestId,
+                submitMethod: detail.submitMethod
+            });
         } else {
             var input = I.$('textInputBox');
             var sendButton = I.$('textSendButton');

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -336,6 +336,22 @@
         I.dispatchHostEvent('action', detail);
     }
 
+    function requestAutoCollapseAfterAcceptedEnter(detail) {
+        if (
+            !detail
+            || detail.submitMethod !== 'enter'
+            || !window.nekoChatWindow
+            || typeof window.nekoChatWindow.requestAutoCollapseAfterEnter !== 'function'
+        ) return false;
+        try {
+            window.nekoChatWindow.requestAutoCollapseAfterEnter({ requestId: detail.requestId });
+            return true;
+        } catch (error) {
+            console.warn('[ReactChatWindow] request auto-collapse after Enter failed:', error);
+            return false;
+        }
+    }
+
     I.handleComposerSubmit = function handleComposerSubmit(payload) {
         if (
             I.state.homeTutorialInteractionLocked
@@ -359,7 +375,9 @@
         if (typeof I.isCatLocalChatActive === 'function' && I.isCatLocalChatActive()) {
             if (!detail.text.trim()) return;
             if (typeof I.submitCatLocalChatText === 'function') {
-                I.submitCatLocalChatText(detail);
+                if (I.submitCatLocalChatText(detail)) {
+                    requestAutoCollapseAfterAcceptedEnter(detail);
+                }
             }
             return;
         }
@@ -414,6 +432,7 @@
             } catch (error) {
                 console.warn('[NewUserIcebreaker] free text broadcast failed:', error);
             }
+            requestAutoCollapseAfterAcceptedEnter(detail);
             return;
         }
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -3103,3 +3103,30 @@ def test_text_mode_screenshot_payload_always_tags_interaction_request():
     assert "if (text)" not in screenshot_block
     assert "msg.request_id = requestId" not in screenshot_block
     assert "request_id: requestId" in text_block
+
+
+def test_deferred_enter_submission_requests_auto_collapse_once_before_queue_flush():
+    script = APP_BUTTONS_PATH.read_text(encoding="utf-8")
+    public_send_block = script.split("async function sendTextPayload(rawText, options)", 1)[1].split(
+        "mod.sendTextPayload = sendTextPayload",
+        1,
+    )[0]
+    deferral_block = public_send_block.split("if (options.skipAvatarInteractionDeferral !== true", 1)[1].split(
+        "return sendTextPayloadInternal",
+        1,
+    )[0]
+
+    assert "var deferredOptions = Object.assign({}, options);" in deferral_block
+    assert "requestChatAutoCollapseAfterAcceptedEnter(deferredOptions, deferredOptions.requestId)" in deferral_block
+    assert "deferredOptions.autoCollapseAfterEnterRequested = true;" in deferral_block
+    assert "queueDeferredTextSubmission(text, deferredOptions);" in deferral_block
+    assert deferral_block.index("requestChatAutoCollapseAfterAcceptedEnter") < deferral_block.index(
+        "queueDeferredTextSubmission"
+    )
+
+    internal_send_block = script.split("async function sendTextPayloadInternal(rawText, options)", 1)[1].split(
+        "function shouldAppendLegacyUserMessage()",
+        1,
+    )[0]
+    assert "if (options.autoCollapseAfterEnterRequested !== true)" in internal_send_block
+    assert "requestChatAutoCollapseAfterAcceptedEnter(options, requestId);" in internal_send_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -3130,3 +3130,37 @@ def test_deferred_enter_submission_requests_auto_collapse_once_before_queue_flus
     )[0]
     assert "if (options.autoCollapseAfterEnterRequested !== true)" in internal_send_block
     assert "requestChatAutoCollapseAfterAcceptedEnter(options, requestId);" in internal_send_block
+
+
+def test_special_enter_submission_paths_request_auto_collapse_only_after_acceptance():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    submit_block = script.split("function handleComposerSubmit(payload)", 1)[1].split(
+        "function prepareCompactHistoryDropSubmit",
+        1,
+    )[0]
+
+    helper_block = script.split("function requestAutoCollapseAfterAcceptedEnter(detail)", 1)[1].split(
+        "function handleComposerSubmit(payload)",
+        1,
+    )[0]
+    assert "detail.submitMethod !== 'enter'" in helper_block
+    assert "window.nekoChatWindow.requestAutoCollapseAfterEnter({ requestId: detail.requestId });" in helper_block
+
+    cat_block = submit_block.split("if (typeof isCatLocalChatActive", 1)[1].split(
+        "var hasAttachments",
+        1,
+    )[0]
+    assert "if (submitCatLocalChatText(detail))" in cat_block
+    assert "requestAutoCollapseAfterAcceptedEnter(detail);" in cat_block
+    assert cat_block.index("submitCatLocalChatText(detail)") < cat_block.index(
+        "requestAutoCollapseAfterAcceptedEnter(detail)"
+    )
+
+    icebreaker_block = submit_block.split(
+        "if (state.choicePrompt && state.choicePrompt.source === 'new_user_icebreaker')",
+        1,
+    )[1].split("if (typeof state.onComposerSubmit", 1)[0]
+    assert "requestAutoCollapseAfterAcceptedEnter(detail);" in icebreaker_block
+    assert icebreaker_block.index("dispatchHostEvent('icebreaker-free-text-submit'") < icebreaker_block.index(
+        "requestAutoCollapseAfterAcceptedEnter(detail)"
+    )


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

为聊天发送事件区分 Enter 与按钮提交，发送被接受后立即请求收起，并修复紧凑聊天框按 Enter 时短暂换行的问题
[新增“回车发送后自动收起”托盘设置，通过 IPC 控制紧凑与完整聊天窗口使用现有状态机收起，并补充八语言文案及测试](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/482)

## 测试 / Testing

已手动测试确认功能可以正常使用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 区分按钮提交与回车提交，并在提交事件中记录提交方式。
  - 普通回车会发送消息并请求聊天窗口自动收起。
  - 普通回车不再插入换行；Shift+Enter 和输入法组合输入行为保持不变。
  - 输入框在回车后失焦时仍可完成提交，提交后清空草稿。
- **Bug 修复**
  - 避免延迟处理时重复请求聊天窗口自动收起。
- **测试**
  - 完善回车提交、按钮提交、失焦处理及自动收起场景的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->