### PR TITLE
fix(live2d): 修复遮罩布局与缓冲区状态恢复

### DIFF
--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -15,6 +15,219 @@ const LIVE2D_MOTION_PRIORITY = Object.freeze({
     FORCE: 3
 });
 
+// The bundled Cubism renderer uses 36 slots for a single render texture and
+// 32 slots per texture when multiple textures are used. Keep a product-level
+// ceiling so unsupported models fail before any mask framebuffer is rendered.
+const LIVE2D_MAX_MASK_RENDER_TEXTURES = 8;
+const LIVE2D_MIN_MASK_RENDER_TEXTURES = 3;
+const LIVE2D_SINGLE_MASK_TEXTURE_CAPACITY = 36;
+const LIVE2D_MULTI_MASK_TEXTURE_CAPACITY = 32;
+
+function getLive2DMaskRenderTextureCount(clippingContextCount) {
+    if (!Number.isSafeInteger(clippingContextCount) || clippingContextCount < 0) {
+        throw new TypeError(`Invalid Live2D clipping context count: ${clippingContextCount}`);
+    }
+    // Preserve the existing three-texture budget to avoid reducing mask
+    // resolution for smaller models. Add textures only when capacity requires it.
+    const renderTextureCount = Math.max(
+        LIVE2D_MIN_MASK_RENDER_TEXTURES,
+        Math.ceil(clippingContextCount / LIVE2D_MULTI_MASK_TEXTURE_CAPACITY)
+    );
+    if (renderTextureCount > LIVE2D_MAX_MASK_RENDER_TEXTURES) {
+        const error = new RangeError(
+            `Live2D model requires ${clippingContextCount} clipping contexts; `
+            + `the supported maximum is ${LIVE2D_MAX_MASK_RENDER_TEXTURES
+                * LIVE2D_MULTI_MASK_TEXTURE_CAPACITY}.`
+        );
+        error.name = 'Live2DMaskCapacityError';
+        throw error;
+    }
+    return renderTextureCount;
+}
+
+function setLive2DMaskLayout(context, bufferIndex, channelNo, index, count) {
+    let columns;
+    let rows;
+    if (count === 1) {
+        columns = 1;
+        rows = 1;
+    } else if (count === 2) {
+        columns = 2;
+        rows = 1;
+    } else if (count <= 4) {
+        columns = 2;
+        rows = 2;
+    } else if (count <= 9) {
+        columns = 3;
+        rows = 3;
+    } else {
+        throw new RangeError(`Unsupported Live2D masks per channel: ${count}`);
+    }
+
+    context._bufferIndex = bufferIndex;
+    context._layoutChannelNo = channelNo;
+    context._layoutBounds.x = (index % columns) / columns;
+    context._layoutBounds.y = Math.floor(index / columns) / rows;
+    context._layoutBounds.width = 1 / columns;
+    context._layoutBounds.height = 1 / rows;
+}
+
+// Correct the bundled SDK's remainder distribution, which leaves contexts
+// unassigned at counts such as 94 and 95 with three textures.
+function setupLive2DMaskLayoutBounds(usingClipCount) {
+    const contexts = this._clippingContextListForMask;
+    const renderTextureCount = this._renderTextureCount;
+    if (!Array.isArray(contexts) || !Number.isSafeInteger(renderTextureCount)
+        || renderTextureCount < 1) {
+        throw new Error('Live2D clipping manager is not initialized.');
+    }
+
+    if (usingClipCount === 0) {
+        // The SDK passes zero for high-precision mode, where masks are drawn
+        // individually and may reuse the full texture. An entirely inactive
+        // frame returns from setupClippingContext before calling this method.
+        contexts.forEach((context) => setLive2DMaskLayout(context, 0, 0, 0, 1));
+        this.__nekoActiveClippingContextCount = 0;
+        return;
+    }
+
+    const capacity = renderTextureCount === 1
+        ? LIVE2D_SINGLE_MASK_TEXTURE_CAPACITY
+        : LIVE2D_MULTI_MASK_TEXTURE_CAPACITY * renderTextureCount;
+    if (!Number.isSafeInteger(usingClipCount) || usingClipCount < 0
+        || usingClipCount > capacity || usingClipCount > contexts.length) {
+        throw new RangeError(
+            `Unsupported active Live2D clipping context count: ${usingClipCount} `
+            + `(capacity: ${capacity}, available: ${contexts.length}).`
+        );
+    }
+
+    // setupClippingContext counts active contexts, but its drawing loop visits
+    // the entire list, including inactive entries. Reserve a stable slot for
+    // every context so inactive entries cannot alias active masks or move their
+    // slots when bounds disappear and return. Texture capacity is also sized
+    // from this full list in configureLive2DClipping.
+    const layoutCount = contexts.length;
+    if (layoutCount > capacity) {
+        throw new RangeError(`Live2D clipping context count exceeds capacity: ${layoutCount}`);
+    }
+    const countPerTexture = Math.ceil(layoutCount / renderTextureCount);
+    const texturesWithOneLess = countPerTexture * renderTextureCount - layoutCount;
+    let contextIndex = 0;
+
+    for (let bufferIndex = 0; bufferIndex < renderTextureCount; bufferIndex++) {
+        const countForTexture = countPerTexture
+            - (bufferIndex >= renderTextureCount - texturesWithOneLess ? 1 : 0);
+        const countPerChannel = Math.floor(countForTexture / 4);
+        const channelsWithOneMore = countForTexture % 4;
+
+        for (let channelNo = 0; channelNo < 4; channelNo++) {
+            const countForChannel = countPerChannel
+                + (channelNo < channelsWithOneMore ? 1 : 0);
+            for (let slotIndex = 0; slotIndex < countForChannel; slotIndex++) {
+                setLive2DMaskLayout(
+                    contexts[contextIndex++],
+                    bufferIndex,
+                    channelNo,
+                    slotIndex,
+                    countForChannel
+                );
+            }
+        }
+    }
+
+    if (contextIndex !== layoutCount) {
+        throw new Error(
+            `Live2D clipping layout assigned ${contextIndex} of ${layoutCount} contexts.`
+        );
+    }
+    this.__nekoActiveClippingContextCount = usingClipCount;
+}
+
+// Number.MIN_VALUE is positive. Recalculate bounds with negative infinity so
+// drawables whose vertices are entirely in negative model space remain tight.
+function calculateLive2DClippedDrawBounds(model, clippingContext) {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (const drawableIndex of clippingContext._clippedDrawableIndexList) {
+        const vertexCount = model.getDrawableVertexCount(drawableIndex);
+        const vertices = model.getDrawableVertices(drawableIndex);
+        for (let vertexIndex = 0; vertexIndex < vertexCount * 2; vertexIndex += 2) {
+            const x = vertices[vertexIndex];
+            const y = vertices[vertexIndex + 1];
+            if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+            minX = Math.min(minX, x);
+            minY = Math.min(minY, y);
+            maxX = Math.max(maxX, x);
+            maxY = Math.max(maxY, y);
+        }
+    }
+
+    if (minX === Infinity) {
+        clippingContext._allClippedDrawRect.x = 0;
+        clippingContext._allClippedDrawRect.y = 0;
+        clippingContext._allClippedDrawRect.width = 0;
+        clippingContext._allClippedDrawRect.height = 0;
+        clippingContext._isUsing = false;
+        return;
+    }
+
+    clippingContext._allClippedDrawRect.x = minX;
+    clippingContext._allClippedDrawRect.y = minY;
+    clippingContext._allClippedDrawRect.width = maxX - minX;
+    clippingContext._allClippedDrawRect.height = maxY - minY;
+    clippingContext._isUsing = true;
+}
+
+function patchLive2DRendererProfile(renderer) {
+    const profile = renderer?._rendererProfile;
+    if (!profile || profile.__nekoBufferBindingFixApplied
+        || typeof profile.save !== 'function') return;
+
+    const originalSave = profile.save;
+    const originalSaveSource = Function.prototype.toString.call(originalSave);
+    const hasBundledBindingBug = /_lastArrayBufferBinding\s*=\s*this\.gl\.getParameter\(\s*this\.gl\.ELEMENT_ARRAY_BUFFER_BINDING\s*\)/
+        .test(originalSaveSource);
+    if (!hasBundledBindingBug) return;
+
+    profile.save = function() {
+        const gl = this.gl;
+        const arrayBufferBinding = gl
+            ? gl.getParameter(gl.ARRAY_BUFFER_BINDING)
+            : undefined;
+        originalSave.call(this);
+        if (gl) {
+            // The bundled save() leaves the element binding in the array field.
+            this._lastElementArrayBufferBinding = this._lastArrayBufferBinding;
+            this._lastArrayBufferBinding = arrayBufferBinding;
+        }
+    };
+    profile.__nekoBufferBindingFixApplied = true;
+}
+
+function configureLive2DClipping(renderer) {
+    const manager = renderer?._clippingManager;
+    if (!manager) return;
+
+    const contextCount = typeof manager.getClippingMaskCount === 'function'
+        ? manager.getClippingMaskCount()
+        : manager._clippingContextListForMask?.length;
+    const renderTextureCount = getLive2DMaskRenderTextureCount(contextCount);
+
+    if (manager._maskTexture?.textures) {
+        throw new Error('Cannot reconfigure Live2D clipping after mask texture allocation.');
+    }
+
+    manager._renderTextureCount = renderTextureCount;
+    manager.setupLayoutBounds = setupLive2DMaskLayoutBounds;
+    manager.calcClippedDrawTotalBounds = calculateLive2DClippedDrawBounds;
+    manager.__nekoClippingFixApplied = true;
+    patchLive2DRendererProfile(renderer);
+}
+
 Live2DManager.prototype.hasActiveActionMotion = function(model = this.currentModel) {
     if (
         model === this.currentModel
@@ -682,6 +895,15 @@ Live2DManager.prototype.loadModel = async function(modelPath, options = {}) {
         return model;
     } catch (error) {
         if (error && error.name === 'LoadSuperseded') {
+            throw error;
+        }
+        if (error && error.name === 'Live2DMaskCapacityError') {
+            console.error('Live2D 模型遮罩数量超过支持上限:', error);
+            const failedModel = this.currentModel;
+            this.currentModel = null;
+            try {
+                failedModel?.destroy?.({ children: true });
+            } catch (_) {}
             throw error;
         }
         if (error && error.name === 'PNGTuberActiveLive2DSkip') {
@@ -1928,12 +2150,14 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
         this.modelName = null;
     }
 
-    // 模型尚未加入舞台，蒙版纹理也尚未创建；此时调整数量即可让首帧
-    // 按三个缓冲区分配。不要再次 initialize()，该方法会向现有的
-    // ClippingContext/Drawable 映射追加数据，导致每次调用都产生重复项。
-    if (model.internalModel && model.internalModel.renderer && model.internalModel.renderer._clippingManager) {
-        model.internalModel.renderer._clippingManager._renderTextureCount = 3;
-        console.log('渲染纹理数量已设置为3');
+    // 在模型加入舞台、mask framebuffer 延迟创建之前校正 vendor clipping。
+    // 不可再次调用 initialize()：该版本会向已有映射追加重复项。
+    if (model.internalModel?.renderer?._clippingManager) {
+        configureLive2DClipping(model.internalModel.renderer);
+        console.log(
+            'Live2D 遮罩缓冲区已配置:',
+            model.internalModel.renderer._clippingManager.getRenderTextureCount()
+        );
     }
 
     // 根据画质设置调整渲染分辨率，不改动 Live2D 图集贴图。

--- a/tests/unit/test_live2d_clipping_static.py
+++ b/tests/unit/test_live2d_clipping_static.py
@@ -9,8 +9,7 @@ from tests.node_harness import run_node_stdin
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-@pytest.mark.parametrize("mask_count", [0, 1, 3, 35, 96])
-def test_clipping_configuration_preserves_mappings_and_allocates_buffers(mask_count):
+def test_clipping_layout_and_capacity_contract():
     node = shutil.which("node")
     if node is None:
         pytest.skip("node not found")
@@ -20,24 +19,31 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const vm = require('node:vm');
 
-// Use the shipped manager and context implementations, not a mock of initialize.
-// These private class names intentionally pin the test to the bundled SDK;
-// a bundle upgrade must recheck this integration.
+// Use the shipped manager and context implementations. Private class names
+// intentionally pin this integration test to the checked-in vendor bundle.
 const bundle = fs.readFileSync('static/libs/index.min.js', 'utf8');
 const start = bundle.indexOf('class fe{');
 const end = bundle.indexOf('class Me{', start);
 assert.ok(start >= 0 && end > start, 'locate bundled clipping classes');
+function bundledClass(name, next) {
+    const first = bundle.indexOf(`class ${name}{`);
+    const last = bundle.indexOf(next, first);
+    assert.ok(first >= 0 && last > first, `locate bundled ${name}`);
+    return new Function(bundle.slice(first, last) + `; return ${name};`)();
+}
 const ClippingManager = new Function('ge', 'Ct', 'bt', 'Bt', 'Ot',
-    'let _e = null; ' + bundle.slice(start, end) + '; return fe;')(
-        class {}, class {}, class {}, () => {}, () => {});
+    'let _e = null, pe = [0, 0, 800, 600]; const Pt = { CubismBlendMode_Normal: 0 }; '
+        + bundle.slice(start, end) + '; return fe;')(
+        bundledClass('ge', 'let me,pe,_e;'), bundledClass('Ct', 'class vt{'),
+        class {}, () => {}, () => {});
 
 const sandbox = { Live2DManager: function () {}, console: { log() {}, warn() {} } };
 vm.createContext(sandbox);
 vm.runInContext(fs.readFileSync('static/live2d/live2d-model.js', 'utf8'), sandbox);
 
-async function check(n) {
-    // Two targets share each context. Alternate single and combined masks;
-    // the trailing source drawables have no masks themselves.
+function makeManager(n) {
+    // Two targets share each unique clipping context. Trailing source
+    // drawables do not themselves use masks.
     const masks = Array.from({ length: n * 3 }, (_, i) => i < n * 2
         ? (n > 1 && i % n % 2 ? [n * 2 + i % n, n * 2] : [n * 2 + i % n])
         : []);
@@ -49,72 +55,250 @@ async function check(n) {
     };
     const manager = new ClippingManager();
     manager.initialize(core, masks.length, masks, counts, 1);
+    return { manager, core };
+}
+
+async function configure(n, rendererOverrides = {}) {
+    const { manager, core } = makeManager(n);
     const contexts = manager._clippingContextListForMask.slice();
     const mapping = manager._clippingContextListForDraw.slice();
-    const targets = contexts.map(c => c._clippedDrawableIndexList.slice());
-    assert.equal(contexts.length, n);
-
-    const model = { internalModel: { renderer: { _clippingManager: manager }, coreModel: core } };
+    const targets = contexts.map(context => context._clippedDrawableIndexList.slice());
+    const renderer = Object.assign({ _clippingManager: manager }, rendererOverrides);
+    const model = { internalModel: { renderer, coreModel: core } };
     const boundary = new Error('stop before unrelated model positioning');
-    // Execute the real application function through clipping configuration.
     const host = {
         _isLoadTokenActive: () => true,
         applyModelSettings() { throw boundary; },
     };
+
     await assert.rejects(
         sandbox.Live2DManager.prototype._configureLoadedModel.call(
             host, model, '/user_live2d/test/test.model3.json', {}, 1),
-        error => error === boundary);
+        error => error === boundary
+    );
 
-    assert.equal(manager.getRenderTextureCount(), 3);
     assert.deepEqual(manager._clippingContextListForDraw, mapping);
     contexts.forEach((context, i) => {
         assert.equal(manager._clippingContextListForMask[i], context);
         assert.deepEqual(context._clippedDrawableIndexList, targets[i]);
     });
+    return { manager, renderer };
+}
 
-    // A fresh three-buffer initialization is the reference for layout semantics.
-    const reference = new ClippingManager();
-    reference.initialize(core, masks.length, masks, counts, 3);
-    manager.setupLayoutBounds(n);
-    reference.setupLayoutBounds(n);
-    const layout = m => m._clippingContextListForMask.map(c =>
-        [c._bufferIndex, c._layoutChannelNo, c._layoutBounds]);
-    assert.deepEqual(layout(manager), layout(reference));
-    if (n === 3) {
-        assert.deepEqual(contexts.map(c => [c._bufferIndex, c._layoutChannelNo]),
-            [[0, 0], [1, 0], [2, 0]]);
+function assertValidLayout(manager, n, activeCount = n, setup = true) {
+    if (setup) manager.setupLayoutBounds(activeCount);
+    assert.equal(manager.__nekoActiveClippingContextCount, activeCount);
+    const slots = new Set();
+
+    manager._clippingContextListForMask.forEach(context => {
+        const bounds = context._layoutBounds;
+        assert.ok(Number.isInteger(context._bufferIndex));
+        assert.ok(context._bufferIndex >= 0);
+        assert.ok(context._bufferIndex < manager.getRenderTextureCount());
+        assert.ok(Number.isInteger(context._layoutChannelNo));
+        assert.ok(context._layoutChannelNo >= 0 && context._layoutChannelNo < 4);
+        [bounds.x, bounds.y, bounds.width, bounds.height].forEach(value => {
+            assert.ok(Number.isFinite(value));
+        });
+        assert.ok(bounds.x >= 0 && bounds.y >= 0);
+        assert.ok(bounds.width > 0 && bounds.height > 0);
+        assert.ok(bounds.x + bounds.width <= 1 + Number.EPSILON);
+        assert.ok(bounds.y + bounds.height <= 1 + Number.EPSILON);
+        const slot = [context._bufferIndex, context._layoutChannelNo,
+            bounds.x, bounds.y, bounds.width, bounds.height].join(':');
+        assert.ok(!slots.has(slot), `duplicate mask slot at count ${n}: ${slot}`);
+        slots.add(slot);
+    });
+    assert.equal(slots.size, n);
+}
+
+(async () => {
+    // Exercise every supported count. This includes the old 63, 94/95 and
+    // 125-127 floor-division holes rather than sampling only even boundaries.
+    for (let n = 1; n <= 256; n++) {
+        const { manager } = await configure(n);
+        const expectedTextures = n <= 96 ? 3 : Math.ceil(n / 32);
+        assert.equal(manager.getRenderTextureCount(), expectedTextures);
+        assert.equal(manager.__nekoClippingFixApplied, true);
+        assertValidLayout(manager, n);
     }
 
-    // Verify lazy resource allocation with a GL call recorder. This checks
-    // resource wiring, not GPU pixels or shader output.
-    const textures = [], framebuffers = [], attachments = [];
-    let bound = null;
-    manager.setGL({
-        createTexture() { const t = {}; textures.push(t); return t; },
-        createFramebuffer() { const f = {}; framebuffers.push(f); return f; },
-        bindFramebuffer(target, framebuffer) { bound = framebuffer; },
-        framebufferTexture2D(target, attachment, type, texture) {
-            attachments.push([bound, texture]);
+    const empty = await configure(0);
+    assert.equal(empty.manager.getRenderTextureCount(), 3);
+    empty.manager.setupLayoutBounds(0);
+
+    // Use the real SDK frame loop, including its rendering of inactive entries.
+    // Slots must stay independent through activity changes and mode switches.
+    for (const n of [5, 37, 95, 256]) {
+        const { manager } = await configure(n);
+        manager.setGL({
+            createTexture: () => ({}), createFramebuffer: () => ({}),
+            bindFramebuffer() {}, framebufferTexture2D() {}, bindTexture() {},
+            texImage2D() {}, texParameteri() {}, viewport() {}, clearColor() {}, clear() {},
+        });
+        let active = new Set(Array.from({ length: n }, (_, i) => i));
+        let invalidVertices = false;
+        const core = {
+            getDrawableVertexCount: i => (i >= n * 2 || active.has(i % n)
+                || invalidVertices) ? 3 : 0,
+            getDrawableVertices: i => i >= n * 2 || active.has(i % n)
+                ? new Float32Array([-4, -3, -2, -1, -4, -1])
+                : new Float32Array([NaN, NaN, Infinity, Infinity, NaN, NaN]),
+            getDrawableDynamicFlagVertexPositionsDidChange: () => true,
+            getDrawableCulling: () => false,
+            getDrawableTextureIndex: () => 0,
+            getDrawableVertexIndexCount: () => 3,
+            getDrawableVertexIndices: () => new Uint16Array([0, 1, 2]),
+            getDrawableVertexUvs: () => new Float32Array([0, 0, 1, 1, 0, 1]),
+            getMultiplyColor: () => ({}), getScreenColor: () => ({}),
+            getDrawableOpacity: () => 1, getPixelsPerUnit: () => 100,
+        };
+        let highPrecision = false;
+        let currentMask;
+        const drawn = new Set();
+        const renderer = {
+            isUsingHighPrecisionMask: () => highPrecision,
+            preDraw() {}, setIsCulling() {},
+            setClippingContextBufferForMask(context) { currentMask = context; },
+            drawMesh() {
+                drawn.add(currentMask);
+                if (currentMask._isUsing) {
+                    assert.ok([...currentMask._matrixForMask.getArray()].every(Number.isFinite));
+                    assert.ok([...currentMask._matrixForDraw.getArray()].every(Number.isFinite));
+                }
+            },
+        };
+        const layout = () => manager._clippingContextListForMask.map(c => [
+            c._bufferIndex, c._layoutChannelNo,
+            c._layoutBounds.x, c._layoutBounds.y,
+            c._layoutBounds.width, c._layoutBounds.height,
+        ]);
+        manager.setupClippingContext(core, renderer);
+        const originalLayout = layout();
+        const contexts = manager._clippingContextListForMask.slice();
+        const mapping = manager._clippingContextListForDraw.slice();
+        for (const indices of [
+            Array.from({ length: n - 1 }, (_, i) => i + 1),
+            [n - 1],
+            Array.from({ length: n }, (_, i) => i).filter(i => i % 2 === 0),
+            [],
+            Array.from({ length: n }, (_, i) => i),
+        ]) {
+            active = new Set(indices);
+            for (invalidVertices of [false, true]) {
+                drawn.clear();
+                manager.setupClippingContext(core, renderer);
+                assert.deepEqual(layout(), originalLayout, 'activity must not move mask slots');
+                assert.deepEqual(manager._clippingContextListForDraw, mapping);
+                contexts.forEach((context, i) => {
+                    assert.equal(manager._clippingContextListForMask[i], context);
+                    assert.equal(context._isUsing, active.has(i));
+                });
+                assert.equal(drawn.size, active.size ? n : 0);
+                // An entirely inactive frame returns before SDK layout setup.
+                if (active.size) assertValidLayout(manager, n, active.size, false);
+            }
+        }
+        highPrecision = true;
+        manager.setupClippingContext(core, renderer);
+        assert.ok(layout().every(slot => slot.join(',') === '0,0,0,0,1,1'));
+        highPrecision = false;
+        active = new Set([n - 1]);
+        manager.setupClippingContext(core, renderer);
+        assertValidLayout(manager, n, 1, false);
+        assert.deepEqual(layout(), originalLayout);
+    }
+
+    // 257 contexts exceed the explicit product limit and must fail before the
+    // model reaches the stage. Never alias every context onto a fallback slot.
+    const overflow = makeManager(257);
+    const overflowModel = {
+        internalModel: { renderer: { _clippingManager: overflow.manager }, coreModel: overflow.core }
+    };
+    await assert.rejects(
+        sandbox.Live2DManager.prototype._configureLoadedModel.call(
+            { _isLoadTokenActive: () => true }, overflowModel,
+            '/user_live2d/test/test.model3.json', {}, 1),
+        error => error?.name === 'Live2DMaskCapacityError'
+            && /supported maximum is 256/.test(error.message)
+    );
+
+    // Regression for Number.MIN_VALUE: an all-negative drawable must not be
+    // expanded to the model-space origin.
+    const negative = await configure(1);
+    const negativeContext = negative.manager._clippingContextListForMask[0];
+    negative.manager.calcClippedDrawTotalBounds({
+        getDrawableVertexCount: () => 2,
+        getDrawableVertices: () => new Float32Array([-4, -3, -2, -1]),
+    }, negativeContext);
+    assert.deepEqual(
+        [negativeContext._allClippedDrawRect.x, negativeContext._allClippedDrawRect.y,
+            negativeContext._allClippedDrawRect.width, negativeContext._allClippedDrawRect.height],
+        [-4, -3, 2, 2]
+    );
+
+    // Resource allocation follows the computed count and remains lazy. Use 95
+    // to cover the former three-texture layout hole at the framebuffer layer.
+    const allocation = await configure(95);
+    const textures = [];
+    const framebuffers = [];
+    const attachments = [];
+    let boundFramebuffer = null;
+    allocation.manager.setGL({
+        createTexture() { const texture = {}; textures.push(texture); return texture; },
+        createFramebuffer() {
+            const framebuffer = {};
+            framebuffers.push(framebuffer);
+            return framebuffer;
         },
-        bindTexture() {}, texImage2D() {}, texParameteri() {},
+        bindFramebuffer(target, framebuffer) { boundFramebuffer = framebuffer; },
+        framebufferTexture2D(target, attachment, type, texture) {
+            attachments.push([boundFramebuffer, texture]);
+        },
+        bindTexture() {},
+        texImage2D() {},
+        texParameteri() {},
     });
-    assert.equal(manager._maskTexture, undefined);
-    const allocated = manager.getMaskRenderTexture();
+    assert.equal(allocation.manager._maskTexture, undefined);
+    const allocated = allocation.manager.getMaskRenderTexture();
     assert.equal(allocated.length, 3);
     assert.equal(textures.length, 3);
     assert.equal(framebuffers.length, 3);
-    attachments.forEach(([framebuffer, texture], i) => {
-        assert.equal(framebuffer, framebuffers[i]);
-        assert.equal(texture, textures[i]);
-    });
     assert.equal(attachments.length, 3);
-    assert.equal(manager.getMaskRenderTexture(), allocated);
+    attachments.forEach(([framebuffer, texture], index) => {
+        assert.equal(framebuffer, framebuffers[index]);
+        assert.equal(texture, textures[index]);
+    });
+    assert.equal(allocation.manager.getMaskRenderTexture(), allocated);
     assert.equal(textures.length, 3, 'reuse allocated mask textures');
-}
-check(MASK_COUNT).catch(error => { console.error(error); process.exitCode = 1; });
-""".replace("MASK_COUNT", str(mask_count))
+
+    // The bundled profile overwrites the saved ARRAY_BUFFER value with the
+    // ELEMENT_ARRAY_BUFFER value. Verify the compatibility patch separates them.
+    const arrayBinding = { name: 'array' };
+    const elementBinding = { name: 'element' };
+    const gl = {
+        ARRAY_BUFFER_BINDING: 1,
+        ELEMENT_ARRAY_BUFFER_BINDING: 2,
+        getParameter(parameter) {
+            return parameter === this.ARRAY_BUFFER_BINDING ? arrayBinding : elementBinding;
+        },
+    };
+    const profile = {
+        gl,
+        save() {
+            this._lastArrayBufferBinding = this.gl.getParameter(this.gl.ARRAY_BUFFER_BINDING);
+            this._lastArrayBufferBinding = this.gl.getParameter(
+                this.gl.ELEMENT_ARRAY_BUFFER_BINDING
+            );
+        },
+    };
+    await configure(1, { _rendererProfile: profile });
+    profile.save();
+    assert.equal(profile._lastArrayBufferBinding, arrayBinding);
+    assert.equal(profile._lastElementArrayBufferBinding, elementBinding);
+})().catch(error => { console.error(error); process.exitCode = 1; });
+"""
     result = run_node_stdin(
-        node, script, cwd=PROJECT_ROOT, capture_output=True, timeout=10, check=False
+        node, script, cwd=PROJECT_ROOT, capture_output=True, timeout=30, check=False
     )
     assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## 改动概述 / Summary

修复 bundled Cubism SDK 的遮罩布局余数分配问题：三个纹理处理 94/95 个上下文时，原布局可能遗漏尾部上下文。按完整上下文列表分配固定、独立的区域，避免活跃状态变化后沿用冲突位置；保持已有 ClippingContext/Drawable 映射，不再次调用 initialize()。

- 保留至少 3 张遮罩纹理；超过 96 个上下文才增加，最多 8 张、256 个上下文。超过上限时在加入舞台前明确失败并销毁模型，不回退默认模型。
- 修正负坐标边界计算中使用正数 Number.MIN_VALUE 初始化最大值的问题。
- 针对 bundled renderer profile 的绑定保存错误，分别恢复 ARRAY_BUFFER 和 ELEMENT_ARRAY_BUFFER。

## 回归报告 / Regression Report

本次仅修改 Live2D 前端实现与对应测试，不涉及受此报告门禁约束的 Python 业务模块。主要回归风险为遮罩区域、模型加载失败清理，以及与其他渲染内容共享的 WebGL 状态。补丁依赖当前 bundled SDK 的私有实现，升级 SDK 时需要重新核对。

## 不拆分理由 / Why Not Split

不适用：仅两个文件，为 Live2D 渲染兼容修复及其回归测试。

## 测试 / Testing

以下独立 pytest 入口运行结果为 **3 passed**：

```bash
UV_CACHE_DIR=.uv-cache PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
NODE_OPTIONS='--preserve-symlinks --preserve-symlinks-main' \
uv run --no-sync pytest --noconftest -o addopts= -p no:cacheprovider \
  tests/unit/test_live2d_clipping_static.py \
  tests/unit/test_live2d_init_static_contracts.py -q
```

- 遍历 1–256 个上下文的布局与容量，并检查超限拒绝和延迟纹理分配。
- 使用实际 bundled SDK 的逐帧遮罩循环，覆盖空顶点、非有限顶点、首项停用、仅尾项活跃、全部停用后恢复，以及高精度模式切换后的布局恢复。
- 在内存中恢复旧分配行为后，新回归测试按预期失败。
- 额外在内存中检查全部支持数量下区域无几何重叠，并用实际 bundled profile 验证两类缓冲区绑定的 save/restore。
- git diff --check 通过。

独立入口绕过了全局 conftest 的浏览器初始化，并关闭插件自动加载；不是完整测试套件结果。运行时有两条未加载 asyncio 插件导致的配置警告。

## Draft 待验证项

- 尚未使用真实模型完成硬件 GPU 渲染对比，也未提供修复前后的截图或录屏；转为正式审阅前需要补充这项视觉验收材料。
- 已观察到的紫色沙漏内容溢出为矩形、头发和脸部异常与本修复方向相符，但**尚未证实本 PR 解决该模型的实际症状**。
- 当前逐帧测试使用模拟 GL，仅对活跃上下文检查矩阵有限性；不能替代异常顶点和空上下文的真实 GPU 验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Live2D 裁剪蒙版布局、边界计算及 WebGL 缓冲区绑定问题。
  * 根据裁剪上下文数量动态分配渲染纹理，并限制最大容量。
  * 改进模型加载失败处理；蒙版容量超限时将终止加载失败的模型，不再回退到默认模型。
  * 提升高精度模式切换及大量裁剪上下文下的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->