### PR TITLE
feat(card-drop): hand Desktop OAuth session to community via one-time native_sync ticket

### DIFF
--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1372,6 +1372,10 @@ async def social_session_init_options(request: Request):
     cors = _sync_cors_headers(request)
     if cors is None:
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    if not client_registration.proof_transport_allowed(_social_base_url()):
+        return JSONResponse(
+            {"detail": "insecure_transport"}, status_code=403, headers=cors
+        )
     return JSONResponse({"ok": True}, headers=cors)
 
 
@@ -1381,19 +1385,37 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
 
     The community SPA (opened by NEKO with a ``#native_sync`` ticket) redeems
     that one-time ticket here. In exchange it receives the Desktop
-    ``neko-servers-desktop-*`` access/refresh tokens, which N.E.K.O.Servers
-    already accepts (``AUTH_ALLOWED_DESKTOP_CLIENT_IDS``). The SPA then runs
-    its normal ``/api/auth/session/bootstrap`` and publishes the session, so no
-    second browser login is needed and both sides share one token family.
+    ``neko-servers-desktop-*`` access token, which N.E.K.O.Servers already
+    accepts (``AUTH_ALLOWED_DESKTOP_CLIENT_IDS``). The SPA then runs its normal
+    ``/api/auth/session/bootstrap`` and publishes the session, so no second
+    browser login is needed.
+
+    The refresh token stays here: Desktop is the sole owner of that rotating
+    family, and a second independent rotator would invalidate both sides. The
+    community session therefore lives as long as the handed-over access token.
 
     Direction is Python → SPA over the allowlisted community Origin only; the
-    Web tab never sends its own bearer to localhost. Ticket is single-use.
+    Web tab never sends its own bearer to localhost. Ticket is single-use, and
+    is consumed only once the response is known to be deliverable.
     """
+    if not (request.headers.get("origin") or "").strip():
+        # CORS cannot authenticate a non-browser caller, and any local process
+        # can mint a ticket via /sync-ticket. Requiring an Origin keeps this
+        # endpoint reachable only from the real cross-origin community tab.
+        return JSONResponse(
+            {"detail": "origin_required"},
+            status_code=403,
+            headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+        )
     cors = _sync_cors_headers(request)
     if cors is None:
         return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    if not client_registration.proof_transport_allowed(_social_base_url()):
+        return JSONResponse(
+            {"detail": "insecure_transport"}, status_code=403, headers=cors
+        )
     sync_ticket = payload.get("sync_ticket") or payload.get("syncTicket")
-    if not _consume_sync_ticket(sync_ticket):
+    if not _sync_ticket_is_valid(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
         )
@@ -1417,17 +1439,37 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         return JSONResponse(
             {"detail": "legacy_session_not_supported"}, status_code=409, headers=cors
         )
+    snapshot_base = str(snapshot.get("base_url") or "").strip().rstrip("/")
+    if snapshot_base and not _same_originish(snapshot_base, _social_base_url()):
+        # The saved login belongs to another community; refuse rather than ship
+        # its bearer to the currently configured one. The session stays on disk
+        # so pointing NEKO_SOCIAL_BASE_URL back restores it.
+        return JSONResponse(
+            {"detail": "desktop_login_required"}, status_code=409, headers=cors
+        )
     from main_routers import community_oauth as _co
 
+    auth = await asyncio.to_thread(_load_auth) or {}
+    # 老会话没存 bind 字段 → 视为已绑（向后兼容，正常单账号场景成立）
+    bind = auth.get("bind") or {"bound": True, "error": None}
+    if not bind.get("bound") and bind.get("error") != _BIND_OWNERSHIP_CONFLICT:
+        # Desktop binds once at callback time and never retries. Redeeming the
+        # ticket used to be the SPA's chance to repair a failed bind, so retry
+        # here before it is spent.
+        bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
+    if not _consume_sync_ticket(sync_ticket):
+        return JSONResponse(
+            {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
+        )
     return JSONResponse(
         {
             "access_token": access_token,
-            "refresh_token": str(snapshot.get("refresh_token") or "").strip() or None,
             "local_user_id": local_user_id,
             "auth_public_url": str(
                 snapshot.get("auth_public_url") or _co._auth_public_url()
             ).rstrip("/"),
             "client_id": str(snapshot.get("client_id") or _co._desktop_client_id()),
+            "bind": bind,
         },
         headers={**cors, "Cache-Control": "no-store", "Pragma": "no-cache"},
     )

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1649,8 +1649,23 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         return JSONResponse(
             {"detail": "desktop_login_required"}, status_code=409, headers=cors
         )
-    # 老会话没存 bind 字段 → 视为已绑（向后兼容，正常单账号场景成立）
+    # The auth mirror may already belong to a newer login while the social
+    # file is still authoritative for this one. Never reuse its bind outcome.
+    # Older mirrors without identity metadata are still tied by the exact
+    # bearer; a missing bind field retains the existing compatibility default.
+    auth_matches_session = (
+        str(auth.get("access_token") or "").strip() == access_token
+        and (not auth.get("local_user_id")
+             or _normalize_local_user_id(auth["local_user_id"]) == local_user_id)
+        and (not auth.get("auth_source")
+             or _normalize_auth_source(auth["auth_source"]) == snapshot["auth_source"])
+    )
     bind = auth.get("bind") or {"bound": True, "error": None}
+    if auth and not auth_matches_session:
+        bind = {"bound": False, "error": "desktop_bind_state_unavailable"}
+        # Issuer/client metadata must not leak across this boundary either.
+        # The authoritative snapshot or configured defaults supply the issuer.
+        auth = {}
     bind_retried = False
     if not bind.get("bound") and bind.get("error") != _BIND_OWNERSHIP_CONFLICT:
         # Desktop binds once at callback time and never retries. Redeeming the

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1457,6 +1457,14 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         # ticket used to be the SPA's chance to repair a failed bind, so retry
         # here before it is spent.
         bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
+        if bind.get("bound"):
+            # Persist it, or /auth-status keeps reporting the stale failure and
+            # every later handoff repeats the bind. Only write when the record
+            # still holds the token we bound, so a concurrent refresh or account
+            # switch is not overwritten.
+            current = await asyncio.to_thread(_load_auth) or {}
+            if str(current.get("access_token") or "").strip() == access_token:
+                await asyncio.to_thread(_save_auth, {**current, "bind": bind})
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -973,13 +973,15 @@ def _clear_auth() -> bool:
                 else:
                     success = False
                     logger.warning("card_drop: credential still exists after clear: %s", path)
+            if success:
+                _clear_native_delegates()
+                # A post-logout guest can mint a ticket as soon as these file
+                # locks are released, so invalidate older proofs before then.
+                with _native_sync_tickets_lock:
+                    _native_sync_tickets.clear()
     except (OSError, TimeoutError) as exc:
         success = False
         logger.warning("card_drop: clear credentials failed to fence writers: %s", exc)
-    if success:
-        _clear_native_delegates()
-        with _native_sync_tickets_lock:
-            _native_sync_tickets.clear()
     return success
 
 

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -756,6 +756,12 @@ def _persist_repaired_bind(access_token: str, bind: dict) -> None:
                     return
                 if _normalize_auth_source(current.get("auth_source")) != social.get("auth_source"):
                     return
+                # Persist the validated bind's session separately: the mirror
+                # may contain either lagging or ahead-of-social credentials.
+                # Rewriting its tokens here could roll back a newer refresh.
+                current["bind_session_fingerprint"] = _desktop_session_fingerprint(social)
+            else:
+                current.pop("bind_session_fingerprint", None)
             _write_private_json(path, {**current, "bind": bind})
     except (OSError, TimeoutError) as exc:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
@@ -1369,6 +1375,18 @@ def _issue_sync_ticket_for_session() -> str:
         return _issue_sync_ticket(_desktop_session_fingerprint(_desktop_session_snapshot()))
 
 
+def _load_auth_for_verified_session(snapshot: dict) -> dict | None:
+    """Read the mirror only while the remotely verified session still owns it."""
+    try:
+        with _social_session_locks(_social_session_paths()):
+            auth = _load_auth() or {}
+            if _desktop_session_fingerprint(_desktop_session_snapshot()) != _desktop_session_fingerprint(snapshot):
+                return None
+            return auth
+    except (OSError, TimeoutError):
+        return None
+
+
 def _consume_sync_ticket_for_verified_session(
     sync_ticket: object,
     access_token: str,
@@ -1433,6 +1451,12 @@ async def _native_delegate_session_snapshot() -> tuple[dict | None, str]:
 
     snapshot = await asyncio.to_thread(_desktop_session_snapshot)
     if snapshot is None:
+        return None, "missing"
+    verified = status.get("snapshot") or {}
+    if not community_oauth._status_snapshot_matches(snapshot, verified) or (
+        snapshot.get("auth_source") != verified.get("auth_source")
+    ):
+        # A local replacement after cloud validation is not itself validated.
         return None, "missing"
     if _desktop_session_fingerprint(snapshot):
         return snapshot, ""
@@ -1637,17 +1661,10 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         )
     from main_routers import community_oauth as _co
 
-    auth = await asyncio.to_thread(_load_auth) or {}
-    # _load_auth 是 await 点，Desktop 登出、刷新、切号都可能在这期间发生。这里
-    # 无条件复查：会话已变就返回 409，既不下发凭据、不消费 ticket，也不带着旧
-    # token 去做 bind 重试的云端副作用。
-    verification_snapshot, _ = await _native_delegate_session_snapshot()
-    verification_token = (
-        str(verification_snapshot.get("access_token") or "").strip()
-        if verification_snapshot
-        else ""
-    )
-    if verification_token != access_token:
+    # Fence the local await against logout/refresh/account changes without
+    # repeating the remote identity lookup that just validated this snapshot.
+    auth = await asyncio.to_thread(_load_auth_for_verified_session, snapshot)
+    if auth is None:
         return JSONResponse(
             {"detail": "desktop_login_required"}, status_code=409, headers=cors
         )
@@ -1664,7 +1681,13 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
     )
     bind = auth.get("bind") or {"bound": True, "error": None}
     if auth and not auth_matches_session:
-        bind = {"bound": False, "error": "desktop_bind_state_unavailable"}
+        repaired_bind_matches = (
+            auth.get("bind_session_fingerprint") == _desktop_session_fingerprint(snapshot)
+            and _normalize_local_user_id(auth.get("local_user_id")) == local_user_id
+            and _normalize_auth_source(auth.get("auth_source")) == snapshot["auth_source"]
+        )
+        if not repaired_bind_matches:
+            bind = {"bound": False, "error": "desktop_bind_state_unavailable"}
         # Issuer/client metadata must not leak across this boundary either.
         # The authoritative snapshot or configured defaults supply the issuer.
         auth = {}

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -671,6 +671,28 @@ def _save_auth(data: dict) -> bool:
     return True
 
 
+def _persist_repaired_bind(access_token: str, bind: dict) -> None:
+    """Record a repaired bind without clobbering a concurrent refresh.
+
+    Read-modify-write under the same lock the social-session CAS uses, merging
+    only the ``bind`` key: a refresh or account switch landing between read and
+    write owns the tokens and must not be rolled back to this snapshot.
+    """
+    path = _auth_path()
+    if path is None:
+        return
+    try:
+        with _social_session_lock(path):
+            current = _read_json_dict(path)
+            if not current:
+                return
+            if str(current.get("access_token") or "").strip() != access_token:
+                return
+            _write_private_json(path, {**current, "bind": bind})
+    except OSError as exc:
+        logger.warning("card_drop: persist repaired bind failed: %s", exc)
+
+
 def _save_social_session(
     base: str,
     access: str | None,
@@ -1459,12 +1481,8 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
         if bind.get("bound"):
             # Persist it, or /auth-status keeps reporting the stale failure and
-            # every later handoff repeats the bind. Only write when the record
-            # still holds the token we bound, so a concurrent refresh or account
-            # switch is not overwritten.
-            current = await asyncio.to_thread(_load_auth) or {}
-            if str(current.get("access_token") or "").strip() == access_token:
-                await asyncio.to_thread(_save_auth, {**current, "bind": bind})
+            # every later handoff repeats the bind.
+            await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1267,8 +1267,15 @@ async def auth_status_endpoint(request: Request):
 
 @router.get("/sync-ticket", summary="签发一次性社区网页登录态同步票据")
 async def sync_ticket_endpoint(request: Request):
-    """Issue a short-lived ticket readable only by the local NEKO page."""
-    if not _local_request_source_allowed(request):
+    """Issue a short-lived ticket readable only by the local NEKO page.
+
+    The ticket transitively redeems the Desktop OAuth bearer, so minting gets
+    the same browser boundary as /native-delegate: Fetch Metadata proving the
+    request came from this server's own page. A headerless native client can
+    no longer mint one; social-session-init then only ever consumes tickets
+    that originated from the trusted local UI.
+    """
+    if not _local_ui_request_source_allowed(request):
         return JSONResponse(
             {"detail": "origin_not_allowed"},
             status_code=403,
@@ -1278,6 +1285,36 @@ async def sync_ticket_endpoint(request: Request):
         {"sync_ticket": _issue_sync_ticket(), "expires_in": _SYNC_TICKET_TTL_SEC},
         headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
     )
+
+
+def _consume_sync_ticket_for_verified_session(
+    sync_ticket: object,
+    access_token: str,
+) -> str:
+    """Consume the ticket only while the verified session still owns the file.
+
+    Returns "ok", "changed" (desktop session was replaced / lock busy; ticket
+    preserved), or "invalid" (the ticket itself is spent).
+    """
+    social_path = _social_session_path()
+    if social_path is None:
+        return "ok" if _consume_sync_ticket(sync_ticket) else "invalid"
+    try:
+        # The Electron main process takes this same lock for logout / account
+        # switch / token refresh, so its write either completed before this
+        # scope (the re-read below mismatches -> 409) or it waits until the
+        # ticket is consumed and the response is already being queued.
+        with _social_session_lock(social_path):
+            current = _desktop_session_snapshot()
+            current_token = str((current or {}).get("access_token") or "").strip()
+            if current_token != access_token:
+                return "changed"
+            return "ok" if _consume_sync_ticket(sync_ticket) else "invalid"
+    except (OSError, TimeoutError) as exc:
+        # A concurrent writer is holding the lock; assume the session is being
+        # replaced and keep the ticket for a retry.
+        logger.warning("card_drop: sync ticket consume fenced off: %s", exc)
+        return "changed"
 
 
 def _handoff_return_url(return_to: str | None, audience: str) -> str | None:
@@ -1466,9 +1503,10 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
     is consumed only once the response is known to be deliverable.
     """
     if not (request.headers.get("origin") or "").strip():
-        # CORS cannot authenticate a non-browser caller, and any local process
-        # can mint a ticket via /sync-ticket. Requiring an Origin keeps this
-        # endpoint reachable only from the real cross-origin community tab.
+        # CORS cannot authenticate a non-browser caller, and the ticket must
+        # never be redeemable by one: /sync-ticket only mints from the local
+        # UI's browser context, so a headerless native client holds no ticket
+        # and this Origin requirement rejects its direct calls.
         return JSONResponse(
             {"detail": "origin_required"},
             status_code=403,
@@ -1524,21 +1562,20 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         # ticket used to be the SPA's chance to repair a failed bind, so retry
         # here before it is spent.
         bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
-        if bind.get("bound"):
-            # Persist it, or /auth-status keeps reporting the stale failure and
-            # every later handoff repeats the bind.
+        if bind.get("bound") or bind.get("error") == _BIND_OWNERSHIP_CONFLICT:
+            # Persist repaired binds and terminal conflicts alike, or
+            # /auth-status keeps reporting the stale transient failure and
+            # every later handoff repeats the bind round trip.
             await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
     # _load_auth 和 _oauth_guest_bind 都是 await 点，Desktop 登出、刷新、切号都可能
-    # 在这期间发生。原先只有 bind 重试分支复查，已绑定和 ownership-conflict 两条常见
-    # 路径直接消费 ticket 并下发 bearer。这里改成无条件复查：会话已变就返回 409，
-    # 既不下发凭据，也不消费 ticket（留给用户重试）。
+    # 在这期间发生。这里无条件复查：会话已变就返回 409，既不下发凭据，也不消费
+    # ticket（留给用户重试）。
     #
-    # 注意这里没有对「复查 → 消费」加锁。Desktop 侧的写入在 _social_session_lock 下
-    # 提交，但复查必须走 _native_delegate_session_snapshot（异步 IPC，读的是 PC 进程
-    # 内存中的当前会话），没法放进同步锁作用域；换成读磁盘的 _desktop_session_snapshot
-    # 会和上面 1489 行的判定源不一致，PC 尚未落盘时会误判。所以复查和消费之间仍有一个
-    # 窄窗口 —— 它把「整段 await 期间」收敛到了「一次 IPC 往返」，但没有完全消除。
-    # 彻底消除需要 PC 侧提供带版本号的会话读取接口，属于跨仓库改动。
+    # 「复查 → 消费」在 _social_session_lock 里执行：Electron 侧的登出/切号/刷新
+    # 写 social_session.json 时持有同一把锁（见 social-session-refresh.js 的
+    # .lock 协议），所以那次写入要么发生在进锁之前（锁内复读磁盘发现 token 已变，
+    # 返回 409），要么被挡到 ticket 消费完成之后。复查本身仍需走异步的云端校验，
+    # 没法放进同步锁作用域；残余窗口只剩「出锁 → 响应送达」这段本地回环时间。
     verification_snapshot, _ = await _native_delegate_session_snapshot()
     verification_token = (
         str(verification_snapshot.get("access_token") or "").strip()
@@ -1549,9 +1586,16 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         return JSONResponse(
             {"detail": "desktop_login_required"}, status_code=409, headers=cors
         )
-    if not _consume_sync_ticket(sync_ticket):
+    consume_outcome = await asyncio.to_thread(
+        _consume_sync_ticket_for_verified_session, sync_ticket, access_token
+    )
+    if consume_outcome == "invalid":
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
+        )
+    if consume_outcome != "ok":
+        return JSONResponse(
+            {"detail": "desktop_login_required"}, status_code=409, headers=cors
         )
     return JSONResponse(
         {

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1453,11 +1453,19 @@ async def _native_delegate_session_snapshot() -> tuple[dict | None, str]:
     if snapshot is None:
         return None, "missing"
     verified = status.get("snapshot") or {}
-    if not community_oauth._status_snapshot_matches(snapshot, verified) or (
-        snapshot.get("auth_source") != verified.get("auth_source")
-    ):
+    credentials_changed = any(
+        snapshot.get(key) != verified.get(key)
+        for key in ("base_url", "access_token", "refresh_token")
+    )
+    identity_changed = any(
+        verified.get(key) and snapshot.get(key) != verified.get(key)
+        for key in ("local_user_id", "auth_source")
+    )
+    if credentials_changed or identity_changed:
         # A local replacement after cloud validation is not itself validated.
         return None, "missing"
+    # A concurrent proof request may have backfilled missing identity metadata
+    # for these same validated credentials. Preserve that verified enrichment.
     if _desktop_session_fingerprint(snapshot):
         return snapshot, ""
 

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1367,6 +1367,72 @@ async def native_delegate_handoff_endpoint(
     )
 
 
+@router.options("/social-session-init", summary="社区网页复用 Desktop 登录态预检")
+async def social_session_init_options(request: Request):
+    cors = _sync_cors_headers(request)
+    if cors is None:
+        return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    return JSONResponse({"ok": True}, headers=cors)
+
+
+@router.post("/social-session-init", summary="一次性消费 native_sync ticket，交付 Desktop OAuth 会话")
+async def social_session_init_endpoint(request: Request, payload: dict = Body(...)):
+    """Hand the Desktop OAuth session to the community tab so it logs in once.
+
+    The community SPA (opened by NEKO with a ``#native_sync`` ticket) redeems
+    that one-time ticket here. In exchange it receives the Desktop
+    ``neko-servers-desktop-*`` access/refresh tokens, which N.E.K.O.Servers
+    already accepts (``AUTH_ALLOWED_DESKTOP_CLIENT_IDS``). The SPA then runs
+    its normal ``/api/auth/session/bootstrap`` and publishes the session, so no
+    second browser login is needed and both sides share one token family.
+
+    Direction is Python → SPA over the allowlisted community Origin only; the
+    Web tab never sends its own bearer to localhost. Ticket is single-use.
+    """
+    cors = _sync_cors_headers(request)
+    if cors is None:
+        return JSONResponse({"detail": "origin_not_allowed"}, status_code=403)
+    sync_ticket = payload.get("sync_ticket") or payload.get("syncTicket")
+    if not _consume_sync_ticket(sync_ticket):
+        return JSONResponse(
+            {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
+        )
+    snapshot, failure = await _native_delegate_session_snapshot()
+    access_token = str((snapshot or {}).get("access_token") or "").strip()
+    local_user_id = str((snapshot or {}).get("local_user_id") or "").strip()
+    if not snapshot or not access_token or not local_user_id:
+        unavailable = failure in {"unavailable", "malformed"}
+        return JSONResponse(
+            {
+                "detail": (
+                    "identity_verification_unavailable"
+                    if unavailable
+                    else "desktop_login_required"
+                )
+            },
+            status_code=503 if unavailable else 409,
+            headers=cors,
+        )
+    if snapshot.get("auth_source") != "oauth":
+        return JSONResponse(
+            {"detail": "legacy_session_not_supported"}, status_code=409, headers=cors
+        )
+    from main_routers import community_oauth as _co
+
+    return JSONResponse(
+        {
+            "access_token": access_token,
+            "refresh_token": str(snapshot.get("refresh_token") or "").strip() or None,
+            "local_user_id": local_user_id,
+            "auth_public_url": str(
+                snapshot.get("auth_public_url") or _co._auth_public_url()
+            ).rstrip("/"),
+            "client_id": str(snapshot.get("client_id") or _co._desktop_client_id()),
+        },
+        headers={**cors, "Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
 @router.options("/sync-session", summary="社区网页登录态同步预检")
 async def sync_session_options(request: Request):
     cors = _sync_cors_headers(request)

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1346,6 +1346,10 @@ async def sync_ticket_endpoint(request: Request):
             headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
         )
     try:
+        # Resolve first, as for native delegates: redemption performs this same
+        # refresh/identity backfill and must not invalidate a just-minted proof.
+        # Missing or offline sessions still retain the guest-bind ticket path.
+        await _native_delegate_session_snapshot()
         ticket = await asyncio.to_thread(_issue_sync_ticket_for_session)
     except (OSError, TimeoutError):
         return JSONResponse(

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -58,7 +58,7 @@ _FACT_QUERY_MAX_EXCLUSIONS = 200
 _FACT_QUERY_MAX_EXCLUSION_LENGTH = 128
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 _SUPPORTED_AUTH_SOURCES = frozenset({"legacy", "oauth"})
-_native_sync_tickets: dict[str, float] = {}
+_native_sync_tickets: dict[str, dict] = {}
 # digest -> {expires_at, scopes, local_user_id, audience, session_fingerprint}
 _native_delegates: dict[str, dict] = {}
 # /sync-ticket 在事件循环线程签发，social-session-init 经 asyncio.to_thread 在
@@ -118,36 +118,42 @@ def _prune_sync_tickets(now: float | None = None) -> None:
     current = time.monotonic() if now is None else now
     expired = [
         digest
-        for digest, expires_at in _native_sync_tickets.items()
-        if expires_at <= current
+        for digest, entry in _native_sync_tickets.items()
+        if entry["expires_at"] <= current
     ]
     for digest in expired:
         _native_sync_tickets.pop(digest, None)
 
 
-def _issue_sync_ticket() -> str:
+def _issue_sync_ticket(session_fingerprint: str = "") -> str:
     now = time.monotonic()
     with _native_sync_tickets_lock:
         _prune_sync_tickets(now)
         while len(_native_sync_tickets) >= _SYNC_TICKET_MAX_ACTIVE:
-            oldest = min(_native_sync_tickets, key=_native_sync_tickets.get)
+            oldest = min(_native_sync_tickets, key=lambda key: _native_sync_tickets[key]["expires_at"])
             _native_sync_tickets.pop(oldest, None)
         ticket = secrets.token_urlsafe(32)
-        _native_sync_tickets[_sync_ticket_digest(ticket)] = now + _SYNC_TICKET_TTL_SEC
+        _native_sync_tickets[_sync_ticket_digest(ticket)] = {
+            "expires_at": now + _SYNC_TICKET_TTL_SEC,
+            "session_fingerprint": session_fingerprint,
+        }
     return ticket
 
 
-def _sync_ticket_is_valid(value: object) -> bool:
+def _sync_ticket_is_valid(value: object, *, session_fingerprint: str | None = None) -> bool:
     ticket = _normalize_sync_ticket(value)
     if not ticket:
         return False
     now = time.monotonic()
     with _native_sync_tickets_lock:
         _prune_sync_tickets(now)
-        return _native_sync_tickets.get(_sync_ticket_digest(ticket), 0) > now
+        entry = _native_sync_tickets.get(_sync_ticket_digest(ticket))
+        return bool(entry and (session_fingerprint is None or (
+            session_fingerprint and entry["session_fingerprint"] == session_fingerprint
+        )))
 
 
-def _consume_sync_ticket(value: object) -> bool:
+def _consume_sync_ticket(value: object, *, session_fingerprint: str | None = None) -> bool:
     ticket = _normalize_sync_ticket(value)
     if not ticket:
         return False
@@ -155,8 +161,13 @@ def _consume_sync_ticket(value: object) -> bool:
     with _native_sync_tickets_lock:
         _prune_sync_tickets(now)
         digest = _sync_ticket_digest(ticket)
-        expires_at = _native_sync_tickets.pop(digest, 0)
-    return expires_at > now
+        entry = _native_sync_tickets.get(digest)
+        if not entry or (session_fingerprint is not None and (
+            not session_fingerprint or entry["session_fingerprint"] != session_fingerprint
+        )):
+            return False
+        _native_sync_tickets.pop(digest)
+        return True
 
 
 def _prune_native_delegates(now: float | None = None) -> None:
@@ -737,6 +748,14 @@ def _persist_repaired_bind(access_token: str, bind: dict) -> None:
                 authoritative = str((social or {}).get("access_token") or "").strip()
                 if authoritative != access_token:
                     return
+                # A two-file account switch can leave a *newer* auth mirror
+                # beside the old social file. Only a matching identity proves
+                # that this is a lagging refresh mirror for the same account.
+                mirror_user = _normalize_local_user_id(current.get("local_user_id"))
+                if not mirror_user or mirror_user != (social or {}).get("local_user_id"):
+                    return
+                if _normalize_auth_source(current.get("auth_source")) != social.get("auth_source"):
+                    return
             _write_private_json(path, {**current, "bind": bind})
     except (OSError, TimeoutError) as exc:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
@@ -959,6 +978,8 @@ def _clear_auth() -> bool:
         logger.warning("card_drop: clear credentials failed to fence writers: %s", exc)
     if success:
         _clear_native_delegates()
+        with _native_sync_tickets_lock:
+            _native_sync_tickets.clear()
     return success
 
 
@@ -1313,11 +1334,10 @@ async def auth_status_endpoint(request: Request):
 async def sync_ticket_endpoint(request: Request):
     """Issue a short-lived ticket readable only by the local NEKO page.
 
-    The ticket transitively redeems the Desktop OAuth bearer, so minting gets
-    the same browser boundary as /native-delegate: Fetch Metadata proving the
-    request came from this server's own page. A headerless native client can
-    no longer mint one; social-session-init then only ever consumes tickets
-    that originated from the trusted local UI.
+    Minting uses the same browser boundary as /native-delegate, with Fetch
+    Metadata and local Origin checks. These headers do not authenticate raw
+    local processes, which can forge them. Bearer redemption additionally
+    requires the ticket to match its persisted issuing session.
     """
     if not _local_ui_request_source_allowed(request):
         return JSONResponse(
@@ -1325,10 +1345,22 @@ async def sync_ticket_endpoint(request: Request):
             status_code=403,
             headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
         )
+    try:
+        ticket = await asyncio.to_thread(_issue_sync_ticket_for_session)
+    except (OSError, TimeoutError):
+        return JSONResponse(
+            {"detail": "desktop_session_busy"}, status_code=503,
+            headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+        )
     return JSONResponse(
-        {"sync_ticket": _issue_sync_ticket(), "expires_in": _SYNC_TICKET_TTL_SEC},
+        {"sync_ticket": ticket, "expires_in": _SYNC_TICKET_TTL_SEC},
         headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
     )
+
+
+def _issue_sync_ticket_for_session() -> str:
+    with _social_session_locks(_social_session_paths()):
+        return _issue_sync_ticket(_desktop_session_fingerprint(_desktop_session_snapshot()))
 
 
 def _consume_sync_ticket_for_verified_session(
@@ -1340,20 +1372,19 @@ def _consume_sync_ticket_for_verified_session(
     Returns "ok", "changed" (desktop session was replaced / lock busy; ticket
     preserved), or "invalid" (the ticket itself is spent).
     """
-    social_path = _social_session_path()
-    if social_path is None:
-        return "ok" if _consume_sync_ticket(sync_ticket) else "invalid"
     try:
         # The Electron main process takes this same lock for logout / account
         # switch / token refresh, so its write either completed before this
         # scope (the re-read below mismatches -> 409) or it waits until the
         # ticket is consumed and the response is already being queued.
-        with _social_session_lock(social_path):
+        with _social_session_locks(_social_session_paths()):
             current = _desktop_session_snapshot()
             current_token = str((current or {}).get("access_token") or "").strip()
             if current_token != access_token:
                 return "changed"
-            return "ok" if _consume_sync_ticket(sync_ticket) else "invalid"
+            return "ok" if _consume_sync_ticket(
+                sync_ticket, session_fingerprint=_desktop_session_fingerprint(current)
+            ) else "invalid"
     except (OSError, TimeoutError) as exc:
         # A concurrent writer is holding the lock; assume the session is being
         # replaced and keep the ticket for a retry.
@@ -1547,10 +1578,8 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
     is consumed only once the response is known to be deliverable.
     """
     if not (request.headers.get("origin") or "").strip():
-        # CORS cannot authenticate a non-browser caller, and the ticket must
-        # never be redeemable by one: /sync-ticket only mints from the local
-        # UI's browser context, so a headerless native client holds no ticket
-        # and this Origin requirement rejects its direct calls.
+        # Require the browser-origin contract even though raw local clients
+        # can forge Origin; this check alone is not process authentication.
         return JSONResponse(
             {"detail": "origin_required"},
             status_code=403,
@@ -1588,6 +1617,10 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         return JSONResponse(
             {"detail": "legacy_session_not_supported"}, status_code=409, headers=cors
         )
+    if not _sync_ticket_is_valid(
+        sync_ticket, session_fingerprint=_desktop_session_fingerprint(snapshot)
+    ):
+        return JSONResponse({"detail": "invalid_sync_ticket"}, status_code=403, headers=cors)
     snapshot_base = str(snapshot.get("base_url") or "").strip().rstrip("/")
     if snapshot_base and not _same_originish(snapshot_base, _social_base_url()):
         # The saved login belongs to another community; refuse rather than ship

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1555,27 +1555,9 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
     from main_routers import community_oauth as _co
 
     auth = await asyncio.to_thread(_load_auth) or {}
-    # 老会话没存 bind 字段 → 视为已绑（向后兼容，正常单账号场景成立）
-    bind = auth.get("bind") or {"bound": True, "error": None}
-    if not bind.get("bound") and bind.get("error") != _BIND_OWNERSHIP_CONFLICT:
-        # Desktop binds once at callback time and never retries. Redeeming the
-        # ticket used to be the SPA's chance to repair a failed bind, so retry
-        # here before it is spent.
-        bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
-        if bind.get("bound") or bind.get("error") == _BIND_OWNERSHIP_CONFLICT:
-            # Persist repaired binds and terminal conflicts alike, or
-            # /auth-status keeps reporting the stale transient failure and
-            # every later handoff repeats the bind round trip.
-            await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
-    # _load_auth 和 _oauth_guest_bind 都是 await 点，Desktop 登出、刷新、切号都可能
-    # 在这期间发生。这里无条件复查：会话已变就返回 409，既不下发凭据，也不消费
-    # ticket（留给用户重试）。
-    #
-    # 「复查 → 消费」在 _social_session_lock 里执行：Electron 侧的登出/切号/刷新
-    # 写 social_session.json 时持有同一把锁（见 social-session-refresh.js 的
-    # .lock 协议），所以那次写入要么发生在进锁之前（锁内复读磁盘发现 token 已变，
-    # 返回 409），要么被挡到 ticket 消费完成之后。复查本身仍需走异步的云端校验，
-    # 没法放进同步锁作用域；残余窗口只剩「出锁 → 响应送达」这段本地回环时间。
+    # _load_auth 是 await 点，Desktop 登出、刷新、切号都可能在这期间发生。这里
+    # 无条件复查：会话已变就返回 409，既不下发凭据、不消费 ticket，也不带着旧
+    # token 去做 bind 重试的云端副作用。
     verification_snapshot, _ = await _native_delegate_session_snapshot()
     verification_token = (
         str(verification_snapshot.get("access_token") or "").strip()
@@ -1586,6 +1568,24 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         return JSONResponse(
             {"detail": "desktop_login_required"}, status_code=409, headers=cors
         )
+    # 老会话没存 bind 字段 → 视为已绑（向后兼容，正常单账号场景成立）
+    bind = auth.get("bind") or {"bound": True, "error": None}
+    if not bind.get("bound") and bind.get("error") != _BIND_OWNERSHIP_CONFLICT:
+        # Desktop binds once at callback time and never retries. Redeeming the
+        # ticket used to be the SPA's chance to repair a failed bind, so retry
+        # here before it is spent — but only after the session revalidation
+        # above, so a superseded account never reaches the cloud bind.
+        bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
+        if bind.get("bound") or bind.get("error") == _BIND_OWNERSHIP_CONFLICT:
+            # Persist repaired binds and terminal conflicts alike, or
+            # /auth-status keeps reporting the stale transient failure and
+            # every later handoff repeats the bind round trip.
+            await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
+    # 「复查 → 消费」在 _social_session_lock 里执行：Electron 侧的登出/切号/刷新
+    # 写 social_session.json 时持有同一把锁（见 social-session-refresh.js 的
+    # .lock 协议），所以那次写入要么发生在进锁之前（锁内复读磁盘发现 token 已变，
+    # 返回 409），要么被挡到 ticket 消费完成之后。bind 重试本身仍是 await 点，
+    # 没法放进同步锁作用域；残余窗口只剩「出锁 → 响应送达」这段本地回环时间。
     consume_outcome = await asyncio.to_thread(
         _consume_sync_ticket_for_verified_session, sync_ticket, access_token
     )

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1528,15 +1528,27 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
             # Persist it, or /auth-status keeps reporting the stale failure and
             # every later handoff repeats the bind.
             await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
-        # The bind retry is a cloud round trip; Desktop may have refreshed,
-        # logged out, or switched accounts while it ran. Shipping the captured
-        # bearer now could hand over a revoked token or the previous account's,
-        # and the ticket would be spent either way.
-        current = await asyncio.to_thread(_desktop_session_snapshot) or {}
-        if str(current.get("access_token") or "").strip() != access_token:
-            return JSONResponse(
-                {"detail": "desktop_login_required"}, status_code=409, headers=cors
-            )
+    # _load_auth 和 _oauth_guest_bind 都是 await 点，Desktop 登出、刷新、切号都可能
+    # 在这期间发生。原先只有 bind 重试分支复查，已绑定和 ownership-conflict 两条常见
+    # 路径直接消费 ticket 并下发 bearer。这里改成无条件复查：会话已变就返回 409，
+    # 既不下发凭据，也不消费 ticket（留给用户重试）。
+    #
+    # 注意这里没有对「复查 → 消费」加锁。Desktop 侧的写入在 _social_session_lock 下
+    # 提交，但复查必须走 _native_delegate_session_snapshot（异步 IPC，读的是 PC 进程
+    # 内存中的当前会话），没法放进同步锁作用域；换成读磁盘的 _desktop_session_snapshot
+    # 会和上面 1489 行的判定源不一致，PC 尚未落盘时会误判。所以复查和消费之间仍有一个
+    # 窄窗口 —— 它把「整段 await 期间」收敛到了「一次 IPC 往返」，但没有完全消除。
+    # 彻底消除需要 PC 侧提供带版本号的会话读取接口，属于跨仓库改动。
+    verification_snapshot, _ = await _native_delegate_session_snapshot()
+    verification_token = (
+        str(verification_snapshot.get("access_token") or "").strip()
+        if verification_snapshot
+        else ""
+    )
+    if verification_token != access_token:
+        return JSONResponse(
+            {"detail": "desktop_login_required"}, status_code=409, headers=cors
+        )
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors
@@ -1546,9 +1558,15 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
             "access_token": access_token,
             "local_user_id": local_user_id,
             "auth_public_url": str(
-                snapshot.get("auth_public_url") or _co._auth_public_url()
+                snapshot.get("auth_public_url")
+                or auth.get("auth_public_url")
+                or _co._auth_public_url()
             ).rstrip("/"),
-            "client_id": str(snapshot.get("client_id") or _co._desktop_client_id()),
+            "client_id": str(
+                snapshot.get("client_id")
+                or auth.get("client_id")
+                or _co._desktop_client_id()
+            ),
             "bind": bind,
         },
         headers={**cors, "Cache-Control": "no-store", "Pragma": "no-cache"},

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -1528,6 +1528,15 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
             # Persist it, or /auth-status keeps reporting the stale failure and
             # every later handoff repeats the bind.
             await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
+        # The bind retry is a cloud round trip; Desktop may have refreshed,
+        # logged out, or switched accounts while it ran. Shipping the captured
+        # bearer now could hand over a revoked token or the previous account's,
+        # and the ticket would be spent either way.
+        current = await asyncio.to_thread(_desktop_session_snapshot) or {}
+        if str(current.get("access_token") or "").strip() != access_token:
+            return JSONResponse(
+                {"detail": "desktop_login_required"}, status_code=409, headers=cors
+            )
     if not _consume_sync_ticket(sync_ticket):
         return JSONResponse(
             {"detail": "invalid_sync_ticket"}, status_code=403, headers=cors

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -674,22 +674,25 @@ def _save_auth(data: dict) -> bool:
 def _persist_repaired_bind(access_token: str, bind: dict) -> None:
     """Record a repaired bind without clobbering a concurrent refresh.
 
-    Read-modify-write under the same lock the social-session CAS uses, merging
-    only the ``bind`` key: a refresh or account switch landing between read and
-    write owns the tokens and must not be rolled back to this snapshot.
+    Serialized on the social-session lock rather than one keyed to the auth
+    file: ``_persist_refreshed_oauth_tokens`` rewrites ``community_auth.json``
+    while holding that lock, so it is the only lock both writers share.
     """
     path = _auth_path()
-    if path is None:
+    social_path = _social_session_path()
+    if path is None or social_path is None:
         return
     try:
-        with _social_session_lock(path):
+        with _social_session_lock(social_path):
             current = _read_json_dict(path)
             if not current:
                 return
+            # A refresh or account switch won the race; its tokens own the
+            # record and this bind describes a session that is no longer there.
             if str(current.get("access_token") or "").strip() != access_token:
                 return
             _write_private_json(path, {**current, "bind": bind})
-    except OSError as exc:
+    except (OSError, TimeoutError) as exc:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
 
 

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -22,7 +22,7 @@ import secrets
 import threading
 import time
 import uuid
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import quote, urlparse
@@ -678,6 +678,15 @@ def _write_social_session_record(path: Path, data: dict) -> None:
         _write_private_json(path, data)
 
 
+@contextmanager
+def _social_session_locks(paths: list[Path]):
+    """Fence primary and legacy credentials in the same order for every writer."""
+    with ExitStack() as locks:
+        for path in sorted(set(paths), key=str):
+            locks.enter_context(_social_session_lock(path))
+        yield
+
+
 def _save_auth_unlocked(data: dict) -> bool:
     """Write community_auth.json without locking; caller must hold the lock."""
     p = _auth_path()
@@ -854,59 +863,60 @@ def _persist_session_identity_metadata(
     expected_access = str(snapshot.get("access_token") or "").strip()
     expected_base = str(snapshot.get("base_url") or _social_base_url()).strip().rstrip("/")
     expected_refresh = str(snapshot.get("refresh_token") or "").strip()
-    social_saved = False
-    found_social_session = False
-    for path in _social_session_paths():
-        try:
-            with _social_session_lock(path):
+    paths = _social_session_paths()
+    try:
+        # The fallback creation and auth mirror update must share the same
+        # fence as deletion, not just the write to an individual social file.
+        with _social_session_locks(paths):
+            auth = _load_auth()
+            for path in paths:
                 data = _read_json_dict(path)
                 access = str((data or {}).get("token") or "").strip()
                 if not data or not access:
                     continue
-                found_social_session = True
                 base = str(data.get("baseUrl") or _social_base_url()).strip().rstrip("/")
                 refresh = str(data.get("refresh_token") or "").strip()
                 if (access, base, refresh) != (
-                    expected_access,
-                    expected_base,
-                    expected_refresh,
+                    expected_access, expected_base, expected_refresh,
                 ):
-                    # The authoritative Electron session changed after validation.
                     return False
-                upgraded = {
+                _write_private_json(path, {
                     **data,
                     "schema_version": _SOCIAL_SESSION_SCHEMA_VERSION,
                     "local_user_id": normalized_user_id,
                     "auth_source": normalized_source,
-                }
-                _write_private_json(path, upgraded)
-        except OSError as exc:
-            logger.warning("card_drop: save social identity metadata failed: %s", exc)
-            return False
-        social_saved = True
-        break
+                })
+                break
+            else:
+                # Only a still-current auth-only session can create its social
+                # companion. A snapshot validated before logout is not enough.
+                if not auth or not paths or (
+                    str(auth.get("access_token") or "").strip(),
+                    str(auth.get("refresh_token") or "").strip(),
+                ) != (expected_access, expected_refresh):
+                    return False
+                if not _save_social_session_unlocked(
+                    paths[0], expected_base, expected_access, expected_refresh or None,
+                    local_user_id=normalized_user_id, auth_source=normalized_source,
+                ):
+                    return False
 
-    if not found_social_session:
-        # A pre-Electron community_auth.json session still needs the companion
-        # file. It is safe to create because no authoritative social file exists.
-        social_saved = _save_social_session(
-            expected_base,
-            expected_access,
-            expected_refresh or None,
-            local_user_id=normalized_user_id,
-            auth_source=normalized_source,
-        )
-
-    auth = _load_auth()
-    auth_saved = True
-    if auth is not None:
-        auth["schema_version"] = _SOCIAL_SESSION_SCHEMA_VERSION
-        auth["local_user_id"] = normalized_user_id
-        auth["auth_source"] = normalized_source
-        user = auth.get("user") if isinstance(auth.get("user"), dict) else {}
-        auth["user"] = {**user, "id": auth["local_user_id"]}
-        auth_saved = _save_auth(auth)
-    return social_saved and auth_saved
+            if auth is not None:
+                # Do not apply an older identity to a newer auth mirror.
+                if str(auth.get("access_token") or "").strip() != expected_access:
+                    return False
+                user = auth.get("user") if isinstance(auth.get("user"), dict) else {}
+                return _save_auth_unlocked({
+                    **auth,
+                    "schema_version": _SOCIAL_SESSION_SCHEMA_VERSION,
+                    "local_user_id": normalized_user_id,
+                    "auth_source": normalized_source,
+                    "user": {**user, "id": normalized_user_id},
+                })
+            return True
+    except (OSError, TimeoutError) as exc:
+        logger.warning("card_drop: save social identity metadata failed: %s", exc)
+        return False
 
 
 def _unlink_credentials(paths: list[Path]) -> bool:
@@ -930,27 +940,23 @@ def _clear_auth() -> bool:
     # community_auth.json 的删除也必须在 social-session 锁内：否则
     # _persist_repaired_bind 可在锁内读到旧记录、在本次删除之后把它写回去，
     # 登出只清掉 social 文件而镜像复活，clear 还会误报失败。
-    lock_path = _social_session_path()
     try:
-        if lock_path is not None:
-            with _social_session_lock(lock_path):
-                success = _unlink_credentials(paths) and success
-        else:
+        with _social_session_locks(_social_session_paths()):
             success = _unlink_credentials(paths) and success
+            for path in paths:
+                try:
+                    path.lstat()
+                except FileNotFoundError:
+                    continue
+                except OSError as exc:
+                    success = False
+                    logger.warning("card_drop: cannot verify credential clear for %s: %s", path, exc)
+                else:
+                    success = False
+                    logger.warning("card_drop: credential still exists after clear: %s", path)
     except (OSError, TimeoutError) as exc:
         success = False
         logger.warning("card_drop: clear credentials failed to fence writers: %s", exc)
-    for path in paths:
-        try:
-            path.lstat()
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            success = False
-            logger.warning("card_drop: cannot verify credential clear for %s: %s", path, exc)
-        else:
-            success = False
-            logger.warning("card_drop: credential still exists after clear: %s", path)
     if success:
         _clear_native_delegates()
     return success

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import secrets
+import threading
 import time
 import uuid
 from contextlib import contextmanager
@@ -60,6 +61,11 @@ _SUPPORTED_AUTH_SOURCES = frozenset({"legacy", "oauth"})
 _native_sync_tickets: dict[str, float] = {}
 # digest -> {expires_at, scopes, local_user_id, audience, session_fingerprint}
 _native_delegates: dict[str, dict] = {}
+# /sync-ticket 在事件循环线程签发，social-session-init 经 asyncio.to_thread 在
+# worker 线程消费（_clear_auth 也可能在线程里清 delegates）；两条线程都会迭代并
+# 修改这两张表，整段持锁，否则并发增删会让迭代抛 RuntimeError 把请求变成 500。
+_native_sync_tickets_lock = threading.Lock()
+_native_delegates_lock = threading.Lock()
 
 
 class _ClientBindingConflict(Exception):
@@ -108,20 +114,26 @@ def _normalize_sync_ticket(value: object) -> str:
 
 
 def _prune_sync_tickets(now: float | None = None) -> None:
+    """Caller must hold ``_native_sync_tickets_lock`` (it is not reentrant)."""
     current = time.monotonic() if now is None else now
-    expired = [digest for digest, expires_at in _native_sync_tickets.items() if expires_at <= current]
+    expired = [
+        digest
+        for digest, expires_at in _native_sync_tickets.items()
+        if expires_at <= current
+    ]
     for digest in expired:
         _native_sync_tickets.pop(digest, None)
 
 
 def _issue_sync_ticket() -> str:
     now = time.monotonic()
-    _prune_sync_tickets(now)
-    while len(_native_sync_tickets) >= _SYNC_TICKET_MAX_ACTIVE:
-        oldest = min(_native_sync_tickets, key=_native_sync_tickets.get)
-        _native_sync_tickets.pop(oldest, None)
-    ticket = secrets.token_urlsafe(32)
-    _native_sync_tickets[_sync_ticket_digest(ticket)] = now + _SYNC_TICKET_TTL_SEC
+    with _native_sync_tickets_lock:
+        _prune_sync_tickets(now)
+        while len(_native_sync_tickets) >= _SYNC_TICKET_MAX_ACTIVE:
+            oldest = min(_native_sync_tickets, key=_native_sync_tickets.get)
+            _native_sync_tickets.pop(oldest, None)
+        ticket = secrets.token_urlsafe(32)
+        _native_sync_tickets[_sync_ticket_digest(ticket)] = now + _SYNC_TICKET_TTL_SEC
     return ticket
 
 
@@ -130,8 +142,9 @@ def _sync_ticket_is_valid(value: object) -> bool:
     if not ticket:
         return False
     now = time.monotonic()
-    _prune_sync_tickets(now)
-    return _native_sync_tickets.get(_sync_ticket_digest(ticket), 0) > now
+    with _native_sync_tickets_lock:
+        _prune_sync_tickets(now)
+        return _native_sync_tickets.get(_sync_ticket_digest(ticket), 0) > now
 
 
 def _consume_sync_ticket(value: object) -> bool:
@@ -139,13 +152,15 @@ def _consume_sync_ticket(value: object) -> bool:
     if not ticket:
         return False
     now = time.monotonic()
-    _prune_sync_tickets(now)
-    digest = _sync_ticket_digest(ticket)
-    expires_at = _native_sync_tickets.pop(digest, 0)
+    with _native_sync_tickets_lock:
+        _prune_sync_tickets(now)
+        digest = _sync_ticket_digest(ticket)
+        expires_at = _native_sync_tickets.pop(digest, 0)
     return expires_at > now
 
 
 def _prune_native_delegates(now: float | None = None) -> None:
+    """Caller must hold ``_native_delegates_lock`` (it is not reentrant)."""
     current = time.monotonic() if now is None else now
     expired = [
         digest
@@ -157,7 +172,8 @@ def _prune_native_delegates(now: float | None = None) -> None:
 
 
 def _clear_native_delegates() -> None:
-    _native_delegates.clear()
+    with _native_delegates_lock:
+        _native_delegates.clear()
 
 
 def _desktop_session_fingerprint(snapshot: dict | None) -> str:
@@ -192,23 +208,24 @@ def _issue_native_delegate(
     scopes: frozenset[str] | None = None,
 ) -> str:
     now = time.monotonic()
-    _prune_native_delegates(now)
-    while len(_native_delegates) >= _NATIVE_DELEGATE_MAX_ACTIVE:
-        oldest = min(
-            _native_delegates,
-            key=lambda digest: float(_native_delegates[digest].get("expires_at") or 0),
-        )
-        _native_delegates.pop(oldest, None)
-    ticket = secrets.token_urlsafe(32)
-    requested_scopes = _NATIVE_DELEGATE_SCOPES if scopes is None else frozenset(scopes)
-    scoped = requested_scopes & _NATIVE_DELEGATE_SCOPES
-    _native_delegates[_sync_ticket_digest(ticket)] = {
-        "expires_at": now + _NATIVE_DELEGATE_TTL_SEC,
-        "scopes": scoped,
-        "local_user_id": _normalize_local_user_id(local_user_id),
-        "audience": (audience or "").strip().rstrip("/"),
-        "session_fingerprint": str(session_fingerprint or ""),
-    }
+    with _native_delegates_lock:
+        _prune_native_delegates(now)
+        while len(_native_delegates) >= _NATIVE_DELEGATE_MAX_ACTIVE:
+            oldest = min(
+                _native_delegates,
+                key=lambda digest: float(_native_delegates[digest].get("expires_at") or 0),
+            )
+            _native_delegates.pop(oldest, None)
+        ticket = secrets.token_urlsafe(32)
+        requested_scopes = _NATIVE_DELEGATE_SCOPES if scopes is None else frozenset(scopes)
+        scoped = requested_scopes & _NATIVE_DELEGATE_SCOPES
+        _native_delegates[_sync_ticket_digest(ticket)] = {
+            "expires_at": now + _NATIVE_DELEGATE_TTL_SEC,
+            "scopes": scoped,
+            "local_user_id": _normalize_local_user_id(local_user_id),
+            "audience": (audience or "").strip().rstrip("/"),
+            "session_fingerprint": str(session_fingerprint or ""),
+        }
     return ticket
 
 
@@ -217,17 +234,19 @@ def _native_delegate_entry(value: object) -> dict | None:
     if not ticket:
         return None
     now = time.monotonic()
-    _prune_native_delegates(now)
-    entry = _native_delegates.get(_sync_ticket_digest(ticket))
-    if not entry or float(entry.get("expires_at") or 0) <= now:
-        return None
-    return entry
+    with _native_delegates_lock:
+        _prune_native_delegates(now)
+        entry = _native_delegates.get(_sync_ticket_digest(ticket))
+        if not entry or float(entry.get("expires_at") or 0) <= now:
+            return None
+        return dict(entry)
 
 
 def _discard_native_delegate(value: object) -> None:
     ticket = _normalize_sync_ticket(value)
     if ticket:
-        _native_delegates.pop(_sync_ticket_digest(ticket), None)
+        with _native_delegates_lock:
+            _native_delegates.pop(_sync_ticket_digest(ticket), None)
 
 
 def _social_base_url() -> str:
@@ -700,10 +719,15 @@ def _persist_repaired_bind(access_token: str, bind: dict) -> None:
             current = _read_json_dict(path)
             if not current:
                 return
-            # A refresh or account switch won the race; its tokens own the
-            # record and this bind describes a session that is no longer there.
             if str(current.get("access_token") or "").strip() != access_token:
-                return
+                # 镜像 token 与本次 bind 的 token 不一致有两种含义：更新的登录或
+                # 刷新赢了（不该动），或者 refresh 已写入权威 social_session.json
+                # 而 community_auth.json 镜像那次 best-effort 写失败（该记，否则
+                # /auth-status 永远停在旧的瞬时错误上）。以权威快照裁决。
+                social = _desktop_session_snapshot()
+                authoritative = str((social or {}).get("access_token") or "").strip()
+                if authoritative != access_token:
+                    return
             _write_private_json(path, {**current, "bind": bind})
     except (OSError, TimeoutError) as exc:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
@@ -885,6 +909,17 @@ def _persist_session_identity_metadata(
     return social_saved and auth_saved
 
 
+def _unlink_credentials(paths: list[Path]) -> bool:
+    success = True
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            success = False
+            logger.warning("card_drop: clear credential failed for %s: %s", path, exc)
+    return success
+
+
 def _clear_auth() -> bool:
     auth_path = _auth_path()
     paths = ([auth_path] if auth_path is not None else []) + _social_session_paths()
@@ -892,16 +927,19 @@ def _clear_auth() -> bool:
     if auth_path is None:
         logger.warning("card_drop: cannot resolve auth path while clearing credentials")
     success = auth_path is not None
-    for path in paths:
-        try:
-            if path.name == _SOCIAL_SESSION_FILENAME:
-                with _social_session_lock(path):
-                    path.unlink(missing_ok=True)
-            else:
-                path.unlink(missing_ok=True)
-        except OSError as exc:
-            success = False
-            logger.warning("card_drop: clear credential failed for %s: %s", path, exc)
+    # community_auth.json 的删除也必须在 social-session 锁内：否则
+    # _persist_repaired_bind 可在锁内读到旧记录、在本次删除之后把它写回去，
+    # 登出只清掉 social 文件而镜像复活，clear 还会误报失败。
+    lock_path = _social_session_path()
+    try:
+        if lock_path is not None:
+            with _social_session_lock(lock_path):
+                success = _unlink_credentials(paths) and success
+        else:
+            success = _unlink_credentials(paths) and success
+    except (OSError, TimeoutError) as exc:
+        success = False
+        logger.warning("card_drop: clear credentials failed to fence writers: %s", exc)
     for path in paths:
         try:
             path.lstat()
@@ -1570,17 +1608,33 @@ async def social_session_init_endpoint(request: Request, payload: dict = Body(..
         )
     # 老会话没存 bind 字段 → 视为已绑（向后兼容，正常单账号场景成立）
     bind = auth.get("bind") or {"bound": True, "error": None}
+    bind_retried = False
     if not bind.get("bound") and bind.get("error") != _BIND_OWNERSHIP_CONFLICT:
         # Desktop binds once at callback time and never retries. Redeeming the
         # ticket used to be the SPA's chance to repair a failed bind, so retry
         # here before it is spent — but only after the session revalidation
         # above, so a superseded account never reaches the cloud bind.
+        bind_retried = True
         bind = await _co._oauth_guest_bind(_social_base_url(), access_token)
         if bind.get("bound") or bind.get("error") == _BIND_OWNERSHIP_CONFLICT:
             # Persist repaired binds and terminal conflicts alike, or
             # /auth-status keeps reporting the stale transient failure and
             # every later handoff repeats the bind round trip.
             await asyncio.to_thread(_persist_repaired_bind, access_token, bind)
+    if bind_retried:
+        # bind 可能包含多个最长 30 秒的云端往返；期间 token 可能已被云端撤销而
+        # 本地文件未变，锁内复读只比本地 token 发现不了。重跑一次带云端校验的
+        # 复查（仅 bind 分支付出这个延迟），拒绝就 409 并保留票据给用户重试。
+        post_bind_snapshot, _ = await _native_delegate_session_snapshot()
+        post_bind_token = (
+            str(post_bind_snapshot.get("access_token") or "").strip()
+            if post_bind_snapshot
+            else ""
+        )
+        if post_bind_token != access_token:
+            return JSONResponse(
+                {"detail": "desktop_login_required"}, status_code=409, headers=cors
+            )
     # 「复查 → 消费」在 _social_session_lock 里执行：Electron 侧的登出/切号/刷新
     # 写 social_session.json 时持有同一把锁（见 social-session-refresh.js 的
     # .lock 协议），所以那次写入要么发生在进锁之前（锁内复读磁盘发现 token 已变，

--- a/main_routers/card_drop_router.py
+++ b/main_routers/card_drop_router.py
@@ -659,7 +659,8 @@ def _write_social_session_record(path: Path, data: dict) -> None:
         _write_private_json(path, data)
 
 
-def _save_auth(data: dict) -> bool:
+def _save_auth_unlocked(data: dict) -> bool:
+    """Write community_auth.json without locking; caller must hold the lock."""
     p = _auth_path()
     if not p:
         return False
@@ -669,6 +670,18 @@ def _save_auth(data: dict) -> bool:
         logger.warning("card_drop: save auth failed: %s", exc)
         return False
     return True
+
+
+def _save_auth(data: dict) -> bool:
+    social_path = _social_session_path()
+    if social_path is None:
+        return _save_auth_unlocked(data)
+    try:
+        with _social_session_lock(social_path):
+            return _save_auth_unlocked(data)
+    except (OSError, TimeoutError) as exc:
+        logger.warning("card_drop: save auth failed: %s", exc)
+        return False
 
 
 def _persist_repaired_bind(access_token: str, bind: dict) -> None:
@@ -696,7 +709,8 @@ def _persist_repaired_bind(access_token: str, bind: dict) -> None:
         logger.warning("card_drop: persist repaired bind failed: %s", exc)
 
 
-def _save_social_session(
+def _save_social_session_unlocked(
+    path: Path,
     base: str,
     access: str | None,
     refresh: str | None,
@@ -706,12 +720,10 @@ def _save_social_session(
     auth_public_url: str | None = None,
     client_id: str | None = None,
 ) -> bool:
+    """Write social session without acquiring lock; caller must hold it."""
     normalized_user_id = _normalize_local_user_id(local_user_id)
     normalized_source = _normalize_auth_source(auth_source)
     if not access or not normalized_user_id or not normalized_source:
-        return False
-    p = _social_session_path()
-    if not p:
         return False
     data = {
         "schema_version": _SOCIAL_SESSION_SCHEMA_VERSION,
@@ -730,11 +742,41 @@ def _save_social_session(
     if oauth_client:
         data["client_id"] = oauth_client
     try:
-        _write_social_session_record(p, data)
+        _write_private_json(path, data)
     except OSError as exc:
         logger.warning("card_drop: save social session failed: %s", exc)
         return False
     return True
+
+
+def _save_social_session(
+    base: str,
+    access: str | None,
+    refresh: str | None,
+    *,
+    local_user_id: str,
+    auth_source: str,
+    auth_public_url: str | None = None,
+    client_id: str | None = None,
+) -> bool:
+    p = _social_session_path()
+    if not p:
+        return False
+    try:
+        with _social_session_lock(p):
+            return _save_social_session_unlocked(
+                p,
+                base,
+                access,
+                refresh,
+                local_user_id=local_user_id,
+                auth_source=auth_source,
+                auth_public_url=auth_public_url,
+                client_id=client_id,
+            )
+    except (OSError, TimeoutError) as exc:
+        logger.warning("card_drop: save social session failed: %s", exc)
+        return False
 
 
 def _persist_session_credentials(

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -411,10 +411,10 @@ async def _resolve_saved_oauth_status(
             return {"logged_in": False, "snapshot": snapshot, "auth": auth}
 
     cleared = await asyncio.to_thread(_clear_rejected_oauth_snapshot, snapshot)
-    if cleared:
-        return {"logged_in": False, "snapshot": None, "auth": {}}
-
-    logger.warning("community_oauth: rejected credential cleanup did not complete")
+    if not cleared:
+        logger.warning("community_oauth: rejected credential cleanup did not complete")
+    # Conditional cleanup may succeed while preserving a concurrent login,
+    # including a newer auth mirror that now becomes the fallback session.
     current, current_auth = await asyncio.to_thread(_load_oauth_status_records)
     if (
         current
@@ -423,6 +423,8 @@ async def _resolve_saved_oauth_status(
     ):
         # A concurrent login replaced the rejected snapshot while cleanup ran.
         return await _resolve_saved_oauth_status(_attempt + 1)
+    if cleared:
+        return {"logged_in": False, "snapshot": current, "auth": current_auth}
     return {
         "logged_in": False,
         "snapshot": current or snapshot,

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -510,18 +510,52 @@ def _persist_oauth_credentials(
         logger.warning("community_oauth: credential snapshot failed: %s", exc)
         return False
 
-    auth_saved = C._save_auth(auth_payload)
-    social_saved = auth_saved and C._save_social_session(
-        social_base,
-        access_token,
-        refresh_token,
-        local_user_id=local_user_id,
-        auth_source="oauth",
-        auth_public_url=auth_public_url,
-        client_id=client_id,
-    )
-    if auth_saved and social_saved:
-        return True
+    auth_saved = False
+    social_saved = False
+    try:
+        # Both credential files must move as one unit: a concurrent bind repair
+        # or refresh holds this same lock, so without it the two records can be
+        # left describing different accounts.
+        with C._social_session_lock(social_path):
+            auth_saved = C._save_auth_unlocked(auth_payload)
+            social_saved = auth_saved and C._save_social_session_unlocked(
+                social_path,
+                social_base,
+                access_token,
+                refresh_token,
+                local_user_id=local_user_id,
+                auth_source="oauth",
+                auth_public_url=auth_public_url,
+                client_id=client_id,
+            )
+            if auth_saved and social_saved:
+                return True
+
+            rollback_ok = True
+            for path, existed, payload in snapshots:
+                if path == social_path and social_saved:
+                    continue
+                try:
+                    if existed and payload is not None:
+                        C._write_private_json(path, payload)
+                    elif not existed:
+                        path.unlink(missing_ok=True)
+                except OSError as exc:
+                    rollback_ok = False
+                    logger.warning(
+                        "community_oauth: credential rollback failed for %s: %s",
+                        path.name,
+                        exc,
+                    )
+            if not rollback_ok:
+                logger.warning(
+                    "community_oauth: credential files may be inconsistent after "
+                    "a failed save"
+                )
+            return False
+    except (OSError, TimeoutError) as exc:
+        logger.warning("community_oauth: credential persist failed: %s", exc)
+        return False
 
     rollback_ok = True
     for path, existed, payload in snapshots:

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -494,29 +494,31 @@ def _persist_oauth_credentials(
     if auth_path is None or social_path is None:
         return False
 
-    snapshots: list[tuple[Path, bool, dict[str, Any] | None]] = []
-    try:
-        for path in (auth_path, social_path):
-            existed = path.exists()
-            payload = C._read_json_dict(path) if existed else None
-            if existed and payload is None:
-                logger.warning(
-                    "community_oauth: refusing to replace unreadable credential file: %s",
-                    path.name,
-                )
-                return False
-            snapshots.append((path, existed, payload))
-    except OSError as exc:
-        logger.warning("community_oauth: credential snapshot failed: %s", exc)
-        return False
-
-    auth_saved = False
-    social_saved = False
+    rollback_ok = True
     try:
         # Both credential files must move as one unit: a concurrent bind repair
         # or refresh holds this same lock, so without it the two records can be
-        # left describing different accounts.
+        # left describing different accounts. The rollback snapshots are read
+        # inside the same scope, or a refresh committing between the read and
+        # the lock would be rolled back onto an already-consumed refresh token.
         with C._social_session_lock(social_path):
+            snapshots: list[tuple[Path, bool, dict[str, Any] | None]] = []
+            try:
+                for path in (auth_path, social_path):
+                    existed = path.exists()
+                    payload = C._read_json_dict(path) if existed else None
+                    if existed and payload is None:
+                        logger.warning(
+                            "community_oauth: refusing to replace unreadable "
+                            "credential file: %s",
+                            path.name,
+                        )
+                        return False
+                    snapshots.append((path, existed, payload))
+            except OSError as exc:
+                logger.warning("community_oauth: credential snapshot failed: %s", exc)
+                return False
+
             auth_saved = C._save_auth_unlocked(auth_payload)
             social_saved = auth_saved and C._save_social_session_unlocked(
                 social_path,
@@ -531,7 +533,6 @@ def _persist_oauth_credentials(
             if auth_saved and social_saved:
                 return True
 
-            rollback_ok = True
             for path, existed, payload in snapshots:
                 if path == social_path and social_saved:
                     continue
@@ -547,36 +548,13 @@ def _persist_oauth_credentials(
                         path.name,
                         exc,
                     )
-            if not rollback_ok:
-                logger.warning(
-                    "community_oauth: credential files may be inconsistent after "
-                    "a failed save"
-                )
-            return False
     except (OSError, TimeoutError) as exc:
         logger.warning("community_oauth: credential persist failed: %s", exc)
         return False
 
-    rollback_ok = True
-    for path, existed, payload in snapshots:
-        # _save_social_session() either atomically replaced the social file and
-        # returned True, or left it untouched. Reaching rollback therefore
-        # means only community_auth.json may need restoration; rewriting the
-        # social snapshot here could overwrite a concurrent Desktop refresh.
-        if path == social_path:
-            continue
-        try:
-            if existed:
-                C._write_private_json(path, payload or {})
-            else:
-                path.unlink(missing_ok=True)
-        except OSError as exc:
-            rollback_ok = False
-            logger.warning(
-                "community_oauth: credential rollback failed for %s: %s",
-                path.name,
-                exc,
-            )
+    # A half-restored pair can pass a new auth record off as an active login.
+    # _clear_auth() takes the same non-reentrant lock, so it can only run once
+    # the scope above released it.
     if not rollback_ok and not C._clear_auth():
         logger.warning("community_oauth: failed to clear credentials after rollback failure")
     return False

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -233,21 +233,25 @@ def _persist_refreshed_oauth_tokens(
     if auth_path is None:
         return True
     try:
-        auth = C._read_json_dict(auth_path)
-        if auth and str(auth.get("access_token") or "").strip() == str(
-            expected.get("access_token") or ""
-        ).strip():
-            C._write_private_json(
-                auth_path,
-                {
-                    **auth,
-                    "schema_version": C._SOCIAL_SESSION_SCHEMA_VERSION,
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                    "session_generation": int(auth.get("session_generation") or 0) + 1,
-                },
-            )
-    except (OSError, ValueError, TypeError) as exc:
+        # The bind-repair path in card_drop_router also writes community_auth.json
+        # while holding the social-session lock, so both writers must serialize
+        # on the same lock to avoid clobbering each other's updates.
+        with C._social_session_lock(social_path):
+            auth = C._read_json_dict(auth_path)
+            if auth and str(auth.get("access_token") or "").strip() == str(
+                expected.get("access_token") or ""
+            ).strip():
+                C._write_private_json(
+                    auth_path,
+                    {
+                        **auth,
+                        "schema_version": C._SOCIAL_SESSION_SCHEMA_VERSION,
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                        "session_generation": int(auth.get("session_generation") or 0) + 1,
+                    },
+                )
+    except (OSError, ValueError, TypeError, TimeoutError) as exc:
         # The Electron-visible social session is authoritative.  A stale legacy
         # mirror must not make a successful refresh look logged out.
         logger.warning("community_oauth: refreshed auth mirror save failed: %s", exc)

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -261,26 +261,25 @@ def _persist_refreshed_oauth_tokens(
 def _clear_rejected_oauth_snapshot(expected: dict) -> bool:
     """Clear only the rejected credential snapshot; preserve a concurrent login."""
     success = True
-    social_path = C._social_session_path()
-    if social_path is not None:
-        try:
-            with C._social_session_lock(social_path):
-                social = C._read_json_dict(social_path)
-                current_access = str((social or {}).get("token") or "").strip()
-                if current_access == str(expected.get("access_token") or "").strip():
-                    social_path.unlink(missing_ok=True)
-        except (OSError, TimeoutError):
-            success = False
+    social_paths = C._social_session_paths()
     auth_path = C._auth_path()
+    expected_access = str(expected.get("access_token") or "").strip()
+    credentials = [(path, "token") for path in social_paths]
     if auth_path is not None:
-        try:
-            auth = C._read_json_dict(auth_path)
-            if str((auth or {}).get("access_token") or "").strip() == str(
-                expected.get("access_token") or ""
-            ).strip():
-                auth_path.unlink(missing_ok=True)
-        except OSError:
-            success = False
+        credentials.append((auth_path, "access_token"))
+    try:
+        # Keep conditional reads and deletions in the same critical section as
+        # bind repair and identity writes, including the legacy session path.
+        with C._social_session_locks(social_paths):
+            for path, token_key in credentials:
+                try:
+                    saved = C._read_json_dict(path)
+                    if str((saved or {}).get(token_key) or "").strip() == expected_access:
+                        path.unlink(missing_ok=True)
+                except OSError:
+                    success = False
+    except (OSError, TimeoutError):
+        success = False
     return success
 
 

--- a/main_routers/community_oauth.py
+++ b/main_routers/community_oauth.py
@@ -534,7 +534,13 @@ def _persist_oauth_credentials(
                 return True
 
             for path, existed, payload in snapshots:
-                if path == social_path and social_saved:
+                # social_saved is necessarily False here: either the social
+                # writer was never reached, or its atomic temp+rename write
+                # failed and left the old file byte-identical. Rewriting it
+                # cannot restore anything, but its failure would flip
+                # rollback_ok and make _clear_auth() delete a still-usable
+                # session, so leave the file alone.
+                if path == social_path:
                     continue
                 try:
                     if existed and payload is not None:

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -754,12 +754,12 @@
                     return '';
                 }
             };
-            const waitForInitialSyncTicket = async (ticketPromise) => {
+            const waitForInitialNativeProof = async (proofPromise, fallback = '') => {
                 let timeoutId;
                 try {
                     return await Promise.race([
-                        ticketPromise,
-                        new Promise(resolve => { timeoutId = setTimeout(() => resolve(''), 4000); })
+                        proofPromise,
+                        new Promise(resolve => { timeoutId = setTimeout(() => resolve(fallback), 4000); })
                     ]);
                 } finally {
                     clearTimeout(timeoutId);
@@ -789,21 +789,25 @@
                 targetUrl.hash = hash;
                 return targetUrl;
             };
-            const completeInitialCommunityHandoff = async (targetUrl, initialNativeDelegate = '') => {
+            const completeInitialCommunityHandoff = async (targetUrl, initialNativeDelegate = '', pendingProofs = {}) => {
                 // 已登录快速路径直接复用并行取得的 delegate。仅在状态接口失败、
                 // 但 auth-status 兜底确认已登录时重试一次，避免重复解析 OAuth 会话。
                 let nativeDelegate = initialNativeDelegate;
+                if (!nativeDelegate && pendingProofs.nativeHandoff) {
+                    nativeDelegate = (await pendingProofs.nativeHandoff).nativeDelegate;
+                }
                 if (!nativeDelegate) {
                     const retryHandoff = await fetchNativeDelegate();
                     nativeDelegate = retryHandoff.nativeDelegate;
                 }
                 if (nativeDelegate) {
-                    // 二次导航使用新签发的 native_sync，并与 delegate 一次性交付。
-                    // 即使首次页面尚未读取 fragment 而被替换，也不会丢失同步能力；
-                    // 同时不会重放首次导航中的一次性票据。
-                    const delegateTargetUrl = await attachNativeSyncTicket(
-                        new URL(targetUrl, window.location.href)
-                    );
+                    // A ticket omitted from the first navigation is still
+                    // unused. Reuse its late result; only mint again when the
+                    // first ticket was already sent or issuance actually failed.
+                    const unusedTicket = pendingProofs.syncTicket ? await pendingProofs.syncTicket : '';
+                    const delegateTargetUrl = unusedTicket
+                        ? applyNativeSyncTicket(new URL(targetUrl, window.location.href), unusedTicket)
+                        : await attachNativeSyncTicket(new URL(targetUrl, window.location.href));
                     attachNativeDelegate(delegateTargetUrl, nativeDelegate);
                     if (isElectron) {
                         if (!openElectronSocialWindow(delegateTargetUrl.toString())) {
@@ -880,8 +884,12 @@
                 const initialSyncTicketPromise = fetchNativeSyncTicket();
                 const initialClientIdPromise = fetchSocialClientId();
                 const initialNativeHandoffPromise = fetchNativeDelegate();
+                const initialNativeHandoffReadiness = waitForInitialNativeProof(
+                    initialNativeHandoffPromise,
+                    { nativeDelegate: '', loginState: 'unknown' }
+                );
                 const [initialSyncTicket, clientId] = await Promise.all([
-                    waitForInitialSyncTicket(initialSyncTicketPromise),
+                    waitForInitialNativeProof(initialSyncTicketPromise),
                     initialClientIdPromise
                 ]);
                 // 只有从本体按钮打开的页面才能拿到一次性同步票据。票据放 fragment，
@@ -902,7 +910,7 @@
                 } else if (!navigateBrowserPopup(url, { keepReference: true })) {
                     throw new Error('popup blocked');
                 }
-                const initialNativeHandoff = await initialNativeHandoffPromise;
+                const initialNativeHandoff = await initialNativeHandoffReadiness;
                 let communityLoggedIn = initialNativeHandoff.loginState === 'logged-in';
                 if (initialNativeHandoff.loginState === 'unknown') {
                     try {
@@ -1010,14 +1018,19 @@
                         } else {
                             await completeInitialCommunityHandoff(
                                 url,
-                                initialNativeHandoff.nativeDelegate
+                                initialNativeHandoff.nativeDelegate,
+                                { nativeHandoff: initialNativeHandoffPromise }
                             );
                         }
                     }
                 } else {
                     await completeInitialCommunityHandoff(
                         url,
-                        initialNativeHandoff.nativeDelegate
+                        initialNativeHandoff.nativeDelegate,
+                        {
+                            nativeHandoff: initialNativeHandoffPromise,
+                            syncTicket: initialSyncTicket ? null : initialSyncTicketPromise
+                        }
                     );
                 }
                 return;

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -689,7 +689,10 @@
             };
             const fetchNativeSyncTicket = async () => {
                 const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 4000);
+                // Both proof endpoints may validate for 60s and refresh for
+                // another 30s. Keep the request alive past the initial window
+                // navigation budget so the completed handoff can still arrive.
+                const timeoutId = setTimeout(() => controller.abort(), 120000);
                 try {
                     const response = await fetch('/api/card-drop/sync-ticket', {
                         cache: 'no-store',
@@ -710,7 +713,7 @@
             };
             const fetchNativeDelegate = async () => {
                 const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 4000);
+                const timeoutId = setTimeout(() => controller.abort(), 120000);
                 try {
                     const response = await fetch('/api/card-drop/native-delegate', {
                         cache: 'no-store',
@@ -749,6 +752,17 @@
                 } catch (error) {
                     console.warn('[social] client_id fetch failed (non-fatal):', error);
                     return '';
+                }
+            };
+            const waitForInitialSyncTicket = async (ticketPromise) => {
+                let timeoutId;
+                try {
+                    return await Promise.race([
+                        ticketPromise,
+                        new Promise(resolve => { timeoutId = setTimeout(() => resolve(''), 4000); })
+                    ]);
+                } finally {
+                    clearTimeout(timeoutId);
                 }
             };
             const applyNativeSyncTicket = (targetUrl, syncTicket) => {
@@ -867,7 +881,7 @@
                 const initialClientIdPromise = fetchSocialClientId();
                 const initialNativeHandoffPromise = fetchNativeDelegate();
                 const [initialSyncTicket, clientId] = await Promise.all([
-                    initialSyncTicketPromise,
+                    waitForInitialSyncTicket(initialSyncTicketPromise),
                     initialClientIdPromise
                 ]);
                 // 只有从本体按钮打开的页面才能拿到一次性同步票据。票据放 fragment，

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -1019,7 +1019,10 @@
                             await completeInitialCommunityHandoff(
                                 url,
                                 initialNativeHandoff.nativeDelegate,
-                                { nativeHandoff: initialNativeHandoffPromise }
+                                {
+                                    nativeHandoff: initialNativeHandoffPromise,
+                                    syncTicket: initialSyncTicket ? null : initialSyncTicketPromise
+                                }
                             );
                         }
                     }

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1785,6 +1785,41 @@ def test_social_session_init_keeps_a_concurrent_refresh_when_persisting_bind(
     assert persisted["refresh_token"] == "desktop-refresh-new"
 
 
+def test_social_session_init_prefers_the_saved_issuer_over_process_defaults(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A social_session.json predating the issuer fields still has the auth mirror."""
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "auth_public_url": "https://auth.custom.example",
+                "client_id": "neko-servers-desktop-custom",
+                "bind": {"bound": True, "error": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    # The process defaults describe a different issuer than the handed-over token.
+    assert payload["auth_public_url"] == "https://auth.custom.example"
+    assert payload["client_id"] == "neko-servers-desktop-custom"
+
+
 def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):
     monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: None)
     ticket = _issue_sync_ticket(client)

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1746,6 +1746,56 @@ def test_social_session_init_refuses_to_consume_when_logout_wins_the_lock(
     assert C._sync_ticket_is_valid(ticket)
 
 
+def test_social_session_init_skips_the_bind_retry_when_the_session_was_replaced(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A superseded account must not reach the cloud bind even in the repair path."""
+    from main_routers import community_oauth
+
+    reads = {"count": 0}
+
+    def aging_snapshot():
+        # The first resolution (outer snapshot) sees account A; every later
+        # read — including the revalidation — sees the replaced session B.
+        reads["count"] += 1
+        token = "desktop-token-a" if reads["count"] <= 2 else "desktop-token-b"
+        return {**_delegate_session(), "access_token": token}
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", aging_snapshot)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def unexpected_guest_bind(_social_base, _access_token):
+        raise AssertionError("a superseded session must not reach the cloud bind")
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", unexpected_guest_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+    persisted = json.loads(auth.read_text(encoding="utf-8"))
+    assert persisted["bind"] == {"bound": False, "error": "cloud_unreachable"}
+
+
 def test_social_session_init_persists_a_terminal_bind_conflict(
     client,
     monkeypatch,

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1447,6 +1447,76 @@ def test_bind_client_approval_uses_persisted_local_id_and_consumes_ticket(
     assert replay.json() == {"detail": "invalid_sync_ticket"}
 
 
+def test_social_session_init_hands_desktop_oauth_to_community_origin(client, monkeypatch):
+    snapshot = {
+        **_delegate_session(),
+        "refresh_token": "desktop-refresh-a",
+        "auth_public_url": "https://auth.example",
+        "client_id": "neko-servers-desktop-dev",
+    }
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: snapshot)
+    ticket = _issue_sync_ticket(client)
+
+    denied = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://evil.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert denied.status_code == 403
+    assert denied.json() == {"detail": "origin_not_allowed"}
+    assert C._sync_ticket_is_valid(ticket)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://community.example"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json() == {
+        "access_token": "desktop-token-a",
+        "refresh_token": "desktop-refresh-a",
+        "local_user_id": USER_A_ID,
+        "auth_public_url": "https://auth.example",
+        "client_id": "neko-servers-desktop-dev",
+    }
+
+    replay = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert replay.status_code == 403
+    assert replay.json() == {"detail": "invalid_sync_ticket"}
+
+
+def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: None)
+    ticket = _issue_sync_ticket(client)
+    missing = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert missing.status_code == 409
+    assert missing.json() == {"detail": "desktop_login_required"}
+
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {**_delegate_session(), "auth_source": "legacy"},
+    )
+    legacy_ticket = _issue_sync_ticket(client)
+    legacy = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": legacy_ticket},
+    )
+    assert legacy.status_code == 409
+    assert legacy.json() == {"detail": "legacy_session_not_supported"}
+
+
 def test_bind_client_approval_rejects_origin_before_consuming_ticket(client, monkeypatch):
     ticket = _issue_sync_ticket(client)
     monkeypatch.setattr(

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -3566,7 +3566,10 @@ def test_social_session_init_validates_a_settled_session_once(client, monkeypatc
 
 @pytest.mark.parametrize("replacement", [
     {"access_token": "replacement-token"},
+    {"refresh_token": "replacement-refresh"},
+    {"base_url": "https://another-community.example"},
     {"local_user_id": USER_B_ID},
+    {"auth_source": "legacy"},
 ])
 @pytest.mark.asyncio
 async def test_native_session_snapshot_rejects_a_replacement_after_cloud_validation(
@@ -3581,3 +3584,28 @@ async def test_native_session_snapshot_rejects_a_replacement_after_cloud_validat
     monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: {**_delegate_session(), **replacement})
     snapshot, _failure = await C._native_delegate_session_snapshot()
     assert snapshot is None
+
+
+@pytest.mark.parametrize("missing_metadata", [
+    {"local_user_id": "", "auth_source": ""},
+    {"local_user_id": ""},
+    {"auth_source": ""},
+])
+@pytest.mark.asyncio
+async def test_native_session_snapshot_accepts_concurrent_identity_backfill(
+    monkeypatch, missing_metadata,
+):
+    from main_routers import community_oauth
+
+    async def validated_session_before_backfill():
+        return {
+            "logged_in": True,
+            "snapshot": {**_delegate_session(), **missing_metadata},
+            "auth": {},
+        }
+
+    monkeypatch.setattr(community_oauth, "resolve_saved_oauth_status", validated_session_before_backfill)
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    snapshot, failure = await C._native_delegate_session_snapshot()
+    assert snapshot == _delegate_session()
+    assert failure == ""

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1875,6 +1875,61 @@ def test_clear_auth_waits_for_the_social_session_lock(tmp_path, monkeypatch):
     assert not social.exists()
 
 
+def test_clear_auth_fences_a_legacy_identity_write(tmp_path, monkeypatch):
+    """A paused legacy writer must finish before logout deletes either path."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    auth = tmp_path / "legacy" / "community_auth.json"
+    legacy = auth.with_name("social_session.json")
+    primary = tmp_path / "desktop" / "social_session.json"
+    auth.parent.mkdir()
+    auth.write_text(json.dumps({"access_token": "token-a"}), encoding="utf-8")
+    legacy.write_text(json.dumps({"token": "token-a"}), encoding="utf-8")
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setenv("NEKO_USER_DATA_DIR", str(primary.parent))
+    assert C._social_session_paths() == [primary, legacy]
+
+    writing = threading.Event()
+    release = threading.Event()
+    clearing = threading.Event()
+    real_write = C._write_private_json
+    real_lock = C._social_session_lock
+
+    def pause_write(path, data):
+        if path == legacy:
+            writing.set()
+            assert release.wait(5)
+        real_write(path, data)
+
+    def observed_lock(path):
+        if writing.is_set():
+            clearing.set()
+        return real_lock(path)
+
+    monkeypatch.setattr(C, "_write_private_json", pause_write)
+    monkeypatch.setattr(C, "_social_session_lock", observed_lock)
+    snapshot = {"access_token": "token-a"}
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        writer = pool.submit(C._persist_session_identity_metadata, snapshot, USER_A_ID, "oauth")
+        try:
+            assert writing.wait(5)
+            logout = pool.submit(C._clear_auth)
+            assert clearing.wait(5)
+            assert not logout.done()
+        finally:
+            release.set()
+        assert writer.result(timeout=5)
+        assert logout.result(timeout=5)
+
+    assert C._load_social_session() is None
+    assert C._load_auth() is None
+    assert not primary.exists()
+    assert not legacy.exists()
+    # A lookup that finishes after logout must not recreate the companion file.
+    assert not C._persist_session_identity_metadata(snapshot, USER_A_ID, "oauth")
+    assert C._desktop_session_snapshot() is None
+
+
 def test_social_session_init_rejects_a_token_revoked_during_the_bind_retry(
     client,
     monkeypatch,

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -927,7 +927,8 @@ def test_expired_native_delegate_does_not_fall_back_to_cloud_auth(
     token = _issue_delegate_from_local_ui(client, monkeypatch, snapshot)
     entry = C._native_delegate_entry(token)
     assert entry is not None
-    entry["expires_at"] = 0
+    # _native_delegate_entry 返回副本（防止调用方改写共享注册表），直接过期注册表条目。
+    C._native_delegates[C._sync_ticket_digest(token)]["expires_at"] = 0
 
     async def unexpected_cloud_auth(_base, _token):
         pytest.fail("expired native delegates must not be retried as cloud tokens")
@@ -1732,6 +1733,188 @@ def test_social_session_init_refuses_to_consume_when_logout_wins_the_lock(
             yield
 
     monkeypatch.setattr(C, "_social_session_lock", logout_under_lock)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+
+
+def test_sync_ticket_registry_survives_cross_thread_churn():
+    """Issue on the loop thread while a worker consumes: no iteration races."""
+    import threading as _threading
+
+    errors: list[Exception] = []
+
+    def churn_issue():
+        try:
+            for _ in range(200):
+                C._issue_sync_ticket()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def churn_consume():
+        try:
+            for _ in range(200):
+                C._consume_sync_ticket(C._issue_sync_ticket())
+                C._sync_ticket_is_valid("not-a-real-ticket-value-ignored")
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        _threading.Thread(target=churn_issue),
+        _threading.Thread(target=churn_consume),
+        _threading.Thread(target=churn_consume),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(C._native_sync_tickets) <= C._SYNC_TICKET_MAX_ACTIVE
+
+
+def test_persist_repaired_bind_accepts_a_stale_auth_mirror(tmp_path, monkeypatch):
+    """A refresh that updated social_session.json but failed its mirror write
+    must not strand the repaired bind behind the mirror's older token."""
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "mirror-stale-token",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    social.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "baseUrl": "https://community.example",
+                "token": "authoritative-token",
+                "access_token": "authoritative-token",
+                "local_user_id": USER_A_ID,
+                "auth_source": "oauth",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: social)
+
+    C._persist_repaired_bind(
+        "authoritative-token", {"bound": True, "error": None}
+    )
+    persisted = json.loads(auth.read_text(encoding="utf-8"))
+    assert persisted["bind"] == {"bound": True, "error": None}
+
+    # An account switch (the authoritative file also moved on) still wins.
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "mirror-stale-token",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    social.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "baseUrl": "https://community.example",
+                "token": "switched-account-token",
+                "access_token": "switched-account-token",
+                "local_user_id": USER_A_ID,
+                "auth_source": "oauth",
+            }
+        ),
+        encoding="utf-8",
+    )
+    C._persist_repaired_bind(
+        "authoritative-token", {"bound": True, "error": None}
+    )
+    preserved = json.loads(auth.read_text(encoding="utf-8"))
+    assert preserved["bind"] == {"bound": False, "error": "cloud_unreachable"}
+
+
+def test_clear_auth_waits_for_the_social_session_lock(tmp_path, monkeypatch):
+    """Deleting the auth mirror must fence repaired-bind writers on the lock."""
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    auth.write_text(json.dumps({"access_token": "token-a"}), encoding="utf-8")
+    social.write_text(
+        json.dumps({"token": "token-a", "access_token": "token-a"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: social)
+
+    # 一个 repaired-bind 写者在持有 social-session 锁：clear 必须在锁上等到
+    # 超时并报告失败，而不是绕过锁把镜像删掉（约 2 秒锁超时）。
+    with C._social_session_lock(social):
+        assert C._clear_auth() is False
+    assert auth.exists()
+    assert social.exists()
+
+    # 锁释放后重试即可正常清理。
+    assert C._clear_auth() is True
+    assert not auth.exists()
+    assert not social.exists()
+
+
+def test_social_session_init_rejects_a_token_revoked_during_the_bind_retry(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A cloud-side revocation during the bind must not burn the ticket."""
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    resolve_calls = {"count": 0}
+
+    async def revoking_resolve():
+        resolve_calls["count"] += 1
+        # The third resolution is the post-bind revalidation.
+        logged_in = resolve_calls["count"] <= 2
+        return {
+            "logged_in": logged_in,
+            "snapshot": _delegate_session() if logged_in else None,
+            "auth": {},
+        }
+
+    monkeypatch.setattr(
+        community_oauth, "resolve_saved_oauth_status", revoking_resolve
+    )
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def binding_guest_bind(_social_base, _access_token):
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", binding_guest_bind)
     ticket = _issue_sync_ticket(client)
 
     response = client.post(

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -652,7 +652,10 @@ def client(monkeypatch, tmp_path):
 
 
 def _issue_sync_ticket(client: TestClient) -> str:
-    response = client.get("/api/card-drop/sync-ticket")
+    response = client.get(
+        "/api/card-drop/sync-ticket",
+        headers={"Sec-Fetch-Site": "same-origin"},
+    )
     assert response.status_code == 200
     assert response.headers["cache-control"] == "no-store"
     ticket = response.json()["sync_ticket"]
@@ -1328,6 +1331,9 @@ def test_sync_ticket_rejects_cross_site_browser_churn(client):
         "/api/card-drop/sync-ticket",
         headers={"Sec-Fetch-Site": "cross-site"},
     )
+    # A headerless caller models a native local process: it must not be able
+    # to mint the ticket that transitively redeems the Desktop OAuth bearer.
+    headerless_native = client.get("/api/card-drop/sync-ticket")
     same_origin = client.get(
         "/api/card-drop/sync-ticket",
         headers={
@@ -1338,6 +1344,7 @@ def test_sync_ticket_rejects_cross_site_browser_churn(client):
 
     assert evil_origin.status_code == 403
     assert blind_browser_get.status_code == 403
+    assert headerless_native.status_code == 403
     assert same_origin.status_code == 200
     assert len(C._native_sync_tickets) == len(before) + 1
 
@@ -1575,6 +1582,9 @@ def test_social_session_init_keeps_the_ticket_when_identity_is_unavailable(
         return outcome["value"]
 
     monkeypatch.setattr(C, "_native_delegate_session_snapshot", resolved_snapshot)
+    # The consume fence re-reads the session file directly; keep it consistent
+    # with the resolved identity so the retry can succeed.
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: _delegate_session())
     ticket = _issue_sync_ticket(client)
 
     unavailable = client.post(
@@ -1696,6 +1706,85 @@ def test_social_session_init_rejects_a_session_replaced_during_the_bind_retry(
     assert "desktop-token-a" not in response.text
     # The handoff never happened, so the ticket must survive for a retry.
     assert C._sync_ticket_is_valid(ticket)
+
+
+def test_social_session_init_refuses_to_consume_when_logout_wins_the_lock(
+    client,
+    monkeypatch,
+):
+    """A desktop logout landing between verification and consumption must not ship the bearer."""
+    from contextlib import contextmanager
+
+    state = {"token": "desktop-token-a"}
+
+    def mutable_snapshot():
+        return {**_delegate_session(), "access_token": state["token"]}
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", mutable_snapshot)
+
+    real_lock = C._social_session_lock
+
+    @contextmanager
+    def logout_under_lock(path):
+        with real_lock(path):
+            # Desktop logs out while the endpoint holds the consume fence.
+            state["token"] = ""
+            yield
+
+    monkeypatch.setattr(C, "_social_session_lock", logout_under_lock)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+
+
+def test_social_session_init_persists_a_terminal_bind_conflict(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A retry that settles on an ownership conflict must not stay a transient failure."""
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def conflicting_guest_bind(_social_base, _access_token):
+        return {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", conflicting_guest_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["bind"] == {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT}
+    # /auth-status must report the settled conflict instead of the stale
+    # transient error, or every later handoff repeats the bind round trip.
+    persisted = json.loads(auth.read_text(encoding="utf-8"))
+    assert persisted["bind"] == {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT}
 
 
 def test_social_session_init_does_not_rebind_a_settled_desktop_client(

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1732,8 +1732,8 @@ def test_social_session_init_refuses_to_consume_when_logout_wins_the_lock(
             state["token"] = ""
             yield
 
-    monkeypatch.setattr(C, "_social_session_lock", logout_under_lock)
     ticket = _issue_sync_ticket(client)
+    monkeypatch.setattr(C, "_social_session_lock", logout_under_lock)
 
     response = client.post(
         "/api/card-drop/social-session-init",
@@ -1791,6 +1791,8 @@ def test_persist_repaired_bind_accepts_a_stale_auth_mirror(tmp_path, monkeypatch
         json.dumps(
             {
                 "access_token": "mirror-stale-token",
+                "local_user_id": USER_A_ID,
+                "auth_source": "oauth",
                 "bind": {"bound": False, "error": "cloud_unreachable"},
             }
         ),
@@ -1824,6 +1826,8 @@ def test_persist_repaired_bind_accepts_a_stale_auth_mirror(tmp_path, monkeypatch
         json.dumps(
             {
                 "access_token": "mirror-stale-token",
+                "local_user_id": USER_A_ID,
+                "auth_source": "oauth",
                 "bind": {"bound": False, "error": "cloud_unreachable"},
             }
         ),
@@ -2019,6 +2023,7 @@ def test_social_session_init_skips_the_bind_retry_when_the_session_was_replaced(
 
     monkeypatch.setattr(community_oauth, "_oauth_guest_bind", unexpected_guest_bind)
     ticket = _issue_sync_ticket(client)
+    reads["count"] = 0  # The issuing snapshot is separate from redemption.
 
     response = client.post(
         "/api/card-drop/social-session-init",
@@ -3343,3 +3348,30 @@ async def test_archive_pick_excludes_trust_arbitration_losers(
     assert payload["facts"] == []
     assert payload["archiveRawCount"] == 1
     assert payload["archiveFilteredCount"] == 0
+
+
+def test_repaired_bind_cannot_change_a_newer_account_mirror(tmp_path, monkeypatch):
+    auth = tmp_path / "community_auth.json"
+    mirror = {"access_token": "account-b", "local_user_id": USER_B_ID,
+              "auth_source": "oauth", "bind": {"bound": False, "error": "B-error"}}
+    auth.write_text(json.dumps(mirror), encoding="utf-8")
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: tmp_path / "social_session.json")
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: _delegate_session())
+    C._persist_repaired_bind(_delegate_session()["access_token"], {"bound": True})
+    assert json.loads(auth.read_text()) == mirror
+
+
+@pytest.mark.parametrize("initial_session", [None, "account-a"])
+def test_old_sync_ticket_cannot_disclose_a_later_account(client, monkeypatch, initial_session):
+    snapshot = _delegate_session() if initial_session else None
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: snapshot)
+    ticket = _issue_sync_ticket(client)
+    snapshot = {**_delegate_session(), "local_user_id": USER_B_ID, "access_token": "account-b"}
+    response = client.post("/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"}, json={"sync_ticket": ticket})
+    assert response.status_code == 403
+    assert response.json() == {"detail": "invalid_sync_ticket"}
+    # The low-level final consumer also checks the minting session, closing a
+    # switch after preflight and preserving guest-bind-only tickets' purpose.
+    assert C._consume_sync_ticket_for_verified_session(ticket, "account-b") == "invalid"

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -2112,7 +2112,7 @@ def test_social_session_init_does_not_rebind_a_settled_desktop_client(
         {"bound": True, "error": None},
         {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT},
     ):
-        auth.write_text(json.dumps({"bind": bind}), encoding="utf-8")
+        auth.write_text(json.dumps({**_delegate_session(), "bind": bind}), encoding="utf-8")
         ticket = _issue_sync_ticket(client)
 
         response = client.post(
@@ -3411,3 +3411,40 @@ def test_sync_ticket_is_redeemable_after_refreshing_an_expired_desktop_session(
     assert response.status_code == 200
     assert response.json()["access_token"] == "refreshed-desktop-token"
     assert not C._sync_ticket_is_valid(ticket)
+
+
+@pytest.mark.parametrize("foreign_bind", [
+    {"bound": True, "error": None},
+    {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT},
+])
+def test_social_session_init_ignores_a_newer_accounts_bind(
+    client, monkeypatch, tmp_path, foreign_bind,
+):
+    from main_routers import community_oauth
+
+    auth_path = tmp_path / "community_auth.json"
+    mirror = {**_delegate_session(local_user_id=USER_B_ID, access_token="account-b"),
+              "auth_public_url": "https://foreign-issuer.example", "client_id": "foreign-client",
+              "bind": foreign_bind}
+    auth_path.write_text(json.dumps(mirror), encoding="utf-8")
+    monkeypatch.setattr(C, "_auth_path", lambda: auth_path)
+    monkeypatch.setattr(C, "_social_session_path", lambda: tmp_path / "social_session.json")
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    bound = []
+
+    async def bind_current_account(_base, token):
+        bound.append(token)
+        return {"bound": False, "error": "cloud_unreachable"}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", bind_current_account)
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": _issue_sync_ticket(client)},
+    )
+    assert response.status_code == 200
+    assert bound == ["desktop-token-a"]
+    assert response.json()["bind"] == {"bound": False, "error": "cloud_unreachable"}
+    assert response.json()["auth_public_url"] != "https://foreign-issuer.example"
+    assert response.json()["client_id"] != "foreign-client"
+    assert json.loads(auth_path.read_text()) == mirror

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1693,6 +1693,59 @@ def test_social_session_init_does_not_rebind_a_settled_desktop_client(
         assert response.json()["bind"] == bind
 
 
+def test_social_session_init_keeps_a_concurrent_refresh_when_persisting_bind(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A refresh landing during the bind call owns the tokens; do not roll it back."""
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "access_token": "desktop-token-a",
+                "refresh_token": "desktop-refresh-old",
+                "bind": {"bound": False, "error": "cloud_unreachable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def rotate_then_bind(social_base, access_token):
+        # Desktop refreshes while the bind cloud call is still in flight.
+        auth.write_text(
+            json.dumps(
+                {
+                    "access_token": "desktop-token-rotated",
+                    "refresh_token": "desktop-refresh-new",
+                    "bind": {"bound": False, "error": "cloud_unreachable"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", rotate_then_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    # The rotated credentials must survive; a whole-record rewrite would have
+    # restored the pre-bind snapshot and broken the next refresh.
+    persisted = json.loads(auth.read_text(encoding="utf-8"))
+    assert persisted["access_token"] == "desktop-token-rotated"
+    assert persisted["refresh_token"] == "desktop-refresh-new"
+
+
 def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):
     monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: None)
     ticket = _issue_sync_ticket(client)

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -621,10 +621,12 @@ async def test_shared_facts_selector_rejects_mismatched_runtime_character(
 
 
 @pytest.fixture
-def client(monkeypatch):
+def client(monkeypatch, tmp_path):
     from main_routers import community_oauth
 
     monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "https://community.example")
+    # Keep the suite off the developer's real credential file.
+    monkeypatch.setattr(C, "_auth_path", lambda: tmp_path / "community_auth.json")
 
     async def current_desktop_status():
         snapshot = await asyncio.to_thread(C._desktop_session_snapshot)
@@ -1476,11 +1478,13 @@ def test_social_session_init_hands_desktop_oauth_to_community_origin(client, mon
     assert response.headers["cache-control"] == "no-store"
     assert response.json() == {
         "access_token": "desktop-token-a",
-        "refresh_token": "desktop-refresh-a",
         "local_user_id": USER_A_ID,
         "auth_public_url": "https://auth.example",
         "client_id": "neko-servers-desktop-dev",
+        "bind": {"bound": True, "error": None},
     }
+    # Desktop stays the sole owner of the refresh-token family.
+    assert "desktop-refresh-a" not in response.text
 
     replay = client.post(
         "/api/card-drop/social-session-init",
@@ -1489,6 +1493,204 @@ def test_social_session_init_hands_desktop_oauth_to_community_origin(client, mon
     )
     assert replay.status_code == 403
     assert replay.json() == {"detail": "invalid_sync_ticket"}
+
+
+def test_social_session_init_rejects_a_request_without_origin(client, monkeypatch):
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {**_delegate_session(), "refresh_token": "desktop-refresh-a"},
+    )
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "origin_required"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+
+
+def test_social_session_init_rejects_a_plaintext_non_loopback_base(client, monkeypatch):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://community.example")
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {
+            **_delegate_session(),
+            "base_url": "http://community.example",
+            "refresh_token": "desktop-refresh-a",
+        },
+    )
+    ticket = _issue_sync_ticket(client)
+
+    preflight = client.options(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "http://community.example"},
+    )
+    assert preflight.status_code == 403
+    assert preflight.json() == {"detail": "insecure_transport"}
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "http://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "insecure_transport"}
+    assert "desktop-token-a" not in response.text
+    assert C._sync_ticket_is_valid(ticket)
+
+
+def test_social_session_init_allows_a_loopback_http_base(client, monkeypatch):
+    monkeypatch.setenv("NEKO_SOCIAL_BASE_URL", "http://localhost:3000")
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {**_delegate_session(), "base_url": "http://127.0.0.1:3000"},
+    )
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "http://localhost:3000"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "desktop-token-a"
+
+
+def test_social_session_init_keeps_the_ticket_when_identity_is_unavailable(
+    client,
+    monkeypatch,
+):
+    outcome = {"value": (None, "unavailable")}
+
+    async def resolved_snapshot():
+        return outcome["value"]
+
+    monkeypatch.setattr(C, "_native_delegate_session_snapshot", resolved_snapshot)
+    ticket = _issue_sync_ticket(client)
+
+    unavailable = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert unavailable.status_code == 503
+    assert unavailable.json() == {"detail": "identity_verification_unavailable"}
+    assert C._sync_ticket_is_valid(ticket)
+
+    outcome["value"] = (_delegate_session(), "")
+    retry = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+    assert retry.status_code == 200
+    assert retry.json()["access_token"] == "desktop-token-a"
+
+
+def test_social_session_init_rejects_a_snapshot_from_another_environment(
+    client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        C,
+        "_desktop_session_snapshot",
+        lambda: {
+            **_delegate_session(),
+            "base_url": "https://production.example",
+            "refresh_token": "prod-refresh",
+            "auth_public_url": "https://auth.production.example",
+            "client_id": "neko-servers-desktop-prod",
+        },
+    )
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "prod-refresh" not in response.text
+    assert "desktop-token-a" not in response.text
+
+
+def test_social_session_init_repairs_a_failed_desktop_bind(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps({"bind": {"bound": False, "error": "cloud_unreachable"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    bound = []
+
+    async def record_guest_bind(social_base, access_token):
+        bound.append((social_base, access_token))
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", record_guest_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 200
+    assert bound == [("https://community.example", "desktop-token-a")]
+    assert response.json()["bind"] == {"bound": True, "error": None}
+
+
+def test_social_session_init_does_not_rebind_a_settled_desktop_client(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    auth = tmp_path / "community_auth.json"
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    async def unexpected_guest_bind(social_base, access_token):
+        raise AssertionError("a settled bind must not cost another cloud round trip")
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", unexpected_guest_bind)
+
+    for bind in (
+        {"bound": True, "error": None},
+        {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT},
+    ):
+        auth.write_text(json.dumps({"bind": bind}), encoding="utf-8")
+        ticket = _issue_sync_ticket(client)
+
+        response = client.post(
+            "/api/card-drop/social-session-init",
+            headers={"Origin": "https://community.example"},
+            json={"sync_ticket": ticket},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["access_token"] == "desktop-token-a"
+        assert response.json()["bind"] == bind
 
 
 def test_social_session_init_requires_oauth_desktop_identity(client, monkeypatch):

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1659,6 +1659,45 @@ def test_social_session_init_repairs_a_failed_desktop_bind(
     assert response.json()["bind"] == {"bound": True, "error": None}
 
 
+def test_social_session_init_rejects_a_session_replaced_during_the_bind_retry(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    """A logout/account switch during the bind round trip must not ship the bearer."""
+    from main_routers import community_oauth
+
+    auth = tmp_path / "community_auth.json"
+    auth.write_text(
+        json.dumps({"bind": {"bound": False, "error": "cloud_unreachable"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+
+    snapshots = [_delegate_session()]
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: snapshots[-1])
+
+    async def switch_account_mid_bind(_social_base, _access_token):
+        # Desktop logs out while the cloud bind is in flight.
+        snapshots.append({**_delegate_session(), "access_token": ""})
+        return {"bound": True, "error": None}
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", switch_account_mid_bind)
+    ticket = _issue_sync_ticket(client)
+
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": ticket},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "desktop_login_required"}
+    assert "desktop-token-a" not in response.text
+    # The handoff never happened, so the ticket must survive for a retry.
+    assert C._sync_ticket_is_valid(ticket)
+
+
 def test_social_session_init_does_not_rebind_a_settled_desktop_client(
     client,
     monkeypatch,

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -2000,12 +2000,10 @@ def test_social_session_init_rejects_a_token_revoked_during_the_bind_retry(
     from main_routers import community_oauth
 
     monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
-    resolve_calls = {"count": 0}
+    state = {"revoked": False}
 
     async def revoking_resolve():
-        resolve_calls["count"] += 1
-        # The third resolution is the post-bind revalidation.
-        logged_in = resolve_calls["count"] <= 2
+        logged_in = not state["revoked"]
         return {
             "logged_in": logged_in,
             "snapshot": _delegate_session() if logged_in else None,
@@ -2028,11 +2026,11 @@ def test_social_session_init_rejects_a_token_revoked_during_the_bind_retry(
     monkeypatch.setattr(C, "_auth_path", lambda: auth)
 
     async def binding_guest_bind(_social_base, _access_token):
+        state["revoked"] = True
         return {"bound": True, "error": None}
 
     monkeypatch.setattr(community_oauth, "_oauth_guest_bind", binding_guest_bind)
     ticket = _issue_sync_ticket(client)
-    resolve_calls["count"] = 0  # Revoke during redemption, after mint validation.
 
     response = client.post(
         "/api/card-drop/social-session-init",
@@ -3494,3 +3492,92 @@ def test_social_session_init_ignores_a_newer_accounts_bind(
     assert response.json()["auth_public_url"] != "https://foreign-issuer.example"
     assert response.json()["client_id"] != "foreign-client"
     assert json.loads(auth_path.read_text()) == mirror
+
+
+@pytest.mark.parametrize("settled_bind", [
+    {"bound": True, "error": None},
+    {"bound": False, "error": C._BIND_OWNERSHIP_CONFLICT},
+])
+def test_social_session_init_reuses_a_repaired_bind_with_a_stale_mirror(
+    client, monkeypatch, tmp_path, settled_bind,
+):
+    from main_routers import community_oauth
+
+    auth = tmp_path / "community_auth.json"
+    mirror = {**_delegate_session(access_token="mirror-token"),
+              "refresh_token": "mirror-refresh",
+              "bind": {"bound": False, "error": "cloud_unreachable"}}
+    auth.write_text(json.dumps(mirror), encoding="utf-8")
+    monkeypatch.setattr(C, "_social_session_path", lambda: tmp_path / "social_session.json")
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    binds = []
+
+    async def bind_account(_base, access):
+        binds.append(access)
+        return settled_bind
+
+    monkeypatch.setattr(community_oauth, "_oauth_guest_bind", bind_account)
+    for _ in range(2):
+        response = client.post(
+            "/api/card-drop/social-session-init",
+            headers={"Origin": "https://community.example"},
+            json={"sync_ticket": _issue_sync_ticket(client)},
+        )
+        assert response.status_code == 200
+        assert response.json()["bind"] == settled_bind
+    assert binds == ["desktop-token-a"]
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: _delegate_session(
+        access_token="rotated-authoritative",
+    ))
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"},
+        json={"sync_ticket": _issue_sync_ticket(client)},
+    )
+    assert response.status_code == 200
+    assert binds == ["desktop-token-a", "rotated-authoritative"]
+    # Repairing a bind must not roll back a mirror whose credentials may have
+    # advanced first during a same-account two-file publication.
+    persisted = json.loads(auth.read_text(encoding="utf-8"))
+    assert persisted["access_token"] == mirror["access_token"]
+    assert persisted["refresh_token"] == mirror["refresh_token"]
+
+
+def test_social_session_init_validates_a_settled_session_once(client, monkeypatch):
+    from main_routers import community_oauth
+
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
+    validations = []
+
+    async def validate_session():
+        validations.append(True)
+        return {"logged_in": True, "snapshot": _delegate_session(), "auth": {}}
+
+    monkeypatch.setattr(community_oauth, "resolve_saved_oauth_status", validate_session)
+    ticket = _issue_sync_ticket(client)
+    validations.clear()
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"}, json={"sync_ticket": ticket},
+    )
+    assert response.status_code == 200
+    assert len(validations) == 1
+
+
+@pytest.mark.parametrize("replacement", [
+    {"access_token": "replacement-token"},
+    {"local_user_id": USER_B_ID},
+])
+@pytest.mark.asyncio
+async def test_native_session_snapshot_rejects_a_replacement_after_cloud_validation(
+    monkeypatch, replacement,
+):
+    from main_routers import community_oauth
+
+    async def validated_previous_session():
+        return {"logged_in": True, "snapshot": _delegate_session(), "auth": {}}
+
+    monkeypatch.setattr(community_oauth, "resolve_saved_oauth_status", validated_previous_session)
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: {**_delegate_session(), **replacement})
+    snapshot, _failure = await C._native_delegate_session_snapshot()
+    assert snapshot is None

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -767,10 +767,12 @@ def test_native_delegate_handoff_is_local_ui_only_and_validates_return_url(
     )
 
 
-def test_native_delegate_backfills_a_verified_legacy_desktop_session(
+@pytest.mark.parametrize("endpoint", ["native-delegate", "sync-ticket"])
+def test_native_proof_backfills_a_verified_legacy_desktop_session(
     client,
     tmp_path,
     monkeypatch,
+    endpoint,
 ):
     auth = tmp_path / "community_auth.json"
     social = tmp_path / "social_session.json"
@@ -802,7 +804,7 @@ def test_native_delegate_backfills_a_verified_legacy_desktop_session(
     )
 
     response = client.get(
-        "/api/card-drop/native-delegate",
+        f"/api/card-drop/{endpoint}",
         headers={"Sec-Fetch-Site": "same-origin"},
     )
 
@@ -811,7 +813,16 @@ def test_native_delegate_backfills_a_verified_legacy_desktop_session(
     saved = json.loads(social.read_text(encoding="utf-8"))
     assert saved["local_user_id"] == USER_A_ID
     assert saved["auth_source"] == "oauth"
-    assert C._native_delegate_entry(response.json()["native_delegate"]) is not None
+    if endpoint == "native-delegate":
+        assert C._native_delegate_entry(response.json()["native_delegate"]) is not None
+    else:
+        redeemed = client.post(
+            "/api/card-drop/social-session-init",
+            headers={"Origin": "https://community.example"},
+            json={"sync_ticket": response.json()["sync_ticket"]},
+        )
+        assert redeemed.status_code == 200
+        assert redeemed.json()["access_token"] == "legacy-desktop-token"
 
 
 def test_native_delegate_is_bound_to_the_refreshed_oauth_session(
@@ -1975,6 +1986,7 @@ def test_social_session_init_rejects_a_token_revoked_during_the_bind_retry(
 
     monkeypatch.setattr(community_oauth, "_oauth_guest_bind", binding_guest_bind)
     ticket = _issue_sync_ticket(client)
+    resolve_calls["count"] = 0  # Revoke during redemption, after mint validation.
 
     response = client.post(
         "/api/card-drop/social-session-init",
@@ -2005,7 +2017,7 @@ def test_social_session_init_skips_the_bind_retry_when_the_session_was_replaced(
         token = "desktop-token-a" if reads["count"] <= 2 else "desktop-token-b"
         return {**_delegate_session(), "access_token": token}
 
-    monkeypatch.setattr(C, "_desktop_session_snapshot", aging_snapshot)
+    monkeypatch.setattr(C, "_desktop_session_snapshot", _delegate_session)
     auth = tmp_path / "community_auth.json"
     auth.write_text(
         json.dumps(
@@ -2023,7 +2035,7 @@ def test_social_session_init_skips_the_bind_retry_when_the_session_was_replaced(
 
     monkeypatch.setattr(community_oauth, "_oauth_guest_bind", unexpected_guest_bind)
     ticket = _issue_sync_ticket(client)
-    reads["count"] = 0  # The issuing snapshot is separate from redemption.
+    monkeypatch.setattr(C, "_desktop_session_snapshot", aging_snapshot)
 
     response = client.post(
         "/api/card-drop/social-session-init",
@@ -3375,3 +3387,27 @@ def test_old_sync_ticket_cannot_disclose_a_later_account(client, monkeypatch, in
     # The low-level final consumer also checks the minting session, closing a
     # switch after preflight and preserving guest-bind-only tickets' purpose.
     assert C._consume_sync_ticket_for_verified_session(ticket, "account-b") == "invalid"
+
+
+def test_sync_ticket_is_redeemable_after_refreshing_an_expired_desktop_session(
+    client, monkeypatch,
+):
+    from main_routers import community_oauth
+
+    current = {"snapshot": _delegate_session(access_token="expired-desktop-token")}
+    refreshed = _delegate_session(access_token="refreshed-desktop-token")
+    monkeypatch.setattr(C, "_desktop_session_snapshot", lambda: current["snapshot"])
+
+    async def refresh_saved_session():
+        current["snapshot"] = refreshed
+        return {"logged_in": True, "snapshot": refreshed, "auth": {}}
+
+    monkeypatch.setattr(community_oauth, "resolve_saved_oauth_status", refresh_saved_session)
+    ticket = _issue_sync_ticket(client)
+    response = client.post(
+        "/api/card-drop/social-session-init",
+        headers={"Origin": "https://community.example"}, json={"sync_ticket": ticket},
+    )
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "refreshed-desktop-token"
+    assert not C._sync_ticket_is_valid(ticket)

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -1945,6 +1945,52 @@ def test_clear_auth_fences_a_legacy_identity_write(tmp_path, monkeypatch):
     assert C._desktop_session_snapshot() is None
 
 
+def test_clear_auth_preserves_tickets_issued_after_unlock(client, tmp_path, monkeypatch):
+    """Logout invalidates old tickets before a guest can mint a fresh proof."""
+    from concurrent.futures import ThreadPoolExecutor
+    from contextlib import contextmanager
+
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    auth.write_text(json.dumps({"access_token": "token-a"}), encoding="utf-8")
+    social.write_text(json.dumps({"token": "token-a"}), encoding="utf-8")
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: social)
+    old_ticket = C._issue_sync_ticket_for_session()
+    unlocked = threading.Event()
+    issued = threading.Event()
+    cleanup_thread = {}
+    real_locks = C._social_session_locks
+
+    @contextmanager
+    def pause_after_logout_unlock(paths):
+        with real_locks(paths):
+            yield
+        if threading.get_ident() == cleanup_thread.get("id"):
+            unlocked.set()
+            assert issued.wait(5)
+
+    def logout():
+        cleanup_thread["id"] = threading.get_ident()
+        return C._clear_auth()
+
+    monkeypatch.setattr(C, "_social_session_locks", pause_after_logout_unlock)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        cleanup = pool.submit(logout)
+        try:
+            assert unlocked.wait(5)
+            new_ticket = C._issue_sync_ticket_for_session()
+        finally:
+            issued.set()
+        assert cleanup.result(timeout=5)
+
+    assert C._desktop_session_snapshot() is None
+    assert not C._sync_ticket_is_valid(old_ticket)
+    assert C._sync_ticket_is_valid(new_ticket)
+    assert C._consume_sync_ticket(new_ticket)
+
+
 def test_social_session_init_rejects_a_token_revoked_during_the_bind_retry(
     client,
     monkeypatch,

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -1207,3 +1207,84 @@ def test_legacy_login_returns_410(oauth_app):
     )
     assert response.status_code == 410
     assert response.json() == {"detail": "legacy_community_login_removed"}
+
+
+@pytest.mark.unit
+def test_rejected_snapshot_cleanup_fences_a_bind_repair(oauth_app, monkeypatch):
+    """A bind repair starting as cleanup releases its lock cannot revive auth."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    _client, auth, social, _pending = oauth_app
+    auth.write_text(json.dumps({"access_token": "rejected-token"}), encoding="utf-8")
+    social.write_text(json.dumps({"token": "rejected-token"}), encoding="utf-8")
+    cleanup_unlocked = threading.Event()
+    continue_cleanup = threading.Event()
+    repair_read = threading.Event()
+    continue_repair = threading.Event()
+    worker_ids = {}
+    real_lock = C._social_session_lock
+    real_read = C._read_json_dict
+
+    @contextmanager
+    def pause_after_cleanup_unlock(path):
+        with real_lock(path):
+            yield
+        if threading.get_ident() == worker_ids.get("cleanup"):
+            cleanup_unlocked.set()
+            assert continue_cleanup.wait(5)
+
+    def pause_after_repair_read(path):
+        data = real_read(path)
+        if path == auth and threading.get_ident() == worker_ids.get("repair"):
+            repair_read.set()
+            assert continue_repair.wait(5)
+        return data
+
+    def clear_rejected():
+        worker_ids["cleanup"] = threading.get_ident()
+        return O._clear_rejected_oauth_snapshot({"access_token": "rejected-token"})
+
+    def repair_bind():
+        worker_ids["repair"] = threading.get_ident()
+        C._persist_repaired_bind("rejected-token", {"bound": True})
+
+    monkeypatch.setattr(C, "_social_session_lock", pause_after_cleanup_unlock)
+    monkeypatch.setattr(C, "_read_json_dict", pause_after_repair_read)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        cleanup = pool.submit(clear_rejected)
+        try:
+            assert cleanup_unlocked.wait(5)
+            repair = pool.submit(repair_bind)
+            assert repair_read.wait(5)
+            continue_cleanup.set()
+            assert cleanup.result(timeout=5)
+        finally:
+            continue_cleanup.set()
+            continue_repair.set()
+        repair.result(timeout=5)
+
+    assert not social.exists()
+    assert not auth.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("current_token", ["rejected-token", "new-login-token"])
+def test_rejected_snapshot_cleanup_checks_both_session_paths(
+    oauth_app, monkeypatch, current_token,
+):
+    _client, auth, social, _pending = oauth_app
+    legacy = social.with_name("legacy_social_session.json")
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: legacy)
+    auth.write_text(json.dumps({"access_token": current_token}), encoding="utf-8")
+    social.write_text(json.dumps({"token": current_token}), encoding="utf-8")
+    legacy.write_text(json.dumps({"token": "rejected-token"}), encoding="utf-8")
+
+    assert O._clear_rejected_oauth_snapshot({"access_token": "rejected-token"})
+
+    assert not legacy.exists()
+    if current_token == "rejected-token":
+        assert not auth.exists()
+        assert not social.exists()
+    else:
+        assert json.loads(auth.read_text(encoding="utf-8"))["access_token"] == current_token
+        assert json.loads(social.read_text(encoding="utf-8"))["token"] == current_token

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import threading
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
@@ -971,6 +972,131 @@ async def test_oauth_callback_rolls_back_partial_credential_write(
     else:
         assert not auth.exists()
         assert not social.exists()
+
+
+@pytest.mark.unit
+def test_persist_oauth_credentials_rolls_back_the_tokens_seen_under_the_lock(
+    tmp_path,
+    monkeypatch,
+):
+    """A refresh committing before the lock owns the tokens; do not roll it back."""
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    auth.write_text(
+        json.dumps({"access_token": "old-access", "refresh_token": "old-refresh"}),
+        encoding="utf-8",
+    )
+    social.write_text(
+        json.dumps(
+            {
+                "token": "old-access",
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "local_user_id": USER_ID,
+                "auth_source": "oauth",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+
+    real_lock = C._social_session_lock
+
+    @contextmanager
+    def rotating_lock(path):
+        with real_lock(path):
+            auth.write_text(
+                json.dumps(
+                    {
+                        "access_token": "rotated-access",
+                        "refresh_token": "rotated-refresh",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            social.write_text(
+                json.dumps(
+                    {
+                        "token": "rotated-access",
+                        "access_token": "rotated-access",
+                        "refresh_token": "rotated-refresh",
+                        "local_user_id": USER_ID,
+                        "auth_source": "oauth",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            yield
+
+    monkeypatch.setattr(C, "_social_session_lock", rotating_lock)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", lambda *_args, **_kwargs: False)
+
+    saved = O._persist_oauth_credentials(
+        {"access_token": "new-access", "refresh_token": "new-refresh"},
+        social_base="https://community.example",
+        access_token="new-access",
+        refresh_token="new-refresh",
+        local_user_id=USER_ID,
+        auth_public_url="https://auth.example",
+        client_id="neko-servers-desktop-dev",
+    )
+
+    assert saved is False
+    # Restoring the pre-refresh snapshot would reinstate a consumed refresh
+    # token and the next refresh would die with invalid_grant.
+    assert json.loads(auth.read_text(encoding="utf-8"))["refresh_token"] == "rotated-refresh"
+    assert json.loads(social.read_text(encoding="utf-8"))["refresh_token"] == "rotated-refresh"
+
+
+@pytest.mark.unit
+def test_persist_oauth_credentials_clears_credentials_when_rollback_fails(
+    tmp_path,
+    monkeypatch,
+):
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    old_auth = {"access_token": "old-access", "refresh_token": "old-refresh"}
+    auth.write_text(json.dumps(old_auth), encoding="utf-8")
+    social.write_text(
+        json.dumps(
+            {
+                "token": "old-access",
+                "access_token": "old-access",
+                "local_user_id": USER_ID,
+                "auth_source": "oauth",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: social)
+
+    real_write = C._write_private_json
+
+    def write_private_json(path, data):
+        if path == auth and data == old_auth:
+            raise OSError("restore failed")
+        real_write(path, data)
+
+    monkeypatch.setattr(C, "_write_private_json", write_private_json)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", lambda *_args, **_kwargs: False)
+
+    saved = O._persist_oauth_credentials(
+        {"access_token": "new-access", "refresh_token": "new-refresh"},
+        social_base="https://community.example",
+        access_token="new-access",
+        refresh_token="new-refresh",
+        local_user_id=USER_ID,
+        auth_public_url="https://auth.example",
+        client_id="neko-servers-desktop-dev",
+    )
+
+    assert saved is False
+    # A new auth record left beside the old session reads as an active login.
+    assert not auth.exists()
+    assert not social.exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -891,8 +891,10 @@ async def test_oauth_callback_offloads_credential_writes(tmp_path, monkeypatch):
     monkeypatch.setattr(O, "_oauth_guest_bind", fake_bind)
     monkeypatch.setattr(O, "_load_oauth_pending", load_pending)
     monkeypatch.setattr(O, "_unlink_pending", unlink_pending)
-    monkeypatch.setattr(C, "_save_auth", save_auth)
-    monkeypatch.setattr(C, "_save_social_session", save_social)
+    # Both records are written inside one social-session lock scope, so the
+    # callback now goes through the unlocked writers.
+    monkeypatch.setattr(C, "_save_auth_unlocked", save_auth)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", save_social)
 
     event_loop_thread = threading.get_ident()
     response = await O._handle_oauth_callback("auth-code", "expected-state")
@@ -956,8 +958,8 @@ async def test_oauth_callback_rolls_back_partial_credential_write(
     monkeypatch.setattr(O, "_exchange_oauth_code", fake_exchange)
     monkeypatch.setattr(O, "_bootstrap_session", fake_bootstrap)
     monkeypatch.setattr(O, "_oauth_guest_bind", fake_bind)
-    monkeypatch.setattr(C, "_save_auth", save_auth)
-    monkeypatch.setattr(C, "_save_social_session", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(C, "_save_auth_unlocked", save_auth)
+    monkeypatch.setattr(C, "_save_social_session_unlocked", lambda *_args, **_kwargs: False)
 
     response = await O._handle_oauth_callback("auth-code", "expected-state")
 

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -1050,6 +1050,60 @@ def test_persist_oauth_credentials_rolls_back_the_tokens_seen_under_the_lock(
 
 
 @pytest.mark.unit
+def test_persist_oauth_credentials_leaves_an_untouched_social_file_alone(
+    tmp_path,
+    monkeypatch,
+):
+    """Rollback must not rewrite (and risk destroying) the social file it never modified."""
+    auth = tmp_path / "community_auth.json"
+    social = tmp_path / "social_session.json"
+    old_auth = {"access_token": "old-access", "refresh_token": "old-refresh"}
+    old_social = {
+        "token": "old-access",
+        "access_token": "old-access",
+        "local_user_id": USER_ID,
+        "auth_source": "oauth",
+    }
+    auth.write_text(json.dumps(old_auth), encoding="utf-8")
+    social.write_text(json.dumps(old_social), encoding="utf-8")
+    monkeypatch.setattr(C, "_auth_path", lambda: auth)
+    monkeypatch.setattr(C, "_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_legacy_social_session_path", lambda: social)
+    monkeypatch.setattr(C, "_save_auth_unlocked", lambda *_args, **_kwargs: False)
+
+    social_writes = []
+    real_write = C._write_private_json
+
+    def write_private_json(path, data):
+        if path == social:
+            social_writes.append(data)
+            raise OSError("rollback must not rewrite the untouched social file")
+        real_write(path, data)
+
+    monkeypatch.setattr(C, "_write_private_json", write_private_json)
+    cleared = []
+    monkeypatch.setattr(C, "_clear_auth", lambda: cleared.append(True) or True)
+
+    saved = O._persist_oauth_credentials(
+        {"access_token": "new-access", "refresh_token": "new-refresh"},
+        social_base="https://community.example",
+        access_token="new-access",
+        refresh_token="new-refresh",
+        local_user_id=USER_ID,
+        auth_public_url="https://auth.example",
+        client_id="neko-servers-desktop-dev",
+    )
+
+    assert saved is False
+    assert social_writes == []
+    # A failed save leaves the old session byte-identical; rewriting it could
+    # fail too and make _clear_auth() delete a still-usable login.
+    assert cleared == []
+    assert json.loads(social.read_text(encoding="utf-8")) == old_social
+    assert json.loads(auth.read_text(encoding="utf-8")) == old_auth
+
+
+@pytest.mark.unit
 def test_persist_oauth_credentials_clears_credentials_when_rollback_fails(
     tmp_path,
     monkeypatch,

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -586,6 +586,48 @@ async def test_oauth_status_reports_rejected_snapshot_when_cleanup_fails(monkeyp
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("replace_social", [False, True])
+async def test_oauth_status_resolves_login_preserved_by_rejected_cleanup(
+    oauth_app, monkeypatch, replace_social,
+):
+    _client, auth, social, _pending = oauth_app
+    auth.write_text(json.dumps({"access_token": "rejected-token"}), encoding="utf-8")
+    social.write_text(json.dumps({"token": "rejected-token"}), encoding="utf-8")
+    new_auth = {
+        "access_token": "new-login-token",
+        "local_user_id": USER_ID,
+        "auth_source": "oauth",
+    }
+    validated = []
+
+    async def lookup_identity(_base, access):
+        validated.append(access)
+        if access == "rejected-token":
+            # A login may have written only the auth mirror when the older
+            # authoritative session's cloud validation comes back rejected.
+            assert C._save_auth(new_auth)
+            if replace_social:
+                assert C._save_social_session(
+                    "https://community.example", "new-login-token", None,
+                    local_user_id=USER_ID, auth_source="oauth",
+                )
+            return C._CloudIdentityLookup(None, 401, "rejected")
+        assert access == "new-login-token"
+        return C._CloudIdentityLookup(C._CloudIdentity(USER_ID, "oauth", {}), 200)
+
+    # Keep real file reads and cleanup: their successful conditional deletion
+    # is precisely what used to bypass revalidation of the surviving login.
+    monkeypatch.setattr(C, "_lookup_cloud_identity", lookup_identity)
+    status = await O.resolve_saved_oauth_status()
+
+    assert status["logged_in"] is True
+    assert status["snapshot"]["access_token"] == "new-login-token"
+    assert status["auth"] == new_auth
+    assert validated == ["rejected-token", "new-login-token"]
+    assert json.loads(auth.read_text(encoding="utf-8")) == new_auth
+
+
+@pytest.mark.unit
 async def test_oauth_logout_offloads_local_file_operations(monkeypatch):
     worker_threads: list[int] = []
 

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -86,9 +86,10 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert "const initialNativeHandoffPromise = fetchNativeDelegate();" in listener
     assert "const [initialSyncTicket, clientId] = await Promise.all([" in listener
     assert "applyNativeSyncTicket(targetUrl, initialSyncTicket);" in listener
-    assert listener.count("setTimeout(() => controller.abort(), 4000)") == 2
+    assert listener.count("setTimeout(() => controller.abort(), 120000)") == 2
+    assert "waitForInitialSyncTicket(initialSyncTicketPromise)" in listener
     assert listener.count("signal: controller.signal") == 2
-    assert listener.count("clearTimeout(timeoutId)") == 2
+    assert listener.count("clearTimeout(timeoutId)") == 3
     assert "native session sync ticket fetch failed: HTTP" in listener
     assert "native delegate fetch failed (non-fatal):" in listener
     assert "targetUrl.searchParams.set('cid', clientId)" in listener
@@ -187,6 +188,62 @@ def test_social_open_request_is_deduped_before_fetching_config():
         r"url,\s*initialNativeHandoff\.nativeDelegate\s*\);\s*\}",
         listener,
     )
+
+
+@pytest.mark.unit
+def test_slow_social_proof_survives_the_initial_window_navigation_budget():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    source = read_js_parts(APP_UI_PATH)
+    helpers = "\n".join(_extract_js_function(source, signature) + ";" for signature in (
+        "const fetchNativeSyncTicket = async () =>",
+        "const waitForInitialSyncTicket = async (ticketPromise) =>",
+    ))
+    script = r"""
+const assert = require('node:assert/strict');
+const timers = new Map();
+let timerId = 0;
+let now = 0;
+const setTimeout = (callback, delay) => {
+    const id = ++timerId;
+    timers.set(id, { callback, at: now + delay });
+    return id;
+};
+const clearTimeout = id => timers.delete(id);
+const advance = elapsed => {
+    now += elapsed;
+    for (const [id, timer] of [...timers]) {
+        if (timer.at <= now) { timers.delete(id); timer.callback(); }
+    }
+};
+let finishFetch;
+let signal;
+const fetch = (_url, options) => new Promise((resolve, reject) => {
+    signal = options.signal;
+    signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    finishFetch = () => resolve({ ok: true, json: async () => ({ sync_ticket: 'late-ticket' }) });
+});
+""" + helpers + r"""
+(async () => {
+    const ticket = fetchNativeSyncTicket();
+    const initial = waitForInitialSyncTicket(ticket);
+    advance(4000);
+    assert.equal(await initial, '', 'the community may open before slow validation finishes');
+    assert.equal(signal.aborted, false, 'navigation must not cancel proof issuance');
+    advance(1000);
+    finishFetch();
+    assert.equal(await ticket, 'late-ticket');
+    assert.equal(timers.size, 0, 'successful completion cleans both deadlines');
+    const timedOut = fetchNativeSyncTicket();
+    advance(120000);
+    assert.equal(await timedOut, '');
+    assert.equal(signal.aborted, true, 'the longer remote validation wait remains bounded');
+    assert.equal(timers.size, 0);
+})().catch(error => { console.error(error); process.exitCode = 1; });
+"""
+    result = run_node_stdin(node, script, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.unit

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -87,7 +87,7 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert "const [initialSyncTicket, clientId] = await Promise.all([" in listener
     assert "applyNativeSyncTicket(targetUrl, initialSyncTicket);" in listener
     assert listener.count("setTimeout(() => controller.abort(), 120000)") == 2
-    assert "waitForInitialSyncTicket(initialSyncTicketPromise)" in listener
+    assert "waitForInitialNativeProof(initialSyncTicketPromise)" in listener
     assert listener.count("signal: controller.signal") == 2
     assert listener.count("clearTimeout(timeoutId)") == 3
     assert "native session sync ticket fetch failed: HTTP" in listener
@@ -132,9 +132,9 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert "fetch('/api/card-drop/oauth/start'" in listener
     assert "请在浏览器完成统一账号登录" in listener
     assert listener.index("openElectronSocialWindow(url)") < listener.index(
-        "const initialNativeHandoff = await initialNativeHandoffPromise;"
+        "const initialNativeHandoff = await initialNativeHandoffReadiness;"
     )
-    assert listener.index("const initialNativeHandoff = await initialNativeHandoffPromise;") < listener.index(
+    assert listener.index("const initialNativeHandoff = await initialNativeHandoffReadiness;") < listener.index(
         "fetch('/api/card-drop/auth-status'"
     )
     assert listener.index("fetch('/api/card-drop/auth-status'") < listener.index(
@@ -155,10 +155,10 @@ def test_social_open_request_is_deduped_before_fetching_config():
         "openElectronSocialWindow(url)"
     )
     assert listener.index("openElectronSocialWindow(url)") < listener.index(
-        "const initialNativeHandoff = await initialNativeHandoffPromise;"
+        "const initialNativeHandoff = await initialNativeHandoffReadiness;"
     )
     helper_start = listener.index(
-        "const completeInitialCommunityHandoff = async (targetUrl, initialNativeDelegate = '') => {"
+        "const completeInitialCommunityHandoff = async (targetUrl, initialNativeDelegate = '', pendingProofs = {}) => {"
     )
     helper_end = listener.index("\n            try {", helper_start)
     helper = listener[helper_start:helper_end]
@@ -167,13 +167,11 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert helper.index("let nativeDelegate = initialNativeDelegate;") < helper.index(
         "openElectronSocialWindow(delegateTargetUrl.toString())"
     )
-    assert re.search(
-        r"const delegateTargetUrl = await attachNativeSyncTicket\(\s*"
-        r"new URL\(targetUrl, window\.location\.href\)\s*\);",
-        listener,
-    )
+    assert "const unusedTicket = pendingProofs.syncTicket ? await pendingProofs.syncTicket : '';" in helper
+    assert "applyNativeSyncTicket(new URL(targetUrl, window.location.href), unusedTicket)" in helper
+    assert "await attachNativeSyncTicket(new URL(targetUrl, window.location.href))" in helper
     assert "attachNativeDelegate(delegateTargetUrl, nativeDelegate);" in listener
-    assert "const completeInitialCommunityHandoff = async (targetUrl, initialNativeDelegate = '') => {" in listener
+    assert "const completeInitialCommunityHandoff = async (targetUrl, initialNativeDelegate = '', pendingProofs = {}) => {" in listener
     assert listener.count(
         "await completeInitialCommunityHandoff("
     ) == 2
@@ -183,10 +181,10 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert main_flow.index("fetch('/api/card-drop/auth-status'") < main_flow.index(
         "await completeInitialCommunityHandoff("
     )
-    assert re.search(
-        r"else \{\s*await completeInitialCommunityHandoff\(\s*"
-        r"url,\s*initialNativeHandoff\.nativeDelegate\s*\);\s*\}",
-        listener,
+    assert "syncTicket: initialSyncTicket ? null : initialSyncTicketPromise" in main_flow
+    assert "nativeHandoff: initialNativeHandoffPromise" in main_flow
+    assert main_flow.index("const initialNativeHandoffReadiness = waitForInitialNativeProof(") < main_flow.index(
+        "const [initialSyncTicket, clientId] = await Promise.all(["
     )
 
 
@@ -198,7 +196,7 @@ def test_slow_social_proof_survives_the_initial_window_navigation_budget():
     source = read_js_parts(APP_UI_PATH)
     helpers = "\n".join(_extract_js_function(source, signature) + ";" for signature in (
         "const fetchNativeSyncTicket = async () =>",
-        "const waitForInitialSyncTicket = async (ticketPromise) =>",
+        "const waitForInitialNativeProof = async (proofPromise, fallback = '') =>",
     ))
     script = r"""
 const assert = require('node:assert/strict');
@@ -227,7 +225,7 @@ const fetch = (_url, options) => new Promise((resolve, reject) => {
 """ + helpers + r"""
 (async () => {
     const ticket = fetchNativeSyncTicket();
-    const initial = waitForInitialSyncTicket(ticket);
+    const initial = waitForInitialNativeProof(ticket);
     advance(4000);
     assert.equal(await initial, '', 'the community may open before slow validation finishes');
     assert.equal(signal.aborted, false, 'navigation must not cancel proof issuance');
@@ -240,6 +238,101 @@ const fetch = (_url, options) => new Promise((resolve, reject) => {
     assert.equal(await timedOut, '');
     assert.equal(signal.aborted, true, 'the longer remote validation wait remains bounded');
     assert.equal(timers.size, 0);
+})().catch(error => { console.error(error); process.exitCode = 1; });
+"""
+    result = run_node_stdin(node, script, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ticket_delay_ms", [2000, 5000])
+def test_social_handoff_reuses_only_unsent_tickets_and_starts_fallback_early(ticket_delay_ms):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    source = read_js_parts(APP_UI_PATH)
+    start = source.index("window.addEventListener('live2d-social-click', async () => {")
+    listener = source[start:source.index("// 睡觉按钮（请她离开）", start)]
+    script = "const ticketDelay = " + str(ticket_delay_ms) + ";\n" + r"""
+const assert = require('node:assert/strict');
+let now = 0;
+let nextTimer = 0;
+const timers = new Map();
+const setTimeout = (callback, delay) => {
+    const id = ++nextTimer;
+    timers.set(id, { callback, at: now + delay });
+    return id;
+};
+const clearTimeout = id => timers.delete(id);
+const advance = elapsed => {
+    now += elapsed;
+    for (const [id, timer] of [...timers]) {
+        if (timer.at <= now) { timers.delete(id); timer.callback(); }
+    }
+};
+const flush = () => new Promise(resolve => setImmediate(resolve));
+let onClick;
+let released = 0;
+const opened = [];
+const requests = [];
+let ticketRequests = 0;
+let delegateRequests = 0;
+const shouldIgnoreSocialOpenRequest = () => false;
+const releaseSocialOpenRequest = () => { released += 1; };
+const isResolvedDarkTheme = () => false;
+const registerSocialThemeTarget = () => null;
+const queueSocialThemeSync = () => {};
+const window = {
+    location: new URL('http://localhost:48911/'),
+    electronShell: { openExternal: async () => { throw new Error('already logged in'); } },
+    addEventListener: (_type, callback) => { onClick = callback; },
+    open: url => { opened.push({ url: new URL(url), at: now }); return { focus() {} }; },
+};
+const response = body => ({ ok: true, json: async () => body });
+const fetch = async (url, options = {}) => {
+    requests.push({ url, at: now, signal: options.signal });
+    if (url === '/api/system/social/config') return response({ social_base_url: 'https://community.example' });
+    if (url === '/api/system/client-id') return response({ client_id: 'device-id' });
+    if (url === '/api/card-drop/sync-ticket') {
+        ticketRequests += 1;
+        if (ticketRequests === 1) {
+            return new Promise(resolve => setTimeout(() => resolve(response({ sync_ticket: 'ticket-1' })), ticketDelay));
+        }
+        return response({ sync_ticket: 'ticket-2' });
+    }
+    if (url === '/api/card-drop/native-delegate') {
+        delegateRequests += 1;
+        return new Promise(resolve => setTimeout(() => resolve(response({ native_delegate: 'desktop-delegate' })), 7000));
+    }
+    if (url === '/api/card-drop/auth-status') {
+        return new Promise(resolve => setTimeout(() => resolve(response({ logged_in: true })), Math.max(0, 7000 - now)));
+    }
+    throw new Error('unexpected request: ' + url);
+};
+""" + listener + r"""
+(async () => {
+    const flow = onClick();
+    await flush();
+    advance(2000); await flush();
+    advance(2000); await flush();
+    assert.equal(opened.length, 1, 'the first community navigation stays within its budget');
+    assert.equal(opened[0].at, Math.min(ticketDelay, 4000));
+    const status = requests.filter(request => request.url === '/api/card-drop/auth-status');
+    assert.equal(status.length, 1, 'fallback must join the still-running validation');
+    assert.equal(status[0].at, 4000, 'delegate readiness must not wait for the long HTTP timeout');
+    assert.ok(requests.filter(request => request.signal).every(request => !request.signal.aborted));
+    advance(1000); await flush();
+    advance(2000); await flush();
+    await flow;
+    assert.equal(delegateRequests, 1, 'reuse the late initial delegate instead of validating again');
+    assert.equal(ticketRequests, ticketDelay > 4000 ? 1 : 2);
+    assert.equal(opened.length, 2);
+    assert.equal(opened[0].url.hash.includes('native_sync'), ticketDelay <= 4000);
+    const finalProofs = new URLSearchParams(opened[1].url.hash.slice(1));
+    assert.equal(finalProofs.get('native_sync'), ticketDelay > 4000 ? 'ticket-1' : 'ticket-2');
+    assert.equal(finalProofs.get('native_delegate'), 'desktop-delegate');
+    assert.equal(timers.size, 0);
+    assert.equal(released, 1);
 })().catch(error => { console.error(error); process.exitCode = 1; });
 """
     result = run_node_stdin(node, script, capture_output=True, check=False)
@@ -262,7 +355,7 @@ def test_social_native_delegate_is_the_fast_path_login_proof_with_safe_fallback(
     assert "loginState: nativeDelegate ? 'logged-in' : 'unknown'" in delegate_helper
     assert delegate_helper.count("{ nativeDelegate: '', loginState: 'unknown' }") == 2
 
-    main_start = listener.index("const initialNativeHandoff = await initialNativeHandoffPromise;")
+    main_start = listener.index("const initialNativeHandoff = await initialNativeHandoffReadiness;")
     main_flow = listener[main_start:]
     unknown_guard = "if (initialNativeHandoff.loginState === 'unknown')"
     assert unknown_guard in main_flow
@@ -318,7 +411,7 @@ def test_social_browser_fallback_preopens_popup_before_async_fetches():
         listener,
     )
     assert listener.index("navigateBrowserPopup(url, { keepReference: true })") < listener.index(
-        "const initialNativeHandoff = await initialNativeHandoffPromise;"
+        "const initialNativeHandoff = await initialNativeHandoffReadiness;"
     )
     assert listener.index("fetch('/api/card-drop/auth-status'") < listener.index(
         "navigateBrowserPopup(authUrl, { keepReference: true })"

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -246,14 +246,20 @@ const fetch = (_url, options) => new Promise((resolve, reject) => {
 
 @pytest.mark.unit
 @pytest.mark.parametrize("ticket_delay_ms", [2000, 5000])
-def test_social_handoff_reuses_only_unsent_tickets_and_starts_fallback_early(ticket_delay_ms):
+@pytest.mark.parametrize("oauth_launch_failed", [False, True])
+def test_social_handoff_reuses_only_unsent_tickets_and_starts_fallback_early(
+    ticket_delay_ms, oauth_launch_failed,
+):
     node = shutil.which("node")
     if not node:
         pytest.skip("node is not installed")
     source = read_js_parts(APP_UI_PATH)
     start = source.index("window.addEventListener('live2d-social-click', async () => {")
     listener = source[start:source.index("// 睡觉按钮（请她离开）", start)]
-    script = "const ticketDelay = " + str(ticket_delay_ms) + ";\n" + r"""
+    script = (
+        "const ticketDelay = " + str(ticket_delay_ms) + ";\n"
+        + "const oauthLaunchFailed = " + str(oauth_launch_failed).lower() + ";\n"
+    ) + r"""
 const assert = require('node:assert/strict');
 let now = 0;
 let nextTimer = 0;
@@ -305,8 +311,10 @@ const fetch = async (url, options = {}) => {
         return new Promise(resolve => setTimeout(() => resolve(response({ native_delegate: 'desktop-delegate' })), 7000));
     }
     if (url === '/api/card-drop/auth-status') {
+        if (oauthLaunchFailed) return response({ logged_in: false });
         return new Promise(resolve => setTimeout(() => resolve(response({ logged_in: true })), Math.max(0, 7000 - now)));
     }
+    if (url === '/api/card-drop/oauth/start' && oauthLaunchFailed) return { ok: false };
     throw new Error('unexpected request: ' + url);
 };
 """ + listener + r"""
@@ -325,6 +333,8 @@ const fetch = async (url, options = {}) => {
     advance(2000); await flush();
     await flow;
     assert.equal(delegateRequests, 1, 'reuse the late initial delegate instead of validating again');
+    assert.equal(requests.filter(request => request.url === '/api/card-drop/oauth/start').length,
+        oauthLaunchFailed ? 1 : 0);
     assert.equal(ticketRequests, ticketDelay > 4000 ? 1 : 2);
     assert.equal(opened.length, 2);
     assert.equal(opened[0].url.hash.includes('native_sync'), ticketDelay <= 4000);


### PR DESCRIPTION
## Summary

Opening the community from a logged-in Desktop can now redeem a one-time `native_sync` ticket through `POST /api/card-drop/social-session-init` and bootstrap the same OAuth account. Only the access token is handed to the SPA; Desktop retains exclusive ownership of the rotating refresh-token family.

- Bind tickets to the persisted Desktop session, validate the community Origin and transport, and consume each ticket under the session file locks after revalidation. Logout clears outstanding tickets; a ticket from another session cannot disclose the current account's bearer.
- Refresh and backfill the Desktop identity before minting a ticket. Slow proof requests remain alive for up to 120 seconds, while the initial community navigation waits at most four seconds for the ticket and finishes the handoff afterward.
- Keep bind outcomes and issuer metadata tied to the authoritative account. Serialize credential clearing, metadata updates, OAuth persistence and rollback to avoid reviving or overwriting a concurrent login.

The local UI's Fetch Metadata/Origin checks enforce a browser-origin boundary. These headers can be forged by raw local processes and do not provide OS-level process authentication. The community SPA never sends its own OAuth bearer to localhost.

Companion PRs: [N.E.K.O.-PC#485](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/485), [N.E.K.O.Verse#336](https://github.com/Project-N-E-K-O/N.E.K.O.Verse/pull/336).

## 回归报告 / Regression Report

- **改动与原因**：为 Desktop 打开的社区提供一次性交接，避免要求用户再走一次 OAuth；同步修复凭据清理、刷新、账号切换和 bind 重试之间的并发问题。
- **前后行为**：已登录的 Desktop 可向社区交付 access token，refresh token 留在 Desktop；旧票据不能兑换另一账号。签发前完成正常刷新，慢校验不会在四秒后被前端取消。账号不匹配的认证镜像不再贡献 bind 或 issuer/client 字段。
- **兼容性与边界**：`/sync-ticket` 仍用于未登录时的 guest client 绑定证明；只有 `/social-session-init` 要求有效 OAuth 会话。无 Desktop 登录或 legacy 会话兑换返回 409，无效/已消费票据返回 403。旧镜像缺少身份字段时仍可通过完全相同的 access token 关联；未存 bind 的旧会话保留既有兼容行为。
- **验证**：相关会话、OAuth 和社交按钮测试合计 154 passed；Ruff、JavaScript 语法检查和 diff whitespace 检查通过。覆盖票据重放/跨账号、自动刷新、旧身份补全、主/legacy 文件锁、bind 重试与镜像隔离、issuer 隔离，以及慢请求晚于首次导航预算完成与最终超时清理。跨仓库自动回归由两个 companion PR 覆盖。

## Test plan

- [x] `pytest tests/unit/test_card_drop_session_facts.py tests/unit/test_community_oauth.py tests/unit/test_social_button_static_contracts.py -q` — 154 passed.
- [x] Ruff on the changed Python files; `node --check static/app/app-ui/surface-floating-controls.js`; `git diff --check`.
- [ ] Manual Desktop/community login, logout, account switch and slow-network exercise across all three builds.

Supersedes #3098 (same branch, reopened for a fresh review).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持将桌面 OAuth 会话安全交接至社区页面。
  - 增加来源校验、一次性同步票据、传输安全及会话一致性检查。
  - 支持账号切换时的会话隔离与绑定状态修复。
  - 初始社区导航可在同步票据较慢时继续，并复用尚未发送的票据。

- **问题修复**
  - 提升 OAuth 凭据刷新、会话保存及并发操作的一致性。
  - 优化异常回滚；凭据恢复失败时清理相关状态。
  - 注销后清除同步票据，改善会话切换、令牌刷新及并发处理的稳定性。
  - 延长交接请求等待时间，减少网络较慢时的失败。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
