### PR TITLE
fix(live2d): avoid duplicate clipping mappings

### DIFF
--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -1896,18 +1896,11 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
         this.modelName = null;
     }
 
-    // 配置渲染纹理数量以支持更多蒙版
+    // 模型尚未加入舞台，蒙版纹理也尚未创建；此时调整数量即可让首帧
+    // 按三个缓冲区分配。不要再次 initialize()，该方法会向现有的
+    // ClippingContext/Drawable 映射追加数据，导致每次调用都产生重复项。
     if (model.internalModel && model.internalModel.renderer && model.internalModel.renderer._clippingManager) {
         model.internalModel.renderer._clippingManager._renderTextureCount = 3;
-        if (typeof model.internalModel.renderer._clippingManager.initialize === 'function') {
-            model.internalModel.renderer._clippingManager.initialize(
-                model.internalModel.coreModel,
-                model.internalModel.coreModel.getDrawableCount(),
-                model.internalModel.coreModel.getDrawableMasks(),
-                model.internalModel.coreModel.getDrawableMaskCounts(),
-                3
-            );
-        }
         console.log('渲染纹理数量已设置为3');
     }
 

--- a/tests/unit/test_live2d_clipping_static.py
+++ b/tests/unit/test_live2d_clipping_static.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
+
+
+def test_clipping_buffer_count_does_not_reinitialize_existing_manager():
+    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    configure_block = source.split(
+        "Live2DManager.prototype._configureLoadedModel =", 1
+    )[1].split("Live2DManager.prototype.", 1)[0]
+
+    assert "._renderTextureCount = 3;" in configure_block
+    assert "._clippingManager.initialize(" not in configure_block

--- a/tests/unit/test_live2d_clipping_static.py
+++ b/tests/unit/test_live2d_clipping_static.py
@@ -1,15 +1,120 @@
+import shutil
 from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_stdin
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
 
 
-def test_clipping_buffer_count_does_not_reinitialize_existing_manager():
-    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
-    configure_block = source.split(
-        "Live2DManager.prototype._configureLoadedModel =", 1
-    )[1].split("Live2DManager.prototype.", 1)[0]
+@pytest.mark.parametrize("mask_count", [0, 1, 3, 35, 96])
+def test_clipping_configuration_preserves_mappings_and_allocates_buffers(mask_count):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not found")
 
