### PR TITLE
fix: align MMD emotion configuration identity and reload behavior

### DIFF
--- a/static/js/mmd_emotion_manager.js
+++ b/static/js/mmd_emotion_manager.js
@@ -178,8 +178,8 @@
 
         loadModelMorphs(modelName, selectionId).then(async (success) => {
             if (success && selectionId === currentSelectionId) {
-                await loadEmotionMapping(modelName, selectionId);
-                if (selectionId === currentSelectionId) saveBtn.disabled = false;
+                const loaded = await loadEmotionMapping(modelName, selectionId);
+                if (selectionId === currentSelectionId) saveBtn.disabled = !loaded;
             }
         });
     }
@@ -470,20 +470,20 @@
         try {
             const response = await fetch(`/api/model/mmd/emotion_mapping?model=${encodeURIComponent(modelName)}`);
 
-            if (selectionId != null && selectionId !== currentSelectionId) return;
+            if (selectionId != null && selectionId !== currentSelectionId) return false;
 
             if (!response.ok) {
-                console.error(`加载情感映射配置失败: HTTP ${response.status}`, await response.text().catch(() => ''));
-                applyDefaultConfig();
-                showStatus(t('mmdEmotionManager.configLoadFailed', '配置加载失败'), 'error');
-                return;
+                throw new Error(`HTTP ${response.status}`);
             }
 
             const data = await response.json();
 
-            if (selectionId != null && selectionId !== currentSelectionId) return;
+            if (selectionId != null && selectionId !== currentSelectionId) return false;
 
-            if (data.success && data.mapping && Object.keys(data.mapping).length > 0) {
+            if (data?.success !== true || !data.mapping || typeof data.mapping !== 'object' || Array.isArray(data.mapping)) {
+                throw new Error('Invalid emotion mapping response');
+            }
+            if (Object.keys(data.mapping).length > 0) {
                 const config = data.mapping;
                 const savedMorphs = emotions.flatMap(emotion => {
                     const names = config[emotion];
@@ -519,11 +519,14 @@
                 applyDefaultConfig();
                 showStatus(t('mmdEmotionManager.configUseDefault', '使用默认配置'), 'info');
             }
+            return true;
         } catch (error) {
             console.error('加载情感映射配置失败:', error);
             if (selectionId == null || selectionId === currentSelectionId) {
                 applyDefaultConfig();
+                showStatus(t('mmdEmotionManager.configLoadFailed', '配置加载失败'), 'error');
             }
+            return false;
         }
     }
 
@@ -596,6 +599,18 @@
                     localStorage.removeItem('neko_mmd_emotion_mapping_changed');
                 } catch (error) {
                     console.warn('[MMD Emotion] 跨窗口配置通知失败，尝试通知父窗口:', error);
+                    // Storage may be unavailable even in a same-origin detached window.
+                    // This sender owns no listener and releases its channel immediately.
+                    let channel = null;
+                    try {
+                        channel = new BroadcastChannel('neko_mmd_emotion_mapping_changed');
+                        channel.postMessage({ model: modelName });
+                        return;
+                    } catch (broadcastError) {
+                        console.warn('[MMD Emotion] Broadcast notification unavailable:', broadcastError);
+                    } finally {
+                        channel?.close();
+                    }
                     if (window.opener && !window.opener.closed) {
                         const parentManager = window.opener.mmdManager;
                         if (parentManager?.currentModel?.configName === modelName) {

--- a/static/js/mmd_emotion_manager.js
+++ b/static/js/mmd_emotion_manager.js
@@ -164,6 +164,7 @@
         const selectionId = currentSelectionId;
 
         currentModelInfo = modelInfo;
+        saveBtn.disabled = true;
         modelSelect.value = modelName;
         modelSingleselectText.textContent = modelName;
         modelSingleselect.classList.remove('active', 'open-up', 'open-down');
@@ -175,9 +176,10 @@
             item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
         });
 
-        loadModelMorphs(modelName, selectionId).then((success) => {
+        loadModelMorphs(modelName, selectionId).then(async (success) => {
             if (success && selectionId === currentSelectionId) {
-                loadEmotionMapping(modelName, selectionId);
+                await loadEmotionMapping(modelName, selectionId);
+                if (selectionId === currentSelectionId) saveBtn.disabled = false;
             }
         });
     }
@@ -412,7 +414,10 @@
     }
 
     // 填充下拉菜单
-    function populateSelects() {
+    function populateSelects(savedMorphs = []) {
+        // 当前模型未在父窗口加载时，候选列表不完整；仍保留已保存名称，不能下次保存时丢失。
+        // 每次重建，不向 availableMorphs 累加，避免跨模型/多次加载残留。
+        const candidates = [...new Set([...availableMorphs, ...savedMorphs])];
         emotions.forEach(emotion => {
             const morphContainer = document.querySelector(`.emotion-morph-select[data-emotion="${emotion}"] .multiselect-options`);
 
@@ -420,7 +425,7 @@
                 morphContainer.innerHTML = '';
                 morphContainer.onclick = (e) => e.stopPropagation();
 
-                availableMorphs.forEach(morph => {
+                candidates.forEach(morph => {
                     const item = document.createElement('div');
                     item.className = 'multiselect-item';
                     item.setAttribute('role', 'option');
@@ -480,6 +485,12 @@
 
             if (data.success && data.mapping && Object.keys(data.mapping).length > 0) {
                 const config = data.mapping;
+                const savedMorphs = emotions.flatMap(emotion => {
+                    const names = config[emotion];
+                    return Array.isArray(names) ? names.filter(name => typeof name === 'string')
+                        : typeof names === 'string' ? [names] : [];
+                });
+                populateSelects(savedMorphs);
 
                 emotions.forEach(emotion => {
                     const morphMS = document.querySelector(`.emotion-morph-select[data-emotion="${emotion}"]`);
@@ -489,8 +500,10 @@
                         updateMultiselectHeader(morphMS);
                     }
 
-                    if (config[emotion]) {
-                        const morphNames = Array.isArray(config[emotion]) ? config[emotion] : [config[emotion]];
+                    const configured = Object.prototype.hasOwnProperty.call(config, emotion)
+                        ? config[emotion] : defaultMoodMap[emotion];
+                    if (configured) {
+                        const morphNames = Array.isArray(configured) ? configured : [configured];
                         if (morphMS) {
                             morphNames.forEach(name => {
                                 const cb = morphMS.querySelector(`input[value="${CSS.escape(name)}"]`);
@@ -535,11 +548,13 @@
 
     // 保存情感映射配置
     async function saveEmotionMapping() {
+        if (saveBtn.disabled) return;
         if (!currentModelInfo) {
             showStatus(t('mmdEmotionManager.pleaseSelectModelFirst', '请先选择模型'), 'error');
             return;
         }
 
+        const modelName = currentModelInfo.name;
         const mapping = {};
 
         emotions.forEach(emotion => {
@@ -547,7 +562,7 @@
 
             if (morphMS) {
                 const selected = Array.from(morphMS.querySelectorAll('input:checked')).map(cb => cb.value);
-                if (selected.length > 0) mapping[emotion] = selected;
+                mapping[emotion] = selected;
             }
         });
 
@@ -558,7 +573,7 @@
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
-                    model: currentModelInfo.name,
+                    model: modelName,
                     mapping: mapping
                 })
             });
@@ -574,11 +589,18 @@
             if (data.success) {
                 showStatus(t('mmdEmotionManager.configSaveSuccess', '配置保存成功！'), 'success');
 
-                // 通知父窗口重新加载 moodMap（仅当父窗口当前模型与编辑的模型一致时）
-                if (window.opener && !window.opener.closed && window.opener.mmdManager && window.opener.mmdManager.expression) {
-                    const parentModel = window.opener.mmdManager.currentModel;
-                    if (parentModel && parentModel.name === currentModelInfo.name) {
-                        window.opener.mmdManager.expression.loadMoodMap(currentModelInfo.name);
+                // 主页面和模型预览窗口均可能持有模型；同源通知也适用于没有 opener 的 Electron 窗口。
+                // 通知只携带配置名，接收方从后端重读；存储项立即删除，不累积状态。
+                try {
+                    localStorage.setItem('neko_mmd_emotion_mapping_changed', JSON.stringify({ model: modelName }));
+                    localStorage.removeItem('neko_mmd_emotion_mapping_changed');
+                } catch (error) {
+                    console.warn('[MMD Emotion] 跨窗口配置通知失败，尝试通知父窗口:', error);
+                    if (window.opener && !window.opener.closed) {
+                        const parentManager = window.opener.mmdManager;
+                        if (parentManager?.currentModel?.configName === modelName) {
+                            void parentManager.expression?.loadMoodMap(modelName);
+                        }
                     }
                 }
             } else {

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -555,6 +555,7 @@ class MMDCore {
             // 存储模型引用
             this.manager.currentModel = mmd;
             this.manager.currentModel.url = modelUrl;
+            this.manager.currentModel.configName = MMDCore.getConfigName(modelUrl);
             this.manager.scene.add(mmd.mesh);
 
             // 材质后处理：修正纹理颜色空间 + 强制材质更新
@@ -870,6 +871,18 @@ class MMDCore {
 
     // ═══════════════════ 模型信息 ═══════════════════
 
+    // 与后端模型列表的 Path.stem 一致；内部模型名仍仅用于展示元信息。
+    static getConfigName(modelUrl) {
+        if (typeof modelUrl !== 'string' || !modelUrl) return '';
+        try {
+            const filename = new URL(modelUrl, window.location.href).pathname.split('/').pop();
+            return decodeURIComponent(filename).replace(/\.(pmx|pmd)$/i, '');
+        } catch (error) {
+            console.warn('[MMD Core] 无法从模型路径获取配置名称:', error);
+            return '';
+        }
+    }
+
     _buildModelInfo(mmd) {
         const mesh = mmd.mesh;
         const pmx = mmd.pmx;
@@ -877,6 +890,7 @@ class MMDCore {
 
         return {
             name: pmx?.header?.modelName || '未知模型',
+            configName: MMDCore.getConfigName(mmd.url),
             comment: pmx?.header?.comment || '',
             vertexCount: geometry?.attributes?.position?.count || 0,
             triangleCount: geometry?.index ? geometry.index.count / 3 : 0,
@@ -894,6 +908,8 @@ class MMDCore {
     // ═══════════════════ 模型清理 ═══════════════════
 
     _clearModel() {
+        // 模型卸载即取消其配置请求、旧表情计时和缓存；不改动画 Morph 写入规则。
+        this.manager.expression?.resetMoodMap();
         // 清理纹理修复兜底定时器（必须在早退之前，防止 currentModel 被外部提前置空时 timer 泄漏）
         if (this._fixMissingTexturesTimer) {
             clearTimeout(this._fixMissingTexturesTimer);

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -876,7 +876,12 @@ class MMDCore {
         if (typeof modelUrl !== 'string' || !modelUrl) return '';
         try {
             const filename = new URL(modelUrl, window.location.href).pathname.split('/').pop();
-            return decodeURIComponent(filename).replace(/\.(pmx|pmd)$/i, '');
+            // Backend URLs can contain literal percent signs. Decode valid runs once,
+            // without rejecting the entire filename or double-decoding escaped names.
+            return filename.replace(/(?:%[0-9a-f]{2})+/gi, encoded => {
+                try { return decodeURIComponent(encoded); }
+                catch (_) { return encoded; }
+            }).replace(/\.(pmx|pmd)$/i, '');
         } catch (error) {
             console.warn('[MMD Core] 无法从模型路径获取配置名称:', error);
             return '';

--- a/static/mmd/mmd-expression.js
+++ b/static/mmd/mmd-expression.js
@@ -50,6 +50,21 @@ class MMDExpression {
             }
         };
         window.addEventListener('storage', this._moodMapStorageHandler);
+        // One fallback receiver per expression instance; closed by dispose().
+        this._moodMapChannel = null;
+        try {
+            if (typeof BroadcastChannel !== 'undefined') {
+                this._moodMapChannel = new BroadcastChannel('neko_mmd_emotion_mapping_changed');
+                this._moodMapChannel.onmessage = (event) => {
+                    const model = event.data?.model;
+                    if (typeof model === 'string' && model === this.manager.currentModel?.configName) {
+                        void this.loadMoodMap(model);
+                    }
+                };
+            }
+        } catch (error) {
+            console.warn('[MMD Expression] Broadcast notifications unavailable:', error);
+        }
 
         // MMD 常见眨眼 morph 名
         this.blinkMorphNames = ['まばたき', 'blink', 'まばたき左', 'まばたき右', 'blink_l', 'blink_r'];
@@ -443,6 +458,11 @@ class MMDExpression {
     dispose() {
         this._moodMapDisposed = true;
         window.removeEventListener('storage', this._moodMapStorageHandler);
+        if (this._moodMapChannel) {
+            this._moodMapChannel.onmessage = null;
+            this._moodMapChannel.close();
+            this._moodMapChannel = null;
+        }
         this.resetMoodMap();
         this.manualBlinkInProgress = null;
     }

--- a/static/mmd/mmd-expression.js
+++ b/static/mmd/mmd-expression.js
@@ -34,15 +34,22 @@ class MMDExpression {
 
         // 常见 MMD 表情名（日文/英文）到情感的映射
         // 默认值，可通过 loadMoodMap() 从后端加载覆盖
-        this.moodMap = {
-            'neutral': ['default', 'ニュートラル'],
-            'happy': ['笑い', 'にやり', 'にこり', 'smile', 'happy', 'joy', 'ワ'],
-            'sad': ['悲しい', '泣き', 'sad', 'sorrow', 'しょんぼり'],
-            'angry': ['怒り', 'angry', 'anger', 'むっ'],
-            'surprised': ['驚き', 'びっくり', 'surprised', 'shock', 'おっ'],
-            'relaxed': ['穏やか', 'relaxed', 'calm', '微笑み'],
-            'fear': ['恐怖', 'fear', 'scared', 'おびえ']
+        this.moodMap = this._createDefaultMoodMap();
+        this._moodMapRequest = null;
+        this._moodMapDisposed = false;
+        // 一个实例仅持有一个监听器，在 dispose 时移除。跨窗口通知不依赖 opener 链。
+        this._moodMapStorageHandler = (event) => {
+            if (event.key !== 'neko_mmd_emotion_mapping_changed' || !event.newValue) return;
+            try {
+                const { model } = JSON.parse(event.newValue);
+                if (typeof model === 'string' && model === this.manager.currentModel?.configName) {
+                    void this.loadMoodMap(model);
+                }
+            } catch (error) {
+                console.warn('[MMD Expression] 无效的配置更新通知:', error);
+            }
         };
+        window.addEventListener('storage', this._moodMapStorageHandler);
 
         // MMD 常见眨眼 morph 名
         this.blinkMorphNames = ['まばたき', 'blink', 'まばたき左', 'まばたき右', 'blink_l', 'blink_r'];
@@ -57,22 +64,79 @@ class MMDExpression {
         };
     }
 
+    _createDefaultMoodMap() {
+        return {
+            'neutral': ['default', 'ニュートラル'],
+            'happy': ['笑い', 'にやり', 'にこり', 'smile', 'happy', 'joy', 'ワ'],
+            'sad': ['悲しい', '泣き', 'sad', 'sorrow', 'しょんぼり'],
+            'angry': ['怒り', 'angry', 'anger', 'むっ'],
+            'surprised': ['驚き', 'びっくり', 'surprised', 'shock', 'おっ'],
+            'relaxed': ['穏やか', 'relaxed', 'calm', '微笑み'],
+            'fear': ['恐怖', 'fear', 'scared', 'おびえ']
+        };
+    }
+
     // ═══════════════════ 后端配置加载 ═══════════════════
 
     async loadMoodMap(modelName) {
-        if (!modelName) return;
+        if (!modelName || this._moodMapDisposed) return;
+        const model = this.manager.currentModel;
+        if (!model || (model.configName && model.configName !== modelName)) return;
+        this._moodMapRequest?.abort();
+        const request = new AbortController();
+        this._moodMapRequest = request;
+        const loadToken = this.manager._activeLoadToken;
+        const isCurrent = () => this._moodMapRequest === request && !this._moodMapDisposed
+            && this.manager.currentModel === model && this.manager._activeLoadToken === loadToken;
+        // 单个在途请求，最多等待 10 秒；替换、卸载和销毁均取消请求。
+        const timeout = setTimeout(() => request.abort(), 10000);
+        let mapping = {};
         try {
-            const response = await fetch(`/api/model/mmd/emotion_mapping?model=${encodeURIComponent(modelName)}`);
-            if (response.ok) {
-                const data = await response.json();
-                if (data.success && data.mapping) {
-                    this.moodMap = { ...this.moodMap, ...data.mapping };
-                    console.log('[MMD Expression] 从后端加载了情感映射');
-                }
+            const response = await fetch(`/api/model/mmd/emotion_mapping?model=${encodeURIComponent(modelName)}`, {
+                signal: request.signal
+            });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const data = await response.json();
+            if (data.success && data.mapping && typeof data.mapping === 'object' && !Array.isArray(data.mapping)) {
+                mapping = data.mapping;
             }
         } catch (error) {
-            console.warn('[MMD Expression] 加载情感映射失败，使用默认配置:', error);
+            if (isCurrent()) console.warn('[MMD Expression] 加载情感映射失败，使用默认配置:', error);
+        } finally {
+            clearTimeout(timeout);
+            if (isCurrent()) {
+                const nextMap = this._createDefaultMoodMap();
+                for (const emotion of Object.keys(nextMap)) {
+                    if (!Object.prototype.hasOwnProperty.call(mapping, emotion)) continue;
+                    const names = mapping[emotion];
+                    // 兼容旧的单字符串；明确 [] 不回退。非法类型不进入运行时。
+                    if (Array.isArray(names)) nextMap[emotion] = names.filter(name => typeof name === 'string');
+                    else if (typeof names === 'string') nextMap[emotion] = [names];
+                }
+                // 热更新移除了当前表情时，仅释放该手动表情，避免旧 Morph 无法被新映射清除。
+                const active = this.manualExpressionInProgress;
+                if (active && !nextMap[this.currentMood]?.includes(active)) {
+                    this.setMorphWeight(active, 0);
+                    clearTimeout(this.neutralReturnTimer);
+                    this.neutralReturnTimer = null;
+                    this.manualExpressionInProgress = null;
+                    this.currentMood = 'neutral';
+                }
+                this.moodMap = nextMap;
+            }
+            if (this._moodMapRequest === request) this._moodMapRequest = null;
         }
+    }
+
+    resetMoodMap() {
+        this._moodMapRequest?.abort();
+        this._moodMapRequest = null;
+        clearTimeout(this.neutralReturnTimer);
+        this.neutralReturnTimer = null;
+        this.manualExpressionInProgress = null;
+        this.currentMood = 'neutral';
+        this.currentWeights = {};
+        this.moodMap = this._createDefaultMoodMap();
     }
 
     // ═══════════════════ Morph 控制 ═══════════════════
@@ -377,12 +441,9 @@ class MMDExpression {
     // ═══════════════════ 清理 ═══════════════════
 
     dispose() {
-        if (this.neutralReturnTimer) {
-            clearTimeout(this.neutralReturnTimer);
-            this.neutralReturnTimer = null;
-        }
-        this.currentWeights = {};
+        this._moodMapDisposed = true;
+        window.removeEventListener('storage', this._moodMapStorageHandler);
+        this.resetMoodMap();
         this.manualBlinkInProgress = null;
-        this.manualExpressionInProgress = null;
     }
 }

--- a/static/mmd/mmd-manager.js
+++ b/static/mmd/mmd-manager.js
@@ -147,8 +147,8 @@ class MMDManager {
             }
 
             // 加载表情映射
-            if (this.expression && modelInfo.name) {
-                await this.expression.loadMoodMap(modelInfo.name);
+            if (this.expression && modelInfo.configName) {
+                await this.expression.loadMoodMap(modelInfo.configName);
             }
 
             // 再次检查（loadMoodMap 是异步的）
@@ -209,8 +209,8 @@ class MMDManager {
                         this.cursorFollow.refresh();
                     }
 
-                    if (this.expression && modelInfo.name) {
-                        await this.expression.loadMoodMap(modelInfo.name);
+                    if (this.expression && modelInfo.configName) {
+                        await this.expression.loadMoodMap(modelInfo.configName);
                     }
 
                     if (this._isDisposed || this._activeLoadToken !== loadToken) {

--- a/tests/frontend/test_mmd_emotion_config.py
+++ b/tests/frontend/test_mmd_emotion_config.py
@@ -40,6 +40,9 @@ def setup_runtime(page: Page):
     ("http://neko.test/workshop/123/%E8%8A%B1%E7%81%AB3.0.PMX?v=4#preview", "花火3.0"),
     ("/static/mmd/a%2520b%23c%3Fd.pMd", "a%20b#c?d"),
     ("/workshop/456/花火3.0.pmx", "花火3.0"),
+    ("/user_mmd/100%_model.pmx", "100%_model"),
+    ("/user_mmd/100%_花火.pmx", "100%_花火"),
+    ("/user_mmd/100%25_model.pmx", "100%_model"),
 ])
 def test_config_name_is_filename_not_internal_metadata(page: Page, url, expected):
     setup_runtime(page)
@@ -202,7 +205,8 @@ def test_vmd_write_order_is_unchanged(page: Page):
 
 
 @pytest.mark.parametrize("switch_editor", [False, True])
-def test_save_notifies_matching_runtime_without_opener(page: Page, switch_editor):
+@pytest.mark.parametrize("storage_blocked", [False, True])
+def test_save_notifies_matching_runtime_without_opener(page: Page, switch_editor, storage_blocked):
     setup_runtime(page)
     page.evaluate("""() => {
         mapping = {happy: ['瞳小']};
@@ -211,6 +215,8 @@ def test_save_notifies_matching_runtime_without_opener(page: Page, switch_editor
     }""")
     with page.context.new_page() as editor:
         setup_editor(editor)
+        if storage_blocked:
+            editor.evaluate("() => { Storage.prototype.setItem = () => { throw new Error('storage denied'); }; }")
         if switch_editor:
             editor.evaluate("""() => {
                 const previousFetch = fetch;
@@ -223,7 +229,7 @@ def test_save_notifies_matching_runtime_without_opener(page: Page, switch_editor
             editor.evaluate("async () => { finishSave(); await savePromise; }")
         else:
             editor.evaluate("MMDEmotionManager.saveEmotionMapping()")
-        page.wait_for_function("expression.moodMap.happy[0] === '瞳小' && shared.moodMap.happy[0] === '瞳小'")
+        page.wait_for_function("expression.moodMap.happy[0] === '瞳小' && shared.moodMap.happy[0] === '瞳小'", timeout=5000)
         assert page.evaluate("other.moodMap.happy[0]") == "笑い"
         assert len(page.evaluate("requests")) == 2
         assert editor.evaluate("localStorage.getItem('neko_mmd_emotion_mapping_changed')") is None
@@ -303,3 +309,80 @@ def test_reload_does_not_restart_unchanged_manual_expression(page: Page):
             manual: expression.manualExpressionInProgress, weight: expression.getMorphWeight('瞳小')};
     }""")
     assert result == {"sameTimer": True, "manual": "瞳小", "weight": 1}
+
+
+@pytest.mark.parametrize("failure", ["http", "json", "network", "unsuccessful", "invalid_mapping"])
+def test_editor_read_failure_cannot_overwrite_saved_mapping(page: Page, failure):
+    setup_editor(page)
+    page.evaluate("""failure => {
+        window.workingFetch = fetch;
+        fetch = async (url, options) => {
+            if (options?.method === 'POST') return workingFetch(url, options);
+            if (failure === 'network') throw new Error('offline');
+            return {ok: failure !== 'http', status: 500, text: async () => 'failed', json: async () => {
+                if (failure === 'json') throw new Error('bad JSON');
+                return failure === 'unsuccessful' ? {success: false} : {success: true, mapping: []};
+            }};
+        };
+    }""", failure)
+    page.locator('.singleselect-item[data-value="other"]').click()
+    page.wait_for_function("document.getElementById('status-message').textContent.includes('配置加载失败')")
+    assert page.locator('#save-btn').is_disabled()
+    page.evaluate("MMDEmotionManager.resetConfig(); MMDEmotionManager.saveEmotionMapping()")
+    assert page.evaluate("saved") is None
+    page.evaluate("fetch = workingFetch; mapping = {}")
+    page.locator('.singleselect-item[data-value="other"]').click()
+    page.wait_for_function("!document.getElementById('save-btn').disabled")
+    page.evaluate("MMDEmotionManager.saveEmotionMapping()")
+    assert page.evaluate("saved.model") == "other"
+
+
+def test_broadcast_fallback_receiver_is_closed_on_dispose(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""() => {
+        const channel = expression._moodMapChannel;
+        if (!channel) return {created: false};
+        let closed = 0;
+        const originalClose = channel.close.bind(channel);
+        channel.close = () => { closed++; originalClose(); };
+        expression.dispose(); expression.dispose();
+        return {created: true, closed, released: expression._moodMapChannel === null,
+            detached: channel.onmessage === null};
+    }""")
+    assert result == {"created": True, "closed": 1, "released": True, "detached": True}
+
+
+@pytest.mark.parametrize("channel_result", ["success", "constructor_error", "post_error"])
+def test_broadcast_sender_cleanup_and_opener_fallback(page: Page, channel_result):
+    setup_editor(page)
+    result = page.evaluate("""async channelResult => {
+        let closed = 0, notified = 0;
+        window.opener = {closed: false, mmdManager: {currentModel: {configName: '花火3.0'},
+            expression: {loadMoodMap: () => { notified++; }}}};
+        Storage.prototype.setItem = () => { throw new Error('storage denied'); };
+        window.BroadcastChannel = class {
+            constructor() { if (channelResult === 'constructor_error') throw new Error('denied'); }
+            postMessage() { if (channelResult === 'post_error') throw new Error('send failed'); }
+            close() { closed++; }
+        };
+        await MMDEmotionManager.saveEmotionMapping();
+        return {closed, notified, saved: saved.model};
+    }""", channel_result)
+    assert result == {"closed": int(channel_result != "constructor_error"),
+                      "notified": int(channel_result != "success"), "saved": "花火3.0"}
+
+
+def test_blocked_broadcast_receiver_keeps_storage_support(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        window.BroadcastChannel = class { constructor() { throw new Error('denied'); } };
+        const receiver = new MMDExpression(manager);
+        mapping = {happy: ['瞳小']};
+        window.dispatchEvent(new StorageEvent('storage', {key: 'neko_mmd_emotion_mapping_changed',
+            newValue: JSON.stringify({model: '花火3.0'})}));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const happy = receiver.moodMap.happy;
+        receiver.dispose();
+        return {happy, channel: receiver._moodMapChannel};
+    }""")
+    assert result == {"happy": ["瞳小"], "channel": None}

--- a/tests/frontend/test_mmd_emotion_config.py
+++ b/tests/frontend/test_mmd_emotion_config.py
@@ -1,0 +1,305 @@
+"""MMD configuration regressions; real browser scripts, no GPU or user files."""
+
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EMOTIONS = ["neutral", "happy", "relaxed", "sad", "angry", "surprised", "fear"]
+pytestmark = pytest.mark.frontend
+
+
+def setup_runtime(page: Page):
+    page.route("http://neko.test/**", lambda route: route.fulfill(body="<html></html>", content_type="text/html"))
+    page.goto("http://neko.test/")
+    for script in ["mmd-core.js", "mmd-expression.js", "mmd-manager.js"]:
+        page.add_script_tag(path=str(ROOT / "static/mmd" / script))
+    page.evaluate("""() => {
+        window.makeModel = (configName = '花火3.0') => ({configName,
+            pmx: {header: {modelName: '花火'}},
+            mesh: {geometry: {}, morphTargetDictionary: {'笑い': 0, '瞳小': 1, '悲しい': 2, 'VMD': 3},
+                morphTargetInfluences: [0, 0, 0, 0]}});
+        window.manager = new MMDManager();
+        manager.currentModel = makeModel();
+        window.expression = manager.expression;
+        expression.autoBlink = false;
+        expression.autoReturnToNeutral = false;
+        window.mapping = {};
+        window.requests = [];
+        window.fetch = async (url) => {
+            requests.push(String(url));
+            return {ok: true, json: async () => ({success: true, mapping})};
+        };
+    }""")
+
+
+@pytest.mark.parametrize("url,expected", [
+    ("/user_mmd/目录/花火3.0.pmx", "花火3.0"),
+    ("http://neko.test/workshop/123/%E8%8A%B1%E7%81%AB3.0.PMX?v=4#preview", "花火3.0"),
+    ("/static/mmd/a%2520b%23c%3Fd.pMd", "a%20b#c?d"),
+    ("/workshop/456/花火3.0.pmx", "花火3.0"),
+])
+def test_config_name_is_filename_not_internal_metadata(page: Page, url, expected):
+    setup_runtime(page)
+    info = page.evaluate("""url => {
+        const model = makeModel(); model.url = url;
+        return manager.core._buildModelInfo(model);
+    }""", url)
+    assert info["name"] == "花火"
+    assert info.get("configName") == expected
+
+
+@pytest.mark.parametrize("fallback", [False, True])
+def test_manager_loads_config_name_on_normal_and_fallback_paths(page: Page, fallback):
+    setup_runtime(page)
+    result = page.evaluate("""async fallback => {
+        mapping = {happy: ['瞳小']};
+        manager.core.loadModel = async url => {
+            if (fallback && url !== MMDManager.DEFAULT_MODEL_PATH) throw new Error('fixture load failure');
+            manager.currentModel = makeModel(fallback ? 'Miku' : '花火3.0');
+            return {name: '内部名', configName: manager.currentModel.configName};
+        };
+        await manager.loadModel('/user_mmd/花火3.0.pmx');
+        expression.setEmotion('happy');
+        return {requests, weights: manager.currentModel.mesh.morphTargetInfluences};
+    }""", fallback)
+    assert result["requests"] == ["/api/model/mmd/emotion_mapping?model=" + ("Miku" if fallback else "%E8%8A%B1%E7%81%AB3.0")]
+    assert result["weights"][:2] == [0, 1]
+
+
+def test_reload_rebuilds_defaults_and_preserves_explicit_empty_and_unmatched(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        mapping = {happy: ['瞳小'], sad: []};
+        await expression.loadMoodMap('花火3.0');
+        mapping = {happy: []};
+        await expression.loadMoodMap('花火3.0');
+        const empty = structuredClone(expression.moodMap);
+        expression.setEmotion('happy');
+        const disabled = [...manager.currentModel.mesh.morphTargetInfluences];
+        mapping = {happy: ['not-in-model']};
+        await expression.loadMoodMap('花火3.0');
+        expression.setEmotion('happy');
+        const unmatched = [...manager.currentModel.mesh.morphTargetInfluences];
+        mapping = {};
+        await expression.loadMoodMap('花火3.0');
+        return {empty, disabled, unmatched, restored: expression.moodMap};
+    }""")
+    assert result["empty"]["happy"] == []
+    assert "悲しい" in result["empty"]["sad"]
+    assert result["disabled"] == result["unmatched"] == [0, 0, 0, 0]
+    assert result["restored"]["happy"][0] == "笑い"
+
+
+def test_late_load_cannot_replace_new_config_or_disposed_state(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        const pending = [];
+        fetch = (url, options) => new Promise(resolve => pending.push({resolve, options}));
+        const oldLoad = expression.loadMoodMap('花火3.0');
+        const newLoad = expression.loadMoodMap('花火3.0');
+        pending[1].resolve({ok: true, json: async () => ({success: true, mapping: {happy: []}})});
+        await newLoad;
+        pending[0].resolve({ok: true, json: async () => ({success: true, mapping: {happy: ['瞳小']}})});
+        await oldLoad;
+        const latest = expression.moodMap.happy;
+        const lastLoad = expression.loadMoodMap('花火3.0');
+        expression.dispose();
+        pending[2].resolve({ok: true, json: async () => ({success: true, mapping: {happy: ['disposed']}})});
+        await lastLoad;
+        return {latest, afterDispose: expression.moodMap.happy,
+            aborted: pending.map(p => p.options?.signal?.aborted ?? false)};
+    }""")
+    assert result["latest"] == []
+    assert result["afterDispose"] != ["disposed"]
+    assert result["aborted"][0] and result["aborted"][2]
+
+
+def test_replaced_mapping_clears_only_active_manual_morph(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        mapping = {happy: ['瞳小']};
+        await expression.loadMoodMap('花火3.0');
+        expression.setEmotion('happy');
+        const weights = manager.currentModel.mesh.morphTargetInfluences;
+        weights[3] = 0.7;
+        mapping = {happy: []};
+        await expression.loadMoodMap('花火3.0');
+        return {weights, manual: expression.manualExpressionInProgress, timer: expression.neutralReturnTimer};
+    }""")
+    assert result == {"weights": [0, 0, 0, 0.7], "manual": None, "timer": None}
+
+
+def setup_editor(page: Page):
+    setup_runtime(page)
+    page.evaluate("""emotions => {
+        document.body.innerHTML = `<select id="model-select"></select>
+            <div id="model-singleselect"><div class="singleselect-header"></div>
+            <div class="selected-text"></div><div class="singleselect-options"></div></div>
+            <div id="emotion-config"></div><button id="save-btn"></button>
+            <button id="reset-btn"></button><div id="status-message"></div><div id="preview-buttons"></div>`;
+        for (const emotion of emotions) {
+            document.getElementById('emotion-config').insertAdjacentHTML('beforeend',
+                `<div class="custom-multiselect emotion-morph-select" data-emotion="${emotion}">
+                <div class="multiselect-header"><span class="selected-text"></span></div>
+                <div class="multiselect-options"></div></div>`);
+        }
+        // Deliberately includes no custom morph: persisted choices must survive a fallback candidate list.
+        window.opener = null;
+        mapping = {happy: ['瞳小'], fear: []};
+        window.saved = null;
+        fetch = async (url, options) => {
+            if (String(url).endsWith('/models')) return {ok: true, json: async () => ({success: true,
+                models: [{name: '花火3.0'}, {name: 'other'}]})};
+            if (options?.method === 'POST') {
+                saved = JSON.parse(options.body);
+                return {ok: true, json: async () => ({success: true})};
+            }
+            return {ok: true, json: async () => ({success: true, mapping})};
+        };
+    }""", EMOTIONS)
+    page.add_script_tag(path=str(ROOT / "static/js/mmd_emotion_manager.js"))
+    page.locator('.singleselect-item[data-value="花火3.0"]').click()
+    page.wait_for_function("document.getElementById('status-message').textContent.includes('配置加载成功')")
+
+
+def test_editor_retains_legacy_defaults_custom_names_and_explicit_empty(page: Page):
+    setup_editor(page)
+    page.evaluate("MMDEmotionManager.saveEmotionMapping()")
+    saved = page.evaluate("saved")
+    assert saved["model"] == "花火3.0"
+    assert saved["mapping"]["happy"] == ["瞳小"]
+    assert saved["mapping"]["fear"] == []
+    assert "悲しい" in saved["mapping"]["sad"]
+    assert set(saved["mapping"]) == set(EMOTIONS)
+
+
+def test_editor_can_save_every_emotion_empty(page: Page):
+    setup_editor(page)
+    page.locator('#emotion-config input').evaluate_all("inputs => inputs.forEach(cb => cb.checked = false)")
+    page.evaluate("MMDEmotionManager.saveEmotionMapping()")
+    assert page.evaluate("saved.mapping") == {emotion: [] for emotion in EMOTIONS}
+
+
+def test_vmd_write_order_is_unchanged(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        mapping = {happy: ['瞳小']};
+        await expression.loadMoodMap('花火3.0');
+        expression.setEmotion('happy');
+        const weights = manager.currentModel.mesh.morphTargetInfluences;
+        weights[3] = 0.6; // A different VMD track can coexist.
+        expression.update(0.016);
+        const different = [...weights];
+        weights[1] = 0.2; // The next VMD frame still owns the same morph.
+        expression.update(0.016);
+        return {different, same: weights};
+    }""")
+    assert result["different"] == [0, 1, 0, 0.6]
+    assert result["same"] == [0, 0.2, 0, 0.6]
+
+
+@pytest.mark.parametrize("switch_editor", [False, True])
+def test_save_notifies_matching_runtime_without_opener(page: Page, switch_editor):
+    setup_runtime(page)
+    page.evaluate("""() => {
+        mapping = {happy: ['瞳小']};
+        window.other = new MMDExpression({currentModel: makeModel('other')});
+        window.shared = new MMDExpression({currentModel: makeModel('花火3.0')});
+    }""")
+    with page.context.new_page() as editor:
+        setup_editor(editor)
+        if switch_editor:
+            editor.evaluate("""() => {
+                const previousFetch = fetch;
+                fetch = (url, options) => options?.method === 'POST'
+                    ? new Promise(resolve => window.finishSave = () => resolve({ok: true,
+                        json: async () => ({success: true})})) : previousFetch(url, options);
+                window.savePromise = MMDEmotionManager.saveEmotionMapping();
+            }""")
+            editor.locator('.singleselect-item[data-value="other"]').click()
+            editor.evaluate("async () => { finishSave(); await savePromise; }")
+        else:
+            editor.evaluate("MMDEmotionManager.saveEmotionMapping()")
+        page.wait_for_function("expression.moodMap.happy[0] === '瞳小' && shared.moodMap.happy[0] === '瞳小'")
+        assert page.evaluate("other.moodMap.happy[0]") == "笑い"
+        assert len(page.evaluate("requests")) == 2
+        assert editor.evaluate("localStorage.getItem('neko_mmd_emotion_mapping_changed')") is None
+
+
+@pytest.mark.parametrize("failure", ["http", "json", "network"])
+def test_failed_load_uses_fresh_defaults_not_previous_model(page: Page, failure):
+    setup_runtime(page)
+    result = page.evaluate("""async failure => {
+        mapping = {happy: ['瞳小'], sad: []};
+        await expression.loadMoodMap('花火3.0');
+        fetch = async () => {
+            if (failure === 'network') throw new Error('offline');
+            return {ok: failure !== 'http', status: 500, json: async () => { throw new Error('bad JSON'); }};
+        };
+        await expression.loadMoodMap('花火3.0');
+        return expression.moodMap;
+    }""", failure)
+    assert result["happy"][0] == "笑い"
+    assert result["sad"][0] == "悲しい"
+
+
+def test_model_unload_cancels_request_and_expression_timer(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        expression.autoReturnToNeutral = true;
+        expression.setEmotion('happy');
+        let finish, signal;
+        fetch = (url, options) => {
+            signal = options.signal;
+            return new Promise(resolve => finish = resolve);
+        };
+        const pending = expression.loadMoodMap('花火3.0');
+        delete manager.currentModel.mesh.geometry; // No GPU resources in this fixture.
+        manager.core._clearModel();
+        manager.currentModel = makeModel('other');
+        finish({ok: true, json: async () => ({success: true, mapping: {happy: ['瞳小']}})});
+        await pending;
+        return {aborted: signal.aborted, timer: expression.neutralReturnTimer,
+            weights: expression.currentWeights, happy: expression.moodMap.happy[0],
+            influences: manager.currentModel.mesh.morphTargetInfluences};
+    }""")
+    assert result == {"aborted": True, "timer": None, "weights": {}, "happy": "笑い", "influences": [0, 0, 0, 0]}
+
+
+def test_request_timeout_and_listener_disposal_are_bounded(page: Page):
+    setup_runtime(page)
+    page.clock.install()
+    page.evaluate("""() => {
+        window.removed = false;
+        const originalRemove = window.removeEventListener.bind(window);
+        window.removeEventListener = (type, handler, ...rest) => {
+            if (type === 'storage' && handler === expression._moodMapStorageHandler) removed = true;
+            originalRemove(type, handler, ...rest);
+        };
+        window.aborted = false;
+        fetch = (url, {signal}) => new Promise((resolve, reject) => {
+            signal.addEventListener('abort', () => { aborted = true; reject(new DOMException('aborted', 'AbortError')); }, {once: true});
+        });
+        window.pending = expression.loadMoodMap('花火3.0');
+    }""")
+    page.clock.fast_forward(10001)
+    page.evaluate("async () => { await pending; expression.dispose(); }")
+    assert page.evaluate("({aborted, removed, request: expression._moodMapRequest})") == {"aborted": True, "removed": True, "request": None}
+
+
+def test_reload_does_not_restart_unchanged_manual_expression(page: Page):
+    setup_runtime(page)
+    result = page.evaluate("""async () => {
+        expression.autoReturnToNeutral = true;
+        mapping = {happy: ['瞳小']};
+        await expression.loadMoodMap('花火3.0');
+        expression.setEmotion('happy');
+        const timer = expression.neutralReturnTimer;
+        await expression.loadMoodMap('花火3.0');
+        return {sameTimer: timer === expression.neutralReturnTimer,
+            manual: expression.manualExpressionInProgress, weight: expression.getMorphWeight('瞳小')};
+    }""")
+    assert result == {"sameTimer": True, "manual": "瞳小", "weight": 1}

--- a/tests/unit/test_mmd_emotion_mapping.py
+++ b/tests/unit/test_mmd_emotion_mapping.py
@@ -1,0 +1,32 @@
+"""The existing API must preserve explicit empty lists and filename-based sharing."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from main_routers import mmd_router
+
+
+@pytest.mark.asyncio
+async def test_emotion_mapping_roundtrip_keeps_disabled_keys(tmp_path, monkeypatch):
+    monkeypatch.setattr(mmd_router, "get_config_manager", lambda: object())
+    monkeypatch.setattr(mmd_router, "_ensure_mmd_directory", lambda _: tmp_path)
+    mapping = {emotion: [] for emotion in ["neutral", "happy", "sad", "angry", "surprised", "relaxed", "fear"]}
+    mapping["happy"] = ["瞳小"]
+    request = AsyncMock()
+    request.json.return_value = {"model": "花火3.0", "mapping": mapping}
+
+    response = await mmd_router.update_emotion_mapping(request)
+    assert response.status_code == 200
+    assert json.loads(mmd_router.get_emotion_mapping("花火3.0").body)["mapping"] == mapping
+    assert json.loads((tmp_path / "emotion_config/花火3.0.json").read_text(encoding="utf-8")) == mapping
+    assert json.loads(mmd_router.get_emotion_mapping("花火").body)["mapping"] == {}
+    assert not (tmp_path / "emotion_config/花火.json").exists()
+
+    # The same stem still addresses the same file, independent of source or character.
+    mapping["happy"] = []
+    response = await mmd_router.update_emotion_mapping(request)
+    assert response.status_code == 200
+    assert json.loads(mmd_router.get_emotion_mapping("花火3.0").body)["mapping"] == mapping
+    assert len(list((tmp_path / "emotion_config").glob("*.json"))) == 1


### PR DESCRIPTION
## Summary

Fix saved MMD emotion selections being ignored when a model's filename differs from its internal PMX name, and deselected emotions continuing to use old/default Morph candidates.

* Use the PMX/PMD filename stem consistently for emotion configuration lookup. Keep the internal PMX model name as metadata.
* Persist all seven emotion keys, including empty arrays. Rebuild runtime mappings on each load: missing keys retain legacy defaults, explicit empty arrays disable that emotion, and nonempty unmatched candidates do not fall back.
* Notify matching runtime windows after editor saves, including same-origin windows without an opener. Cancel superseded requests, reject stale responses, and release requests, timers and listeners on unload/disposal.
* Preserve saved custom candidate names in the editor and prevent saves while loading a newly selected model.

## Scope and compatibility

* One model configuration remains shared across character cards. Existing filename-stem sharing across different directories/sources is unchanged.
* No configuration migration or fallback to the internal PMX name. Handwritten configurations named only after a different internal name need to use the filename stem instead; no files are deleted or renamed automatically.
* VMD versus manual-expression Morph priority, blinking, lip-sync, model deletion and rename behavior are unchanged.
* No backend storage or Electron repository changes are required for this configuration-only fix.

## Testing

* Before the fix, the initial 12 browser regression cases produced 11 failures and one pass (the unchanged VMD ordering check).
* After rebasing onto upstream `b0b283e34`, 58 targeted pytest cases pass, including real-JavaScript browser tests, API persistence in a temporary directory, stale-request/disposal coverage, MMD hot reload/visibility, frame pacing, animation completion and lip-sync contracts. Two existing dependency deprecation warnings remain.

```text
uv run python -m pytest tests/frontend/test_mmd_emotion_config.py tests/frontend/test_mmd_hot_reload_visibility_race.py tests/unit/test_mmd_interaction_static_contracts.py tests/unit/test_vrm_lipsync_formant_static_contracts.py tests/unit/test_mmd_emotion_mapping.py tests/unit/test_pet_frame_pacing_gate.py tests/unit/test_mmd_animation_completion.py -q --tb=short
```

* JavaScript syntax checks for all four changed product files and `git diff --check` pass.
* Real PMX loader comparison: a model whose filename stem differs from its internal name selected the saved custom Morph after the fix, instead of the default smile. Internal-name metadata and runtime Morph counts were unchanged.
* Automated real-backend Chromium acceptance used a dedicated character card and a real PMX with physics/rendering enabled. Clicked the real editor controls to save one custom Morph, clear all emotions, and select another Morph from a detached editor window; verified runtime weights, screenshots, hot reload without replacing the mesh, and persistence after page reload. Shared model configuration was restored afterward.
* That UI acceptance used browser interception only for the four changed JavaScript resources against an existing backend and ran before the final rebase; the targeted suite was rerun afterward. It triggered `setEmotion` directly rather than relying on natural-language classification. Native Electron shell behavior and the language classifier were not tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持情感映射在模型切换、重新加载及跨窗口编辑后自动同步。
  - 保存的 Morph 即使模型暂未加载，也会保留在候选列表中。
  - 支持显式保存空的情感映射，并在模型卸载后重置相关状态。
  - 支持通过备用通知机制同步跨窗口的配置更新。

- **错误修复**
  - 加载情感映射期间暂时禁用保存按钮，避免异步操作导致配置丢失。
  - 改善映射加载失败、超时及快速切换模型时的处理，避免旧配置覆盖当前模型。
  - 修复映射读取失败时可能覆盖已有配置的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->