### PR TITLE
fix(context-prompt): 请她离开模式下跳过情境弹窗

### DIFF
--- a/static/app/app-context-prompt.js
+++ b/static/app/app-context-prompt.js
@@ -131,7 +131,7 @@
 
     function _dismissActiveContextPromptForGameRoute() {
         // 内置小游戏不属于活动情境提示场景。丢掉尚未重放的信号，并把 play
-        // 记作已处理，避免游戏结束后把“检测到外部游戏”的过期提示补弹。
+        // 记作已处理，避免游戏结束后把"检测到外部游戏"的过期提示补弹。
         _pendingContexts.clear();
         _shownPlay = true;
         if (!_activeContext) return;
@@ -143,6 +143,22 @@
         if (_activePromptOverlay && typeof _activePromptOverlay.click === 'function') {
             _activePromptOverlay.click();
         }
+    }
+
+    function _dismissActiveContextPromptForGoodbye() {
+        // 请她离开模式开启时，所有主动搭话已静默，弹窗无意义。
+        _pendingContexts.clear();
+        if (!_activeContext) return;
+        _markShown(_activeContext);
+
+        _cancelActivePrompt = true;
+        if (_activePromptOverlay && typeof _activePromptOverlay.click === 'function') {
+            _activePromptOverlay.click();
+        }
+    }
+
+    function _isGoodbyeActive() {
+        return !!(window.__nekoGoodbyeSilentState && window.__nekoGoodbyeSilentState.active);
     }
 
     async function handle(context) {
@@ -199,7 +215,7 @@
                 ],
                 onShown: function (modal) {
                     _activePromptOverlay = modal && modal.overlay ? modal.overlay : null;
-                    if (_cancelActivePrompt || S.gameRouteActive) {
+                    if (_cancelActivePrompt || S.gameRouteActive || _isGoodbyeActive()) {
                         _cancelActivePrompt = true;
                         if (_activePromptOverlay && typeof _activePromptOverlay.click === 'function') {
                             _activePromptOverlay.click();
@@ -256,6 +272,15 @@
         const detail = event && event.detail ? event.detail : {};
         if (detail.action === 'opened') {
             _dismissActiveContextPromptForGameRoute();
+        }
+    });
+    // 请她离开模式开启时，dismiss 正在显示或排队中的情境弹窗。
+    window.addEventListener('live2d-goodbye-click', function () {
+        _dismissActiveContextPromptForGoodbye();
+    });
+    window.addEventListener('neko:auto-goodbye:state-change', function (event) {
+        if (_isGoodbyeActive()) {
+            _dismissActiveContextPromptForGoodbye();
         }
     });
 

--- a/static/app/app-context-prompt.js
+++ b/static/app/app-context-prompt.js
@@ -152,6 +152,8 @@
             _pendingContexts.delete(context);
             return;
         }
+        // 请她离开模式：所有主动搭话已静默，弹窗无意义
+        if (window.__nekoGoodbyeSilentState && window.__nekoGoodbyeSilentState.active) return;
         // settings 还没合并就绪（branch 未决议，nekoTelemetryBranch 为 undefined）：暂存
         // 这次事件，等 neko:telemetry-branch-resolved 再重放。不能直接丢——后端一次性推送
         // 不会重发。GET 失败时 branch 永远 undefined、该事件也永不重放，等于 fail-closed

--- a/static/app/app-context-prompt.js
+++ b/static/app/app-context-prompt.js
@@ -275,8 +275,14 @@
         }
     });
     // 请她离开模式开启时，dismiss 正在显示或排队中的情境弹窗。
+    // tryAutoGoodbye() 先派发 live2d-goodbye-click 再确认 isGoodbyeActive()；
+    // 激活被拒时会恢复静默状态。延到微任务再检查，避免误杀。
     window.addEventListener('live2d-goodbye-click', function () {
-        _dismissActiveContextPromptForGoodbye();
+        queueMicrotask(function () {
+            if (_isGoodbyeActive()) {
+                _dismissActiveContextPromptForGoodbye();
+            }
+        });
     });
     window.addEventListener('neko:auto-goodbye:state-change', function (event) {
         if (_isGoodbyeActive()) {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

就一行代码

请她离开模式下不再询问是否关闭屏幕分享

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->

## 不拆分理由 / Why Not Split

<!--
仅当本 PR 改动计入上限的文件 > 20 个时必填：为什么不拆成多个更小的 PR。
计入上限的文件数 ≤ 20：写「不适用」或删除本节。（新增文件、i18n locale 文件、测试文件不计入这个上限）
-->

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->

应该没问题吧（思考

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化“请她离开”静默模式的处理，避免在模式未成功激活时误清理情境弹窗。
  * 静默模式激活后，将清理暂存的情境事件，并取消正在显示或排队中的情境弹窗。
  * 静默期间不再显示新的情境提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->