-    assert "._renderTextureCount = 3;" in configure_block
-    assert "._clippingManager.initialize(" not in configure_block
+    script = r"""
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+// Use the shipped manager and context implementations, not a mock of initialize.
+// These private class names intentionally pin the test to the bundled SDK;
+// a bundle upgrade must recheck this integration.
+const bundle = fs.readFileSync('static/libs/index.min.js', 'utf8');
+const start = bundle.indexOf('class fe{');
+const end = bundle.indexOf('class Me{', start);
+assert.ok(start >= 0 && end > start, 'locate bundled clipping classes');
+const ClippingManager = new Function('ge', 'Ct', 'bt', 'Bt', 'Ot',
+    'let _e = null; ' + bundle.slice(start, end) + '; return fe;')(
+        class {}, class {}, class {}, () => {}, () => {});
+
+const sandbox = { Live2DManager: function () {}, console: { log() {}, warn() {} } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync('static/live2d/live2d-model.js', 'utf8'), sandbox);
+
+async function check(n) {
+    // Two targets share each context. Alternate single and combined masks;
+    // the trailing source drawables have no masks themselves.
+    const masks = Array.from({ length: n * 3 }, (_, i) => i < n * 2
+        ? (n > 1 && i % n % 2 ? [n * 2 + i % n, n * 2] : [n * 2 + i % n])
+        : []);
+    const counts = masks.map(ids => ids.length);
+    const core = {
+        getDrawableCount: () => masks.length,
+        getDrawableMasks: () => masks,
+        getDrawableMaskCounts: () => counts,
+    };
+    const manager = new ClippingManager();
+    manager.initialize(core, masks.length, masks, counts, 1);
+    const contexts = manager._clippingContextListForMask.slice();
+    const mapping = manager._clippingContextListForDraw.slice();
+    const targets = contexts.map(c => c._clippedDrawableIndexList.slice());
+    assert.equal(contexts.length, n);
+
+    const model = { internalModel: { renderer: { _clippingManager: manager }, coreModel: core } };
+    const boundary = new Error('stop before unrelated model positioning');
+    // Execute the real application function through clipping configuration.
+    const host = {
+        _isLoadTokenActive: () => true,
+        applyModelSettings() { throw boundary; },
+    };
+    await assert.rejects(
+        sandbox.Live2DManager.prototype._configureLoadedModel.call(
+            host, model, '/user_live2d/test/test.model3.json', {}, 1),
+        error => error === boundary);
+
+    assert.equal(manager.getRenderTextureCount(), 3);
+    assert.deepEqual(manager._clippingContextListForDraw, mapping);
+    contexts.forEach((context, i) => {
+        assert.equal(manager._clippingContextListForMask[i], context);
+        assert.deepEqual(context._clippedDrawableIndexList, targets[i]);
+    });
+
+    // A fresh three-buffer initialization is the reference for layout semantics.
+    const reference = new ClippingManager();
+    reference.initialize(core, masks.length, masks, counts, 3);
+    manager.setupLayoutBounds(n);
+    reference.setupLayoutBounds(n);
+    const layout = m => m._clippingContextListForMask.map(c =>
+        [c._bufferIndex, c._layoutChannelNo, c._layoutBounds]);
+    assert.deepEqual(layout(manager), layout(reference));
+    if (n === 3) {
+        assert.deepEqual(contexts.map(c => [c._bufferIndex, c._layoutChannelNo]),
+            [[0, 0], [1, 0], [2, 0]]);
+    }
+
+    // Verify lazy resource allocation with a GL call recorder. This checks
+    // resource wiring, not GPU pixels or shader output.
+    const textures = [], framebuffers = [], attachments = [];
+    let bound = null;
+    manager.setGL({
+        createTexture() { const t = {}; textures.push(t); return t; },
+        createFramebuffer() { const f = {}; framebuffers.push(f); return f; },
+        bindFramebuffer(target, framebuffer) { bound = framebuffer; },
+        framebufferTexture2D(target, attachment, type, texture) {
+            attachments.push([bound, texture]);
+        },
+        bindTexture() {}, texImage2D() {}, texParameteri() {},
+    });
+    assert.equal(manager._maskTexture, undefined);
+    const allocated = manager.getMaskRenderTexture();
+    assert.equal(allocated.length, 3);
+    assert.equal(textures.length, 3);
+    assert.equal(framebuffers.length, 3);
+    attachments.forEach(([framebuffer, texture], i) => {
+        assert.equal(framebuffer, framebuffers[i]);
+        assert.equal(texture, textures[i]);
+    });
+    assert.equal(attachments.length, 3);
+    assert.equal(manager.getMaskRenderTexture(), allocated);
+    assert.equal(textures.length, 3, 'reuse allocated mask textures');
+}
+check(MASK_COUNT).catch(error => { console.error(error); process.exitCode = 1; });
+""".replace("MASK_COUNT", str(mask_count))
+    result = run_node_stdin(
+        node, script, cwd=PROJECT_ROOT, capture_output=True, timeout=10, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
# fix(live2d): avoid duplicate clipping mappings

## 改动概述 / Summary

模型加载后再次调用 Cubism clipping manager 的 initialize() 会向已有 Drawable 映射和被剪贴对象列表追加重复项。本次移除二次初始化，保留首帧渲染前设置三个遮罩缓冲的行为。

行为测试执行真实应用配置函数及当前捆绑库的遮罩管理器，验证共享、组合遮罩的映射不重复，布局与一次性三缓冲初始化一致，以及遮罩纹理与 FBO 的分配、关联和复用。

## 回归报告 / Regression Report

不适用：未修改 app/、main_logic/、main_routers/、memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：仅涉及一个运行时代码文件及其测试。

## 测试 / Testing

- `uv run --no-sync --no-cache python -B -m pytest --noconftest -p no:cacheprovider tests/unit/test_live2d_clipping_static.py -q`：5 passed，覆盖 0、1、3、35、96 个遮罩上下文。pytest 提示两个 asyncio 配置项未知。
- `git diff --check`：通过。
- 测试使用 GL 调用记录器，不验证实际 GPU 像素输出。此提交修复重复映射，尚未证实能够修复用户沙漏砂子的剪贴异常。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复 Live2D 模型加载时裁剪蒙版配置重复追加的问题。
  - 优化蒙版纹理分配，确保渲染资源按需创建并在重复使用时保持稳定。
  - 改善不同蒙版数量下的渲染表现，避免潜在的显示异常和资源重复分配。

- **测试**
  - 增加多种蒙版数量场景的自动化验证，覆盖资源分配、映射关系及重复调用行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->