### PR TITLE
feat(card-drop): hand Desktop OAuth session to community via one-time native_sync ticket

### DIFF
--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1372,6 +1372,10 @@ async def social_session_init_options(request: Request):
     cors = _sync_cors_headers(request)
     if cors is None:
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    if not client_registration.proof_transport_allowed(_social_base_url()):
+        return JSONResponse(
+            {"detail": "insecure_transport"}, status_code=403, headers=cors
+        )
     return JSONResponse({"ok": True}, headers=cors)
 
 
@@ -1381,19 +1385,37 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
 
     The community SPA (opened by NEKO with a ``#native_sync`` ticket) redeems
     that one-time ticket here. In exchange it receives the Desktop
-    ``neko-servers-desktop-*`` access/refresh tokens, which N.E.K.O.Servers
-    already accepts (``AUTH_ALLOWED_DESKTOP_CLIENT_IDS``). The SPA then runs
-    its normal ``/api/auth/session/bootstrap`` and publishes the session, so no
-    second browser login is needed and both sides share one token family.
+    ``neko-servers-desktop-*`` access token, which N.E.K.O.Servers already
+    accepts (``AUTH_ALLOWED_DESKTOP_CLIENT_IDS``). The SPA then runs its normal
+    ``/api/auth/session/bootstrap`` and publishes the session, so no second
+    browser login is needed.
+
+    The refresh token stays here: Desktop is the sole owner of that rotating
+    family, and a second independent rotator would invalidate both sides. The
+    community session therefore lives as long as the handed-over access token.
 
     Direction is Python → SPA over the allowlisted community Origin only; the
-    Web tab never sends its own bearer to localhost. Ticket is single-use.
+    Web tab never sends its own bearer to localhost. Ticket is single-use, and
+    is consumed only once the response is known to be deliverable.
     """
+    if not (request.headers.get("origin") or "").strip():
+        # CORS cannot authenticate a non-browser caller, and any local process
+        # can mint a ticket via /sync-ticket. Requiring an Origin keeps this
+        # endpoint reachable only from the real cross-origin community tab.
+        return JSONResponse(
+            {"detail": "origin_required"},
+            status_code=403,
+            headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+        )
     cors = _sync_cors_headers(request)
     if cors is None:
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    if not client_registration.proof_transport_allowed(_social_base_url()):
+        return JSONResponse(
+            {"detail": "insecure_transport"}, status_code=403, headers=cors
+        )
     sync_ticket = payload.get("sync_ticket") or payload.get("syncTicket")
-    if not _consume_sync_ticket(sync_ticket):
+    if not _sync_ticket_is_valid(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
         )
@@ -1417,17 +1439,37 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         return JSONResponse(
             {"detail": "legacy_session_not_supported"}, status_code=409, headers=cors
         )
+    snapshot_base = str(snapshot.get("base_url") or "").strip().rstrip("/")
+    if snapshot_base and not _same_originish(snapshot_base, _social_base_url()):
+        # The saved login belongs to another community; refuse rather than ship
+        # its bearer to the currently configured one. The session stays on disk
+        # so pointing NEKO_SOCIAL_BASE_URL back restores it.
+        return JSONResponse(
+            {"detail": "desktop_login_required"}, status_code=409, headers=cors
+        )
     from main_routers import community_oauth as _co
 
+    auth = await asyncio.to_thread(_load_auth) or {}
+    # 老会话没存 bind 字段 → 视为已绑（向后兼容，正常单账号场景成立）
+    bind = auth.get("bind") or {"bound": True, "error": None}
+    if not bind.get("bound") and bind.get("error") != _BIND_OWNERSHIP_CONFLICT:
+        # Desktop binds once at callback time and never retries. Redeeming the
+        # ticket used to be the SPA's chance to repair a failed bind, so retry
+        # here before it is spent.
+        bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
+    if not _consume_sync_ticket(sync_ticket):
+        return JSONResponse(
+            {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
+        )
     return JSONResponse(
         {
             "access_token": access_token,
-            "refresh_token": str(snapshot.get("refresh_token") or "").strip() or None,
             "local_user_id": local_user_id,
             "auth_public_url": str(
                 snapshot.get("auth_public_url") or _co._auth_public_url()
             ).rstrip("/"),
             "client_id": str(snapshot.get("client_id") or _co._desktop_client_id()),
+            "bind": bind,
         },
         headers={**cors, "Cache-Control": "no-store", "Pragma": "no-cache"},
     )

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1457,6 +1457,14 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         # ticket used to be the SPA's chance to repair a failed bind, so retry
         # here before it is spent.
         bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
+        if bind.get("bound"):
+            # Persist it, or /auth-status keeps reporting the stale failure and
+            # every later handoff repeats the bind. Only write when the record
+            # still holds the token we bound, so a concurrent refresh or account
+            # switch is not overwritten.
+            current = await asyncio.to_thread(_load_auth) or {}
+            if str(current.get("access_token") or "").strip() == access_token:
+                await asyncio.to_thread(_save_auth, {**current, "bind": bind})
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -671,6 +671,28 @@ def _save_auth(data: dict) -> bool:
     return True
 
 
+def _persist_repaired_bind(access_token: str, bind: dict) -> None:
+    """Record a repaired bind without clobbering a concurrent refresh.
+
+    Read-modify-write under the same lock the social-session CAS uses, merging
+    only the ``bind`` key: a refresh or account switch landing between read and
+    write owns the tokens and must not be rolled back to this snapshot.
+    """
+    path = _auth_path()
+    if path is None:
+        return
+    try:
+        with _social_session_lock(path):
+            current = _read_json_dict(path)
+            if not current:
+                return
+            if str(current.get("access_token") or "").strip() != access_token:
+                return
+            _write_private_json(path, {**current, "bind": bind})
+    except OSError as exc:
+        logger.warning("card_drop: persist repaired bind failed: %s", exc)
+
+
 def _save_social_session(
     base: str,
     access: str | None,
@@ -1459,12 +1481,8 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
         if bind.get("bound"):
             # Persist it, or /auth-status keeps reporting the stale failure and
-            # every later handoff repeats the bind. Only write when the record
-            # still holds the token we bound, so a concurrent refresh or account
-            # switch is not overwritten.
-            current = await asyncio.to_thread(_load_auth) or {}
-            if str(current.get("access_token") or "").strip() == access_token:
-                await asyncio.to_thread(_save_auth, {**current, "bind": bind})
+            # every later handoff repeats the bind.
+            await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1367,6 +1367,72 @@ async def native_delegate_handoff_endpoint(
     )
 
 
+@router.options("/social-session-init", summary="社区网页复用 Desktop 登录态预检")
+async def social_session_init_options(request: Request):
+    cors = _sync_cors_headers(request)
+    if cors is None:
+        return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    return JSONResponse({"ok": True}, headers=cors)
+
+
+@router.post("/social-session-init", summary="一次性消费 native_sync ticket，交付 Desktop OAuth 会话")
+async def social_session_init_endpoint(request: Request, payload: dict = Body(...)):
+    """Hand the Desktop OAuth session to the community tab so it logs in once.
+
+    The community SPA (opened by NEKO with a ``#native_sync`` ticket) redeems
+    that one-time ticket here. In exchange it receives the Desktop
+    ``neko-servers-desktop-*`` access/refresh tokens, which N.E.K.O.Servers
+    already accepts (``AUTH_ALLOWED_DESKTOP_CLIENT_IDS``). The SPA then runs
+    its normal ``/api/auth/session/bootstrap`` and publishes the session, so no
+    second browser login is needed and both sides share one token family.
+
+    Direction is Python → SPA over the allowlisted community Origin only; the
+    Web tab never sends its own bearer to localhost. Ticket is single-use.
+    """
+    cors = _sync_cors_headers(request)
+    if cors is None:
+        return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    sync_ticket = payload.get("sync_ticket") or payload.get("syncTicket")
+    if not _consume_sync_ticket(sync_ticket):
+        return JSONResponse(
+            {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
+        )
+    snapshot, failure = await _native_delegate_session_snapshot()
+    access_token = str((snapshot or {}).get("access_token") or "").strip()
+    local_user_id = str((snapshot or {}).get("local_user_id") or "").strip()
+    if not snapshot or not access_token or not local_user_id:
+        unavailable = failure in {"unavailable", "malformed"}
+        return JSONResponse(
+            {
+                "detail": (
+                    "identity_verification_unavailable"
+                    if unavailable
+                    else "desktop_login_required"
+                )
+            },
+            status_code=503 if unavailable else 409,
+            headers=cors,
+        )
+    if snapshot.get("auth_source") != "oauth":
+        return JSONResponse(
+            {"detail": "legacy_session_not_supported"}, status_code=409, headers=cors
+        )
+    from main_routers import community_oauth as _co
+
+    return JSONResponse(
+        {
+            "access_token": access_token,
+            "refresh_token": str(snapshot.get("refresh_token") or "").strip() or None,
+            "local_user_id": local_user_id,
+            "auth_public_url": str(
+                snapshot.get("auth_public_url") or _co._auth_public_url()
+            ).rstrip("/"),
+            "client_id": str(snapshot.get("client_id") or _co._desktop_client_id()),
+        },
+        headers={**cors, "Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
 @router.options("/sync-session", summary="社区网页登录态同步预检")
 async def sync_session_options(request: Request):
     cors = _sync_cors_headers(request)

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1528,15 +1528,27 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
             # Persist it, or /auth-status keeps reporting the stale failure and
             # every later handoff repeats the bind.
             await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
-        # The bind retry is a cloud round trip; Desktop may have refreshed,
-        # logged out, or switched accounts while it ran. Shipping the captured
-        # bearer now could hand over a revoked token or the previous account's,
-        # and the ticket would be spent either way.
-        current = await asyncio.to_thread(_desktop_session_snapshot) or {}
-        if str(current.get("access_token") or "").strip() != access_token:
-            return JSONResponse(
-                {"detail": "desktop_login_required"}, status_code=409, headers=cors
-            )
+    # _load_auth 和 _oauth_guest_bind 都是 await 点，Desktop 登出、刷新、切号都可能
+    # 在这期间发生。原先只有 bind 重试分支复查，已绑定和 ownership-conflict 两条常见
+    # 路径直接消费 ticket 并下发 bearer。这里改成无条件复查：会话已变就返回 409，
+    # 既不下发凭据，也不消费 ticket（留给用户重试）。
+    #
+    # 注意这里没有对「复查 → 消费」加锁。Desktop 侧的写入在 _social_session_lock 下
+    # 提交，但复查必须走 _native_delegate_session_snapshot（异步 IPC，读的是 PC 进程
+    # 内存中的当前会话），没法放进同步锁作用域；换成读磁盘的 _desktop_session_snapshot
+    # 会和上面 1489 行的判定源不一致，PC 尚未落盘时会误判。所以复查和消费之间仍有一个
+    # 窄窗口 —— 它把「整段 await 期间」收敛到了「一次 IPC 往返」，但没有完全消除。
+    # 彻底消除需要 PC 侧提供带版本号的会话读取接口，属于跨仓库改动。
+    verification_snapshot, _ = await _native_delegate_session_snapshot()
+    verification_token = (
+        str(verification_snapshot.get("access_token") or "").strip()
+        if verification_snapshot
+        else ""
+    )
+    if verification_token != access_token:
+        return JSONResponse(
+            {"detail": "desktop_login_required"}, status_code=409, headers=cors
+        )
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
@@ -1546,9 +1558,15 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
             "access_token": access_token,
             "local_user_id": local_user_id,
             "auth_public_url": str(
-                snapshot.get("auth_public_url") or _co._auth_public_url()
+                snapshot.get("auth_public_url")
+                or auth.get("auth_public_url")
+                or _co._auth_public_url()
             ).rstrip("/"),
-            "client_id": str(snapshot.get("client_id") or _co._desktop_client_id()),
+            "client_id": str(
+                snapshot.get("client_id")
+                or auth.get("client_id")
+                or _co._desktop_client_id()
+            ),
             "bind": bind,
         },
         headers={**cors, "Cache-Control": "no-store", "Pragma": "no-cache"},

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1528,6 +1528,15 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
             # Persist it, or /auth-status keeps reporting the stale failure and
             # every later handoff repeats the bind.
             await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
+        # The bind retry is a cloud round trip; Desktop may have refreshed,
+        # logged out, or switched accounts while it ran. Shipping the captured
+        # bearer now could hand over a revoked token or the previous account's,
+        # and the ticket would be spent either way.
+        current = await asyncio.to_thread(_desktop_session_snapshot) or {}
+        if str(current.get("access_token") or "").strip() != access_token:
+            return JSONResponse(
+                {"detail": "desktop_login_required"}, status_code=409, headers=cors
+            )
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -674,22 +674,25 @@ def _save_auth(data: dict) -> bool:
 def _persist_repaired_bind(access_token: str, bind: dict) -> None:
     """Record a repaired bind without clobbering a concurrent refresh.
 
-    Read-modify-write under the same lock the social-session CAS uses, merging
-    only the ``bind`` key: a refresh or account switch landing between read and
-    write owns the tokens and must not be rolled back to this snapshot.
+    Serialized on the social-session lock rather than one keyed to the auth
+    file: ``_persist_refreshed_oauth_tokens`` rewrites ``community_auth.json``
+    while holding that lock, so it is the only lock both writers share.
     """
     path = _auth_path()
-    if path is None:
+    social_path = _social_session_path()
+    if path is None or social_path is None:
         return
     try:
-        with _social_session_lock(path):
+        with _social_session_lock(social_path):
             current = _read_json_dict(path)
             if not current:
                 return
+            # A refresh or account switch won the race; its tokens own the
+            # record and this bind describes a session that is no longer there.
             if str(current.get("access_token") or "").strip() != access_token:
                 return
             _write_private_json(path, {**current, "bind": bind})
-    except OSError as exc:
+    except (OSError, TimeoutError) as exc:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
 
 

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -659,7 +659,8 @@ def _write_social_session_record(path: Path, data: dict) -> None:
         _write_private_json(path, data)
 
 
-def _save_auth(data: dict) -> bool:
+def _save_auth_unlocked(data: dict) -> bool:
+    """Write community_auth.json without locking; caller must hold the lock."""
     p = _auth_path()
     if not p:
         return False
@@ -669,6 +670,18 @@ def _save_auth(data: dict) -> bool:
         logger.warning("card_drop: save auth failed: %s", exc)
         return False
     return True
+
+
+def _save_auth(data: dict) -> bool:
+    social_path = _social_session_path()
+    if social_path is None:
+        return _save_auth_unlocked(data)
+    try:
+        with _social_session_lock(social_path):
+            return _save_auth_unlocked(data)
+    except (OSError, TimeoutError) as exc:
+        logger.warning("card_drop: save auth failed: %s", exc)
+        return False
 
 
 def _persist_repaired_bind(access_token: str, bind: dict) -> None:
@@ -696,7 +709,8 @@ def _persist_repaired_bind(access_token: str, bind: dict) -> None:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
 
 
-def _save_social_session(
+def _save_social_session_unlocked(
+    path: Path,
     base: str,
     access: str | None,
     refresh: str | None,
@@ -706,12 +720,10 @@ def _save_social_session(
     auth_public_url: str | None = None,
     client_id: str | None = None,
 ) -> bool:
+    """Write social session without acquiring lock; caller must hold it."""
     normalized_user_id = _normalize_local_user_id(local_user_id)
     normalized_source = _normalize_auth_source(auth_source)
     if not access or not normalized_user_id or not normalized_source:
-        return False
-    p = _social_session_path()
-    if not p:
         return False
     data = {
         "schema_version": _SOCIAL_SESSION_SCHEMA_VERSION,
@@ -730,11 +742,41 @@ def _save_social_session(
     if oauth_client:
         data["client_id"] = oauth_client
     try:
-        _write_social_session_record(p, data)
+        _write_private_json(path, data)
     except OSError as exc:
         logger.warning("card_drop: save social session failed: %s", exc)
         return False
     return True
+
+
+def _save_social_session(
+    base: str,
+    access: str | None,
+    refresh: str | None,
+    *,
+    local_user_id: str,
+    auth_source: str,
+    auth_public_url: str | None = None,
+    client_id: str | None = None,
+) -> bool:
+    p = _social_session_path()
+    if not p:
+        return False
+    try:
+        with _social_session_lock(p):
+            return _save_social_session_unlocked(
+                p,
+                base,
+                access,
+                refresh,
+                local_user_id=local_user_id,
+                auth_source=auth_source,
+                auth_public_url=auth_public_url,
+                client_id=client_id,
+            )
+    except (OSError, TimeoutError) as exc:
+        logger.warning("card_drop: save social session failed: %s", exc)
+        return False
 
 
 def _persist_session_credentials(

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -510,18 +510,52 @@ def _persist_oauth_credentials(
         logger.warning("community_oauth: credential snapshot failed: %s", exc)
         return False
 
-    auth_saved = C._save_auth(auth_payload)
-    social_saved = auth_saved and C._save_social_session(
-        social_base,
-        access_token,
-        refresh_token,
-        local_user_id=local_user_id,
-        auth_source="oauth",
-        auth_public_url=auth_public_url,
-        client_id=client_id,
-    )
-    if auth_saved and social_saved:
-        return True
+    auth_saved = False
+    social_saved = False
+    try:
+        # Both credential files must move as one unit: a concurrent bind repair
+        # or refresh holds this same lock, so without it the two records can be
+        # left describing different accounts.
+        with C._social_session_lock(social_path):
+            auth_saved = C._save_auth_unlocked(auth_payload)
+            social_saved = auth_saved and C._save_social_session_unlocked(
+                social_path,
+                social_base,
+                access_token,
+                refresh_token,
+                local_user_id=local_user_id,
+                auth_source="oauth",
+                auth_public_url=auth_public_url,
+                client_id=client_id,
+            )
+            if auth_saved and social_saved:
+                return True
+
+            rollback_ok = True
+            for path, existed, payload in snapshots:
+                if path == social_path and social_saved:
+                    continue
+                try:
+                    if existed and payload is not None:
+                        C._write_private_json(path, payload)
+                    elif not existed:
+                        path.unlink(missing_ok=True)
+                except OSError as exc:
+                    rollback_ok = False
+                    logger.warning(
+                        "community_oauth: credential rollback failed for %s: %s",
+                        path.name,
+                        exc,
+                    )
+            if not rollback_ok:
+                logger.warning(
+                    "community_oauth: credential files may be inconsistent after "
+                    "a failed save"
+                )
+            return False
+    except (OSError, TimeoutError) as exc:
+        logger.warning("community_oauth: credential persist failed: %s", exc)
+        return False
 
     rollback_ok = True
     for path, existed, payload in snapshots:

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -494,29 +494,31 @@ def _persist_oauth_credentials(
     if auth_path is None or social_path is None:
         return False
 
-    snapshots: list[tuple[Path, bool, dict[str, Any] | None]] = []
-    try:
-        for path in (auth_path, social_path):
-            existed = path.exists()
-            payload = C._read_json_dict(path) if existed else None
-            if existed and payload is None:
-                logger.warning(
-                    "community_oauth: refusing to replace unreadable credential file: %s",
-                    path.name,
-                )
-                return False
-            snapshots.append((path, existed, payload))
-    except OSError as exc:
-        logger.warning("community_oauth: credential snapshot failed: %s", exc)
-        return False
-
-    auth_saved = False
-    social_saved = False
+    rollback_ok = True
     try:
         # Both credential files must move as one unit: a concurrent bind repair
         # or refresh holds this same lock, so without it the two records can be
-        # left describing different accounts.
+        # left describing different accounts. The rollback snapshots are read
+        # inside the same scope, or a refresh committing between the read and
+        # the lock would be rolled back onto an already-consumed refresh token.
         with C._social_session_lock(social_path):
+            snapshots: list[tuple[Path, bool, dict[str, Any] | None]] = []
+            try:
+                for path in (auth_path, social_path):
+                    existed = path.exists()
+                    payload = C._read_json_dict(path) if existed else None
+                    if existed and payload is None:
+                        logger.warning(
+                            "community_oauth: refusing to replace unreadable "
+                            "credential file: %s",
+                            path.name,
+                        )
+                        return False
+                    snapshots.append((path, existed, payload))
+            except OSError as exc:
+                logger.warning("community_oauth: credential snapshot failed: %s", exc)
+                return False
+
             auth_saved = C._save_auth_unlocked(auth_payload)
             social_saved = auth_saved and C._save_social_session_unlocked(
                 social_path,
@@ -531,7 +533,6 @@ def _persist_oauth_credentials(
             if auth_saved and social_saved:
                 return True
 
-            rollback_ok = True
             for path, existed, payload in snapshots:
                 if path == social_path and social_saved:
                     continue
@@ -547,36 +548,13 @@ def _persist_oauth_credentials(
                         path.name,
                         exc,
                     )
-            if not rollback_ok:
-                logger.warning(
-                    "community_oauth: credential files may be inconsistent after "
-                    "a failed save"
-                )
-            return False
     except (OSError, TimeoutError) as exc:
         logger.warning("community_oauth: credential persist failed: %s", exc)
         return False
 
-    rollback_ok = True
-    for path, existed, payload in snapshots:
-        # _save_social_session() either atomically replaced the social file and
-        # returned True, or left it untouched. Reaching rollback therefore
-        # means only community_auth.json may need restoration; rewriting the
-        # social snapshot here could overwrite a concurrent Desktop refresh.
-        if path == social_path:
-            continue
-        try:
-            if existed:
-                C._write_private_json(path, payload or {})
-            else:
-                path.unlink(missing_ok=True)
-        except OSError as exc:
-            rollback_ok = False
-            logger.warning(
-                "community_oauth: credential rollback failed for %s: %s",
-                path.name,
-                exc,
-            )
+    # A half-restored pair can pass a new auth record off as an active login.
+    # _clear_auth() takes the same non-reentrant lock, so it can only run once
+    # the scope above released it.
     if not rollback_ok and not C._clear_auth():
         logger.warning("community_oauth: failed to clear credentials after rollback failure")
     return False

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -233,21 +233,25 @@ def _persist_refreshed_oauth_tokens(
     if auth_path is None:
         return True
     try:
-        auth = C._read_json_dict(auth_path)
-        if auth and str(auth.get("access_token") or "").strip() == str(
-            expected.get("access_token") or ""
-        ).strip():
-            C._write_private_json(
-                auth_path,
-                {
-                    **auth,
-                    "schema_version": C._SOCIAL_SESSION_SCHEMA_VERSION,
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                    "session_generation": int(auth.get("session_generation") or 0) + 1,
-                },
-            )
-    except (OSError, ValueError, TypeError) as exc:
+        # The bind-repair path in card_drop_router also writes community_auth.json
+        # while holding the social-session lock, so both writers must serialize
+        # on the same lock to avoid clobbering each other's updates.
+        with C._social_session_lock(social_path):
+            auth = C._read_json_dict(auth_path)
+            if auth and str(auth.get("access_token") or "").strip() == str(
+                expected.get("access_token") or ""
+            ).strip():
+                C._write_private_json(
+                    auth_path,
+                    {
+                        **auth,
+                        "schema_version": C._SOCIAL_SESSION_SCHEMA_VERSION,
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                        "session_generation": int(auth.get("session_generation") or 0) + 1,
+                    },
+                )
+    except (OSError, ValueError, TypeError, TimeoutError) as exc:
         # The Electron-visible social session is authoritative.  A stale legacy
         # mirror must not make a successful refresh look logged out.
         logger.warning("community_oauth: refreshed auth mirror save failed: %s", exc)

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1785,6 +1785,41 @@ def test_social_session_init_keeps_a_concurrent_refresh_when_persisting_bind(
     assert persisted["refresh_token"] == "desktop-refresh-new"
 
 
+def test_social_session_init_prefers_the_saved_issuer_over_process_defaults(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A social_session.json predating the issuer fields still has the auth mirror."""
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "auth_public_url": "https://auth.custom.example",
+                "client_id": "neko-servers-desktop-custom",
+                "bind": {"bound": True, "error": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    # The process defaults describe a different issuer than the handed-over token.
+    assert payload["auth_public_url"] == "https://auth.custom.example"
+    assert payload["client_id"] == "neko-servers-desktop-custom"
+
+
 def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):
     monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: None)
     ticket = _issue_sync_ticket(client)

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1447,6 +1447,76 @@ def test_bind_client_approval_uses_persisted_local_id_and_consumes_ticket(
     assert replay.json() == {"detail": "invalid_sync_ticket"}
 
 
+def test_social_session_init_hands_desktop_oauth_to_community_origin(client, monkeypatch):
+    snapshot = {
+        **_delegate_session(),
+        "refresh_token": "desktop-refresh-a",
+        "auth_public_url": "https://auth.example",
+        "client_id": "neko-servers-desktop-dev",
+    }
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: snapshot)
+    ticket = _issue_sync_ticket(client)
+
+    denied = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://evil.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert denied.status_code == 403
+    assert denied.json() == {"detail": "origin_not_allowed"}
+    assert C._sync_ticket_is_valid(ticket)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://community.example"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json() == {
+        "access_token": "desktop-token-a",
+        "refresh_token": "desktop-refresh-a",
+        "local_user_id": USER_A_ID,
+        "auth_public_url": "https://auth.example",
+        "client_id": "neko-servers-desktop-dev",
+    }
+
+    replay = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert replay.status_code == 403
+    assert replay.json() == {"detail": "invalid_sync_ticket"}
+
+
+def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: None)
+    ticket = _issue_sync_ticket(client)
+    missing = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert missing.status_code == 409
+    assert missing.json() == {"detail": "desktop_login_required"}
+
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {**_delegate_session(), "auth_source": "legacy"},
+    )
+    legacy_ticket = _issue_sync_ticket(client)
+    legacy = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": legacy_ticket},
+    )
+    assert legacy.status_code == 409
+    assert legacy.json() == {"detail": "legacy_session_not_supported"}
+
+
 def test_bind_client_approval_rejects_origin_before_consuming_ticket(client, monkeypatch):
     ticket = _issue_sync_ticket(client)
     monkeypatch.setattr(

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1693,6 +1693,59 @@ def test_social_session_init_does_not_rebind_a_settled_desktop_client(
         assert response.json()["bind"] == bind
 
 
+def test_social_session_init_keeps_a_concurrent_refresh_when_persisting_bind(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A refresh landing during the bind call owns the tokens; do not roll it back."""
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "refresh_token": "desktop-refresh-old",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def rotate_then_bind(social_base, access_token):
+        # Desktop refreshes while the bind cloud call is still in flight.
+        auth.write_text(
+            json.dumps(
+                {
+                    "access_token": "desktop-token-rotated",
+                    "refresh_token": "desktop-refresh-new",
+                    "bind": {"bound": False, "error": "cloud_unreachable"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", rotate_then_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    # The rotated credentials must survive; a whole-record rewrite would have
+    # restored the pre-bind snapshot and broken the next refresh.
+    persisted = json.loads(auth.read_text(encoding="utf-8"))
+    assert persisted["access_token"] == "desktop-token-rotated"
+    assert persisted["refresh_token"] == "desktop-refresh-new"
+
+
 def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):
     monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: None)
     ticket = _issue_sync_ticket(client)

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -621,10 +621,12 @@ async def test_shared_facts_selector_rejects_mismatched_runtime_character(
 
 
 @pytest.fixture
-def client(monkeypatch):
+def client(monkeypatch, tmp_path):
     from main_routers import community_oauth
 
     monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "https://community.example")
+    # Keep the suite off the developer's real credential file.
+    monkeypatch.setattr(C, "_auth_path", lambda: tmp_path / "community_auth.json")
 
     async def current_desktop_status():
         snapshot = await asyncio.to_thread(C._desktop_session_snapshot)
@@ -1476,11 +1478,13 @@ def test_social_session_init_hands_desktop_oauth_to_community_origin(client, mon
     assert response.headers["cache-control"] == "no-store"
     assert response.json() == {
         "access_token": "desktop-token-a",
-        "refresh_token": "desktop-refresh-a",
         "local_user_id": USER_A_ID,
         "auth_public_url": "https://auth.example",
         "client_id": "neko-servers-desktop-dev",
+        "bind": {"bound": True, "error": None},
     }
+    # Desktop stays the sole owner of the refresh-token family.
+    assert "desktop-refresh-a" not in response.text
 
     replay = client.post(
         "/api/card-drop/social-session-init",
@@ -1489,6 +1493,204 @@ def test_social_session_init_hands_desktop_oauth_to_community_origin(client, mon
     )
     assert replay.status_code == 403
     assert replay.json() == {"detail": "invalid_sync_ticket"}
+
+
+def test_social_session_init_rejects_a_request_without_origin(client, monkeypatch):
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {**_delegate_session(), "refresh_token": "desktop-refresh-a"},
+    )
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "origin_required"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+
+
+def test_social_session_init_rejects_a_plaintext_non_loopback_base(client, monkeypatch):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://community.example")
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {
+            **_delegate_session(),
+            "base_url": "http://community.example",
+            "refresh_token": "desktop-refresh-a",
+        },
+    )
+    ticket = _issue_sync_ticket(client)
+
+    preflight = client.options(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "http://community.example"},
+    )
+    assert preflight.status_code == 403
+    assert preflight.json() == {"detail": "insecure_transport"}
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "http://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "insecure_transport"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+
+
+def test_social_session_init_allows_a_loopback_http_base(client, monkeypatch):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://localhost:3000")
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {**_delegate_session(), "base_url": "http://127.0.0.1:3000"},
+    )
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "http://localhost:3000"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "desktop-token-a"
+
+
+def test_social_session_init_keeps_the_ticket_when_identity_is_unavailable(
+    client,
+    monkeypatch,
+):
+    outcome = {"value": (None, "unavailable")}
+
+    async def resolved_snapshot():
+        return outcome["value"]
+
+    monkeypatch.setattr(C, "_native_delegate_session_snapshot", resolved_snapshot)
+    ticket = _issue_sync_ticket(client)
+
+    unavailable = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert unavailable.status_code == 503
+    assert unavailable.json() == {"detail": "identity_verification_unavailable"}
+    assert C._sync_ticket_is_valid(ticket)
+
+    outcome["value"] = (_delegate_session(), "")
+    retry = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert retry.status_code == 200
+    assert retry.json()["access_token"] == "desktop-token-a"
+
+
+def test_social_session_init_rejects_a_snapshot_from_another_environment(
+    client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {
+            **_delegate_session(),
+            "base_url": "https://production.example",
+            "refresh_token": "prod-refresh",
+            "auth_public_url": "https://auth.production.example",
+            "client_id": "neko-servers-desktop-prod",
+        },
+    )
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "prod-refresh" not in response.text
+    assert "desktop-token-a" not in response.text
+
+
+def test_social_session_init_repairs_a_failed_desktop_bind(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps({"bind": {"bound": False, "error": "cloud_unreachable"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    bound = []
+
+    async def record_guest_bind(social_base, access_token):
+        bound.append((social_base, access_token))
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", record_guest_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    assert bound == [("https://community.example", "desktop-token-a")]
+    assert response.json()["bind"] == {"bound": True, "error": None}
+
+
+def test_social_session_init_does_not_rebind_a_settled_desktop_client(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def unexpected_guest_bind(social_base, access_token):
+        raise AssertionError("a settled bind must not cost another cloud round trip")
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", unexpected_guest_bind)
+
+    for bind in (
+        {"bound": True, "error": None},
+        {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT},
+    ):
+        auth.write_text(json.dumps({"bind": bind}), encoding="utf-8")
+        ticket = _issue_sync_ticket(client)
+
+        response = client.post(
+            "/api/card-drop/social-session-init",
+            headers={"Origin": "https://community.example"},
+            json={"sync_ticket": ticket},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["access_token"] == "desktop-token-a"
+        assert response.json()["bind"] == bind
 
 
 def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1659,6 +1659,45 @@ def test_social_session_init_repairs_a_failed_desktop_bind(
     assert response.json()["bind"] == {"bound": True, "error": None}
 
 
+def test_social_session_init_rejects_a_session_replaced_during_the_bind_retry(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A logout/account switch during the bind round trip must not ship the bearer."""
+    from main_routers import community_oauth
+
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps({"bind": {"bound": False, "error": "cloud_unreachable"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    snapshots = [_delegate_session()]
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: snapshots[-1])
+
+    async def switch_account_mid_bind(_social_base, _access_token):
+        # Desktop logs out while the cloud bind is in flight.
+        snapshots.append({**_delegate_session(), "access_token": ""})
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", switch_account_mid_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "desktop-token-a" not in response.text
+    # The handoff never happened, so the ticket must survive for a retry.
+    assert C._sync_ticket_is_valid(ticket)
+
+
 def test_social_session_init_does_not_rebind_a_settled_desktop_client(
     client,
     monkeypatch,

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import threading
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
@@ -971,6 +972,131 @@ async def test_oauth_callback_rolls_back_partial_credential_write(
     else:
         assert not auth.exists()
         assert not social.exists()
+
+
+@pytest.mark.unit
+def test_persist_oauth_credentials_rolls_back_the_tokens_seen_under_the_lock(
+    tmp_path,
+    monkeypatch,
+):
+    """A refresh committing before the lock owns the tokens; do not roll it back."""
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    auth.write_text(
+        json.dumps({"access_token": "old-access", "refresh_token": "old-refresh"}),
+        encoding="utf-8",
+    )
+    social.write_text(
+        json.dumps(
+            {
+                "token": "old-access",
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "local_user_id": USER_ID,
+                "auth_source": "oauth",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+
+    real_lock = C._social_session_lock
+
+    @contextmanager
+    def rotating_lock(path):
+        with real_lock(path):
+            auth.write_text(
+                json.dumps(
+                    {
+                        "access_token": "rotated-access",
+                        "refresh_token": "rotated-refresh",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            social.write_text(
+                json.dumps(
+                    {
+                        "token": "rotated-access",
+                        "access_token": "rotated-access",
+                        "refresh_token": "rotated-refresh",
+                        "local_user_id": USER_ID,
+                        "auth_source": "oauth",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            yield
+
+    monkeypatch.setattr(C, "_social_session_lock", rotating_lock)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", lambda *_args, **_kwargs: False)
+
+    saved = O._persist_oauth_credentials(
+        {"access_token": "new-access", "refresh_token": "new-refresh"},
+        social_base="https://community.example",
+        access_token="new-access",
+        refresh_token="new-refresh",
+        local_user_id=USER_ID,
+        auth_public_url="https://auth.example",
+        client_id="neko-servers-desktop-dev",
+    )
+
+    assert saved is False
+    # Restoring the pre-refresh snapshot would reinstate a consumed refresh
+    # token and the next refresh would die with invalid_grant.
+    assert json.loads(auth.read_text(encoding="utf-8"))["refresh_token"] == "rotated-refresh"
+    assert json.loads(social.read_text(encoding="utf-8"))["refresh_token"] == "rotated-refresh"
+
+
+@pytest.mark.unit
+def test_persist_oauth_credentials_clears_credentials_when_rollback_fails(
+    tmp_path,
+    monkeypatch,
+):
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    old_auth = {"access_token": "old-access", "refresh_token": "old-refresh"}
+    auth.write_text(json.dumps(old_auth), encoding="utf-8")
+    social.write_text(
+        json.dumps(
+            {
+                "token": "old-access",
+                "access_token": "old-access",
+                "local_user_id": USER_ID,
+                "auth_source": "oauth",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: social)
+
+    real_write = C._write_private_json
+
+    def write_private_json(path, data):
+        if path == auth and data == old_auth:
+            raise OSError("restore failed")
+        real_write(path, data)
+
+    monkeypatch.setattr(C, "_write_private_json", write_private_json)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", lambda *_args, **_kwargs: False)
+
+    saved = O._persist_oauth_credentials(
+        {"access_token": "new-access", "refresh_token": "new-refresh"},
+        social_base="https://community.example",
+        access_token="new-access",
+        refresh_token="new-refresh",
+        local_user_id=USER_ID,
+        auth_public_url="https://auth.example",
+        client_id="neko-servers-desktop-dev",
+    )
+
+    assert saved is False
+    # A new auth record left beside the old session reads as an active login.
+    assert not auth.exists()
+    assert not social.exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -891,8 +891,10 @@ async def test_oauth_callback_offloads_credential_writes(tmp_path, monkeypatch):
     monkeypatch.setattr(O, "_oauth_guest_bind", fake_bind)
     monkeypatch.setattr(O, "_load_oauth_pending", load_pending)
     monkeypatch.setattr(O, "_unlink_pending", unlink_pending)
-    monkeypatch.setattr(C, "_save_auth", save_auth)
-    monkeypatch.setattr(C, "_save_social_session", save_social)
+    # Both records are written inside one social-session lock scope, so the
+    # callback now goes through the unlocked writers.
+    monkeypatch.setattr(C, "_save_auth_unlocked", save_auth)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", save_social)
 
     event_loop_thread = threading.get_ident()
     response = await O._handle_oauth_callback("auth-code", "expected-state")
@@ -956,8 +958,8 @@ async def test_oauth_callback_rolls_back_partial_credential_write(
     monkeypatch.setattr(O, "_exchange_oauth_code", fake_exchange)
     monkeypatch.setattr(O, "_bootstrap_session", fake_bootstrap)
     monkeypatch.setattr(O, "_oauth_guest_bind", fake_bind)
-    monkeypatch.setattr(C, "_save_auth", save_auth)
-    monkeypatch.setattr(C, "_save_social_session", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(C, "_save_auth_unlocked", save_auth)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", lambda *_args, **_kwargs: False)
 
     response = await O._handle_oauth_callback("auth-code", "expected-state")
 


### PR DESCRIPTION
## Summary
- Add `POST /api/card-drop/social-session-init` so the community tab can redeem a one-time `#native_sync` ticket and receive the Desktop `neko-servers-desktop-*` access/refresh tokens.
- CORS stays on the configured social origin; the ticket is single-use. Missing or non-OAuth desktop login returns 409, invalid ticket returns 403.
- The Web tab never sends its own bearer to localhost — direction is Python → SPA only.

Companion PRs: [N.E.K.O.Verse#333](https://github.com/Project-N-E-K-O/N.E.K.O.Verse/pull/333), [N.E.K.O.-PC#483](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/483)

## Test plan
- [ ] `pytest tests/unit/test_card_drop_session_facts.py -k social_session_init`
- [ ] Desktop logged in + valid ticket + community Origin → 200 with access_token / refresh_token / local_user_id
- [ ] Replay the same ticket → 403 `invalid_sync_ticket`
- [ ] Wrong Origin → 403 `origin_not_allowed` and ticket is not consumed
- [ ] No desktop session / legacy session → 409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增社交会话初始化流程，支持通过一次性票据获取桌面 OAuth 登录凭据。
  - 支持绑定状态修复与失败重试；已完成绑定不会重复请求。
  - 支持从本地认证配置恢复认证地址和客户端标识。

- **变更**
  - 初始化响应不再返回刷新令牌。
  - 强化来源、传输安全及社区来源校验；不匹配的桌面会话将被拒绝。
  - 会话变化时要求重新登录，且不会消耗同步票据。

- **错误修复**
  - 修复并发刷新、绑定及登录写入时凭据被覆盖或状态不一致的问题。
  - 凭据写入失败时可正确回滚，保持认证信息一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->