### PR TITLE
fix(minigame-sdk): media.mount 先校验参数，media.request 按 UTF-8 字节限长

### DIFF
--- a/static/game/sdk/neko-minigame-sdk.js
+++ b/static/game/sdk/neko-minigame-sdk.js
@@ -5232,15 +5232,14 @@
       async request(action, payload = {}) {
         requireCapability('media-timeline', 'media.request');
         if (!payload || typeof payload !== 'object' || Array.isArray(payload)) fail('invalid_request', 'Media payload must be an object');
-        // Measure and send one plain snapshot: spreading drops a prototype
-        // toJSON() and an own toJSON is removed, so the UTF-8 budget covers the
-        // transported fields. Host fields are appended afterwards.
+        // Serialize once and send the parsed result: toJSON() at any depth is
+        // applied exactly once, so the measured UTF-8 bytes are the transported
+        // data. Host fields are appended afterwards.
         let body;
-        try { const { toJSON: _toJSON, ...fields } = payload; body = fields; }
+        try { body = JSON.parse(JSON.stringify(payload)); }
         catch (_) { fail('invalid_request', 'Media payload must be JSON'); }
-        const payloadBytes = jsonByteLength(body);
-        if (payloadBytes === Number.POSITIVE_INFINITY) fail('invalid_request', 'Media payload must be JSON');
-        if (payloadBytes > 65536) fail('invalid_request', 'Media payload too large');
+        if (!body || typeof body !== 'object' || Array.isArray(body)) fail('invalid_request', 'Media payload must be an object');
+        if (jsonByteLength(body) > 65536) fail('invalid_request', 'Media payload too large');
         if (!['history', 'watches', 'load', 'watch', 'prepare', 'preparation', 'character', 'discover'].includes(action)) fail('invalid_request', 'Unknown media operation');
         if (action === 'watch') requireActiveRuntimeRoute('media.watch');
         try { return await transport.requestMedia(action, { ...body, sdk_route_instance_id: runtimeRouteInstanceId }); }

--- a/static/game/sdk/neko-minigame-sdk.js
+++ b/static/game/sdk/neko-minigame-sdk.js
@@ -5232,27 +5232,35 @@
       async request(action, payload = {}) {
         requireCapability('media-timeline', 'media.request');
         if (!payload || typeof payload !== 'object' || Array.isArray(payload)) fail('invalid_request', 'Media payload must be an object');
-        // SDK payload budget in UTF-8 bytes; host fields are appended afterwards.
-        const payloadBytes = jsonByteLength(payload);
+        // Measure and send one plain snapshot: spreading drops a prototype
+        // toJSON() and an own toJSON is removed, so the UTF-8 budget covers the
+        // transported fields. Host fields are appended afterwards.
+        let body;
+        try { const { toJSON: _toJSON, ...fields } = payload; body = fields; }
+        catch (_) { fail('invalid_request', 'Media payload must be JSON'); }
+        const payloadBytes = jsonByteLength(body);
         if (payloadBytes === Number.POSITIVE_INFINITY) fail('invalid_request', 'Media payload must be JSON');
         if (payloadBytes > 65536) fail('invalid_request', 'Media payload too large');
         if (!['history', 'watches', 'load', 'watch', 'prepare', 'preparation', 'character', 'discover'].includes(action)) fail('invalid_request', 'Unknown media operation');
         if (action === 'watch') requireActiveRuntimeRoute('media.watch');
-        try { return await transport.requestMedia(action, { ...payload, sdk_route_instance_id: runtimeRouteInstanceId }); }
+        try { return await transport.requestMedia(action, { ...body, sdk_route_instance_id: runtimeRouteInstanceId }); }
         catch(error) { throw normalizeTransportError(error, 'media.request'); }
       },
       async mount(config) {
         requireCapability('media-timeline', 'media.mount');
         requireActiveRuntimeRoute('media.mount');
-        // Validate before claiming the pending slot: a TypeError past this point
-        // would skip the finally below and leave every later mount busy.
+        // Validate and read caller input before claiming the pending slot: an
+        // exception past that point would skip the finally below and leave every
+        // later mount busy.
         if (!config || typeof config !== 'object' || Array.isArray(config)) fail('invalid_request', 'Media mount config must be an object');
+        let callerSignal;
+        try { callerSignal = config.signal; }
+        catch (_) { fail('invalid_request', 'Media mount config signal is unreadable'); }
         if (mediaControllers.size || mediaMountPending) fail('busy', 'A media timeline is already mounted');
         const generation = runtimeRouteInstanceId;
         mediaMountPending = true;
         mediaMountAbort = new AbortControllerImpl();
         const mountAbort = mediaMountAbort;
-        const callerSignal = config.signal;
         const abortFromCaller = () => mountAbort.abort();
         let controller;
         try {

--- a/static/game/sdk/neko-minigame-sdk.js
+++ b/static/game/sdk/neko-minigame-sdk.js
@@ -5232,8 +5232,10 @@
       async request(action, payload = {}) {
         requireCapability('media-timeline', 'media.request');
         if (!payload || typeof payload !== 'object' || Array.isArray(payload)) fail('invalid_request', 'Media payload must be an object');
-        try { if (JSON.stringify(payload).length > 65536) fail('invalid_request', 'Media payload too large'); }
-        catch(error) { if (error instanceof NekoMiniGameError) throw error; fail('invalid_request', 'Media payload must be JSON'); }
+        // SDK payload budget in UTF-8 bytes; host fields are appended afterwards.
+        const payloadBytes = jsonByteLength(payload);
+        if (payloadBytes === Number.POSITIVE_INFINITY) fail('invalid_request', 'Media payload must be JSON');
+        if (payloadBytes > 65536) fail('invalid_request', 'Media payload too large');
         if (!['history', 'watches', 'load', 'watch', 'prepare', 'preparation', 'character', 'discover'].includes(action)) fail('invalid_request', 'Unknown media operation');
         if (action === 'watch') requireActiveRuntimeRoute('media.watch');
         try { return await transport.requestMedia(action, { ...payload, sdk_route_instance_id: runtimeRouteInstanceId }); }
@@ -5242,6 +5244,9 @@
       async mount(config) {
         requireCapability('media-timeline', 'media.mount');
         requireActiveRuntimeRoute('media.mount');
+        // Validate before claiming the pending slot: a TypeError past this point
+        // would skip the finally below and leave every later mount busy.
+        if (!config || typeof config !== 'object' || Array.isArray(config)) fail('invalid_request', 'Media mount config must be an object');
         if (mediaControllers.size || mediaMountPending) fail('busy', 'A media timeline is already mounted');
         const generation = runtimeRouteInstanceId;
         mediaMountPending = true;

--- a/tests/frontend/test_neko_minigame_sdk_runtime.js
+++ b/tests/frontend/test_neko_minigame_sdk_runtime.js
@@ -1498,6 +1498,17 @@ async function main() {
   assertInvalid(nonJson,'non-JSON media payload must expose the SDK invalid_request error');
   assert(/JSON/.test(nonJson.message),'non-JSON media payload lost its JSON error message');
   assert(await mediaClient.media.request('history',{text:'a'.repeat(60000)}).then(()=>true,()=>false),'ASCII media payload under the byte limit was rejected');
+  // Evaluate both hostile inputs before asserting so one run shows each result.
+  const hostileFailures=[];
+  const throwingSignal=await mediaClient.media.mount({get signal(){throw Error('signal getter');}}).then(()=>null,error=>error);
+  const afterThrowingSignal=await mediaClient.media.mount({}).then(controller=>{controller.dispose();return null;},error=>error);
+  if(!(throwingSignal instanceof window.NekoMiniGame.Error && throwingSignal.code==='invalid_request')||afterThrowingSignal!==null)hostileFailures.push('a throwing config.signal getter left the media slot busy');
+  class DisguisedPayload{constructor(){this.text='a'.repeat(70000);}toJSON(){return {};}}
+  let sentMediaPayload=null;
+  mediaTransport.requestMedia=async(_action,payload)=>{sentMediaPayload=payload;return {};};
+  const disguised=await mediaClient.media.request('history',new DisguisedPayload()).then(()=>null,error=>error);
+  if(!(disguised instanceof window.NekoMiniGame.Error && disguised.code==='invalid_request'))hostileFailures.push(`media payload limit measured toJSON() instead of the transported fields (sent ${sentMediaPayload?JSON.stringify(sentMediaPayload).length:0} chars)`);
+  assert(hostileFailures.length===0,hostileFailures.join('; '));
   mediaClient.dispose();
   process.stdout.write('mini-game SDK runtime test passed\n');
 }

--- a/tests/frontend/test_neko_minigame_sdk_runtime.js
+++ b/tests/frontend/test_neko_minigame_sdk_runtime.js
@@ -1503,11 +1503,21 @@ async function main() {
   const throwingSignal=await mediaClient.media.mount({get signal(){throw Error('signal getter');}}).then(()=>null,error=>error);
   const afterThrowingSignal=await mediaClient.media.mount({}).then(controller=>{controller.dispose();return null;},error=>error);
   if(!(throwingSignal instanceof window.NekoMiniGame.Error && throwingSignal.code==='invalid_request')||afterThrowingSignal!==null)hostileFailures.push('a throwing config.signal getter left the media slot busy');
+  // Invariant: a request is either rejected or transports at most the budget,
+  // counted the way the host clones it (enumerable data, toJSON ignored).
+  const rawChars=value=>typeof value==='string'?value.length:(value&&typeof value==='object')?Object.entries(value).reduce((sum,[key,item])=>key==='toJSON'?sum:sum+key.length+rawChars(item),0):0;
   class DisguisedPayload{constructor(){this.text='a'.repeat(70000);}toJSON(){return {};}}
-  let sentMediaPayload=null;
-  mediaTransport.requestMedia=async(_action,payload)=>{sentMediaPayload=payload;return {};};
-  const disguised=await mediaClient.media.request('history',new DisguisedPayload()).then(()=>null,error=>error);
-  if(!(disguised instanceof window.NekoMiniGame.Error && disguised.code==='invalid_request'))hostileFailures.push(`media payload limit measured toJSON() instead of the transported fields (sent ${sentMediaPayload?JSON.stringify(sentMediaPayload).length:0} chars)`);
+  const disguisedPayloads={
+    'prototype toJSON':()=>new DisguisedPayload(),
+    'nested toJSON':()=>({nested:{text:'a'.repeat(70000),toJSON(){return {};}}}),
+  };
+  for(const [label,makePayload] of Object.entries(disguisedPayloads)){
+    let sentMediaPayload=null;
+    mediaTransport.requestMedia=async(_action,payload)=>{sentMediaPayload=payload;return {};};
+    const outcome=await mediaClient.media.request('history',makePayload()).then(()=>null,error=>error);
+    const rejected=outcome instanceof window.NekoMiniGame.Error && outcome.code==='invalid_request';
+    if(!rejected&&!(sentMediaPayload&&rawChars(sentMediaPayload)<=65536))hostileFailures.push(`${label}: media payload limit measured toJSON() instead of the transported fields (sent ${rawChars(sentMediaPayload)} chars)`);
+  }
   assert(hostileFailures.length===0,hostileFailures.join('; '));
   mediaClient.dispose();
   process.stdout.write('mini-game SDK runtime test passed\n');

--- a/tests/frontend/test_neko_minigame_sdk_runtime.js
+++ b/tests/frontend/test_neko_minigame_sdk_runtime.js
@@ -1486,6 +1486,18 @@ async function main() {
   finishCancelledMount({dispose(){mediaDisposed++;}});
   assertCancelled(await lateMount);
   assert(mediaDisposed===2,'late cancelled controller was not disposed');
+  const assertInvalid=(error,message)=>assert(error instanceof window.NekoMiniGame.Error && error.code==='invalid_request',message);
+  mediaTransport.mountMedia=async()=>({dispose(){mediaDisposed++;},play(){},pause(){},interrupt(){}});
+  for(const config of [undefined,null,[],'config']){
+    assertInvalid(await mediaClient.media.mount(config).then(()=>null,error=>error),'invalid media mount config must expose the SDK invalid_request error');
+  }
+  const afterInvalidMount=await mediaClient.media.mount({});afterInvalidMount.dispose();
+  assert(mediaDisposed===3,'invalid media mount config left the media slot busy');
+  assertInvalid(await mediaClient.media.request('history',{text:'中'.repeat(30000)}).then(()=>null,error=>error),'media payload limit must count UTF-8 bytes');
+  const nonJson=await mediaClient.media.request('history',{value:1n}).then(()=>null,error=>error);
+  assertInvalid(nonJson,'non-JSON media payload must expose the SDK invalid_request error');
+  assert(/JSON/.test(nonJson.message),'non-JSON media payload lost its JSON error message');
+  assert(await mediaClient.media.request('history',{text:'a'.repeat(60000)}).then(()=>true,()=>false),'ASCII media payload under the byte limit was rejected');
   mediaClient.dispose();
   process.stdout.write('mini-game SDK runtime test passed\n');
 }


### PR DESCRIPTION
## 改动概述 / Summary

修 #3106 引入的小游戏 SDK `media` 接口两处入参问题（CodeRabbit 在 #3095 合并提交上以 outside-diff 形式报出，代码本身来自 #3106，main 上一致）。

- **`media.mount()` 传 `null`/`undefined` 会永久卡死媒体挂载**：原实现先置 `mediaMountPending = true`，再在 `try/finally` 之外读 `config.signal`。参数缺省时抛原始 `TypeError`，`finally` 不执行，此后该客户端每次 `media.mount()` 都返回 `busy`。现在在占位前校验 config 必须是对象，否则返回 `invalid_request`。
- **`media.request()` 负载上限按 UTF-16 code unit 计**：`JSON.stringify(payload).length` 对中文约少算 3 倍，`{text: '中'.repeat(30000)}` 实际 90011 字节仍能通过 65536 的限制。改为复用已有的 `jsonByteLength()` 按 UTF-8 字节计，保留非 JSON 负载的独立报错。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/`。

## 不拆分理由 / Why Not Split

不适用：计入上限的文件 1 个。

## 测试 / Testing

- 在 `tests/frontend/test_neko_minigame_sdk_runtime.js` 现有 media 用例后补回归：非法 mount 参数（`undefined`/`null`/数组/字符串）返回 `invalid_request` 且之后仍能正常挂载；中文负载按字节超限被拒；非 JSON 负载保留 JSON 报错；ASCII 60000 字节负载正常通过。
- 先红后绿：旧实现上红在 mount 断言；只修 mount 后红在 UTF-8 断言；两处都修后通过。
- `uv` 环境跑 `tests/frontend/test_neko_minigame_sdk_node.py` + `tests/unit/test_neko_minigame_manifest_schema.py`：15 passed，2 failed。失败的 `test_neko_minigame_drawing_avatar_host_runtime.js`、`test_drawing_guess_sdk_integration.js` 在干净 main（16a48f711）上以相同报错失败（`setView` / `commands` 契约由 #3095 提供），与本 PR 无关。
- `node --check`、`git diff --check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 媒体请求现按 UTF-8 字节数限制 JSON 数据大小，最大为 64 KiB。
  * 校验和发送使用一致的数据内容，避免请求数据不匹配。
  * 无法序列化或超出大小限制的数据将被拒绝，并返回明确错误。
  * 媒体挂载会提前验证配置；读取信号失败或配置无效时返回 `invalid_request`。
  * 修复无效配置导致媒体资源无法再次使用的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->