### PR TITLE
feat: integrate image generation infrastructure into core API management

### DIFF
--- a/docs/development/image-generation.md
+++ b/docs/development/image-generation.md
@@ -43,7 +43,10 @@ Newer DashScope multimodal-generation protocols are a separate adapter extension
 not inferred from a model name.
 
 Requests generate one image, with a bounded prompt, dimensions, response body and
-total timeout. No automatic retries are performed because submission may already
+total timeout (180 seconds by default, configurable up to 600 seconds). The total
+deadline also governs transport requests and polling; no shorter read timeout is
+imposed. Requests advertise Accept-Encoding: identity and reject compressed
+responses before reading them to prevent unbounded decompression. No automatic retries are performed because submission may already
 be billed. Cancellation propagates; it does not cancel an already submitted remote
 job. Failures expose stable ImageGenerationError.code values without provider
 bodies, prompts or credentials. No prompt/result logging or disk writes occur.

--- a/docs/development/image-generation.md
+++ b/docs/development/image-generation.md
@@ -1,0 +1,59 @@
+# Core image generation
+
+This capability replaces the plugin proposal in [PR #2830](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2830).
+The provider protocol design is adapted from Alumin-Hydro's contribution. The
+plugin, its panel, generation history, cache and chat hooks are not included.
+
+## Configure
+
+In API management, enable custom model configuration and expand **Image generation**.
+Choose OpenAI, Qwen Beijing, Qwen Singapore, or an OpenAI-compatible custom endpoint.
+Named providers use their corresponding API Key Book entry; their endpoints are
+fixed to prevent forwarding a provider credential to an unrelated host.
+Custom endpoints use an independent key and require HTTPS. Changing a custom
+endpoint requires replacing or explicitly clearing the saved custom key.
+
+The settings use the existing core_config.json persistence and /core_api masked
+secret round trip. They do not establish a new credential store. The default
+unconfigured slot has no fallback to conversation/vision models or free services.
+Saving settings never generates a paid test image.
+
+## Call
+
+    from utils.image_generation import ImageRequest, generate_image
+
+    result = await generate_image(ImageRequest(prompt="A small garden", size="1024x1024"))
+    # result.provider, result.model
+    # result.image.data: bytes, OR result.image.url: temporary HTTPS URL
+
+ConfigManager.get_model_api_config("image") and its asynchronous counterpart
+resolve the same configuration. Each generation uses one configuration snapshot.
+OpenAI and DashScope implement the same adapter contract in separate modules.
+
+There is deliberately no public HTTP generation route or automatic consumer.
+Callers own concurrency, authorization, artifact validation/decoding, retrieval,
+storage and display. Returned bytes have been base64-decoded but have not been
+decoded as an image. URLs are untrusted, may expire, and are never downloaded by
+this module. A future server-side downloader must enforce its own SSRF/DNS policy,
+size limits and redirect policy; syntactic HTTPS validation is not sufficient.
+
+The initial adapters support OpenAI Images generations (including GPT Image) and
+DashScope's asynchronous text2image/image-synthesis API (Wan 2.1/2.5 family).
+Newer DashScope multimodal-generation protocols are a separate adapter extension,
+not inferred from a model name.
+
+Requests generate one image, with a bounded prompt, dimensions, response body and
+total timeout. No automatic retries are performed because submission may already
+be billed. Cancellation propagates; it does not cancel an already submitted remote
+job. Failures expose stable ImageGenerationError.code values without provider
+bodies, prompts or credentials. No prompt/result logging or disk writes occur.
+
+Protocol references:
+- https://developers.openai.com/api/docs/guides/image-generation
+- https://www.alibabacloud.com/help/en/model-studio/text-to-image-v2-api-reference
+
+## Validation
+
+Tests use httpx.MockTransport and never call a paid provider. They cover request
+shape, regional credential isolation, masked settings, configuration snapshots,
+endpoint changes, response bounds, errors, cancellation and frontend round trips.

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -573,13 +573,13 @@ async def update_core_config(request: Request):
                 ) if field in data
             }}
             apply_core_config_secret_update(candidate, data, "imageModelApiKey")
-            if candidate.get("imageModelProvider") == "custom":
+            if core_cfg.get("imageModelApiKey"):
                 old_url = core_cfg.get("imageModelUrl", "")
                 new_url = candidate.get("imageModelUrl", "")
                 from utils.http.url import same_endpoint
                 equivalent_url = (
                     isinstance(old_url, str) and isinstance(new_url, str)
-                    and same_endpoint(old_url.strip().rstrip("/"), new_url.strip().rstrip("/"))
+                    and same_endpoint(old_url.strip(), new_url.strip())
                 )
                 if not equivalent_url and core_cfg.get("imageModelApiKey") and (
                     "imageModelApiKey" not in data

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -34,7 +34,7 @@ CORE_CONFIG_SECRET_SENTINEL = "__NEKO_SECRET_MASKED__"
 
 CORE_CONFIG_MODEL_TYPES = (
     'conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion',
-    'vision', 'agent', 'omni', 'tts',
+    'vision', 'agent', 'omni', 'tts', 'image',
 )
 
 CORE_CONFIG_ASSIST_API_KEY_FIELDS = (
@@ -562,6 +562,30 @@ async def update_core_config(request: Request):
             and not is_core_config_secret_placeholder(data['ttsModelApiKey'])
         )
 
+        # A retained custom credential must never follow an endpoint change.
+        if any(field in data for field in (
+            "imageModelProvider", "imageModelUrl", "imageModelId", "imageModelApiKey"
+        )):
+            from utils.image_generation.config import resolve_image_config
+            candidate = {**core_cfg, **{
+                field: data[field] for field in (
+                    "imageModelProvider", "imageModelUrl", "imageModelId"
+                ) if field in data
+            }}
+            apply_core_config_secret_update(candidate, data, "imageModelApiKey")
+            if candidate.get("imageModelProvider") == "custom":
+                old_url = core_cfg.get("imageModelUrl", "")
+                new_url = candidate.get("imageModelUrl", "")
+                if old_url != new_url and core_cfg.get("imageModelApiKey") and (
+                    "imageModelApiKey" not in data
+                    or is_core_config_secret_placeholder(data["imageModelApiKey"])
+                ):
+                    return {"success": False, "error": "Changing image endpoint requires replacing or clearing its API key"}
+            try:
+                resolve_image_config(candidate)
+            except ValueError as exc:
+                return {"success": False, "error": str(exc)}
+
         # 自定义API配置（Provider / Url / Id / ApiKey per model type）
         for mt in CORE_CONFIG_MODEL_TYPES:
             for suffix in ['Provider', 'Url', 'Id', 'ApiKey']:
@@ -733,7 +757,10 @@ async def get_api_providers_config():
             logger.warning(f"加载 TTS provider 元数据失败: {e}")
             tts_providers = []
 
+        from utils.image_generation.config import PROVIDERS as image_providers
+
         return {
+            "image_providers": image_providers,
             "success": True,
             "core_api_providers": core_providers,
             "assist_api_providers": assist_providers,

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -576,7 +576,12 @@ async def update_core_config(request: Request):
             if candidate.get("imageModelProvider") == "custom":
                 old_url = core_cfg.get("imageModelUrl", "")
                 new_url = candidate.get("imageModelUrl", "")
-                if old_url != new_url and core_cfg.get("imageModelApiKey") and (
+                from utils.http.url import same_endpoint
+                equivalent_url = (
+                    isinstance(old_url, str) and isinstance(new_url, str)
+                    and same_endpoint(old_url.strip().rstrip("/"), new_url.strip().rstrip("/"))
+                )
+                if not equivalent_url and core_cfg.get("imageModelApiKey") and (
                     "imageModelApiKey" not in data
                     or is_core_config_secret_placeholder(data["imageModelApiKey"])
                 ):

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -566,30 +566,41 @@ async def update_core_config(request: Request):
         if any(field in data for field in (
             "imageModelProvider", "imageModelUrl", "imageModelId", "imageModelApiKey"
         )):
-            from utils.image_generation.config import resolve_image_config
+            from utils.image_generation.config import PROVIDERS, resolve_image_config
             candidate = {**core_cfg, **{
                 field: data[field] for field in (
                     "imageModelProvider", "imageModelUrl", "imageModelId"
                 ) if field in data
             }}
             apply_core_config_secret_update(candidate, data, "imageModelApiKey")
-            if core_cfg.get("imageModelApiKey"):
-                old_url = core_cfg.get("imageModelUrl", "")
-                new_url = candidate.get("imageModelUrl", "")
-                from utils.http.url import same_endpoint
-                equivalent_url = (
-                    isinstance(old_url, str) and isinstance(new_url, str)
-                    and same_endpoint(old_url.strip(), new_url.strip())
-                )
-                if not equivalent_url and core_cfg.get("imageModelApiKey") and (
-                    "imageModelApiKey" not in data
-                    or is_core_config_secret_placeholder(data["imageModelApiKey"])
-                ):
-                    return {"success": False, "error": "Changing image endpoint requires replacing or clearing its API key"}
-            try:
-                resolve_image_config(candidate)
-            except ValueError as exc:
-                return {"success": False, "error": str(exc)}
+            stored_image_provider = core_cfg.get("imageModelProvider")
+            preserve_unknown_image = (
+                isinstance(stored_image_provider, str)
+                and stored_image_provider not in ("", "disabled")
+                and stored_image_provider not in PROVIDERS
+                and all(candidate.get(field, "") == core_cfg.get(field, "") for field in (
+                    "imageModelProvider", "imageModelUrl", "imageModelId", "imageModelApiKey"
+                ))
+            )
+            # Older builds may retain a future provider, but must not create or edit it.
+            if not preserve_unknown_image:
+                if core_cfg.get("imageModelApiKey"):
+                    old_url = core_cfg.get("imageModelUrl", "")
+                    new_url = candidate.get("imageModelUrl", "")
+                    from utils.http.url import same_endpoint
+                    equivalent_url = (
+                        isinstance(old_url, str) and isinstance(new_url, str)
+                        and same_endpoint(old_url.strip(), new_url.strip())
+                    )
+                    if not equivalent_url and core_cfg.get("imageModelApiKey") and (
+                        "imageModelApiKey" not in data
+                        or is_core_config_secret_placeholder(data["imageModelApiKey"])
+                    ):
+                        return {"success": False, "error": "Changing image endpoint requires replacing or clearing its API key"}
+                try:
+                    resolve_image_config(candidate)
+                except ValueError as exc:
+                    return {"success": False, "error": str(exc)}
 
         # 自定义API配置（Provider / Url / Id / ApiKey per model type）
         for mt in CORE_CONFIG_MODEL_TYPES:

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -567,6 +567,10 @@ async def update_core_config(request: Request):
             "imageModelProvider", "imageModelUrl", "imageModelId", "imageModelApiKey"
         )):
             from utils.image_generation.config import PROVIDERS, resolve_image_config
+            if any(not isinstance(data[field], str) for field in (
+                "imageModelProvider", "imageModelUrl", "imageModelId", "imageModelApiKey"
+            ) if field in data):
+                return {"success": False, "error": "Image settings must be strings"}
             candidate = {**core_cfg, **{
                 field: data[field] for field in (
                     "imageModelProvider", "imageModelUrl", "imageModelId"

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -2159,3 +2159,11 @@ font-size: 0.8em;
         box-shadow: 0 0 6px rgba(64, 197, 241, 0.5);
     }
 }
+
+/* Image infrastructure owns a full row without shifting existing model pairs. */
+.custom-api-container > .model-config-container:has(> #image-model-content) {
+    grid-column: 1 / -1;
+}
+.custom-api-container > .model-config-container > #image-model-content.expanded {
+    width: 100%;
+}

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1166,7 +1166,7 @@ padding-left: 4px;
     }
 
     .custom-api-container
-        > .model-config-container:has(> #vision-model-content, > #correction-model-content, > #omni-model-content, > #tts-model-content)
+        > .model-config-container:has(> #vision-model-content, > #correction-model-content, > #omni-model-content, > #tts-model-content, > #image-model-content)
         > .model-content.expanded {
         margin-left: calc(-100% - 18px);
     }
@@ -1178,7 +1178,9 @@ padding-left: 4px;
     .custom-api-container:has(#emotion-model-content:is(.expanded, .is-collapsing)):has(#omni-model-content:is(.expanded, .is-collapsing))
         :is(#emotion-model-content, #omni-model-content):is(.expanded, .is-collapsing),
     .custom-api-container:has(#agent-model-content:is(.expanded, .is-collapsing)):has(#tts-model-content:is(.expanded, .is-collapsing))
-        :is(#agent-model-content, #tts-model-content):is(.expanded, .is-collapsing) {
+        :is(#agent-model-content, #tts-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#game-model-content:is(.expanded, .is-collapsing)):has(#image-model-content:is(.expanded, .is-collapsing))
+        :is(#game-model-content, #image-model-content):is(.expanded, .is-collapsing) {
         width: 100%;
         margin-left: 0;
     }
@@ -1203,6 +1205,12 @@ padding-left: 4px;
         > .model-header[aria-expanded="false"],
     .custom-api-container:has(#agent-model-content.expanded)
         > .model-config-container:has(> #tts-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#game-model-content.expanded)
+        > .model-config-container:has(> #image-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#image-model-content.expanded)
+        > .model-config-container:has(> #game-model-content)
         > .model-header[aria-expanded="false"],
     .custom-api-container:has(#tts-model-content.expanded)
         > .model-config-container:has(> #agent-model-content)
@@ -2158,12 +2166,4 @@ font-size: 0.8em;
         animation: none;
         box-shadow: 0 0 6px rgba(64, 197, 241, 0.5);
     }
-}
-
-/* Image infrastructure owns a full row without shifting existing model pairs. */
-.custom-api-container > .model-config-container:has(> #image-model-content) {
-    grid-column: 1 / -1;
-}
-.custom-api-container > .model-config-container > #image-model-content.expanded {
-    width: 100%;
 }

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -31,7 +31,7 @@
     // locale 资源版本（用于 cache-busting，避免客户端长期缓存旧语言包导致新增 key 不生效）
     // 保留上游你画我猜、PNGTuber 文案并新增足球 SDK 启动失败提示；递增版本让
     // Electron、Docker 等长期缓存重新拉取完整语言包，避免显示未本地化 key。
-    const LOCALE_VERSION = '2026-09-11-soccer-sdk-migration';
+    const LOCALE_VERSION = '2026-09-12-core-image-generation';
     function initDecorativeImageDragGuard() {
         const markImage = (img) => {
             if (!(img instanceof HTMLImageElement)) return;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -5553,7 +5553,14 @@ function populateImageProviders(providers) {
         option.disabled = !!isProviderRestricted(key);
         select.appendChild(option);
     });
-    select.value = Object.hasOwn(providers, previous) ? previous : 'disabled';
+    if (previous && previous !== 'disabled' && !Object.hasOwn(providers, previous)) {
+        const option = document.createElement('option');
+        option.value = previous;
+        option.textContent = previous;
+        option.disabled = !!isProviderRestricted(previous);
+        select.appendChild(option);
+    }
+    select.value = previous || 'disabled';
 }
 
 function onImageProviderChange({ loading = false } = {}) {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -5546,12 +5546,13 @@ function populateImageProviders(providers) {
     select.replaceChildren();
     appendModelProviderOption(select, 'disabled', 'api.imageDisabled', '未配置');
     Object.entries(providers).forEach(([key, meta]) => {
+        if (isProviderRestricted(key)) return;
         const option = document.createElement('option');
         option.value = key;
         option.textContent = meta.name;
         select.appendChild(option);
     });
-    select.value = Object.hasOwn(providers, previous) ? previous : 'disabled';
+    select.value = Object.hasOwn(providers, previous) && !isProviderRestricted(previous) ? previous : 'disabled';
 }
 
 function onImageProviderChange({ loading = false } = {}) {
@@ -5581,7 +5582,8 @@ function onImageProviderChange({ loading = false } = {}) {
 function loadImageSettings(data) {
     const select = document.getElementById('imageModelProvider');
     if (!select) return;
-    const provider = data.imageModelProvider || 'disabled';
+    const savedProvider = data.imageModelProvider || 'disabled';
+    const provider = isProviderRestricted(savedProvider) ? 'disabled' : savedProvider;
     // Preserve an unknown saved selection when metadata is temporarily missing.
     if (!Array.from(select.options).some(option => option.value === provider)) {
         const option = document.createElement('option');

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -5611,10 +5611,11 @@ function imageSettingsPayload() {
     const select = document.getElementById('imageModelProvider');
     if (!select) return {};
     const payload = { imageModelProvider: select.value };
+    const knownProvider = select.value === 'disabled' || Object.hasOwn(_imageProviders, select.value);
     for (const suffix of ['Url', 'Id', 'ApiKey']) {
         const input = document.getElementById('imageModel' + suffix);
         payload['imageModel' + suffix] = suffix === 'ApiKey'
-            ? getRealKey(input) : input.value.trim();
+            ? getRealKey(input) : (knownProvider ? input.value.trim() : input.value);
     }
     return payload;
 }

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -20,6 +20,7 @@ let _coreApiProviders = {};
 // tts_provider_registry，统一驱动下拉过滤 / 端点字段解锁 / 连通性探测，
 // 新增此类 provider 不再需要在本文件多处硬编码 provider key
 let _ttsProviders = {};
+let _imageProviders = {};
 // 连通性测试确认可用的区域 URL，key 形如 "assist:qwen_intl"
 let _resolvedProviderUrls = {};
 // 核心 Key 输入框是否被用户手动改过；未改动时优先采用服务商管理簿的专属 Key
@@ -1741,6 +1742,7 @@ async function loadApiProviders() {
             if (data.success) {
                 // Store registry and full provider info
                 _apiKeyRegistry = data.api_key_registry || {};
+                populateImageProviders(data.image_providers || {});
                 _coreApiProviders = data.core_api_providers_full || {};
                 _assistApiProviders = data.assist_api_providers_full || {};
                 _keyBookApiProviders = data.keybook_api_providers_full || {};
@@ -2073,6 +2075,7 @@ async function loadCurrentApiKey() {
             setInputValue('emotionModelId', data.emotionModelId);
             setSecretInputValue('emotionModelApiKey', data.emotionModelApiKey);
 
+            loadImageSettings(data);
             setInputValue('visionModelUrl', data.visionModelUrl);
             setInputValue('visionModelId', data.visionModelId);
             setSecretInputValue('visionModelApiKey', data.visionModelApiKey);
@@ -2844,6 +2847,7 @@ async function save_button_down(e) {
     const payload = {
         apiKey: apiKeyForSave, coreApi, assistApi,
         ...bookPayload,
+        ...imageSettingsPayload(),
         conversationModelUrl, conversationModelId, conversationModelApiKey,
         summaryModelUrl, summaryModelId, summaryModelApiKey,
         gameMainModelUrl, gameMainModelId, gameMainModelApiKey,
@@ -3539,7 +3543,7 @@ function navigateToCustomModelConfig(modelType) {
 // 页面加载完成后初始化折叠状态
 document.addEventListener('DOMContentLoaded', function () {
     // 初始化所有模型配置为折叠状态
-    const modelTypes = ["conversation", 'summary', 'game', 'game-main', 'game-summary', 'correction', 'emotion', 'vision', 'agent', 'omni', 'tts', 'gptsovits'];
+    const modelTypes = ["conversation", 'summary', 'game', 'game-main', 'game-summary', 'correction', 'emotion', 'vision', 'image', 'agent', 'omni', 'tts', 'gptsovits'];
     modelTypes.forEach(modelType => {
         const content = document.getElementById(`${modelType}-model-content`);
         if (content) {
@@ -5524,4 +5528,76 @@ function closeSettingsPage() {
             }, 100);
         }
     }
+}
+
+
+// Image generation is configured here but is never probed with a paid request.
+function populateImageProviders(providers) {
+    _imageProviders = providers;
+    const select = document.getElementById('imageModelProvider');
+    if (!select) return;
+    const previous = select.value;
+    select.replaceChildren();
+    appendModelProviderOption(select, 'disabled', 'api.imageDisabled', '未配置');
+    Object.entries(providers).forEach(([key, meta]) => {
+        const option = document.createElement('option');
+        option.value = key;
+        option.textContent = meta.name;
+        select.appendChild(option);
+    });
+    select.value = Object.hasOwn(providers, previous) ? previous : 'disabled';
+}
+
+function onImageProviderChange({ loading = false } = {}) {
+    const select = document.getElementById('imageModelProvider');
+    if (!select) return;
+    const meta = _imageProviders[select.value];
+    const url = document.getElementById('imageModelUrl');
+    const model = document.getElementById('imageModelId');
+    const key = document.getElementById('imageModelApiKey');
+    const custom = select.value === 'custom';
+    url.readOnly = !custom;
+    key.disabled = !custom;
+    if (!loading) {
+        url.value = meta?.base_url || '';
+        model.value = meta?.model || '';
+        setSecretInputValue('imageModelApiKey', '');
+    }
+    if (!custom) {
+        url.value = meta?.base_url || '';
+        if (!model.value && meta) model.value = meta.model || '';
+        // Named providers resolve the current Key Book value on the server.
+        setSecretInputValue('imageModelApiKey', '');
+    }
+    syncProviderSelectDropdowns(select);
+}
+
+function loadImageSettings(data) {
+    const select = document.getElementById('imageModelProvider');
+    if (!select) return;
+    const provider = data.imageModelProvider || 'disabled';
+    // Preserve an unknown saved selection when metadata is temporarily missing.
+    if (!Array.from(select.options).some(option => option.value === provider)) {
+        const option = document.createElement('option');
+        option.value = provider;
+        option.textContent = provider;
+        select.appendChild(option);
+    }
+    select.value = provider;
+    document.getElementById('imageModelUrl').value = data.imageModelUrl || '';
+    document.getElementById('imageModelId').value = data.imageModelId || '';
+    setSecretInputValue('imageModelApiKey', data.imageModelApiKey || '');
+    if (provider === 'disabled' || _imageProviders[provider]) onImageProviderChange({ loading: true });
+}
+
+function imageSettingsPayload() {
+    const select = document.getElementById('imageModelProvider');
+    if (!select) return {};
+    const payload = { imageModelProvider: select.value };
+    for (const suffix of ['Url', 'Id', 'ApiKey']) {
+        const input = document.getElementById('imageModel' + suffix);
+        payload['imageModel' + suffix] = suffix === 'ApiKey'
+            ? getRealKey(input) : input.value.trim();
+    }
+    return payload;
 }

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -5546,13 +5546,14 @@ function populateImageProviders(providers) {
     select.replaceChildren();
     appendModelProviderOption(select, 'disabled', 'api.imageDisabled', '未配置');
     Object.entries(providers).forEach(([key, meta]) => {
-        if (isProviderRestricted(key)) return;
+        if (isProviderRestricted(key) && key !== previous) return;
         const option = document.createElement('option');
         option.value = key;
         option.textContent = meta.name;
+        option.disabled = !!isProviderRestricted(key);
         select.appendChild(option);
     });
-    select.value = Object.hasOwn(providers, previous) && !isProviderRestricted(previous) ? previous : 'disabled';
+    select.value = Object.hasOwn(providers, previous) ? previous : 'disabled';
 }
 
 function onImageProviderChange({ loading = false } = {}) {
@@ -5582,13 +5583,14 @@ function onImageProviderChange({ loading = false } = {}) {
 function loadImageSettings(data) {
     const select = document.getElementById('imageModelProvider');
     if (!select) return;
-    const savedProvider = data.imageModelProvider || 'disabled';
-    const provider = isProviderRestricted(savedProvider) ? 'disabled' : savedProvider;
-    // Preserve an unknown saved selection when metadata is temporarily missing.
+    const provider = data.imageModelProvider || 'disabled';
+    // Preserve saved restricted selections without making them available to choose.
+    // Also preserve unknown selections when metadata is temporarily missing.
     if (!Array.from(select.options).some(option => option.value === provider)) {
         const option = document.createElement('option');
         option.value = provider;
-        option.textContent = provider;
+        option.textContent = _imageProviders[provider]?.name || provider;
+        option.disabled = !!isProviderRestricted(provider);
         select.appendChild(option);
     }
     select.value = provider;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -3426,6 +3426,8 @@ const MODEL_CONFIG_ROW_PAIRS = Object.freeze({
     omni: 'emotion',
     agent: 'tts',
     tts: 'agent',
+    game: 'image',
+    image: 'game',
 });
 
 function finishModelConfigCollapse(content, pairedContent, transitionId) {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -2566,6 +2566,12 @@ function confirmClearCustomApi() {
         }
     });
 
+    const imageProvider = document.getElementById('imageModelProvider');
+    if (imageProvider) {
+        imageProvider.value = 'disabled';
+        onImageProviderChange();
+    }
+
     // 清空 TTS Voice ID
     const ttsVoiceIdEl = document.getElementById('ttsVoiceId');
     if (ttsVoiceIdEl) ttsVoiceIdEl.value = '';

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1058,6 +1058,10 @@
         "connectionError": "Connection Error"
     },
     "api": {
+    "imageModelConfig": "Image generation",
+    "imageModelExamplePlaceholder": "e.g., gpt-image-2, wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "Custom endpoint key; named providers use the API Key Book",
+    "imageDisabled": "Not configured",
         "settings": "API Key Settings",
         "settingsTitle": "API Key Settings - Project Lanlan",
         "quickStart": "Quick Start",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1058,6 +1058,10 @@
         "connectionError": "Error de conexión"
     },
     "api": {
+    "imageModelConfig": "Generación de imágenes",
+    "imageModelExamplePlaceholder": "Ej.: gpt-image-2, wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "Clave del endpoint personalizado; los proveedores usan el registro de claves API",
+    "imageDisabled": "Sin configurar",
         "settings": "Configuración de clave API",
         "settingsTitle": "Configuración de clave API - Proyecto Lanlan",
         "quickStart": "Inicio rápido",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1058,6 +1058,10 @@
         "connectionError": "接続エラー"
     },
     "api": {
+    "imageModelConfig": "画像生成",
+    "imageModelExamplePlaceholder": "例: gpt-image-2、wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "カスタム接続先のキー。既定プロバイダーは API キー管理簿を使用",
+    "imageDisabled": "未設定",
         "settings": "APIキー設定",
         "settingsTitle": "APIキー設定 - Project Lanlan",
         "quickStart": "クイックスタート",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1058,6 +1058,10 @@
         "connectionError": "연결 오류"
     },
     "api": {
+    "imageModelConfig": "이미지 생성",
+    "imageModelExamplePlaceholder": "예: gpt-image-2, wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "사용자 지정 엔드포인트 키. 기본 제공자는 API 키 관리부 사용",
+    "imageDisabled": "설정되지 않음",
         "settings": "API 키 설정",
         "settingsTitle": "API 키 설정 - 프로젝트 Lanlan",
         "quickStart": "빠른 시작",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1058,6 +1058,10 @@
         "connectionError": "Erro de conexão"
     },
     "api": {
+    "imageModelConfig": "Geração de imagens",
+    "imageModelExamplePlaceholder": "Ex.: gpt-image-2, wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "Chave do endpoint personalizado; provedores usam o cadastro de chaves API",
+    "imageDisabled": "Não configurado",
         "settings": "Configurações de chave de API",
         "settingsTitle": "Configurações de chave de API - Projeto Lanlan",
         "quickStart": "Início rápido",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1058,6 +1058,10 @@
         "connectionError": "Ошибка подключения"
     },
     "api": {
+    "imageModelConfig": "Генерация изображений",
+    "imageModelExamplePlaceholder": "Например, gpt-image-2, wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "Ключ своего сервера; провайдеры используют книгу ключей API",
+    "imageDisabled": "Не настроено",
         "settings": "Настройки API Key",
         "settingsTitle": "Настройки API Key — Project Lanlan",
         "quickStart": "Быстрый старт",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1058,6 +1058,10 @@
         "connectionError": "连接错误"
     },
     "api": {
+    "imageModelConfig": "图片生成",
+    "imageModelExamplePlaceholder": "例如 gpt-image-2、wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "自定义端点密钥；预设服务商使用 API 管理簿密钥",
+    "imageDisabled": "未配置",
         "settings": "API Key 设置",
         "settingsTitle": "API Key 设置 - Project Lanlan",
         "quickStart": "快速开始",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1058,6 +1058,10 @@
         "connectionError": "連接錯誤"
     },
     "api": {
+    "imageModelConfig": "圖片生成",
+    "imageModelExamplePlaceholder": "例如 gpt-image-2、wanx2.1-t2i-turbo",
+    "imageModelApiKeyPlaceholder": "自訂端點金鑰；預設服務商使用 API 管理簿金鑰",
+    "imageDisabled": "未設定",
         "settings": "API Key 設置",
         "settingsTitle": "API Key 設置 - Project Lanlan",
         "quickStart": "快速開始",

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -378,6 +378,46 @@
                                     </div>
                                 </div>
 
+                                <!-- 图片生成 -->
+                                <div class="model-config-container">
+                                    <div class="model-header" onclick="toggleModelConfig('image')">
+                                        <span class="model-title">
+                                            <img src="/static/icons/vision_model_icon.png"
+                                                data-i18n-alt="api.imageModelConfig" class="model-title-icon">
+                                            <span data-i18n="api.imageModelConfig">图片生成</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </div>
+                                    <div id="image-model-content" class="model-content">
+                                        <div class="field-row">
+                                            <label for="imageModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="imageModelProvider" onchange="onImageProviderChange()" class="api-provider-select" style="max-width: 600px;">
+                                            </select>
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="imageModelUrl"
+                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                placeholder="e.g., https://api.openai.com/v1" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="imageModelId"
+                                                data-i18n-placeholder="api.imageModelExamplePlaceholder"
+                                                placeholder="e.g., gpt-image-2, wanx2.1-t2i-turbo" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="imageModelApiKey"
+                                                data-i18n-placeholder="api.imageModelApiKeyPlaceholder"
+                                                placeholder="API Key" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                    </div>
+                                </div>
+
                                 <!-- 摘要模型 -->
                                 <div class="model-config-container">
                                     <div class="model-header" onclick="toggleModelConfig('summary')">

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -378,48 +378,6 @@
                                     </div>
                                 </div>
 
-                                <!-- 图片生成 -->
-                                <div class="model-config-container">
-                                    <button type="button" class="model-header" onclick="toggleModelConfig('image')"
-                                        aria-controls="image-model-content" aria-expanded="false"
-                                        style="width: 100%; border: 0; text-align: left; font: inherit;">
-                                        <span class="model-title">
-                                            <img src="/static/icons/vision_model_icon.png"
-                                                data-i18n-alt="api.imageModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.imageModelConfig">图片生成</span>
-                                        </span>
-                                        <span class="toggle-icon">▼</span>
-                                    </button>
-                                    <div id="image-model-content" class="model-content">
-                                        <div class="field-row">
-                                            <label for="imageModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                            <select id="imageModelProvider" onchange="onImageProviderChange()" class="api-provider-select" style="max-width: 600px;">
-                                            </select>
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="imageModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                            <input type="text" id="imageModelUrl"
-                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                placeholder="e.g., https://api.openai.com/v1" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="imageModelId" data-i18n="api.modelId">模型ID</label>
-                                            <input type="text" id="imageModelId"
-                                                data-i18n-placeholder="api.imageModelExamplePlaceholder"
-                                                placeholder="e.g., gpt-image-2, wanx2.1-t2i-turbo" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="imageModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                            <input type="text" id="imageModelApiKey"
-                                                data-i18n-placeholder="api.imageModelApiKeyPlaceholder"
-                                                placeholder="API Key" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                    </div>
-                                </div>
-
                                 <!-- 摘要模型 -->
                                 <div class="model-config-container">
                                     <div class="model-header" onclick="toggleModelConfig('summary')">
@@ -729,6 +687,48 @@
                                                 </div>
                                             </div>
 
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 图片生成 -->
+                                <div class="model-config-container">
+                                    <button type="button" class="model-header" onclick="toggleModelConfig('image')"
+                                        aria-controls="image-model-content" aria-expanded="false"
+                                        style="width: 100%; border: 0; text-align: left; font: inherit;">
+                                        <span class="model-title">
+                                            <img src="/static/icons/vision_model_icon.png"
+                                                data-i18n-alt="api.imageModelConfig" class="model-title-icon">
+                                            <span data-i18n="api.imageModelConfig">图片生成</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </button>
+                                    <div id="image-model-content" class="model-content">
+                                        <div class="field-row">
+                                            <label for="imageModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="imageModelProvider" onchange="onImageProviderChange()" class="api-provider-select" style="max-width: 600px;">
+                                            </select>
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="imageModelUrl"
+                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                placeholder="e.g., https://api.openai.com/v1" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="imageModelId"
+                                                data-i18n-placeholder="api.imageModelExamplePlaceholder"
+                                                placeholder="e.g., gpt-image-2, wanx2.1-t2i-turbo" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="imageModelApiKey"
+                                                data-i18n-placeholder="api.imageModelApiKeyPlaceholder"
+                                                placeholder="API Key" value=""
+                                                style="max-width: 600px;">
                                         </div>
                                     </div>
                                 </div>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -380,14 +380,16 @@
 
                                 <!-- 图片生成 -->
                                 <div class="model-config-container">
-                                    <div class="model-header" onclick="toggleModelConfig('image')">
+                                    <button type="button" class="model-header" onclick="toggleModelConfig('image')"
+                                        aria-controls="image-model-content" aria-expanded="false"
+                                        style="width: 100%; border: 0; text-align: left; font: inherit;">
                                         <span class="model-title">
                                             <img src="/static/icons/vision_model_icon.png"
                                                 data-i18n-alt="api.imageModelConfig" class="model-title-icon">
                                             <span data-i18n="api.imageModelConfig">图片生成</span>
                                         </span>
                                         <span class="toggle-icon">▼</span>
-                                    </div>
+                                    </button>
                                     <div id="image-model-content" class="model-content">
                                         <div class="field-row">
                                             <label for="imageModelProvider" data-i18n="api.providerLabel">服务商</label>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -691,48 +691,6 @@
                                     </div>
                                 </div>
 
-                                <!-- 图片生成 -->
-                                <div class="model-config-container">
-                                    <button type="button" class="model-header" onclick="toggleModelConfig('image')"
-                                        aria-controls="image-model-content" aria-expanded="false"
-                                        style="width: 100%; border: 0; text-align: left; font: inherit;">
-                                        <span class="model-title">
-                                            <img src="/static/icons/vision_model_icon.png"
-                                                data-i18n-alt="api.imageModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.imageModelConfig">图片生成</span>
-                                        </span>
-                                        <span class="toggle-icon">▼</span>
-                                    </button>
-                                    <div id="image-model-content" class="model-content">
-                                        <div class="field-row">
-                                            <label for="imageModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                            <select id="imageModelProvider" onchange="onImageProviderChange()" class="api-provider-select" style="max-width: 600px;">
-                                            </select>
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="imageModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                            <input type="text" id="imageModelUrl"
-                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                placeholder="e.g., https://api.openai.com/v1" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="imageModelId" data-i18n="api.modelId">模型ID</label>
-                                            <input type="text" id="imageModelId"
-                                                data-i18n-placeholder="api.imageModelExamplePlaceholder"
-                                                placeholder="e.g., gpt-image-2, wanx2.1-t2i-turbo" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="imageModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                            <input type="text" id="imageModelApiKey"
-                                                data-i18n-placeholder="api.imageModelApiKeyPlaceholder"
-                                                placeholder="API Key" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                    </div>
-                                </div>
-
                                 <!-- 小游戏模型 -->
                                 <div class="model-config-container">
                                     <button type="button" class="model-header" onclick="toggleModelConfig('game')" aria-expanded="false" aria-controls="game-model-content">
@@ -816,6 +774,48 @@
                                                         style="max-width: 600px;">
                                                 </div>
                                             </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 图片生成 -->
+                                <div class="model-config-container">
+                                    <button type="button" class="model-header" onclick="toggleModelConfig('image')"
+                                        aria-controls="image-model-content" aria-expanded="false"
+                                        style="width: 100%; border: 0; text-align: left; font: inherit;">
+                                        <span class="model-title">
+                                            <img src="/static/icons/vision_model_icon.png"
+                                                data-i18n-alt="api.imageModelConfig" class="model-title-icon">
+                                            <span data-i18n="api.imageModelConfig">图片生成</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </button>
+                                    <div id="image-model-content" class="model-content">
+                                        <div class="field-row">
+                                            <label for="imageModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="imageModelProvider" onchange="onImageProviderChange()" class="api-provider-select" style="max-width: 600px;">
+                                            </select>
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="imageModelUrl"
+                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                placeholder="e.g., https://api.openai.com/v1" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="imageModelId"
+                                                data-i18n-placeholder="api.imageModelExamplePlaceholder"
+                                                placeholder="e.g., gpt-image-2, wanx2.1-t2i-turbo" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="imageModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="imageModelApiKey"
+                                                data-i18n-placeholder="api.imageModelApiKeyPlaceholder"
+                                                placeholder="API Key" value=""
+                                                style="max-width: 600px;">
                                         </div>
                                     </div>
                                 </div>

--- a/tests/frontend/image_generation_settings.test.cjs
+++ b/tests/frontend/image_generation_settings.test.cjs
@@ -65,3 +65,13 @@ test('restricted providers preserve saved selection without becoming selectable'
     context.onImageProviderChange();
     assert.equal(context.imageSettingsPayload().imageModelProvider, 'disabled');
 });
+
+
+test('unknown provider fields round trip verbatim across reloads', () => {
+    const {context} = setup();
+    context.populateImageProviders({});
+    const saved = {imageModelProvider: 'future', imageModelUrl: '  https://future.example/v1  ', imageModelId: ' model ', imageModelApiKey: '__NEKO_SECRET_MASKED__'};
+    context.loadImageSettings(saved);
+    context.populateImageProviders({custom: {name: 'Custom'}});
+    assert.deepEqual(JSON.parse(JSON.stringify(context.imageSettingsPayload())), saved);
+});

--- a/tests/frontend/image_generation_settings.test.cjs
+++ b/tests/frontend/image_generation_settings.test.cjs
@@ -5,7 +5,7 @@ const test = require('node:test');
 const vm = require('node:vm');
 const source = fs.readFileSync(path.join(__dirname, '../../static/js/api_key_settings.js'), 'utf8');
 
-function setup() {
+function setup(restricted = []) {
     const inputs = Object.fromEntries(['Provider', 'Url', 'Id', 'ApiKey'].map(suffix => [
         'imageModel' + suffix, {value: '', dataset: {}, options: [], appendChild(option) { this.options.push(option); }, replaceChildren() { this.options = []; }}
     ]));
@@ -15,6 +15,7 @@ function setup() {
         setSecretInputValue: (id, value) => { inputs[id].value = value; },
         getRealKey: input => input.value,
         syncProviderSelectDropdowns: () => {},
+        isProviderRestricted: key => restricted.includes(key),
     });
     vm.runInContext('let _imageProviders = {};\n'.replace('\\n', '\n') + source.slice(source.indexOf('function populateImageProviders(')), context);
     return {inputs, context};
@@ -44,4 +45,13 @@ test('missing provider metadata preserves saved values', () => {
     context.loadImageSettings({imageModelProvider: 'qwen', imageModelUrl: 'https://dashscope.aliyuncs.com', imageModelId: 'saved-model', imageModelApiKey: ''});
     assert.equal(context.imageSettingsPayload().imageModelProvider, 'qwen');
     assert.equal(context.imageSettingsPayload().imageModelId, 'saved-model');
+});
+
+test('restricted providers cannot be selected or restored from saved settings', () => {
+    const {inputs, context} = setup(['openai', 'qwen_intl']);
+    context.populateImageProviders({openai: {name: 'OpenAI'}, qwen_intl: {name: 'Singapore'}, qwen: {name: 'Beijing'}, custom: {name: 'Custom'}});
+    assert.deepEqual(inputs.imageModelProvider.options.map(option => option.value), ['disabled', 'qwen', 'custom']);
+    context.loadImageSettings({imageModelProvider: 'openai', imageModelId: 'saved'});
+    assert.equal(context.imageSettingsPayload().imageModelProvider, 'disabled');
+    assert.equal(inputs.imageModelProvider.options.some(option => option.value === 'openai'), false);
 });

--- a/tests/frontend/image_generation_settings.test.cjs
+++ b/tests/frontend/image_generation_settings.test.cjs
@@ -47,11 +47,18 @@ test('missing provider metadata preserves saved values', () => {
     assert.equal(context.imageSettingsPayload().imageModelId, 'saved-model');
 });
 
-test('restricted providers cannot be selected or restored from saved settings', () => {
+test('restricted providers preserve saved selection without becoming selectable', () => {
     const {inputs, context} = setup(['openai', 'qwen_intl']);
     context.populateImageProviders({openai: {name: 'OpenAI'}, qwen_intl: {name: 'Singapore'}, qwen: {name: 'Beijing'}, custom: {name: 'Custom'}});
     assert.deepEqual(inputs.imageModelProvider.options.map(option => option.value), ['disabled', 'qwen', 'custom']);
     context.loadImageSettings({imageModelProvider: 'openai', imageModelId: 'saved'});
+    assert.equal(context.imageSettingsPayload().imageModelProvider, 'openai');
+    assert.equal(context.imageSettingsPayload().imageModelId, 'saved');
+    assert.equal(inputs.imageModelProvider.options.find(option => option.value === 'openai').disabled, true);
+    context.populateImageProviders({openai: {name: 'OpenAI'}, qwen: {name: 'Beijing'}});
+    assert.equal(context.imageSettingsPayload().imageModelProvider, 'openai');
+    assert.equal(inputs.imageModelProvider.options.find(option => option.value === 'openai').disabled, true);
+    inputs.imageModelProvider.value = 'disabled';
+    context.onImageProviderChange();
     assert.equal(context.imageSettingsPayload().imageModelProvider, 'disabled');
-    assert.equal(inputs.imageModelProvider.options.some(option => option.value === 'openai'), false);
 });

--- a/tests/frontend/image_generation_settings.test.cjs
+++ b/tests/frontend/image_generation_settings.test.cjs
@@ -45,6 +45,9 @@ test('missing provider metadata preserves saved values', () => {
     context.loadImageSettings({imageModelProvider: 'qwen', imageModelUrl: 'https://dashscope.aliyuncs.com', imageModelId: 'saved-model', imageModelApiKey: ''});
     assert.equal(context.imageSettingsPayload().imageModelProvider, 'qwen');
     assert.equal(context.imageSettingsPayload().imageModelId, 'saved-model');
+    context.populateImageProviders({custom: {name: 'Custom'}});
+    assert.equal(context.imageSettingsPayload().imageModelProvider, 'qwen');
+    assert.equal(context.imageSettingsPayload().imageModelId, 'saved-model');
 });
 
 test('restricted providers preserve saved selection without becoming selectable', () => {

--- a/tests/frontend/image_generation_settings.test.cjs
+++ b/tests/frontend/image_generation_settings.test.cjs
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+const source = fs.readFileSync(path.join(__dirname, '../../static/js/api_key_settings.js'), 'utf8');
+
+function setup() {
+    const inputs = Object.fromEntries(['Provider', 'Url', 'Id', 'ApiKey'].map(suffix => [
+        'imageModel' + suffix, {value: '', dataset: {}, options: [], appendChild(option) { this.options.push(option); }, replaceChildren() { this.options = []; }}
+    ]));
+    const context = vm.createContext({
+        document: {getElementById: id => inputs[id], createElement: () => ({})},
+        appendModelProviderOption: (select, value) => select.appendChild({value}),
+        setSecretInputValue: (id, value) => { inputs[id].value = value; },
+        getRealKey: input => input.value,
+        syncProviderSelectDropdowns: () => {},
+    });
+    vm.runInContext('let _imageProviders = {};\n'.replace('\\n', '\n') + source.slice(source.indexOf('function populateImageProviders(')), context);
+    return {inputs, context};
+}
+test('image settings preserve masked custom key and entered endpoint', () => {
+    const {inputs, context} = setup();
+    context.populateImageProviders({custom: {name: 'Custom', base_url: '', model: ''}});
+    context.loadImageSettings({imageModelProvider: 'custom', imageModelUrl: 'https://custom.example/v1', imageModelId: 'model', imageModelApiKey: '__NEKO_SECRET_MASKED__'});
+    assert.equal(context.imageSettingsPayload().imageModelApiKey, '__NEKO_SECRET_MASKED__');
+    assert.equal(inputs.imageModelUrl.value, 'https://custom.example/v1');
+    assert.equal(inputs.imageModelUrl.readOnly, false);
+});
+test('switching from custom clears its key and uses named endpoint defaults', () => {
+    const {inputs, context} = setup();
+    context.populateImageProviders({openai: {name: 'OpenAI', base_url: 'https://api.openai.com/v1', model: 'gpt-image-2'}});
+    inputs.imageModelApiKey.value = 'custom-secret';
+    inputs.imageModelProvider.value = 'openai';
+    context.onImageProviderChange();
+    assert.equal(context.imageSettingsPayload().imageModelApiKey, '');
+    assert.equal(inputs.imageModelApiKey.disabled, true);
+    assert.equal(inputs.imageModelUrl.value, 'https://api.openai.com/v1');
+    assert.equal(inputs.imageModelId.value, 'gpt-image-2');
+});
+test('missing provider metadata preserves saved values', () => {
+    const {context} = setup();
+    context.populateImageProviders({});
+    context.loadImageSettings({imageModelProvider: 'qwen', imageModelUrl: 'https://dashscope.aliyuncs.com', imageModelId: 'saved-model', imageModelApiKey: ''});
+    assert.equal(context.imageSettingsPayload().imageModelProvider, 'qwen');
+    assert.equal(context.imageSettingsPayload().imageModelId, 'saved-model');
+});

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -366,6 +366,7 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
             agent: rect(cards[6]),
             tts: rect(cards[7]),
             game: rect(cards[8]),
+            image: rect(cards[9]),
         };
     }""")
 
@@ -381,6 +382,7 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
         "agent-model-content",
         "tts-model-content",
         "game-model-content",
+        "image-model-content",
     ]
     assert desktop["titleKeys"] == [
         "api.conversationModelConfig",
@@ -392,6 +394,7 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
         "api.agentApiConfigTitle",
         "api.ttsModelConfig",
         "api.gameModelsConfig",
+        "api.imageModelConfig",
     ]
     assert desktop["summaryTypes"] == [
         "conversation",
@@ -414,6 +417,8 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
         "omni": "emotion",
         "agent": "tts",
         "tts": "agent",
+        "game": "image",
+        "image": "game",
     }
     assert desktop["conversation"]["top"] == desktop["vision"]["top"]
     assert desktop["conversation"]["left"] < desktop["vision"]["left"]
@@ -424,6 +429,8 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
     assert desktop["emotion"]["top"] == desktop["omni"]["top"]
     assert desktop["agent"]["top"] == desktop["tts"]["top"]
     assert desktop["game"]["top"] > desktop["agent"]["top"]
+    assert desktop["game"]["top"] == desktop["image"]["top"]
+    assert desktop["game"]["left"] < desktop["image"]["left"]
 
     mock_page.evaluate("toggleModelConfig('conversation')")
     mock_page.wait_for_timeout(350)

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -38,8 +38,8 @@ def test_image_settings_real_page_round_trip(mock_page, running_server):
         document.getElementById('custom-api-container').style.display = 'grid';
     }""")
     mock_page.set_viewport_size({"width": 1280, "height": 1000})
-    # Existing pairs retain their columns; the image card owns a separate row.
-    for left, right in [("conversation", "vision"), ("summary", "correction"), ("emotion", "omni"), ("agent", "tts")]:
+    # Existing pairs retain their columns; image generation sits beside mini-games.
+    for left, right in [("conversation", "vision"), ("summary", "correction"), ("emotion", "omni"), ("agent", "tts"), ("game", "image")]:
         bounds = mock_page.evaluate("""([left, right]) => {
             const box = type => document.getElementById(type + '-model-content').parentElement.getBoundingClientRect();
             const a = box(left), b = box(right);

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -31,3 +31,21 @@ def test_image_settings_real_page_round_trip(mock_page, running_server):
     assert state["imageModelApiKey"] == ""
     assert mock_page.locator("#imageModelApiKey").is_disabled()
     assert mock_page.evaluate("CONNECTIVITY_TESTABLE_TYPES.includes('image')") is False
+
+    # Keyboard activation uses the native button and keeps aria state in sync.
+    mock_page.evaluate("""() => {
+        document.getElementById('custom-api-options').style.display = 'block';
+        document.getElementById('custom-api-container').style.display = 'block';
+    }""")
+    header = mock_page.locator('button[aria-controls="image-model-content"]')
+    header.focus()
+    header.press("Enter")
+    expect(header).to_have_attribute("aria-expanded", "true")
+    header.press("Space")
+    expect(header).to_have_attribute("aria-expanded", "false")
+    mock_page.evaluate("confirmClearCustomApi()")
+    state = mock_page.evaluate("imageSettingsPayload()")
+    assert state == {
+        "imageModelProvider": "disabled", "imageModelUrl": "",
+        "imageModelId": "", "imageModelApiKey": "",
+    }

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -35,8 +35,26 @@ def test_image_settings_real_page_round_trip(mock_page, running_server):
     # Keyboard activation uses the native button and keeps aria state in sync.
     mock_page.evaluate("""() => {
         document.getElementById('custom-api-options').style.display = 'block';
-        document.getElementById('custom-api-container').style.display = 'block';
+        document.getElementById('custom-api-container').style.display = 'grid';
     }""")
+    mock_page.set_viewport_size({"width": 1280, "height": 1000})
+    # Existing pairs retain their columns; the image card owns a separate row.
+    for left, right in [("conversation", "vision"), ("summary", "correction"), ("emotion", "omni"), ("agent", "tts")]:
+        bounds = mock_page.evaluate("""([left, right]) => {
+            const box = type => document.getElementById(type + '-model-content').parentElement.getBoundingClientRect();
+            const a = box(left), b = box(right);
+            return {sameRow: Math.abs(a.top - b.top) < 1, ordered: a.left < b.left};
+        }""", [left, right])
+        assert bounds == {"sameRow": True, "ordered": True}
+    for model in ["correction", "omni", "tts", "image"]:
+        mock_page.evaluate("type => toggleModelConfig(type)", model)
+        mock_page.wait_for_function("""type => {
+            const outer = document.getElementById('custom-api-container').getBoundingClientRect();
+            const inner = document.getElementById(type + '-model-content').getBoundingClientRect();
+            return inner.width > outer.width * 0.8 && inner.left >= outer.left - 1 && inner.right <= outer.right + 1;
+        }""", arg=model)
+        mock_page.evaluate("type => toggleModelConfig(type)", model)
+        mock_page.wait_for_function("type => !document.getElementById(type + '-model-content').classList.contains('is-collapsing')", arg=model)
     header = mock_page.locator('button[aria-controls="image-model-content"]')
     header.focus()
     header.press("Enter")

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -80,3 +80,11 @@ def test_image_settings_real_page_round_trip(mock_page, running_server):
     assert mock_page.locator('#imageModelProvider option[value="openai"]').is_disabled()
     mock_page.evaluate("confirmClearCustomApi()")
     assert mock_page.evaluate("imageSettingsPayload().imageModelProvider") == "disabled"
+
+    # Locale/registry reloads must also retain an unknown saved provider.
+    mock_page.evaluate("""() => {
+        loadImageSettings({imageModelProvider: 'future-provider', imageModelId: 'saved-future'});
+        populateImageProviders(_imageProviders);
+    }""")
+    assert mock_page.evaluate("imageSettingsPayload().imageModelProvider") == "future-provider"
+    assert mock_page.evaluate("imageSettingsPayload().imageModelId") == "saved-future"

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -67,3 +67,16 @@ def test_image_settings_real_page_round_trip(mock_page, running_server):
         "imageModelProvider": "disabled", "imageModelUrl": "",
         "imageModelId": "", "imageModelApiKey": "",
     }
+
+    # A saved restricted provider survives unrelated saves in the real select widget.
+    mock_page.evaluate("""() => {
+        isMainlandChinaUser = true;
+        _apiKeyRegistry.openai = {..._apiKeyRegistry.openai, restricted: true};
+        populateImageProviders(_imageProviders);
+        loadImageSettings({imageModelProvider: 'openai', imageModelId: 'saved-image'});
+    }""")
+    assert mock_page.evaluate("imageSettingsPayload().imageModelProvider") == "openai"
+    assert mock_page.evaluate("imageSettingsPayload().imageModelId") == "saved-image"
+    assert mock_page.locator('#imageModelProvider option[value="openai"]').is_disabled()
+    mock_page.evaluate("confirmClearCustomApi()")
+    assert mock_page.evaluate("imageSettingsPayload().imageModelProvider") == "disabled"

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -83,8 +83,9 @@ def test_image_settings_real_page_round_trip(mock_page, running_server):
 
     # Locale/registry reloads must also retain an unknown saved provider.
     mock_page.evaluate("""() => {
-        loadImageSettings({imageModelProvider: 'future-provider', imageModelId: 'saved-future'});
+        loadImageSettings({imageModelProvider: 'future-provider', imageModelId: ' saved-future ', imageModelUrl: ' https://future.example/v1 '});
         populateImageProviders(_imageProviders);
     }""")
     assert mock_page.evaluate("imageSettingsPayload().imageModelProvider") == "future-provider"
-    assert mock_page.evaluate("imageSettingsPayload().imageModelId") == "saved-future"
+    assert mock_page.evaluate("imageSettingsPayload().imageModelId") == " saved-future "
+    assert mock_page.evaluate("imageSettingsPayload().imageModelUrl") == " https://future.example/v1 "

--- a/tests/frontend/test_image_generation_settings.py
+++ b/tests/frontend/test_image_generation_settings.py
@@ -1,0 +1,33 @@
+import pytest
+from playwright.sync_api import expect
+
+
+@pytest.mark.frontend
+def test_image_settings_real_page_round_trip(mock_page, running_server):
+    mock_page.add_init_script("localStorage.setItem('neko_tutorial_settings', 'seen')")
+    def seed(route):
+        route.fulfill(json={
+            "success": True, "coreApi": "free", "assistApi": "free",
+            "api_key": "free-access", "enableCustomApi": True,
+            "imageModelProvider": "custom", "imageModelUrl": "https://custom.example/v1",
+            "imageModelId": "custom-image", "imageModelApiKey": "__NEKO_SECRET_MASKED__",
+        })
+    mock_page.route("**/api/config/core_api", seed)
+    mock_page.goto(running_server + "/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_function("document.getElementById('imageModelProvider').value === 'custom'")
+    state = mock_page.evaluate("imageSettingsPayload()")
+    assert state["imageModelUrl"] == "https://custom.example/v1"
+    assert state["imageModelApiKey"] == "__NEKO_SECRET_MASKED__"
+    mock_page.evaluate("""() => {
+        const select = document.getElementById('imageModelProvider');
+        select.value = 'qwen';
+        select.dispatchEvent(new Event('change', {bubbles: true}));
+    }""")
+    state = mock_page.evaluate("imageSettingsPayload()")
+    assert state["imageModelProvider"] == "qwen"
+    assert state["imageModelUrl"] == "https://dashscope.aliyuncs.com"
+    assert state["imageModelId"] == "wanx2.1-t2i-turbo"
+    assert state["imageModelApiKey"] == ""
+    assert mock_page.locator("#imageModelApiKey").is_disabled()
+    assert mock_page.evaluate("CONNECTIVITY_TESTABLE_TYPES.includes('image')") is False

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -665,8 +665,8 @@ def test_multiple_trailing_slashes_do_not_preserve_custom_key(config_manager, co
 ])
 def test_unknown_image_provider_preserved_only_unchanged(config_manager, core_config_router, change, success):
     image = {
-        "imageModelProvider": "future-provider", "imageModelUrl": "https://future.example/v1",
-        "imageModelId": "future-model", "imageModelApiKey": "private-image-key",
+        "imageModelProvider": "future-provider", "imageModelUrl": " https://future.example/v1 ",
+        "imageModelId": " future-model ", "imageModelApiKey": "private-image-key",
     }
     _write_core_config(config_manager, {
         "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access", **image,
@@ -690,3 +690,15 @@ def test_new_unknown_image_provider_still_rejected(config_manager, core_config_r
     _write_core_config(config_manager, {"coreApi": "free", "assistApi": "free", "coreApiKey": "free-access"})
     result = asyncio.run(core_config_router.update_core_config(_FakeRequest({"imageModelProvider": "future-provider"})))
     assert result["success"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["imageModelProvider", "imageModelUrl", "imageModelId", "imageModelApiKey"])
+@pytest.mark.parametrize("value", [None, 123, False, [], {}])
+def test_disabled_image_fields_require_strings(config_manager, core_config_router, field, value):
+    original = {"coreApi": "free", "assistApi": "free", "coreApiKey": "free-access", "imageModelProvider": "disabled"}
+    _write_core_config(config_manager, original)
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({"imageModelProvider": "disabled", field: value})))
+    assert result["success"] is False
+    assert result["error"] == "Image settings must be strings"
+    assert config_manager.load_json_config("core_config.json", {}) == original

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -579,3 +579,45 @@ def test_image_config_round_trip_uses_core_snapshot(config_manager, core_config_
     response = asyncio.run(core_config_router.get_core_config_api())
     assert response["assistApiKeyQwen"] == core_config_router.CORE_CONFIG_SECRET_SENTINEL
     assert response["imageModelProvider"] == "qwen"
+
+@pytest.mark.unit
+@pytest.mark.parametrize("core,assist,image,expected", [
+    ("qwen", "qwen", "qwen", "legacy-key"),
+    ("openai", "openai", "openai", "legacy-key"),
+    ("qwen_intl", "qwen_intl", "qwen_intl", "legacy-key"),
+    ("openai", "qwen", "qwen", "legacy-key"),
+    ("openai", "openai", "qwen", ""),
+    ("free", "free", "qwen", ""),
+])
+def test_image_legacy_key_fallback_matches_key_book(
+    config_manager, core_config_router, core, assist, image, expected
+):
+    _write_core_config(config_manager, {
+        "coreApi": core, "assistApi": assist,
+        "coreApiKey": "free-access" if core == "free" else "legacy-key",
+        "enableCustomApi": True, "imageModelProvider": image,
+    })
+    config = config_manager.get_model_api_config("image")
+    assert config["api_key"] == expected
+    response = asyncio.run(core_config_router.get_core_config_api())
+    field = {"qwen": "assistApiKeyQwen", "qwen_intl": "assistApiKeyQwenIntl", "openai": "assistApiKeyOpenai"}[image]
+    assert bool(response[field]) == bool(expected)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("url", [
+    "https://old.example/v1/", "  https://old.example/v1  ",
+    "https://OLD.example:443/v1",
+])
+def test_image_equivalent_endpoint_preserves_custom_key(config_manager, core_config_router, url):
+    _write_core_config(config_manager, {
+        "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access",
+        "imageModelProvider": "custom", "imageModelUrl": "https://old.example/v1",
+        "imageModelId": "image-model", "imageModelApiKey": "private-image-key",
+    })
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        "imageModelUrl": url,
+        "imageModelApiKey": core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+    })))
+    assert result["success"] is True
+    assert config_manager.load_json_config("core_config.json", {})["imageModelApiKey"] == "private-image-key"

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -621,3 +621,34 @@ def test_image_equivalent_endpoint_preserves_custom_key(config_manager, core_con
     })))
     assert result["success"] is True
     assert config_manager.load_json_config("core_config.json", {})["imageModelApiKey"] == "private-image-key"
+
+@pytest.mark.unit
+@pytest.mark.parametrize("provider", ["disabled", "qwen"])
+def test_retained_image_key_cannot_move_while_inactive(config_manager, core_config_router, provider):
+    _write_core_config(config_manager, {
+        "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access",
+        "imageModelProvider": "custom", "imageModelUrl": "https://old.example/v1",
+        "imageModelId": "image-model", "imageModelApiKey": "private-image-key",
+    })
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        "imageModelProvider": provider, "imageModelUrl": "https://new.example/v1",
+        "imageModelApiKey": core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+    })))
+    assert result["success"] is False
+    saved = config_manager.load_json_config("core_config.json", {})
+    assert saved["imageModelUrl"] == "https://old.example/v1"
+    assert saved["imageModelProvider"] == "custom"
+
+
+@pytest.mark.unit
+def test_multiple_trailing_slashes_do_not_preserve_custom_key(config_manager, core_config_router):
+    _write_core_config(config_manager, {
+        "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access",
+        "imageModelProvider": "custom", "imageModelUrl": "https://old.example/v1",
+        "imageModelId": "image-model", "imageModelApiKey": "private-image-key",
+    })
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        "imageModelUrl": "https://old.example/v1//",
+        "imageModelApiKey": core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+    })))
+    assert result["success"] is False

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -652,3 +652,41 @@ def test_multiple_trailing_slashes_do_not_preserve_custom_key(config_manager, co
         "imageModelApiKey": core_config_router.CORE_CONFIG_SECRET_SENTINEL,
     })))
     assert result["success"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("change,success", [
+    ({}, True),
+    ({"imageModelId": "changed"}, False),
+    ({"imageModelUrl": "https://changed.example/v1"}, False),
+    ({"imageModelApiKey": "replacement"}, False),
+    ({"imageModelProvider": "another-future-provider"}, False),
+    ({"imageModelProvider": "disabled", "imageModelUrl": "", "imageModelId": "", "imageModelApiKey": ""}, True),
+])
+def test_unknown_image_provider_preserved_only_unchanged(config_manager, core_config_router, change, success):
+    image = {
+        "imageModelProvider": "future-provider", "imageModelUrl": "https://future.example/v1",
+        "imageModelId": "future-model", "imageModelApiKey": "private-image-key",
+    }
+    _write_core_config(config_manager, {
+        "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access", **image,
+    })
+    payload = {**image, "imageModelApiKey": core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+               "disableTts": True, **change}
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest(payload)))
+    assert result["success"] is success
+    saved = config_manager.load_json_config("core_config.json", {})
+    if success:
+        assert saved["disableTts"] is True
+    if not change or not success:
+        assert {field: saved[field] for field in image} == image
+    else:
+        assert saved["imageModelProvider"] == "disabled"
+        assert saved["imageModelApiKey"] == ""
+
+
+@pytest.mark.unit
+def test_new_unknown_image_provider_still_rejected(config_manager, core_config_router):
+    _write_core_config(config_manager, {"coreApi": "free", "assistApi": "free", "coreApiKey": "free-access"})
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({"imageModelProvider": "future-provider"})))
+    assert result["success"] is False

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -19,7 +19,7 @@ _ASSIST_API_KEY_FIELDS = (
 
 _MODEL_TYPES = (
     'conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion',
-    'vision', 'agent', 'omni', 'tts',
+    'vision', 'agent', 'omni', 'tts', 'image',
 )
 
 _MODEL_API_KEY_FIELDS = tuple(
@@ -546,3 +546,36 @@ def test_legacy_masks_are_narrowly_recognized_as_placeholders(
     assert saved['assistApiKeyQwen'] == stored['assistApiKeyQwen']
     assert saved['assistApiKeyOpenai'] == '**'
     assert saved['mcpToken'] == 'real***secret'
+
+@pytest.mark.unit
+def test_image_endpoint_change_requires_new_custom_key(config_manager, core_config_router):
+    _write_core_config(config_manager, {
+        "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access",
+        "imageModelProvider": "custom", "imageModelUrl": "https://old.example/v1",
+        "imageModelId": "image-model", "imageModelApiKey": "private-image-key",
+    })
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        "imageModelUrl": "https://new.example/v1",
+        "imageModelApiKey": core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+    })))
+    assert result["success"] is False
+    assert config_manager.load_json_config("core_config.json", {})["imageModelUrl"] == "https://old.example/v1"
+
+
+@pytest.mark.unit
+def test_image_config_round_trip_uses_core_snapshot(config_manager, core_config_router):
+    _write_core_config(config_manager, {
+        "coreApi": "free", "assistApi": "free", "coreApiKey": "free-access",
+        "enableCustomApi": True,
+    })
+    result = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        "imageModelProvider": "qwen", "imageModelUrl": "https://dashscope.aliyuncs.com",
+        "imageModelId": "wanx2.1-t2i-turbo", "assistApiKeyQwen": "image-qwen-key",
+    })))
+    assert result["success"] is True
+    config = config_manager.get_model_api_config("image")
+    assert config["api_key"] == "image-qwen-key"
+    assert config["protocol"] == "dashscope"
+    response = asyncio.run(core_config_router.get_core_config_api())
+    assert response["assistApiKeyQwen"] == core_config_router.CORE_CONFIG_SECRET_SENTINEL
+    assert response["imageModelProvider"] == "qwen"

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -163,3 +163,12 @@ async def test_owned_client_creation_error_is_sanitized(monkeypatch, error):
 def test_multiple_trailing_slashes_rejected_at_runtime():
     with pytest.raises(ValueError):
         resolve_image_config(manager("custom", imageModelUrl="https://custom.example/v1//", imageModelId="image").raw)
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_provider_json_is_normalized():
+    import sys
+    payload = b'[' * (sys.getrecursionlimit() + 100) + b'0' + b']' * (sys.getrecursionlimit() + 100)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(lambda request: httpx.Response(200, content=payload))) as client:
+        with pytest.raises(ImageGenerationError, match="^invalid_response$"):
+            await generate_image(ImageRequest("test"), config_manager=manager(), client=client)

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -148,3 +148,18 @@ async def test_response_limit(monkeypatch):
     async with httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(200, content=b"x"*33))) as client:
         with pytest.raises(ImageGenerationError, match="response_too_large"):
             await generate_image(ImageRequest("cat"), config_manager=manager(), client=client)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [ValueError("private proxy"), FileNotFoundError("private cert")])
+async def test_owned_client_creation_error_is_sanitized(monkeypatch, error):
+    def fail(**kwargs):
+        raise error
+    monkeypatch.setattr(httpx, "AsyncClient", fail)
+    with pytest.raises(ImageGenerationError, match="client_initialization_failed") as caught:
+        await generate_image(ImageRequest("cat"), config_manager=manager())
+    assert "private" not in str(caught.value)
+
+
+def test_multiple_trailing_slashes_rejected_at_runtime():
+    with pytest.raises(ValueError):
+        resolve_image_config(manager("custom", imageModelUrl="https://custom.example/v1//", imageModelId="image").raw)

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -150,7 +150,7 @@ async def test_response_limit(monkeypatch):
             await generate_image(ImageRequest("cat"), config_manager=manager(), client=client)
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("error", [ValueError("private proxy"), FileNotFoundError("private cert")])
+@pytest.mark.parametrize("error", [ValueError("private proxy"), FileNotFoundError("private cert"), httpx.InvalidURL("private proxy URL")])
 async def test_owned_client_creation_error_is_sanitized(monkeypatch, error):
     def fail(**kwargs):
         raise error
@@ -264,3 +264,20 @@ async def test_transport_invalid_url_is_normalized():
     async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
         with pytest.raises(ImageGenerationError, match="^invalid_configuration$"):
             await generate_image(ImageRequest("test"), config_manager=manager(), client=client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", ["https://\U0001f4a9.com/v1", "https://1.2.3.999/v1"])
+async def test_invalid_returned_hostname_is_normalized(url):
+    async with httpx.AsyncClient(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"data": [{"url": url}]})
+    )) as client:
+        with pytest.raises(ImageGenerationError, match="^invalid_image_url$"):
+            await generate_image(ImageRequest("test"), config_manager=manager(), client=client)
+
+
+@pytest.mark.asyncio
+async def test_invalid_environment_proxy_is_normalized(monkeypatch):
+    monkeypatch.setenv("HTTP_PROXY", "http://example.com:bad")
+    with pytest.raises(ImageGenerationError, match="^client_initialization_failed$"):
+        await generate_image(ImageRequest("test"), config_manager=manager())

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -172,3 +172,46 @@ async def test_deeply_nested_provider_json_is_normalized():
     async with httpx.AsyncClient(transport=httpx.MockTransport(lambda request: httpx.Response(200, content=payload))) as client:
         with pytest.raises(ImageGenerationError, match="^invalid_response$"):
             await generate_image(ImageRequest("test"), config_manager=manager(), client=client)
+
+
+@pytest.mark.parametrize("provider,url,canonical", [
+    ("openai", "https://API.OPENAI.COM:443/v1/", "https://api.openai.com/v1"),
+    ("qwen", "https://DASHSCOPE.ALIYUNCS.COM:443/", "https://dashscope.aliyuncs.com"),
+    ("qwen_intl", "https://DASHSCOPE-INTL.ALIYUNCS.COM:443/", "https://dashscope-intl.aliyuncs.com"),
+])
+def test_named_equivalent_endpoint_uses_canonical_destination(provider, url, canonical):
+    assert resolve_image_config(manager(provider, imageModelUrl=url).raw).base_url == canonical
+
+
+@pytest.mark.parametrize("url", ["https://api.openai.com:444/v1", "https://api.openai.com/V1", "https://api.openai.com/v1//"])
+def test_named_different_endpoint_still_rejected(url):
+    with pytest.raises(ValueError):
+        resolve_image_config(manager(imageModelUrl=url).raw)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "provider_error", "cancelled"])
+async def test_owned_client_close_failure_preserves_primary_outcome(monkeypatch, outcome):
+    from utils.image_generation import openai
+    from utils.image_generation.types import GeneratedImage
+
+    class Client:
+        async def aclose(self):
+            raise RuntimeError("private transport details")
+
+    async def generate(*args):
+        if outcome == "provider_error":
+            raise ImageGenerationError("provider_http_error")
+        if outcome == "cancelled":
+            raise asyncio.CancelledError()
+        return GeneratedImage(data=b"image")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: Client())
+    monkeypatch.setattr(openai, "generate", generate)
+    if outcome == "cancelled":
+        with pytest.raises(asyncio.CancelledError):
+            await generate_image(ImageRequest("cat"), config_manager=manager())
+    else:
+        expected = "client_close_failed" if outcome == "success" else "provider_http_error"
+        with pytest.raises(ImageGenerationError, match="^" + expected + "$"):
+            await generate_image(ImageRequest("cat"), config_manager=manager())

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -249,3 +249,18 @@ async def test_generation_budget_is_not_shortened_by_transport(provider):
     async with httpx.AsyncClient(transport=httpx.MockTransport(handle), timeout=1) as client:
         result = await generate_image(ImageRequest("test"), config_manager=manager(provider), client=client, timeout=600)
     assert result.image.url == "https://images.example/result.png"
+
+
+@pytest.mark.parametrize("url", ["https://\U0001f4a9.com/v1", "https://1.2.3.999/v1"])
+def test_transport_invalid_custom_hostname_rejected(url):
+    with pytest.raises(ValueError):
+        resolve_image_config(manager("custom", imageModelUrl=url, imageModelId="image").raw)
+
+
+@pytest.mark.asyncio
+async def test_transport_invalid_url_is_normalized():
+    def handle(request):
+        raise httpx.InvalidURL("private endpoint details")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(ImageGenerationError, match="^invalid_configuration$"):
+            await generate_image(ImageRequest("test"), config_manager=manager(), client=client)

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -215,3 +215,37 @@ async def test_owned_client_close_failure_preserves_primary_outcome(monkeypatch,
         expected = "client_close_failed" if outcome == "success" else "provider_http_error"
         with pytest.raises(ImageGenerationError, match="^" + expected + "$"):
             await generate_image(ImageRequest("cat"), config_manager=manager())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "gzip, br"])
+async def test_compressed_response_rejected_before_reading(encoding):
+    class UnreadableStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            pytest.fail("compressed response must be rejected before reading or decoding")
+            yield b""
+
+    def handle(request):
+        assert request.headers["accept-encoding"] == "identity"
+        return httpx.Response(200, headers={"Content-Encoding": encoding}, stream=UnreadableStream())
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(ImageGenerationError, match="^unsupported_content_encoding$"):
+            await generate_image(ImageRequest("test"), config_manager=manager(), client=client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["openai", "qwen"])
+async def test_generation_budget_is_not_shortened_by_transport(provider):
+    def handle(request):
+        # Both synchronous generation and async submission/polling use the outer deadline.
+        assert all(value is None for value in request.extensions["timeout"].values())
+        if provider == "openai":
+            return httpx.Response(200, json={"data": [{"url": "https://images.example/result.png"}]})
+        if request.method == "POST":
+            return httpx.Response(200, json={"output": {"task_id": "task-1"}})
+        return httpx.Response(200, json={"output": {"task_status": "SUCCEEDED", "results": [{"url": "https://images.example/result.png"}]}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle), timeout=1) as client:
+        result = await generate_image(ImageRequest("test"), config_manager=manager(provider), client=client, timeout=600)
+    assert result.image.url == "https://images.example/result.png"

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -1,0 +1,149 @@
+"""Image infrastructure protocol, configuration, cancellation and isolation tests."""
+import asyncio
+import base64
+import json
+
+import httpx
+import pytest
+
+from utils.image_generation import ImageGenerationError, ImageRequest, generate_image
+from utils.image_generation.config import resolve_image_config
+from utils.config_manager.core_config import CoreConfigMixin
+
+
+class Manager(CoreConfigMixin):
+    def __init__(self, raw, enabled=True):
+        self.raw = raw
+        self.enabled = enabled
+
+    def get_core_config(self):
+        return {"ENABLE_CUSTOM_API": self.enabled, "IMAGE_GENERATION_CONFIG": self.raw}
+
+
+def manager(provider="openai", **extra):
+    return Manager({"imageModelProvider": provider, "assistApiKeyOpenai": "openai-key",
+                    "assistApiKeyQwen": "beijing-key", "assistApiKeyQwenIntl": "singapore-key",
+                    "imageModelApiKey": "custom-key", **extra})
+
+
+@pytest.mark.parametrize("provider,key", [("openai", "openai-key"), ("qwen", "beijing-key"), ("qwen_intl", "singapore-key")])
+def test_named_provider_uses_own_key_book(provider, key):
+    result = manager(provider).get_model_api_config("image")
+    assert result["api_key"] == key
+    assert result["enabled"]
+    assert "key" not in repr(resolve_image_config(manager(provider).raw))
+
+
+def test_disabled_has_no_chat_fallback():
+    assert Manager({}, False).get_model_api_config("image") == {"enabled": False}
+    assert Manager({}).get_model_api_config("image") == {"enabled": False}
+
+
+@pytest.mark.parametrize("url", ["http://example.com/v1", "https://user:pass@example.com", "https://example.com:bad", "https://example.com?token=x"])
+def test_custom_endpoint_validation(url):
+    with pytest.raises(ValueError):
+        resolve_image_config(manager("custom", imageModelUrl=url, imageModelId="model").raw)
+
+
+def test_named_key_cannot_be_sent_to_custom_endpoint():
+    with pytest.raises(ValueError):
+        resolve_image_config(manager(imageModelUrl="https://other.example/v1").raw)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model,legacy", [("gpt-image-2", False), ("vendor/gpt-image-2:version", False), ("dall-e-3", True)])
+async def test_openai_wire_contract(model, legacy):
+    calls = []
+    def handle(request):
+        calls.append(request)
+        assert request.url.path == "/v1/images/generations"
+        assert request.headers["authorization"] == "Bearer openai-key"
+        body = json.loads(request.content)
+        assert body["n"] == 1
+        assert ("response_format" in body) == legacy
+        return httpx.Response(200, json={"data": [{"b64_json": base64.b64encode(b"image").decode()}]})
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        result = await generate_image(ImageRequest("private prompt"), config_manager=manager(imageModelId=model), client=client)
+        assert not client.is_closed
+    assert result.image.data == b"image"
+    assert len(calls) == 1
+    assert "private prompt" not in repr(ImageRequest("private prompt"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider,host,key", [
+    ("qwen", "dashscope.aliyuncs.com", "beijing-key"),
+    ("qwen_intl", "dashscope-intl.aliyuncs.com", "singapore-key"),
+])
+async def test_dashscope_create_poll_and_result(provider, host, key):
+    calls = []
+    def handle(request):
+        calls.append(request)
+        assert request.url.host == host
+        assert request.headers["authorization"] == "Bearer " + key
+        if request.method == "POST":
+            assert request.headers["x-dashscope-async"] == "enable"
+            assert json.loads(request.content)["parameters"] == {"n": 1, "size": "1024*1024"}
+            return httpx.Response(200, json={"output": {"task_id": "task-1"}})
+        assert request.url.path == "/api/v1/tasks/task-1"
+        return httpx.Response(200, json={"output": {"task_status": "SUCCEEDED", "results": [{"url": "https://images.example/result.png"}]}})
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        result = await generate_image(ImageRequest("cat"), config_manager=manager(provider), client=client)
+    assert result.image.url == "https://images.example/result.png"
+    assert len(calls) == 2  # Result URL is never fetched.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,payload,code", [
+    (401, {"error": "secret private prompt"}, "provider_http_error"),
+    (302, {}, "provider_http_error"),
+    (200, {"data": [{"url": "http://127.0.0.1/private"}]}, "invalid_image_url"),
+    (200, {"data": [{"b64_json": "%%%"}]}, "invalid_image_data"),
+    (200, {"data": []}, "invalid_response"),
+])
+async def test_errors_are_sanitized_and_not_retried(status, payload, code):
+    calls = []
+    def handle(request):
+        calls.append(request)
+        return httpx.Response(status, json=payload, headers={"Location": "https://other.example/"})
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle), follow_redirects=True) as client:
+        with pytest.raises(ImageGenerationError, match=code) as caught:
+            await generate_image(ImageRequest("private prompt"), config_manager=manager(), client=client)
+    assert str(caught.value) == code
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_and_cancellation_do_not_resubmit():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    async def handle(request):
+        entered.set()
+        await release.wait()
+        return httpx.Response(200, json={})
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(ImageGenerationError, match="provider_timeout"):
+            await generate_image(ImageRequest("cat"), config_manager=manager(), client=client, timeout=0.01)
+        task = asyncio.create_task(generate_image(ImageRequest("cat"), config_manager=manager(), client=client))
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_disabled_never_calls_provider():
+    def handle(request):
+        pytest.fail("disabled slot must not make a request")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(ImageGenerationError, match="not_configured"):
+            await generate_image(ImageRequest("cat"), config_manager=Manager({}), client=client)
+
+
+@pytest.mark.asyncio
+async def test_response_limit(monkeypatch):
+    from utils.image_generation import transport
+    monkeypatch.setattr(transport, "MAX_RESPONSE_BYTES", 32)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(200, content=b"x"*33))) as client:
+        with pytest.raises(ImageGenerationError, match="response_too_large"):
+            await generate_image(ImageRequest("cat"), config_manager=manager(), client=client)

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -51,7 +51,7 @@ def test_named_key_cannot_be_sent_to_custom_endpoint():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model,legacy", [("gpt-image-2", False), ("vendor/gpt-image-2:version", False), ("dall-e-3", True)])
+@pytest.mark.parametrize("model,legacy", [("gpt-image-2", False), ("vendor/gpt-image-2:version", False), ("dall-e-3", True), ("prod-image", False)])
 async def test_openai_wire_contract(model, legacy):
     calls = []
     def handle(request):
@@ -124,6 +124,7 @@ async def test_timeout_and_cancellation_do_not_resubmit():
     async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
         with pytest.raises(ImageGenerationError, match="provider_timeout"):
             await generate_image(ImageRequest("cat"), config_manager=manager(), client=client, timeout=0.01)
+        entered.clear()
         task = asyncio.create_task(generate_image(ImageRequest("cat"), config_manager=manager(), client=client))
         await entered.wait()
         task.cancel()

--- a/tests/unit/test_locale_cache_bust_contract.py
+++ b/tests/unit/test_locale_cache_bust_contract.py
@@ -137,6 +137,7 @@ RETIRED_LOCALE_VERSIONS = frozenset(
         "2026-09-08-drawing-guess",
         "2026-09-09-pngtuber-import-status",
         "2026-09-10-drawing-guess-pngtuber-import-status",
+        "2026-09-11-soccer-sdk-migration",
     }
 )
 
@@ -149,7 +150,7 @@ RETIRED_LOCALE_VERSIONS = frozenset(
 #
 # 数组也按下标展开，所以往 badminton.lines.* 这类台词数组里追加一条同样会打红：
 # 陈旧缓存下那一条会取到 undefined，症状和缺 key 是一类。
-LOCALE_KEY_SIGNATURE = "c2c1aa469a4f9723005029b3ee7f958da618d423390337dca976fadf493f037f"
+LOCALE_KEY_SIGNATURE = "a0e4b44219cb2cc10073ab0b0f29d3c3a6ca2f071ba7bb36e61612d2fdbde00f"
 
 _BUMP_INSTRUCTIONS = (
     "static/locales 的 key 结构变了。请在 static/i18n-i18next.js 里把 LOCALE_VERSION "

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1623,6 +1623,13 @@ class CoreConfigMixin:
         if isinstance(config.get('AGENT_MODEL_URL'), str):
             config['AGENT_MODEL_URL'] = self._normalize_agent_url(config['AGENT_MODEL_URL'])
 
+        # Keep a raw, independent image slot: no chat fallback or implicit generation.
+        config["IMAGE_GENERATION_CONFIG"] = {
+            key: core_cfg.get(key, "")
+            for key in ("imageModelProvider", "imageModelUrl", "imageModelId",
+                        "imageModelApiKey", "assistApiKeyOpenai",
+                        "assistApiKeyQwen", "assistApiKeyQwenIntl")
+        }
         return config
 
     def get_model_api_config(self, model_type: str, *, _core_config: dict | None = None) -> dict:
@@ -1657,6 +1664,19 @@ class CoreConfigMixin:
 
         core_config = self.get_core_config() if _core_config is None else _core_config
         enable_custom_api = core_config.get('ENABLE_CUSTOM_API', False)
+        if model_type == "image":
+            from utils.image_generation.config import resolve_image_config
+            image = resolve_image_config(
+                core_config.get("IMAGE_GENERATION_CONFIG", {}),
+                enabled=enable_custom_api,
+            )
+            if image is None:
+                return {"enabled": False}
+            return {
+                "enabled": True, "provider": image.provider,
+                "protocol": image.protocol, "base_url": image.base_url,
+                "model": image.model, "api_key": image.api_key, "is_custom": True,
+            }
 
         # GPT-SoVITS 启用时，tts_custom slot 视为自定义 API：UI 上勾 GSV 在产品语义上
         # 就是 "启用一个自定义 TTS"，但前端 (api_key_settings.js) 并不会顺手把

--- a/utils/config_manager/core_config.py
+++ b/utils/config_manager/core_config.py
@@ -1630,6 +1630,14 @@ class CoreConfigMixin:
                         "imageModelApiKey", "assistApiKeyOpenai",
                         "assistApiKeyQwen", "assistApiKeyQwenIntl")
         }
+        # Reuse the same provider-gated legacy key resolution as the Key Book.
+        # Never introduce a cross-provider fallback for image generation.
+        for field, resolved_field in (
+            ("assistApiKeyOpenai", "ASSIST_API_KEY_OPENAI"),
+            ("assistApiKeyQwen", "ASSIST_API_KEY_QWEN"),
+            ("assistApiKeyQwenIntl", "ASSIST_API_KEY_QWEN_INTL"),
+        ):
+            config["IMAGE_GENERATION_CONFIG"][field] = config.get(resolved_field, "")
         return config
 
     def get_model_api_config(self, model_type: str, *, _core_config: dict | None = None) -> dict:

--- a/utils/image_generation/__init__.py
+++ b/utils/image_generation/__init__.py
@@ -45,7 +45,10 @@ async def generate_image(request: ImageRequest, *, config_manager=None, client=N
         raise ImageGenerationError("invalid_configuration")
     owned = client is None
     if owned:
-        client = await asyncio.to_thread(httpx.AsyncClient, trust_env=True, follow_redirects=False)
+        try:
+            client = await asyncio.to_thread(httpx.AsyncClient, trust_env=True, follow_redirects=False)
+        except (ValueError, OSError):
+            raise ImageGenerationError("client_initialization_failed") from None
     try:
         async with asyncio.timeout(timeout):
             image = await adapter.generate(client, config, request)

--- a/utils/image_generation/__init__.py
+++ b/utils/image_generation/__init__.py
@@ -1,0 +1,59 @@
+"""Core image generation infrastructure. No plugin, HTTP route or UI consumer."""
+import asyncio
+import math
+import re
+
+import httpx
+
+from . import dashscope, openai
+from .config import ImageConfig
+from .types import GeneratedImage, ImageGenerationError, ImageRequest, ImageResult
+
+__all__ = ["generate_image", "GeneratedImage", "ImageGenerationError", "ImageRequest", "ImageResult"]
+
+
+async def generate_image(request: ImageRequest, *, config_manager=None, client=None, timeout: float = 180) -> ImageResult:
+    """Generate one image using a single snapshot of core API settings.
+
+    No automatic retry (a failed/timeout request may already have been billed).
+    Cancellation propagates; a submitted provider job may still finish remotely.
+    Injected clients remain caller-owned. No disk, logging or chat side effects.
+    """
+    if not isinstance(request, ImageRequest) or not isinstance(request.prompt, str) or not request.prompt.strip() or len(request.prompt) > 2000:
+        raise ImageGenerationError("invalid_prompt")
+    if not isinstance(request.size, str) or not re.fullmatch(r"[1-9][0-9]{1,3}x[1-9][0-9]{1,3}", request.size):
+        raise ImageGenerationError("invalid_size")
+    width, height = map(int, request.size.split("x"))
+    if max(width, height) > 4096 or min(width, height) < 64:
+        raise ImageGenerationError("invalid_size")
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or not math.isfinite(timeout) or not 0 < timeout <= 600:
+        raise ImageGenerationError("invalid_timeout")
+    if config_manager is None:
+        from utils.config_manager import get_config_manager
+        config_manager = get_config_manager()
+    try:
+        resolved = await config_manager.aget_model_api_config("image")
+    except ValueError:
+        raise ImageGenerationError("invalid_configuration") from None
+    if not resolved.get("enabled"):
+        raise ImageGenerationError("not_configured")
+    config = ImageConfig(resolved["provider"], resolved["protocol"], resolved["base_url"], resolved["model"], resolved["api_key"])
+    if not config.api_key:
+        raise ImageGenerationError("missing_api_key")
+    adapter = {"openai": openai, "dashscope": dashscope}.get(config.protocol)
+    if adapter is None:
+        raise ImageGenerationError("invalid_configuration")
+    owned = client is None
+    if owned:
+        client = await asyncio.to_thread(httpx.AsyncClient, trust_env=True, follow_redirects=False)
+    try:
+        async with asyncio.timeout(timeout):
+            image = await adapter.generate(client, config, request)
+        return ImageResult(config.provider, config.model, image)
+    except (TimeoutError, httpx.TimeoutException):
+        raise ImageGenerationError("provider_timeout") from None
+    except httpx.HTTPError:
+        raise ImageGenerationError("provider_network_error") from None
+    finally:
+        if owned:
+            await client.aclose()

--- a/utils/image_generation/__init__.py
+++ b/utils/image_generation/__init__.py
@@ -48,7 +48,7 @@ async def generate_image(request: ImageRequest, *, config_manager=None, client=N
     if owned:
         try:
             client = await asyncio.to_thread(httpx.AsyncClient, trust_env=True, follow_redirects=False)
-        except (ValueError, OSError):
+        except (ValueError, OSError, httpx.InvalidURL):
             raise ImageGenerationError("client_initialization_failed") from None
     try:
         async with asyncio.timeout(timeout):

--- a/utils/image_generation/__init__.py
+++ b/utils/image_generation/__init__.py
@@ -2,6 +2,7 @@
 import asyncio
 import math
 import re
+import sys
 
 import httpx
 
@@ -59,4 +60,10 @@ async def generate_image(request: ImageRequest, *, config_manager=None, client=N
         raise ImageGenerationError("provider_network_error") from None
     finally:
         if owned:
-            await client.aclose()
+            active_error = sys.exception()
+            try:
+                await client.aclose()
+            except Exception:
+                # Cleanup must not replace a provider error or cancellation.
+                if active_error is None:
+                    raise ImageGenerationError("client_close_failed") from None

--- a/utils/image_generation/__init__.py
+++ b/utils/image_generation/__init__.py
@@ -56,6 +56,8 @@ async def generate_image(request: ImageRequest, *, config_manager=None, client=N
         return ImageResult(config.provider, config.model, image)
     except (TimeoutError, httpx.TimeoutException):
         raise ImageGenerationError("provider_timeout") from None
+    except httpx.InvalidURL:
+        raise ImageGenerationError("invalid_configuration") from None
     except httpx.HTTPError:
         raise ImageGenerationError("provider_network_error") from None
     finally:

--- a/utils/image_generation/config.py
+++ b/utils/image_generation/config.py
@@ -1,0 +1,65 @@
+"""Image generation profiles owned by the core API settings.
+
+Inspired by Alumin-Hydro's image generator in PR #2830. No plugin runtime
+or consumer state belongs here.
+"""
+from dataclasses import dataclass, field
+from urllib.parse import urlsplit
+
+PROVIDERS = {
+    "openai": {"name": "OpenAI", "protocol": "openai", "base_url": "https://api.openai.com/v1", "model": "gpt-image-2", "key_field": "assistApiKeyOpenai"},
+    "qwen": {"name": "Qwen (Beijing)", "protocol": "dashscope", "base_url": "https://dashscope.aliyuncs.com", "model": "wanx2.1-t2i-turbo", "key_field": "assistApiKeyQwen"},
+    "qwen_intl": {"name": "Qwen (Singapore)", "protocol": "dashscope", "base_url": "https://dashscope-intl.aliyuncs.com", "model": "wanx2.1-t2i-turbo", "key_field": "assistApiKeyQwenIntl"},
+    "custom": {"name": "OpenAI-compatible", "protocol": "openai", "base_url": "", "model": "", "key_field": ""},
+}
+
+
+@dataclass(frozen=True)
+class ImageConfig:
+    provider: str
+    protocol: str
+    base_url: str
+    model: str
+    api_key: str = field(repr=False)
+
+
+def resolve_image_config(raw: dict, *, enabled: bool = True) -> ImageConfig | None:
+    """Resolve only image settings; never fall back to a chat model or key."""
+    provider = raw.get("imageModelProvider", "")
+    if not enabled or provider in ("", "disabled", None):
+        return None
+    if not isinstance(provider, str) or provider not in PROVIDERS:
+        raise ValueError("Unsupported image provider")
+    profile = PROVIDERS[provider]
+    values = {}
+    for suffix in ("Url", "Id", "ApiKey"):
+        value = raw.get(f"imageModel{suffix}", "")
+        if not isinstance(value, str):
+            raise ValueError("Image settings must be strings")
+        values[suffix] = value.strip()
+    # Named providers own their endpoint and use only their own Key Book entry.
+    # An arbitrary endpoint always requires the explicitly separate custom key.
+    url = values["Url"] if provider == "custom" else profile["base_url"]
+    if provider != "custom" and values["Url"] and values["Url"].rstrip("/") != url:
+        raise ValueError("Use custom image provider for a custom endpoint")
+    model = values["Id"] or profile["model"]
+    key = values["ApiKey"] if provider == "custom" else raw.get(profile["key_field"], "")
+    if not isinstance(key, str):
+        raise ValueError("Image API key must be a string")
+    key = key.strip()
+    try:
+        parsed = urlsplit(url)
+        # Access .port separately to reject malformed ports, while allowing 443 implicit.
+        parsed.port
+        valid_url = parsed.scheme == "https" and parsed.hostname and not (
+            parsed.username or parsed.password or parsed.query or parsed.fragment
+        )
+    except ValueError:
+        valid_url = False
+    if not valid_url or any(c.isspace() or ord(c) < 32 for c in url):
+        raise ValueError("Image endpoint must be an HTTPS base URL")
+    if not model or len(model) > 200 or any(ord(c) < 32 for c in model):
+        raise ValueError("Invalid image model")
+    if len(key) > 4096 or any(ord(c) < 33 or ord(c) > 126 for c in key):
+        raise ValueError("Invalid image API key")
+    return ImageConfig(provider, profile["protocol"], url.rstrip("/"), model, key)

--- a/utils/image_generation/config.py
+++ b/utils/image_generation/config.py
@@ -6,6 +6,8 @@ or consumer state belongs here.
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit
 
+import httpx
+
 from utils.http.url import same_endpoint
 
 PROVIDERS = {
@@ -50,6 +52,7 @@ def resolve_image_config(raw: dict, *, enabled: bool = True) -> ImageConfig | No
         raise ValueError("Image API key must be a string")
     key = key.strip()
     try:
+        httpx.URL(url)  # Match the transport parser, including IDNA and IPv4 validation.
         parsed = urlsplit(url)
         # Access .port separately to reject malformed ports, while allowing 443 implicit.
         parsed.port
@@ -57,7 +60,7 @@ def resolve_image_config(raw: dict, *, enabled: bool = True) -> ImageConfig | No
             parsed.username or parsed.password or parsed.query or parsed.fragment
             or parsed.path.endswith("//")
         )
-    except ValueError:
+    except (ValueError, httpx.InvalidURL):
         valid_url = False
     if not valid_url or any(c.isspace() or ord(c) < 32 for c in url):
         raise ValueError("Image endpoint must be an HTTPS base URL")

--- a/utils/image_generation/config.py
+++ b/utils/image_generation/config.py
@@ -6,6 +6,8 @@ or consumer state belongs here.
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit
 
+from utils.http.url import same_endpoint
+
 PROVIDERS = {
     "openai": {"name": "OpenAI", "protocol": "openai", "base_url": "https://api.openai.com/v1", "model": "gpt-image-2", "key_field": "assistApiKeyOpenai"},
     "qwen": {"name": "Qwen (Beijing)", "protocol": "dashscope", "base_url": "https://dashscope.aliyuncs.com", "model": "wanx2.1-t2i-turbo", "key_field": "assistApiKeyQwen"},
@@ -40,7 +42,7 @@ def resolve_image_config(raw: dict, *, enabled: bool = True) -> ImageConfig | No
     # Named providers own their endpoint and use only their own Key Book entry.
     # An arbitrary endpoint always requires the explicitly separate custom key.
     url = values["Url"] if provider == "custom" else profile["base_url"]
-    if provider != "custom" and values["Url"] and values["Url"].rstrip("/") != url:
+    if provider != "custom" and values["Url"] and not same_endpoint(values["Url"], url):
         raise ValueError("Use custom image provider for a custom endpoint")
     model = values["Id"] or profile["model"]
     key = values["ApiKey"] if provider == "custom" else raw.get(profile["key_field"], "")

--- a/utils/image_generation/config.py
+++ b/utils/image_generation/config.py
@@ -53,6 +53,7 @@ def resolve_image_config(raw: dict, *, enabled: bool = True) -> ImageConfig | No
         parsed.port
         valid_url = parsed.scheme == "https" and parsed.hostname and not (
             parsed.username or parsed.password or parsed.query or parsed.fragment
+            or parsed.path.endswith("//")
         )
     except ValueError:
         valid_url = False

--- a/utils/image_generation/dashscope.py
+++ b/utils/image_generation/dashscope.py
@@ -1,0 +1,35 @@
+"""DashScope asynchronous text-to-image protocol adapter."""
+import asyncio
+import re
+
+from .transport import parse_image, request_json
+from .types import ImageGenerationError
+
+
+async def generate(client, config, request):
+    result = await request_json(
+        client, "POST", config.base_url + "/api/v1/services/aigc/text2image/image-synthesis",
+        key=config.api_key, headers={"X-DashScope-Async": "enable"},
+        json={"model": config.model, "input": {"prompt": request.prompt},
+              "parameters": {"n": 1, "size": request.size.replace("x", "*")}},
+    )
+    output = result.get("output")
+    task_id = output.get("task_id") if isinstance(output, dict) else None
+    if not isinstance(task_id, str) or not re.fullmatch(r"[a-zA-Z0-9-]{1,128}", task_id):
+        raise ImageGenerationError("invalid_response")
+    while True:
+        result = await request_json(client, "GET", config.base_url + "/api/v1/tasks/" + task_id, key=config.api_key)
+        output = result.get("output")
+        if not isinstance(output, dict):
+            raise ImageGenerationError("invalid_response")
+        status = output.get("task_status")
+        if status == "SUCCEEDED":
+            items = output.get("results")
+            if not isinstance(items, list) or len(items) != 1:
+                raise ImageGenerationError("invalid_response")
+            return await asyncio.to_thread(parse_image, items[0])
+        if status in ("FAILED", "CANCELED", "UNKNOWN"):
+            raise ImageGenerationError("provider_task_failed")
+        if status not in ("PENDING", "RUNNING"):
+            raise ImageGenerationError("invalid_response")
+        await asyncio.sleep(5)

--- a/utils/image_generation/openai.py
+++ b/utils/image_generation/openai.py
@@ -7,8 +7,9 @@ from .types import ImageGenerationError
 
 async def generate(client, config, request):
     body = {"model": config.model, "prompt": request.prompt, "n": 1, "size": request.size}
-    # GPT Image always returns base64 and rejects the legacy response_format flag.
-    if not config.model.rsplit("/", 1)[-1].startswith(("gpt-image", "chatgpt-image")):
+    # Only known legacy models opt in. Unknown aliases may route to GPT Image,
+    # which rejects this flag; the response parser also accepts default URL output.
+    if config.model in ("dall-e-2", "dall-e-3"):
         body["response_format"] = "b64_json"
     result = await request_json(client, "POST", config.base_url + "/images/generations", key=config.api_key, json=body)
     items = result.get("data")

--- a/utils/image_generation/openai.py
+++ b/utils/image_generation/openai.py
@@ -1,0 +1,17 @@
+"""OpenAI Images protocol adapter."""
+import asyncio
+
+from .transport import parse_image, request_json
+from .types import ImageGenerationError
+
+
+async def generate(client, config, request):
+    body = {"model": config.model, "prompt": request.prompt, "n": 1, "size": request.size}
+    # GPT Image always returns base64 and rejects the legacy response_format flag.
+    if not config.model.rsplit("/", 1)[-1].startswith(("gpt-image", "chatgpt-image")):
+        body["response_format"] = "b64_json"
+    result = await request_json(client, "POST", config.base_url + "/images/generations", key=config.api_key, json=body)
+    items = result.get("data")
+    if not isinstance(items, list) or len(items) != 1:
+        raise ImageGenerationError("invalid_response")
+    return await asyncio.to_thread(parse_image, items[0])

--- a/utils/image_generation/transport.py
+++ b/utils/image_generation/transport.py
@@ -1,0 +1,64 @@
+"""Bounded provider response handling shared by both image protocols."""
+import asyncio
+import base64
+import binascii
+import ipaddress
+import json
+from urllib.parse import urlsplit
+
+from .types import GeneratedImage, ImageGenerationError
+
+MAX_RESPONSE_BYTES = 32 * 1024 * 1024
+
+
+async def request_json(client, method, url, *, key, **kwargs):
+    headers = {"Authorization": f"Bearer {key}", **kwargs.pop("headers", {})}
+    async with client.stream(method, url, headers=headers, follow_redirects=False, timeout=120, **kwargs) as response:
+        if response.status_code < 200 or response.status_code >= 300:
+            raise ImageGenerationError("provider_http_error")
+        body = bytearray()
+        async for chunk in response.aiter_bytes():
+            if len(body) + len(chunk) > MAX_RESPONSE_BYTES:
+                raise ImageGenerationError("response_too_large")
+            body.extend(chunk)
+    try:
+        result = await asyncio.to_thread(json.loads, body)
+    except (ValueError, UnicodeError):
+        raise ImageGenerationError("invalid_response") from None
+    if not isinstance(result, dict):
+        raise ImageGenerationError("invalid_response")
+    return result
+
+
+def parse_image(item):
+    if not isinstance(item, dict):
+        raise ImageGenerationError("invalid_response")
+    encoded = item.get("b64_json")
+    if isinstance(encoded, str) and encoded:
+        try:
+            data = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error):
+            raise ImageGenerationError("invalid_image_data") from None
+        if not data:
+            raise ImageGenerationError("invalid_image_data")
+        return GeneratedImage(data=data)
+    url = item.get("url")
+    try:
+        p = urlsplit(url) if isinstance(url, str) and len(url) <= 8192 else None
+        if not p or p.scheme != "https" or not p.hostname or p.username or p.password or p.fragment:
+            raise ValueError()
+        p.port
+        host = p.hostname.lower().rstrip(".")
+        if host == "localhost" or host.endswith((".localhost", ".local")):
+            raise ValueError()
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            address = None
+        if address is not None and not address.is_global:
+            raise ValueError()
+        if any(c.isspace() or ord(c) < 32 for c in url):
+            raise ValueError()
+    except ValueError:
+        raise ImageGenerationError("invalid_image_url") from None
+    return GeneratedImage(url=url)

--- a/utils/image_generation/transport.py
+++ b/utils/image_generation/transport.py
@@ -12,10 +12,14 @@ MAX_RESPONSE_BYTES = 32 * 1024 * 1024
 
 
 async def request_json(client, method, url, *, key, **kwargs):
-    headers = {"Authorization": f"Bearer {key}", **kwargs.pop("headers", {})}
-    async with client.stream(method, url, headers=headers, follow_redirects=False, timeout=120, **kwargs) as response:
+    headers = {"Authorization": f"Bearer {key}", **kwargs.pop("headers", {}), "Accept-Encoding": "identity"}
+    # generate_image owns the total deadline, including every polling request.
+    async with client.stream(method, url, headers=headers, follow_redirects=False, timeout=None, **kwargs) as response:
         if response.status_code < 200 or response.status_code >= 300:
             raise ImageGenerationError("provider_http_error")
+        # Reject before aiter_bytes can allocate decompressed transport chunks.
+        if response.headers.get("content-encoding", "identity").strip().lower() != "identity":
+            raise ImageGenerationError("unsupported_content_encoding")
         body = bytearray()
         async for chunk in response.aiter_bytes():
             if len(body) + len(chunk) > MAX_RESPONSE_BYTES:

--- a/utils/image_generation/transport.py
+++ b/utils/image_generation/transport.py
@@ -6,6 +6,8 @@ import ipaddress
 import json
 from urllib.parse import urlsplit
 
+import httpx
+
 from .types import GeneratedImage, ImageGenerationError
 
 MAX_RESPONSE_BYTES = 32 * 1024 * 1024
@@ -51,6 +53,7 @@ def parse_image(item):
         p = urlsplit(url) if isinstance(url, str) and len(url) <= 8192 else None
         if not p or p.scheme != "https" or not p.hostname or p.username or p.password or p.fragment:
             raise ValueError()
+        httpx.URL(url)
         p.port
         host = p.hostname.lower().rstrip(".")
         if host == "localhost" or host.endswith((".localhost", ".local")):
@@ -63,6 +66,6 @@ def parse_image(item):
             raise ValueError()
         if any(c.isspace() or ord(c) < 32 for c in url):
             raise ValueError()
-    except ValueError:
+    except (ValueError, httpx.InvalidURL):
         raise ImageGenerationError("invalid_image_url") from None
     return GeneratedImage(url=url)

--- a/utils/image_generation/transport.py
+++ b/utils/image_generation/transport.py
@@ -23,7 +23,7 @@ async def request_json(client, method, url, *, key, **kwargs):
             body.extend(chunk)
     try:
         result = await asyncio.to_thread(json.loads, body)
-    except (ValueError, UnicodeError):
+    except (ValueError, UnicodeError, RecursionError):
         raise ImageGenerationError("invalid_response") from None
     if not isinstance(result, dict):
         raise ImageGenerationError("invalid_response")

--- a/utils/image_generation/types.py
+++ b/utils/image_generation/types.py
@@ -1,0 +1,34 @@
+"""Consumer-independent image generation contract."""
+from dataclasses import dataclass, field
+
+
+class ImageGenerationError(Exception):
+    """Stable, sanitized error code; never contains prompts, keys or provider bodies."""
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class ImageRequest:
+    prompt: str = field(repr=False)
+    size: str = "1024x1024"
+
+
+@dataclass(frozen=True)
+class GeneratedImage:
+    """Exactly one of data/url. URLs expire; consumers own retrieval and storage.
+
+    Provider URLs are untrusted network locations, not authorization to fetch
+    internal resources. The generation layer never downloads or displays them.
+    """
+    data: bytes | None = field(default=None, repr=False)
+    url: str | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class ImageResult:
+    provider: str
+    model: str
+    image: GeneratedImage = field(repr=False)


### PR DESCRIPTION
## Summary

Image generation belongs in the core API management infrastructure, even before a consumer exists. This PR adds an image model slot to the existing settings page and a consumer-independent asynchronous generation API.

Supersedes #2830. The provider protocol design is adapted from @Alumin-Hydro's contribution, credited in the code/docs and the commit co-author trailer. The plugin, plugin panel, history/cache and chat integration are not included. Keep #2830 open until this replacement merges; the maintainer's follow-up automation will then close it.

- Resolve image configuration through ConfigManager.get_model_api_config("image"), with no fallback to chat/vision/free models.
- Reuse core_config.json, the API Key Book and masked secret round trips. Named endpoints use only their own provider key; custom endpoints use an independent key.
- Provide symmetric OpenAI Images and DashScope asynchronous text-to-image adapters with bounded responses, total timeout, cancellation and sanitized errors.
- Return bytes or a temporary provider URL. Consumers own retrieval, image decoding, storage and display; generation never downloads output URLs or logs prompts.
- Add all eight locale strings. Saving settings never submits a paid generation probe.

The initial DashScope adapter targets text2image/image-synthesis (Wan 2.1/2.5); newer multimodal-generation protocols are outside this initial implementation.

## Testing

- 210 Python tests passed: image protocols, core secret redaction, API configuration management and custom model slot resolution.
- 5 Node frontend tests passed.
- 1 real Chromium settings-page test passed.
- Ruff, async-blocking, module-layering, i18n synchronization and git diff checks passed.
- Existing api_key_secret_masking.test.cjs has 5 unrelated failures also reproduced against unchanged main: missing _secretDisplayCache in its harness and stale bullet-mask expectations. No production masking behavior was changed.
- Latest verification: 105 image/core-secret Python tests, 5 Node tests and 1 Chromium test passed. Provider tests use MockTransport; no paid API calls. A requested live GPT Image 2.5 smoke test awaits local service credentials.

## 回归报告 / Regression Report

The core configuration router now returns image provider metadata and persists/masks image model fields. Previously API management had no image generation slot; afterward it can configure image generation without installing a plugin. This is necessary to establish core ownership before consumers exist. Regression risks are key round trips, provider switches, and existing model-slot resolution: 210 targeted Python tests and the real Chromium settings-page test passed. A retained custom image key is rejected when its endpoint changes; no automatic paid probe or consumer is attached.

## 不拆分理由 / Why Not Split

Not applicable: fewer than 20 counted existing production files. Configuration, adapters and their tests form one usable infrastructure capability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增图片生成功能，支持 OpenAI、Qwen、DashScope 及自定义兼容服务商。
  * 可独立配置图片模型、端点和 API 密钥，并支持启用或停用。
  * 支持异步生成、超时、取消、响应校验及安全错误处理。
  * 配置面板支持服务商切换、默认值回填和自定义设置。
* **文档**
  * 新增配置、调用协议、限制及错误处理说明。
* **本地化**
  * 补充多种语言的图片生成配置界面文案。
* **界面优化**
  * 优化图片生成与小游戏模型卡片的布局及展开交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

